### PR TITLE
STM v2 language specification

### DIFF
--- a/STM-V2-SPEC.md
+++ b/STM-V2-SPEC.md
@@ -1,0 +1,1241 @@
+# STM v2 — Language Specification
+
+**Version:** 2.0.0-draft
+**Date:** 2026-03-18
+
+---
+
+## 1. Design Philosophy
+
+STM (Structured Transform Markup) is a concise notation for describing data schemas, mappings, and transformations. It is designed to be read and written by both humans and LLMs.
+
+### Principles
+
+1. **The parser is an LLM.** Structure exists to delineate intent and scope — not to be exhaustively parseable by a formal grammar. Ambiguity that a competent human can resolve is acceptable.
+2. **Natural language is a first-class citizen.** Complex transform logic belongs in quoted English, not in a pseudo-programming language.
+3. **Three delimiters, three jobs.** `( )` for metadata, `{ }` for structural content, `" "` for natural language. Every use of a delimiter should fit exactly one of these roles.
+4. **Token-efficient.** Eliminate ceremony. If something can be inferred, don't require it.
+5. **Extensible without grammar changes.** New vocabulary tokens (like `scd`, `datavault`, `hub`) are interpreted by the LLM, not reserved by the language.
+
+---
+
+## 2. Lexical Rules
+
+### 2.1 Delimiters
+
+| Delimiter | Role | Contains |
+|-----------|------|----------|
+| `( )` | Metadata / annotations | Key-value pairs, flags, notes about the preceding element |
+| `{ }` | Structural content | Fields, arrows, map entries, pipe chains, child blocks |
+| `" "` | Natural language | Human-readable descriptions, transform logic, documentation |
+
+These roles are **mutually exclusive**. Metadata never appears in `{ }`. Structural children never appear in `( )`. Natural language always uses `" "`.
+
+Metadata blocks `( )` may span multiple lines for readability — especially when they contain long notes or many tokens.
+
+### 2.2 Strings and Quoting
+
+- **Double quotes** `" "` — natural language strings. Always double quotes. Escape inner double quotes with `\"`. Single quotes are free inside.
+- **Triple double quotes** `""" """` — multiline natural language with Markdown support. No escaping needed for inner `"`. Use for notes with headings, bold, lists, or multi-paragraph content. Leading indentation from the content is preserved as-is.
+- **Backticks** `` ` ` `` — name references. Used for identifiers containing special characters (spaces, dots, hyphens) or for cross-referencing identifiers inside NL strings.
+
+```
+schema 'My Schema' { ... }           // name in single quotes (block label)
+`Lead_Source_Detail__c` STRING       // backtick for special-char identifiers
+"Look up `customer_id` in the dim"   // backtick reference inside NL
+"Short note — single line"           // single-line string
+"""                                  // multiline string with Markdown
+# Heading
+Some **bold** text and a list:
+- Item one
+- Item two
+"""
+```
+
+### 2.3 Block Labels
+
+Block labels (the name after a keyword) use **single quotes** when they contain special characters, or are bare identifiers otherwise:
+
+```
+schema customers { ... }
+schema 'order-headers-parquet' { ... }
+fragment 'US Address' { ... }
+```
+
+### 2.4 Comments
+
+| Syntax | Meaning | Behaviour |
+|--------|---------|-----------|
+| `//` | Comment | Author-side. Stripped by tooling. Not exported. |
+| `//!` | Warning | Flags a known issue or risk. May be surfaced by tooling. |
+| `//?` | Question/TODO | Open question. May be surfaced by tooling. |
+
+Comments run to end of line. There are no block comments.
+
+### 2.5 Operators
+
+| Operator | Meaning |
+|----------|---------|
+| `->` | Maps source to target |
+| `->` (no left side) | Computed/derived target field |
+| `\|` | Pipeline step separator |
+| `...` | Spread/expand a fragment or named transform |
+| `:` | Separator in map entries |
+
+### 2.6 Reserved Keywords
+
+These keywords introduce structural blocks and cannot be used as bare identifiers:
+
+`schema` `fragment` `mapping` `transform` `source` `target` `map` `record` `list` `note` `import`
+
+### 2.7 Vocabulary Tokens
+
+These are **not reserved** — they are context-dependent tokens interpreted by the LLM. They can appear in `( )` metadata or as pipeline steps. This list is open-ended:
+
+- **Constraints:** `pk`, `required`, `unique`, `indexed`, `pii`, `encrypt`
+- **Types/formats:** `enum`, `default`, `format`, `ref`
+- **Operations:** `filter`, `join`, `flatten`, `coalesce`, `trim`, `lowercase`, `uppercase`, `round`
+- **Domain:** `xpath`, `namespace`, `datavault`, `scd`, `hub`, `satellite`
+
+New vocabulary tokens can be introduced at any time without language changes.
+
+---
+
+## 3. Schema Blocks
+
+A schema block declares the structure of a data source or target. STM v2 uses a single `schema` keyword — there is no `table`, `message`, `source`, or `target` distinction at the schema level.
+
+### 3.1 Basic Structure
+
+```
+schema <name> (<metadata>) {
+  <field declarations>
+}
+```
+
+Example:
+
+```
+schema customers (format parquet) {
+  customer_id    UUID       (pk)
+  name           VARCHAR(200) (required)
+  email          VARCHAR(255) (format email, pii)
+  status         VARCHAR(20)  (enum {active, suspended, closed})
+  created_at     TIMESTAMPTZ  (required)
+}
+```
+
+### 3.2 Field Declarations
+
+A field is declared as:
+
+```
+<name>  <type>  (<metadata>)
+```
+
+- **Name** — bare identifier or backtick-quoted.
+- **Type** — a vocabulary token (interpreted by the LLM, not formally validated). Common types: `STRING`, `VARCHAR(n)`, `INT`, `DECIMAL(p,s)`, `BOOLEAN`, `DATE`, `TIMESTAMPTZ`, `UUID`, `JSON`, `TEXT`.
+- **Metadata** — optional `( )` block with flags and key-value pairs.
+
+### 3.3 Nested Structures: `record` and `list`
+
+Use `record` for a single nested structure and `list` for a repeated nested structure. Like `schema` and `fragment`, the keyword comes before the name:
+
+```
+schema order {
+  order_id     STRING (pk)
+  record customer {
+    id           STRING
+    email        STRING (pii)
+  }
+  list line_items {
+    sku          STRING (required)
+    quantity     INT
+    unit_price   DECIMAL(12,2)
+  }
+}
+```
+
+`record` and `list` can be nested to any depth. Metadata goes in `( )` between name and `{ }`.
+
+### 3.4 Notes
+
+Notes are persistent documentation — they travel with the spec (exported to docs, Excel, etc.), unlike `//` comments which are stripped by tooling.
+
+**On schemas and fields:** notes are metadata, so they go in `( )`. Use `"` for short notes, `"""` when you need Markdown:
+
+```
+schema legacy_customers (note "Primary customer store from 2005-2024.") {
+  PHONE_NBR  VARCHAR(50) (
+    note """
+    No consistent format across the dataset:
+    - **42%** `(555) 123-4567` — US with parentheses
+    - **31%** `555.123.4567` — dot-separated
+    - **15%** `+15551234567` — already E.164
+    - **8%** `5551234567` — raw 10-digit
+    - **4%** other (international, extensions, garbage)
+    """
+  )
+}
+```
+
+**At top level or inside mapping blocks:** use `note { }` as a structural block. These often benefit from `"""` for rich Markdown content:
+
+```
+note {
+  """
+  # Legacy Customer Migration
+
+  Part of **Project Phoenix** — decommissioning the legacy SQL Server 2008
+  instance by Q2 2026.
+
+  ## Constraints
+  - Runs in **batches of 10,000** to prevent memory issues
+  - Target enforces referential integrity — addresses created *before* customers
+  """
+}
+```
+
+This distinction follows the three-delimiter rule: `( )` for metadata *about* an element, `{ }` for standalone structural content.
+
+### 3.5 Format-Specific Metadata
+
+Format details go in `( )` on the schema or field:
+
+```
+schema commerce_order (format xml, namespace ord "http://example.com/commerce/order/v2", namespace com "http://example.com/common/v1") {
+  record Order (xpath "/ord:OrderMessage/ord:Order") {
+    OrderId    STRING (xpath "ord:OrderId")
+    Channel    STRING (xpath "ord:Channel")
+  }
+}
+```
+
+### 3.6 Fragments
+
+A fragment is a reusable set of field declarations. Fragments are structural templates — they stamp out their fields wherever they are spread.
+
+```
+fragment 'address fields' {
+  street_line_1   VARCHAR(200)
+  street_line_2   VARCHAR(200)
+  city            VARCHAR(100)
+  state_province  VARCHAR(50)
+  postal_code     VARCHAR(20)
+  country_code    CHAR(2)
+}
+
+schema customers {
+  customer_id   UUID (pk)
+  ...address fields
+}
+```
+
+The spread `...address fields` inlines all fields from the fragment into the schema.
+
+---
+
+## 4. Mapping Blocks
+
+A mapping block describes how data flows from one or more sources to a target.
+
+### 4.1 Basic Structure
+
+```
+mapping <name> {
+  source { <schema references> }
+  target { <schema reference> }
+
+  <arrow declarations>
+}
+```
+
+The `source` and `target` sub-blocks use backtick references to previously declared schemas (or declare them inline). The mapping name is optional.
+
+### 4.2 Arrow Declarations
+
+An arrow maps a source field to a target field:
+
+```
+source_field -> target_field
+```
+
+#### Direct mapping (no transform)
+
+```
+Id -> opp_key
+AccountId -> account_key
+```
+
+#### With transform pipeline
+
+```
+EMAIL_ADDR -> email { trim | lowercase | validate_email | null_if_invalid }
+```
+
+#### With natural language transform
+
+```
+PHONE_NBR -> phone {
+  "Extract digits. If 10 digits assume US +1. Format as E.164.
+   If unparseable, set null and log warning."
+}
+```
+
+#### Mixed pipeline (mechanical + NL)
+
+```
+Amount -> amount_usd {
+  "Multiply by rate from currency_rates lookup using CurrencyIsoCode"
+  | round(2)
+}
+```
+
+The **first `"..."` in an arrow's `{ }`** is implicitly the transform description. Additional NL strings can appear after pipes.
+
+#### Computed/derived fields (no source)
+
+When the target field has no single source field, omit the left side of the arrow:
+
+```
+-> display_name {
+  "If CUST_TYPE is null or 'R', concat and trim FIRST_NM + LAST_NM.
+   Otherwise use COMPANY_NM."
+}
+
+-> migration_timestamp { now_utc() }
+```
+
+#### Arrow metadata
+
+Use `( )` on an arrow for metadata (notes, conditions, flags):
+
+```
+CUST_ID -> customer_id (note "Deterministic UUID from legacy ID") {
+  uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID)
+}
+```
+
+### 4.3 Value Maps
+
+Use `map { }` for discrete value mappings. The `:` separates input from output:
+
+```
+CUST_TYPE -> customer_type {
+  map {
+    R: "retail"
+    B: "business"
+    G: "government"
+    null: "retail"
+  }
+}
+```
+
+#### Conditional maps
+
+```
+LOYALTY_POINTS -> loyalty_tier {
+  map {
+    < 1000: "bronze"
+    < 5000: "silver"
+    < 10000: "gold"
+    default: "platinum"
+  }
+}
+```
+
+#### Wildcard default
+
+Use `default` or `_` for the catch-all entry:
+
+```
+StageName -> pipeline_stage {
+  map {
+    Prospecting: "top_funnel"
+    Qualification: "mid_funnel"
+    "Value Prop": "mid_funnel"
+    Closed_Won: "closed_won"
+    Closed_Lost: "closed_lost"
+    _: "unknown"
+  }
+}
+```
+
+### 4.4 Nested Mappings
+
+When source and target have nested/repeated structures, nest the arrows:
+
+```
+POReferences[] -> ShipmentHeader.asnDetails[] (
+  note "Each PO reference generates one asnDetails entry.
+        Line items and quantities correlated by position."
+) {
+  .REFNUM -> .orderNo { split("/") | first | to_number }
+
+  LineItems[] -> .items[] {
+    .ITEMNO -> .item { trim | "Resolve via MFCS supplier item cross-reference" }
+    Quantities[].QUANTITY -> .unitQuantity {
+      "Divide by 10000 (4 implied decimals), multiply by PO pack size from MFCS"
+    }
+  }
+}
+```
+
+The `.` prefix indicates a field relative to the current nesting context. `[]` indicates a repeated element.
+
+### 4.5 Fallback Sources
+
+When a primary source may be null, specify a fallback within the transform:
+
+```
+LAST_MOD_DATE -> updated_at {
+  parse("MM/DD/YYYY hh:mm:ss a") | to_utc
+  | "If null, fall back to CREATED_DATE parsed as MM/DD/YYYY in UTC"
+}
+```
+
+### 4.6 Flattening
+
+Use `flatten` as a vocabulary token in the mapping declaration:
+
+```
+mapping 'order lines' (flatten `Order.LineItems[]`) {
+  source { `commerce_order` }
+  target { `order_lines_parquet` }
+
+  Order.OrderId -> order_id
+  Order.LineItems[].SKU -> sku { trim | uppercase }
+  // ...
+}
+```
+
+### 4.7 Multi-Source Joins
+
+Describe joins in natural language within the source block or as a top-level NL string:
+
+```
+mapping 'opportunity enrichment' {
+  source {
+    `sfdc_opportunity`
+    `sfdc_account`
+    "Join on sfdc_opportunity.AccountId = sfdc_account.Id"
+  }
+  target { `snowflake_opps` }
+  // ...
+}
+```
+
+### 4.8 Note Blocks
+
+Use `note { }` at file top level or inside mapping blocks for contextual documentation:
+
+```
+mapping 'customer migration' {
+  note {
+    "All timestamps assumed US Eastern unless otherwise noted.
+     NULL handling: source NULLs preserved unless target has a stated default.
+     Names are title-cased on migration."
+  }
+
+  source { `legacy_sqlserver` }
+  target { `postgres_db` }
+  // ...
+}
+```
+
+---
+
+## 5. Reusability
+
+### 5.1 Fragments
+
+Fragments declare reusable field sets for schemas:
+
+```
+fragment 'audit fields' {
+  created_at    TIMESTAMPTZ (required)
+  updated_at    TIMESTAMPTZ
+  created_by    VARCHAR(100)
+}
+```
+
+Spread into schemas with `...`:
+
+```
+schema users {
+  user_id  UUID (pk)
+  name     VARCHAR(200)
+  ...audit fields
+}
+```
+
+### 5.2 Named Transforms
+
+Named transforms declare reusable transform logic for mapping pipelines:
+
+```
+transform 'clean email' {
+  "Trim whitespace, lowercase, validate RFC 5322 format, return null if invalid"
+}
+
+transform 'to utc date' {
+  parse("MM/DD/YYYY") | assume_utc | to_iso8601
+}
+```
+
+Spread into pipelines with `...`:
+
+```
+EMAIL_ADDR -> email { ...clean email }
+CREATED_DATE -> created_at { ...to utc date }
+```
+
+### 5.3 Imports
+
+Import fragments, transforms, or schemas from other files:
+
+```
+import { 'address fields', 'audit fields' } from "lib/common.stm"
+import { 'currency rates' } from "lookups/finance.stm"
+```
+
+Import syntax follows the pattern `import { <names> } from "<path>"`. Exact resolution semantics (relative paths, registries, etc.) are implementation-defined.
+
+---
+
+## 6. Vocabulary Conventions
+
+Vocabulary tokens are **not keywords** — they are interpreted by the LLM based on context. This section documents common conventions.
+
+### 6.1 Field Metadata Tokens (used in `( )`)
+
+| Token | Meaning | Example |
+|-------|---------|---------|
+| `pk` | Primary key | `(pk)` |
+| `required` | Must not be null | `(required)` |
+| `unique` | Values must be unique | `(unique)` |
+| `indexed` | Should have an index | `(indexed)` |
+| `pii` | Personally identifiable information | `(pii)` |
+| `encrypt` | Must be encrypted | `(encrypt AES-256-GCM)` |
+| `enum` | Restricted value set | `(enum {a, b, c})` |
+| `default` | Default value | `(default 0)` |
+| `format` | Data format constraint | `(format email)` |
+| `ref` | Foreign key reference | `(ref addresses.id)` |
+| `xpath` | XML path expression | `(xpath "ord:OrderId")` |
+| `namespace` | XML namespace declaration | `(namespace ord "http://...")` |
+| `filter` | Row-level filter condition | `(filter QUAL == "ON")` |
+| `note` | Persistent documentation | `(note "Converted at daily spot rate")` |
+
+### 6.2 Pipeline Tokens (used in `{ }`)
+
+| Token | Meaning |
+|-------|---------|
+| `trim` | Strip whitespace |
+| `lowercase` / `uppercase` | Case conversion |
+| `coalesce(val)` | Replace null with val |
+| `round(n)` | Round to n decimal places |
+| `split(sep)` | Split string on separator |
+| `first` / `last` | Take first/last element |
+| `to_utc` | Convert to UTC |
+| `to_iso8601` | Format as ISO 8601 |
+| `parse(fmt)` | Parse string with format |
+| `null_if_empty` | Convert empty string to null |
+| `null_if_invalid` | Convert invalid value to null |
+| `validate_email` | Validate email format |
+| `now_utc()` | Current UTC timestamp |
+| `title_case` | Convert to title case |
+| `escape_html` | Escape HTML entities |
+| `truncate(n)` | Truncate to n characters |
+| `to_number` | Convert to numeric type |
+| `prepend(str)` | Prefix a string |
+| `max_length(n)` | Enforce maximum length |
+
+### 6.3 Domain Tokens
+
+These are freely extensible. Common domain-specific tokens:
+
+- **Data Vault:** `datavault`, `hub`, `satellite`, `link`, `scd`, `hashkey`
+- **Streaming:** `watermark`, `late_arrival`, `dedup`
+- **Governance:** `classification`, `retention`, `lineage`
+
+---
+
+## 7. Complete Examples
+
+### 7.1 Database to Database — Legacy Customer Migration
+
+```
+// STM v2 — Legacy Customer Migration
+
+import { 'address fields' } from "lib/common.stm"
+
+note {
+  """
+  # Legacy Customer Migration
+
+  Part of **Project Phoenix** — decommissioning the legacy SQL Server 2008
+  instance by Q2 2026. Migrates customer records to a normalized PostgreSQL
+  schema with proper typing, encryption, and referential integrity.
+
+  ## Constraints
+  - Runs in **batches of 10,000** to prevent memory issues
+  - Target enforces referential integrity — addresses created *before* customers
+  - Estimated total: **2.4M records**, ~180 batches
+
+  ## Dependencies
+  - Address normalization service must be running
+  - Secrets Manager: `tax_encryption_key` must be provisioned
+  - Profanity filter word list v3.2 must be loaded
+  """
+}
+
+
+// --- Source ---
+
+schema legacy_sqlserver (
+  note "CUSTOMER table — SQL Server 2008. No app-level validation until 2018."
+) {
+  CUST_ID         INT            (pk)                          // sequential, gaps from deletions
+  CUST_TYPE       CHAR(1)        (enum {R, B, G}, default R)   //! some records have NULL
+  FIRST_NM        VARCHAR(100)                                 // retail customers only
+  LAST_NM         VARCHAR(100)                                 // retail customers only
+  COMPANY_NM      VARCHAR(200)                                 // business/government only
+  EMAIL_ADDR      VARCHAR(255)   (pii)                         //! not validated — contains garbage
+  PHONE_NBR       VARCHAR(50) (
+    note """
+    No consistent format across the dataset:
+    - **42%** `(555) 123-4567` — US with parentheses
+    - **31%** `555.123.4567` — dot-separated
+    - **15%** `+15551234567` — already E.164
+    - **8%** `5551234567` — raw 10-digit
+    - **4%** other (international, extensions, garbage)
+    """
+  )
+  ADDR_LINE_1     VARCHAR(200)
+  ADDR_LINE_2     VARCHAR(200)
+  CITY            VARCHAR(100)
+  STATE_PROV      VARCHAR(50)                                  //! full names AND 2-char codes mixed
+  ZIP_POSTAL      VARCHAR(20)
+  COUNTRY_CD      CHAR(2)        (default US)
+  CREDIT_LIMIT    DECIMAL(12,2)                                // NULL = no credit extended
+  ACCOUNT_STATUS  CHAR(1)        (enum {A, S, C, D}, default A)
+  CREATED_DATE    VARCHAR(10)                                  //! stored as MM/DD/YYYY string
+  LAST_MOD_DATE   VARCHAR(20)                                  //! MM/DD/YYYY HH:MM:SS AM/PM
+  TAX_ID          VARCHAR(20)    (pii, encrypt)                //! plaintext in legacy — SSN or EIN
+  LOYALTY_POINTS  INT            (default 0)
+  PREF_CONTACT    CHAR(1)        (enum {E, P, M, N}, default E)
+  NOTES           VARCHAR(MAX)                                 // free-text, may contain profanity
+}
+
+
+// --- Target ---
+
+schema postgres_db (note "Normalized customer schema — PostgreSQL 16") {
+  customer_id              UUID           (pk, required)
+  legacy_customer_id       INTEGER        (unique, indexed)
+  customer_type            VARCHAR(20)    (enum {retail, business, government}, required)
+  display_name             VARCHAR(200)   (required)
+  first_name               VARCHAR(100)
+  last_name                VARCHAR(100)
+  company_name             VARCHAR(200)
+  email                    VARCHAR(255)   (format email, pii)
+  phone                    VARCHAR(20)    (format E.164)
+  address_id               UUID           (ref addresses.id)
+  credit_limit_cents       BIGINT         (default 0)
+  status                   VARCHAR(20)    (enum {active, suspended, closed, delinquent}, required)
+  created_at               TIMESTAMPTZ    (required)
+  updated_at               TIMESTAMPTZ
+  tax_identifier_encrypted TEXT           (pii, encrypt AES-256-GCM)
+  loyalty_tier             VARCHAR(20)    (enum {bronze, silver, gold, platinum})
+  preferred_contact_method VARCHAR(20)    (enum {email, phone, mail, none})
+  notes                    TEXT
+  migration_timestamp      TIMESTAMPTZ
+}
+
+
+// --- Mapping ---
+
+mapping 'customer migration' {
+  note {
+    "Mapping assumptions:
+     - All timestamps assumed US Eastern unless otherwise noted
+     - NULL handling: source NULLs preserved unless target has stated default
+     - Names are title-cased on migration"
+  }
+
+  source { `legacy_sqlserver` }
+  target { `postgres_db` }
+
+  // --- Identifiers ---
+  CUST_ID -> customer_id { uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID) }
+  CUST_ID -> legacy_customer_id
+
+  // --- Customer Type ---
+  CUST_TYPE -> customer_type {
+    map {
+      R: "retail"
+      B: "business"
+      G: "government"
+      null: "retail"
+    }
+  }
+
+  // --- Name Handling ---
+  -> display_name {
+    "If CUST_TYPE is null or 'R', trim and concat FIRST_NM + ' ' + LAST_NM.
+     Otherwise, trim COMPANY_NM."
+  }
+
+  FIRST_NM   -> first_name    { trim | title_case | null_if_empty }
+  LAST_NM    -> last_name     { trim | title_case | null_if_empty }
+  COMPANY_NM -> company_name  { trim | null_if_empty }
+
+  // --- Contact ---
+  EMAIL_ADDR -> email { trim | lowercase | validate_email | null_if_invalid }
+
+  PHONE_NBR -> phone {
+    "Extract all digits. If 11 digits starting with 1, treat as US.
+     If 10 digits, assume US country code +1. Format as E.164.
+     For other patterns, attempt to determine country from COUNTRY_CD.
+     If unparseable, set null and log warning with original value."
+  }
+
+  // --- Address (FK to separate table) ---
+  -> address_id {
+    "Create a record in the addresses table using ADDR_LINE_1, ADDR_LINE_2,
+     CITY, STATE_PROV, ZIP_POSTAL, COUNTRY_CD. Normalize STATE_PROV to
+     2-char code (handle full names). Deduplicate against existing addresses
+     by normalized street + zip. Return the UUID of the new or existing record."
+  }
+
+  // --- Financial ---
+  CREDIT_LIMIT -> credit_limit_cents { coalesce(0) | * 100 | round }
+
+  // --- Status ---
+  ACCOUNT_STATUS -> status {
+    map { A: "active", S: "suspended", C: "closed", D: "delinquent" }
+  }
+
+  // --- Dates ---
+  CREATED_DATE -> created_at { parse("MM/DD/YYYY") | assume_utc | to_iso8601 }
+
+  LAST_MOD_DATE -> updated_at {
+    parse("MM/DD/YYYY hh:mm:ss a") | to_utc | to_iso8601
+    | "If null, fall back to CREATED_DATE parsed as MM/DD/YYYY in UTC"
+  }
+
+  // --- Security ---
+  TAX_ID -> tax_identifier_encrypted { encrypt(AES-256-GCM, secrets.tax_encryption_key) }
+
+  // --- Calculated ---
+  LOYALTY_POINTS -> loyalty_tier {
+    map {
+      < 1000:  "bronze"
+      < 5000:  "silver"
+      < 10000: "gold"
+      default: "platinum"
+    }
+  }
+
+  PREF_CONTACT -> preferred_contact_method {
+    map { E: "email", P: "phone", M: "mail", N: "none" }
+  }
+
+  // --- Text ---
+  NOTES -> notes {
+    "Filter profanity using corporate word list v3.2, replacing matches with asterisks"
+    | escape_html
+    | truncate(5000)
+  }
+
+  // --- Audit ---
+  -> migration_timestamp { now_utc() }
+}
+```
+
+### 7.2 EDI to JSON — ASN Shipment
+
+```
+// STM v2 — EDI 856 → MFCS Shipment
+
+note {
+  """
+  # EDI 856 → MFCS Shipment
+
+  Transforms EDI 856 (DESADV) fixed-length ASN messages into
+  MFCS JSON Shipment format for warehouse ingestion.
+  Based on mapping specification v1.0 (18/11/2025).
+
+  ## Open issues
+  - `containers` array is **required** by MFCS schema but has
+    **no source mapping** in the current EDI specification
+  - `containerId` and `finalLocation` are required but unpopulated
+  - Awaiting clarification from warehouse team (Jira: DWHT-2847)
+  """
+}
+
+
+// --- Source ---
+
+schema edi_desadv (
+  format fixed-length,
+  note "EDI 856 Despatch Advice — Fixed Length Format"
+) {
+  record BeginningOfMessage {
+    DOCNUM      CHAR(35)                          // despatch advice number
+    MESSGFUN    CHAR(3)                           // message function: 9 = Original
+  }
+
+  record DateTime {
+    DATEQUAL    CHAR(3)                           // qualifier: 137 = document date/time
+    DATETIME    CHAR(35)                          // date/time value
+    DATEFMT     CHAR(3)                           // format: 102=CCYYMMDD, 203=CCYYMMDDHHMM
+  }
+
+  list ShipmentRefs (filter SHPRFQUAL == "SRN") {
+    SHPRFQUAL   CHAR(3)
+    SHIPREF     CHAR(70)                          // shipment reference number
+  }
+
+  list POReferences (filter REFQUAL == "ON") {
+    REFQUAL     CHAR(3)
+    REFNUM      CHAR(35)                          // PO Number + "/" + Dissection No
+  }
+
+  record NameAddress {
+    PARTYQUAL   CHAR(3)                           // BY=Buyer, SU=Supplier
+    PARTYID     CHAR(35)                          // 13-digit ANA number
+  }
+
+  list LineItems {
+    LINENUM     NUMBER(6)
+    ITEMNO      CHAR(35)                          // product identifier
+    ITEMTYPE    CHAR(3)                           // EN=EAN, UP=UPC12
+  }
+
+  list Quantities (filter QUANTQUAL == "12") {    // only despatch quantities
+    QUANTQUAL   CHAR(3)
+    QUANTITY    NUMBER(15)                         //! 4 implied decimal places
+  }
+}
+
+
+// --- Target ---
+
+schema mfcs_json (format json, note "MFCS Shipment Ingestion Format") {
+  record ShipmentHeader {
+    toLocation            NUMBER(10)
+    asnNo                 STRING(30)   (required)
+    shipDate              DATE         (required)
+    estimatedArrivalDate  DATE
+    comments              STRING(2000)
+    carrierCode           STRING(4)
+    asnType               STRING(1)    (required)     // C=UCC-128, 0=ASN Shipment
+    supplier              NUMBER(10)   (required)
+    shipPayMethod         STRING(2)
+
+    list asnDetails {
+      orderNo             NUMBER(12)   (required)
+      notAfterDate        DATE
+
+      list containers (
+        note """
+        ## DATA GAP
+        This entire array is **required** by the MFCS schema but has
+        **no source data** in the current EDI 856 mapping.
+        See Jira: DWHT-2847 for resolution status.
+        """
+      ) {
+        containerId       STRING(30)   (required)     //! no source mapping
+        finalLocation     NUMBER(10)   (required)     //! no source mapping
+        list items {
+          item            STRING(25)
+          unitQuantity    NUMBER(12,4)                 //! no source mapping
+        }
+      }
+
+      list items {
+        item              STRING(25)
+        unitQuantity      NUMBER(12,4)  (required)
+        vpn               STRING(30)
+        referenceItem     STRING(25)
+      }
+    }
+  }
+}
+
+
+// --- Mapping ---
+
+mapping 'edi to mfcs' {
+  source { `edi_desadv` }
+  target { `mfcs_json` }
+
+  // --- Header ---
+  BeginningOfMessage.DOCNUM -> ShipmentHeader.asnNo { trim | max_length(30) }
+
+  DateTime.DATETIME -> ShipmentHeader.shipDate {
+    "Parse using sibling field DATEFMT: if 102 parse as CCYYMMDD,
+     if 203 parse as CCYYMMDDHHMM. Output format: YYYY-MM-DD."
+  }
+
+  -> ShipmentHeader.asnType { "0" }    // default: ASN Shipment
+
+  POReferences[].REFNUM -> ShipmentHeader.toLocation {
+    "Extract PO number from REFNUM (digits before '/').
+     Look up the PO in MFCS to determine the delivery location."
+  }
+
+  POReferences[].REFNUM -> ShipmentHeader.supplier {
+    split("/") | first | to_number
+    | "Validate supplier exists in MFCS PO table."
+  }
+
+  ShipmentRefs[].SHIPREF -> ShipmentHeader.comments { prepend("Shipment reference number: ") }
+
+  // --- Detail lines grouped by PO ---
+  POReferences[] -> ShipmentHeader.asnDetails[] (
+    note "Each PO reference generates one asnDetails entry.
+          Line items and quantities are correlated by position."
+  ) {
+    .REFNUM -> .orderNo { split("/") | first | to_number }
+
+    LineItems[] -> .items[] {
+      .ITEMNO -> .item {
+        trim
+        | "Retrieve MFCS item number using the supplier's traded code
+           from the MFCS supplier item cross-reference."
+      }
+
+      Quantities[].QUANTITY -> .unitQuantity {
+        "Divide by 10000 to account for 4 implied decimal places.
+         Then multiply by PO pack size from MFCS (Action A-504).
+         Pack size retrieved from MFCS PO line matching this item."
+      }
+    }
+  }
+
+  //! DATA GAP: containers[] required but no source data
+  -> ShipmentHeader.asnDetails[].containers {
+    "Required by MFCS schema but no source data available in EDI 856.
+     Options under discussion:
+     1. Populate with a single placeholder container per order
+     2. Request EDI 856 extension from suppliers
+     3. Derive from warehouse receiving logic
+     Blocked on: MFCS-2847"
+  }
+}
+```
+
+### 7.3 XML to Parquet — Commerce Orders
+
+```
+// STM v2 — Order XML to Lakehouse Parquet
+
+note {
+  """
+  # Order XML to Lakehouse Parquet
+
+  Ingests canonical commerce order XML messages from the integration bus
+  and lands two curated Parquet datasets:
+  - `order_headers_parquet` at one row per order
+  - `order_lines_parquet` at one row per line item
+
+  The source XML is namespace-qualified and contains repeated discount
+  fragments, optional loyalty identifiers, and mixed timestamp formats
+  depending on upstream channel.
+  """
+}
+
+
+// --- Source ---
+
+schema commerce_order (
+  format xml,
+  namespace ord "http://example.com/commerce/order/v2",
+  namespace com "http://example.com/common/v1",
+  note "Canonical commerce order message"
+) {
+  record Order (xpath "/ord:OrderMessage/ord:Order") {
+    OrderId           STRING       (xpath "ord:OrderId")
+    Channel           STRING       (xpath "ord:Channel")
+    OrderTimestamp    STRING       (xpath "ord:OrderTimestamp")
+    CurrencyCode      STRING       (xpath "ord:Currency/com:Code")
+
+    record Customer {
+      CustomerId      STRING       (xpath "ord:CustomerId")
+      Email           STRING       (xpath "ord:Email")
+      LoyaltyTier     STRING       (xpath "ord:LoyaltyTier")
+    }
+
+    record ShippingAddress {
+      CountryCode     STRING       (xpath "ord:CountryCode")
+      RegionCode      STRING       (xpath "ord:RegionCode")
+      PostalCode      STRING       (xpath "ord:PostalCode")
+    }
+
+    record Totals {
+      SubtotalAmount  DECIMAL(12,2)  (xpath "ord:SubtotalAmount")
+      TaxAmount       DECIMAL(12,2)  (xpath "ord:TaxAmount")
+      TotalAmount     DECIMAL(12,2)  (xpath "ord:TotalAmount")
+    }
+
+    list Discounts (xpath "ord:Discounts/ord:Discount") {
+      DiscountCode    STRING       (xpath "ord:Code")
+      DiscountAmount  DECIMAL(12,2) (xpath "ord:Amount")
+      DiscountType    STRING       (xpath "ord:Type")
+    }
+
+    list LineItems (xpath "ord:LineItems/ord:LineItem") {
+      LineNumber      INT32        (xpath "ord:LineNumber")
+      SKU             STRING       (xpath "ord:SKU")
+      FulfillmentType STRING       (xpath "ord:FulfillmentType")
+      Quantity        INT32        (xpath "ord:Quantity")
+      UnitPrice       DECIMAL(12,2) (xpath "ord:UnitPrice")
+      ExtendedAmount  DECIMAL(12,2) (xpath "ord:ExtendedAmount")
+      TaxAmount       DECIMAL(12,2) (xpath "ord:TaxAmount")
+      IsGift          BOOLEAN      (xpath "ord:IsGift")
+    }
+  }
+}
+
+
+// --- Targets ---
+
+schema order_headers_parquet (format parquet, note "Curated order header dataset") {
+  order_id             STRING         (pk)
+  order_channel        STRING         (enum {web, mobile, store, marketplace}, required)
+  order_timestamp_utc  TIMESTAMPTZ    (required)
+  customer_id          STRING
+  customer_email       STRING         (format email, pii)
+  loyalty_tier         STRING         (enum {bronze, silver, gold, platinum})
+  ship_country         STRING         (required)
+  ship_region          STRING
+  ship_postal_code     STRING
+  currency_code        STRING         (required)
+  subtotal_amount      DECIMAL(12,2)
+  tax_amount           DECIMAL(12,2)
+  total_amount         DECIMAL(12,2)  (required)
+  discount_codes       JSON
+  discount_total       DECIMAL(12,2)
+  line_count           INT32
+  ingest_date          DATE           (required)
+}
+
+schema order_lines_parquet (format parquet, note "Curated order line dataset") {
+  order_id             STRING         (required)
+  line_number          INT32          (required)
+  sku                  STRING         (required)
+  fulfillment_type     STRING         (enum {ship, pickup, digital, service})
+  quantity             INT32          (required)
+  unit_price           DECIMAL(12,2)
+  extended_amount      DECIMAL(12,2)  (required)
+  line_tax_amount      DECIMAL(12,2)
+  is_gift              BOOLEAN
+  currency_code        STRING         (required)
+  order_channel        STRING         (required)
+  customer_id          STRING
+  ship_country         STRING
+  ingest_date          DATE           (required)
+}
+
+
+// --- Mapping: Order Headers ---
+
+mapping 'order headers' {
+  source { `commerce_order` }
+  target { `order_headers_parquet` }
+
+  Order.OrderId -> order_id
+  Order.Channel -> order_channel { trim | lowercase }
+
+  Order.OrderTimestamp -> order_timestamp_utc {
+    "Parse either ISO-8601 with timezone or local store time in
+     America/New_York depending on channel. Output UTC timestamp."
+  }
+
+  Order.Customer.CustomerId -> customer_id
+  Order.Customer.Email -> customer_email { trim | lowercase | validate_email | null_if_invalid }
+  Order.Customer.LoyaltyTier -> loyalty_tier { trim | lowercase | null_if_empty }
+
+  Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
+  Order.ShippingAddress.RegionCode -> ship_region { trim | uppercase | null_if_empty }
+  Order.ShippingAddress.PostalCode -> ship_postal_code { trim | null_if_empty }
+
+  Order.CurrencyCode -> currency_code { trim | uppercase }
+
+  Order.Totals.SubtotalAmount -> subtotal_amount
+  Order.Totals.TaxAmount -> tax_amount
+  Order.Totals.TotalAmount -> total_amount
+
+  -> discount_codes {
+    "Collect DiscountCode values from Order.Discounts[] preserving source order.
+     Emit as a JSON array string. If no discounts, emit []."
+  }
+
+  -> discount_total {
+    "Sum DiscountAmount across Order.Discounts[] for the current order.
+     If no discounts, emit 0.00."
+  }
+
+  -> line_count {
+    "Count Order.LineItems[] elements for the current order."
+  }
+
+  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+}
+
+
+// --- Mapping: Order Lines (flattened) ---
+
+mapping 'order lines' (flatten `Order.LineItems[]`) {
+  source { `commerce_order` }
+  target { `order_lines_parquet` }
+
+  Order.OrderId -> order_id
+  Order.LineItems[].LineNumber -> line_number
+  Order.LineItems[].SKU -> sku { trim | uppercase }
+  Order.LineItems[].FulfillmentType -> fulfillment_type { trim | lowercase }
+  Order.LineItems[].Quantity -> quantity
+  Order.LineItems[].UnitPrice -> unit_price
+  Order.LineItems[].ExtendedAmount -> extended_amount
+  Order.LineItems[].TaxAmount -> line_tax_amount
+  Order.LineItems[].IsGift -> is_gift
+
+  Order.CurrencyCode -> currency_code { trim | uppercase }
+  Order.Channel -> order_channel { trim | lowercase }
+  Order.Customer.CustomerId -> customer_id
+  Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
+
+  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+}
+```
+
+### 7.4 Salesforce to Snowflake — Opportunity Ingestion
+
+```
+// STM v2 — Salesforce to Snowflake Pipeline
+
+import { 'sfdc standard types' } from "lib/sfdc_fragments.stm"
+import { 'currency rates' } from "lookups/finance.stm"
+
+note {
+  """
+  # Salesforce to Snowflake Pipeline
+
+  Maps Sales Cloud `Opportunity` and `Account` objects into the
+  `ANALYTICS.RAW_SFDC` schema.
+
+  ## Sync Strategy
+  - **Incremental:** Uses `SystemModStamp` to pull changes every 15 minutes.
+  - **Hard Deletes:** Captured via the `isDeleted` flag in SFDC.
+  """
+}
+
+
+// --- Sources ---
+
+schema sfdc_opportunity (note "SFDC Opportunity Object") {
+  Id                          ID             (pk)
+  Name                        STRING(120)    (required)
+  AccountId                   ID             (ref sfdc_account.Id)
+  Amount                      CURRENCY(18,2)
+  CurrencyIsoCode             STRING(3)      (default "USD")
+  StageName                   PICKLIST       (enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost})
+  CloseDate                   DATE           (required)
+  Probability                 PERCENT(3,0)
+  `Lead_Source_Detail__c`     STRING(255)
+  `ARR_Override__c`           CURRENCY(18,2)  //! manual override used by Finance
+  SystemModStamp              DATETIME       (required)
+}
+
+schema sfdc_account (note "SFDC Account Object") {
+  Id              ID             (pk)
+  Name            STRING(255)    (required)
+  Type            PICKLIST       (enum {Customer, Prospect, Partner, Competitor})
+  BillingCountry  STRING(80)
+}
+
+
+// --- Target ---
+
+schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
+  opp_key          VARCHAR(18)    (pk)
+  account_key      VARCHAR(18)    (indexed)
+  opportunity_name VARCHAR(120)
+  amount_raw       NUMBER(18,2)
+  amount_usd       NUMBER(18,2)   (note "Converted at daily spot rate")
+  arr_value        NUMBER(18,2)   (required)
+  pipeline_stage   VARCHAR(50)    (enum {top_funnel, mid_funnel, closed_won, closed_lost})
+  is_closed        BOOLEAN
+  close_date       DATE
+  source_system    VARCHAR(10)    (default "SFDC")
+  ingested_at      TIMESTAMP_NTZ
+}
+
+
+// --- Mapping ---
+
+mapping 'opportunity ingestion' {
+  source { `sfdc_opportunity` }
+  target { `snowflake_opps` }
+
+  // --- Direct identifiers ---
+  Id -> opp_key
+  AccountId -> account_key
+  Name -> opportunity_name
+
+  // --- Financial ---
+  Amount -> amount_raw { coalesce(0) }
+
+  Amount -> amount_usd {
+    "Multiply by rate from `currency rates` lookup using CurrencyIsoCode"
+    | round(2)
+  }
+
+  `ARR_Override__c` -> arr_value {
+    "Use ARR_Override__c if not null, otherwise fall back to Amount"
+    | coalesce(0)
+  }
+
+  // --- Stage normalization ---
+  StageName -> pipeline_stage {
+    map {
+      Prospecting:  "top_funnel"
+      Qualification: "mid_funnel"
+      "Value Prop":  "mid_funnel"
+      Closed_Won:    "closed_won"
+      Closed_Lost:   "closed_lost"
+      _:             "unknown"
+    }
+  }
+
+  -> is_closed {
+    "True if StageName is 'Closed_Won' or 'Closed_Lost', false otherwise."
+  }
+
+  CloseDate -> close_date
+
+  // --- Metadata ---
+  SystemModStamp -> ingested_at { to_utc }
+}
+```
+
+---
+
+## 8. Summary of Changes from v1
+
+| v1 | v2 | Rationale |
+|----|-----|-----------|
+| `[pk, required]` bracket tags | `(pk, required)` parentheses | `()` = metadata, `[]` freed |
+| `@xpath(...)`, `@format(...)` annotations | `(xpath ..., format ...)` in metadata | Unified in `()` |
+| `table`, `message`, `source`, `target` keywords | Single `schema` keyword | Simpler — role is contextual |
+| `STRUCT { }` / `ARRAY { }` | `record Name { }` / `list Name { }` | Keyword-first, less nerdy |
+| `nl("...")` function | Bare `"..."` in `{ }` | NL is first-class |
+| `: transform` after arrow | `{ transform }` after arrow | Consistent — `{}` holds content |
+| `when/else` clauses | `map { }` with conditions or NL | Simpler, more flexible |
+| `fallback` keyword | NL fallback description | Let the LLM interpret |
+| `[enum: {a, b}]` | `(enum {a, b})` | Braces for value sets, parens for metadata |
+| `note '''...'''` triple-quoted | `(note "...")` or `(note """...""")` | Notes are metadata; `"""` for Markdown |
+| `integration { }` block | `note { """...""" }` block | Structured, consistent with delimiter rules |
+| `=> target` computed fields | `-> target` (no left side) | Consistent arrow syntax |

--- a/examples-v2/common.stm
+++ b/examples-v2/common.stm
@@ -1,0 +1,38 @@
+// STM v2 — Common Lookups and Fragments
+// Library file: import specific items into your integration files.
+
+schema country_codes (note "ISO 3166 country code mapping") {
+  alpha2    STRING(2)    (pk)
+  alpha3    STRING(3)
+  name      STRING(100)
+}
+
+schema currency_rates (note "Daily FX rates") {
+  from_ccy  ISO-4217     (pk)
+  to_ccy    ISO-4217     (pk)
+  rate      DECIMAL(18,8)
+  as_of     DATE
+}
+
+schema product_catalog (note "Product reference data") {
+  sku            STRING(20)    (pk)
+  internal_code  STRING(20)
+  description    STRING(255)
+  category       STRING(100)
+}
+
+fragment 'address fields' {
+  line1        STRING(200)    (required)
+  line2        STRING(200)
+  city         STRING(100)    (required)
+  state        STRING(50)
+  postal_code  STRING(20)     (required)
+  country      ISO-3166-a2    (required)
+}
+
+fragment 'audit columns' {
+  created_at   TIMESTAMPTZ    (required)
+  created_by   VARCHAR(100)   (required)
+  updated_at   TIMESTAMPTZ
+  updated_by   VARCHAR(100)
+}

--- a/examples-v2/db-to-db.stm
+++ b/examples-v2/db-to-db.stm
@@ -1,0 +1,186 @@
+// STM v2 — Legacy Customer Migration
+
+import { 'address fields' } from "lib/common.stm"
+
+note {
+  """
+  # Legacy Customer Migration
+
+  Part of **Project Phoenix** — decommissioning the legacy SQL Server 2008
+  instance by Q2 2026. Migrates customer records to a normalized PostgreSQL
+  schema with proper typing, encryption, and referential integrity.
+
+  ## Constraints
+  - Runs in **batches of 10,000** to prevent memory issues
+  - Target enforces referential integrity — addresses created *before* customers
+  - Estimated total: **2.4M records**, ~180 batches
+
+  ## Dependencies
+  - Address normalization service must be running
+  - Secrets Manager: `tax_encryption_key` must be provisioned
+  - Profanity filter word list v3.2 must be loaded
+  """
+}
+
+
+// --- Source ---
+
+schema legacy_sqlserver (
+  note "CUSTOMER table — SQL Server 2008. No app-level validation until 2018."
+) {
+  CUST_ID         INT            (pk)                          // sequential, gaps from deletions
+  CUST_TYPE       CHAR(1)        (enum {R, B, G}, default R)   //! some records have NULL
+  FIRST_NM        VARCHAR(100)                                 // retail customers only
+  LAST_NM         VARCHAR(100)                                 // retail customers only
+  COMPANY_NM      VARCHAR(200)                                 // business/government only
+  EMAIL_ADDR      VARCHAR(255)   (pii)                         //! not validated — contains garbage
+  PHONE_NBR       VARCHAR(50) (
+    note """
+    No consistent format across the dataset:
+    - **42%** `(555) 123-4567` — US with parentheses
+    - **31%** `555.123.4567` — dot-separated
+    - **15%** `+15551234567` — already E.164
+    - **8%** `5551234567` — raw 10-digit
+    - **4%** other (international, extensions, garbage)
+    """
+  )
+  ADDR_LINE_1     VARCHAR(200)
+  ADDR_LINE_2     VARCHAR(200)
+  CITY            VARCHAR(100)
+  STATE_PROV      VARCHAR(50)                                  //! full names AND 2-char codes mixed
+  ZIP_POSTAL      VARCHAR(20)
+  COUNTRY_CD      CHAR(2)        (default US)
+  CREDIT_LIMIT    DECIMAL(12,2)                                // NULL = no credit extended
+  ACCOUNT_STATUS  CHAR(1)        (enum {A, S, C, D}, default A)
+  CREATED_DATE    VARCHAR(10)                                  //! stored as MM/DD/YYYY string
+  LAST_MOD_DATE   VARCHAR(20)                                  //! MM/DD/YYYY HH:MM:SS AM/PM
+  TAX_ID          VARCHAR(20)    (pii, encrypt)                //! plaintext in legacy — SSN or EIN
+  LOYALTY_POINTS  INT            (default 0)
+  PREF_CONTACT    CHAR(1)        (enum {E, P, M, N}, default E)
+  NOTES           VARCHAR(MAX)                                 // free-text, may contain profanity
+}
+
+
+// --- Target ---
+
+schema postgres_db (note "Normalized customer schema — PostgreSQL 16") {
+  customer_id              UUID           (pk, required)
+  legacy_customer_id       INTEGER        (unique, indexed)
+  customer_type            VARCHAR(20)    (enum {retail, business, government}, required)
+  display_name             VARCHAR(200)   (required)
+  first_name               VARCHAR(100)
+  last_name                VARCHAR(100)
+  company_name             VARCHAR(200)
+  email                    VARCHAR(255)   (format email, pii)
+  phone                    VARCHAR(20)    (format E.164)
+  address_id               UUID           (ref addresses.id)
+  credit_limit_cents       BIGINT         (default 0)
+  status                   VARCHAR(20)    (enum {active, suspended, closed, delinquent}, required)
+  created_at               TIMESTAMPTZ    (required)
+  updated_at               TIMESTAMPTZ
+  tax_identifier_encrypted TEXT           (pii, encrypt AES-256-GCM)
+  loyalty_tier             VARCHAR(20)    (enum {bronze, silver, gold, platinum})
+  preferred_contact_method VARCHAR(20)    (enum {email, phone, mail, none})
+  notes                    TEXT
+  migration_timestamp      TIMESTAMPTZ
+}
+
+
+// --- Mapping ---
+
+mapping 'customer migration' {
+  note {
+    "Mapping assumptions:
+     - All timestamps assumed US Eastern unless otherwise noted
+     - NULL handling: source NULLs preserved unless target has stated default
+     - Names are title-cased on migration"
+  }
+
+  source { `legacy_sqlserver` }
+  target { `postgres_db` }
+
+  // --- Identifiers ---
+  CUST_ID -> customer_id { uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID) }
+  CUST_ID -> legacy_customer_id
+
+  // --- Customer Type ---
+  CUST_TYPE -> customer_type {
+    map {
+      R: "retail"
+      B: "business"
+      G: "government"
+      null: "retail"
+    }
+  }
+
+  // --- Name Handling ---
+  -> display_name {
+    "If CUST_TYPE is null or 'R', trim and concat FIRST_NM + ' ' + LAST_NM.
+     Otherwise, trim COMPANY_NM."
+  }
+
+  FIRST_NM   -> first_name    { trim | title_case | null_if_empty }
+  LAST_NM    -> last_name     { trim | title_case | null_if_empty }
+  COMPANY_NM -> company_name  { trim | null_if_empty }
+
+  // --- Contact ---
+  EMAIL_ADDR -> email { trim | lowercase | validate_email | null_if_invalid }
+
+  PHONE_NBR -> phone {
+    "Extract all digits. If 11 digits starting with 1, treat as US.
+     If 10 digits, assume US country code +1. Format as E.164.
+     For other patterns, attempt to determine country from COUNTRY_CD.
+     If unparseable, set null and log warning with original value."
+  }
+
+  // --- Address (FK to separate table) ---
+  -> address_id {
+    "Create a record in the addresses table using ADDR_LINE_1, ADDR_LINE_2,
+     CITY, STATE_PROV, ZIP_POSTAL, COUNTRY_CD. Normalize STATE_PROV to
+     2-char code (handle full names). Deduplicate against existing addresses
+     by normalized street + zip. Return the UUID of the new or existing record."
+  }
+
+  // --- Financial ---
+  CREDIT_LIMIT -> credit_limit_cents { coalesce(0) | * 100 | round }
+
+  // --- Status ---
+  ACCOUNT_STATUS -> status {
+    map { A: "active", S: "suspended", C: "closed", D: "delinquent" }
+  }
+
+  // --- Dates ---
+  CREATED_DATE -> created_at { parse("MM/DD/YYYY") | assume_utc | to_iso8601 }
+
+  LAST_MOD_DATE -> updated_at {
+    parse("MM/DD/YYYY hh:mm:ss a") | to_utc | to_iso8601
+    | "If null, fall back to CREATED_DATE parsed as MM/DD/YYYY in UTC"
+  }
+
+  // --- Security ---
+  TAX_ID -> tax_identifier_encrypted { encrypt(AES-256-GCM, secrets.tax_encryption_key) }
+
+  // --- Calculated ---
+  LOYALTY_POINTS -> loyalty_tier {
+    map {
+      < 1000:  "bronze"
+      < 5000:  "silver"
+      < 10000: "gold"
+      default: "platinum"
+    }
+  }
+
+  PREF_CONTACT -> preferred_contact_method {
+    map { E: "email", P: "phone", M: "mail", N: "none" }
+  }
+
+  // --- Text ---
+  NOTES -> notes {
+    "Filter profanity using corporate word list v3.2, replacing matches with asterisks"
+    | escape_html
+    | truncate(5000)
+  }
+
+  // --- Audit ---
+  -> migration_timestamp { now_utc() }
+}

--- a/examples-v2/edi-to-json.stm
+++ b/examples-v2/edi-to-json.stm
@@ -1,0 +1,169 @@
+// STM v2 — EDI 856 → MFCS Shipment
+
+note {
+  """
+  # EDI 856 → MFCS Shipment
+
+  Transforms EDI 856 (DESADV) fixed-length ASN messages into
+  MFCS JSON Shipment format for warehouse ingestion.
+  Based on mapping specification v1.0 (18/11/2025).
+
+  ## Open issues
+  - `containers` array is **required** by MFCS schema but has
+    **no source mapping** in the current EDI specification
+  - `containerId` and `finalLocation` are required but unpopulated
+  - Awaiting clarification from warehouse team (Jira: DWHT-2847)
+  """
+}
+
+
+// --- Source ---
+
+schema edi_desadv (
+  format fixed-length,
+  note "EDI 856 Despatch Advice — Fixed Length Format"
+) {
+  record BeginningOfMessage {
+    DOCNUM      CHAR(35)                          // despatch advice number
+    MESSGFUN    CHAR(3)                           // message function: 9 = Original
+  }
+
+  record DateTime {
+    DATEQUAL    CHAR(3)                           // qualifier: 137 = document date/time
+    DATETIME    CHAR(35)                          // date/time value
+    DATEFMT     CHAR(3)                           // format: 102=CCYYMMDD, 203=CCYYMMDDHHMM
+  }
+
+  list ShipmentRefs (filter SHPRFQUAL == "SRN") {
+    SHPRFQUAL   CHAR(3)
+    SHIPREF     CHAR(70)                          // shipment reference number
+  }
+
+  list POReferences (filter REFQUAL == "ON") {
+    REFQUAL     CHAR(3)
+    REFNUM      CHAR(35)                          // PO Number + "/" + Dissection No
+  }
+
+  record NameAddress {
+    PARTYQUAL   CHAR(3)                           // BY=Buyer, SU=Supplier
+    PARTYID     CHAR(35)                          // 13-digit ANA number
+  }
+
+  list LineItems {
+    LINENUM     NUMBER(6)
+    ITEMNO      CHAR(35)                          // product identifier
+    ITEMTYPE    CHAR(3)                           // EN=EAN, UP=UPC12
+  }
+
+  list Quantities (filter QUANTQUAL == "12") {    // only despatch quantities
+    QUANTQUAL   CHAR(3)
+    QUANTITY    NUMBER(15)                         //! 4 implied decimal places
+  }
+}
+
+
+// --- Target ---
+
+schema mfcs_json (format json, note "MFCS Shipment Ingestion Format") {
+  record ShipmentHeader {
+    toLocation            NUMBER(10)
+    asnNo                 STRING(30)   (required)
+    shipDate              DATE         (required)
+    estimatedArrivalDate  DATE
+    comments              STRING(2000)
+    carrierCode           STRING(4)
+    asnType               STRING(1)    (required)     // C=UCC-128, 0=ASN Shipment
+    supplier              NUMBER(10)   (required)
+    shipPayMethod         STRING(2)
+
+    list asnDetails {
+      orderNo             NUMBER(12)   (required)
+      notAfterDate        DATE
+
+      list containers (
+        note """
+        ## DATA GAP
+        This entire array is **required** by the MFCS schema but has
+        **no source data** in the current EDI 856 mapping.
+        See Jira: DWHT-2847 for resolution status.
+        """
+      ) {
+        containerId       STRING(30)   (required)     //! no source mapping
+        finalLocation     NUMBER(10)   (required)     //! no source mapping
+        list items {
+          item            STRING(25)
+          unitQuantity    NUMBER(12,4)                 //! no source mapping
+        }
+      }
+
+      list items {
+        item              STRING(25)
+        unitQuantity      NUMBER(12,4)  (required)
+        vpn               STRING(30)
+        referenceItem     STRING(25)
+      }
+    }
+  }
+}
+
+
+// --- Mapping ---
+
+mapping 'edi to mfcs' {
+  source { `edi_desadv` }
+  target { `mfcs_json` }
+
+  // --- Header ---
+  BeginningOfMessage.DOCNUM -> ShipmentHeader.asnNo { trim | max_length(30) }
+
+  DateTime.DATETIME -> ShipmentHeader.shipDate {
+    "Parse using sibling field DATEFMT: if 102 parse as CCYYMMDD,
+     if 203 parse as CCYYMMDDHHMM. Output format: YYYY-MM-DD."
+  }
+
+  -> ShipmentHeader.asnType { "0" }    // default: ASN Shipment
+
+  POReferences[].REFNUM -> ShipmentHeader.toLocation {
+    "Extract PO number from REFNUM (digits before '/').
+     Look up the PO in MFCS to determine the delivery location."
+  }
+
+  POReferences[].REFNUM -> ShipmentHeader.supplier {
+    split("/") | first | to_number
+    | "Validate supplier exists in MFCS PO table."
+  }
+
+  ShipmentRefs[].SHIPREF -> ShipmentHeader.comments { prepend("Shipment reference number: ") }
+
+  // --- Detail lines grouped by PO ---
+  POReferences[] -> ShipmentHeader.asnDetails[] (
+    note "Each PO reference generates one asnDetails entry.
+          Line items and quantities are correlated by position."
+  ) {
+    .REFNUM -> .orderNo { split("/") | first | to_number }
+
+    LineItems[] -> .items[] {
+      .ITEMNO -> .item {
+        trim
+        | "Retrieve MFCS item number using the supplier's traded code
+           from the MFCS supplier item cross-reference."
+      }
+
+      Quantities[].QUANTITY -> .unitQuantity {
+        "Divide by 10000 to account for 4 implied decimal places.
+         Then multiply by PO pack size from MFCS (Action A-504).
+         Pack size retrieved from MFCS PO line matching this item."
+      }
+    }
+  }
+
+  //! DATA GAP: containers[] required but no source data
+  -> ShipmentHeader.asnDetails[].containers {
+    "Required by MFCS schema but no source data available in EDI 856.
+     Options under discussion:
+     1. Populate with a single placeholder container per order
+     2. Request EDI 856 extension from suppliers
+     3. Derive from warehouse receiving logic
+     Blocked on: MFCS-2847"
+  }
+}

--- a/examples-v2/lib/sfdc_fragments.stm
+++ b/examples-v2/lib/sfdc_fragments.stm
@@ -1,0 +1,50 @@
+// STM v2 — SFDC Standard Fragments Library
+// Reusable field sets for common Salesforce objects
+
+fragment 'sfdc standard types' {
+  Id                ID             (pk, unique)
+  Name              STRING(255)    (required)
+  CreatedDate       DATETIME       (required)
+  CreatedById       ID             (ref User.Id)
+  LastModifiedDate  DATETIME       (required)
+  LastModifiedById  ID             (ref User.Id)
+  SystemModStamp    DATETIME       (required)
+  IsDeleted         BOOLEAN        (default false)
+}
+
+fragment 'sfdc address' {
+  Street      STRING(255)
+  City        STRING(40)
+  State       STRING(80)
+  PostalCode  STRING(20)
+  Country     STRING(80)
+  Latitude    DECIMAL(18,15)
+  Longitude   DECIMAL(18,15)
+}
+
+fragment 'sfdc opportunity standard' {
+  AccountId                ID             (ref Account.Id)
+  Amount                   CURRENCY(18,2)
+  CloseDate                DATE           (required)
+  StageName                PICKLIST       (required)
+  Probability              PERCENT(3,0)
+  ExpectedRevenue          CURRENCY(18,2)
+  TotalOpportunityQuantity DECIMAL(18,2)
+  LeadSource               PICKLIST
+  Type                     PICKLIST
+}
+
+fragment 'sfdc account standard' {
+  Type            PICKLIST
+  ParentId        ID             (ref Account.Id)
+  record BillingAddress {
+    ...sfdc address
+  }
+  record ShippingAddress {
+    ...sfdc address
+  }
+  Phone           PHONE
+  Website         URL
+  Industry        PICKLIST
+  NumberOfEmployees INT
+}

--- a/examples-v2/lookups/finance.stm
+++ b/examples-v2/lookups/finance.stm
@@ -1,0 +1,9 @@
+// STM v2 — Finance Lookups
+
+schema currency_rates (
+  note "Sourced from OpenExchangeRates API. Updated daily at 00:01 UTC."
+) {
+  iso_code    STRING(3)    (pk)
+  rate        DECIMAL(10,6)
+  updated_at  DATETIME
+}

--- a/examples-v2/multi-source-hub.stm
+++ b/examples-v2/multi-source-hub.stm
@@ -1,0 +1,131 @@
+// STM v2 — Multi-Source Data Hub
+
+note {
+  """
+  # Data Hub
+
+  Aggregates customer, payment, and inventory data from three
+  independent sources and distributes to analytics, notification,
+  and reporting targets.
+  """
+}
+
+
+// --- Sources ---
+
+schema crm_system (note "CRM customer data") {
+  customer_id     UUID
+  email           EMAIL
+  phone           STRING(20)
+  loyalty_points  INT32
+}
+
+schema payment_gateway (note "Payment transaction data") {
+  transaction_id  UUID
+  customer_email  EMAIL
+  amount          DECIMAL(12,2)
+  currency        ISO-4217
+  status          ENUM (enum {pending, completed, failed})
+}
+
+schema inventory_system (note "Inventory management") {
+  product_sku          STRING(20)
+  stock_level          INT32
+  warehouse_location   STRING(50)
+}
+
+
+// --- Targets ---
+
+schema analytics_db (note "Analytics database") {
+  customer_id           UUID
+  email                 VARCHAR(255)
+  total_spent           DECIMAL(12,2)
+  transaction_count     INT
+  last_transaction_date TIMESTAMPTZ
+}
+
+schema notification_service (note "Notification message format") {
+  recipient_email  EMAIL
+  recipient_phone  STRING(20)
+  message_type     ENUM
+  message_body     TEXT
+  priority         ENUM (enum {low, medium, high})
+}
+
+schema reporting_warehouse (note "Reporting data warehouse") {
+  product_id       VARCHAR(20)
+  available_stock  INT
+  location         VARCHAR(50)
+  reorder_needed   BOOLEAN
+}
+
+
+// --- Mappings ---
+
+mapping 'crm to analytics' {
+  source { `crm_system` }
+  target { `analytics_db` }
+
+  customer_id -> customer_id
+  email -> email
+}
+
+mapping 'payments to analytics' {
+  source { `payment_gateway` }
+  target { `analytics_db` }
+
+  amount -> total_spent {
+    "Sum all transactions where status = 'completed', grouped by customer_email.
+     Join to crm_system on email to resolve customer_id."
+  }
+
+  -> transaction_count {
+    "Count transactions where status = 'completed', per customer."
+  }
+
+  -> last_transaction_date {
+    "Max transaction timestamp where status = 'completed', per customer."
+  }
+}
+
+mapping 'crm to notifications' {
+  source { `crm_system` }
+  target { `notification_service` }
+
+  email -> recipient_email
+  phone -> recipient_phone
+
+  -> message_type {
+    "Set to 'loyalty_update' if loyalty_points > 1000, otherwise null."
+  }
+
+  -> priority {
+    "Check payment_gateway: if any transaction has status = 'failed' for
+     this customer, set 'high'. Otherwise 'low'."
+  }
+}
+
+mapping 'payments to notifications' {
+  source { `payment_gateway` }
+  target { `notification_service` }
+
+  customer_email -> recipient_email
+
+  transaction_id -> message_body {
+    "Format as 'Transaction {transaction_id} completed successfully.'"
+  }
+}
+
+mapping 'inventory to reporting' {
+  source { `inventory_system` }
+  target { `reporting_warehouse` }
+
+  product_sku -> product_id
+  stock_level -> available_stock
+  warehouse_location -> location
+
+  -> reorder_needed {
+    "True if stock_level < 10, false otherwise."
+  }
+}

--- a/examples-v2/protobuf-to-parquet.stm
+++ b/examples-v2/protobuf-to-parquet.stm
@@ -1,0 +1,148 @@
+// STM v2 — Protobuf Commerce Events to Session Parquet
+
+note {
+  """
+  # Protobuf Commerce Events to Session Parquet
+
+  Consumes protobuf commerce events from Kafka and produces a session-level
+  Parquet dataset for product analytics. The pipeline groups events by
+  `session_id` and computes session metrics such as purchase totals,
+  product interaction breadth, and checkout completion.
+
+  This example demonstrates protobuf annotations, nested repeated fields,
+  group-by aggregation, and per-field error-handling defaults.
+  """
+}
+
+
+// --- Source ---
+
+schema commerce_event_pb (
+  format protobuf,
+  schema_registry "https://registry.example.com",
+  schema_version "12.4.0",
+  namespace "com.example.commerce.events",
+  note "Commerce event protobuf envelope"
+) {
+  event_id         STRING      (tag 1)
+  event_type       STRING      (tag 2)
+  event_ts         STRING      (tag 3)
+  source_system    STRING      (tag 4)
+  session_id       STRING      (tag 5)
+  user_id          STRING      (tag 6)
+  country_code     STRING      (tag 7)
+  currency_code    STRING      (tag 8)
+
+  record Context (tag 9) {
+    device_type    STRING      (tag 1)
+    app_version    STRING      (tag 2)
+    entry_channel  STRING      (tag 3)
+  }
+
+  list CartLines (tag 10) {
+    sku            STRING      (tag 1)
+    quantity       INT32       (tag 2)
+    unit_price     DECIMAL(12,2) (tag 3)
+    discount_amt   DECIMAL(12,2) (tag 4)
+    category       STRING      (tag 5)
+  }
+
+  list Attributes (tag 11) {
+    key            STRING      (tag 1)
+    value          STRING      (tag 2)
+  }
+}
+
+
+// --- Target ---
+
+schema commerce_session_parquet (format parquet, note "Session-level analytics dataset") {
+  session_id                 STRING         (pk)
+  user_id                    STRING
+  session_start_utc          TIMESTAMPTZ    (required)
+  session_end_utc            TIMESTAMPTZ    (required)
+  source_system              STRING
+  country_code               STRING
+  currency_code              STRING
+  entry_channel              STRING         (enum {web, mobile_app, kiosk, marketplace})
+  device_type                STRING         (enum {desktop, mobile, tablet, pos})
+  event_count                INT32          (required)
+  distinct_event_types       JSON
+  viewed_product_count       INT32
+  cart_add_count             INT32
+  purchase_event_count       INT32
+  checkout_completed         BOOLEAN        (required)
+  gross_merchandise_value    DECIMAL(14,2)
+  total_discount_amount      DECIMAL(14,2)
+  distinct_product_count     INT32
+  top_category               STRING
+  session_quality            STRING         (enum {bounce, browse, engaged, purchaser})
+}
+
+
+// --- Mapping ---
+
+mapping 'session aggregation' (group_by session_id, on_error log, error_threshold 0.02) {
+  source { `commerce_event_pb` }
+  target { `commerce_session_parquet` }
+
+  session_id -> session_id
+  user_id -> user_id { first }
+
+  event_ts -> session_start_utc { min | "Parse the minimum timestamp in the group as UTC." }
+  event_ts -> session_end_utc { max | "Parse the maximum timestamp in the group as UTC." }
+
+  source_system -> source_system { first }
+  country_code -> country_code { first | uppercase }
+  currency_code -> currency_code { first | uppercase }
+  Context.entry_channel -> entry_channel { first | lowercase }
+  Context.device_type -> device_type { first | lowercase }
+
+  -> event_count { count }
+
+  event_type -> distinct_event_types {
+    distinct | "Emit the distinct event_type values as a JSON array string."
+  }
+
+  -> viewed_product_count {
+    "Count records in the group where event_type == 'product_view'."
+  }
+
+  -> cart_add_count {
+    "Count records in the group where event_type == 'add_to_cart'."
+  }
+
+  -> purchase_event_count {
+    "Count records in the group where event_type == 'purchase'."
+  }
+
+  event_type -> checkout_completed {
+    map { purchase: true, _: false } | max
+  }
+
+  CartLines[].unit_price -> gross_merchandise_value {
+    "For each event, multiply CartLines[].unit_price by CartLines[].quantity,
+     sum within the event, then sum across the session group."
+  }
+
+  CartLines[].discount_amt -> total_discount_amount {
+    "Sum discount_amt across all CartLines[] elements in all events in the group."
+  }
+
+  -> distinct_product_count {
+    "Count distinct CartLines[].sku values across all events in the session."
+  }
+
+  -> top_category {
+    "Find the most frequent CartLines[].category across the session.
+     Break ties by highest gross merchandise value."
+  }
+
+  -> session_quality {
+    "Classify the grouped session as:
+     purchaser if any purchase event exists;
+     engaged if there is any add_to_cart event;
+     browse if there are multiple product_view events;
+     otherwise bounce."
+  }
+}

--- a/examples-v2/sfdc_to_snowflake.stm
+++ b/examples-v2/sfdc_to_snowflake.stm
@@ -1,0 +1,105 @@
+// STM v2 — Salesforce to Snowflake Pipeline
+
+import { 'sfdc standard types' } from "lib/sfdc_fragments.stm"
+import { 'currency rates' } from "lookups/finance.stm"
+
+note {
+  """
+  # Salesforce to Snowflake Pipeline
+
+  Maps Sales Cloud `Opportunity` and `Account` objects into the
+  `ANALYTICS.RAW_SFDC` schema.
+
+  ## Sync Strategy
+  - **Incremental:** Uses `SystemModStamp` to pull changes every 15 minutes.
+  - **Hard Deletes:** Captured via the `isDeleted` flag in SFDC.
+  """
+}
+
+
+// --- Sources ---
+
+schema sfdc_opportunity (note "SFDC Opportunity Object") {
+  Id                          ID             (pk)
+  Name                        STRING(120)    (required)
+  AccountId                   ID             (ref sfdc_account.Id)
+  Amount                      CURRENCY(18,2)
+  CurrencyIsoCode             STRING(3)      (default USD)
+  StageName                   PICKLIST       (enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost})
+  CloseDate                   DATE           (required)
+  Probability                 PERCENT(3,0)
+  `Lead_Source_Detail__c`     STRING(255)
+  `ARR_Override__c`           CURRENCY(18,2)  //! manual override used by Finance
+  SystemModStamp              DATETIME       (required)
+}
+
+schema sfdc_account (note "SFDC Account Object") {
+  Id              ID             (pk)
+  Name            STRING(255)    (required)
+  Type            PICKLIST       (enum {Customer, Prospect, Partner, Competitor})
+  BillingCountry  STRING(80)
+}
+
+
+// --- Target ---
+
+schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
+  opp_key          VARCHAR(18)    (pk)
+  account_key      VARCHAR(18)    (indexed)
+  opportunity_name VARCHAR(120)
+  amount_raw       NUMBER(18,2)
+  amount_usd       NUMBER(18,2)   (note "Converted at daily spot rate")
+  arr_value        NUMBER(18,2)   (required)
+  pipeline_stage   VARCHAR(50)    (enum {top_funnel, mid_funnel, closed_won, closed_lost})
+  is_closed        BOOLEAN
+  close_date       DATE
+  source_system    VARCHAR(10)    (default SFDC)
+  ingested_at      TIMESTAMP_NTZ
+}
+
+
+// --- Mapping ---
+
+mapping 'opportunity ingestion' {
+  source { `sfdc_opportunity` }
+  target { `snowflake_opps` }
+
+  // --- Direct identifiers ---
+  Id -> opp_key
+  AccountId -> account_key
+  Name -> opportunity_name
+
+  // --- Financial ---
+  Amount -> amount_raw { coalesce(0) }
+
+  Amount -> amount_usd {
+    "Multiply by rate from `currency rates` lookup using CurrencyIsoCode"
+    | round(2)
+  }
+
+  `ARR_Override__c` -> arr_value {
+    "Use ARR_Override__c if not null, otherwise fall back to Amount"
+    | coalesce(0)
+  }
+
+  // --- Stage normalization ---
+  StageName -> pipeline_stage {
+    map {
+      Prospecting:  "top_funnel"
+      Qualification: "mid_funnel"
+      "Value Prop":  "mid_funnel"
+      Closed_Won:    "closed_won"
+      Closed_Lost:   "closed_lost"
+      _:             "unknown"
+    }
+  }
+
+  -> is_closed {
+    "True if StageName is 'Closed_Won' or 'Closed_Lost', false otherwise."
+  }
+
+  CloseDate -> close_date
+
+  // --- Metadata ---
+  SystemModStamp -> ingested_at { to_utc }
+}

--- a/examples-v2/xml-to-parquet.stm
+++ b/examples-v2/xml-to-parquet.stm
@@ -1,0 +1,179 @@
+// STM v2 — Order XML to Lakehouse Parquet
+
+note {
+  """
+  # Order XML to Lakehouse Parquet
+
+  Ingests canonical commerce order XML messages from the integration bus
+  and lands two curated Parquet datasets:
+  - `order_headers_parquet` at one row per order
+  - `order_lines_parquet` at one row per line item
+
+  The source XML is namespace-qualified and contains repeated discount
+  fragments, optional loyalty identifiers, and mixed timestamp formats
+  depending on upstream channel.
+  """
+}
+
+
+// --- Source ---
+
+schema commerce_order (
+  format xml,
+  namespace ord "http://example.com/commerce/order/v2",
+  namespace com "http://example.com/common/v1",
+  note "Canonical commerce order message"
+) {
+  record Order (xpath "/ord:OrderMessage/ord:Order") {
+    OrderId           STRING       (xpath "ord:OrderId")
+    Channel           STRING       (xpath "ord:Channel")
+    OrderTimestamp    STRING       (xpath "ord:OrderTimestamp")
+    CurrencyCode      STRING       (xpath "ord:Currency/com:Code")
+
+    record Customer {
+      CustomerId      STRING       (xpath "ord:CustomerId")
+      Email           STRING       (xpath "ord:Email")
+      LoyaltyTier     STRING       (xpath "ord:LoyaltyTier")
+    }
+
+    record ShippingAddress {
+      CountryCode     STRING       (xpath "ord:CountryCode")
+      RegionCode      STRING       (xpath "ord:RegionCode")
+      PostalCode      STRING       (xpath "ord:PostalCode")
+    }
+
+    record Totals {
+      SubtotalAmount  DECIMAL(12,2)  (xpath "ord:SubtotalAmount")
+      TaxAmount       DECIMAL(12,2)  (xpath "ord:TaxAmount")
+      TotalAmount     DECIMAL(12,2)  (xpath "ord:TotalAmount")
+    }
+
+    list Discounts (xpath "ord:Discounts/ord:Discount") {
+      DiscountCode    STRING       (xpath "ord:Code")
+      DiscountAmount  DECIMAL(12,2) (xpath "ord:Amount")
+      DiscountType    STRING       (xpath "ord:Type")
+    }
+
+    list LineItems (xpath "ord:LineItems/ord:LineItem") {
+      LineNumber      INT32        (xpath "ord:LineNumber")
+      SKU             STRING       (xpath "ord:SKU")
+      FulfillmentType STRING       (xpath "ord:FulfillmentType")
+      Quantity        INT32        (xpath "ord:Quantity")
+      UnitPrice       DECIMAL(12,2) (xpath "ord:UnitPrice")
+      ExtendedAmount  DECIMAL(12,2) (xpath "ord:ExtendedAmount")
+      TaxAmount       DECIMAL(12,2) (xpath "ord:TaxAmount")
+      IsGift          BOOLEAN      (xpath "ord:IsGift")
+    }
+  }
+}
+
+
+// --- Targets ---
+
+schema order_headers_parquet (format parquet, note "Curated order header dataset") {
+  order_id             STRING         (pk)
+  order_channel        STRING         (enum {web, mobile, store, marketplace}, required)
+  order_timestamp_utc  TIMESTAMPTZ    (required)
+  customer_id          STRING
+  customer_email       STRING         (format email, pii)
+  loyalty_tier         STRING         (enum {bronze, silver, gold, platinum})
+  ship_country         STRING         (required)
+  ship_region          STRING
+  ship_postal_code     STRING
+  currency_code        STRING         (required)
+  subtotal_amount      DECIMAL(12,2)
+  tax_amount           DECIMAL(12,2)
+  total_amount         DECIMAL(12,2)  (required)
+  discount_codes       JSON
+  discount_total       DECIMAL(12,2)
+  line_count           INT32
+  ingest_date          DATE           (required)
+}
+
+schema order_lines_parquet (format parquet, note "Curated order line dataset") {
+  order_id             STRING         (required)
+  line_number          INT32          (required)
+  sku                  STRING         (required)
+  fulfillment_type     STRING         (enum {ship, pickup, digital, service})
+  quantity             INT32          (required)
+  unit_price           DECIMAL(12,2)
+  extended_amount      DECIMAL(12,2)  (required)
+  line_tax_amount      DECIMAL(12,2)
+  is_gift              BOOLEAN
+  currency_code        STRING         (required)
+  order_channel        STRING         (required)
+  customer_id          STRING
+  ship_country         STRING
+  ingest_date          DATE           (required)
+}
+
+
+// --- Mapping: Order Headers ---
+
+mapping 'order headers' {
+  source { `commerce_order` }
+  target { `order_headers_parquet` }
+
+  Order.OrderId -> order_id
+  Order.Channel -> order_channel { trim | lowercase }
+
+  Order.OrderTimestamp -> order_timestamp_utc {
+    "Parse either ISO-8601 with timezone or local store time in
+     America/New_York depending on channel. Output UTC timestamp."
+  }
+
+  Order.Customer.CustomerId -> customer_id
+  Order.Customer.Email -> customer_email { trim | lowercase | validate_email | null_if_invalid }
+  Order.Customer.LoyaltyTier -> loyalty_tier { trim | lowercase | null_if_empty }
+
+  Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
+  Order.ShippingAddress.RegionCode -> ship_region { trim | uppercase | null_if_empty }
+  Order.ShippingAddress.PostalCode -> ship_postal_code { trim | null_if_empty }
+
+  Order.CurrencyCode -> currency_code { trim | uppercase }
+
+  Order.Totals.SubtotalAmount -> subtotal_amount
+  Order.Totals.TaxAmount -> tax_amount
+  Order.Totals.TotalAmount -> total_amount
+
+  -> discount_codes {
+    "Collect DiscountCode values from Order.Discounts[] preserving source order.
+     Emit as a JSON array string. If no discounts, emit []."
+  }
+
+  -> discount_total {
+    "Sum DiscountAmount across Order.Discounts[] for the current order.
+     If no discounts, emit 0.00."
+  }
+
+  -> line_count {
+    "Count Order.LineItems[] elements for the current order."
+  }
+
+  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+}
+
+
+// --- Mapping: Order Lines (flattened) ---
+
+mapping 'order lines' (flatten `Order.LineItems[]`) {
+  source { `commerce_order` }
+  target { `order_lines_parquet` }
+
+  Order.OrderId -> order_id
+  Order.LineItems[].LineNumber -> line_number
+  Order.LineItems[].SKU -> sku { trim | uppercase }
+  Order.LineItems[].FulfillmentType -> fulfillment_type { trim | lowercase }
+  Order.LineItems[].Quantity -> quantity
+  Order.LineItems[].UnitPrice -> unit_price
+  Order.LineItems[].ExtendedAmount -> extended_amount
+  Order.LineItems[].TaxAmount -> line_tax_amount
+  Order.LineItems[].IsGift -> is_gift
+
+  Order.CurrencyCode -> currency_code { trim | uppercase }
+  Order.Channel -> order_channel { trim | lowercase }
+  Order.Customer.CustomerId -> customer_id
+  Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
+
+  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+}


### PR DESCRIPTION
## Summary
- Adds `STM-V2-SPEC.md` — the authoritative v2 language spec covering design philosophy, lexical rules, schema/mapping blocks, reusability, and vocabulary conventions
- Adds `examples-v2/` with all 8 v1 examples rewritten in v2 syntax (db-to-db, edi-to-json, xml-to-parquet, sfdc-to-snowflake, multi-source-hub, protobuf-to-parquet, plus lib/lookups)

### Key v2 design decisions
- **Three delimiters, three jobs:** `()` metadata, `{}` structure, `""` natural language
- **Single `schema` keyword** replaces `table`/`message`/`source`/`target`/`event`
- **`record`/`list` keyword-first** nesting: `record Customer {}`, `list LineItems {}`
- **`enum {}`** value sets with bare identifiers: `(enum {active, suspended, closed})`
- **`"""`** triple-quote Markdown notes for rich documentation
- **`note`** in `()` metadata for element-level docs, `note {}` blocks for top-level/mapping context
- **NL first-class** — bare `"..."` in transform `{}` for complex logic, pipe `|` for mechanical steps

## Test plan
- [ ] Read through spec for internal consistency
- [ ] Verify every example follows the three-delimiter rule
- [ ] Check `enum {}` syntax is consistent across all files
- [ ] Confirm `record`/`list` keyword-before-name in all nested structures
- [ ] Validate `"""` triple-quotes used appropriately for Markdown content

🤖 Generated with [Claude Code](https://claude.com/claude-code)