### PR TITLE
Audit feature status, add SAP PO example and parser fixtures

### DIFF
--- a/.tickets/stm-eq1n.md
+++ b/.tickets/stm-eq1n.md
@@ -1,6 +1,6 @@
 ---
 id: stm-eq1n
-status: open
+status: closed
 deps: []
 links: [stm-7rz4]
 created: 2026-03-19T07:16:41Z

--- a/.tickets/stm-n5i6.md
+++ b/.tickets/stm-n5i6.md
@@ -1,0 +1,25 @@
+---
+id: stm-n5i6
+status: open
+deps: []
+links: []
+created: 2026-03-19T07:38:38Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, coverage, tree-sitter]
+---
+# stm fields --unmapped-by reports nested target list as unmapped
+
+Reproduced against examples/sap-po-to-mfcs.stm.
+
+Observed behavior:
+- `node tooling/stm-cli/src/index.js mapping 'sap po to mfcs' examples/sap-po-to-mfcs.stm --json` reports a nested mapping arrow with `src: "Items[]"` and `tgt: "items[]"`.\n- `node tooling/stm-cli/src/index.js fields mfcs_purchase_order --unmapped-by 'sap po to mfcs' examples/sap-po-to-mfcs.stm --json` still returns the top-level target list field `items` as unmapped.\n\nWhy this is a bug:\n- The target list container is structurally mapped by the nested arrow, so coverage output should not classify it as unmapped.\n- This makes coverage checks misleading for nested list targets and can cause agents or humans to think a mapped collection is missing.\n\nReproduction:\n1. Open `examples/sap-po-to-mfcs.stm`.\n2. Confirm the mapping contains `Items[] -> items[] (...) { ... }`.\n3. Run: `node tooling/stm-cli/src/index.js fields mfcs_purchase_order --unmapped-by 'sap po to mfcs' examples/sap-po-to-mfcs.stm --json`\n4. Observe that the result includes the `items` list field.\n5. Run: `node tooling/stm-cli/src/index.js mapping 'sap po to mfcs' examples/sap-po-to-mfcs.stm --json`\n6. Observe that the mapping output includes a nested arrow for `Items[] -> items[]`.\n\nActual result:\n- `fields --unmapped-by` reports `items` as unmapped.\n\nExpected result:\n- A target list field should count as mapped when a nested arrow targets that list, even if child fields are populated inside the nested block.\n- If the command intentionally distinguishes container coverage from child coverage, that distinction needs to be represented explicitly rather than calling the list unmapped.
+
+## Acceptance Criteria
+
+- Add a regression test covering a target schema with a nested list mapped by `src[] -> tgt[] { ... }`.
+- `fields <target> --unmapped-by <mapping>` must not report the target list container as unmapped when the mapping contains a nested arrow to that list.
+- The fix must preserve existing unmapped reporting for genuinely unmapped top-level fields and genuinely unmapped nested children.
+- Document the intended coverage semantics for nested list containers if any edge-case behavior remains.
+

--- a/.tickets/stm-zy83.md
+++ b/.tickets/stm-zy83.md
@@ -1,6 +1,6 @@
 ---
 id: stm-zy83
-status: open
+status: closed
 deps: []
 links: [stm-7rz4]
 created: 2026-03-19T07:16:49Z

--- a/examples/sap-po-to-mfcs.stm
+++ b/examples/sap-po-to-mfcs.stm
@@ -1,0 +1,182 @@
+// STM v2 — SAP Purchase Order to Oracle MFCS
+
+note {
+  """
+  # SAP Purchase Order to Oracle MFCS
+
+  Maps a logical SAP ERP purchase order into an Oracle MFCS purchase order
+  ingestion contract.
+
+  This example is intentionally business-level rather than transport-level:
+  it models the SAP purchase order as a normalized contract instead of raw
+  IDoc or BAPI payload segments so the mapping intent stays readable.
+
+  ## Assumptions
+  - One MFCS purchase order is emitted per SAP purchase order
+  - Header-level receiving site is available and authoritative for location
+  - Currency is already aligned to the MFCS target environment
+
+  ## Open issues
+  - Supplier resolution depends on an MFCS supplier cross-reference
+  - Material resolution depends on an MFCS item cross-reference
+  - UOM and pack conversion rules depend on MFCS supplier-item setup
+  - If line-level plants differ from the header receiving site, the target
+    flow may need to split one SAP PO into multiple MFCS orders
+  """
+}
+
+
+// --- Source ---
+
+schema sap_purchase_order (
+  format sap,
+  note "Logical SAP ERP purchase order contract"
+) {
+  EBELN          STRING(10)    (pk, required, note "SAP purchase order number")
+  BUKRS          STRING(4)     (required, note "Company code")
+  BSART          STRING(4)     (required, enum {NB, UB, FO, ZST}, note "Purchasing document type")
+  BSTYP          STRING(1)     (required, enum {F}, note "Document category: purchase order")
+  LIFNR          STRING(10)    (required, note "Vendor account number")
+  EKORG          STRING(4)     (required, note "Purchasing organization")
+  EKGRP          STRING(3)     (note "Purchasing group")
+  WAERS          STRING(3)     (required, note "Document currency")
+  BEDAT          DATE          (required, note "PO document date")
+  ReceivingSite  STRING(10)    (required, note "Business receiving site used for MFCS location resolution")
+  HeaderText     STRING(1000)
+
+  list Items {
+    EBELP        STRING(5)     (required, note "PO line number")
+    MATNR        STRING(18)    (required, note "SAP material number")
+    TXZ01        STRING(250)   (note "Short item description")
+    MENGE        NUMBER(13,3)  (required, note "Ordered quantity")
+    MEINS        STRING(3)     (required, note "Base unit of measure")
+    NETPR        NUMBER(13,4)  (required, note "Net price")
+    PEINH        NUMBER(5)     (default 1, note "Price unit divisor")
+    WERKS        STRING(4)     (required, note "Plant")
+    LGORT        STRING(4)     (note "Storage location")
+    EINDT        DATE          (note "Requested delivery date")
+  }
+}
+
+
+// --- Target ---
+
+schema mfcs_purchase_order (
+  format json,
+  note "Logical Oracle MFCS purchase order ingestion contract"
+) {
+  orderNo        NUMBER(12)    (required)
+  supplier       NUMBER(10)    (required)   //! requires MFCS supplier cross-reference
+  location       NUMBER(10)    (required)   //! requires site-to-location resolution
+  currencyCode   STRING(3)     (required)
+  orderType      STRING(20)    (required)
+  notBeforeDate  DATE
+  comments       STRING(1000)
+
+  list items {
+    item         STRING(25)      (required)   //! requires material-to-item cross-reference
+    orderedQty   NUMBER(12,4)    (required)
+    unitCost     NUMBER(12,4)
+    uom          STRING(10)      (required)
+    needByDate   DATE
+    referenceLine NUMBER(6)      (required)
+    description  STRING(250)
+  }
+}
+
+
+// --- Mapping ---
+
+mapping 'sap po to mfcs' {
+  note {
+    """
+    Mapping policy:
+    - Preserve one target line per SAP PO item
+    - Resolve supplier, item, and location through MFCS reference data
+    - Keep pack/UOM conversion logic explicit in NL until a deterministic
+      token vocabulary exists for supplier-item conversion rules
+    """
+  }
+
+  source { `sap_purchase_order` }
+  target { `mfcs_purchase_order` }
+
+  //! ASSUMPTION: header ReceivingSite is authoritative for target location
+  //? If Items[].WERKS varies by line, should this integration split one SAP PO
+  //? into multiple MFCS orders by location instead of rejecting the document?
+
+  // --- Header ---
+  EBELN -> orderNo { to_number }
+
+  LIFNR -> supplier {
+    trim
+    | "Resolve SAP vendor number to MFCS supplier id using the approved
+       supplier cross-reference. Reject the document if no active MFCS
+       supplier exists for the vendor."
+  }
+
+  ReceivingSite -> location {
+    trim
+    | "Resolve the business receiving site to an MFCS location id.
+       If no direct mapping exists, fall back to a plant-to-location mapping
+       approved by merchandising operations."
+  }
+
+  WAERS -> currencyCode { trim | uppercase }
+
+  BSART -> orderType {
+    map {
+      NB: "standard"
+      UB: "transfer"
+      FO: "framework"
+      ZST: "stock"
+      default: "standard"
+    }
+  }
+
+  Items[].EINDT -> notBeforeDate {
+    "Take the earliest non-null requested delivery date across all lines.
+     If all line dates are null, fall back to BEDAT."
+  }
+
+  HeaderText -> comments {
+    trim
+    | max_length(1000)
+  }
+
+  // --- Lines ---
+  Items[] -> items[] (
+    note "One MFCS target line per SAP purchase order item."
+  ) {
+    .EBELP -> .referenceLine { to_number }
+
+    .MATNR -> .item {
+      trim
+      | uppercase
+      | "Translate SAP material number to the MFCS item identifier using the
+         supplier-item or material cross-reference. Reject the line if no
+         active MFCS item can be resolved."
+    }
+
+    .MENGE -> .orderedQty {
+      "If MEINS represents supplier packs or cases, convert to the target
+       stocking quantity using the MFCS supplier-item pack configuration.
+       Otherwise preserve the numeric quantity. Round to 4 decimal places."
+    }
+
+    .NETPR -> .unitCost {
+      "If PEINH is greater than 1, divide NETPR by PEINH to derive the
+       per-unit cost in document currency. Round to 4 decimal places."
+    }
+
+    .MEINS -> .uom {
+      trim
+      | uppercase
+      | "Map SAP UOM values to the MFCS UOM vocabulary. Escalate any value
+         that cannot be resolved through the approved conversion table."
+    }
+
+    .EINDT -> .needByDate
+    .TXZ01 -> .description { trim | max_length(250) }
+  }
+}

--- a/tooling/tree-sitter-stm/test/corpus/sap_po_patterns.txt
+++ b/tooling/tree-sitter-stm/test/corpus/sap_po_patterns.txt
@@ -1,0 +1,488 @@
+================================================================================
+Relative-to-relative arrow inside nested block
+================================================================================
+
+mapping {
+  source { orders }
+  target { fact_orders }
+  items[] -> lines[] {
+    .sku -> .product_code
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (nested_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier))))))))
+
+================================================================================
+Relative-to-relative arrow with transform
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  items[] -> lines[] {
+    .line_no -> .ref_line { to_number }
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (nested_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier)))
+          (pipe_chain
+            (pipe_step
+              (token_call
+                (identifier)))))))))
+
+================================================================================
+Pipe chain with token then NL string
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  vendor_id -> supplier {
+    trim
+    | "Resolve vendor to supplier using cross-reference."
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (map_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (pipe_chain
+          (pipe_step
+            (token_call
+              (identifier)))
+          (pipe_step
+            (nl_string)))))))
+
+================================================================================
+Pipe chain with multiple tokens then NL string
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  material -> item {
+    trim
+    | uppercase
+    | "Translate material number to item identifier."
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (map_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (pipe_chain
+          (pipe_step
+            (token_call
+              (identifier)))
+          (pipe_step
+            (token_call
+              (identifier)))
+          (pipe_step
+            (nl_string)))))))
+
+================================================================================
+Nested arrow with note metadata
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  items[] -> lines[] (
+    note "One target line per source item."
+  ) {
+    .sku -> .product_code
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (nested_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (metadata_block
+          (note_tag
+            (nl_string)))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier))))))))
+
+================================================================================
+Nested arrow with mixed relative arrow types
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  Items[] -> items[] {
+    .line_no -> .ref { to_number }
+    .code -> .item {
+      trim | uppercase | "Resolve code to item."
+    }
+    .qty -> .quantity {
+      "Convert quantity using pack config."
+    }
+    .desc -> .description { trim | max_length(250) }
+    .date -> .need_date
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (nested_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier)))
+          (pipe_chain
+            (pipe_step
+              (token_call
+                (identifier)))))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier)))
+          (pipe_chain
+            (pipe_step
+              (token_call
+                (identifier)))
+            (pipe_step
+              (token_call
+                (identifier)))
+            (pipe_step
+              (nl_string))))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier)))
+          (pipe_chain
+            (pipe_step
+              (nl_string))))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier)))
+          (pipe_chain
+            (pipe_step
+              (token_call
+                (identifier)))
+            (pipe_step
+              (token_call
+                (identifier)
+                (number_literal)))))
+        (map_arrow
+          (src_path
+            (relative_field_path
+              (identifier)))
+          (tgt_path
+            (relative_field_path
+              (identifier))))))))
+
+================================================================================
+Map literal with default key inside arrow
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  doc_type -> order_type {
+    map {
+      NB: "standard"
+      UB: "transfer"
+      default: "standard"
+    }
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (map_arrow
+        (src_path
+          (field_path
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (pipe_chain
+          (pipe_step
+            (map_literal
+              (map_entry
+                (map_key
+                  (identifier))
+                (map_value
+                  (nl_string)))
+              (map_entry
+                (map_key
+                  (identifier))
+                (map_value
+                  (nl_string)))
+              (map_entry
+                (map_key)
+                (map_value
+                  (nl_string))))))))))
+
+================================================================================
+Array-dotted source path to simple target
+================================================================================
+
+mapping {
+  source { src }
+  target { tgt }
+  Items[].EINDT -> notBeforeDate {
+    "Take the earliest date across all lines."
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (mapping_block
+    (mapping_body
+      (source_block
+        (source_ref
+          (identifier)))
+      (target_block
+        (source_ref
+          (identifier)))
+      (map_arrow
+        (src_path
+          (field_path
+            (identifier)
+            (identifier)))
+        (tgt_path
+          (field_path
+            (identifier)))
+        (pipe_chain
+          (pipe_step
+            (nl_string)))))))
+
+================================================================================
+Schema with list block and field-level note metadata
+================================================================================
+
+schema purchase_order (
+  format sap,
+  note "Logical purchase order contract"
+) {
+  order_no STRING(10) (pk, required, note "Order number")
+  doc_type STRING(4)  (required, enum {NB, UB})
+  currency STRING(3)  (required)
+
+  list Items {
+    line_no  STRING(5)     (required, note "Line number")
+    quantity NUMBER(13,3)  (required)
+    price    NUMBER(13,4)  (required)
+    divisor  NUMBER(5)     (default 1, note "Price unit divisor")
+  }
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (schema_block
+    (block_label
+      (identifier))
+    (metadata_block
+      (key_value_pair
+        (kv_key
+          (identifier))
+        (identifier))
+      (note_tag
+        (nl_string)))
+    (schema_body
+      (field_decl
+        (field_name
+          (identifier))
+        (type_expr)
+        (metadata_block
+          (tag_token
+            (identifier))
+          (tag_token
+            (identifier))
+          (note_tag
+            (nl_string))))
+      (field_decl
+        (field_name
+          (identifier))
+        (type_expr)
+        (metadata_block
+          (tag_token
+            (identifier))
+          (enum_body
+            (identifier)
+            (identifier))))
+      (field_decl
+        (field_name
+          (identifier))
+        (type_expr)
+        (metadata_block
+          (tag_token
+            (identifier))))
+      (list_block
+        (block_label
+          (identifier))
+        (schema_body
+          (field_decl
+            (field_name
+              (identifier))
+            (type_expr)
+            (metadata_block
+              (tag_token
+                (identifier))
+              (note_tag
+                (nl_string))))
+          (field_decl
+            (field_name
+              (identifier))
+            (type_expr)
+            (metadata_block
+              (tag_token
+                (identifier))))
+          (field_decl
+            (field_name
+              (identifier))
+            (type_expr)
+            (metadata_block
+              (tag_token
+                (identifier))))
+          (field_decl
+            (field_name
+              (identifier))
+            (type_expr)
+            (metadata_block
+              (key_value_pair
+                (kv_key
+                  (identifier))
+                (number_literal))
+              (note_tag
+                (nl_string)))))))))

--- a/tooling/tree-sitter-stm/test/fixtures/examples/sap-po-to-mfcs.json
+++ b/tooling/tree-sitter-stm/test/fixtures/examples/sap-po-to-mfcs.json
@@ -1,0 +1,3 @@
+{
+  "source": "../../../../../examples/sap-po-to-mfcs.stm"
+}


### PR DESCRIPTION
## Summary
- Audit all features: mark 8 as completed, create tickets for remaining work
- Add `examples/sap-po-to-mfcs.stm` — SAP Purchase Order to Oracle MFCS mapping example
- Add 9 tree-sitter corpus tests covering patterns from the new example (relative-to-relative arrows, token+NL pipe chains, nested arrows with note metadata, map literals with default keys)
- Add JSON parse-validation fixture for the new example
- Update top-level docs (README, PROJECT-OVERVIEW, FUTURE-WORK) to reflect current project state

## Test plan
- [x] All 199 tree-sitter corpus tests pass
- [x] All 224 CLI tests pass
- [x] All 10 fixture parse-validations pass (including new SAP PO fixture)
- [x] ESLint passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)