### PR TITLE
Fix NL-ref false positives for fragment spread fields

### DIFF
--- a/.tickets/sc-45sz.md
+++ b/.tickets/sc-45sz.md
@@ -1,0 +1,82 @@
+---
+id: sc-45sz
+status: closed
+deps: []
+links: []
+created: 2026-03-20T16:53:38Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, validate]
+---
+# NL-ref validation emits false-positive unresolved warnings for fields from fragment spreads
+
+## Problem
+
+`satsuma validate` emits spurious `nl-ref-unresolved` warnings when a backtick NL reference in a mapping transform expression points to a field that exists in the target schema only via a fragment spread.
+
+For example, given:
+
+```stm
+namespace example {
+  fragment common_measures {
+    SALES_VALUE  DECIMAL(15,4) (required)
+    RETURN_VALUE DECIMAL(15,4) (required)
+  }
+
+  schema product_day {
+    DAY_DATE DATE (pk)
+    ...common_measures
+  }
+
+  schema summary_day {
+    DAY_DATE DATE (pk)
+    TOTAL_SALES DECIMAL(15,4) (required)
+    TOTAL_RETURNS DECIMAL(15,4) (required)
+  }
+
+  mapping 'Product to Summary' {
+    source { `product_day` }
+    target { `summary_day` }
+
+    -> TOTAL_SALES { "SUM(`example::product_day.SALES_VALUE`)" }
+    -> TOTAL_RETURNS { "SUM(`example::product_day.RETURN_VALUE`)" }
+  }
+}
+```
+
+`satsuma validate` reports:
+
+```
+warning [nl-ref-unresolved] NL reference `example::product_day.SALES_VALUE` in mapping 'example::Product to Summary' does not resolve to any known identifier
+warning [nl-ref-unresolved] NL reference `example::product_day.RETURN_VALUE` in mapping 'example::Product to Summary' does not resolve to any known identifier
+```
+
+Both fields exist in `product_day` via the `...common_measures` spread — these are false positives.
+
+## Root Cause
+
+`resolveRef()` in `nl-ref-extract.js` (lines 70–79) resolves `namespace-qualified-field` refs by calling `hasField(schema.fields, fieldName)`. `hasField` iterates over the raw field list from the index, which contains spread reference nodes (e.g. `...common_measures`) rather than the expanded fragment fields. So any field contributed by a fragment spread is invisible to NL-ref resolution.
+
+By contrast, the arrow-field validation in `validate.js` (lines 303–309) already calls `expandSpreads()` from `spread-expand.js` before checking field membership — so it does not have this problem.
+
+The same issue affects the `dotted-field` (lines 82–98) and bare-identifier (lines 101–108) classification branches, which also call `hasField` without spread expansion.
+
+## Fix
+
+`resolveRef` needs to see expanded fields. Two options:
+
+**Option A (index-time):** Have the index builder pre-expand fragment fields into each schema's field list (or a parallel `expandedFields` set). Then `hasField` works as-is.
+
+**Option B (resolve-time):** In the field-checking branches of `resolveRef`, call `expandEntityFields()` (already exported from `spread-expand.js`) to get the full field set when the initial `hasField` check fails and the schema has spreads.
+
+Option B is simpler and consistent with existing patterns. `expandEntityFields` already handles transitive spreads, cycles, and diamonds.
+
+## Acceptance Criteria
+
+1. `satsuma validate` on a workspace where a mapping NL-ref (any classification: `ns::schema.field`, `schema.field`, or bare `field`) targets a field that exists only via a fragment spread produces **no** `nl-ref-unresolved` warning for that ref.
+2. `satsuma validate` still warns for NL-refs that genuinely don't resolve (field not in schema or any of its spreads).
+3. Transitive spreads work: if fragment A spreads fragment B, and a schema spreads fragment A, a ref to a field from B resolves.
+4. Existing `nl-ref-extract.test.js` and `nl-ref-validate.test.js` tests continue to pass.
+5. New test cases cover at least: (a) namespace-qualified-field via spread, (b) dotted-field via spread, (c) bare identifier via spread, (d) transitive spread, (e) genuine miss still warns.
+

--- a/tooling/satsuma-cli/src/nl-ref-extract.js
+++ b/tooling/satsuma-cli/src/nl-ref-extract.js
@@ -9,6 +9,8 @@
  * arrows, context, and the nl-refs command.
  */
 
+import { expandEntityFields } from "./spread-expand.js";
+
 // ── Extraction ──────────────────────────────────────────────────────────────
 
 const BACKTICK_RE = /`([^`]+)`/g;
@@ -73,7 +75,7 @@ export function resolveRef(ref, mappingContext, index) {
     const schemaRef = ref.slice(0, dotIdx);
     const fieldName = ref.slice(dotIdx + 1);
     const schema = index.schemas.get(schemaRef);
-    if (schema && hasField(schema.fields, fieldName)) {
+    if (schema && hasFieldWithSpreads(schema, fieldName, index)) {
       return { resolved: true, resolvedTo: { kind: "field", name: ref } };
     }
     return { resolved: false, resolvedTo: null };
@@ -90,7 +92,7 @@ export function resolveRef(ref, mappingContext, index) {
       const baseName = nsIdx !== -1 ? s.slice(nsIdx + 2) : s;
       if (baseName === schemaName || s === schemaName) {
         const schema = index.schemas.get(s);
-        if (schema && hasField(schema.fields, fieldName)) {
+        if (schema && hasFieldWithSpreads(schema, fieldName, index)) {
           return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${fieldName}` } };
         }
       }
@@ -102,7 +104,7 @@ export function resolveRef(ref, mappingContext, index) {
   const allSchemaNames = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
   for (const s of allSchemaNames) {
     const schema = index.schemas.get(s);
-    if (schema && hasField(schema.fields, ref)) {
+    if (schema && hasFieldWithSpreads(schema, ref, index)) {
       return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${ref}` } };
     }
   }
@@ -132,6 +134,18 @@ function hasField(fields, name) {
     if (f.children && hasField(f.children, name)) return true;
   }
   return false;
+}
+
+/**
+ * Check if a schema has a field, including fields contributed by fragment spreads.
+ * Falls back to expandEntityFields when the raw field list doesn't contain the name.
+ */
+function hasFieldWithSpreads(schema, fieldName, index) {
+  if (hasField(schema.fields, fieldName)) return true;
+  if (!schema.hasSpreads) return false;
+  const ns = schema.namespace ?? null;
+  const expanded = expandEntityFields(schema, ns, index);
+  return hasField(expanded, fieldName);
 }
 
 // ── CST Walking (for extractFileData integration) ───────────────────────────

--- a/tooling/satsuma-cli/test/nl-ref-extract.test.js
+++ b/tooling/satsuma-cli/test/nl-ref-extract.test.js
@@ -157,6 +157,138 @@ describe("resolveRef", () => {
   });
 });
 
+// ── resolveRef with fragment spreads ─────────────────────────────────────────
+
+describe("resolveRef — fragment spread expansion", () => {
+  const makeIndex = (schemas = {}, transforms = {}, fragments = {}) => ({
+    schemas: new Map(Object.entries(schemas)),
+    transforms: new Map(Object.entries(transforms)),
+    fragments: new Map(Object.entries(fragments)),
+  });
+
+  it("resolves namespace-qualified field via fragment spread", () => {
+    const index = makeIndex(
+      {
+        "ex::product_day": {
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+      },
+      {},
+      {
+        "ex::common_measures": {
+          fields: [{ name: "SALES_VALUE" }, { name: "RETURN_VALUE" }],
+          hasSpreads: false,
+        },
+      },
+    );
+    const result = resolveRef("ex::product_day.SALES_VALUE", {}, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+  });
+
+  it("resolves dotted-field via fragment spread", () => {
+    const index = makeIndex(
+      {
+        "ex::product_day": {
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+      },
+      {},
+      {
+        "ex::common_measures": {
+          fields: [{ name: "SALES_VALUE" }],
+          hasSpreads: false,
+        },
+      },
+    );
+    const context = { sources: ["ex::product_day"], targets: [] };
+    const result = resolveRef("product_day.SALES_VALUE", context, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+  });
+
+  it("resolves bare identifier via fragment spread", () => {
+    const index = makeIndex(
+      {
+        "ex::product_day": {
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+      },
+      {},
+      {
+        "ex::common_measures": {
+          fields: [{ name: "SALES_VALUE" }],
+          hasSpreads: false,
+        },
+      },
+    );
+    const context = { sources: ["ex::product_day"], targets: [] };
+    const result = resolveRef("SALES_VALUE", context, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+  });
+
+  it("resolves field via transitive fragment spread", () => {
+    const index = makeIndex(
+      {
+        "ex::product_day": {
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["base_measures"],
+          namespace: "ex",
+        },
+      },
+      {},
+      {
+        "ex::base_measures": {
+          fields: [{ name: "QUANTITY" }],
+          hasSpreads: true,
+          spreads: ["audit_fields"],
+          namespace: "ex",
+        },
+        "ex::audit_fields": {
+          fields: [{ name: "CREATED_AT" }, { name: "UPDATED_AT" }],
+          hasSpreads: false,
+        },
+      },
+    );
+    const result = resolveRef("ex::product_day.CREATED_AT", {}, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+  });
+
+  it("still returns unresolved for genuine miss with spreads", () => {
+    const index = makeIndex(
+      {
+        "ex::product_day": {
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+      },
+      {},
+      {
+        "ex::common_measures": {
+          fields: [{ name: "SALES_VALUE" }],
+          hasSpreads: false,
+        },
+      },
+    );
+    const result = resolveRef("ex::product_day.NONEXISTENT", {}, index);
+    assert.equal(result.resolved, false);
+  });
+});
+
 // ── isSchemaInMappingSources ────────────────────────────────────────────────
 
 describe("isSchemaInMappingSources", () => {

--- a/tooling/satsuma-cli/test/nl-ref-validate.test.js
+++ b/tooling/satsuma-cli/test/nl-ref-validate.test.js
@@ -155,6 +155,97 @@ describe("NL ref validation: nl-ref-not-in-source", () => {
   });
 });
 
+describe("NL ref validation: fragment spread fields", () => {
+  it("does not warn for NL refs targeting fields from fragment spreads", () => {
+    const index = makeIndex({
+      schemas: [
+        {
+          name: "ex::product_day",
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+        { name: "ex::summary_day", fields: [{ name: "TOTAL_SALES" }, { name: "TOTAL_RETURNS" }] },
+      ],
+      mappings: [{
+        name: "ex::Product to Summary",
+        namespace: "ex",
+        sources: ["ex::product_day"],
+        targets: ["ex::summary_day"],
+      }],
+      nlRefData: [
+        {
+          text: "SUM(`ex::product_day.SALES_VALUE`)",
+          mapping: "Product to Summary",
+          namespace: "ex",
+          targetField: "TOTAL_SALES",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+        {
+          text: "SUM(`ex::product_day.RETURN_VALUE`)",
+          mapping: "Product to Summary",
+          namespace: "ex",
+          targetField: "TOTAL_RETURNS",
+          file: "test.stm",
+          line: 11,
+          column: 6,
+        },
+      ],
+    });
+    // Add fragments to the index
+    index.fragments.set("ex::common_measures", {
+      fields: [{ name: "SALES_VALUE" }, { name: "RETURN_VALUE" }],
+      hasSpreads: false,
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule === "nl-ref-unresolved");
+    assert.equal(nlWarnings.length, 0, "Fields from fragment spreads should not produce nl-ref-unresolved warnings");
+  });
+
+  it("still warns for genuine misses even when schema has spreads", () => {
+    const index = makeIndex({
+      schemas: [
+        {
+          name: "ex::product_day",
+          fields: [{ name: "DAY_DATE" }],
+          hasSpreads: true,
+          spreads: ["common_measures"],
+          namespace: "ex",
+        },
+        { name: "ex::summary_day", fields: [{ name: "TOTAL" }] },
+      ],
+      mappings: [{
+        name: "ex::m1",
+        namespace: "ex",
+        sources: ["ex::product_day"],
+        targets: ["ex::summary_day"],
+      }],
+      nlRefData: [{
+        text: "SUM(`ex::product_day.NONEXISTENT`)",
+        mapping: "m1",
+        namespace: "ex",
+        targetField: "TOTAL",
+        file: "test.stm",
+        line: 10,
+        column: 6,
+      }],
+    });
+    index.fragments.set("ex::common_measures", {
+      fields: [{ name: "SALES_VALUE" }],
+      hasSpreads: false,
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule === "nl-ref-unresolved");
+    assert.equal(nlWarnings.length, 1, "Genuine miss should still warn");
+    assert.ok(nlWarnings[0].message.includes("NONEXISTENT"));
+  });
+});
+
 describe("NL ref validation: bare field matching", () => {
   it("does not warn for bare field that matches a source schema field", () => {
     const index = makeIndex({


### PR DESCRIPTION
## Summary
- `resolveRef()` in `nl-ref-extract.js` now calls `expandEntityFields()` when a field isn't found in the raw field list and the schema has spreads, eliminating false-positive `nl-ref-unresolved` warnings
- Fixes all three ref classification branches: namespace-qualified-field, dotted-field, and bare identifier
- Transitive spreads (fragment A → fragment B) resolve correctly

## Test plan
- [x] 5 new unit tests in `nl-ref-extract.test.js` (ns-qualified, dotted, bare, transitive, genuine miss)
- [x] 2 new integration tests in `nl-ref-validate.test.js` (spread resolution, genuine miss with spreads)
- [x] All 464 existing tests pass
- [x] Pre-commit hooks (lint + full test suite) pass

Closes sc-45sz

🤖 Generated with [Claude Code](https://claude.com/claude-code)