### PR TITLE
Remove macOS Intel build from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
             platform: linux-x64
           - os: macos-latest
             platform: darwin-arm64
-          - os: macos-13
-            platform: darwin-x64
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -84,9 +82,6 @@ jobs:
           ```bash
           # macOS (Apple Silicon)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/stm-cli-darwin-arm64.tgz
-
-          # macOS (Intel)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/stm-cli-darwin-x64.tgz
 
           # Linux (x64)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/stm-cli-linux-x64.tgz


### PR DESCRIPTION
## Summary
- Remove the `macos-13` / `darwin-x64` matrix entry from the release workflow
- Remove the corresponding Intel macOS install instructions from the release notes

## Test plan
- [ ] Verify the release workflow runs successfully with only `ubuntu-latest` and `macos-latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)