### PR TITLE
Fix fragment spread expansion across all CLI commands

### DIFF
--- a/.tickets/sc-c2yw.md
+++ b/.tickets/sc-c2yw.md
@@ -1,0 +1,20 @@
+---
+id: sc-c2yw
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:04:01Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, schema]
+---
+# schema show misreads fragment_spread label (uses block_label instead of spread_label)
+
+In schema.js line 102, the code looks for 'block_label' inside a fragment_spread node, but the tree-sitter grammar produces 'spread_label' as the child of fragment_spread. This means the spread name is never extracted and the output shows '...' with no label. Same bug pattern as existed in where-used.js (which already handles both spread_label and block_label as a fallback).
+
+## Acceptance Criteria
+
+1. `satsuma schema` output shows spread labels correctly (e.g. `...audit_fields` not just `...`)
+2. A test covers fragment_spread rendering in schema output
+

--- a/.tickets/sc-c2yw.md
+++ b/.tickets/sc-c2yw.md
@@ -1,6 +1,6 @@
 ---
 id: sc-c2yw
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:04:01Z

--- a/.tickets/sc-uzx5.md
+++ b/.tickets/sc-uzx5.md
@@ -1,6 +1,6 @@
 ---
 id: sc-uzx5
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:04:43Z

--- a/.tickets/sc-uzx5.md
+++ b/.tickets/sc-uzx5.md
@@ -1,0 +1,20 @@
+---
+id: sc-uzx5
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:04:43Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, where-used]
+---
+# where-used fails to match quoted fragment spread labels
+
+In where-used.js, findFragmentSpreads compares the raw spread_label node text (e.g. "'audit fields'" with quotes) against the resolved fragment name from the index (e.g. "audit fields" without quotes, since extractFragments uses labelText which strips quotes). This means `satsuma where-used 'audit fields'` will never find spread usages like `...'audit fields'` because the comparison fails due to the quote mismatch.
+
+## Acceptance Criteria
+
+1. `satsuma where-used 'audit fields'` correctly finds schemas that spread `...'audit fields'`
+2. A test covers quoted fragment spread matching in where-used
+

--- a/.tickets/sg-u8sh.md
+++ b/.tickets/sg-u8sh.md
@@ -1,6 +1,6 @@
 ---
 id: sg-u8sh
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T15:05:34Z

--- a/.tickets/sg-u8sh.md
+++ b/.tickets/sg-u8sh.md
@@ -1,0 +1,21 @@
+---
+id: sg-u8sh
+status: open
+deps: []
+links: []
+created: 2026-03-20T15:05:34Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, validator]
+---
+# Validator does not expand fragment spreads when checking field-not-in-schema
+
+When validating arrows, the CLI resolves fields against the raw schema body but does not inline fragment spreads (`...fragment_name`). This means fields contributed by a spread fragment are not recognised, causing spurious `field-not-in-schema` warnings for any arrow that references a fragment-contributed field.
+
+## Acceptance Criteria
+
+1. Arrow sources/targets that resolve to fields contributed by a `...fragment` spread pass validation without `field-not-in-schema` warnings.
+2. Existing tests continue to pass — no regressions in non-fragment validation.
+3. At least one corpus or integration test covers a mapping arrow referencing a fragment-spread field.
+

--- a/.tickets/sg-yl8q.md
+++ b/.tickets/sg-yl8q.md
@@ -1,6 +1,6 @@
 ---
 id: sg-yl8q
-status: open
+status: closed
 deps: []
 links: [stm-7rz4]
 created: 2026-03-20T13:13:53Z

--- a/.tickets/sl-307v.md
+++ b/.tickets/sl-307v.md
@@ -1,6 +1,6 @@
 ---
 id: sl-307v
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:42Z

--- a/.tickets/sl-307v.md
+++ b/.tickets/sl-307v.md
@@ -1,0 +1,19 @@
+---
+id: sl-307v
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:42Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# where-used misses fragment-to-fragment spread references
+
+The satsuma where-used command does not report fragment-to-fragment spreads. When fragment A is spread inside fragment B, running where-used for fragment A only shows schemas that spread A directly, not fragment B.
+
+## Acceptance Criteria
+
+Given fragment "address fields" and fragment "full address" that spreads ...address fields, and schema customer_with_address that spreads ...full address: running satsuma where-used "address fields" should show 3 references — src_customers (schema), tgt_customers (schema), AND "full address" (fragment). Currently it only shows the 2 schema references and misses the fragment-to-fragment usage.
+

--- a/.tickets/sl-3aff.md
+++ b/.tickets/sl-3aff.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3aff
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:09Z

--- a/.tickets/sl-3aff.md
+++ b/.tickets/sl-3aff.md
@@ -1,0 +1,19 @@
+---
+id: sl-3aff
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:09Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# fields command drops fragment spread fields
+
+The satsuma fields command silently drops all fields from fragment spreads. Only directly declared fields are shown.
+
+## Acceptance Criteria
+
+Given a schema with ...audit fields spread (where audit fields defines created_at TIMESTAMPTZ and updated_at TIMESTAMPTZ), running satsuma fields <schema> only shows directly declared fields and omits created_at and updated_at. Expected: the command should resolve and expand fragment spreads, inlining fragment fields into the output. This should work for simple spreads, transitive spreads (fragments spreading other fragments), and namespace-qualified spreads.
+

--- a/.tickets/sl-3fvu.md
+++ b/.tickets/sl-3fvu.md
@@ -1,0 +1,55 @@
+---
+id: sl-3fvu
+status: closed
+deps: []
+links: []
+created: 2026-03-20T16:25:03Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+#  command drops fragment spread fields
+
+The `satsuma fields <schema>` command silently drops all fields that come from fragment spreads (`...fragmentName`). Only directly declared fields are shown.
+
+## Acceptance Criteria
+
+Given this input:
+
+```stm
+fragment 'audit fields' {
+  created_at    TIMESTAMPTZ  (required)
+  updated_at    TIMESTAMPTZ
+}
+
+schema tgt_customers {
+  customer_id     UUID         (pk, required)
+  email           VARCHAR(255) (format email, pii)
+  ...audit fields
+}
+```
+
+Running `satsuma fields tgt_customers <file>` currently outputs:
+
+```
+  customer_id  UUID
+  email        VARCHAR(255)
+```
+
+Expected output should include the fragment fields:
+
+```
+  customer_id  UUID
+  email        VARCHAR(255)
+  created_at   TIMESTAMPTZ
+  updated_at   TIMESTAMPTZ
+```
+
+The `fields` command should resolve and expand fragment spreads, inlining the fragment's fields into the output. This should work for:
+- Simple spreads (`...audit fields`)
+- Transitive spreads (fragments that spread other fragments)
+- Namespace-qualified spreads (`...ns::fragmentName`)
+
+The `schema` command already renders spreads verbatim (e.g., `...audit fields`), which is correct for that command. But `fields` is used by downstream tools and LLMs to get the complete field list, so it must expand spreads.
+

--- a/.tickets/sl-h1b0.md
+++ b/.tickets/sl-h1b0.md
@@ -1,0 +1,19 @@
+---
+id: sl-h1b0
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:17Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# arrows command cannot find fields from fragment spreads
+
+The satsuma arrows command fails with "Field not found in schema" when looking up a field that was introduced via a fragment spread. The command does not expand spreads when building its field lookup set.
+
+## Acceptance Criteria
+
+Given fragment "audit fields" with created_at/updated_at, and schema tgt with ...audit fields spread, and a mapping arrow "-> created_at { now_utc() }", running satsuma arrows tgt.created_at should find and display that arrow. Currently it errors with "Field created_at not found in schema tgt". Fix: expand fragment spreads in the field lookup used by the arrows command, same as validate already does.
+

--- a/.tickets/sl-h1b0.md
+++ b/.tickets/sl-h1b0.md
@@ -1,6 +1,6 @@
 ---
 id: sl-h1b0
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:17Z

--- a/.tickets/sl-t6lt.md
+++ b/.tickets/sl-t6lt.md
@@ -1,6 +1,6 @@
 ---
 id: sl-t6lt
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:31Z

--- a/.tickets/sl-t6lt.md
+++ b/.tickets/sl-t6lt.md
@@ -1,0 +1,19 @@
+---
+id: sl-t6lt
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:31Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# graph JSON output omits fragment spread fields from schema nodes
+
+The satsuma graph --json command outputs schema nodes with only directly declared fields, omitting fields from fragment spreads. The fields array in each schema node does not include spread fields.
+
+## Acceptance Criteria
+
+Given schema tgt with customer_id UUID, email VARCHAR(255), and ...audit fields (which defines created_at TIMESTAMPTZ, updated_at TIMESTAMPTZ), the graph JSON output currently only lists customer_id and email in the fields array. Expected: the fields array should also include created_at and updated_at from the expanded fragment. Additionally, the graph should include edges from fragment nodes to the schemas that spread them.
+

--- a/.tickets/sl-wrzl.md
+++ b/.tickets/sl-wrzl.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wrzl
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:22Z

--- a/.tickets/sl-wrzl.md
+++ b/.tickets/sl-wrzl.md
@@ -1,0 +1,19 @@
+---
+id: sl-wrzl
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:22Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# match-fields ignores fields from fragment spreads
+
+The satsuma match-fields command does not include fields from fragment spreads when comparing source and target schemas. Fields that both schemas share via the same spread are not matched.
+
+## Acceptance Criteria
+
+Given two schemas that both spread ...address fields (containing street_line_1, city, etc.), running satsuma match-fields --source src --target tgt should show those spread fields as matched pairs. Currently they are completely absent from the output. The command should expand fragment spreads before comparing field lists.
+

--- a/.tickets/sl-zjec.md
+++ b/.tickets/sl-zjec.md
@@ -1,0 +1,19 @@
+---
+id: sl-zjec
+status: open
+deps: []
+links: []
+created: 2026-03-20T16:25:49Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, fragment-spread]
+---
+# schema --json fields array omits fragment spread fields
+
+The satsuma schema --json command includes spread markers in fieldLines but omits spread fields from the fields array. The fields array only contains directly declared fields. This is inconsistent — fieldLines shows "...audit fields" but the structured fields array does not contain the expanded fields.
+
+## Acceptance Criteria
+
+Given schema tgt_customers with ...audit fields spread (containing created_at, updated_at, created_by), the --json output should either: (a) include the expanded fragment fields in the fields array with a marker indicating their origin, or (b) include a spreads array listing which fragments are spread and their field definitions. Currently the fields array silently drops all spread fields while fieldLines shows the raw spread syntax.
+

--- a/.tickets/sl-zjec.md
+++ b/.tickets/sl-zjec.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zjec
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-20T16:25:49Z

--- a/examples/lookups/finance.stm
+++ b/examples/lookups/finance.stm
@@ -1,6 +1,6 @@
 // Satsuma v2 — Finance Lookups
 
-schema currency_rates (
+schema fx_spot_rates (
   note "Sourced from OpenExchangeRates API. Updated daily at 00:01 UTC."
 ) {
   iso_code    STRING(3)    (pk)

--- a/examples/metric_sources.stm
+++ b/examples/metric_sources.stm
@@ -1,0 +1,71 @@
+// Satsuma v2 — Metric Source Schemas
+// Fact and dimension tables referenced by metrics.stm
+
+schema fact_subscriptions (note "Active and historical subscription records") {
+  subscription_id   STRING(36)     (pk)
+  customer_id       STRING(36)     (ref dim_customer.customer_id)
+  product_line      STRING(50)
+  amount            DECIMAL(14,2)
+  billing_period    STRING(10)     (enum {monthly, quarterly, annual})
+  status            STRING(20)     (enum {active, cancelled, trial})
+  started_at        TIMESTAMPTZ
+  cancelled_at      TIMESTAMPTZ
+}
+
+schema fact_orders (note "Commerce order header records") {
+  order_id          STRING(36)     (pk)
+  customer_id       STRING(36)     (ref dim_customer.customer_id)
+  order_date        DATE
+  order_channel     STRING(30)
+  currency_code     ISO-4217
+  total_amount      DECIMAL(14,2)
+  is_gift           BOOLEAN        (default false)
+  ship_country      ISO-3166-a2
+  loyalty_tier      STRING(20)
+}
+
+schema fact_opportunities (note "Sales pipeline opportunity snapshots") {
+  opportunity_id    STRING(36)     (pk)
+  pipeline_stage    STRING(50)
+  region            STRING(50)
+  account_segment   STRING(50)
+  arr_value         DECIMAL(18,2)
+  probability       DECIMAL(5,2)
+  close_quarter     STRING(6)
+  is_deleted        BOOLEAN        (default false)
+  snapshot_date     DATE
+}
+
+schema fact_sessions (note "Web/app checkout sessions for abandonment tracking") {
+  session_id        STRING(64)     (pk)
+  session_type      STRING(20)
+  order_channel     STRING(30)
+  device_type       STRING(20)
+  customer_segment  STRING(30)
+  started_at        TIMESTAMPTZ
+}
+
+schema dim_customer (note "Customer dimension") {
+  customer_id        STRING(36)    (pk)
+  segment            STRING(30)
+  region             STRING(50)
+  acquisition_channel STRING(50)
+  cohort_year        INTEGER
+  customer_segment   STRING(30)
+}
+
+schema dim_date (note "Date dimension for time-series analysis") {
+  date_key    DATE       (pk)
+  year        INTEGER
+  quarter     STRING(2)
+  month       INTEGER
+  day_of_week STRING(10)
+}
+
+schema dim_stage (note "Pipeline stage dimension") {
+  stage_key    STRING(50)   (pk)
+  stage_name   STRING(100)
+  stage_order  INTEGER
+  is_won       BOOLEAN
+  is_lost      BOOLEAN
+}

--- a/examples/sfdc_to_snowflake.stm
+++ b/examples/sfdc_to_snowflake.stm
@@ -1,7 +1,7 @@
 // Satsuma v2 — Salesforce to Snowflake Pipeline
 
 import { 'sfdc standard types' } from "lib/sfdc_fragments.stm"
-import { currency_rates } from "lookups/finance.stm"
+import { fx_spot_rates } from "lookups/finance.stm"
 
 note {
   """
@@ -61,7 +61,7 @@ schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
 // --- Mapping ---
 
 mapping 'opportunity ingestion' {
-  source { `sfdc_opportunity`, `currency_rates` }
+  source { `sfdc_opportunity`, `fx_spot_rates` }
   target { `snowflake_opps` }
 
   // --- Direct identifiers ---
@@ -73,7 +73,7 @@ mapping 'opportunity ingestion' {
   Amount -> amount_raw { coalesce(0) }
 
   Amount -> amount_usd {
-    "Multiply by rate from `currency_rates` lookup using CurrencyIsoCode"
+    "Multiply by rate from `fx_spot_rates` lookup using CurrencyIsoCode"
     | round(2)
   }
 

--- a/features/18-typescript-migration/PRD.md
+++ b/features/18-typescript-migration/PRD.md
@@ -1,0 +1,214 @@
+# Feature 18: TypeScript Migration for Satsuma CLI
+
+## Problem
+
+The Satsuma CLI (`tooling/satsuma-cli/`) is ~2,790 lines of plain JavaScript across 35 source files. Complex data shapes (WorkspaceIndex, extraction records, tree-sitter CST nodes) flow through multiple layers with no compile-time safety beyond scattered JSDoc annotations. This creates risk during refactoring, makes it harder to onboard contributors, and leaves shape mismatches to be caught only by tests or at runtime.
+
+## Goal
+
+Incrementally migrate the CLI from JavaScript to TypeScript, gaining compile-time type safety while keeping the CLI functional at every step. All 224 tests must pass throughout the migration.
+
+## Success Criteria
+
+- All `src/*.js` files converted to `.ts`
+- `tsc --strict` passes with no errors
+- All existing tests pass against compiled output
+- CLI works end-to-end (`satsuma summary`, `satsuma schema`, etc.)
+- No runtime TypeScript dependency (compiled to JS via `tsc`)
+- Single-binary distribution story unchanged (still requires Node.js)
+
+## Non-Goals
+
+- Converting test files to TypeScript (deferred — tests stay as `.js`)
+- Adding a bundler (esbuild, rollup, etc.)
+- Using runtime TS loaders (tsx, ts-node, `--experimental-strip-types`)
+- Changing the CLI's architecture or public API
+
+## Strategy
+
+**Compile with `tsc` to `dist/`, keep tests as `.js`.**
+
+- Source: `src/*.ts` (and `src/*.js` during migration via `allowJs`)
+- Output: `dist/` (compiled JS + declarations + source maps)
+- Bin entry point: `./dist/index.js`
+- Tests: remain `.js`, import from `dist/` via package.json subpath imports (`#src/*`)
+
+**Import paths need no changes.** All imports already use `.js` extensions. TypeScript with `"module": "node16"` resolves `./classify.js` to `./classify.ts` at compile time and emits `./classify.js` in output.
+
+## Implementation Steps
+
+### Step 0: Infrastructure
+
+1. Add `tsconfig.json`:
+   - `module`/`moduleResolution`: `"node16"`
+   - `target`: `"es2022"`, `outDir`: `"dist"`, `rootDir`: `"src"`
+   - `strict: true`, `noImplicitAny: false` (deferred until tree-sitter types stabilize)
+   - `allowJs: true` for coexistence
+   - `declaration: true`, `sourceMap: true`
+
+2. Update `package.json`:
+   - Add devDeps: `typescript ^5.8`, `@types/node ^22`
+   - Change bin to `"satsuma": "./dist/index.js"`
+   - Add scripts: `"build": "tsc"`, `"pretest": "tsc"`, `"prepare": "tsc"`, `"dev": "tsc --watch"`
+   - Add `"imports": { "#src/*": "./dist/*" }` for test imports
+
+3. Add `dist/` to `.gitignore`
+
+4. Update all test files to import from `#src/` instead of `../src/`
+
+5. **Verify**: `npx tsc` compiles all `.js` into `dist/`, `npm test` passes, `node dist/index.js summary ../../examples` works end-to-end.
+
+### Step 1: Type foundations + leaf modules
+
+1. Create `src/types.ts` with core interfaces:
+   - `SyntaxNode`, `Tree`, `Parser` — structural types matching tree-sitter v0.25 usage patterns
+   - `SchemaRecord`, `MetricRecord`, `MappingRecord`, `FragmentRecord`, `ArrowRecord` — domain entity types
+   - `WorkspaceIndex`, `ParsedFile` — pipeline data structures
+   - `LintDiagnostic`, `LintFix`, `LintRule` — lint framework types
+   - `RegisterFn` — command registration signature
+
+2. Convert leaf modules (no internal imports):
+   - `classify.js` → `classify.ts`
+   - `normalize.js` → `normalize.ts`
+   - `errors.js` → `errors.ts`
+   - `diff.js` → `diff.ts`
+
+3. **Verify**: `tsc` passes, all tests pass.
+
+### Step 2: Standalone extractors
+
+Convert modules imported by many but importing nothing internal:
+- `nl-extract.js` → `nl-extract.ts`
+- `meta-extract.js` → `meta-extract.ts`
+- `cst-query.js` → `cst-query.ts`
+- `nl-ref-extract.js` → `nl-ref-extract.ts`
+
+These benefit immediately from `SyntaxNode` parameter types.
+
+### Step 3: Core pipeline
+
+- `extract.js` → `extract.ts` (largest file, ~484 lines, highest ROI for type safety)
+- `index-builder.js` → `index-builder.ts` (constructs WorkspaceIndex — the central data structure)
+- `workspace.js` → `workspace.ts` (file discovery, async I/O)
+- `parser.js` → `parser.ts` (CJS interop via `createRequire` — cast to custom `Parser` interface)
+
+### Step 4: Validation and analysis
+
+- `validate.js` → `validate.ts`
+- `lint-engine.js` → `lint-engine.ts`
+- `graph-builder.js` → `graph-builder.ts`
+
+### Step 5: Commands + entry point
+
+- Convert all 19 command files in `src/commands/` (uniform pattern: `export function register(program: Command)`)
+- Convert `src/index.js` → `src/index.ts`
+- Remove `allowJs: true` from tsconfig
+
+### Step 6: Hardening (post-migration)
+
+- Enable `noImplicitAny: true`, fix remaining `any` types
+- Enable `noUncheckedIndexedAccess: true`
+- Update CI workflow if an explicit build step is clearer than relying on `pretest`
+
+## Key Design Decisions
+
+### Why `tsc` over alternatives
+
+| Option | Rejected because |
+|--------|-----------------|
+| tsx/ts-node at runtime | Adds startup latency to a CLI invoked frequently by agents |
+| Node `--experimental-strip-types` | No `enum`/`namespace` support, no declaration output, ties min Node version to 22+ |
+| esbuild/swc | Overkill — no bundling needed for a CLI tool |
+
+### Why tests stay as `.js`
+
+- Node's built-in test runner works natively with `.js`
+- Tests validate compiled output (the actual artifact), not source
+- Mock CST helpers are intentionally minimal — typing them adds little value
+- Can be converted in a future phase if desired
+
+### CJS interop for tree-sitter
+
+The `createRequire` pattern in `parser.js` works identically in TypeScript. There are no `@types/tree-sitter` for v0.25, so we define minimal structural interfaces (`SyntaxNode`, `Tree`, `Parser`) matching the subset the codebase actually uses. The mock CST nodes in tests already conform to this shape.
+
+```typescript
+const require = createRequire(import.meta.url);
+const ParserCtor = require("tree-sitter") as new () => Parser;
+const STM = require("tree-sitter-satsuma") as unknown;
+```
+
+### tsconfig.json
+
+```jsonc
+{
+  "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
+    "target": "es2022",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowJs": true,       // removed after full migration
+    "checkJs": false,
+    "strict": true,
+    "noImplicitAny": false, // enabled in Step 6
+    "esModuleInterop": true,
+    "forceConsistentCasingInImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}
+```
+
+## Dependency Graph (migration order rationale)
+
+```
+Leaves (no internal imports):
+  classify, normalize, errors, diff
+
+Layer 1 (imports only leaves):
+  extract → classify
+
+Layer 2 (no internal imports, but widely imported):
+  nl-extract, meta-extract, cst-query, nl-ref-extract
+
+Layer 3 (core pipeline):
+  index-builder → extract, nl-ref-extract
+  workspace → extract
+  parser (CJS interop, no internal imports)
+
+Layer 4 (analysis):
+  validate → nl-ref-extract, index-builder
+  lint-engine → nl-ref-extract
+  graph-builder → nl-ref-extract
+
+Layer 5 (commands — all follow same pattern):
+  commands/*.js → workspace, parser, index-builder, etc.
+
+Layer 6 (entry point):
+  index.js → commands/* (dynamic import)
+```
+
+## Verification (after each step)
+
+1. `npx tsc --noEmit` — type-check passes
+2. `npm run build` — `dist/` generated successfully
+3. `npm test` — all 224 tests pass
+4. `node dist/index.js summary ../../examples` — CLI works end-to-end
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `node-gyp` native binding breaks with new build setup | tree-sitter-satsuma is a runtime `file:` dep, not compiled by `tsc` — unaffected |
+| Test import path changes break tests | Step 0 validates all tests before any `.ts` conversion begins |
+| `allowJs` masks type errors in unconverted files | Expected — unconverted files are checked only after conversion |
+| Dynamic command import in `index.ts` | Cast to `{ register: RegisterFn }` — commands in `dist/` are plain `.js` |
+
+## Rollback
+
+At any point, renaming a `.ts` file back to `.js` is safe because `allowJs: true` ensures `tsc` handles both. The `dist/` output is identical either way.

--- a/tooling/satsuma-cli/src/commands/arrows.js
+++ b/tooling/satsuma-cli/src/commands/arrows.js
@@ -15,6 +15,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
+import { expandEntityFields } from "../spread-expand.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -59,14 +60,16 @@ export function register(program) {
         process.exit(1);
       }
 
-      // Validate field exists in schema
+      // Validate field exists in schema (including fragment spread fields)
       const schema = resolvedSchema.entry;
-      const fieldExists = schema.fields.some((f) => f.name === fieldName);
+      const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
+      const allFields = [...schema.fields, ...spreadFields];
+      const fieldExists = allFields.some((f) => f.name === fieldName);
       if (!fieldExists) {
         console.error(
           `Field '${fieldName}' not found in schema '${schemaName}'.`,
         );
-        const close = schema.fields.find(
+        const close = allFields.find(
           (f) => f.name.toLowerCase() === fieldName.toLowerCase(),
         );
         if (close) console.error(`Did you mean '${close.name}'?`);

--- a/tooling/satsuma-cli/src/commands/fields.js
+++ b/tooling/satsuma-cli/src/commands/fields.js
@@ -13,6 +13,7 @@
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
+import { expandEntityFields } from "../spread-expand.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -48,6 +49,10 @@ export function register(program) {
 
       const schema = resolved.entry;
       let fields = schema.fields.map((f) => ({ ...f }));
+
+      // Expand fragment spreads — inline fields from spread fragments
+      const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
+      fields = [...fields, ...spreadFields];
 
       // Enrich with metadata if requested
       if (opts.withMeta) {

--- a/tooling/satsuma-cli/src/commands/graph.js
+++ b/tooling/satsuma-cli/src/commands/graph.js
@@ -19,6 +19,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
 import { buildFullGraph } from "../graph-builder.js";
+import { expandEntityFields } from "../spread-expand.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -105,7 +106,8 @@ function buildWorkspaceGraph(index, schemaGraph, root, opts) {
       note: schema.note ?? null,
     };
     if (!schemaOnly) {
-      node.fields = schema.fields.map((f) => ({
+      const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
+      node.fields = [...schema.fields, ...spreadFields].map((f) => ({
         name: f.name,
         type: f.type ?? null,
       }));
@@ -168,6 +170,22 @@ function buildWorkspaceGraph(index, schemaGraph, root, opts) {
 
   // Build schema-level edges from the directed graph
   const schemaEdges = buildSchemaEdges(index, schemaGraph, includedNodeIds, nsFilter);
+
+  // Add fragment spread edges: fragment -> schema that spreads it
+  for (const [id, schema] of index.schemas) {
+    if (nsFilter && schema.namespace !== nsFilter) continue;
+    if (!schema.hasSpreads) continue;
+    for (const spreadName of (schema.spreads ?? [])) {
+      // Resolve fragment name in the schema's namespace context
+      const fragKey = [...index.fragments.keys()].find((k) => {
+        const bare = k.includes("::") ? k.split("::")[1] : k;
+        return bare === spreadName || k === spreadName;
+      });
+      if (fragKey && includedNodeIds.has(fragKey)) {
+        schemaEdges.push({ from: fragKey, to: id, role: "fragment_spread" });
+      }
+    }
+  }
 
   // Build field-level edges from arrow records
   let fieldEdges = [];

--- a/tooling/satsuma-cli/src/commands/match-fields.js
+++ b/tooling/satsuma-cli/src/commands/match-fields.js
@@ -13,6 +13,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { matchFields } from "../normalize.js";
+import { expandEntityFields } from "../spread-expand.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -52,8 +53,16 @@ export function register(program) {
         resolvedNames[name] = resolved;
       }
 
-      const srcFields = resolvedNames[opts.source].entry.fields;
-      const tgtFields = resolvedNames[opts.target].entry.fields;
+      const srcEntry = resolvedNames[opts.source].entry;
+      const tgtEntry = resolvedNames[opts.target].entry;
+      const srcFields = [
+        ...srcEntry.fields,
+        ...expandEntityFields(srcEntry, srcEntry.namespace ?? null, index),
+      ];
+      const tgtFields = [
+        ...tgtEntry.fields,
+        ...expandEntityFields(tgtEntry, tgtEntry.namespace ?? null, index),
+      ];
       const result = matchFields(srcFields, tgtFields);
 
       if (opts.json) {

--- a/tooling/satsuma-cli/src/commands/schema.js
+++ b/tooling/satsuma-cli/src/commands/schema.js
@@ -99,10 +99,19 @@ function collectFields(bodyNode, indent = 0) {
       if (nested) lines.push(...collectFields(nested, indent + 1));
       lines.push({ indent, text: `${pad}}` });
     } else if (c.type === "fragment_spread") {
-      const lbl = c.namedChildren.find((x) => x.type === "block_label");
-      const inner = lbl?.namedChildren[0];
-      // quoted_name.text already includes surrounding single quotes
-      const sname = inner?.text ?? "";
+      const lbl = c.namedChildren.find((x) => x.type === "spread_label");
+      let sname = "";
+      if (lbl) {
+        const q = lbl.namedChildren.find((x) => x.type === "quoted_name");
+        if (q) {
+          sname = q.text;
+        } else {
+          sname = lbl.namedChildren
+            .filter((x) => x.type === "identifier" || x.type === "qualified_name")
+            .map((x) => x.text)
+            .join(" ");
+        }
+      }
       lines.push({ indent, text: `${pad}...${sname}` });
     }
   }

--- a/tooling/satsuma-cli/src/commands/schema.js
+++ b/tooling/satsuma-cli/src/commands/schema.js
@@ -14,6 +14,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
+import { expandEntityFields } from "../spread-expand.js";
 
 /** @param {import('commander').Command} program */
 export function register(program) {
@@ -63,7 +64,7 @@ export function register(program) {
         : null;
 
       if (opts.json) {
-        printJson(entry, schemaNode);
+        printJson(entry, schemaNode, index);
       } else if (opts.fieldsOnly) {
         printFieldsOnly(entry);
       } else {
@@ -120,13 +121,15 @@ function collectFields(bodyNode, indent = 0) {
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
-function printJson(entry, schemaNode) {
+function printJson(entry, schemaNode, index) {
+  const spreadFields = expandEntityFields(entry, entry.namespace ?? null, index);
+  const allFields = [...entry.fields, ...spreadFields];
   const out = {
     name: entry.name,
     note: entry.note,
     file: entry.file,
     row: entry.row,
-    fields: entry.fields,
+    fields: allFields,
   };
 
   // Enrich with nested structure if CST is available

--- a/tooling/satsuma-cli/src/commands/where-used.js
+++ b/tooling/satsuma-cli/src/commands/where-used.js
@@ -184,7 +184,18 @@ function walkForSpreads(bodyNode, fragmentName, blockName, results) {
     if (c.type === "fragment_spread") {
       // fragment_spread children use spread_label, not block_label
       const lbl = c.namedChildren.find((x) => x.type === "spread_label" || x.type === "block_label");
-      let sname = lbl?.text ?? "";
+      let sname = "";
+      if (lbl) {
+        const q = lbl.namedChildren.find((x) => x.type === "quoted_name");
+        if (q) {
+          sname = q.text.slice(1, -1);
+        } else {
+          sname = lbl.namedChildren
+            .filter((x) => x.type === "identifier" || x.type === "qualified_name")
+            .map((x) => x.text)
+            .join(" ");
+        }
+      }
       if (sname === fragmentName) {
         results.push({ block: blockName, row: c.startPosition.row });
       }

--- a/tooling/satsuma-cli/src/extract.js
+++ b/tooling/satsuma-cli/src/extract.js
@@ -339,8 +339,15 @@ export function extractFragments(rootNode) {
   return collectFromNamespaces(rootNode, "fragment_block").map(({ node, namespace }) => {
     const name = labelText(node);
     const body = child(node, "schema_body");
-    const fields = body ? extractDirectFields(body) : [];
-    return { name, namespace, fields, row: node.startPosition.row };
+    const fieldTree = body ? extractFieldTree(body) : { fields: [], hasSpreads: false, spreads: [] };
+    return {
+      name,
+      namespace,
+      fields: fieldTree.fields,
+      hasSpreads: fieldTree.hasSpreads,
+      spreads: fieldTree.spreads,
+      row: node.startPosition.row,
+    };
   });
 }
 

--- a/tooling/satsuma-cli/src/extract.js
+++ b/tooling/satsuma-cli/src/extract.js
@@ -85,6 +85,7 @@ function extractDirectFields(bodyNode) {
 function extractFieldTree(bodyNode) {
   const fields = [];
   let hasSpreads = false;
+  const spreads = [];
 
   for (const c of bodyNode.namedChildren) {
     if (c.type === "field_decl") {
@@ -97,7 +98,7 @@ function extractFieldTree(bodyNode) {
     } else if (c.type === "record_block" || c.type === "list_block") {
       const name = labelText(c);
       const innerBody = child(c, "schema_body");
-      const nested = innerBody ? extractFieldTree(innerBody) : { fields: [], hasSpreads: false };
+      const nested = innerBody ? extractFieldTree(innerBody) : { fields: [], hasSpreads: false, spreads: [] };
       fields.push({
         name,
         type: c.type === "list_block" ? "list" : "record",
@@ -105,12 +106,31 @@ function extractFieldTree(bodyNode) {
         children: nested.fields,
       });
       if (nested.hasSpreads) hasSpreads = true;
+      spreads.push(...nested.spreads);
     } else if (c.type === "fragment_spread") {
       hasSpreads = true;
+      const label = child(c, "spread_label");
+      if (label) {
+        spreads.push(spreadLabelText(label));
+      }
     }
   }
 
-  return { fields, hasSpreads };
+  return { fields, hasSpreads, spreads };
+}
+
+/**
+ * Extract the text from a spread_label node.
+ * spread_label → qualified_name | quoted_name | _spread_words (identifier+)
+ */
+function spreadLabelText(labelNode) {
+  const qn = child(labelNode, "qualified_name");
+  if (qn) return qualifiedNameText(qn);
+  const q = child(labelNode, "quoted_name");
+  if (q) return q.text.slice(1, -1);
+  // Multi-word or single-word: join all identifiers with spaces
+  const ids = children(labelNode, "identifier");
+  return ids.map((id) => id.text).join(" ");
 }
 
 /**
@@ -195,13 +215,14 @@ export function extractSchemas(rootNode) {
       ? stringText(noteTag.namedChildren.find((c) => c.type === "nl_string" || c.type === "multiline_string"))
       : null;
     const body = child(node, "schema_body");
-    const fieldTree = body ? extractFieldTree(body) : { fields: [], hasSpreads: false };
+    const fieldTree = body ? extractFieldTree(body) : { fields: [], hasSpreads: false, spreads: [] };
     return {
       name,
       namespace,
       note: noteStr,
       fields: fieldTree.fields,
       hasSpreads: fieldTree.hasSpreads,
+      spreads: fieldTree.spreads,
       row: node.startPosition.row,
     };
   });

--- a/tooling/satsuma-cli/src/index-builder.js
+++ b/tooling/satsuma-cli/src/index-builder.js
@@ -181,6 +181,14 @@ export function buildIndex(parsedFiles) {
           if (!existingNames.has(f.name)) existing.fields.push(f);
         }
         existing.hasSpreads = existing.hasSpreads || s.hasSpreads;
+        if (s.spreads?.length) {
+          const existingSpreads = new Set(existing.spreads ?? []);
+          for (const sp of s.spreads) {
+            if (!existingSpreads.has(sp)) {
+              (existing.spreads ??= []).push(sp);
+            }
+          }
+        }
       } else {
         schemas.set(key, { ...s, file: filePath });
       }
@@ -246,7 +254,7 @@ export function buildIndex(parsedFiles) {
     );
   }
 
-  const referenceGraph = buildReferenceGraph({ metrics, mappings });
+  const referenceGraph = buildReferenceGraph({ schemas, metrics, mappings });
   const fieldArrows = buildFieldArrows(allArrowRecords, mappings);
 
   return {
@@ -353,7 +361,7 @@ function buildFieldArrows(arrowRecords, mappings) {
  *   metricsReferences: Map<string, string[]> // metric → source schema names
  * }}
  */
-function buildReferenceGraph({ metrics, mappings }) {
+function buildReferenceGraph({ schemas, metrics, mappings }) {
   // schema/fragment → which mappings reference it (as source or target)
   const usedByMappings = new Map();
 
@@ -365,10 +373,14 @@ function buildReferenceGraph({ metrics, mappings }) {
     }
   }
 
-  // fragment → which schemas/fragments use it via ...spread (tracked via fields named '...')
-  // We don't have spread info in the current extraction, so we leave a placeholder.
-  // (fragment_spread nodes are inside schema_body but not captured in extractDirectFields)
+  // fragment → which schemas use it via ...spread
   const fragmentsUsedIn = new Map();
+  for (const [schemaKey, schema] of schemas) {
+    for (const spreadName of schema.spreads ?? []) {
+      if (!fragmentsUsedIn.has(spreadName)) fragmentsUsedIn.set(spreadName, []);
+      fragmentsUsedIn.get(spreadName).push(schemaKey);
+    }
+  }
 
   // metric → source schema references
   const metricsReferences = new Map();

--- a/tooling/satsuma-cli/src/spread-expand.js
+++ b/tooling/satsuma-cli/src/spread-expand.js
@@ -1,0 +1,168 @@
+/**
+ * spread-expand.js — Fragment spread expansion for Satsuma workspaces
+ *
+ * Resolves fragment spreads in schemas and fragments, inlining the fragment
+ * fields into the caller's field set. Handles transitive spreads, cycle
+ * detection, and diamond-shaped spread graphs.
+ *
+ * Shared by validate.js and CLI commands that need expanded field lists.
+ */
+
+import { resolveScopedEntityRef } from "./index-builder.js";
+
+/**
+ * Resolve an entity name against the index with namespace-aware lookup.
+ */
+function resolveEntityRef(ref, currentNs, entityMap) {
+  return resolveScopedEntityRef(ref, currentNs, entityMap);
+}
+
+/**
+ * Recursively collect all valid dotted field paths from a field tree.
+ *
+ * @param {Array<{name:string, type:string, children?:Array}>} fields
+ * @param {string} prefix  dot-separated path prefix (e.g. "Order.")
+ * @param {Set<string>} paths  accumulator set
+ */
+export function collectFieldPaths(fields, prefix, paths) {
+  for (const f of fields) {
+    const fullPath = prefix + f.name;
+    paths.add(fullPath);
+    if (f.isList) {
+      paths.add(prefix + f.name + "[]");
+    }
+    if (f.children && f.children.length > 0) {
+      collectFieldPaths(f.children, fullPath + ".", paths);
+      if (f.isList) {
+        collectFieldPaths(f.children, fullPath + "[].", paths);
+      }
+    }
+  }
+}
+
+/**
+ * Expand fragment spreads for a set of schema keys, adding fragment fields
+ * to the fieldPaths set. Returns true if any spread references an
+ * unresolvable fragment.
+ *
+ * @param {string[]} schemaKeys  resolved schema keys to expand
+ * @param {string|null} currentNs  namespace context for resolution
+ * @param {object} index  WorkspaceIndex
+ * @param {Set<string>} fieldPaths  accumulator set (mutated)
+ * @param {Array} diagnostics  accumulator for cycle warnings (optional)
+ * @returns {boolean}  true if any spread could not be resolved
+ */
+export function expandSpreads(schemaKeys, currentNs, index, fieldPaths, diagnostics = []) {
+  let hasUnresolved = false;
+  const visited = new Set();
+  for (const key of schemaKeys) {
+    const schema = index.schemas.get(key);
+    if (!schema?.hasSpreads) continue;
+    if (!expandEntitySpreads(schema, currentNs, index, fieldPaths, visited, diagnostics, [])) {
+      hasUnresolved = true;
+    }
+  }
+  return hasUnresolved;
+}
+
+/**
+ * Expand fragment spreads for a single entity (schema or fragment), returning
+ * the expanded field objects (not paths). Useful for commands that need the
+ * actual field objects rather than just path strings.
+ *
+ * @param {object} entity  schema or fragment with spreads/hasSpreads/fields
+ * @param {string|null} currentNs  namespace context for resolution
+ * @param {object} index  WorkspaceIndex
+ * @returns {Array<{name:string, type:string, fromFragment?:string}>}  expanded fields
+ */
+export function expandEntityFields(entity, currentNs, index) {
+  const expandedFields = [];
+  if (!entity?.hasSpreads) return expandedFields;
+
+  const visited = new Set();
+  collectExpandedFields(entity, currentNs, index, expandedFields, visited, []);
+  return expandedFields;
+}
+
+/**
+ * Recursively collect expanded field objects from fragment spreads.
+ */
+function collectExpandedFields(entity, currentNs, index, fields, visited, chain) {
+  const spreads = entity.spreads ?? [];
+  if (spreads.length === 0) return;
+
+  const ancestors = new Set(chain);
+  for (const spreadName of spreads) {
+    const resolvedKey = resolveEntityRef(spreadName, currentNs, index.fragments);
+    if (!resolvedKey) continue;
+    if (ancestors.has(resolvedKey)) continue; // cycle
+    if (visited.has(resolvedKey)) continue; // diamond
+    visited.add(resolvedKey);
+
+    const fragment = index.fragments.get(resolvedKey);
+    if (!fragment) continue;
+
+    for (const f of fragment.fields) {
+      fields.push({ ...f, fromFragment: resolvedKey });
+    }
+
+    // Recursively expand spreads within this fragment
+    if (fragment.hasSpreads) {
+      collectExpandedFields(fragment, currentNs, index, fields, visited, [...chain, resolvedKey]);
+    }
+  }
+}
+
+/**
+ * Recursively expand spreads for a schema or fragment, adding fragment fields
+ * to the fieldPaths set. Detects cycles and emits diagnostics for them.
+ *
+ * @param {object} entity  schema or fragment with spreads/hasSpreads/fields
+ * @param {string|null} currentNs  namespace context for resolution
+ * @param {object} index  WorkspaceIndex
+ * @param {Set<string>} fieldPaths  accumulator set (mutated)
+ * @param {Set<string>} expanded  already fully expanded keys (efficiency)
+ * @param {Array} diagnostics  accumulator for cycle warnings
+ * @param {string[]} chain  current expansion chain for cycle reporting
+ * @returns {boolean}  true if all spreads resolved, false if any unresolvable
+ */
+function expandEntitySpreads(entity, currentNs, index, fieldPaths, expanded, diagnostics, chain) {
+  const spreads = entity.spreads ?? [];
+  if (spreads.length === 0 && entity.hasSpreads) return false;
+  const ancestors = new Set(chain);
+  let allResolved = true;
+  for (const spreadName of spreads) {
+    const resolvedKey = resolveEntityRef(spreadName, currentNs, index.fragments);
+    if (!resolvedKey) {
+      allResolved = false;
+      continue;
+    }
+    if (ancestors.has(resolvedKey)) {
+      const cycleStart = chain.indexOf(resolvedKey);
+      const cyclePath = [...chain.slice(cycleStart), resolvedKey];
+      diagnostics.push({
+        file: entity.file ?? "unknown",
+        line: entity.row != null ? entity.row + 1 : 1,
+        column: 1,
+        severity: "error",
+        rule: "circular-spread",
+        message: `Circular fragment spread detected: ${cyclePath.join(" → ")}`,
+      });
+      continue;
+    }
+    if (expanded.has(resolvedKey)) continue;
+    expanded.add(resolvedKey);
+    const fragment = index.fragments.get(resolvedKey);
+    if (!fragment) {
+      allResolved = false;
+      continue;
+    }
+    collectFieldPaths(fragment.fields, "", fieldPaths);
+    if (fragment.hasSpreads) {
+      if (!expandEntitySpreads(fragment, currentNs, index, fieldPaths, expanded, diagnostics, [...chain, resolvedKey])) {
+        allResolved = false;
+      }
+    }
+  }
+  return allResolved;
+}

--- a/tooling/satsuma-cli/src/validate.js
+++ b/tooling/satsuma-cli/src/validate.js
@@ -299,9 +299,13 @@ export function collectSemanticWarnings(index) {
       const tgtFieldPaths = new Set();
       collectFieldPaths(tgtFields, "", tgtFieldPaths);
 
-      // Check if source or target schema has unresolved spreads
-      const srcHasSpreads = resolvedSrcKeys.some((s) => index.schemas.get(s)?.hasSpreads);
-      const tgtHasSpreads = resolvedTgtKey ? (index.schemas.get(resolvedTgtKey)?.hasSpreads ?? false) : false;
+      // Expand fragment spreads: inline fragment fields into the field path sets.
+      // If a spread references an unknown fragment, fall back to suppressing
+      // field-not-in-schema for that side (conservative: avoid false positives).
+      const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, index, srcFieldPaths);
+      const tgtHasUnresolved = resolvedTgtKey
+        ? expandSpreads([resolvedTgtKey], currentNs, index, tgtFieldPaths)
+        : false;
 
       for (const arrow of uniqueArrows) {
         if (arrow.mapping !== mapping.name || (arrow.namespace ?? null) !== currentNs) continue;
@@ -310,7 +314,7 @@ export function collectSemanticWarnings(index) {
           arrow.source &&
           srcSchema &&
           index.schemas.has(srcSchema) &&
-          !srcHasSpreads &&
+          !srcHasUnresolved &&
           !resolveFieldPath(arrow.source, resolvedSrcKeys, index, srcFieldPaths)
         ) {
           diagnostics.push({
@@ -326,7 +330,7 @@ export function collectSemanticWarnings(index) {
           arrow.target &&
           resolvedTgtKey &&
           index.schemas.has(resolvedTgtKey) &&
-          !tgtHasSpreads &&
+          !tgtHasUnresolved &&
           !resolveFieldPath(arrow.target, [resolvedTgtKey], index, tgtFieldPaths)
         ) {
           diagnostics.push({
@@ -410,6 +414,56 @@ function resolveFieldPath(path, schemaNames, index, fieldPaths) {
   }
 
   return false;
+}
+
+/**
+ * Expand fragment spreads for a set of schemas, adding fragment fields to the
+ * fieldPaths set. Returns true if any spread references an unresolvable
+ * fragment (in which case validation should be suppressed for that side).
+ *
+ * @param {string[]} schemaKeys  resolved schema keys to expand
+ * @param {string|null} currentNs  namespace context for resolution
+ * @param {object} index  WorkspaceIndex
+ * @param {Set<string>} fieldPaths  accumulator set (mutated)
+ * @returns {boolean}  true if any spread could not be resolved
+ */
+function expandSpreads(schemaKeys, currentNs, index, fieldPaths) {
+  let hasUnresolved = false;
+  const visited = new Set(); // prevent infinite loops from circular spreads
+  for (const key of schemaKeys) {
+    const schema = index.schemas.get(key);
+    if (!schema?.hasSpreads) continue;
+    if (!expandSchemaFragments(schema, currentNs, index, fieldPaths, visited)) {
+      hasUnresolved = true;
+    }
+  }
+  return hasUnresolved;
+}
+
+/**
+ * Recursively expand spreads for a single schema, adding fragment fields
+ * to the fieldPaths set. Returns false if any spread is unresolvable.
+ */
+function expandSchemaFragments(schema, currentNs, index, fieldPaths, visited) {
+  const spreads = schema.spreads ?? [];
+  if (spreads.length === 0 && schema.hasSpreads) return false; // hasSpreads but no extracted names
+  let allResolved = true;
+  for (const spreadName of spreads) {
+    const resolvedKey = resolveEntityRef(spreadName, currentNs, index.fragments);
+    if (!resolvedKey) {
+      allResolved = false;
+      continue;
+    }
+    if (visited.has(resolvedKey)) continue;
+    visited.add(resolvedKey);
+    const fragment = index.fragments.get(resolvedKey);
+    if (!fragment) {
+      allResolved = false;
+      continue;
+    }
+    collectFieldPaths(fragment.fields, "", fieldPaths);
+  }
+  return allResolved;
 }
 
 function capitalize(str) {

--- a/tooling/satsuma-cli/src/validate.js
+++ b/tooling/satsuma-cli/src/validate.js
@@ -13,6 +13,7 @@ import {
   isSchemaInMappingSources,
 } from "./nl-ref-extract.js";
 import { resolveScopedEntityRef } from "./index-builder.js";
+import { expandSpreads, collectFieldPaths } from "./spread-expand.js";
 
 /**
  * @typedef {Object} Diagnostic
@@ -352,32 +353,6 @@ export function collectSemanticWarnings(index) {
 // ── Field path resolution helpers ─────────────────────────────────────────────
 
 /**
- * Recursively collect all valid dotted field paths from a field tree.
- * E.g. for schema { record Order { OrderId INT, record Customer { Email STRING } } }
- * collects: "Order", "Order.OrderId", "Order.Customer", "Order.Customer.Email"
- *
- * @param {Array<{name:string, type:string, children?:Array}>} fields
- * @param {string} prefix  dot-separated path prefix (e.g. "Order.")
- * @param {Set<string>} paths  accumulator set
- */
-function collectFieldPaths(fields, prefix, paths) {
-  for (const f of fields) {
-    const fullPath = prefix + f.name;
-    paths.add(fullPath);
-    // list fields can be accessed with [] notation — add both forms
-    if (f.isList) {
-      paths.add(prefix + f.name + "[]");
-    }
-    if (f.children && f.children.length > 0) {
-      collectFieldPaths(f.children, fullPath + ".", paths);
-      if (f.isList) {
-        collectFieldPaths(f.children, fullPath + "[].", paths);
-      }
-    }
-  }
-}
-
-/**
  * Resolve an arrow field path against available schemas and field paths.
  * Handles:
  * - Direct match in fieldPaths set (covers nested dotted paths)
@@ -416,90 +391,6 @@ function resolveFieldPath(path, schemaNames, index, fieldPaths) {
   return false;
 }
 
-/**
- * Expand fragment spreads for a set of schemas, adding fragment fields to the
- * fieldPaths set. Returns true if any spread references an unresolvable
- * fragment (in which case validation should be suppressed for that side).
- *
- * @param {string[]} schemaKeys  resolved schema keys to expand
- * @param {string|null} currentNs  namespace context for resolution
- * @param {object} index  WorkspaceIndex
- * @param {Set<string>} fieldPaths  accumulator set (mutated)
- * @param {Array} diagnostics  accumulator for cycle warnings
- * @returns {boolean}  true if any spread could not be resolved
- */
-function expandSpreads(schemaKeys, currentNs, index, fieldPaths, diagnostics) {
-  let hasUnresolved = false;
-  const visited = new Set(); // prevent infinite loops from circular spreads
-  for (const key of schemaKeys) {
-    const schema = index.schemas.get(key);
-    if (!schema?.hasSpreads) continue;
-    if (!expandEntitySpreads(schema, currentNs, index, fieldPaths, visited, diagnostics, [])) {
-      hasUnresolved = true;
-    }
-  }
-  return hasUnresolved;
-}
-
-/**
- * Recursively expand spreads for a schema or fragment, adding fragment fields
- * to the fieldPaths set. Detects cycles and emits diagnostics for them.
- *
- * Uses two tracking sets:
- * - `ancestors`: keys currently on the recursion stack (for cycle detection)
- * - `expanded`: keys already fully expanded (to avoid redundant work in diamonds)
- *
- * @param {object} entity  schema or fragment with spreads/hasSpreads/fields
- * @param {string|null} currentNs  namespace context for resolution
- * @param {object} index  WorkspaceIndex
- * @param {Set<string>} fieldPaths  accumulator set (mutated)
- * @param {Set<string>} expanded  already fully expanded keys (efficiency)
- * @param {Array} diagnostics  accumulator for cycle warnings
- * @param {string[]} chain  current expansion chain for cycle reporting
- * @returns {boolean}  true if all spreads resolved, false if any unresolvable
- */
-function expandEntitySpreads(entity, currentNs, index, fieldPaths, expanded, diagnostics, chain) {
-  const spreads = entity.spreads ?? [];
-  if (spreads.length === 0 && entity.hasSpreads) return false; // hasSpreads but no extracted names
-  const ancestors = new Set(chain);
-  let allResolved = true;
-  for (const spreadName of spreads) {
-    const resolvedKey = resolveEntityRef(spreadName, currentNs, index.fragments);
-    if (!resolvedKey) {
-      allResolved = false;
-      continue;
-    }
-    if (ancestors.has(resolvedKey)) {
-      // Cycle detected — emit diagnostic
-      const cycleStart = chain.indexOf(resolvedKey);
-      const cyclePath = [...chain.slice(cycleStart), resolvedKey];
-      diagnostics.push({
-        file: entity.file ?? "unknown",
-        line: entity.row != null ? entity.row + 1 : 1,
-        column: 1,
-        severity: "error",
-        rule: "circular-spread",
-        message: `Circular fragment spread detected: ${cyclePath.join(" → ")}`,
-      });
-      continue;
-    }
-    if (expanded.has(resolvedKey)) continue; // already expanded via another path (diamond)
-    expanded.add(resolvedKey);
-    const fragment = index.fragments.get(resolvedKey);
-    if (!fragment) {
-      allResolved = false;
-      continue;
-    }
-    collectFieldPaths(fragment.fields, "", fieldPaths);
-    // Recursively expand spreads within this fragment
-    if (fragment.hasSpreads) {
-      if (!expandEntitySpreads(fragment, currentNs, index, fieldPaths, expanded, diagnostics, [...chain, resolvedKey])) {
-        allResolved = false;
-      }
-    }
-  }
-  return allResolved;
-}
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/tooling/satsuma-cli/src/validate.js
+++ b/tooling/satsuma-cli/src/validate.js
@@ -302,9 +302,9 @@ export function collectSemanticWarnings(index) {
       // Expand fragment spreads: inline fragment fields into the field path sets.
       // If a spread references an unknown fragment, fall back to suppressing
       // field-not-in-schema for that side (conservative: avoid false positives).
-      const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, index, srcFieldPaths);
+      const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, index, srcFieldPaths, diagnostics);
       const tgtHasUnresolved = resolvedTgtKey
-        ? expandSpreads([resolvedTgtKey], currentNs, index, tgtFieldPaths)
+        ? expandSpreads([resolvedTgtKey], currentNs, index, tgtFieldPaths, diagnostics)
         : false;
 
       for (const arrow of uniqueArrows) {
@@ -425,15 +425,16 @@ function resolveFieldPath(path, schemaNames, index, fieldPaths) {
  * @param {string|null} currentNs  namespace context for resolution
  * @param {object} index  WorkspaceIndex
  * @param {Set<string>} fieldPaths  accumulator set (mutated)
+ * @param {Array} diagnostics  accumulator for cycle warnings
  * @returns {boolean}  true if any spread could not be resolved
  */
-function expandSpreads(schemaKeys, currentNs, index, fieldPaths) {
+function expandSpreads(schemaKeys, currentNs, index, fieldPaths, diagnostics) {
   let hasUnresolved = false;
   const visited = new Set(); // prevent infinite loops from circular spreads
   for (const key of schemaKeys) {
     const schema = index.schemas.get(key);
     if (!schema?.hasSpreads) continue;
-    if (!expandSchemaFragments(schema, currentNs, index, fieldPaths, visited)) {
+    if (!expandEntitySpreads(schema, currentNs, index, fieldPaths, visited, diagnostics, [])) {
       hasUnresolved = true;
     }
   }
@@ -441,12 +442,26 @@ function expandSpreads(schemaKeys, currentNs, index, fieldPaths) {
 }
 
 /**
- * Recursively expand spreads for a single schema, adding fragment fields
- * to the fieldPaths set. Returns false if any spread is unresolvable.
+ * Recursively expand spreads for a schema or fragment, adding fragment fields
+ * to the fieldPaths set. Detects cycles and emits diagnostics for them.
+ *
+ * Uses two tracking sets:
+ * - `ancestors`: keys currently on the recursion stack (for cycle detection)
+ * - `expanded`: keys already fully expanded (to avoid redundant work in diamonds)
+ *
+ * @param {object} entity  schema or fragment with spreads/hasSpreads/fields
+ * @param {string|null} currentNs  namespace context for resolution
+ * @param {object} index  WorkspaceIndex
+ * @param {Set<string>} fieldPaths  accumulator set (mutated)
+ * @param {Set<string>} expanded  already fully expanded keys (efficiency)
+ * @param {Array} diagnostics  accumulator for cycle warnings
+ * @param {string[]} chain  current expansion chain for cycle reporting
+ * @returns {boolean}  true if all spreads resolved, false if any unresolvable
  */
-function expandSchemaFragments(schema, currentNs, index, fieldPaths, visited) {
-  const spreads = schema.spreads ?? [];
-  if (spreads.length === 0 && schema.hasSpreads) return false; // hasSpreads but no extracted names
+function expandEntitySpreads(entity, currentNs, index, fieldPaths, expanded, diagnostics, chain) {
+  const spreads = entity.spreads ?? [];
+  if (spreads.length === 0 && entity.hasSpreads) return false; // hasSpreads but no extracted names
+  const ancestors = new Set(chain);
   let allResolved = true;
   for (const spreadName of spreads) {
     const resolvedKey = resolveEntityRef(spreadName, currentNs, index.fragments);
@@ -454,14 +469,34 @@ function expandSchemaFragments(schema, currentNs, index, fieldPaths, visited) {
       allResolved = false;
       continue;
     }
-    if (visited.has(resolvedKey)) continue;
-    visited.add(resolvedKey);
+    if (ancestors.has(resolvedKey)) {
+      // Cycle detected — emit diagnostic
+      const cycleStart = chain.indexOf(resolvedKey);
+      const cyclePath = [...chain.slice(cycleStart), resolvedKey];
+      diagnostics.push({
+        file: entity.file ?? "unknown",
+        line: entity.row != null ? entity.row + 1 : 1,
+        column: 1,
+        severity: "error",
+        rule: "circular-spread",
+        message: `Circular fragment spread detected: ${cyclePath.join(" → ")}`,
+      });
+      continue;
+    }
+    if (expanded.has(resolvedKey)) continue; // already expanded via another path (diamond)
+    expanded.add(resolvedKey);
     const fragment = index.fragments.get(resolvedKey);
     if (!fragment) {
       allResolved = false;
       continue;
     }
     collectFieldPaths(fragment.fields, "", fieldPaths);
+    // Recursively expand spreads within this fragment
+    if (fragment.hasSpreads) {
+      if (!expandEntitySpreads(fragment, currentNs, index, fieldPaths, expanded, diagnostics, [...chain, resolvedKey])) {
+        allResolved = false;
+      }
+    }
   }
   return allResolved;
 }

--- a/tooling/satsuma-cli/test/fixtures/fragment-spread-commands.stm
+++ b/tooling/satsuma-cli/test/fixtures/fragment-spread-commands.stm
@@ -1,0 +1,51 @@
+// Test fixture for fragment spread expansion across CLI commands
+// Exercises: fields, arrows, match-fields, graph, schema, where-used
+
+fragment 'audit fields' {
+  created_at   TIMESTAMPTZ
+  updated_at   TIMESTAMPTZ
+  created_by   VARCHAR(100)
+}
+
+fragment 'address fields' {
+  street_line_1  VARCHAR(200)
+  city           VARCHAR(100)
+  state          VARCHAR(50)
+  postal_code    VARCHAR(20)
+}
+
+// Transitive spread: full address spreads address fields
+fragment 'full address' {
+  ...address fields
+  country        VARCHAR(100)
+}
+
+schema src_customers {
+  customer_id   UUID         (pk)
+  email         VARCHAR(255)
+  ...address fields
+}
+
+schema tgt_customers {
+  customer_id   UUID         (pk)
+  email         VARCHAR(255)
+  ...audit fields
+  ...address fields
+}
+
+schema customer_with_full_address {
+  customer_id   UUID         (pk)
+  ...full address
+}
+
+mapping 'customer sync' {
+  source { `src_customers` }
+  target { `tgt_customers` }
+
+  customer_id -> customer_id
+  email       -> email        { trim | lowercase }
+  street_line_1 -> street_line_1
+  city        -> city
+  -> created_at { now_utc() }
+  -> updated_at { now_utc() }
+}

--- a/tooling/satsuma-cli/test/fixtures/fragment-spread-validate.stm
+++ b/tooling/satsuma-cli/test/fixtures/fragment-spread-validate.stm
@@ -1,0 +1,26 @@
+// Fixture: fragment spread expansion in validation
+// The mapping arrow references created_at which comes from the fragment,
+// not from the target schema's direct fields. Validation should pass.
+
+fragment audit_fields {
+  created_at    TIMESTAMPTZ
+  updated_at    TIMESTAMPTZ
+}
+
+schema src_orders {
+  order_id     INT
+  created_at   TIMESTAMPTZ
+}
+
+schema tgt_orders {
+  order_id     INT
+  ...audit_fields
+}
+
+mapping 'order load' {
+  source { src_orders }
+  target { tgt_orders }
+
+  order_id   -> order_id
+  created_at -> created_at
+}

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1269,7 +1269,7 @@ describe("satsuma nl-refs", () => {
   });
 
   it("supports --unresolved filter with no results", async () => {
-    const { _stdout, code } = await run("nl-refs", "--unresolved", NS_MERGING);
+    const { code } = await run("nl-refs", "--unresolved", NS_MERGING);
     assert.equal(code, 0);
   });
 
@@ -1596,6 +1596,142 @@ describe("satsuma lineage --to upstream branches (sg-pufq)", () => {
     const names = data.nodes.map((n) => n.name);
     assert.ok(names.includes("vault::hub_contact"), `expected vault::hub_contact in ${names}`);
     assert.ok(names.includes("vault::sat_contact_details"), `expected vault::sat_contact_details in ${names}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fixes: fragment spread expansion across CLI commands
+// (sl-3aff, sl-h1b0, sl-wrzl, sl-t6lt, sl-zjec, sl-307v)
+// ---------------------------------------------------------------------------
+const SPREAD_FIXTURE = resolve(__dirname, "fixtures", "fragment-spread-commands.stm");
+
+describe("satsuma fields — fragment spread expansion (sl-3aff)", () => {
+  it("includes fields from fragment spreads", async () => {
+    const { stdout, code } = await run("fields", "tgt_customers", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    // Direct fields
+    assert.match(stdout, /customer_id/);
+    assert.match(stdout, /email/);
+    // Fragment spread fields from 'audit fields'
+    assert.match(stdout, /created_at/);
+    assert.match(stdout, /updated_at/);
+    assert.match(stdout, /created_by/);
+    // Fragment spread fields from 'address fields'
+    assert.match(stdout, /street_line_1/);
+    assert.match(stdout, /city/);
+  });
+
+  it("--json includes fragment spread fields", async () => {
+    const { stdout, code } = await run("fields", "tgt_customers", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const fields = JSON.parse(stdout);
+    const names = fields.map((f) => f.name);
+    assert.ok(names.includes("created_at"), "should include created_at from audit fields");
+    assert.ok(names.includes("street_line_1"), "should include street_line_1 from address fields");
+  });
+
+  it("includes transitive spread fields", async () => {
+    const { stdout, code } = await run("fields", "customer_with_full_address", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const fields = JSON.parse(stdout);
+    const names = fields.map((f) => f.name);
+    // From 'full address' fragment directly
+    assert.ok(names.includes("country"), "should include country from full address");
+    // Transitive from 'address fields' via 'full address'
+    assert.ok(names.includes("street_line_1"), "should include street_line_1 transitively");
+    assert.ok(names.includes("city"), "should include city transitively");
+  });
+});
+
+describe("satsuma arrows — fragment spread expansion (sl-h1b0)", () => {
+  it("finds arrows targeting fields from fragment spreads", async () => {
+    const { stdout, code } = await run("arrows", "tgt_customers.created_at", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    assert.match(stdout, /now_utc/);
+  });
+
+  it("finds arrows targeting spread source fields", async () => {
+    const { stdout, code } = await run("arrows", "src_customers.street_line_1", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    assert.match(stdout, /street_line_1/);
+  });
+
+  it("does not error for spread field lookup", async () => {
+    const { stderr, code } = await run("arrows", "tgt_customers.updated_at", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    assert.ok(!stderr.includes("not found"), "should not error for spread field");
+  });
+});
+
+describe("satsuma match-fields — fragment spread expansion (sl-wrzl)", () => {
+  it("matches fields from shared fragment spreads", async () => {
+    const { stdout, code } = await run(
+      "match-fields", "--source", "src_customers", "--target", "tgt_customers",
+      "--json", SPREAD_FIXTURE,
+    );
+    assert.equal(code, 0);
+    const result = JSON.parse(stdout);
+    const matchedNames = result.matched.map((m) => m.source);
+    // Both schemas spread 'address fields' — these should match
+    assert.ok(matchedNames.includes("street_line_1"), "street_line_1 should be matched");
+    assert.ok(matchedNames.includes("city"), "city should be matched");
+    assert.ok(matchedNames.includes("state"), "state should be matched");
+  });
+});
+
+describe("satsuma graph --json — fragment spread expansion (sl-t6lt)", () => {
+  it("includes fragment spread fields in schema node fields arrays", async () => {
+    const { stdout, code } = await run("graph", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const graph = JSON.parse(stdout);
+    const tgtNode = graph.nodes.find((n) => n.id === "tgt_customers");
+    assert.ok(tgtNode, "tgt_customers node should exist");
+    const fieldNames = tgtNode.fields.map((f) => f.name);
+    assert.ok(fieldNames.includes("created_at"), "should include created_at from audit fields");
+    assert.ok(fieldNames.includes("street_line_1"), "should include street_line_1 from address fields");
+  });
+
+  it("includes fragment spread edges", async () => {
+    const { stdout, code } = await run("graph", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const graph = JSON.parse(stdout);
+    const spreadEdges = graph.schema_edges.filter((e) => e.role === "fragment_spread");
+    assert.ok(spreadEdges.length > 0, "should have fragment_spread edges");
+  });
+});
+
+describe("satsuma schema --json — fragment spread expansion (sl-zjec)", () => {
+  it("includes expanded fragment fields in fields array", async () => {
+    const { stdout, code } = await run("schema", "tgt_customers", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const fieldNames = data.fields.map((f) => f.name);
+    assert.ok(fieldNames.includes("created_at"), "should include created_at from audit fields");
+    assert.ok(fieldNames.includes("updated_at"), "should include updated_at from audit fields");
+    assert.ok(fieldNames.includes("created_by"), "should include created_by from audit fields");
+    assert.ok(fieldNames.includes("street_line_1"), "should include street_line_1 from address fields");
+  });
+
+  it("still shows spread syntax in fieldLines", async () => {
+    const { stdout, code } = await run("schema", "tgt_customers", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.fieldLines.some((l) => l.includes("...audit fields")));
+    assert.ok(data.fieldLines.some((l) => l.includes("...address fields")));
+  });
+});
+
+describe("satsuma where-used — fragment-to-fragment spreads (sl-307v)", () => {
+  it("finds fragment-to-fragment spread references", async () => {
+    const { stdout, code } = await run("where-used", "address fields", "--json", SPREAD_FIXTURE);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const spreadRefs = data.refs.filter((r) => r.kind === "fragment_spread");
+    const refNames = spreadRefs.map((r) => r.name);
+    // Should find spreads in: src_customers, tgt_customers, full address, customer_with_full_address (transitive via full address)
+    assert.ok(refNames.includes("src_customers"), "should find spread in src_customers");
+    assert.ok(refNames.includes("tgt_customers"), "should find spread in tgt_customers");
+    assert.ok(refNames.includes("full address"), "should find spread in fragment 'full address'");
   });
 });
 

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -728,6 +728,13 @@ describe("satsuma validate", () => {
     assert.ok(data[0].rule);
     assert.ok(data[0].message);
   });
+
+  it("expands fragment spreads — no false field-not-in-schema warnings", async () => {
+    const FIXTURE = resolve(import.meta.dirname, "fixtures", "fragment-spread-validate.stm");
+    const { stdout, code } = await run("validate", FIXTURE);
+    assert.equal(code, 0, `Expected clean validation but got:\n${stdout}`);
+    assert.match(stdout, /no issues/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tooling/satsuma-cli/test/schema.test.js
+++ b/tooling/satsuma-cli/test/schema.test.js
@@ -18,6 +18,10 @@ function blockLabel(name) {
   const inner = name.startsWith("'") ? quoted(name.slice(1, -1)) : ident(name);
   return n("block_label", [inner]);
 }
+function spreadLabel(name) {
+  if (name.startsWith("'")) return n("spread_label", [quoted(name.slice(1, -1))]);
+  return n("spread_label", name.split(" ").map(ident));
+}
 function fieldName(name) { return n("field_name", [ident(name)]); }
 function typeExpr(t) { return n("type_expr", [], t); }
 function fieldDecl(name, type, meta = null) {
@@ -52,9 +56,19 @@ function collectFields(bodyNode, indent = 0) {
       if (nested) lines.push(...collectFields(nested, indent + 1));
       lines.push({ indent, text: `${pad}}` });
     } else if (c.type === "fragment_spread") {
-      const lbl = c.namedChildren.find((x) => x.type === "block_label");
-      const inner = lbl?.namedChildren[0];
-      const sname = inner?.text ?? "";
+      const lbl = c.namedChildren.find((x) => x.type === "spread_label");
+      let sname = "";
+      if (lbl) {
+        const q = lbl.namedChildren.find((x) => x.type === "quoted_name");
+        if (q) {
+          sname = q.text;
+        } else {
+          sname = lbl.namedChildren
+            .filter((x) => x.type === "identifier" || x.type === "qualified_name")
+            .map((x) => x.text)
+            .join(" ");
+        }
+      }
       lines.push({ indent, text: `${pad}...${sname}` });
     }
   }
@@ -105,12 +119,19 @@ describe("collectFields", () => {
     assert.equal(lines[2].text, "}");
   });
 
-  it("renders fragment_spread", () => {
-    const spread = n("fragment_spread", [blockLabel("'address fields'")]);
+  it("renders quoted fragment_spread", () => {
+    const spread = n("fragment_spread", [spreadLabel("'address fields'")]);
     const body = n("schema_body", [spread]);
     const lines = collectFields(body, 1);
-    // quoted_name.text includes surrounding single quotes
+    // quoted_name.text includes surrounding single quotes in display
     assert.equal(lines[0].text.trim(), "...'address fields'");
+  });
+
+  it("renders unquoted fragment_spread", () => {
+    const spread = n("fragment_spread", [spreadLabel("audit fields")]);
+    const body = n("schema_body", [spread]);
+    const lines = collectFields(body, 0);
+    assert.equal(lines[0].text, "...audit fields");
   });
 
   it("returns empty array for empty body", () => {

--- a/tooling/satsuma-cli/test/validate-bugs.test.js
+++ b/tooling/satsuma-cli/test/validate-bugs.test.js
@@ -423,6 +423,96 @@ describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
   });
 });
 
+// ── Bug 4b: Fragment spread cycles and nested expansion ──────────────────────
+
+describe("Bug 4b: fragment spread cycles and nested expansion", () => {
+  it("expands fragment that spreads another fragment (transitive)", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["base_fields"] },
+      ],
+      fragments: [
+        { name: "base_fields", fields: [{ name: "name", type: "VARCHAR" }], hasSpreads: true, spreads: ["audit_fields"] },
+        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }, { name: "updated_at", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "created_at", target: "created_at", file: "test.stm", line: 10 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const fieldWarnings = warnings.filter((w) => w.rule === "field-not-in-schema");
+    assert.equal(fieldWarnings.length, 0, "Transitively spread fragment field should pass validation");
+  });
+
+  it("detects self-referential fragment spread", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "id", type: "INT" }] },
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["loop"] },
+      ],
+      fragments: [
+        { name: "loop", fields: [{ name: "x", type: "INT" }], hasSpreads: true, spreads: ["loop"] },
+      ],
+      mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "id", target: "id", file: "test.stm", line: 1 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const cycleWarnings = warnings.filter((w) => w.rule === "circular-spread");
+    assert.equal(cycleWarnings.length, 1, "Should detect self-referential spread");
+    assert.ok(cycleWarnings[0].message.includes("loop"), "Should mention the cyclic fragment name");
+  });
+
+  it("detects mutual cycle between two fragments", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["frag_a"] },
+      ],
+      fragments: [
+        { name: "frag_a", fields: [{ name: "a", type: "INT" }], hasSpreads: true, spreads: ["frag_b"] },
+        { name: "frag_b", fields: [{ name: "b", type: "INT" }], hasSpreads: true, spreads: ["frag_a"] },
+      ],
+      mappings: [{ name: "m1", sources: ["tgt"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "id", target: "id", file: "test.stm", line: 1 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const cycleWarnings = warnings.filter((w) => w.rule === "circular-spread");
+    assert.ok(cycleWarnings.length >= 1, "Should detect cycle between frag_a and frag_b");
+    assert.ok(cycleWarnings[0].message.includes("Circular fragment spread"));
+  });
+
+  it("does not false-positive on diamond-shaped spreads", () => {
+    // base is spread by both frag_a and frag_b; schema spreads both.
+    // No cycle — just shared dependency.
+    const index = makeIndex({
+      schemas: [
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["frag_a", "frag_b"] },
+      ],
+      fragments: [
+        { name: "frag_a", fields: [{ name: "a", type: "INT" }], hasSpreads: true, spreads: ["base"] },
+        { name: "frag_b", fields: [{ name: "b", type: "INT" }], hasSpreads: true, spreads: ["base"] },
+        { name: "base", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m1", sources: ["tgt"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "id", target: "id", file: "test.stm", line: 1 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const cycleWarnings = warnings.filter((w) => w.rule === "circular-spread");
+    assert.equal(cycleWarnings.length, 0, "Diamond shape is not a cycle");
+  });
+});
+
 // ── Bug 6: Duplicate named definitions ───────────────────────────────────────
 
 describe("Bug 6: duplicate named definitions", () => {

--- a/tooling/satsuma-cli/test/validate-bugs.test.js
+++ b/tooling/satsuma-cli/test/validate-bugs.test.js
@@ -309,15 +309,39 @@ describe("Bug 3: metric source extraction", () => {
 
 // ── Bug 4: Suppress for schemas with unresolved spreads ──────────────────────
 
+function spreadLabel(name) {
+  // spread_label children: quoted_name for 'quoted', identifier for bare
+  if (name.startsWith("'") || name.startsWith('"')) {
+    return n("spread_label", [n("quoted_name", [], name)]);
+  }
+  const ids = name.split(" ").map((w) => ident(w));
+  return n("spread_label", ids);
+}
+
+function fragmentSpread(name) {
+  return n("fragment_spread", [spreadLabel(name)], `...${name}`);
+}
+
 describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
-  it("detects fragment_spread in schema body", () => {
-    const spread = n("fragment_spread", [], "...audit fields");
+  it("detects fragment_spread in schema body and extracts spread names", () => {
+    const spread = fragmentSpread("audit_fields");
     const body = n("schema_body", [fieldDecl("id", "INT"), spread]);
     const block = n("schema_block", [blockLabel("my_schema"), body]);
     const root = n("source_file", [block]);
 
     const schemas = extractSchemas(root);
     assert.equal(schemas[0].hasSpreads, true);
+    assert.deepEqual(schemas[0].spreads, ["audit_fields"]);
+  });
+
+  it("extracts quoted spread names", () => {
+    const spread = fragmentSpread("'audit fields'");
+    const body = n("schema_body", [fieldDecl("id", "INT"), spread]);
+    const block = n("schema_block", [blockLabel("my_schema"), body]);
+    const root = n("source_file", [block]);
+
+    const schemas = extractSchemas(root);
+    assert.deepEqual(schemas[0].spreads, ["audit fields"]);
   });
 
   it("suppresses field-not-in-schema for target with unresolved spreads", () => {
@@ -335,6 +359,67 @@ describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w) => w.rule === "field-not-in-schema");
     assert.equal(fieldWarnings.length, 0, "Should not warn for target schema with unresolved spreads");
+  });
+
+  it("expands fragment fields and validates arrow targets", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
+      ],
+      fragments: [
+        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }, { name: "updated_at", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "created_at", target: "created_at", file: "test.stm", line: 10 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const fieldWarnings = warnings.filter((w) => w.rule === "field-not-in-schema");
+    assert.equal(fieldWarnings.length, 0, "Fragment-contributed field should pass validation");
+  });
+
+  it("warns for fields not in schema or expanded fragments", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "bogus_field", type: "VARCHAR" }] },
+        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
+      ],
+      fragments: [
+        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "bogus_field", target: "nonexistent_field", file: "test.stm", line: 10 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const fieldWarnings = warnings.filter((w) => w.rule === "field-not-in-schema");
+    assert.equal(fieldWarnings.length, 1, "Should warn for field not in schema or fragment");
+    assert.ok(fieldWarnings[0].message.includes("nonexistent_field"));
+  });
+
+  it("expands fragment fields for source schemas", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
+        { name: "tgt", fields: [{ name: "id", type: "INT" }, { name: "created_at", type: "TIMESTAMP" }] },
+      ],
+      fragments: [
+        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
+      fieldArrows: [
+        { mapping: "m1", source: "created_at", target: "created_at", file: "test.stm", line: 10 },
+      ],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const fieldWarnings = warnings.filter((w) => w.rule === "field-not-in-schema");
+    assert.equal(fieldWarnings.length, 0, "Fragment-contributed source field should pass validation");
   });
 });
 

--- a/tooling/satsuma-cli/test/where-used.test.js
+++ b/tooling/satsuma-cli/test/where-used.test.js
@@ -16,16 +16,29 @@ function blockLabel(name) {
   const inner = name.startsWith("'") ? quoted(name.slice(1, -1)) : ident(name);
   return n("block_label", [inner]);
 }
+function spreadLabel(name) {
+  if (name.startsWith("'")) return n("spread_label", [quoted(name.slice(1, -1))]);
+  return n("spread_label", name.split(" ").map(ident));
+}
 
 // ── Inline findFragmentSpreads + walkForSpreads ───────────────────────────────
 
 function walkForSpreads(bodyNode, fragmentName, blockName, results) {
   for (const c of bodyNode.namedChildren) {
     if (c.type === "fragment_spread") {
-      const lbl = c.namedChildren.find((x) => x.type === "block_label");
-      const inner = lbl?.namedChildren[0];
-      let sname = inner?.text ?? "";
-      if (inner?.type === "quoted_name") sname = sname.slice(1, -1);
+      const lbl = c.namedChildren.find((x) => x.type === "spread_label" || x.type === "block_label");
+      let sname = "";
+      if (lbl) {
+        const q = lbl.namedChildren.find((x) => x.type === "quoted_name");
+        if (q) {
+          sname = q.text.slice(1, -1);
+        } else {
+          sname = lbl.namedChildren
+            .filter((x) => x.type === "identifier" || x.type === "qualified_name")
+            .map((x) => x.text)
+            .join(" ");
+        }
+      }
       if (sname === fragmentName) results.push({ block: blockName, row: c.startPosition.row });
     } else if (c.type === "record_block" || c.type === "list_block") {
       const nested = c.namedChildren.find((x) => x.type === "schema_body");
@@ -52,8 +65,8 @@ function findFragmentSpreads(rootNode, fragmentName) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("findFragmentSpreads", () => {
-  it("finds a fragment spread in a schema", () => {
-    const spread = n("fragment_spread", [blockLabel("'address fields'")], "", 5);
+  it("finds a quoted fragment spread in a schema", () => {
+    const spread = n("fragment_spread", [spreadLabel("'address fields'")], "", 5);
     const body = n("schema_body", [spread]);
     const schemaBlock = n("schema_block", [blockLabel("orders"), body]);
     const root = n("source_file", [schemaBlock]);
@@ -73,8 +86,8 @@ describe("findFragmentSpreads", () => {
   });
 
   it("finds fragment spread in multiple schemas", () => {
-    const spread1 = n("fragment_spread", [blockLabel("'audit columns'")]);
-    const spread2 = n("fragment_spread", [blockLabel("'audit columns'")]);
+    const spread1 = n("fragment_spread", [spreadLabel("'audit columns'")]);
+    const spread2 = n("fragment_spread", [spreadLabel("'audit columns'")]);
     const body1 = n("schema_body", [spread1]);
     const body2 = n("schema_body", [spread2]);
     const s1 = n("schema_block", [blockLabel("orders"), body1]);
@@ -88,7 +101,7 @@ describe("findFragmentSpreads", () => {
   });
 
   it("does not match different fragment names", () => {
-    const spread = n("fragment_spread", [blockLabel("'other frag'")]);
+    const spread = n("fragment_spread", [spreadLabel("'other frag'")]);
     const body = n("schema_body", [spread]);
     const block = n("schema_block", [blockLabel("t"), body]);
     const root = n("source_file", [block]);
@@ -97,11 +110,22 @@ describe("findFragmentSpreads", () => {
   });
 
   it("finds spreads in record_block nested bodies", () => {
-    const spread = n("fragment_spread", [blockLabel("'audit columns'")], "", 10);
+    const spread = n("fragment_spread", [spreadLabel("'audit columns'")], "", 10);
     const innerBody = n("schema_body", [spread]);
     const recBlock = n("record_block", [blockLabel("audit"), innerBody]);
     const outerBody = n("schema_body", [recBlock]);
     const schemaBlock = n("schema_block", [blockLabel("orders"), outerBody]);
+    const root = n("source_file", [schemaBlock]);
+
+    const results = findFragmentSpreads(root, "audit columns");
+    assert.equal(results.length, 1);
+    assert.equal(results[0].block, "orders");
+  });
+
+  it("finds unquoted multi-word fragment spreads", () => {
+    const spread = n("fragment_spread", [spreadLabel("audit columns")], "", 3);
+    const body = n("schema_body", [spread]);
+    const schemaBlock = n("schema_block", [blockLabel("orders"), body]);
     const root = n("source_file", [schemaBlock]);
 
     const results = findFragmentSpreads(root, "audit columns");

--- a/tooling/tree-sitter-satsuma/test/fixtures/examples/metric_sources.json
+++ b/tooling/tree-sitter-satsuma/test/fixtures/examples/metric_sources.json
@@ -1,0 +1,3 @@
+{
+  "source": "../../../../../examples/metric_sources.stm"
+}


### PR DESCRIPTION
## Summary
- **Extract shared spread expansion module** (`spread-expand.js`) from `validate.js` so all CLI commands can reuse fragment spread resolution with cycle detection and diamond handling
- **Fix 6 bugs** where CLI commands silently dropped fields from fragment spreads: `fields` (sl-3aff), `arrows` (sl-h1b0), `match-fields` (sl-wrzl), `graph` (sl-t6lt), `schema --json` (sl-zjec), `where-used` (sl-307v)
- **Add 12 regression tests** covering direct spreads, transitive spreads, and fragment-to-fragment references across all affected commands

## Test plan
- [x] All 457 tests pass (12 new + 445 existing)
- [x] ESLint passes
- [x] `fields` includes fragment spread fields in default and `--json` output
- [x] `arrows` resolves fields from spreads without "field not found" errors
- [x] `match-fields` matches fields shared via fragment spreads
- [x] `graph --json` includes spread fields in schema nodes + `fragment_spread` edges
- [x] `schema --json` expands spread fields in the `fields` array while preserving spread syntax in `fieldLines`
- [x] `where-used` finds fragment-to-fragment spread references

🤖 Generated with [Claude Code](https://claude.com/claude-code)