### PR TITLE
Fix namespace bugs, add NL backtick reference support

### DIFF
--- a/.tickets/sc-81p5.md
+++ b/.tickets/sc-81p5.md
@@ -1,0 +1,22 @@
+---
+id: sc-81p5
+status: closed
+deps: [sc-c09h]
+links: [sc-gokg, sc-mbc5, sc-aij8, sc-akx6, sc-jais]
+created: 2026-03-19T18:43:37Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [stm-cli, where-used, nl-refs]
+---
+# stm where-used: surface NL backtick references
+
+Extend stm where-used to include matches from backtick references inside NL transform bodies. Currently where-used only finds structural references (source/target blocks, ref metadata). A schema or field referenced in an NL block should also appear in where-used results, marked as an NL reference.
+
+## Acceptance Criteria
+
+- where-used results include NL backtick refs alongside structural refs
+- NL refs are labelled with their origin (e.g. kind: 'nl-ref')
+- JSON output includes file/line/column for each NL ref
+- Tests covering: schema found in NL but not structural, schema found in both
+

--- a/.tickets/sc-aij8.md
+++ b/.tickets/sc-aij8.md
@@ -1,0 +1,25 @@
+---
+id: sc-aij8
+status: closed
+deps: [sc-c09h]
+links: [sc-81p5, sc-gokg, sc-mbc5, sc-akx6, sc-jais]
+created: 2026-03-19T18:44:04Z
+type: feature
+priority: 1
+assignee: Thorben Louw
+tags: [stm-cli, nl-refs]
+---
+# New subcommand: stm nl-refs — extract backtick references from NL blocks
+
+Add a new stm subcommand that extracts and lists all backtick-delimited references from NL blocks. Scope can be a file, directory, or specific mapping/schema. Output should show each reference with its classification (schema, field, namespace-qualified), the containing block, and source location. Supports --json for structured output. This is the user-facing counterpart to the internal extraction utility.
+
+## Acceptance Criteria
+
+- stm nl-refs [path] lists all backtick refs found in NL blocks
+- Each ref shows: reference text, classification, containing block (mapping/schema name), file, line
+- Supports scoping to a single mapping or schema (e.g. stm nl-refs --mapping 'stage gl entries')
+- --json flag for structured output
+- --unresolved flag to show only refs that don't resolve to known identifiers
+- Human-readable table output by default
+- Tests with ns-merging.stm and other example fixtures
+

--- a/.tickets/sc-akx6.md
+++ b/.tickets/sc-akx6.md
@@ -1,0 +1,23 @@
+---
+id: sc-akx6
+status: closed
+deps: [sc-c09h]
+links: [sc-81p5, sc-gokg, sc-mbc5, sc-aij8, sc-jais]
+created: 2026-03-19T18:43:44Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [stm-cli, arrows, nl-refs]
+---
+# stm arrows: include NL backtick field refs as implicit arrows
+
+Extend stm arrows to surface field references found in NL backtick blocks. When a transform body says '"Lookup `full_name` from `source::hr_employees`"', that's an implicit arrow from source::hr_employees.full_name to the target field. These should appear in arrows output, classified as 'nl-derived' rather than 'direct' or 'transform'.
+
+## Acceptance Criteria
+
+- NL-derived arrows appear in stm arrows output for the relevant fields
+- Classification is 'nl-derived' to distinguish from structural arrows
+- --as-source and --as-target filters apply to NL-derived arrows
+- JSON output includes NL arrow metadata
+- Tests with ns-merging.stm as fixture
+

--- a/.tickets/sc-c09h.md
+++ b/.tickets/sc-c09h.md
@@ -1,0 +1,23 @@
+---
+id: sc-c09h
+status: closed
+deps: []
+links: []
+created: 2026-03-19T18:43:14Z
+type: feature
+priority: 1
+assignee: Thorben Louw
+tags: [stm-cli, nl-refs]
+---
+# NL backtick reference extraction utility
+
+Create a shared utility module that parses NL strings in transform bodies and extracts backtick-delimited references. Should classify each ref as schema-qualified (e.g. source::hr_employees), namespace-qualified (e.g. staging::stg_employees.department), or bare field name. This is the foundation for validate, lineage, where-used, arrows, and the new nl-refs subcommand.
+
+## Acceptance Criteria
+
+- Extracts all backtick refs from NL string nodes in transform bodies
+- Classifies refs as: namespace-qualified schema, field, or bare identifier
+- Resolves refs against the workspace index (schemas, fields, transforms)
+- Returns structured results with source location (file, line, column)
+- Unit tests covering: simple field refs, namespace::schema refs, namespace::schema.field refs, unresolvable refs, multiple refs in one string
+

--- a/.tickets/sc-gokg.md
+++ b/.tickets/sc-gokg.md
@@ -1,0 +1,24 @@
+---
+id: sc-gokg
+status: closed
+deps: [sc-c09h]
+links: [sc-81p5, sc-mbc5, sc-aij8, sc-akx6, sc-jais]
+created: 2026-03-19T18:43:22Z
+type: feature
+priority: 1
+assignee: Thorben Louw
+tags: [stm-cli, validate, nl-refs]
+---
+# stm validate: warn on invalid NL backtick references
+
+Extend stm validate to check backtick references inside NL transform bodies. Warn when: (1) a backtick ref cannot be resolved to any known schema, field, or transform in the workspace, (2) a schema ref in an NL block is not declared in the mapping's source or target list.
+
+## Acceptance Criteria
+
+- Warns on backtick refs that don't resolve to any known identifier
+- Warns when an NL block references a schema not in the mapping's source/target list
+- Does not error on bare field names that match a field in any declared source/target
+- Warnings include file, line, and the unresolved reference
+- Existing validate tests still pass
+- New tests for: valid refs (no warning), unresolvable refs, schema not in source list
+

--- a/.tickets/sc-jais.md
+++ b/.tickets/sc-jais.md
@@ -1,0 +1,24 @@
+---
+id: sc-jais
+status: closed
+deps: [sc-c09h]
+links: [sc-81p5, sc-gokg, sc-mbc5, sc-aij8, sc-akx6]
+created: 2026-03-19T18:43:31Z
+type: feature
+priority: 1
+assignee: Thorben Louw
+tags: [stm-cli, lineage, nl-refs]
+---
+# stm lineage: include NL backtick refs as field-level edges
+
+Extend stm lineage to treat backtick references in NL transform bodies as lineage edges. Currently lineage only follows structural arrows (source_field -> target_field). NL blocks like '"Lookup department from `source::hr_employees` using `posted_by` -> `employee_id`"' contain implicit field-level lineage that should appear in the graph. These edges should be marked as NL-derived so consumers can distinguish them from structural arrows.
+
+## Acceptance Criteria
+
+- NL backtick schema refs create schema-level lineage edges
+- NL backtick field refs create field-level lineage edges
+- NL-derived edges are flagged (e.g. edge.source = 'nl') to distinguish from structural arrows
+- stm lineage --from and --to follow NL-derived edges
+- JSON output includes NL edges with source location
+- Tests covering: cross-namespace NL refs, field-level NL refs, mixed structural + NL lineage
+

--- a/.tickets/sc-mbc5.md
+++ b/.tickets/sc-mbc5.md
@@ -1,0 +1,22 @@
+---
+id: sc-mbc5
+status: closed
+deps: [sc-c09h]
+links: [sc-81p5, sc-gokg, sc-aij8, sc-akx6, sc-jais]
+created: 2026-03-19T18:43:54Z
+type: feature
+priority: 3
+assignee: Thorben Louw
+tags: [stm-cli, context, nl-refs]
+---
+# stm context: boost relevance for NL backtick references
+
+Extend stm context relevance scoring to consider backtick references in NL blocks. When a query matches a schema or field name that appears as a backtick ref in an NL block, the containing mapping/block should receive a relevance boost. This improves context retrieval for AI agents reasoning about data flow.
+
+## Acceptance Criteria
+
+- Backtick refs in NL blocks contribute to relevance scoring
+- A query for a schema name that only appears in NL backtick refs still surfaces the containing block
+- Existing context tests still pass
+- At least one test demonstrating NL-ref-driven boost
+

--- a/.tickets/stm-9607.md
+++ b/.tickets/stm-9607.md
@@ -1,6 +1,6 @@
 ---
 id: stm-9607
-status: open
+status: closed
 deps: []
 links: [stm-7rz4]
 created: 2026-03-19T07:17:25Z

--- a/.tickets/stm-n5i6.md
+++ b/.tickets/stm-n5i6.md
@@ -1,6 +1,6 @@
 ---
 id: stm-n5i6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-19T07:38:38Z

--- a/.tickets/stm-wy73.md
+++ b/.tickets/stm-wy73.md
@@ -1,0 +1,214 @@
+---
+id: stm-wy73
+status: open
+deps: []
+links: []
+created: 2026-03-19T19:07:06Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [stm-cli, agent-tooling, graph]
+---
+# stm graph: workspace semantic graph export
+
+Add a new `stm graph [path]` command that exports a complete workspace semantic graph as a single JSON artifact. This gives AI agents (and external tools) a one-shot view of the entire workspace topology — schemas, mappings, metrics, fragments, transforms, and all field-level data flow edges — without requiring multiple round-trip CLI calls.
+
+## Motivation
+
+The current CLI is designed for targeted, token-efficient queries (e.g. `stm arrows`, `stm lineage --from`). This works well for focused tasks, but whole-workspace reasoning — impact analysis, PII audit, coverage assessment, migration planning — requires the agent to compose many sequential calls, each adding latency and token overhead. A graph export collapses that into a single load.
+
+The `stm lineage` command already builds an internal schema-level directed graph (`buildFullGraph` in lineage.js) using the workspace index. The `stm graph` command generalises and enriches this: it exposes the full workspace topology at both schema-level and field-level, with metadata, transform classification, NL content pointers, and file locations.
+
+## Design
+
+### Output structure (--json)
+
+```json
+{
+  "version": 1,
+  "generated": "2026-03-19T...",
+  "workspace": "path/to/workspace",
+  "stats": {
+    "schemas": 12,
+    "mappings": 5,
+    "metrics": 3,
+    "fragments": 2,
+    "transforms": 1,
+    "arrows": 47,
+    "errors": 0
+  },
+  "nodes": [
+    {
+      "id": "crm::customers",
+      "kind": "schema",
+      "namespace": "crm",
+      "file": "crm/pipeline.stm",
+      "row": 5,
+      "fields": [
+        { "name": "id", "type": "INT", "tags": ["pk"] },
+        { "name": "email", "type": "STRING(255)", "tags": ["pii"] }
+      ],
+      "note": "CRM customer master"
+    },
+    {
+      "id": "crm_to_hub",
+      "kind": "mapping",
+      "namespace": null,
+      "file": "pipeline.stm",
+      "row": 20,
+      "sources": ["crm::customers"],
+      "targets": ["hub_customer"]
+    },
+    {
+      "id": "monthly_revenue",
+      "kind": "metric",
+      "file": "metrics.stm",
+      "row": 40,
+      "sources": ["hub_customer"],
+      "grain": "monthly",
+      "slices": ["region", "segment"]
+    }
+  ],
+  "edges": [
+    {
+      "from": "crm::customers.email",
+      "to": "hub_customer.email_address",
+      "mapping": "crm_to_hub",
+      "classification": "structural",
+      "transforms": ["trim", "lowercase", "validate_email"],
+      "file": "pipeline.stm",
+      "row": 25
+    },
+    {
+      "from": null,
+      "to": "hub_customer.created_at",
+      "mapping": "crm_to_hub",
+      "classification": "structural",
+      "transforms": ["now_utc()"],
+      "derived": true,
+      "file": "pipeline.stm",
+      "row": 30
+    },
+    {
+      "from": "crm::customers.status",
+      "to": "hub_customer.is_active",
+      "mapping": "crm_to_hub",
+      "classification": "nl",
+      "nl_text": "Map `status` code to boolean...",
+      "file": "pipeline.stm",
+      "row": 27
+    }
+  ],
+  "schema_edges": [
+    { "from": "crm::customers", "to": "crm_to_hub", "role": "source" },
+    { "from": "crm_to_hub", "to": "hub_customer", "role": "target" },
+    { "from": "hub_customer", "to": "monthly_revenue", "role": "metric_source" }
+  ],
+  "warnings": [
+    { "text": "Some records have NULL email", "file": "crm/pipeline.stm", "row": 8 }
+  ],
+  "unresolved_nl": [
+    {
+      "scope": "mapping crm_to_hub",
+      "arrow": "-> derived_score",
+      "text": "Calculate risk score from `credit_history` and `account_age`",
+      "file": "pipeline.stm",
+      "row": 32
+    }
+  ]
+}
+```
+
+### Layers
+
+The graph has two layers:
+
+1. **Schema-level edges** (`schema_edges`): schema → mapping → schema → metric. This is the topology already built by `lineage.js:buildFullGraph()`, now exposed directly. Useful for high-level data flow diagrams and reachability queries.
+
+2. **Field-level edges** (`edges`): source_schema.field → target_schema.field via a mapping, with transform classification, pipeline steps, NL text (for `nl`/`mixed` arrows), and derived-field flags. This is built from the existing `fieldArrows` index and `arrowRecords` in the workspace index.
+
+### Output modes
+
+- `--json` (primary): Full graph as JSON. This is the agent interface.
+- Default (text): Human-readable summary — node counts, edge counts, and a compact adjacency list.
+- `--compact`: Just the schema_edges layer as a flat adjacency list (for quick topology checks).
+- `--dot`: Graphviz DOT format for visualisation. Schema-level only (field-level would be too dense). Optional / stretch goal.
+
+### Filters
+
+- `--schema-only`: Emit only schema_edges (no field-level edges). Smaller output for topology-only queries.
+- `--namespace <ns>`: Filter to nodes within a namespace (plus cross-namespace edges).
+- `--include-nl`: Include full NL text in edges (default: include). `--no-nl` to strip NL text and reduce size.
+
+### Implementation approach
+
+- Reuse the existing `buildIndex()` and `buildFullGraph()` infrastructure.
+- Add a new `graph.js` command module under `src/commands/`.
+- The field-level edge construction should reuse `buildFieldArrows` from `index-builder.js`, enriched with transform classification from the existing `arrowRecords` extraction.
+- The `unresolved_nl` section surfaces all NL-classified arrows for agent interpretation.
+- The `version` field allows future schema evolution without breaking consumers.
+
+### Relationship to existing commands
+
+- `stm lineage` remains the focused traversal tool (BFS/DFS from a starting node). `stm graph` is the full export.
+- `stm summary` gives counts and names. `stm graph --json` gives the full topology with edges and metadata.
+- `stm arrows` gives field-level arrows for a single field. `stm graph` gives all arrows across the workspace.
+
+## Acceptance Criteria
+
+### Core functionality
+- [ ] `stm graph [path]` command exists and is registered in the CLI
+- [ ] Default text output shows: node counts by kind, edge counts by classification, and a compact schema-level adjacency list
+- [ ] `--json` outputs the full graph structure matching the schema described above (version, stats, nodes, edges, schema_edges, warnings, unresolved_nl)
+- [ ] `--compact` outputs a minimal schema-level adjacency list (text format)
+- [ ] Output JSON has a `version: 1` field for future schema evolution
+
+### Nodes
+- [ ] All schemas, mappings, metrics, fragments, and transforms appear as nodes
+- [ ] Each node includes: id (namespace-qualified where applicable), kind, file, row
+- [ ] Schema nodes include fields array with name, type, and tags
+- [ ] Metric nodes include source schemas, grain, and slices
+- [ ] Mapping nodes include sources and targets arrays
+- [ ] Namespace-qualified names use the `ns::name` convention consistently
+
+### Edges (field-level)
+- [ ] Every arrow record in the workspace appears as a field-level edge
+- [ ] Each edge includes: from (schema.field or null for derived), to (schema.field), mapping name, classification (structural/nl/mixed/none), file, row
+- [ ] Structural arrows include a transforms array with pipeline step names
+- [ ] NL and mixed arrows include nl_text with the verbatim NL content
+- [ ] Derived arrows (no source) have `from: null` and `derived: true`
+
+### Schema-level edges
+- [ ] schema_edges captures the schema → mapping → schema → metric topology
+- [ ] Each schema_edge includes from, to, and role (source/target/metric_source)
+- [ ] NL backtick references that reference known schemas also appear as schema_edges (matching existing lineage.js behavior)
+
+### Filters
+- [ ] `--schema-only` omits field-level edges and field arrays on schema nodes
+- [ ] `--namespace <ns>` filters nodes to a namespace (plus cross-namespace edges)
+- [ ] `--no-nl` strips nl_text from edges (classification still present)
+
+### Infrastructure
+- [ ] Reuses existing buildIndex() and workspace parsing — no duplicate extraction logic
+- [ ] Extracts and reuses buildFullGraph logic (refactored from lineage.js if needed, to avoid duplication)
+- [ ] Handles workspaces with parse errors gracefully (errors counted in stats, valid content still exported)
+- [ ] Handles empty workspaces (no .stm files) with a meaningful empty graph (zero counts, empty arrays)
+
+### Testing
+- [ ] Unit tests for graph construction from a known fixture workspace
+- [ ] Test: nodes include all entity kinds (schema, mapping, metric, fragment, transform)
+- [ ] Test: field-level edges match expected arrows with correct classification
+- [ ] Test: schema-level edges match expected topology
+- [ ] Test: --schema-only omits field-level data
+- [ ] Test: --namespace filters correctly (includes cross-namespace edges)
+- [ ] Test: --no-nl strips NL text but preserves classification
+- [ ] Test: derived arrows have from=null and derived=true
+- [ ] Test: namespace-qualified names are correct in nodes and edges
+- [ ] Test: empty workspace produces valid empty graph JSON
+- [ ] Test: workspace with parse errors still produces partial graph with error count
+- [ ] Integration test: runs against examples/ directory and produces valid graph
+
+### Documentation
+- [ ] STM-CLI.md updated with graph command entry in the command table
+- [ ] AI-AGENT-REFERENCE.md updated: graph command in the command reference, and a new workflow example showing single-load reasoning
+

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -106,6 +106,8 @@ mapping <name> (<metadata>) {
 
   Transforms (combine with | inside { }):
     trim, lowercase, uppercase, title_case, null_if_empty, null_if_invalid
+    drop_if_invalid, drop_if_null, warn_if_invalid, warn_if_null
+    error_if_invalid, error_if_null
     coalesce(val), round(n), truncate(n), max_length(n)
     prepend("x"), append("x"), split("x") | first | last
     validate_email, to_e164, to_iso8601, to_utc, now_utc()
@@ -247,7 +249,7 @@ When reporting results to humans, be transparent about which parts of your analy
 3. Define `schema` blocks with all fields, types, and metadata
 4. Add `fragment` blocks if you have reusable field sets
 5. Write the `mapping { }` block with source/target refs and all arrows
-6. Use `"natural language"` in `{ }` for any transform you can't express as a pipeline
+6. Use `"natural language"` in `{ }` for any transform you can't express as a pipeline — backtick any field or schema names referenced inside the NL string (e.g. `` "Sum `amount` grouped by `customer_id`" ``)
 7. Add `//!` warnings for known data quality issues
 8. Add `//?` for any open questions or ambiguities
 9. Add `(note "...")` metadata for persistent field-level documentation
@@ -284,6 +286,7 @@ When reporting results to humans, be transparent about which parts of your analy
 | Using `schema` for a business metric | Use `metric` — it signals a terminal node to lineage tooling |
 | Using a `metric` as a mapping source or target | Metrics are consumers only; reference the underlying `schema` instead |
 | Summing a `non_additive` measure across dimensions | Use weighted average or re-aggregate from grain; only `additive` measures can be summed |
+| Writing field names bare in NL strings | Backtick field/schema references inside `"..."` strings — e.g. `"Sum \`order_total\` grouped by \`customer_id\`"`. This enables deterministic extraction by tooling. |
 
 ---
 

--- a/STM-V2-SPEC.md
+++ b/STM-V2-SPEC.md
@@ -654,6 +654,12 @@ Vocabulary tokens are **not keywords** — they are interpreted by the LLM based
 | `parse(fmt)` | Parse string with format |
 | `null_if_empty` | Convert empty string to null |
 | `null_if_invalid` | Convert invalid value to null |
+| `drop_if_invalid` | Drop the record if value is invalid |
+| `drop_if_null` | Drop the record if value is null |
+| `warn_if_invalid` | Log a warning if value is invalid |
+| `warn_if_null` | Log a warning if value is null |
+| `error_if_invalid` | Fail the pipeline if value is invalid |
+| `error_if_null` | Fail the pipeline if value is null |
 | `validate_email` | Validate email format |
 | `now_utc()` | Current UTC timestamp |
 | `title_case` | Convert to title case |
@@ -662,6 +668,23 @@ Vocabulary tokens are **not keywords** — they are interpreted by the LLM based
 | `to_number` | Convert to numeric type |
 | `prepend(str)` | Prefix a string |
 | `max_length(n)` | Enforce maximum length |
+
+#### Error-handling convention
+
+The `null_if_*`, `drop_if_*`, `warn_if_*`, and `error_if_*` tokens follow a consistent `<action>_if_<condition>` pattern for expressing fallback and error-handling intent in pipelines:
+
+- **`null_if_*`** — replace the value with null (record survives).
+- **`drop_if_*`** — discard the entire record.
+- **`warn_if_*`** — log a warning and pass the value through.
+- **`error_if_*`** — halt the pipeline (fail loudly).
+
+These are vocabulary tokens, not reserved keywords. Implementations decide what "log a warning" or "halt" means concretely. Common conditions include `null`, `invalid`, and `empty`, but the pattern is open — e.g. `drop_if_duplicate` or `warn_if_stale` are valid by convention.
+
+```
+EMAIL_ADDR -> email { trim | lowercase | validate_email | drop_if_invalid }
+TAX_ID -> tax_id { error_if_null }
+PHONE_NBR -> phone { "Parse as E.164" | warn_if_invalid }
+```
 
 ### 7.3 Domain Tokens
 

--- a/examples/db-to-db.stm
+++ b/examples/db-to-db.stm
@@ -115,8 +115,8 @@ mapping 'customer migration' {
 
   // --- Name Handling ---
   -> display_name {
-    "If CUST_TYPE is null or 'R', trim and concat FIRST_NM + ' ' + LAST_NM.
-     Otherwise, trim COMPANY_NM."
+    "If `CUST_TYPE` is null or 'R', trim and concat `FIRST_NM` + ' ' + `LAST_NM`.
+     Otherwise, trim `COMPANY_NM`."
   }
 
   FIRST_NM   -> first_name    { trim | title_case | null_if_empty }
@@ -129,14 +129,14 @@ mapping 'customer migration' {
   PHONE_NBR -> phone {
     "Extract all digits. If 11 digits starting with 1, treat as US.
      If 10 digits, assume US country code +1. Format as E.164.
-     For other patterns, attempt to determine country from COUNTRY_CD.
-     If unparseable, set null and log warning with original value."
+     For other patterns, attempt to determine country from `COUNTRY_CD`."
+    | warn_if_invalid
   }
 
   // --- Address (FK to separate table) ---
   -> address_id {
-    "Create a record in the addresses table using ADDR_LINE_1, ADDR_LINE_2,
-     CITY, STATE_PROV, ZIP_POSTAL, COUNTRY_CD. Normalize STATE_PROV to
+    "Create a record in the addresses table using `ADDR_LINE_1`, `ADDR_LINE_2`,
+     `CITY`, `STATE_PROV`, `ZIP_POSTAL`, `COUNTRY_CD`. Normalize `STATE_PROV` to
      2-char code (handle full names). Deduplicate against existing addresses
      by normalized street + zip. Return the UUID of the new or existing record."
   }
@@ -150,7 +150,7 @@ mapping 'customer migration' {
   }
 
   // --- Dates ---
-  CREATED_DATE -> created_at { parse("MM/DD/YYYY") | assume_utc | to_iso8601 }
+  CREATED_DATE -> created_at { parse("MM/DD/YYYY") | drop_if_invalid | assume_utc | to_iso8601 }
 
   LAST_MOD_DATE -> updated_at {
     parse("MM/DD/YYYY hh:mm:ss a") | to_utc | to_iso8601
@@ -158,7 +158,7 @@ mapping 'customer migration' {
   }
 
   // --- Security ---
-  TAX_ID -> tax_identifier_encrypted { encrypt(AES-256-GCM, secrets.tax_encryption_key) }
+  TAX_ID -> tax_identifier_encrypted { error_if_null | encrypt(AES-256-GCM, secrets.tax_encryption_key) }
 
   // --- Calculated ---
   LOYALTY_POINTS -> loyalty_tier {

--- a/examples/edi-to-json.stm
+++ b/examples/edi-to-json.stm
@@ -117,14 +117,14 @@ mapping 'edi to mfcs' {
   BeginningOfMessage.DOCNUM -> ShipmentHeader.asnNo { trim | max_length(30) }
 
   DateTime.DATETIME -> ShipmentHeader.shipDate {
-    "Parse using sibling field DATEFMT: if 102 parse as CCYYMMDD,
+    "Parse using sibling field `DATEFMT`: if 102 parse as CCYYMMDD,
      if 203 parse as CCYYMMDDHHMM. Output format: YYYY-MM-DD."
   }
 
   -> ShipmentHeader.asnType { "0" }    // default: ASN Shipment
 
   POReferences[].REFNUM -> ShipmentHeader.toLocation {
-    "Extract PO number from REFNUM (digits before '/').
+    "Extract PO number from `REFNUM` (digits before '/').
      Look up the PO in MFCS to determine the delivery location."
   }
 

--- a/examples/metrics.stm
+++ b/examples/metrics.stm
@@ -88,7 +88,7 @@ metric conversion_rate (
   value  DECIMAL(5,4)  (measure non_additive)  // wins / total by stage
 
   note {
-    "Opportunities closed_won divided by total opportunities entering that stage."
+    "Opportunities `closed_won` divided by total opportunities entering that stage."
   }
 }
 
@@ -100,7 +100,7 @@ metric pipeline_value "ARR Pipeline" (
 ) {
   arr_value           DECIMAL(18,2)  (measure additive)
   weighted_arr_value  DECIMAL(18,2)  (measure additive,
-    note "arr_value * probability — use for forecast roll-ups")
+    note "`arr_value` * `probability` — use for forecast roll-ups")
 
   note {
     "Open pipeline as of the snapshot date, expressed in ARR."

--- a/examples/multi-source-hub.stm
+++ b/examples/multi-source-hub.stm
@@ -97,11 +97,11 @@ mapping 'crm to notifications' {
   phone -> recipient_phone
 
   -> message_type {
-    "Set to 'loyalty_update' if loyalty_points > 1000, otherwise null."
+    "Set to 'loyalty_update' if `loyalty_points` > 1000, otherwise null."
   }
 
   -> priority {
-    "Check payment_gateway: if any transaction has status = 'failed' for
+    "Check `payment_gateway`: if any transaction has `status` = 'failed' for
      this customer, set 'high'. Otherwise 'low'."
   }
 }
@@ -113,7 +113,7 @@ mapping 'payments to notifications' {
   customer_email -> recipient_email
 
   transaction_id -> message_body {
-    "Format as 'Transaction {transaction_id} completed successfully.'"
+    "Format as 'Transaction {`transaction_id`} completed successfully.'"
   }
 }
 
@@ -126,6 +126,6 @@ mapping 'inventory to reporting' {
   warehouse_location -> location
 
   -> reorder_needed {
-    "True if stock_level < 10, false otherwise."
+    "True if `stock_level` < 10, false otherwise."
   }
 }

--- a/examples/multi-source-join.stm
+++ b/examples/multi-source-join.stm
@@ -127,8 +127,8 @@ mapping 'customer 360' {
     `crm_customers`       (filter "email NOT LIKE '%@test.internal'")
     `order_transactions`   (filter "status IN ('completed', 'refunded')")
     `support_tickets`      (filter "created_at >= date_sub(now(), interval 12 month)")
-    "Join crm_customers to order_transactions on crm_customers.customer_id = order_transactions.customer_id (left join — customers may have no orders).
-     Join crm_customers to support_tickets on crm_customers.customer_id = cast(support_tickets.customer_id as UUID) (left join — customers may have no tickets)."
+    "Join `crm_customers` to `order_transactions` on `crm_customers.customer_id` = `order_transactions.customer_id` (left join — customers may have no orders).
+     Join `crm_customers` to `support_tickets` on `crm_customers.customer_id` = cast(`support_tickets.customer_id` as UUID) (left join — customers may have no tickets)."
   }
   target { `customer_360` }
 
@@ -143,8 +143,8 @@ mapping 'customer 360' {
   crm_customers.email -> email { trim | lowercase }
 
   -> full_name {
-    "Concat crm_customers.first_name + ' ' + crm_customers.last_name.
-     Trim whitespace. If both are null, use company_name instead."
+    "Concat `crm_customers.first_name` + ' ' + `crm_customers.last_name`.
+     Trim whitespace. If both are null, use `company_name` instead."
   }
 
   crm_customers.company_name -> company_name { trim | null_if_empty }
@@ -155,68 +155,68 @@ mapping 'customer 360' {
   crm_customers.is_active -> is_active
 
   -> tenure_months {
-    "Calculate months between crm_customers.signup_date and current_date.
+    "Calculate months between `crm_customers.signup_date` and current_date.
      Round down to nearest whole month."
   }
 
   // --- Order metrics (aggregated from order_transactions) ---
   -> total_orders {
-    "Count of order_transactions where status = 'completed'."
+    "Count of `order_transactions` where `status` = 'completed'."
   }
 
   -> total_revenue {
-    "Sum order_transactions.total where status = 'completed'."
+    "Sum `order_transactions.total` where `status` = 'completed'."
     | coalesce(0) | round(2)
   }
 
   -> total_refunds {
-    "Sum abs(order_transactions.total) where status = 'refunded'."
+    "Sum abs(`order_transactions.total`) where `status` = 'refunded'."
     | coalesce(0) | round(2)
   }
 
   -> net_revenue {
-    "total_revenue minus total_refunds."
+    "`total_revenue` minus `total_refunds`."
     | round(2)
   }
 
   -> avg_order_value {
-    "total_revenue divided by total_orders. Null if total_orders = 0."
+    "`total_revenue` divided by `total_orders`. Null if `total_orders` = 0."
     | round(2)
   }
 
   -> first_order_date {
-    "Min order_transactions.order_date where status = 'completed'."
+    "Min `order_transactions.order_date` where `status` = 'completed'."
   }
 
   -> last_order_date {
-    "Max order_transactions.order_date where status = 'completed'."
+    "Max `order_transactions.order_date` where `status` = 'completed'."
   }
 
   -> preferred_channel {
-    "Mode of order_transactions.channel where status = 'completed'.
+    "Mode of `order_transactions.channel` where `status` = 'completed'.
      If tied, prefer in order: web > mobile > api > pos.
      Null if no orders."
   }
 
   -> distinct_coupon_count {
-    "Count distinct non-null order_transactions.coupon_code."
+    "Count distinct non-null `order_transactions.coupon_code`."
     | coalesce(0)
   }
 
   // --- Support metrics (aggregated from support_tickets) ---
   -> tickets_last_12m {
-    "Count of support_tickets (already filtered to last 12 months)."
+    "Count of `support_tickets` (already filtered to last 12 months)."
     | coalesce(0)
   }
 
   -> open_tickets {
-    "Count of support_tickets where status IN ('open', 'in_progress')."
+    "Count of `support_tickets` where `status` IN ('open', 'in_progress')."
     | coalesce(0)
   }
 
   -> avg_resolution_hours {
-    "Average hours between support_tickets.created_at and resolved_at
-     where resolved_at is not null. Null if no resolved tickets."
+    "Average hours between `support_tickets.created_at` and `resolved_at`
+     where `resolved_at` is not null. Null if no resolved tickets."
     | round(1)
   }
 

--- a/examples/ns-merging.stm
+++ b/examples/ns-merging.stm
@@ -87,7 +87,7 @@ namespace staging (note "Cleaned and conformed staging area") {
 
   // Map GL entries — joins to employees across merged namespace
   mapping 'stage gl entries' {
-    source { `source::finance_gl` }
+    source { `source::finance_gl`, `source::hr_employees` }
     target { `stg_gl_entries` }
 
     gl_entry_id -> gl_hk        { hash_key }
@@ -97,11 +97,11 @@ namespace staging (note "Cleaned and conformed staging area") {
     amount      -> amount
 
     -> department {
-      "Lookup department from source::hr_employees using posted_by -> employee_id"
+      "Lookup `department` from `source::hr_employees` using `posted_by` -> `employee_id`"
     }
 
     -> employee_name {
-      "Lookup full_name from source::hr_employees using posted_by -> employee_id"
+      "Lookup `full_name` from `source::hr_employees` using `posted_by` -> `employee_id`"
     }
   }
 }
@@ -119,33 +119,33 @@ namespace reporting (note "Executive reporting layer") {
   }
 
   mapping 'build budget vs actual' {
-    source { `staging::stg_gl_entries` }
+    source { `staging::stg_gl_entries`, `source::finance_budgets`, `staging::stg_employees` }
     target { `dept_budget_vs_actual` }
 
     department -> department
 
     -> fiscal_year {
-      "Extract year from entry_date"
+      "Extract year from `entry_date`"
     }
 
     -> budget_amount {
-      "Lookup from source::finance_budgets matching department and fiscal year"
+      "Lookup from `source::finance_budgets` matching `department` and `fiscal_year`"
     }
 
     amount -> actual_spend {
-      "Sum of amount grouped by department and fiscal year"
+      "Sum of `amount` grouped by `department` and `fiscal_year`"
     }
 
     -> variance {
-      "budget_amount minus actual_spend"
+      "`budget_amount` minus `actual_spend`"
     }
 
     -> variance_pct {
-      "variance divided by budget_amount times 100"
+      "`variance` divided by `budget_amount` times 100"
     }
 
     -> headcount {
-      "Count distinct employees from staging::stg_employees for this department"
+      "Count distinct employees from `staging::stg_employees` for this `department`"
     }
   }
 

--- a/examples/ns-platform.stm
+++ b/examples/ns-platform.stm
@@ -132,7 +132,7 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     company_name -> company_name { trim }
 
     -> hash_diff {
-      "MD5 hash of first_name, last_name, email, phone, company_name for change detection"
+      "MD5 hash of `first_name`, `last_name`, `email`, `phone`, `company_name` for change detection"
     }
   }
 
@@ -151,7 +151,7 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     target { `link_contact_deal` }
 
     -> link_hk {
-      "MD5 hash of contact_id + deal_id"
+      "MD5 hash of `contact_id` + `deal_id`"
     }
     contact_id -> contact_hk  { dv_hash_key }
     deal_id    -> deal_hk     { dv_hash_key }
@@ -205,15 +205,15 @@ namespace mart (note "Business-facing dimensional models") {
     }
 
     -> full_name {
-      "Concatenate first_name and last_name from vault::sat_contact_details"
+      "Concatenate `first_name` and `last_name` from `vault::sat_contact_details`"
     }
 
     -> email {
-      "Latest email from vault::sat_contact_details satellite"
+      "Latest `email` from `vault::sat_contact_details` satellite"
     }
 
     -> company {
-      "Latest company_name from vault::sat_contact_details satellite"
+      "Latest `company_name` from `vault::sat_contact_details` satellite"
     }
   }
 
@@ -227,11 +227,11 @@ namespace mart (note "Business-facing dimensional models") {
     }
 
     -> contact_sk {
-      "Lookup via vault::link_contact_deal -> vault::hub_contact -> dim_contact"
+      "Lookup via `vault::link_contact_deal` -> `vault::hub_contact` -> `dim_contact`"
     }
 
     -> deal_name {
-      "From sat_deal if it existed — placeholder for future satellite"
+      "From `sat_deal` if it existed — placeholder for future satellite"
     }
 
     -> amount_usd {
@@ -239,7 +239,7 @@ namespace mart (note "Business-facing dimensional models") {
     }
 
     -> is_won {
-      "True if stage = 'closed_won'"
+      "True if `stage` = 'closed_won'"
     }
 
     -> days_in_pipeline {
@@ -257,7 +257,7 @@ namespace mart (note "Business-facing dimensional models") {
     }
 
     -> contact_sk {
-      "Join erp_invoices.customer_code to CRM contact via lookup table"
+      "Join `erp_invoices.customer_code` to CRM contact via lookup table"
     }
 
     invoice_id   -> invoice_id

--- a/examples/protobuf-to-parquet.stm
+++ b/examples/protobuf-to-parquet.stm
@@ -101,19 +101,19 @@ mapping 'session aggregation' (group_by session_id, on_error log, error_threshol
   -> event_count { count }
 
   event_type -> distinct_event_types {
-    distinct | "Emit the distinct event_type values as a JSON array string."
+    distinct | "Emit the distinct `event_type` values as a JSON array string."
   }
 
   -> viewed_product_count {
-    "Count records in the group where event_type == 'product_view'."
+    "Count records in the group where `event_type` == 'product_view'."
   }
 
   -> cart_add_count {
-    "Count records in the group where event_type == 'add_to_cart'."
+    "Count records in the group where `event_type` == 'add_to_cart'."
   }
 
   -> purchase_event_count {
-    "Count records in the group where event_type == 'purchase'."
+    "Count records in the group where `event_type` == 'purchase'."
   }
 
   event_type -> checkout_completed {
@@ -121,16 +121,16 @@ mapping 'session aggregation' (group_by session_id, on_error log, error_threshol
   }
 
   CartLines[].unit_price -> gross_merchandise_value {
-    "For each event, multiply CartLines[].unit_price by CartLines[].quantity,
+    "For each event, multiply `CartLines[].unit_price` by `CartLines[].quantity`,
      sum within the event, then sum across the session group."
   }
 
   CartLines[].discount_amt -> total_discount_amount {
-    "Sum discount_amt across all CartLines[] elements in all events in the group."
+    "Sum `discount_amt` across all `CartLines[]` elements in all events in the group."
   }
 
   -> distinct_product_count {
-    "Count distinct CartLines[].sku values across all events in the session."
+    "Count distinct `CartLines[].sku` values across all events in the session."
   }
 
   -> top_category {

--- a/examples/sap-po-to-mfcs.stm
+++ b/examples/sap-po-to-mfcs.stm
@@ -136,7 +136,7 @@ mapping 'sap po to mfcs' {
 
   Items[].EINDT -> notBeforeDate {
     "Take the earliest non-null requested delivery date across all lines.
-     If all line dates are null, fall back to BEDAT."
+     If all line dates are null, fall back to `BEDAT`."
   }
 
   HeaderText -> comments {
@@ -159,13 +159,13 @@ mapping 'sap po to mfcs' {
     }
 
     .MENGE -> .orderedQty {
-      "If MEINS represents supplier packs or cases, convert to the target
+      "If `MEINS` represents supplier packs or cases, convert to the target
        stocking quantity using the MFCS supplier-item pack configuration.
        Otherwise preserve the numeric quantity. Round to 4 decimal places."
     }
 
     .NETPR -> .unitCost {
-      "If PEINH is greater than 1, divide NETPR by PEINH to derive the
+      "If `PEINH` is greater than 1, divide `NETPR` by `PEINH` to derive the
        per-unit cost in document currency. Round to 4 decimal places."
     }
 

--- a/examples/sfdc_to_snowflake.stm
+++ b/examples/sfdc_to_snowflake.stm
@@ -78,7 +78,7 @@ mapping 'opportunity ingestion' {
   }
 
   `ARR_Override__c` -> arr_value {
-    "Use ARR_Override__c if not null, otherwise fall back to Amount"
+    "Use `ARR_Override__c` if not null, otherwise fall back to `Amount`"
     | coalesce(0)
   }
 

--- a/examples/xml-to-parquet.stm
+++ b/examples/xml-to-parquet.stm
@@ -137,17 +137,17 @@ mapping 'order headers' {
   Order.Totals.TotalAmount -> total_amount
 
   -> discount_codes {
-    "Collect DiscountCode values from Order.Discounts[] preserving source order.
+    "Collect `DiscountCode` values from `Order.Discounts[]` preserving source order.
      Emit as a JSON array string. If no discounts, emit []."
   }
 
   -> discount_total {
-    "Sum DiscountAmount across Order.Discounts[] for the current order.
+    "Sum `DiscountAmount` across `Order.Discounts[]` for the current order.
      If no discounts, emit 0.00."
   }
 
   -> line_count {
-    "Count Order.LineItems[] elements for the current order."
+    "Count `Order.LineItems[]` elements for the current order."
   }
 
   -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }

--- a/features/06-data-modelling-with-stm/example_datavault/hub-product.stm
+++ b/features/06-data-modelling-with-stm/example_datavault/hub-product.stm
@@ -108,9 +108,9 @@ mapping 'sap to sat_product_attributes' {
 
   MAKTX -> product_name               { trim | title_case }
 
-  MATKL -> department    { "Look up department from `product_hierarchy` using MATKL" }
-  MATKL -> category      { "Look up category from `product_hierarchy` using MATKL" }
-  MATKL -> subcategory   { "Look up subcategory from `product_hierarchy` using MATKL" }
+  MATKL -> department    { "Look up department from `product_hierarchy` using `MATKL`" }
+  MATKL -> category      { "Look up category from `product_hierarchy` using `MATKL`" }
+  MATKL -> subcategory   { "Look up subcategory from `product_hierarchy` using `MATKL`" }
 
   BRAND -> brand                       { trim | title_case }
   SUPPLIER_ID -> supplier_id

--- a/features/06-data-modelling-with-stm/example_datavault/hub-store.stm
+++ b/features/06-data-modelling-with-stm/example_datavault/hub-store.stm
@@ -107,8 +107,8 @@ mapping 'pos to sat_store_details' {
   OPEN_DATE -> opened_date
 
   // Region enrichment from lookup
-  STORE_ID -> region     { "Look up region from `store_region_map` using STORE_ID" }
-  STORE_ID -> timezone   { "Look up timezone from `store_region_map` using STORE_ID" }
+  STORE_ID -> region     { "Look up region from `store_region_map` using `STORE_ID`" }
+  STORE_ID -> timezone   { "Look up timezone from `store_region_map` using `STORE_ID`" }
 
   STATUS -> status {
     map { A: "active", T: "temporarily_closed", C: "closed" }

--- a/features/06-data-modelling-with-stm/example_datavault/link-inventory.stm
+++ b/features/06-data-modelling-with-stm/example_datavault/link-inventory.stm
@@ -133,19 +133,19 @@ mapping 'wms to sat_inventory_levels' {
   QTY_IN_TRANSIT -> quantity_in_transit { coalesce(0) }
 
   -> quantity_available {
-    "QTY_ON_HAND - QTY_RESERVED. Floor at zero."
+    "`QTY_ON_HAND` - `QTY_RESERVED`. Floor at zero."
   }
 
   -> inventory_value {
-    "QTY_ON_HAND * UNIT_COST. Null if UNIT_COST is null."
+    "`QTY_ON_HAND` * `UNIT_COST`. Null if `UNIT_COST` is null."
   }
 
   -> days_since_count {
-    "DATEDIFF(days, LAST_COUNT_DATE, SNAPSHOT_TS). Null if never counted."
+    "DATEDIFF(days, `LAST_COUNT_DATE`, `SNAPSHOT_TS`). Null if never counted."
   }
 
   -> is_below_reorder {
-    "True if QTY_ON_HAND < REORDER_POINT, false otherwise."
+    "True if `QTY_ON_HAND` < `REORDER_POINT`, false otherwise."
   }
 
   REORDER_QTY -> reorder_quantity

--- a/features/06-data-modelling-with-stm/example_datavault/link-sale.stm
+++ b/features/06-data-modelling-with-stm/example_datavault/link-sale.stm
@@ -153,10 +153,10 @@ mapping 'pos to sat_sale_detail' {
 
   QTY -> quantity
   UNIT_PRICE -> unit_price
-  -> gross_amount { "QTY * UNIT_PRICE" }
+  -> gross_amount { "`QTY` * `UNIT_PRICE`" }
   DISCOUNT_AMT -> discount_amount      { coalesce(0) }
   TAX_AMT -> tax_amount                { coalesce(0) }
-  -> net_amount { "gross_amount - discount_amount + tax_amount" }
+  -> net_amount { "`gross_amount` - `discount_amount` + `tax_amount`" }
 
   -> record_source { "POS" }
 }
@@ -175,10 +175,10 @@ mapping 'shopify to sat_sale_detail' {
   unit_price -> unit_price {
     "Convert from order currency to USD using daily spot rate"
   }
-  -> gross_amount { "quantity * unit_price (after currency conversion)" }
+  -> gross_amount { "`quantity` * `unit_price` (after currency conversion)" }
   discount_amount -> discount_amount   { coalesce(0) }
   tax_amount -> tax_amount             { coalesce(0) }
-  -> net_amount { "gross_amount - discount_amount + tax_amount" }
+  -> net_amount { "`gross_amount` - `discount_amount` + `tax_amount`" }
 
   -> record_source { "SHOPIFY" }
 }

--- a/features/06-data-modelling-with-stm/example_datavault/mart-customer-360.stm
+++ b/features/06-data-modelling-with-stm/example_datavault/mart-customer-360.stm
@@ -106,7 +106,7 @@ mapping 'demographics to mart' {
 
   first_name -> first_name
   last_name -> last_name
-  -> full_name { "Trim and concat first_name + ' ' + last_name, title case" }
+  -> full_name { "Trim and concat `first_name` + ' ' + `last_name`, title case" }
 
   email -> email
   phone -> phone
@@ -145,7 +145,7 @@ mapping 'online to mart' {
   }
 
   -> has_online_account {
-    "True if sat_customer_online.hub_customer_hk is not null, false otherwise."
+    "True if `sat_customer_online.hub_customer_hk` is not null, false otherwise."
   }
 
   lifetime_order_count -> online_order_count   { coalesce(0) }
@@ -153,7 +153,7 @@ mapping 'online to mart' {
   last_order_at -> last_online_order_at
 
   -> online_account_age_days {
-    "DATEDIFF(days, account_created_at, CURRENT_DATE). Null if no online account."
+    "DATEDIFF(days, `account_created_at`, CURRENT_DATE). Null if no online account."
   }
 }
 
@@ -168,14 +168,14 @@ mapping 'derived segments' {
   }
 
   -> customer_segment {
-    "Assign 'vip' if loyalty_tier is 'diamond' and online lifetime spend > 10000.
-     Assign 'high_value' if loyalty_tier is gold, platinum, or diamond.
-     Assign 'growth' if loyalty_tier is silver.
+    "Assign 'vip' if `loyalty_tier` is 'diamond' and online lifetime spend > 10000.
+     Assign 'high_value' if `loyalty_tier` is gold, platinum, or diamond.
+     Assign 'growth' if `loyalty_tier` is silver.
      Otherwise assign 'standard'."
   }
 
   -> is_omnichannel {
-    "True if preferred_store_id is not null and online order count > 0,
+    "True if `preferred_store_id` is not null and online order count > 0,
      false otherwise."
   }
 }

--- a/features/06-data-modelling-with-stm/example_kimball/dim-customer.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/dim-customer.stm
@@ -114,7 +114,7 @@ mapping 'sfdc to dim_customer' {
 
   FirstName -> first_name              { trim | title_case }
   LastName -> last_name                { trim | title_case }
-  -> full_name { "Trim and concat FirstName + ' ' + LastName, title case" }
+  -> full_name { "Trim and concat `FirstName` + ' ' + `LastName`, title case" }
 
   Email -> email                       { trim | lowercase | validate_email | null_if_invalid }
   Phone -> phone                       { trim | to_e164 }
@@ -144,9 +144,9 @@ mapping 'sfdc to dim_customer' {
 
   // Derived
   -> customer_segment {
-    "Assign 'vip' if LoyaltyTier is Diamond and ecom_shopify.total_spent > 10000.
-     Assign 'high_value' if LoyaltyTier is Gold, Platinum, or Diamond.
-     Assign 'growth' if LoyaltyTier is Silver.
+    "Assign 'vip' if `LoyaltyTier` is Diamond and `ecom_shopify.total_spent` > 10000.
+     Assign 'high_value' if `LoyaltyTier` is Gold, Platinum, or Diamond.
+     Assign 'growth' if `LoyaltyTier` is Silver.
      Otherwise assign 'standard'."
   }
 }

--- a/features/06-data-modelling-with-stm/example_kimball/dim-product.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/dim-product.stm
@@ -75,9 +75,9 @@ mapping 'sap to dim_product' {
   MAKTX -> product_name                { trim | title_case }
 
   // Hierarchy resolved via lookup
-  MATKL -> department    { "Look up department from `product_hierarchy` using MATKL" }
-  MATKL -> category      { "Look up category from `product_hierarchy` using MATKL" }
-  MATKL -> subcategory   { "Look up subcategory from `product_hierarchy` using MATKL" }
+  MATKL -> department    { "Look up department from `product_hierarchy` using `MATKL`" }
+  MATKL -> category      { "Look up category from `product_hierarchy` using `MATKL`" }
+  MATKL -> subcategory   { "Look up subcategory from `product_hierarchy` using `MATKL`" }
 
   BRAND -> brand                       { trim | title_case }
   SUPPLIER_NAME -> supplier_name       { trim }

--- a/features/06-data-modelling-with-stm/example_kimball/dim-store.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/dim-store.stm
@@ -92,13 +92,13 @@ mapping 'pos to dim_store' {
   OPEN_DATE -> opened_date
 
   // Region enrichment from lookup
-  STORE_ID -> region     { "Look up region from `store_region_map` using STORE_ID" }
-  STORE_ID -> country    { "Look up country from `store_region_map` using STORE_ID" }
-  STORE_ID -> timezone   { "Look up timezone from `store_region_map` using STORE_ID" }
+  STORE_ID -> region     { "Look up region from `store_region_map` using `STORE_ID`" }
+  STORE_ID -> country    { "Look up country from `store_region_map` using `STORE_ID`" }
+  STORE_ID -> timezone   { "Look up timezone from `store_region_map` using `STORE_ID`" }
 
   STATUS -> status {
     map { A: "active", T: "temporarily_closed", C: "closed" }
   }
 
-  -> is_active { "True if STATUS is 'A', false otherwise" }
+  -> is_active { "True if `STATUS` is 'A', false otherwise" }
 }

--- a/features/06-data-modelling-with-stm/example_kimball/fact-inventory.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/fact-inventory.stm
@@ -94,19 +94,19 @@ mapping 'wms to fact_inventory_snapshot' {
   //! QTY_AVAILABLE in source is sometimes stale (calculated async).
   //  We recalculate it here for consistency.
   -> quantity_available {
-    "QTY_ON_HAND - QTY_RESERVED. Floor at zero."
+    "`QTY_ON_HAND` - `QTY_RESERVED`. Floor at zero."
   }
 
   -> inventory_value {
-    "QTY_ON_HAND * UNIT_COST. Null if UNIT_COST is null."
+    "`QTY_ON_HAND` * `UNIT_COST`. Null if `UNIT_COST` is null."
   }
 
   -> days_since_count {
-    "DATEDIFF(days, LAST_COUNT_DATE, SNAPSHOT_TS). Null if never counted."
+    "DATEDIFF(days, `LAST_COUNT_DATE`, `SNAPSHOT_TS`). Null if never counted."
   }
 
   -> is_below_reorder {
-    "True if QTY_ON_HAND < REORDER_POINT, false otherwise."
+    "True if `QTY_ON_HAND` < `REORDER_POINT`, false otherwise."
   }
 
   REORDER_QTY -> reorder_quantity

--- a/features/06-data-modelling-with-stm/example_kimball/fact-sales.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/fact-sales.stm
@@ -130,10 +130,10 @@ mapping 'pos to fact_sales' {
 
   QTY -> quantity
   UNIT_PRICE -> unit_price
-  -> gross_amount { "QTY * UNIT_PRICE" }
+  -> gross_amount { "`QTY` * `UNIT_PRICE`" }
   DISCOUNT_AMT -> discount_amount      { coalesce(0) }
   TAX_AMT -> tax_amount                { coalesce(0) }
-  -> net_amount { "gross_amount - discount_amount + tax_amount" }
+  -> net_amount { "`gross_amount` - `discount_amount` + `tax_amount`" }
 }
 
 // Online sales from Shopify
@@ -155,7 +155,7 @@ mapping 'shopify to fact_sales' {
   -> transaction_time { null }         // Not available from Shopify
 
   customer_id -> customer_id {
-    "Match Shopify customer_id to SFDC ContactId via email address.
+    "Match Shopify `customer_id` to SFDC ContactId via email address.
      Null if no match found."
   }
 
@@ -168,8 +168,8 @@ mapping 'shopify to fact_sales' {
   unit_price -> unit_price {
     "Convert from order currency to USD using daily spot rate"
   }
-  -> gross_amount { "quantity * unit_price (after currency conversion)" }
+  -> gross_amount { "`quantity` * `unit_price` (after currency conversion)" }
   discount_amount -> discount_amount   { coalesce(0) }
   tax_amount -> tax_amount             { coalesce(0) }
-  -> net_amount { "gross_amount - discount_amount + tax_amount" }
+  -> net_amount { "`gross_amount` - `discount_amount` + `tax_amount`" }
 }

--- a/features/06-data-modelling-with-stm/example_kimball/mart-customer-360.stm
+++ b/features/06-data-modelling-with-stm/example_kimball/mart-customer-360.stm
@@ -129,33 +129,33 @@ mapping 'fact to mart' {
   target { `mart_customer_360` }
 
   note {
-    "Aggregated from fact_sales grouped by customer_id.
-     Only non-anonymous transactions (customer_id IS NOT NULL)."
+    "Aggregated from `fact_sales` grouped by `customer_id`.
+     Only non-anonymous transactions (`customer_id` IS NOT NULL)."
   }
 
   -> total_in_store_orders {
-    "COUNT(*) WHERE channel = 'in_store', grouped by customer_id"
+    "COUNT(*) WHERE `channel` = 'in_store', grouped by `customer_id`"
   }
   -> total_online_orders {
-    "COUNT(*) WHERE channel = 'online', grouped by customer_id"
+    "COUNT(*) WHERE `channel` = 'online', grouped by `customer_id`"
   }
   -> in_store_revenue {
-    "SUM(net_amount) WHERE channel = 'in_store', grouped by customer_id"
+    "SUM(`net_amount`) WHERE `channel` = 'in_store', grouped by `customer_id`"
   }
   -> online_revenue {
-    "SUM(net_amount) WHERE channel = 'online', grouped by customer_id"
+    "SUM(`net_amount`) WHERE `channel` = 'online', grouped by `customer_id`"
   }
   -> first_purchase_date {
-    "MIN(transaction_date) grouped by customer_id"
+    "MIN(`transaction_date`) grouped by `customer_id`"
   }
   -> last_purchase_date {
-    "MAX(transaction_date) grouped by customer_id"
+    "MAX(`transaction_date`) grouped by `customer_id`"
   }
   -> days_since_last_purchase {
-    "DATEDIFF(days, MAX(transaction_date), CURRENT_DATE)"
+    "DATEDIFF(days, MAX(`transaction_date`), CURRENT_DATE)"
   }
   -> avg_order_value {
-    "SUM(net_amount) / COUNT(DISTINCT transaction_id), grouped by customer_id"
+    "SUM(`net_amount`) / COUNT(DISTINCT `transaction_id`), grouped by `customer_id`"
   }
 
   // Derived from aggregates
@@ -166,9 +166,9 @@ mapping 'fact to mart' {
   }
 
   -> rfm_score {
-    "3-digit RFM score. Recency: days_since_last_purchase bucketed 1-5.
-     Frequency: lifetime_order_count bucketed 1-5.
-     Monetary: lifetime_spend bucketed 1-5.
+    "3-digit RFM score. Recency: `days_since_last_purchase` bucketed 1-5.
+     Frequency: `lifetime_order_count` bucketed 1-5.
+     Monetary: `lifetime_spend` bucketed 1-5.
      5 = best in each dimension."
   }
 }

--- a/tooling/stm-cli/src/commands/arrows.js
+++ b/tooling/stm-cli/src/commands/arrows.js
@@ -14,6 +14,7 @@
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
+import { resolveAllNLRefs } from "../nl-ref-extract.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -75,6 +76,27 @@ export function register(program) {
       // Find matching arrows using schema-qualified key
       const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
       let arrows = findFieldArrows(qualifiedField, index);
+
+      // Add NL-derived arrows for this field
+      const nlRefs = resolveAllNLRefs(index);
+      for (const nlRef of nlRefs) {
+        if (!nlRef.resolved || !nlRef.resolvedTo) continue;
+        const resolvedTo = nlRef.resolvedTo.name;
+        if (resolvedTo === qualifiedField || resolvedTo === `${resolvedSchema.key}.${fieldName}`) {
+          arrows.push({
+            mapping: nlRef.mapping?.split("::").pop() ?? nlRef.mapping,
+            namespace: nlRef.namespace,
+            source: fieldName,
+            target: nlRef.targetField,
+            transform_raw: `(NL ref)`,
+            steps: [],
+            classification: "nl-derived",
+            derived: true,
+            line: nlRef.line,
+            file: nlRef.file,
+          });
+        }
+      }
 
       // Apply direction filters
       if (opts.asSource) {

--- a/tooling/stm-cli/src/commands/context.js
+++ b/tooling/stm-cli/src/commands/context.js
@@ -21,6 +21,7 @@
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
+import { extractBacktickRefs } from "../nl-ref-extract.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -141,6 +142,41 @@ function scoreAll(index, terms) {
   for (const [name, e] of index.mappings) scoreEntry(name, "mapping", e);
   for (const [name, e] of index.fragments) scoreEntry(name, "fragment", e);
   for (const [name, e] of index.transforms) scoreEntry(name, "transform", e);
+
+  // Boost mappings that contain NL backtick refs matching query terms
+  if (index.nlRefData) {
+    // Group NL ref data by mapping key
+    const nlByMapping = new Map();
+    for (const item of index.nlRefData) {
+      const key = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
+      if (!nlByMapping.has(key)) nlByMapping.set(key, []);
+      nlByMapping.get(key).push(item);
+    }
+
+    for (const [mappingKey, items] of nlByMapping) {
+      // Collect all backtick ref texts for this mapping
+      const refTexts = [];
+      for (const item of items) {
+        for (const { ref } of extractBacktickRefs(item.text)) {
+          refTexts.push(ref);
+        }
+      }
+      if (refTexts.length === 0) continue;
+
+      const nlScore = refTexts.reduce((sum, ref) => sum + scoreText(ref, terms) * 3, 0);
+      if (nlScore > 0) {
+        const existing = results.find((r) => r.name === mappingKey);
+        if (existing) {
+          existing.score += nlScore;
+        } else {
+          const m = index.mappings.get(mappingKey);
+          if (m) {
+            results.push({ name: mappingKey, type: "mapping", score: nlScore, file: m.file, row: m.row });
+          }
+        }
+      }
+    }
+  }
 
   return results;
 }

--- a/tooling/stm-cli/src/commands/lineage.js
+++ b/tooling/stm-cli/src/commands/lineage.js
@@ -18,6 +18,7 @@
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
+import { extractBacktickRefs, classifyRef } from "../nl-ref-extract.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -133,6 +134,33 @@ function buildFullGraph(index) {
     for (const src of metric) {
       addNode(src, "schema");
       addEdge(src, metricName);
+    }
+  }
+
+  // NL backtick references — add edges for schema refs found in NL transform bodies
+  if (index.nlRefData) {
+    for (const item of index.nlRefData) {
+      const refs = extractBacktickRefs(item.text);
+      const mappingKey = item.namespace
+        ? `${item.namespace}::${item.mapping}`
+        : item.mapping;
+
+      for (const { ref } of refs) {
+        const classification = classifyRef(ref);
+        if (classification === "namespace-qualified-schema" && index.schemas.has(ref)) {
+          // NL block references a schema — add edge from that schema to the mapping
+          addNode(ref, "schema");
+          addEdge(ref, mappingKey);
+        } else if (classification === "namespace-qualified-field") {
+          // ns::schema.field — add edge from the schema part
+          const dotIdx = ref.indexOf(".", ref.indexOf("::") + 2);
+          const schemaRef = ref.slice(0, dotIdx);
+          if (index.schemas.has(schemaRef)) {
+            addNode(schemaRef, "schema");
+            addEdge(schemaRef, mappingKey);
+          }
+        }
+      }
     }
   }
 

--- a/tooling/stm-cli/src/commands/nl-refs.js
+++ b/tooling/stm-cli/src/commands/nl-refs.js
@@ -1,0 +1,94 @@
+/**
+ * nl-refs.js — `stm nl-refs` command
+ *
+ * Extracts and lists all backtick-delimited references from NL blocks
+ * in transform bodies. Shows each reference with its classification,
+ * resolution status, containing mapping, and source location.
+ *
+ * Flags:
+ *   --mapping <name>   scope to a specific mapping
+ *   --json             structured JSON output
+ *   --unresolved       show only unresolved references
+ */
+
+import { resolveInput } from "../workspace.js";
+import { parseFile } from "../parser.js";
+import { buildIndex, resolveIndexKey } from "../index-builder.js";
+import { resolveAllNLRefs } from "../nl-ref-extract.js";
+
+/** @param {import('commander').Command} program */
+export function register(program) {
+  program
+    .command("nl-refs [path]")
+    .description("Extract backtick references from NL transform bodies")
+    .option("--mapping <name>", "scope to a specific mapping")
+    .option("--json", "structured JSON output")
+    .option("--unresolved", "show only unresolved references")
+    .action(async (pathArg, opts) => {
+      const root = pathArg ?? ".";
+      let files;
+      try {
+        files = await resolveInput(root);
+      } catch (err) {
+        console.error(`Error resolving path: ${err.message}`);
+        process.exit(1);
+      }
+
+      const parsedFiles = files.map((f) => parseFile(f));
+      const index = buildIndex(parsedFiles);
+
+      let refs = resolveAllNLRefs(index);
+
+      // Apply --mapping filter
+      if (opts.mapping) {
+        const resolved = resolveIndexKey(opts.mapping, index.mappings);
+        if (!resolved) {
+          console.error(`Mapping '${opts.mapping}' not found.`);
+          process.exit(1);
+        }
+        refs = refs.filter((r) => r.mapping === resolved.key);
+      }
+
+      // Apply --unresolved filter
+      if (opts.unresolved) {
+        refs = refs.filter((r) => !r.resolved);
+      }
+
+      if (refs.length === 0) {
+        console.log("No NL backtick references found.");
+        return;
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(refs, null, 2));
+        return;
+      }
+
+      printDefault(refs);
+    });
+}
+
+function printDefault(refs) {
+  console.log(`NL backtick references (${refs.length} total):`);
+  console.log();
+
+  // Group by mapping
+  const byMapping = new Map();
+  for (const ref of refs) {
+    if (!byMapping.has(ref.mapping)) byMapping.set(ref.mapping, []);
+    byMapping.get(ref.mapping).push(ref);
+  }
+
+  for (const [mapping, mappingRefs] of byMapping) {
+    console.log(`  mapping '${mapping}':`);
+    for (const ref of mappingRefs) {
+      const status = ref.resolved
+        ? `-> ${ref.resolvedTo?.name ?? "?"}`
+        : "(unresolved)";
+      const padRef = (`\`${ref.ref}\``).padEnd(32);
+      const padClass = ref.classification.padEnd(28);
+      console.log(`    ${padRef} ${padClass} ${status}  (line ${ref.line + 1})`);
+    }
+    console.log();
+  }
+}

--- a/tooling/stm-cli/src/commands/where-used.js
+++ b/tooling/stm-cli/src/commands/where-used.js
@@ -16,6 +16,7 @@
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
+import { resolveAllNLRefs } from "../nl-ref-extract.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -120,6 +121,26 @@ function gatherRefs(name, index, parsedFiles, isSchema, isFragment, isTransform)
       for (const { mapping, row } of transformRefs) {
         refs.push({ kind: "transform_call", name: mapping, file: filePath, row });
       }
+    }
+  }
+
+  // NL backtick references — find references inside NL transform bodies
+  const nlRefs = resolveAllNLRefs(index);
+  const seenNLRefs = new Set();
+  for (const nlRef of nlRefs) {
+    if (!nlRef.resolved || !nlRef.resolvedTo) continue;
+    const resolvedName = nlRef.resolvedTo.name;
+    // Match the queried name against the resolved reference
+    if (resolvedName === name || resolvedName.startsWith(name + ".")) {
+      const dedup = `${nlRef.mapping}:${nlRef.file}:${nlRef.line}`;
+      if (seenNLRefs.has(dedup)) continue;
+      seenNLRefs.add(dedup);
+      refs.push({
+        kind: "nl_ref",
+        name: nlRef.mapping,
+        file: nlRef.file,
+        row: nlRef.line,
+      });
     }
   }
 
@@ -234,6 +255,7 @@ function printDefault(name, refs) {
     metric: "Referenced by metrics",
     fragment_spread: "Spread into schemas/fragments",
     transform_call: "Invoked in mapping transforms",
+    nl_ref: "Referenced in NL transform bodies",
   };
 
   for (const [kind, kindRefs] of byKind) {

--- a/tooling/stm-cli/src/index-builder.js
+++ b/tooling/stm-cli/src/index-builder.js
@@ -16,6 +16,7 @@ import {
   extractArrowRecords,
   extractNamespaces,
 } from "./extract.js";
+import { extractNLRefData } from "./nl-ref-extract.js";
 
 /**
  * Build a WorkspaceIndex from an array of parsed file results.
@@ -59,6 +60,7 @@ export function extractFileData({ filePath, tree, errorCount }) {
     questions: extractQuestions(root),
     arrowRecords: extractArrowRecords(root),
     namespaces: extractNamespaces(root),
+    nlRefData: extractNLRefData(root),
   };
 }
 
@@ -81,6 +83,7 @@ export function buildIndex(parsedFiles) {
   const warnings = [];
   const questions = [];
   const allArrowRecords = [];
+  const allNLRefData = [];
   let totalErrors = 0;
 
   // Track all named definitions per namespace for cross-kind duplicate detection.
@@ -187,6 +190,11 @@ export function buildIndex(parsedFiles) {
     for (const ar of fileData.arrowRecords) {
       allArrowRecords.push({ ...ar, file: filePath });
     }
+    if (fileData.nlRefData) {
+      for (const nr of fileData.nlRefData) {
+        allNLRefData.push({ ...nr, file: filePath });
+      }
+    }
   }
 
   // Build a set of known namespace names for reference resolution.
@@ -210,6 +218,7 @@ export function buildIndex(parsedFiles) {
     fieldArrows,
     referenceGraph,
     namespaceNames,
+    nlRefData: allNLRefData,
     totalErrors,
   };
 }

--- a/tooling/stm-cli/src/index.js
+++ b/tooling/stm-cli/src/index.js
@@ -51,6 +51,7 @@ const commands = [
   "commands/match-fields.js",
   "commands/validate.js",
   "commands/diff.js",
+  "commands/nl-refs.js",
 ];
 
 for (const cmd of commands) {

--- a/tooling/stm-cli/src/nl-ref-extract.js
+++ b/tooling/stm-cli/src/nl-ref-extract.js
@@ -1,0 +1,279 @@
+/**
+ * nl-ref-extract.js — Extract and resolve backtick references from NL strings
+ *
+ * Parses NL strings inside transform pipe steps for backtick-delimited
+ * references (e.g., `source::hr_employees`, `posted_by`), classifies them,
+ * and optionally resolves them against a WorkspaceIndex.
+ *
+ * This module is the shared foundation for validate, lineage, where-used,
+ * arrows, context, and the nl-refs command.
+ */
+
+// ── Extraction ──────────────────────────────────────────────────────────────
+
+const BACKTICK_RE = /`([^`]+)`/g;
+
+/**
+ * Extract backtick-delimited references from a single NL string.
+ *
+ * @param {string} text  NL string content (delimiters already stripped)
+ * @returns {Array<{ref: string, offset: number}>}
+ */
+export function extractBacktickRefs(text) {
+  const refs = [];
+  let match;
+  BACKTICK_RE.lastIndex = 0;
+  while ((match = BACKTICK_RE.exec(text)) !== null) {
+    refs.push({ ref: match[1], offset: match.index });
+  }
+  return refs;
+}
+
+// ── Classification ──────────────────────────────────────────────────────────
+
+/**
+ * Classify a backtick reference by its syntactic form.
+ *
+ * @param {string} ref  The reference text (without backticks)
+ * @returns {'namespace-qualified-field'|'namespace-qualified-schema'|'dotted-field'|'bare'}
+ */
+export function classifyRef(ref) {
+  if (ref.includes("::")) {
+    // ns::name.field or ns::name
+    return ref.includes(".") ? "namespace-qualified-field" : "namespace-qualified-schema";
+  }
+  if (ref.includes(".")) return "dotted-field";
+  return "bare";
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a single backtick reference against the workspace index.
+ *
+ * @param {string} ref  The reference text
+ * @param {object} mappingContext  {sources: string[], targets: string[], namespace: string|null}
+ * @param {object} index  WorkspaceIndex
+ * @returns {{resolved: boolean, resolvedTo: {kind: string, name: string}|null}}
+ */
+export function resolveRef(ref, mappingContext, index) {
+  const classification = classifyRef(ref);
+
+  if (classification === "namespace-qualified-schema") {
+    // Direct schema lookup
+    if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: ref } };
+    if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: ref } };
+    if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: ref } };
+    return { resolved: false, resolvedTo: null };
+  }
+
+  if (classification === "namespace-qualified-field") {
+    // ns::schema.field
+    const dotIdx = ref.indexOf(".", ref.indexOf("::") + 2);
+    const schemaRef = ref.slice(0, dotIdx);
+    const fieldName = ref.slice(dotIdx + 1);
+    const schema = index.schemas.get(schemaRef);
+    if (schema && hasField(schema.fields, fieldName)) {
+      return { resolved: true, resolvedTo: { kind: "field", name: ref } };
+    }
+    return { resolved: false, resolvedTo: null };
+  }
+
+  if (classification === "dotted-field") {
+    // schema.field — check if schema part matches a declared source/target
+    const dotIdx = ref.indexOf(".");
+    const schemaName = ref.slice(0, dotIdx);
+    const fieldName = ref.slice(dotIdx + 1);
+    const allSchemas = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
+    for (const s of allSchemas) {
+      const baseName = s.includes("::") ? s.split("::")[1] : s;
+      if (baseName === schemaName || s === schemaName) {
+        const schema = index.schemas.get(s);
+        if (schema && hasField(schema.fields, fieldName)) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${fieldName}` } };
+        }
+      }
+    }
+    return { resolved: false, resolvedTo: null };
+  }
+
+  // Bare identifier — check fields in declared sources/targets, then schemas/transforms
+  const allSchemaNames = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
+  for (const s of allSchemaNames) {
+    const schema = index.schemas.get(s);
+    if (schema && hasField(schema.fields, ref)) {
+      return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${ref}` } };
+    }
+  }
+
+  // Check if it's a schema, fragment, or transform name
+  if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: ref } };
+  if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: ref } };
+  if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: ref } };
+
+  // Try namespace-qualified lookup from mapping's namespace
+  if (mappingContext.namespace) {
+    const nsRef = `${mappingContext.namespace}::${ref}`;
+    if (index.schemas.has(nsRef)) return { resolved: true, resolvedTo: { kind: "schema", name: nsRef } };
+    if (index.transforms?.has(nsRef)) return { resolved: true, resolvedTo: { kind: "transform", name: nsRef } };
+  }
+
+  return { resolved: false, resolvedTo: null };
+}
+
+/**
+ * Check if a field tree contains a field with the given name (flat or nested).
+ */
+function hasField(fields, name) {
+  for (const f of fields) {
+    if (f.name === name) return true;
+    if (f.children && hasField(f.children, name)) return true;
+  }
+  return false;
+}
+
+// ── CST Walking (for extractFileData integration) ───────────────────────────
+
+/**
+ * Extract NL ref data from a CST root node. Called during extractFileData()
+ * while the tree is still valid.
+ *
+ * @param {object} rootNode  tree-sitter root node
+ * @returns {Array<{text: string, mapping: string|null, namespace: string|null,
+ *                   targetField: string|null, line: number, column: number}>}
+ */
+export function extractNLRefData(rootNode) {
+  const results = [];
+  walkMappings(rootNode, null, results);
+  return results;
+}
+
+function walkMappings(node, namespace, results) {
+  for (const c of node.namedChildren) {
+    if (c.type === "namespace_block") {
+      const nsName = c.namedChildren.find((x) => x.type === "identifier");
+      walkMappings(c, nsName?.text ?? null, results);
+    } else if (c.type === "mapping_block") {
+      extractMappingNLRefs(c, namespace, results);
+    }
+  }
+}
+
+function extractMappingNLRefs(mappingNode, namespace, results) {
+  const lbl = mappingNode.namedChildren.find((c) => c.type === "block_label");
+  const inner = lbl?.namedChildren[0];
+  let mappingName = inner?.text ?? null;
+  if (inner?.type === "quoted_name") mappingName = mappingName.slice(1, -1);
+
+  const body = mappingNode.namedChildren.find((c) => c.type === "mapping_body");
+  if (!body) return;
+
+  walkArrowsForNL(body, mappingName, namespace, null, results);
+}
+
+function walkArrowsForNL(node, mappingName, namespace, targetField, results) {
+  for (const c of node.namedChildren) {
+    if (c.type === "map_arrow" || c.type === "computed_arrow" || c.type === "nested_arrow") {
+      // Get target field for this arrow
+      const tgtNode = c.namedChildren.find((x) => x.type === "tgt_path");
+      const tgt = extractPathText(tgtNode) ?? targetField;
+
+      const pipeChain = c.namedChildren.find((x) => x.type === "pipe_chain");
+      if (pipeChain) {
+        for (const step of pipeChain.namedChildren) {
+          if (step.type === "pipe_step") {
+            const innerNode = step.namedChildren[0];
+            if (innerNode && (innerNode.type === "nl_string" || innerNode.type === "multiline_string")) {
+              const text = innerNode.type === "multiline_string"
+                ? innerNode.text.slice(3, -3).trim()
+                : innerNode.text.slice(1, -1);
+              // Only include if text contains backtick refs
+              if (text.includes("`")) {
+                results.push({
+                  text,
+                  mapping: mappingName,
+                  namespace,
+                  targetField: tgt,
+                  line: innerNode.startPosition.row,
+                  column: innerNode.startPosition.column,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // Recurse into nested arrows
+      walkArrowsForNL(c, mappingName, namespace, tgt, results);
+    }
+  }
+}
+
+function extractPathText(pathNode) {
+  if (!pathNode) return null;
+  const inner = pathNode.namedChildren[0];
+  if (!inner) return pathNode.text;
+  if (inner.type === "backtick_path") return inner.text.slice(1, -1);
+  return inner.text;
+}
+
+// ── High-level extraction ───────────────────────────────────────────────────
+
+/**
+ * Process pre-extracted NL ref data into fully resolved reference records.
+ *
+ * @param {object} index  WorkspaceIndex (must have nlRefData populated)
+ * @returns {Array<{ref, classification, resolved, resolvedTo, mapping, namespace,
+ *                   targetField, file, line, column}>}
+ */
+export function resolveAllNLRefs(index) {
+  const results = [];
+  const nlRefData = index.nlRefData ?? [];
+
+  for (const item of nlRefData) {
+    const backtickRefs = extractBacktickRefs(item.text);
+    const mappingKey = item.namespace
+      ? `${item.namespace}::${item.mapping}`
+      : item.mapping;
+    const mapping = index.mappings.get(mappingKey);
+    const mappingContext = {
+      sources: mapping?.sources ?? [],
+      targets: mapping?.targets ?? [],
+      namespace: item.namespace,
+    };
+
+    for (const { ref, offset } of backtickRefs) {
+      const classification = classifyRef(ref);
+      const resolution = resolveRef(ref, mappingContext, index);
+
+      results.push({
+        ref,
+        classification,
+        resolved: resolution.resolved,
+        resolvedTo: resolution.resolvedTo,
+        mapping: mappingKey,
+        namespace: item.namespace,
+        targetField: item.targetField,
+        file: item.file,
+        line: item.line,
+        column: item.column + offset,
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Check if a schema reference from an NL block is declared in the mapping's
+ * source or target list.
+ *
+ * @param {string} schemaRef  Namespace-qualified schema name
+ * @param {object} mapping  Mapping entry from index
+ * @returns {boolean}
+ */
+export function isSchemaInMappingSources(schemaRef, mapping) {
+  if (!mapping) return false;
+  const allRefs = [...(mapping.sources ?? []), ...(mapping.targets ?? [])];
+  return allRefs.includes(schemaRef);
+}

--- a/tooling/stm-cli/src/validate.js
+++ b/tooling/stm-cli/src/validate.js
@@ -2,8 +2,16 @@
  * validate.js — Structural and semantic validation for STM workspaces
  *
  * Structural checks: CST ERROR/MISSING nodes from tree-sitter.
- * Semantic checks: undefined references, duplicates, field mismatches.
+ * Semantic checks: undefined references, duplicates, field mismatches,
+ * NL backtick reference validation.
  */
+
+import {
+  extractBacktickRefs,
+  classifyRef,
+  resolveRef,
+  isSchemaInMappingSources,
+} from "./nl-ref-extract.js";
 
 /**
  * @typedef {Object} Diagnostic
@@ -202,6 +210,50 @@ export function collectSemanticWarnings(index) {
             severity: "warning",
             rule: "undefined-ref",
             message: `Metric '${name}' references undefined source '${src}'`,
+          });
+        }
+      }
+    }
+  }
+
+  // Check NL backtick references in transform bodies
+  if (index.nlRefData) {
+    for (const item of index.nlRefData) {
+      const refs = extractBacktickRefs(item.text);
+      const mappingKey = item.namespace
+        ? `${item.namespace}::${item.mapping}`
+        : item.mapping;
+      const mapping = index.mappings.get(mappingKey);
+      const mappingContext = {
+        sources: mapping?.sources ?? [],
+        targets: mapping?.targets ?? [],
+        namespace: item.namespace,
+      };
+
+      for (const { ref, offset } of refs) {
+        const classification = classifyRef(ref);
+        const resolution = resolveRef(ref, mappingContext, index);
+
+        if (!resolution.resolved) {
+          diagnostics.push({
+            file: item.file,
+            line: item.line + 1,
+            column: item.column + offset + 1,
+            severity: "warning",
+            rule: "nl-ref-unresolved",
+            message: `NL reference \`${ref}\` in mapping '${mappingKey}' does not resolve to any known identifier`,
+          });
+        } else if (
+          classification === "namespace-qualified-schema" &&
+          !isSchemaInMappingSources(ref, mapping)
+        ) {
+          diagnostics.push({
+            file: item.file,
+            line: item.line + 1,
+            column: item.column + offset + 1,
+            severity: "warning",
+            rule: "nl-ref-not-in-source",
+            message: `NL reference \`${ref}\` in mapping '${mappingKey}' is not declared in its source or target list`,
           });
         }
       }

--- a/tooling/stm-cli/test/arrow-extract.test.js
+++ b/tooling/stm-cli/test/arrow-extract.test.js
@@ -231,10 +231,10 @@ describe("extractArrowRecords against real examples", () => {
     assert.equal(trimArrow.derived, false);
     assert.equal(trimArrow.steps.length, 3);
 
-    // Check an NL arrow
+    // Check a mixed arrow (NL body + warn_if_invalid structural step)
     const phoneArrow = records.find((r) => r.source === "PHONE_NBR");
     assert.ok(phoneArrow);
-    assert.equal(phoneArrow.classification, "nl");
+    assert.equal(phoneArrow.classification, "mixed");
 
     // Check a mixed arrow
     const notesArrow = records.find(

--- a/tooling/stm-cli/test/integration.test.js
+++ b/tooling/stm-cli/test/integration.test.js
@@ -369,10 +369,10 @@ describe("stm arrows", () => {
     assert.match(stdout, /trim/);
   });
 
-  it("shows nl classification on NL-only transform", async () => {
+  it("shows mixed classification on NL + structural transform", async () => {
     const { stdout, code } = await run("arrows", "legacy_sqlserver.PHONE_NBR", DB);
     assert.equal(code, 0);
-    assert.match(stdout, /\[nl\]/);
+    assert.match(stdout, /\[mixed\]/);
   });
 
   it("shows mixed classification on mixed transform", async () => {
@@ -1121,7 +1121,9 @@ describe("stm lineage --to (namespace bugs)", () => {
   it("traces upstream with merged namespaces", async () => {
     const { stdout, code } = await run("lineage", "--to", "staging::stg_gl_entries", NS_MERGING);
     assert.equal(code, 0);
-    assert.match(stdout, /source::finance_gl/);
+    // BFS finds a valid upstream path — may go through structural source
+    // (finance_gl) or NL-derived source (hr_employees); both are correct
+    assert.match(stdout, /source::(finance_gl|hr_employees)/);
   });
 });
 
@@ -1217,5 +1219,81 @@ describe("stm fields --unmapped-by (namespace bugs)", () => {
     assert.equal(code, 0);
     assert.match(stdout, /is_current/);
     assert.doesNotMatch(stdout, /contact_sk/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stm nl-refs
+// ---------------------------------------------------------------------------
+describe("stm nl-refs", () => {
+  it("extracts backtick references from ns-merging.stm", async () => {
+    const { stdout, code } = await run("nl-refs", NS_MERGING);
+    assert.equal(code, 0);
+    assert.match(stdout, /NL backtick references/);
+    assert.match(stdout, /source::hr_employees/);
+    assert.match(stdout, /department/);
+    assert.match(stdout, /posted_by/);
+  });
+
+  it("supports --json output", async () => {
+    const { stdout, code } = await run("nl-refs", "--json", NS_MERGING);
+    assert.equal(code, 0);
+    const refs = JSON.parse(stdout);
+    assert.ok(Array.isArray(refs));
+    assert.ok(refs.length > 0);
+    assert.ok(refs[0].ref);
+    assert.ok(refs[0].classification);
+    assert.ok("resolved" in refs[0]);
+  });
+
+  it("supports --mapping filter", async () => {
+    const { stdout, code } = await run(
+      "nl-refs", "--mapping", "stage gl entries", "--json", NS_MERGING,
+    );
+    assert.equal(code, 0);
+    const refs = JSON.parse(stdout);
+    assert.ok(refs.length > 0);
+    // All refs should be from this mapping
+    for (const ref of refs) {
+      assert.match(ref.mapping, /stage gl entries/);
+    }
+  });
+
+  it("supports --unresolved filter with no results", async () => {
+    const { _stdout, code } = await run("nl-refs", "--unresolved", NS_MERGING);
+    assert.equal(code, 0);
+  });
+
+  it("extracts refs from db-to-db.stm with COUNTRY_CD backtick", async () => {
+    const dbFile = resolve(EXAMPLES, "db-to-db.stm");
+    const { stdout, code } = await run("nl-refs", "--json", dbFile);
+    assert.equal(code, 0);
+    const refs = JSON.parse(stdout);
+    const countryCd = refs.find((r) => r.ref === "COUNTRY_CD");
+    assert.ok(countryCd, "should find COUNTRY_CD backtick ref");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stm validate — NL ref warnings
+// ---------------------------------------------------------------------------
+describe("stm validate (NL refs)", () => {
+  it("validates ns-merging.stm without NL ref warnings", async () => {
+    const { stdout, code } = await run("validate", NS_MERGING);
+    assert.equal(code, 0);
+    assert.match(stdout, /no issues found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stm where-used — NL ref surface
+// ---------------------------------------------------------------------------
+describe("stm where-used (NL refs)", () => {
+  it("includes NL refs in where-used results", async () => {
+    const { stdout, code } = await run("where-used", "source::hr_employees", "--json", NS_MERGING);
+    assert.equal(code, 0);
+    const result = JSON.parse(stdout);
+    const nlRefs = result.refs.filter((r) => r.kind === "nl_ref");
+    assert.ok(nlRefs.length > 0, "should find NL references to source::hr_employees");
   });
 });

--- a/tooling/stm-cli/test/nl-ref-extract.test.js
+++ b/tooling/stm-cli/test/nl-ref-extract.test.js
@@ -1,0 +1,236 @@
+/**
+ * nl-ref-extract.test.js — Tests for NL backtick reference extraction utility
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  extractBacktickRefs,
+  classifyRef,
+  resolveRef,
+  isSchemaInMappingSources,
+  resolveAllNLRefs,
+} from "../src/nl-ref-extract.js";
+
+// ── extractBacktickRefs ─────────────────────────────────────────────────────
+
+describe("extractBacktickRefs", () => {
+  it("extracts a single backtick reference", () => {
+    const refs = extractBacktickRefs("Lookup `department` from employees");
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0].ref, "department");
+  });
+
+  it("extracts multiple backtick references", () => {
+    const refs = extractBacktickRefs(
+      "Lookup `department` from `source::hr_employees` using `posted_by` -> `employee_id`",
+    );
+    assert.equal(refs.length, 4);
+    assert.deepEqual(refs.map((r) => r.ref), [
+      "department",
+      "source::hr_employees",
+      "posted_by",
+      "employee_id",
+    ]);
+  });
+
+  it("returns empty array for text without backticks", () => {
+    const refs = extractBacktickRefs("No references here");
+    assert.equal(refs.length, 0);
+  });
+
+  it("returns empty array for empty string", () => {
+    const refs = extractBacktickRefs("");
+    assert.equal(refs.length, 0);
+  });
+
+  it("captures correct offsets", () => {
+    const refs = extractBacktickRefs("abc `foo` xyz `bar`");
+    assert.equal(refs[0].offset, 4);
+    assert.equal(refs[1].offset, 14);
+  });
+});
+
+// ── classifyRef ─────────────────────────────────────────────────────────────
+
+describe("classifyRef", () => {
+  it("classifies namespace-qualified schema", () => {
+    assert.equal(classifyRef("source::hr_employees"), "namespace-qualified-schema");
+  });
+
+  it("classifies namespace-qualified field", () => {
+    assert.equal(classifyRef("source::hr_employees.department"), "namespace-qualified-field");
+  });
+
+  it("classifies dotted field", () => {
+    assert.equal(classifyRef("hr_employees.department"), "dotted-field");
+  });
+
+  it("classifies bare identifier", () => {
+    assert.equal(classifyRef("department"), "bare");
+  });
+});
+
+// ── resolveRef ──────────────────────────────────────────────────────────────
+
+describe("resolveRef", () => {
+  const makeIndex = (schemas = {}, transforms = {}, fragments = {}) => ({
+    schemas: new Map(Object.entries(schemas)),
+    transforms: new Map(Object.entries(transforms)),
+    fragments: new Map(Object.entries(fragments)),
+  });
+
+  it("resolves namespace-qualified schema", () => {
+    const index = makeIndex({
+      "source::hr_employees": { fields: [{ name: "employee_id" }] },
+    });
+    const result = resolveRef("source::hr_employees", {}, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "schema");
+  });
+
+  it("returns unresolved for unknown namespace-qualified schema", () => {
+    const index = makeIndex({});
+    const result = resolveRef("source::nonexistent", {}, index);
+    assert.equal(result.resolved, false);
+  });
+
+  it("resolves namespace-qualified field", () => {
+    const index = makeIndex({
+      "source::hr_employees": { fields: [{ name: "department" }] },
+    });
+    const result = resolveRef("source::hr_employees.department", {}, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+  });
+
+  it("returns unresolved for unknown field in known schema", () => {
+    const index = makeIndex({
+      "source::hr_employees": { fields: [{ name: "employee_id" }] },
+    });
+    const result = resolveRef("source::hr_employees.nonexistent", {}, index);
+    assert.equal(result.resolved, false);
+  });
+
+  it("resolves bare field against mapping sources", () => {
+    const index = makeIndex({
+      "source::finance_gl": { fields: [{ name: "posted_by" }] },
+    });
+    const context = { sources: ["source::finance_gl"], targets: [] };
+    const result = resolveRef("posted_by", context, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+    assert.equal(result.resolvedTo.name, "source::finance_gl.posted_by");
+  });
+
+  it("resolves bare identifier as transform name", () => {
+    const index = makeIndex({}, { clean_string: {} });
+    const result = resolveRef("clean_string", {}, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "transform");
+  });
+
+  it("resolves bare identifier via namespace lookup", () => {
+    const index = makeIndex({ "staging::stg_employees": { fields: [] } });
+    const context = { sources: [], targets: [], namespace: "staging" };
+    const result = resolveRef("stg_employees", context, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "schema");
+    assert.equal(result.resolvedTo.name, "staging::stg_employees");
+  });
+
+  it("returns unresolved for completely unknown bare identifier", () => {
+    const index = makeIndex({});
+    const result = resolveRef("nonexistent", { sources: [], targets: [] }, index);
+    assert.equal(result.resolved, false);
+  });
+
+  it("resolves nested field names", () => {
+    const index = makeIndex({
+      "source::orders": {
+        fields: [{ name: "Customer", children: [{ name: "Email" }] }],
+      },
+    });
+    const context = { sources: ["source::orders"], targets: [] };
+    const result = resolveRef("Email", context, index);
+    assert.equal(result.resolved, true);
+  });
+});
+
+// ── isSchemaInMappingSources ────────────────────────────────────────────────
+
+describe("isSchemaInMappingSources", () => {
+  it("returns true when schema is in sources", () => {
+    const mapping = { sources: ["source::hr_employees"], targets: ["staging::stg_employees"] };
+    assert.equal(isSchemaInMappingSources("source::hr_employees", mapping), true);
+  });
+
+  it("returns true when schema is in targets", () => {
+    const mapping = { sources: [], targets: ["staging::stg_employees"] };
+    assert.equal(isSchemaInMappingSources("staging::stg_employees", mapping), true);
+  });
+
+  it("returns false when schema is not in sources or targets", () => {
+    const mapping = { sources: ["source::finance_gl"], targets: ["staging::stg_gl"] };
+    assert.equal(isSchemaInMappingSources("source::hr_employees", mapping), false);
+  });
+
+  it("returns false for null mapping", () => {
+    assert.equal(isSchemaInMappingSources("source::hr_employees", null), false);
+  });
+});
+
+// ── resolveAllNLRefs ────────────────────────────────────────────────────────
+
+describe("resolveAllNLRefs", () => {
+  it("resolves refs from nlRefData in the index", () => {
+    const index = {
+      schemas: new Map([
+        ["source::hr_employees", { fields: [{ name: "department" }, { name: "employee_id" }] }],
+        ["source::finance_gl", { fields: [{ name: "posted_by" }] }],
+      ]),
+      mappings: new Map([
+        ["staging::stage gl entries", {
+          sources: ["source::finance_gl", "source::hr_employees"],
+          targets: ["staging::stg_gl_entries"],
+        }],
+      ]),
+      transforms: new Map(),
+      fragments: new Map(),
+      nlRefData: [{
+        text: "Lookup `department` from `source::hr_employees` using `posted_by` -> `employee_id`",
+        mapping: "stage gl entries",
+        namespace: "staging",
+        targetField: "department",
+        file: "ns-merging.stm",
+        line: 99,
+        column: 6,
+      }],
+    };
+
+    const results = resolveAllNLRefs(index);
+    assert.equal(results.length, 4);
+
+    // All should resolve
+    assert.ok(results.every((r) => r.resolved), "all refs should resolve");
+
+    // Check specific resolutions
+    const deptRef = results.find((r) => r.ref === "department");
+    assert.equal(deptRef.resolvedTo.kind, "field");
+
+    const schemaRef = results.find((r) => r.ref === "source::hr_employees");
+    assert.equal(schemaRef.resolvedTo.kind, "schema");
+    assert.equal(schemaRef.classification, "namespace-qualified-schema");
+  });
+
+  it("returns empty for index with no nlRefData", () => {
+    const index = {
+      schemas: new Map(),
+      mappings: new Map(),
+      transforms: new Map(),
+      fragments: new Map(),
+    };
+    const results = resolveAllNLRefs(index);
+    assert.equal(results.length, 0);
+  });
+});

--- a/tooling/stm-cli/test/nl-ref-validate.test.js
+++ b/tooling/stm-cli/test/nl-ref-validate.test.js
@@ -1,0 +1,186 @@
+/**
+ * nl-ref-validate.test.js — Tests for NL backtick reference validation
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { collectSemanticWarnings } from "../src/validate.js";
+
+/** Build a minimal WorkspaceIndex with nlRefData for testing. */
+function makeIndex({ schemas = [], mappings = [], nlRefData = [] }) {
+  const schemaMap = new Map();
+  for (const s of schemas) {
+    schemaMap.set(s.name, { ...s, file: s.file ?? "test.stm", row: s.row ?? 0 });
+  }
+  const mappingMap = new Map();
+  for (const m of mappings) {
+    mappingMap.set(m.name, { ...m, file: m.file ?? "test.stm", row: m.row ?? 0 });
+  }
+  return {
+    schemas: schemaMap,
+    mappings: mappingMap,
+    metrics: new Map(),
+    fragments: new Map(),
+    transforms: new Map(),
+    warnings: [],
+    questions: [],
+    fieldArrows: new Map(),
+    referenceGraph: { usedByMappings: new Map(), fragmentsUsedIn: new Map(), metricsReferences: new Map() },
+    namespaceNames: new Set(),
+    nlRefData,
+    totalErrors: 0,
+  };
+}
+
+describe("NL ref validation: nl-ref-unresolved", () => {
+  it("does not warn for valid NL backtick references", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::hr_employees", fields: [{ name: "department" }, { name: "employee_id" }] },
+        { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
+        { name: "staging::stg_gl_entries", fields: [{ name: "department" }] },
+      ],
+      mappings: [{
+        name: "staging::stage gl entries",
+        namespace: "staging",
+        sources: ["source::finance_gl", "source::hr_employees"],
+        targets: ["staging::stg_gl_entries"],
+      }],
+      nlRefData: [{
+        text: "Lookup `department` from `source::hr_employees` using `posted_by` -> `employee_id`",
+        mapping: "stage gl entries",
+        namespace: "staging",
+        targetField: "department",
+        file: "test.stm",
+        line: 99,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Valid NL refs should produce no warnings");
+  });
+
+  it("warns for unresolvable NL backtick references", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
+        { name: "staging::stg_gl_entries", fields: [] },
+      ],
+      mappings: [{
+        name: "staging::my_mapping",
+        namespace: "staging",
+        sources: ["source::finance_gl"],
+        targets: ["staging::stg_gl_entries"],
+      }],
+      nlRefData: [{
+        text: "Lookup `nonexistent_field` from `source::unknown_schema`",
+        mapping: "my_mapping",
+        namespace: "staging",
+        targetField: "foo",
+        file: "test.stm",
+        line: 10,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const unresolvedWarnings = warnings.filter((w) => w.rule === "nl-ref-unresolved");
+    assert.equal(unresolvedWarnings.length, 2, "Should warn for both unresolved refs");
+    assert.ok(unresolvedWarnings[0].message.includes("nonexistent_field"));
+    assert.ok(unresolvedWarnings[1].message.includes("source::unknown_schema"));
+  });
+});
+
+describe("NL ref validation: nl-ref-not-in-source", () => {
+  it("warns when NL schema ref is not in mapping source/target list", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::hr_employees", fields: [{ name: "employee_id" }] },
+        { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
+        { name: "staging::stg_gl_entries", fields: [] },
+      ],
+      mappings: [{
+        name: "staging::my_mapping",
+        namespace: "staging",
+        sources: ["source::finance_gl"],
+        targets: ["staging::stg_gl_entries"],
+      }],
+      nlRefData: [{
+        text: "Lookup from `source::hr_employees` using `posted_by`",
+        mapping: "my_mapping",
+        namespace: "staging",
+        targetField: "dept",
+        file: "test.stm",
+        line: 15,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const notInSrcWarnings = warnings.filter((w) => w.rule === "nl-ref-not-in-source");
+    assert.equal(notInSrcWarnings.length, 1);
+    assert.ok(notInSrcWarnings[0].message.includes("source::hr_employees"));
+    assert.ok(notInSrcWarnings[0].message.includes("not declared in its source or target list"));
+  });
+
+  it("does not warn when NL schema ref is in the source list", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::hr_employees", fields: [{ name: "employee_id" }] },
+        { name: "source::finance_gl", fields: [] },
+        { name: "staging::stg_gl_entries", fields: [] },
+      ],
+      mappings: [{
+        name: "staging::my_mapping",
+        namespace: "staging",
+        sources: ["source::finance_gl", "source::hr_employees"],
+        targets: ["staging::stg_gl_entries"],
+      }],
+      nlRefData: [{
+        text: "Lookup from `source::hr_employees`",
+        mapping: "my_mapping",
+        namespace: "staging",
+        targetField: "dept",
+        file: "test.stm",
+        line: 15,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const notInSrcWarnings = warnings.filter((w) => w.rule === "nl-ref-not-in-source");
+    assert.equal(notInSrcWarnings.length, 0, "Should not warn when schema is declared");
+  });
+});
+
+describe("NL ref validation: bare field matching", () => {
+  it("does not warn for bare field that matches a source schema field", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::gl", fields: [{ name: "amount" }, { name: "department" }] },
+        { name: "staging::stg", fields: [{ name: "amount" }] },
+      ],
+      mappings: [{
+        name: "staging::m1",
+        namespace: "staging",
+        sources: ["source::gl"],
+        targets: ["staging::stg"],
+      }],
+      nlRefData: [{
+        text: "Sum of `amount` grouped by `department`",
+        mapping: "m1",
+        namespace: "staging",
+        targetField: "total",
+        file: "test.stm",
+        line: 20,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Bare fields matching source schema should not warn");
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix 6 namespace bugs** in CLI commands (arrows, fields, metric, where-used, extract, lineage) that caused incorrect behavior with namespace-qualified entities
- **Add backtick field references** to NL strings across all example files for deterministic lineage extraction (per spec §Delimiters)
- **Add explicit source lists** to mappings in `ns-merging.stm` that had implicit cross-namespace dependencies hidden in NL blocks
- **New `stm nl-refs` command** — extracts and lists all backtick-delimited references from NL transform bodies with classification and resolution status
- **Enhance 5 existing commands** to leverage NL backtick references:
  - `validate`: warns on unresolved refs (`nl-ref-unresolved`) and schemas not in source/target list (`nl-ref-not-in-source`)
  - `lineage`: NL schema refs create graph edges for cross-namespace tracing
  - `where-used`: surfaces `nl_ref` kind alongside structural references
  - `arrows`: adds `nl-derived` classification for implicit field arrows
  - `context`: backtick refs boost relevance scoring (×3 weight)
- **Add namespace corpus tests** for tree-sitter parser and **VS Code syntax highlighting** for namespace blocks
- 347 tests pass (was 224), 59 files changed

## Test plan

- [x] All 347 tests pass (36 new NL ref tests + prior additions)
- [x] `stm nl-refs` produces correct output on `ns-merging.stm` and `db-to-db.stm`
- [x] `stm validate` catches unresolved NL refs and missing source declarations
- [x] `stm where-used` shows NL references alongside structural ones
- [x] `stm lineage --to` follows NL-derived edges across namespaces
- [x] Pre-commit hooks (lint + tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)