### PR TITLE
Add branch protection and agent contribution workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run smoke tests (parse all examples)
         run: python3 scripts/test_smoke_summary.py
 
+      - name: Audit npm dependencies
+        run: npm audit --omit=dev
+
   vscode-extension:
     name: VS Code extension
     runs-on: ubuntu-latest
@@ -72,3 +75,18 @@ jobs:
 
       - name: Run fixture and golden tests
         run: npm test
+
+      - name: Audit npm dependencies
+        run: npm audit --omit=dev
+
+  secrets:
+    name: Secret scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
   secrets:
     name: Secret scanning
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ log.html
 scripts/__pycache__
 tooling/tree-sitter-stm/scripts/__pycache__
 **/node_modules
+.worktrees/

--- a/AGENT-CONTRIBUTIONS.md
+++ b/AGENT-CONTRIBUTIONS.md
@@ -1,0 +1,156 @@
+# Agent Contribution Workflow
+
+This document describes how AI agents should contribute code to this repository.
+Human contributors should also follow the branch protection rules but may skip
+the worktree conventions if they prefer their own workflow.
+
+## Branch Protection
+
+Direct pushes to `main` are blocked. All changes must go through a pull request
+that passes both CI checks (Tree-sitter parser, VS Code extension) before merge.
+PRs are merged via rebase — no merge commits or squash merges.
+
+Repository admins can bypass protection in emergencies but should avoid doing so
+routinely.
+
+## Worktree-Based Isolation
+
+Agents must use git worktrees for all feature work. Worktrees live inside the
+repository at `.worktrees/` (gitignored) so they stay self-contained and don't
+pollute the parent directory.
+
+### Why worktrees
+
+- Multiple agents can work on separate features in parallel without stepping on
+  each other's working directory state.
+- Each worktree has its own independent checkout — file edits, staged changes,
+  and build artifacts are fully isolated.
+- The main worktree stays clean and always reflects `main`, making it easy to
+  review the overall project state.
+
+### Creating a worktree
+
+```bash
+# From the repo root
+git worktree add .worktrees/<branch-name> -b <branch-name>
+```
+
+Use the ticket ID as the branch name when the work maps to a ticket:
+
+```bash
+git worktree add .worktrees/stm-14x.8 -b stm-14x.8
+```
+
+For work spanning multiple tickets under one feature, use a descriptive name:
+
+```bash
+git worktree add .worktrees/feat/semantic-tokens -b feat/semantic-tokens
+```
+
+### Working inside a worktree
+
+Once created, `cd` into the worktree and work normally. The worktree is a full
+checkout — you can run tests, install dependencies, and commit just like the
+main working directory.
+
+```bash
+cd .worktrees/stm-14x.8
+npm install                                 # if touching node packages
+# ... do work, run tests, commit ...
+git push -u origin stm-14x.8
+gh pr create --title "..." --body "..."
+```
+
+Important: each worktree needs its own `node_modules` if you're running npm
+scripts. Run `npm install` (or `npm ci`) in the relevant package directory
+within the worktree after creation.
+
+### Cleaning up worktrees
+
+After a PR is merged:
+
+```bash
+# From the repo root (main worktree)
+git worktree remove .worktrees/stm-14x.8
+git branch -d stm-14x.8
+```
+
+List active worktrees:
+
+```bash
+git worktree list
+```
+
+## Branch Naming
+
+| Scope | Pattern | Example |
+|-------|---------|---------|
+| Single ticket | `stm-<id>` | `stm-14x.8` |
+| Feature (multi-ticket) | `feat/<name>` | `feat/semantic-tokens` |
+| Bug fix | `fix/<name>` | `fix/conflict-count` |
+| Chore / CI / docs | `chore/<name>` | `chore/ci-caching` |
+
+## Commit and PR Conventions
+
+- Keep commits focused — one logical change per commit.
+- Write commit messages that explain *why*, not just *what*.
+- PR titles should be under 70 characters. Use the body for details.
+- Reference ticket IDs in PR descriptions (e.g. "Closes stm-14x.8").
+- PRs must pass CI before merge. Do not ask reviewers to merge failing PRs.
+
+## Parallel Agent Work
+
+The worktree model is designed for multiple agents to work simultaneously.
+Follow these rules to avoid conflicts:
+
+### 1. One branch per feature scope
+
+Each agent claims a feature or ticket by creating its worktree and branch. Two
+agents must not work on the same branch. If two tickets touch the same files,
+they should be sequenced (via ticket dependencies) rather than parallelized.
+
+### 2. Rebase before PR
+
+Before opening a PR, rebase onto the latest `main`:
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+This keeps the commit history linear and surfaces conflicts early. If rebase
+conflicts arise, resolve them in the worktree — don't force-push over someone
+else's work.
+
+### 3. Minimize cross-cutting changes
+
+Prefer narrowly-scoped changes that touch only the files relevant to the
+feature. Avoid reformatting, renaming, or refactoring files outside the ticket
+scope — these create unnecessary merge conflicts for parallel work.
+
+### 4. Coordinate through tickets
+
+Check ticket dependencies before starting work. If your ticket depends on
+another that is in progress, wait for it to merge to `main` first. The ticket
+graph (`tk deps <id>`) is the coordination mechanism.
+
+## Agent Checklist
+
+Before starting work:
+
+- [ ] Identify the ticket(s) to implement
+- [ ] Verify dependencies are closed or merged
+- [ ] Create a worktree: `git worktree add .worktrees/<branch> -b <branch>`
+- [ ] `cd` into the worktree
+
+Before opening a PR:
+
+- [ ] All tests pass (`npm test` in relevant packages)
+- [ ] Rebase onto latest `main`
+- [ ] Commits are focused and well-described
+- [ ] Push and create PR via `gh pr create`
+
+After PR is merged:
+
+- [ ] Remove the worktree: `git worktree remove .worktrees/<branch>`
+- [ ] Delete the local branch: `git branch -d <branch>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,23 @@ When making changes or answering questions about syntax, semantics, or supported
 - Use the example corpus as golden fixtures whenever possible.
 - Document any ambiguity, unsupported syntax, or recovery behavior near the implementation.
 
+## Security
+
+CI runs `npm audit` and `gitleaks` secret scanning on every PR. Before pushing,
+agents must also verify locally:
+
+- **No secrets in commits.** Never commit API keys, tokens, passwords, or
+  credentials. Check staged diffs for anything that looks like a secret before
+  committing. If a secret is accidentally committed, alert the user immediately —
+  do not just remove it in a follow-up commit (the value is already in git history).
+- **No dependencies with critical vulnerabilities.** Run `npm audit` in any
+  package directory where you added or updated dependencies. Do not merge work
+  that introduces critical or high severity vulnerabilities without explicit
+  user approval.
+- **No `.env` or credential files.** Never stage `.env`, `credentials.json`,
+  `*.pem`, or similar files. If these are needed for local development, ensure
+  they are in `.gitignore`.
+
 ## Shell Command Expectations
 
 Always use non-interactive flags with shell commands that may prompt for confirmation. Agent work must not hang waiting for terminal input from aliased or interactive defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Prefer these forms over prompt-prone variants such as plain `cp`, `mv`, or `rm`.
 
 ## Running tree-sitter Commands
 
-Use the repo-local wrapper [`scripts/tree-sitter-local.sh`](/Users/thorben/dev/personal/stm/scripts/tree-sitter-local.sh) for every Tree-sitter command. It sets `XDG_CACHE_HOME` to a repo-local cache directory and uses a repo-local config file so agent runs do not depend on `~/.cache/tree-sitter` or global parser config.
+Use the repo-local wrapper [`scripts/tree-sitter-local.sh`](scripts/tree-sitter-local.sh) for every Tree-sitter command. It sets `XDG_CACHE_HOME` to a repo-local cache directory and uses a repo-local config file so agent runs do not depend on `~/.cache/tree-sitter` or global parser config.
 
 Preferred forms:
 
@@ -155,6 +155,12 @@ Expected workflow:
 
 ## Agent Workflow
 
+- **All code changes must go through a PR.** Direct pushes to `main` are blocked.
+  See [AGENT-CONTRIBUTIONS.md](AGENT-CONTRIBUTIONS.md) for the
+  full contribution workflow including worktree setup, branch naming, and parallel
+  work conventions.
+- Use git worktrees in `.worktrees/` for feature isolation. Create one per feature
+  branch so multiple agents can work in parallel without conflicts.
 - Read the relevant feature doc in `features/` before implementing planned work.
 - Inspect existing examples and docs before making syntax or tooling assumptions.
 - Keep changes scoped and directly tied to the current task.


### PR DESCRIPTION
## Summary

- Enable GitHub ruleset on `main`: require PR with passing CI, rebase-only merges
- Add `AGENT-CONTRIBUTIONS.md` with worktree-based isolation workflow, branch naming
  conventions, parallel work rules, and agent checklist
- Update `AGENTS.md` to reference the contribution guide and PR requirement
- Add `.worktrees/` to `.gitignore` for in-repo worktree isolation

## Test plan

- [ ] Verify direct push to `main` is rejected
- [ ] Verify PR merge requires passing CI checks
- [ ] Verify `git worktree add .worktrees/test -b test` works and directory is gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)