### PR TITLE
Update GitHub URLs to satsuma-lang

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: Thorben
     affiliation: Equal Experts
 license: MIT
-repository-code: "https://github.com/thorbenlouw/stm-grammar"
-url: "https://github.com/thorbenlouw/stm-grammar"
+repository-code: "https://github.com/thorbenlouw/satsuma-lang"
+url: "https://github.com/thorbenlouw/satsuma-lang"
 abstract: >-
   Satsuma is a domain-specific language for source-to-target data mapping,
   designed to replace ad hoc spreadsheets and verbose structured specs

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Satsuma
 
-[![CI](https://github.com/thorbenlouw/stm-grammar/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/thorbenlouw/stm-grammar/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
-[![Release](https://github.com/thorbenlouw/stm-grammar/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/thorbenlouw/stm-grammar/actions/workflows/release.yml)
+[![CI](https://github.com/thorbenlouw/satsuma-lang/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/thorbenlouw/satsuma-lang/actions/workflows/ci.yml?query=branch%3Amain+event%3Apush)
+[![Release](https://github.com/thorbenlouw/satsuma-lang/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/thorbenlouw/satsuma-lang/actions/workflows/release.yml)
 
 Satsuma is a domain-specific language for source-to-target data mapping.
 
@@ -63,13 +63,13 @@ Pre-built binaries are published on every merge to `main`. Install with npm
 
 ```bash
 # macOS (Apple Silicon)
-npm install -g https://github.com/thorbenlouw/stm-grammar/releases/download/latest/satsuma-cli-darwin-arm64.tgz
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz
 
 # macOS (Intel)
-npm install -g https://github.com/thorbenlouw/stm-grammar/releases/download/latest/satsuma-cli-darwin-x64.tgz
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-x64.tgz
 
 # Linux (x64)
-npm install -g https://github.com/thorbenlouw/stm-grammar/releases/download/latest/satsuma-cli-linux-x64.tgz
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz
 ```
 
 This gives you the `satsuma` command on your PATH. Run `satsuma --help` to see


### PR DESCRIPTION
## Summary
- Update all GitHub URLs from `thorbenlouw/stm-grammar` to `thorbenlouw/satsuma-lang` after repo rename
- Affected files: `CITATION.cff` (repository-code, url) and `README.md` (CI/Release badges, npm download links, author link)

## Test plan
- [ ] Verify badge URLs resolve correctly on the PR preview
- [ ] Verify npm download links point to the new repo location

🤖 Generated with [Claude Code](https://claude.com/claude-code)