### PR TITLE
Add schema format conventions for esoteric formats

### DIFF
--- a/docs/conventions-for-schema-formats/README.md
+++ b/docs/conventions-for-schema-formats/README.md
@@ -23,6 +23,7 @@ This directory documents conventions for representing esoteric and non-standard 
 |--------|-----------|-----------------|
 | ISO 8583 | [`iso8583/`](iso8583/) | Bitmap-driven fields, numeric identifiers, variable-length encoding |
 | SWIFT MT | [`swift-mt/`](swift-mt/) | Block/tag structure, semi-structured text fields |
+| ISO 20022 | [`iso20022/`](iso20022/) | Verbose XML, structural compression, legacy MT migration |
 | FIX Protocol | [`fix-protocol/`](fix-protocol/) | Tag=value encoding, repeating groups, order sensitivity |
 
 ### Specialised Technical Formats
@@ -30,6 +31,8 @@ This directory documents conventions for representing esoteric and non-standard 
 |--------|-----------|-----------------|
 | ASN.1 | [`asn1/`](asn1/) | Tag-based encoding, BER/DER, CHOICE/OPTIONAL semantics |
 | DICOM | [`dicom/`](dicom/) | Tag dictionaries, value representations, vendor extensions |
+| MARC21 | [`marc21/`](marc21/) | Tag/indicator/subfield model, cataloguing semantics |
+| iCalendar | [`icalendar/`](icalendar/) | Line folding, recurrence rules, timezone handling |
 
 ## General Principles
 
@@ -54,5 +57,6 @@ The `examples/` directory at the repo root contains full working STM files for s
 - **Protobuf** — `examples/protobuf-to-parquet.stm` (tagged fields, repeated groups)
 - **Avro** — referenced in the spec (JSON-based, unions, schema evolution)
 - **OpenAPI** — representable using standard STM metadata (`format`, `enum`, `pii`)
+- **COBOL → Avro** — `examples/cobol-to-avro.stm` (legacy-to-modern transformation bridge)
 
 The conventions in this directory focus on formats that are **not** yet covered by canonical examples and where STM's mixed-model approach provides the most value.

--- a/docs/conventions-for-schema-formats/README.md
+++ b/docs/conventions-for-schema-formats/README.md
@@ -1,0 +1,58 @@
+# Conventions for Schema Formats
+
+STM is designed to represent schemas from any data format — including legacy, binary, positional, and industry-specific interchange standards. The vocabulary token system means format-specific metadata can be expressed directly in `( )` without language changes.
+
+This directory documents conventions for representing esoteric and non-standard formats in STM. Each subdirectory covers one format family with:
+
+- **Why** the format is difficult to represent in traditional schema languages
+- **Metadata conventions** — which vocabulary tokens to use and what they mean
+- **How natural language helps** — where `" "` descriptions fill semantic gaps
+- **A short valid STM example**
+
+## Format Categories
+
+### Legacy and Positional
+| Format | Directory | What it Stresses |
+|--------|-----------|-----------------|
+| COBOL Copybook | [`cobol-copybook/`](cobol-copybook/) | Positional layout, packed decimals, REDEFINES, OCCURS |
+| HL7 v2.x | [`hl7/`](hl7/) | Delimiter-based segments, inconsistent real-world feeds |
+| X12 / HIPAA | [`x12-hipaa/`](x12-hipaa/) | Loop hierarchies, qualifiers, implementation guide divergence |
+
+### Financial Messaging and Protocols
+| Format | Directory | What it Stresses |
+|--------|-----------|-----------------|
+| ISO 8583 | [`iso8583/`](iso8583/) | Bitmap-driven fields, numeric identifiers, variable-length encoding |
+| SWIFT MT | [`swift-mt/`](swift-mt/) | Block/tag structure, semi-structured text fields |
+| FIX Protocol | [`fix-protocol/`](fix-protocol/) | Tag=value encoding, repeating groups, order sensitivity |
+
+### Specialised Technical Formats
+| Format | Directory | What it Stresses |
+|--------|-----------|-----------------|
+| ASN.1 | [`asn1/`](asn1/) | Tag-based encoding, BER/DER, CHOICE/OPTIONAL semantics |
+| DICOM | [`dicom/`](dicom/) | Tag dictionaries, value representations, vendor extensions |
+
+## General Principles
+
+These conventions apply across all formats:
+
+1. **Preserve the original vocabulary.** Use metadata tokens that mirror the format's own terminology (`pic`, `segment`, `tag`, `block`). Engineers familiar with the format should recognise them immediately.
+
+2. **Separate physical layout from logical meaning.** Tokens like `offset`, `length`, and `encoding` describe the physical representation. The `record`/`list` structure and field names describe the logical model. Keep both.
+
+3. **Use natural language for interpretation rules.** Conditional logic (which REDEFINES variant to use, how to resolve a qualifier, when a field is populated) belongs in `" "` descriptions within mappings, not forced into metadata.
+
+4. **Format goes on the schema.** Declare the wire format in schema-level metadata: `(format copybook, encoding ebcdic)`. Field-level metadata then adds format-specific detail.
+
+5. **Derived fields belong in mappings.** Computed fields (`->`) are a mapping construct. Schema blocks describe structure; interpretation and derivation happen in `mapping` blocks.
+
+## Formats Already Covered by Canonical Examples
+
+The `examples/` directory at the repo root contains full working STM files for several formats:
+
+- **EDIFACT** — `examples/edi-to-json.stm` (EDI 856 fixed-length)
+- **XML / WSDL** — `examples/xml-to-parquet.stm` (namespace-qualified XML)
+- **Protobuf** — `examples/protobuf-to-parquet.stm` (tagged fields, repeated groups)
+- **Avro** — referenced in the spec (JSON-based, unions, schema evolution)
+- **OpenAPI** — representable using standard STM metadata (`format`, `enum`, `pii`)
+
+The conventions in this directory focus on formats that are **not** yet covered by canonical examples and where STM's mixed-model approach provides the most value.

--- a/docs/conventions-for-schema-formats/asn1/conventions.md
+++ b/docs/conventions-for-schema-formats/asn1/conventions.md
@@ -1,0 +1,100 @@
+# ASN.1 Conventions
+
+## Why This Format is Difficult
+
+ASN.1 (Abstract Syntax Notation One) is used in telecom (CDRs, signalling), PKI (X.509 certificates), and network protocols (SNMP, LDAP). It is challenging because:
+
+- **Tag-based encoding** — fields are identified by numeric tags, not names, on the wire
+- **Multiple encoding rules** — BER, DER, PER, and OER produce entirely different wire formats from the same schema
+- **Implicit vs explicit tagging** — whether a tag includes its own type information depends on the module's tagging mode
+- **CHOICE and OPTIONAL** — union types and optional fields are structural, not annotated
+- **Deep nesting** — real-world ASN.1 modules (e.g., 3GPP CDR specs) can be dozens of levels deep
+
+The decoded logical structure is often straightforward; the difficulty is in documenting the relationship between wire format and meaning.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `asn1` | `format asn1` |
+| `encoding` | Wire encoding rule | `encoding ber` |
+| `module` | ASN.1 module name if relevant | `module "TAP3-12"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `asn1_tag` | Context-specific tag number | `asn1_tag 0` |
+| `asn1_type` | Underlying ASN.1 type if not obvious | `asn1_type "OCTET STRING"` |
+| `optional` | Field may be absent | `optional` |
+| `choice` | Field is one of several alternatives | `choice` |
+| `tagging` | Implicit or explicit if overridden | `tagging implicit` |
+
+### Guidelines
+
+- Use `asn1_tag` on every field — tag numbers are the canonical wire-format identifiers
+- Include `encoding` at schema level so the decoding context is always clear
+- Use `record` for SEQUENCE and `list` for SEQUENCE OF
+- Document CHOICE resolution in `note` — the rules for determining which variant is present often depend on context or accompanying fields
+
+## How Natural Language Helps
+
+- **Tagging mode** — "Module uses implicit tagging; context tags replace the universal tag of the underlying type"
+- **CHOICE resolution** — "Determined by the tag number present: tag 0 = mobile originated, tag 1 = mobile terminated"
+- **Encoding quirks** — "BER allows indefinite-length encoding; DER requires definite-length and canonical ordering"
+- **Decoded vs wire structure** — "After decoding, the nested SEQUENCE becomes a flat record with named fields"
+
+## Example
+
+```stm
+// STM v2 — ASN.1 Telecom CDR Record (simplified TAP3)
+
+schema telecom_cdr (format asn1, encoding ber,
+  module "TAP3-12",
+  note "Transferred Account Procedure v3 — call detail record"
+) {
+  record CALL_EVENT (asn1_tag 0) {
+    record MOBILE_ORIGINATED (asn1_tag 0, choice,
+      note "Present when the call was originated by the recorded subscriber"
+    ) {
+      IMSI           STRING  (asn1_tag 0, required)
+      MSISDN         STRING  (asn1_tag 1)
+      CALLED_NUMBER  STRING  (asn1_tag 2)
+
+      record CALL_DURATION (asn1_tag 3) {
+        DURATION     INTEGER (asn1_tag 0, note "Duration in seconds")
+      }
+
+      CALL_TIMESTAMP STRING  (asn1_tag 4,
+        asn1_type "OCTET STRING",
+        note "BCD-encoded timestamp: YYMMDDhhmmss with timezone offset"
+      )
+
+      CAUSE_FOR_TERM STRING  (asn1_tag 5, optional,
+        note "0=normal, 1=busy, 2=no answer — per 3GPP TS 32.298"
+      )
+    }
+
+    record MOBILE_TERMINATED (asn1_tag 1, choice,
+      note "Present when the call was terminated at the recorded subscriber"
+    ) {
+      IMSI           STRING  (asn1_tag 0, required)
+      MSISDN         STRING  (asn1_tag 1)
+      CALLING_NUMBER STRING  (asn1_tag 2)
+
+      record CALL_DURATION (asn1_tag 3) {
+        DURATION     INTEGER (asn1_tag 0)
+      }
+    }
+  }
+}
+```
+
+### Key patterns
+
+- **CHOICE as variant records.** Mobile originated and mobile terminated calls are mutually exclusive — `choice` on the record makes this explicit.
+- **Tag numbers everywhere.** `asn1_tag` on every element mirrors the wire format and lets engineers cross-reference against the ASN.1 module definition.
+- **Encoding-specific notes.** BCD-encoded timestamps and the encoding rule itself are documented close to the fields they affect.
+- **3GPP references.** Notes cite the relevant telecom specification for code table interpretation.

--- a/docs/conventions-for-schema-formats/cobol-copybook/conventions.md
+++ b/docs/conventions-for-schema-formats/cobol-copybook/conventions.md
@@ -1,0 +1,142 @@
+# COBOL Copybook Conventions
+
+## Why This Format is Difficult
+
+COBOL copybooks are memory layouts disguised as schemas. They remain ubiquitous in finance, insurance, and government systems, but present several challenges for modern tooling:
+
+- **Positional layout** — fields are defined by byte offset and length, with no delimiters
+- **PIC clauses** — type, precision, and display format compressed into a terse notation (`PIC S9(7)V99`)
+- **Packed decimals (COMP-3)** — binary nibble encoding where each byte holds two digits and the final nibble is a sign indicator
+- **REDEFINES** — the same bytes can represent entirely different structures depending on runtime context
+- **OCCURS** — fixed-size arrays that may be partially populated, sometimes with a dynamic count via `DEPENDS ON`
+- **FILLER** — padding bytes that occupy physical space but carry no semantic meaning
+- **External interpretation** — the rules for choosing between REDEFINES variants or determining how many OCCURS entries are valid often live outside the copybook entirely
+
+Traditional schema languages either lose the physical layout detail (JSON Schema, Avro) or cannot express the interpretation rules (XSD, DDL).
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `copybook` | `format copybook` |
+| `encoding` | Character encoding of the source file | `encoding ebcdic` |
+| `note` | Context about the record's origin or system | `note "Customer master from VSAM"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `pic` | Original COBOL PIC clause, quoted | `pic "S9(7)V99"` |
+| `offset` | Byte offset (1-based) in the record | `offset 31` |
+| `length` | Field length in bytes | `length 5` |
+| `encoding` | Field-specific encoding (for packed fields) | `encoding comp-3` |
+| `occurs` | Repetition count (on `list`) | `occurs 5` |
+| `depends_on` | Dynamic OCCURS count field | `depends_on ITEM_COUNT` |
+| `redefines` | Names the record this one aliases | `redefines DATA_BLOCK` |
+
+### Guidelines
+
+- Always quote the `pic` value — it contains parentheses that would conflict with metadata syntax
+- Include `offset` and `length` on every field to make the physical layout reconstructible
+- Use `encoding comp-3` on packed decimal fields, with a `note` explaining sign-nibble conventions if the audience may not know them
+- Represent FILLER fields explicitly with a `note` marking them as padding — do not silently omit them, as this breaks offset calculations
+
+## How Natural Language Helps
+
+Copybooks are the format where natural language adds the most value in STM. The key interpretation rules that NL captures:
+
+- **REDEFINES resolution** — "If RECORD_TYPE = 'P', interpret these bytes as CARD_PAYMENT" — this conditional logic has no structural home in a schema
+- **OCCURS population rules** — "Only the first N entries are valid; trailing entries have blank ITEM_CODE" — the schema says 5 slots, reality says fewer
+- **Packed decimal details** — "Last nibble is sign: C = positive, D = negative" — critical for correct decoding
+- **Business meaning** — mapping status codes, explaining field overloading, documenting system-specific quirks
+
+These rules belong in `" "` descriptions within mapping blocks, not forced into metadata tokens.
+
+## Example
+
+```stm
+// STM v2 — COBOL Customer Master Record
+
+schema cobol_customer (format copybook, encoding ebcdic,
+  note "Customer master record from mainframe VSAM file"
+) {
+  CUST_ID        INTEGER    (pic "9(10)", offset 1, length 10, required)
+  CUST_TYPE      STRING     (pic "X(1)", offset 11, enum {R, B})
+
+  record NAME (offset 12, length 40) {
+    FIRST_NAME   STRING     (pic "X(20)", offset 12)
+    LAST_NAME    STRING     (pic "X(20)", offset 32)
+  }
+
+  record ADDRESS (offset 52, length 57) {
+    STREET       STRING     (pic "X(30)", offset 52)
+    CITY         STRING     (pic "X(20)", offset 82)
+    STATE        STRING     (pic "X(2)", offset 102)
+    ZIP          INTEGER    (pic "9(5)", offset 104)
+  }
+
+  CREDIT_LIMIT   DECIMAL(9,2) (
+    pic "S9(7)V99",
+    encoding comp-3,
+    offset 109,
+    length 5,
+    note "Packed decimal: last nibble is sign (C=positive, D=negative)"
+  )
+
+  ACCOUNT_BAL    DECIMAL(9,2) (
+    pic "S9(7)V99",
+    encoding comp-3,
+    offset 114,
+    length 5
+  )
+
+  STATUS_CODE    STRING     (pic "X(1)", offset 119, enum {A, I, S})
+
+  FILLER         STRING     (pic "X(10)", offset 120, length 10,
+    note "Unused padding — ignore in downstream systems"
+  )
+}
+```
+
+## Advanced: REDEFINES and OCCURS
+
+REDEFINES and OCCURS are the constructs that make copybooks genuinely difficult. Here is a record that uses both:
+
+```stm
+schema cobol_transaction (format copybook, encoding ebcdic,
+  note "Transaction record with polymorphic payload and repeating line items"
+) {
+  RECORD_TYPE   STRING     (pic "X(1)", offset 1)
+  ACCOUNT_ID    INTEGER    (pic "9(10)", offset 2)
+
+  record DATA_BLOCK (offset 12, length 11) {
+    AMOUNT      DECIMAL(9,2) (pic "S9(7)V99", encoding comp-3, offset 12, length 5)
+    CURRENCY    STRING       (pic "X(3)", offset 17)
+  }
+
+  record CARD_PAYMENT (redefines DATA_BLOCK, offset 12,
+    note "Interpreted when RECORD_TYPE = 'P'"
+  ) {
+    CARD_NUMBER STRING     (pic "X(16)", offset 12)
+    EXPIRY_DATE STRING     (pic "9(6)", offset 28)
+  }
+
+  ITEM_COUNT    INTEGER    (pic "9(2)", offset 34)
+
+  list LINE_ITEMS (occurs 10, depends_on ITEM_COUNT,
+    note "Only the first ITEM_COUNT entries are populated"
+  ) {
+    ITEM_CODE   STRING     (pic "X(10)")
+    QUANTITY    INTEGER    (pic "9(3)")
+    UNIT_PRICE  DECIMAL(7,2) (pic "S9(5)V99", encoding comp-3)
+  }
+}
+```
+
+### Key patterns
+
+- **REDEFINES as explicit variant.** The `redefines` token makes the aliasing visible. The `note` on the record states the discriminator condition.
+- **OCCURS with `depends_on`.** The physical capacity (10 slots) is separate from the logical count (`ITEM_COUNT`). The `note` explains population semantics.
+- **Resolution belongs in mappings.** A mapping that consumes this schema would use `->` arrows with NL descriptions like `"If RECORD_TYPE = 'P', interpret DATA_BLOCK as CARD_PAYMENT"`.

--- a/docs/conventions-for-schema-formats/dicom/conventions.md
+++ b/docs/conventions-for-schema-formats/dicom/conventions.md
@@ -1,0 +1,109 @@
+# DICOM Conventions
+
+## Why This Format is Difficult
+
+DICOM (Digital Imaging and Communications in Medicine) is the standard for medical imaging data — CT scans, MRIs, X-rays, and associated metadata. It is challenging because:
+
+- **Tag-based binary format** — fields are identified by (group, element) tag pairs like `(0010,0010)` for patient name
+- **Value Representations (VR)** — each field has a VR code that determines its encoding and length rules (e.g., `PN` for person name, `DA` for date, `SQ` for sequence)
+- **Nested sequences** — `SQ` (Sequence of Items) creates arbitrarily deep nesting
+- **Private tags** — vendors define custom tag ranges for proprietary data, with no universal registry
+- **Modality variance** — different imaging modalities (CT, MR, US) populate different subsets of tags with different conventions
+- **Patient safety stakes** — incorrect interpretation of DICOM metadata can affect clinical decisions
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `dicom` | `format dicom` |
+| `modality` | Imaging modality if specific | `modality "CT"` |
+| `sop_class` | SOP Class UID if relevant | `sop_class "1.2.840.10008.5.1.4.1.1.2"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `dicom_tag` | Tag as (group,element) | `dicom_tag "0010,0010"` |
+| `vr` | Value Representation code | `vr PN` |
+| `vm` | Value Multiplicity | `vm "1-n"` |
+| `private` | Marks a vendor-specific private tag | `private` |
+| `private_creator` | Identifies the vendor for a private tag | `private_creator "SIEMENS MR"` |
+
+### Guidelines
+
+- Always include `dicom_tag` and `vr` on every field — these are the canonical identifiers in DICOM
+- Use the standard DICOM tag name as the field name (e.g., `PATIENT_NAME`, `STUDY_DATE`)
+- Use `list` with `vr SQ` for sequence tags — these are DICOM's nesting mechanism
+- Document private tags with `private_creator` so the vendor can be identified
+- Mark PII fields (`pii`) — DICOM headers contain extensive patient information
+
+## How Natural Language Helps
+
+- **VR parsing** — "PN (Person Name) uses ^ as component separator: last^first^middle^prefix^suffix"
+- **Modality-specific tags** — "Tag (0018,0050) Slice Thickness is populated for CT and MR but absent for CR"
+- **Private tag interpretation** — "Siemens private tag (0019,100C) contains b-value for diffusion-weighted MRI sequences"
+- **De-identification** — "For research export, tags in groups 0010 (Patient) and 0038 (Visit) must be anonymised per DICOM PS3.15 Annex E"
+
+## Example
+
+```stm
+// STM v2 — DICOM CT Study Metadata (simplified)
+
+schema dicom_ct_study (format dicom, modality "CT",
+  note "CT study-level metadata — core patient and study tags"
+) {
+  // --- Patient module ---
+
+  PATIENT_NAME       STRING  (dicom_tag "0010,0010", vr PN, pii,
+    note "Person Name: last^first^middle^prefix^suffix"
+  )
+  PATIENT_ID         STRING  (dicom_tag "0010,0020", vr LO, pii)
+  PATIENT_DOB        STRING  (dicom_tag "0010,0030", vr DA, pii,
+    note "Format: YYYYMMDD"
+  )
+  PATIENT_SEX        STRING  (dicom_tag "0010,0040", vr CS, enum {M, F, O})
+
+  // --- Study module ---
+
+  STUDY_DATE         STRING  (dicom_tag "0008,0020", vr DA)
+  STUDY_TIME         STRING  (dicom_tag "0008,0030", vr TM,
+    note "Format: HHMMSS.FFFFFF — fractional seconds may be truncated"
+  )
+  STUDY_DESCRIPTION  STRING  (dicom_tag "0008,1030", vr LO)
+  STUDY_INSTANCE_UID STRING  (dicom_tag "0020,000D", vr UI, required)
+  ACCESSION_NUMBER   STRING  (dicom_tag "0008,0050", vr SH)
+
+  // --- Series-level (nested) ---
+
+  list SERIES (dicom_tag "0020,000E", vr SQ,
+    note "One entry per imaging series within the study"
+  ) {
+    SERIES_INSTANCE_UID STRING (dicom_tag "0020,000E", vr UI, required)
+    SERIES_NUMBER       INTEGER (dicom_tag "0020,0011", vr IS)
+    SERIES_DESCRIPTION  STRING  (dicom_tag "0008,103E", vr LO)
+    SLICE_THICKNESS     DECIMAL (dicom_tag "0018,0050", vr DS,
+      note "In millimetres — may be absent for scout/localiser series"
+    )
+  }
+
+  // --- Vendor private tags ---
+
+  SIEMENS_B_VALUE    INTEGER (
+    dicom_tag "0019,100C",
+    vr IS,
+    private,
+    private_creator "SIEMENS MR",
+    note "Diffusion b-value — only present in diffusion-weighted sequences"
+  )
+}
+```
+
+### Key patterns
+
+- **Standard tag notation.** `dicom_tag "0010,0010"` matches DICOM documentation and viewer tools exactly.
+- **VR as a type system.** `vr PN`, `vr DA`, `vr SQ` encode DICOM's value representation — richer than a simple type annotation.
+- **Sequences as lists.** DICOM `SQ` tags map naturally to `list` blocks.
+- **Private tags with provenance.** `private` + `private_creator` makes vendor-specific tags traceable rather than opaque.
+- **PII marking.** Patient group tags are marked `pii` for de-identification workflows.

--- a/docs/conventions-for-schema-formats/fix-protocol/conventions.md
+++ b/docs/conventions-for-schema-formats/fix-protocol/conventions.md
@@ -1,0 +1,96 @@
+# FIX Protocol Conventions
+
+## Why This Format is Difficult
+
+FIX (Financial Information eXchange) is the dominant protocol for electronic trading — equities, FX, derivatives, and fixed income. It is challenging because:
+
+- **Tag=value wire format** — fields are encoded as `tag=value|` pairs with SOH (0x01) delimiters, producing a flat stream with no hierarchy
+- **Repeating groups** — groups of related fields repeat N times, but the grouping is implicit (the count tag precedes the group, and field order determines boundaries)
+- **Tag number semantics** — fields are identified by numeric tags (e.g., tag 35 = MsgType, tag 44 = Price), requiring domain knowledge to interpret
+- **Order sensitivity** — field order matters within repeating groups; reordering can change meaning
+- **Venue-specific variants** — exchanges and ECNs define private tags and override standard field semantics
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `fix` | `format fix` |
+| `fix_version` | FIX version | `fix_version "4.4"` |
+| `venue` | Exchange or venue if applicable | `venue "LSE"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `tag` | FIX tag number | `tag 35` |
+| `count_tag` | Tag that holds the repeating group count | `count_tag 453` |
+
+### Guidelines
+
+- Always include `tag` on every field — FIX engineers think in tag numbers
+- Use human-readable field names (e.g., `MSG_TYPE` not `TAG35`) with the tag in metadata
+- Use `list` for repeating groups, with `count_tag` identifying the count field
+- Document venue-specific tag interpretations in `note`
+- Field ordering within a repeating group is significant — document it if non-obvious
+
+## How Natural Language Helps
+
+- **Repeating group boundaries** — "Group starts at tag 448 (PartyID); each repetition contains tags 448, 447, 452, 802 in order"
+- **Venue-specific tags** — "LSE uses private tag 9730 for order priority timestamp; not present on other venues"
+- **Message type semantics** — "MsgType D = New Order Single; MsgType 8 = Execution Report"
+- **Conditional fields** — "Tag 44 (Price) is required for limit orders (OrdType=2) but absent for market orders (OrdType=1)"
+
+## Example
+
+```stm
+// STM v2 — FIX 4.4 New Order Single (simplified)
+
+schema fix_new_order (format fix, fix_version "4.4",
+  note "New Order Single (MsgType=D) — core order fields"
+) {
+  MSG_TYPE        STRING  (tag 35, required, note "D = New Order Single")
+  CL_ORD_ID      STRING  (tag 11, required, note "Client-assigned order identifier")
+  SYMBOL         STRING  (tag 55, required)
+  SIDE           STRING  (tag 54, required, enum {1, 2},
+    note "1=Buy, 2=Sell"
+  )
+  ORDER_QTY      DECIMAL (tag 38, required)
+  ORD_TYPE       STRING  (tag 40, required, enum {1, 2, 3, 4},
+    note "1=Market, 2=Limit, 3=Stop, 4=Stop Limit"
+  )
+  PRICE          DECIMAL (tag 44,
+    note "Required when OrdType is 2 (Limit) or 4 (Stop Limit); absent for market orders"
+  )
+  TIME_IN_FORCE  STRING  (tag 59, enum {0, 1, 3, 6},
+    note "0=Day, 1=GTC, 3=IOC, 6=GTD"
+  )
+  TRANSACT_TIME  STRING  (tag 60, required,
+    note "UTC timestamp: YYYYMMDD-HH:MM:SS.sss"
+  )
+
+  list PARTIES (count_tag 453,
+    note """
+    Repeating group of party identifications.
+    Each repetition contains PartyID, PartyIDSource, PartyRole in order.
+    Tag 453 (NoPartyIDs) holds the count.
+    """
+  ) {
+    PARTY_ID       STRING (tag 448)
+    PARTY_SOURCE   STRING (tag 447, enum {B, D},
+      note "B=BIC, D=proprietary/custom"
+    )
+    PARTY_ROLE     STRING (tag 452,
+      note "1=executing firm, 3=client, 7=entering firm, 36=entering trader"
+    )
+  }
+}
+```
+
+### Key patterns
+
+- **Tag numbers as canonical identifiers.** Every field carries `tag N`, matching FIX documentation and wire traces.
+- **Repeating groups as lists.** `count_tag 453` makes the implicit grouping mechanism explicit; the `note` documents field ordering within the group.
+- **Conditional presence.** Price is documented as conditionally required based on order type — this cannot be expressed structurally, so it lives in a `note`.
+- **Enum codes with meaning.** FIX uses numeric codes for everything; `note` provides the human-readable mapping alongside the `enum`.

--- a/docs/conventions-for-schema-formats/hl7/conventions.md
+++ b/docs/conventions-for-schema-formats/hl7/conventions.md
@@ -1,0 +1,104 @@
+# HL7 v2.x Conventions
+
+## Why This Format is Difficult
+
+HL7 v2.x is the dominant messaging standard in healthcare. It is delimiter-based, like EDIFACT, but adds its own layer of difficulty:
+
+- **Delimiter hierarchy** — segments separated by `\r`, fields by `|`, components by `^`, sub-components by `&`, and repetitions by `~`
+- **Positional addressing** — fields are identified by segment and position (e.g., `PID-5` is the fifth field of the PID segment)
+- **Component decomposition** — a single field can contain multiple components (e.g., patient name = last^first^middle^suffix^prefix)
+- **Inconsistent real-world feeds** — the standard is loosely followed; hospitals, labs, and vendors each produce their own variants
+- **Trigger events and message types** — the same segment structures appear across different message types (ADT, ORM, ORU) with different semantics
+
+HL7 v2 is one of the formats where the gap between specification and reality is widest. Natural language is essential for documenting site-specific behaviour.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `hl7` | `format hl7` |
+| `message_type` | HL7 message type | `message_type "ADT^A08"` |
+| `version` | HL7 version | `version "2.5.1"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `segment` | HL7 segment identifier | `segment PID` |
+| `field` | Field position within segment (1-based) | `field 5` |
+| `component` | Component position within field | `component 1` |
+| `repetition` | Which repetition (if repeating field) | `repetition 1` |
+
+### Guidelines
+
+- Use `segment` on `record` blocks to map each HL7 segment to a structural unit
+- Use `field` and `component` together for composite fields like patient name
+- Document feed-specific deviations prominently — HL7 feeds are notorious for non-conformance
+- Use `list` for repeating segments (e.g., multiple OBX observation segments in an ORU message)
+
+## How Natural Language Helps
+
+- **Component parsing** — "PID-5 contains last^first^middle^suffix^prefix — not all components are always present"
+- **Feed-specific quirks** — "Lab system X sends PID-3 as MRN only; Hospital Y includes MRN~encounter number with repetition"
+- **Code table interpretation** — "PID-8 administrative sex: M, F, O, U, A, N per HL7 table 0001 — but some feeds send 'MALE'/'FEMALE' as free text"
+- **Trigger event context** — "ADT^A08 is an update to patient information; ADT^A01 is an admit — same PID segment, different downstream handling"
+
+## Example
+
+```stm
+// STM v2 — HL7 ADT Patient Demographics (simplified)
+
+schema hl7_patient (format hl7, message_type "ADT^A08", version "2.5.1",
+  note "Patient demographics from ADT update message"
+) {
+  record MSH (segment MSH, note "Message header — controls routing and versioning") {
+    sending_app     STRING  (field 3)
+    sending_facility STRING (field 4)
+    message_type    STRING  (field 9, note "ADT^A08 for patient update")
+    version_id      STRING  (field 12)
+  }
+
+  record PID (segment PID, note "Patient identification segment") {
+    patient_id      STRING  (field 3, component 1,
+      note "CX data type — component 1 is the ID number, component 5 is the ID type"
+    )
+
+    last_name       STRING  (field 5, component 1)
+    first_name      STRING  (field 5, component 2)
+    middle_name     STRING  (field 5, component 3)
+
+    date_of_birth   STRING  (field 7,
+      note "Format varies: YYYYMMDD expected, but some feeds send YYYY-MM-DD or MM/DD/YYYY"
+    )
+
+    admin_sex       STRING  (field 8, enum {M, F, O, U},
+      note "HL7 table 0001 — some feeds send full words instead of codes"
+    )
+
+    address_street  STRING  (field 11, component 1)
+    address_city    STRING  (field 11, component 3)
+    address_state   STRING  (field 11, component 4)
+    address_zip     STRING  (field 11, component 5)
+
+    phone_home      STRING  (field 13, pii)
+  }
+
+  list OBX (segment OBX, note "Observation segments — repeats per result") {
+    value_type      STRING  (field 2, note "NM=numeric, ST=string, CE=coded entry")
+    observation_id  STRING  (field 3, component 1)
+    observation_text STRING (field 3, component 2)
+    value           STRING  (field 5)
+    units           STRING  (field 6)
+    abnormal_flag   STRING  (field 8, enum {L, H, LL, HH, N})
+  }
+}
+```
+
+### Key patterns
+
+- **Segment-as-record.** Each HL7 segment maps to a `record` block, keeping the familiar structure.
+- **Component addressing for composite fields.** PID-5 (patient name) is decomposed into components rather than left as a single string.
+- **Repeating segments as lists.** OBX segments repeat per observation result — `list` captures this naturally.
+- **Feed variance documented.** Notes flag where real-world feeds deviate from the standard (date formats, sex codes, ID types).

--- a/docs/conventions-for-schema-formats/icalendar/conventions.md
+++ b/docs/conventions-for-schema-formats/icalendar/conventions.md
@@ -1,0 +1,142 @@
+# iCalendar Conventions
+
+## Why This Format is Difficult
+
+iCalendar (RFC 5545) is the universal standard for calendar data exchange — `.ics` files, CalDAV, meeting invitations. It is technically familiar but deceptively complex in practice:
+
+- **Line folding** — long lines are wrapped by inserting CRLF + whitespace, requiring unfolding before parsing
+- **Property parameters** — properties carry inline parameters with different syntax (e.g., `DTSTART;TZID=Europe/London:20260315T090000`)
+- **Recurrence rules (RRULE)** — a compact DSL for expressing repeating events that encodes complex temporal logic in a single property value
+- **Timezone handling** — timezone definitions are embedded inline (VTIMEZONE components) or referenced by TZID, with no guarantee of IANA identifier usage
+- **Component nesting** — events (VEVENT), alarms (VALARM), and timezones (VTIMEZONE) nest within the calendar (VCALENDAR) with different property sets
+- **Real-world variance** — Google Calendar, Outlook, and Apple Calendar each produce subtly different iCalendar output
+
+iCalendar is a good "bridge" example: familiar enough that most readers have encountered `.ics` files, but complex enough to demonstrate STM's value.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `icalendar` | `format icalendar` |
+| `component` | iCalendar component type | `component VEVENT` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `property` | iCalendar property name | `property DTSTART` |
+| `param` | Property parameter | `param TZID` |
+| `value_type` | Value data type per RFC 5545 | `value_type DATE-TIME` |
+
+### Guidelines
+
+- Use `property` on every field — iCalendar properties are the canonical identifiers
+- Use `record` for nested components (VALARM inside VEVENT, VTIMEZONE inside VCALENDAR)
+- Document RRULE interpretation in `note` — recurrence rules are compact and easy to misread
+- Note timezone handling explicitly — it is the most common source of bugs in calendar interop
+
+## How Natural Language Helps
+
+- **Recurrence interpretation** — "RRULE:FREQ=MONTHLY;BYDAY=2TU means the second Tuesday of every month"
+- **Timezone resolution** — "If TZID is not an IANA identifier, fall back to the embedded VTIMEZONE offset rules"
+- **Line folding** — "All property values must be unfolded before interpretation — continuation lines start with a single space or tab"
+- **Cross-client quirks** — "Outlook sends DTSTART as floating (no TZID) for all-day events; Google sends DATE value type instead"
+
+## Example
+
+```stm
+// STM v2 — iCalendar Event (simplified)
+
+schema icalendar_event (format icalendar, component VEVENT,
+  note """
+  Single calendar event from an iCalendar feed.
+  Assumes line unfolding has been applied before parsing.
+  """
+) {
+  UID              STRING  (property UID, required,
+    note "Globally unique identifier — typically a UUID or URI"
+  )
+
+  SUMMARY          STRING  (property SUMMARY, required,
+    note "Event title — plain text, may contain escaped commas and semicolons"
+  )
+
+  DESCRIPTION      STRING  (property DESCRIPTION,
+    note "Event body — may contain escaped newlines (\\n) and basic formatting"
+  )
+
+  DTSTART          STRING  (property DTSTART, value_type DATE-TIME, required,
+    note """
+    Start date-time. Three possible forms:
+    - With TZID parameter: `DTSTART;TZID=Europe/London:20260315T090000`
+    - UTC: `DTSTART:20260315T090000Z`
+    - Floating (no timezone): `DTSTART:20260315T090000`
+    For all-day events, value type is DATE: `DTSTART;VALUE=DATE:20260315`
+    """
+  )
+
+  DTEND            STRING  (property DTEND, value_type DATE-TIME,
+    note "End date-time — same format rules as DTSTART. Mutually exclusive with DURATION."
+  )
+
+  DURATION         STRING  (property DURATION,
+    note "ISO 8601 duration (e.g., PT1H30M). Used instead of DTEND for some recurring events."
+  )
+
+  LOCATION         STRING  (property LOCATION)
+
+  STATUS           STRING  (property STATUS, enum {TENTATIVE, CONFIRMED, CANCELLED})
+
+  RRULE            STRING  (property RRULE,
+    note """
+    Recurrence rule — compact DSL for repeating events. Examples:
+    - `FREQ=WEEKLY;BYDAY=MO,WE,FR` — every Mon/Wed/Fri
+    - `FREQ=MONTHLY;BYDAY=2TU` — second Tuesday of each month
+    - `FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15` — every 15 March
+    - `FREQ=DAILY;COUNT=10` — daily for 10 occurrences
+    - `FREQ=WEEKLY;UNTIL=20261231T235959Z` — weekly until end of 2026
+    """
+  )
+
+  list EXDATE (property EXDATE,
+    note "Exception dates — specific occurrences removed from a recurrence set"
+  ) {
+    date             STRING (value_type DATE-TIME)
+  }
+
+  ORGANIZER        STRING  (property ORGANIZER,
+    note "mailto: URI of the event organiser — e.g., mailto:jane@example.com"
+  )
+
+  list ATTENDEES (property ATTENDEE) {
+    address          STRING (note "mailto: URI of the attendee")
+    role             STRING (param ROLE, enum {CHAIR, REQ-PARTICIPANT, OPT-PARTICIPANT})
+    partstat         STRING (param PARTSTAT,
+      enum {NEEDS-ACTION, ACCEPTED, DECLINED, TENTATIVE}
+    )
+    rsvp             STRING (param RSVP, enum {TRUE, FALSE})
+  }
+
+  record ALARM (component VALARM,
+    note "Nested alarm component — triggers a reminder before the event"
+  ) {
+    action           STRING (property ACTION, enum {DISPLAY, AUDIO, EMAIL})
+    trigger          STRING (property TRIGGER,
+      note "Duration before event start (e.g., -PT15M = 15 minutes before)"
+    )
+    description      STRING (property DESCRIPTION,
+      note "Reminder text — required when ACTION=DISPLAY"
+    )
+  }
+}
+```
+
+### Key patterns
+
+- **Property names as identifiers.** `property DTSTART`, `property RRULE` match the RFC directly.
+- **Parameters as metadata.** Attendee properties carry inline parameters (ROLE, PARTSTAT) expressed as `param` tokens.
+- **RRULE documented via NL.** The recurrence rule DSL is explained with concrete examples in a `note` rather than decomposed into separate fields.
+- **Nested components as records.** VALARM inside VEVENT maps to a `record` block.
+- **Variant representations acknowledged.** DTSTART documents all three possible forms (TZID, UTC, floating) and the all-day DATE alternative.

--- a/docs/conventions-for-schema-formats/iso20022/conventions.md
+++ b/docs/conventions-for-schema-formats/iso20022/conventions.md
@@ -1,0 +1,148 @@
+# ISO 20022 Conventions
+
+## Why This Format is Difficult
+
+ISO 20022 is the modern XML-based standard for financial messaging, gradually replacing SWIFT MT. It covers payments (pacs), cash management (camt), securities (sese/semt), and trade finance (tsmt). The format is challenging not because it is underspecified, but because it is *over-specified*:
+
+- **Deeply nested XML** — a simple credit transfer (pacs.008) can be 6+ levels deep with dozens of optional elements
+- **Namespace-heavy** — every message type has its own XML namespace, and versions change the namespace URI
+- **Verbose element names** — `<CdtTrfTxInf>`, `<RmtInf>`, `<InstdAmt>` are abbreviated but not intuitive
+- **Rich type system** — ISO 20022 defines its own data types (ActiveCurrencyAndAmount, ISODateTime, etc.) with embedded constraints
+- **Optional everywhere** — most elements are optional, making the actual population pattern message- and institution-dependent
+- **Code sets** — extensive external code lists (purpose codes, category purpose, charge bearer) with hundreds of values
+
+The irony is that ISO 20022 schemas are technically precise — the XSD is authoritative. But the schemas are so large and deeply nested that they are effectively unreadable for humans. STM's value here is compression: making a 400-element schema scannable.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `iso20022` | `format iso20022` |
+| `message_type` | ISO 20022 message identifier | `message_type "pacs.008.001.10"` |
+| `namespace` | XML namespace for the message | `namespace "urn:iso:std:iso:20022:tech:xsd:pacs.008.001.10"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `xpath` | Path within the XML document | `xpath "CdtTrfTxInf/Amt/InstdAmt"` |
+| `iso20022_type` | ISO 20022 data type if non-obvious | `iso20022_type "ActiveCurrencyAndAmount"` |
+| `code_set` | External code list reference | `code_set "ExternalPurpose1Code"` |
+
+### Guidelines
+
+- Use `xpath` relative to the message root — ISO 20022 paths are long enough without repeating the envelope
+- Use `record` generously to mirror the XML nesting — but only for groups that carry distinct semantic meaning
+- Collapse trivially nested wrappers into flatter structures with notes explaining what was elided
+- Include `code_set` references so readers can look up valid values without digging through the XSD
+
+## How Natural Language Helps
+
+- **Structural compression** — "The full path is FIToFICstmrCdtTrf/CdtTrfTxInf/RmtInf/Strd/CdtrRefInf/Ref — collapsed here to the semantically meaningful elements"
+- **Population patterns** — "IntrBkSttlmDt is technically optional but always populated by SWIFT gpi members"
+- **Currency embedding** — "InstdAmt carries the currency as an XML attribute (Ccy), not a child element"
+- **Version differences** — "In pacs.008.001.08, BIC was under FinInstnId/BIC; from .001.09 onwards it moved to FinInstnId/BICFI"
+
+## Relationship to SWIFT MT
+
+ISO 20022 is replacing SWIFT MT messages. Common equivalences:
+
+| SWIFT MT | ISO 20022 | Description |
+|----------|-----------|-------------|
+| MT103 | pacs.008 | Customer credit transfer |
+| MT202 | pacs.009 | Financial institution transfer |
+| MT940 | camt.053 | Statement of account |
+| MT199 | admi.004 | Free-format message |
+
+See [`swift-mt/conventions.md`](../swift-mt/conventions.md) for the legacy counterpart. A mapping between MT103 and pacs.008 schemas would demonstrate the migration path.
+
+## Example
+
+```stm
+// STM v2 — ISO 20022 pacs.008 Customer Credit Transfer (simplified)
+
+schema iso20022_credit_transfer (
+  format iso20022,
+  message_type "pacs.008.001.10",
+  namespace "urn:iso:std:iso:20022:tech:xsd:pacs.008.001.10",
+  note """
+  FI to FI Customer Credit Transfer — simplified to core payment fields.
+  Full XSD defines 400+ elements; this captures the operationally
+  significant subset for typical SWIFT gpi payments.
+  """
+) {
+  record GROUP_HEADER (xpath "GrpHdr") {
+    message_id       STRING       (xpath "MsgId", required)
+    creation_dt      STRING       (xpath "CreDtTm", required,
+      iso20022_type "ISODateTime"
+    )
+    num_transactions INTEGER      (xpath "NbOfTxs", required)
+    settlement_method STRING      (xpath "SttlmInf/SttlmMtd", required,
+      enum {INDA, INGA, COVE, CLRG},
+      note "INDA=instructed agent, INGA=instructing agent, COVE=cover, CLRG=clearing"
+    )
+  }
+
+  list TRANSACTIONS (xpath "CdtTrfTxInf",
+    note "One entry per payment instruction within the message"
+  ) {
+    end_to_end_id    STRING       (xpath "PmtId/EndToEndId", required)
+    instruction_id   STRING       (xpath "PmtId/InstrId")
+    uetr             STRING       (xpath "PmtId/UETR",
+      note "Unique End-to-End Transaction Reference — UUID v4, required for SWIFT gpi"
+    )
+
+    interbank_amount DECIMAL(18,5) (xpath "IntrBkSttlmAmt", required,
+      note "Currency carried as Ccy XML attribute on the element, not a child"
+    )
+    interbank_currency STRING     (xpath "IntrBkSttlmAmt/@Ccy", required)
+    settlement_date  DATE         (xpath "IntrBkSttlmDt")
+
+    charge_bearer    STRING       (xpath "ChrgBr", enum {DEBT, CRED, SHAR, SLEV},
+      note "DEBT=debtor pays, CRED=creditor pays, SHAR=shared, SLEV=service level"
+    )
+
+    record DEBTOR (xpath "Dbtr") {
+      name           STRING       (xpath "Nm")
+      record address (xpath "PstlAdr") {
+        country      STRING       (xpath "Ctry")
+        address_lines STRING      (xpath "AdrLine",
+          note "Up to 7 lines of 70 characters each"
+        )
+      }
+    }
+
+    DEBTOR_ACCOUNT   STRING       (xpath "DbtrAcct/Id/IBAN")
+    DEBTOR_AGENT_BIC STRING       (xpath "DbtrAgt/FinInstnId/BICFI", required)
+
+    record CREDITOR (xpath "Cdtr") {
+      name           STRING       (xpath "Nm", required)
+      record address (xpath "PstlAdr") {
+        country      STRING       (xpath "Ctry")
+      }
+    }
+
+    CREDITOR_ACCOUNT STRING       (xpath "CdtrAcct/Id/IBAN")
+    CREDITOR_AGENT_BIC STRING     (xpath "CdtrAgt/FinInstnId/BICFI", required)
+
+    REMITTANCE_INFO  STRING       (xpath "RmtInf/Ustrd",
+      note "Unstructured remittance — up to 140 characters"
+    )
+
+    PURPOSE_CODE     STRING       (xpath "Purp/Cd",
+      code_set "ExternalPurpose1Code",
+      note "e.g., SALA=salary, SUPP=supplier payment, TAXS=tax payment"
+    )
+  }
+}
+```
+
+### Key patterns
+
+- **Structural compression.** A 400-element XSD is reduced to the operationally significant subset. The `note` on the schema documents what was elided and why.
+- **XPath relative to message root.** Paths like `CdtTrfTxInf/PmtId/EndToEndId` are relative, avoiding repetition of the envelope.
+- **XML attribute access.** `xpath "IntrBkSttlmAmt/@Ccy"` captures the currency attribute — a detail that would be invisible in a flat field list.
+- **Collapsed wrappers.** `DbtrAgt/FinInstnId/BICFI` is a single field rather than three nested records — the intermediate wrappers add no semantic value.
+- **Code set references.** `code_set "ExternalPurpose1Code"` points readers to the external list without inlining hundreds of values.

--- a/docs/conventions-for-schema-formats/iso8583/conventions.md
+++ b/docs/conventions-for-schema-formats/iso8583/conventions.md
@@ -1,0 +1,111 @@
+# ISO 8583 Conventions
+
+## Why This Format is Difficult
+
+ISO 8583 is the international standard for card payment messages. It underpins ATM transactions, point-of-sale authorisations, and inter-network settlement. The format is challenging because:
+
+- **Bitmap-driven structure** — field presence is indicated by bits in a bitmap header, not by position or delimiters
+- **Numeric field identifiers** — fields are referred to as "data elements" (DE2, DE3, ..., DE128) with no human-readable names in the wire format
+- **Variable-length fields** — some fields have fixed lengths, others are prefixed with length indicators (LLVAR, LLLVAR)
+- **Encoding diversity** — fields may be ASCII, EBCDIC, BCD-packed, or binary, sometimes within the same message
+- **Network dialects** — Visa, Mastercard, and regional networks each define their own variants with different field semantics, sub-fields, and private data elements
+
+Without domain knowledge, an ISO 8583 message is essentially unreadable.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `iso8583` | `format iso8583` |
+| `version` | ISO 8583 version | `version "1987"` or `version "1993"` |
+| `network` | Network dialect if applicable | `network visa` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `de` | Data element number | `de 2` |
+| `length` | Field length or max length | `length 19` |
+| `length_type` | Fixed, LLVAR, or LLLVAR | `length_type llvar` |
+| `encoding` | Field-level encoding | `encoding bcd` |
+| `bitmap` | Bitmap position (if different from DE number) | `bitmap 1` |
+
+### Guidelines
+
+- Always include `de` on every field — this is the canonical identifier that domain engineers will look for
+- Use human-readable field names alongside the DE number (e.g., `PAN` not `DE2`, with `de 2` in metadata)
+- Include `length_type` to distinguish fixed from variable-length fields — this is critical for parsing
+- Document network-specific semantics in `note` — the same DE can mean different things on different networks
+
+## How Natural Language Helps
+
+- **MTI interpretation** — "0100 = authorisation request, 0110 = authorisation response" — the message type indicator encodes transaction semantics in a 4-digit code
+- **Sub-field parsing** — "DE-3 processing code: positions 1-2 = transaction type, 3-4 = from account, 5-6 = to account"
+- **Network-specific behaviour** — "On Visa, DE-48 contains TLV-encoded subelements; on Mastercard, it's a fixed structure"
+- **Bitmap mechanics** — "If bit 1 of the primary bitmap is set, a secondary bitmap follows, enabling DE-65 through DE-128"
+
+## Example
+
+```stm
+// STM v2 — ISO 8583 Authorisation Request (simplified)
+
+schema iso8583_auth_request (format iso8583, version "1987",
+  note "Card authorisation request — common fields across networks"
+) {
+  MTI              STRING     (length 4, encoding bcd,
+    note "Message Type Indicator: 0100 = auth request, 0110 = auth response"
+  )
+
+  BITMAP           BINARY     (length 8,
+    note "Primary bitmap — each set bit indicates the presence of the corresponding DE"
+  )
+
+  PAN              STRING     (de 2, length 19, length_type llvar, pii,
+    note "Primary Account Number — variable length, up to 19 digits"
+  )
+
+  PROCESSING_CODE  STRING     (de 3, length 6, encoding bcd,
+    note """
+    6-digit code:
+    - Positions 1-2: transaction type (00=purchase, 01=cash advance)
+    - Positions 3-4: from account type (00=default, 10=savings)
+    - Positions 5-6: to account type
+    """
+  )
+
+  AMOUNT           INTEGER    (de 4, length 12, encoding bcd,
+    note "Transaction amount in minor units of the transaction currency"
+  )
+
+  TRANSMISSION_DT  STRING     (de 7, length 10, encoding bcd,
+    note "MMDDhhmmss — date and time of transmission"
+  )
+
+  TRACE_NUMBER     STRING     (de 11, length 6,
+    note "Systems trace audit number — unique per transaction within a day"
+  )
+
+  EXPIRY_DATE      STRING     (de 14, length 4, encoding bcd, pii,
+    note "YYMM format"
+  )
+
+  CURRENCY_CODE    STRING     (de 49, length 3,
+    note "ISO 4217 numeric currency code"
+  )
+
+  record ADDITIONAL_DATA (de 48, length_type lllvar,
+    note "Network-specific: contains TLV sub-elements on Visa, fixed structure on Mastercard"
+  ) {
+    //? Structure varies by network — document per-network sub-fields as needed
+  }
+}
+```
+
+### Key patterns
+
+- **DE numbers as canonical identifiers.** Every field carries `de N`, matching the ISO 8583 standard numbering. Field names are human-readable aliases.
+- **Length type matters.** `length_type llvar` vs fixed length is critical for wire-format parsing.
+- **Sub-field semantics via NL.** DE-3's positional sub-fields are explained in a `note` rather than decomposed into separate fields — matching how the standard documents them.
+- **Network variance acknowledged.** The `ADDITIONAL_DATA` record uses a question comment (`//?`) to flag that its structure depends on the network.

--- a/docs/conventions-for-schema-formats/marc21/conventions.md
+++ b/docs/conventions-for-schema-formats/marc21/conventions.md
@@ -1,0 +1,145 @@
+# MARC21 Conventions
+
+## Why This Format is Difficult
+
+MARC21 (Machine-Readable Cataloguing) is the standard for bibliographic records in libraries worldwide. It has been in continuous use since the 1960s and remains the backbone of library catalogue systems. It is challenging because:
+
+- **Tag/indicator/subfield model** — each field is identified by a 3-digit tag (e.g., `245` for title), has two single-character indicators, and contains subfields marked by delimiter codes (`$a`, `$b`, etc.)
+- **Domain-specific semantics** — tag meanings are defined by cataloguing rules (RDA, AACR2) that assume deep domain knowledge
+- **Indicator significance** — the two indicator positions modify field behaviour in non-obvious ways (e.g., `245` indicator 2 = number of non-filing characters to skip for sorting)
+- **Repeatable vs non-repeatable** — some fields and subfields can repeat, others cannot, and the rules vary by tag
+- **Fixed-length control fields** — tags 001-009 have positional data with character-by-character meaning (e.g., tag `008` positions 35-37 = language code)
+- **Authority vs bibliographic** — the same tag numbers mean different things in authority records vs bibliographic records
+
+MARC21 is unlike any other format in this collection. It is not a data interchange format in the enterprise sense — it is a cultural knowledge representation that predates modern schema concepts.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `marc21` | `format marc21` |
+| `record_type` | Bibliographic, authority, or holdings | `record_type bibliographic` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `tag` | 3-digit MARC field tag | `tag "245"` |
+| `ind1` | First indicator value or meaning | `ind1 "1"` |
+| `ind2` | Second indicator value or meaning | `ind2 "0"` |
+| `subfield` | Subfield code | `subfield a` |
+| `positions` | Character positions for fixed fields | `positions "35-37"` |
+| `repeatable` | Whether the field/subfield can repeat | `repeatable` |
+
+### Guidelines
+
+- Use `tag` on every field — MARC cataloguers think in tag numbers
+- Use human-readable names alongside tags (e.g., `TITLE_PROPER` with `tag "245"`)
+- Use `record` for variable fields with subfield breakdowns
+- Use positional metadata for fixed-length control fields (tags 001-009, especially 008)
+- Document indicator meanings in `note` — they are rarely self-explanatory
+
+## How Natural Language Helps
+
+- **Indicator interpretation** — "245 indicator 2 = number of non-filing characters (e.g., 4 for 'The ' including the space)"
+- **Cataloguing rule context** — "Under RDA, 264 replaces 260 for publication information; older records use 260"
+- **Subfield relationships** — "In 700, subfield $e (relator term) qualifies the person in $a — e.g., 'editor', 'translator'"
+- **Fixed-field decoding** — "Tag 008 positions 15-17 = place of publication code from MARC Code List for Countries"
+
+## Example
+
+```stm
+// STM v2 — MARC21 Bibliographic Record (simplified)
+
+schema marc21_bibliographic (format marc21, record_type bibliographic,
+  note "Core bibliographic fields for a monograph record"
+) {
+  // --- Control fields (fixed-length, positional) ---
+
+  CONTROL_NUMBER   STRING  (tag "001",
+    note "Unique record identifier assigned by the cataloguing agency"
+  )
+
+  record FIXED_DATA (tag "008",
+    note """
+    40-character fixed-length data field. Each character position
+    has a defined meaning. Common positions for books:
+    - 00-05: date entered on file (YYMMDD)
+    - 06: type of date (s=single, m=multiple, etc.)
+    - 07-10: date 1
+    - 15-17: place of publication (MARC country code)
+    - 35-37: language (MARC language code)
+    """
+  ) {
+    date_entered     STRING  (positions "00-05")
+    date_type        STRING  (positions "06")
+    date_1           STRING  (positions "07-10")
+    pub_country      STRING  (positions "15-17",
+      note "MARC Code List for Countries — e.g., enk=England, xxu=United States"
+    )
+    language         STRING  (positions "35-37",
+      note "MARC Code List for Languages — e.g., eng=English, fre=French"
+    )
+  }
+
+  // --- Variable fields ---
+
+  list ISBN (tag "020", repeatable) {
+    isbn             STRING  (subfield a)
+    qualifying_info  STRING  (subfield q, note "e.g., hardback, paperback")
+  }
+
+  record TITLE (tag "245",
+    note """
+    Title statement. Indicator meanings:
+    - ind1: 0=no added entry, 1=added entry
+    - ind2: number of non-filing characters (e.g., 4 for 'The ')
+    """
+  ) {
+    title_proper     STRING  (subfield a, required)
+    remainder        STRING  (subfield b, note "Subtitle or other title information")
+    responsibility   STRING  (subfield c, note "Statement of responsibility — e.g., 'by Jane Smith'")
+    nonfiling_chars  INTEGER (ind2,
+      note "Number of characters to skip for sorting (includes trailing space)"
+    )
+  }
+
+  record PUBLICATION (tag "264", ind2 "1",
+    note "Production, publication, distribution — ind2=1 means publication"
+  ) {
+    place            STRING  (subfield a)
+    publisher        STRING  (subfield b)
+    date             STRING  (subfield c)
+  }
+
+  record PHYSICAL_DESC (tag "300") {
+    extent           STRING  (subfield a, note "e.g., 'xi, 342 pages'")
+    dimensions       STRING  (subfield c, note "e.g., '24 cm'")
+  }
+
+  list SUBJECTS (tag "650", repeatable, ind2 "0",
+    note "Subject headings — ind2=0 means Library of Congress Subject Headings (LCSH)"
+  ) {
+    topical_term     STRING  (subfield a)
+    general_subdiv   STRING  (subfield x)
+    geographic_subdiv STRING (subfield z)
+  }
+
+  list ADDED_AUTHORS (tag "700", repeatable) {
+    name             STRING  (subfield a)
+    relator          STRING  (subfield e,
+      note "Relationship to the work — e.g., 'editor', 'translator', 'illustrator'"
+    )
+  }
+}
+```
+
+### Key patterns
+
+- **Tag numbers as primary identifiers.** `tag "245"` is immediately recognisable to any cataloguer, with human-readable field names for everyone else.
+- **Positional decoding for control fields.** Tag 008 uses `positions` metadata to decode a fixed-length string character by character.
+- **Indicator semantics via metadata and notes.** `ind2 "1"` on the publication field, with `note` explaining what the indicator means.
+- **Repeatable fields as lists.** ISBN, subjects, and added authors can repeat — `list` with `repeatable` captures this.
+- **Domain vocabulary preserved.** Terms like "non-filing characters", "relator", and "topical term" are MARC terminology that cataloguers expect.

--- a/docs/conventions-for-schema-formats/swift-mt/conventions.md
+++ b/docs/conventions-for-schema-formats/swift-mt/conventions.md
@@ -1,0 +1,128 @@
+# SWIFT MT Conventions
+
+## Why This Format is Difficult
+
+SWIFT MT (Message Type) messages are the legacy standard for international financial messaging. MT103 (single customer credit transfer) is the most common. The format is challenging because:
+
+- **Block structure** — messages are divided into numbered blocks (1-5), each with different syntax rules
+- **Tag-based fields** — within the text block, fields are identified by tags like `:20:`, `:32A:`, `:59:`
+- **Composite text fields** — a single tag can contain multiple semantic elements separated by line breaks or positional conventions (e.g., `:32A:` encodes date + currency + amount in one field)
+- **Free-text conventions** — some fields (like `:70:` remittance info) are semi-structured text with implied sub-fields
+- **Legacy interpretation** — banking conventions accumulated over decades determine how fields are parsed, validated, and routed
+
+SWIFT MT is being gradually replaced by ISO 20022 XML, but remains in widespread production use.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `swift_mt` | `format swift_mt` |
+| `message_type` | MT number | `message_type "103"` |
+
+### Field-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `tag` | SWIFT field tag | `tag "32A"` |
+| `block` | Block number (1-5) | `block 2` |
+| `status` | Mandatory/Optional per SWIFT spec | `status mandatory` |
+
+### Guidelines
+
+- Use `tag` on every field in the text block — this is how SWIFT engineers identify fields
+- Use `record` for composite tags that contain multiple semantic values (e.g., `:32A:` → date + currency + amount)
+- Document sub-field parsing in `note` — the positional rules within a tag are rarely obvious
+- Represent the block structure explicitly when the full message envelope matters
+
+## How Natural Language Helps
+
+- **Composite field parsing** — "Tag 32A contains: 6-digit date (YYMMDD), 3-letter currency code, then amount with comma as decimal separator"
+- **Ordering account conventions** — "Tag 50K: first line is account number (starting with /), remaining lines are name and address (up to 4x35 characters)"
+- **Routing logic** — "Block 2 input/output indicator determines whether the message is sent or received"
+- **Validation rules** — "Amount must not exceed 15 digits including decimal; currency must be valid ISO 4217"
+
+## Example
+
+```stm
+// STM v2 — SWIFT MT103 Single Customer Credit Transfer (simplified)
+
+schema swift_mt103 (format swift_mt, message_type "103",
+  note "Single customer credit transfer — core payment fields"
+) {
+  record BASIC_HEADER (block 1) {
+    app_id          STRING  (note "F = FIN, A = GPA")
+    service_id      STRING  (note "01 = FIN/GPA, 21 = ACK/NAK")
+    sender_bic      STRING  (length 12, required)
+  }
+
+  record APPLICATION_HEADER (block 2) {
+    io_indicator    STRING  (note "I = input (sent), O = output (received)")
+    message_type    STRING  (note "103")
+    receiver_bic    STRING  (length 12, required)
+  }
+
+  // --- Text block (block 4) fields ---
+
+  REFERENCE        STRING  (tag "20", block 4, status mandatory,
+    note "Sender's reference — up to 16 characters, uniquely identifies the transaction"
+  )
+
+  record VALUE_DATE_AMOUNT (tag "32A", block 4, status mandatory,
+    note """
+    Composite field containing three values on a single line:
+    - 6 digits: value date (YYMMDD)
+    - 3 characters: currency code (ISO 4217)
+    - Remaining: amount with comma as decimal separator
+    Example: `230315GBP1250,00`
+    """
+  ) {
+    value_date      DATE
+    currency        STRING  (length 3)
+    amount          DECIMAL (note "Comma-separated decimal in source")
+  }
+
+  record ORDERING_CUSTOMER (tag "50K", block 4, status mandatory,
+    note """
+    Multi-line field:
+    - Line 1: account number (prefixed with `/`)
+    - Lines 2-5: name and address (up to 4 x 35 characters)
+    """
+  ) {
+    account         STRING
+    name_address    STRING  (note "Up to 4 lines of 35 characters each")
+  }
+
+  BENEFICIARY_BIC  STRING  (tag "57A", block 4,
+    note "Account-with institution — BIC of the beneficiary's bank"
+  )
+
+  record BENEFICIARY (tag "59", block 4, status mandatory,
+    note """
+    Multi-line field:
+    - Line 1: account number (prefixed with `/`, optional)
+    - Lines 2-5: beneficiary name and address
+    """
+  ) {
+    account         STRING
+    name_address    STRING
+  }
+
+  REMITTANCE_INFO  STRING  (tag "70", block 4,
+    note "Up to 4 x 35 characters of payment details — often contains structured references"
+  )
+
+  CHARGES          STRING  (tag "71A", block 4, status mandatory,
+    enum {BEN, OUR, SHA},
+    note "BEN=beneficiary pays, OUR=sender pays, SHA=shared"
+  )
+}
+```
+
+### Key patterns
+
+- **Block structure preserved.** `block 1`, `block 2`, `block 4` make the message envelope explicit.
+- **Composite tags as records.** Tag `:32A:` is a single wire field but contains three semantic values — `record` makes the decomposition explicit.
+- **Multi-line field conventions.** Tags like `:50K:` and `:59:` have line-based sub-structures documented in `note` descriptions.
+- **Familiar identifiers.** `tag "32A"` is immediately recognisable to anyone who works with SWIFT messages.

--- a/docs/conventions-for-schema-formats/x12-hipaa/conventions.md
+++ b/docs/conventions-for-schema-formats/x12-hipaa/conventions.md
@@ -1,0 +1,99 @@
+# X12 / HIPAA EDI Conventions
+
+## Why This Format is Difficult
+
+ANSI X12 is the dominant EDI standard in the United States, particularly for healthcare transactions under HIPAA (837 claims, 835 remittance, 270/271 eligibility). It shares EDIFACT's positional, qualifier-driven nature but adds its own complexity:
+
+- **Loop hierarchies** — segments are grouped into loops (e.g., `2000A`, `2010AA`) with hierarchical nesting via HL segments
+- **Qualifier-driven semantics** — the same segment type (e.g., `NM1`) means different things depending on an entity identifier qualifier
+- **Implementation guide divergence** — the formal X12 standard and payer-specific implementation guides frequently disagree
+- **Segment/element/component addressing** — fields are identified by segment ID, element position, and sub-element position (e.g., `NM1-03` is the third element of the NM1 segment)
+
+The repo already has an EDIFACT example (`examples/edi-to-json.stm`). X12 conventions here focus on the differences: loop IDs, HL hierarchies, and qualifier resolution in a US healthcare context.
+
+## Metadata Conventions
+
+### Schema-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `format` | Always `x12` | `format x12` |
+| `transaction` | X12 transaction set identifier | `transaction 837` |
+| `version` | X12 version | `version "005010X222A1"` |
+
+### Field and record-level
+
+| Token | Usage | Example |
+|-------|-------|---------|
+| `segment` | X12 segment identifier | `segment NM1` |
+| `element` | Element position within segment | `element 3` |
+| `component` | Sub-element position | `component 1` |
+| `qualifier` | Qualifying value that selects this instance | `qualifier "85"` |
+| `loop` | X12 loop identifier | `loop "2010AA"` |
+
+### Guidelines
+
+- Use `loop` on `record` or `list` blocks to make the hierarchical grouping explicit
+- Always include `qualifier` when the same segment type appears in multiple roles (e.g., `NM1` for billing provider vs subscriber)
+- Reference element positions by number, matching the implementation guide notation (e.g., `NM1-09` → `element 9`)
+- Document payer-specific deviations in `note` metadata — these are common and consequential
+
+## How Natural Language Helps
+
+- **Qualifier resolution** — "Qualifier 85 = billing provider, 87 = pay-to provider" — segment meaning depends entirely on these codes
+- **Loop grouping** — "Each HL segment with hlevel=20 begins a new subscriber loop" — the nesting logic is implicit in the data stream
+- **Implementation guide quirks** — "Payer X requires NM1-09 as NPI even when the guide says it's optional" — the gap between spec and practice
+- **Hierarchical parent-child resolution** — "HL-02 references the parent HL-01 to establish claim-to-subscriber relationships"
+
+## Example
+
+```stm
+// STM v2 — X12 837 Professional Claim (simplified)
+
+schema x12_837_claim (format x12, transaction 837,
+  version "005010X222A1",
+  note "HIPAA 837P professional claim — simplified for convention reference"
+) {
+  record BILLING_PROVIDER (loop "2010AA", segment NM1, qualifier "85") {
+    entity_type     STRING  (element 1, note "1=person, 2=organisation")
+    last_name       STRING  (element 3)
+    first_name      STRING  (element 4)
+    id_qualifier    STRING  (element 8, note "Expected: XX (NPI)")
+    npi             STRING  (element 9)
+  }
+
+  record SUBSCRIBER (loop "2010BA", segment NM1, qualifier "IL") {
+    last_name       STRING  (element 3)
+    first_name      STRING  (element 4)
+    member_id       STRING  (element 9)
+  }
+
+  record SUBSCRIBER_DEMO (loop "2010BA", segment DMG) {
+    date_of_birth   STRING  (element 2, note "Format: CCYYMMDD")
+    gender          STRING  (element 3, enum {M, F, U})
+  }
+
+  list CLAIM_LINES (loop "2400") {
+    record SERVICE (segment SV1) {
+      procedure_code  STRING (element 1, component 2,
+        note "HCPCS or CPT code from the composite element"
+      )
+      charge_amount   DECIMAL(10,2) (element 2)
+      unit_type       STRING (element 3, enum {UN, MJ})
+      units           DECIMAL(6,2) (element 4)
+    }
+
+    record SERVICE_DATE (segment DTP, qualifier "472") {
+      date_format     STRING (element 2, note "D8=CCYYMMDD, RD8=range")
+      service_date    STRING (element 3)
+    }
+  }
+}
+```
+
+### Key patterns
+
+- **Qualifier-scoped records.** `NM1` appears multiple times; `qualifier "85"` and `qualifier "IL"` disambiguate without renaming the segment.
+- **Loop IDs as structural grouping.** `loop "2010AA"` on a `record` maps directly to the implementation guide's hierarchy.
+- **Composite elements.** `element 1, component 2` addresses sub-element positions within composite fields like procedure codes.
+- **Implementation guide notes.** `note` on fields documents expectations that differ from the base X12 standard.

--- a/examples/cobol-to-avro.stm
+++ b/examples/cobol-to-avro.stm
@@ -1,0 +1,170 @@
+// STM v2 — COBOL Customer Master to Avro Events
+
+note {
+  """
+  # COBOL Customer Master to Avro Events
+
+  Transforms a mainframe COBOL customer master record into an Avro
+  customer-change event for streaming into Kafka. Demonstrates the
+  legacy-to-modern bridge: positional packed-decimal records on one
+  side, schema-evolved typed events on the other.
+
+  ## Key challenges
+  - COMP-3 packed decimals must be decoded and rescaled
+  - REDEFINES requires conditional interpretation based on CUST_TYPE
+  - OCCURS array must be filtered to exclude trailing blank entries
+  - EBCDIC → UTF-8 string encoding conversion
+  """
+}
+
+
+// --- Source ---
+
+schema cobol_customer_master (format copybook, encoding ebcdic,
+  note "Customer master record from mainframe VSAM file"
+) {
+  CUST_ID        INTEGER    (pic "9(10)", offset 1, length 10, required)
+  CUST_TYPE      STRING     (pic "X(1)", offset 11, enum {R, B})
+
+  record PERSONAL_NAME (offset 12, length 40,
+    note "Present when CUST_TYPE = 'R' (retail customer)"
+  ) {
+    FIRST_NAME   STRING     (pic "X(20)", offset 12)
+    LAST_NAME    STRING     (pic "X(20)", offset 32)
+  }
+
+  record BUSINESS_NAME (redefines PERSONAL_NAME, offset 12,
+    note "Present when CUST_TYPE = 'B' (business customer)"
+  ) {
+    COMPANY_NAME STRING     (pic "X(40)", offset 12)
+  }
+
+  record ADDRESS (offset 52, length 57) {
+    STREET       STRING     (pic "X(30)", offset 52)
+    CITY         STRING     (pic "X(20)", offset 82)
+    STATE        STRING     (pic "X(2)", offset 102)
+    ZIP          INTEGER    (pic "9(5)", offset 104)
+  }
+
+  CREDIT_LIMIT   DECIMAL(9,2) (
+    pic "S9(7)V99",
+    encoding comp-3,
+    offset 109,
+    length 5,
+    note "Packed decimal: last nibble is sign (C=positive, D=negative)"
+  )
+
+  ACCOUNT_BAL    DECIMAL(9,2) (
+    pic "S9(7)V99",
+    encoding comp-3,
+    offset 114,
+    length 5
+  )
+
+  STATUS_CODE    STRING     (pic "X(1)", offset 119, enum {A, I, S})
+
+  PHONE_COUNT    INTEGER    (pic "9(1)", offset 120)
+
+  list PHONE_NUMBERS (occurs 3, depends_on PHONE_COUNT,
+    note "Only the first PHONE_COUNT entries are populated"
+  ) {
+    PHONE_TYPE   STRING     (pic "X(1)", note "H=home, W=work, M=mobile")
+    PHONE_NUM    STRING     (pic "X(15)")
+  }
+}
+
+
+// --- Target ---
+
+schema customer_event_avro (format avro, evolution backward,
+  schema_registry "https://registry.example.com",
+  namespace "com.example.customer.events",
+  note "Customer change event — published to Kafka topic customer.changes"
+) {
+  event_id         STRING       (required)
+  event_type       STRING       (required, enum {created, updated, deactivated})
+  event_timestamp  STRING       (required)
+  customer_id      STRING       (required)
+  customer_type    STRING       (required, enum {retail, business})
+  display_name     STRING       (required)
+
+  record contact_info {
+    email          STRING
+    list phones {
+      type         STRING       (enum {home, work, mobile})
+      number       STRING       (note "E.164 format")
+    }
+  }
+
+  record address {
+    street         STRING
+    city           STRING
+    state          STRING
+    postal_code    STRING
+    country        STRING
+  }
+
+  credit_limit     DECIMAL(12,2)
+  account_balance  DECIMAL(12,2)
+  status           STRING       (required, enum {active, inactive, suspended})
+}
+
+
+// --- Mapping ---
+
+mapping 'cobol customer to avro event' {
+  source { `cobol_customer_master` }
+  target { `customer_event_avro` }
+
+  -> event_id { uuid_v4() }
+  -> event_type { "updated" }
+  -> event_timestamp { now_utc() }
+
+  CUST_ID -> customer_id { to_string | lpad(10, "0") }
+
+  CUST_TYPE -> customer_type {
+    map {
+      R: "retail"
+      B: "business"
+    }
+  }
+
+  -> display_name {
+    "If CUST_TYPE = 'R', trim and concatenate FIRST_NAME + ' ' + LAST_NAME.
+     If CUST_TYPE = 'B', use COMPANY_NAME trimmed.
+     This resolves the REDEFINES: PERSONAL_NAME vs BUSINESS_NAME."
+  }
+
+  ADDRESS.STREET -> address.street { trim }
+  ADDRESS.CITY -> address.city { trim }
+  ADDRESS.STATE -> address.state { trim | uppercase }
+  ADDRESS.ZIP -> address.postal_code { to_string | lpad(5, "0") }
+  -> address.country { "US" }
+
+  CREDIT_LIMIT -> credit_limit
+  ACCOUNT_BAL -> account_balance
+
+  STATUS_CODE -> status {
+    map {
+      A: "active"
+      I: "inactive"
+      S: "suspended"
+    }
+  }
+
+  PHONE_NUMBERS[] -> contact_info.phones[] {
+    .PHONE_TYPE -> .type {
+      map {
+        H: "home"
+        W: "work"
+        M: "mobile"
+      }
+    }
+
+    .PHONE_NUM -> .number {
+      trim
+      | "Extract digits. If 10 digits assume US +1. Format as E.164.
+         If unparseable, set null and log warning."
+    }
+  }
+}

--- a/tooling/tree-sitter-stm/scripts/test_smoke_summary.py
+++ b/tooling/tree-sitter-stm/scripts/test_smoke_summary.py
@@ -156,6 +156,17 @@ EXPECTATIONS: dict[str, dict] = {
         "min_annotations": 2,
         "block_types": {"schema_block"},
     },
+    "examples/cobol-to-avro.stm": {
+        "parse_ok": True,
+        "min_blocks": 3,
+        "min_schema_members": 39,
+        "min_map_items": 17,
+        "min_paths": 29,
+        "min_comments": 4,
+        "min_notes": 1,
+        "min_annotations": 30,
+        "block_types": {"mapping_block", "schema_block"},
+    },
 }
 
 

--- a/tooling/tree-sitter-stm/test/fixtures/examples/cobol-to-avro.json
+++ b/tooling/tree-sitter-stm/test/fixtures/examples/cobol-to-avro.json
@@ -1,0 +1,3 @@
+{
+  "source": "../../../../../examples/cobol-to-avro.stm"
+}


### PR DESCRIPTION
## Summary
- Adds `docs/conventions-for-schema-formats/` with per-format subdirectories for 8 esoteric/industry schema formats
- Each format has a conventions doc covering: why it's hard, metadata token table, how NL helps, and a valid STM example
- Formats: COBOL copybook, X12/HIPAA, ISO 8583, SWIFT MT, HL7, ASN.1, FIX protocol, DICOM
- README indexes all formats by category and documents general principles

## Test plan
- [ ] Review STM examples for spec compliance (metadata in `()`, structure in `{}`, NL in `""`)
- [ ] Verify no `->` derived fields appear in schema blocks (only in mappings)
- [ ] Check metadata token conventions are consistent across formats
- [ ] Confirm links in README resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)