### PR TITLE
Fix residual 0-indexed line numbers in schema and nl-refs JSON output

### DIFF
--- a/.tickets/sl-2usp.md
+++ b/.tickets/sl-2usp.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2usp
-status: open
+status: closed
 deps: []
 links: [sl-udpf]
 created: 2026-03-22T07:45:03Z
@@ -35,3 +35,12 @@ Actual: "row": 3
 
 Verified across multiple files — the row value is always exactly 1 less than the actual file line number. The sl-m02g fix may have missed the schema command, or the schema command reads the row from a different code path than the one that was fixed.
 
+
+## Notes
+
+**2026-03-22T09:39:35Z**
+
+**2026-03-22T12:00:00Z**
+
+Cause: Schema command outputs tree-sitter's 0-indexed `startPosition.row` directly without converting to 1-indexed.
+Fix: Added `+ 1` to `row: entry.row` in `schema.ts` JSON output.

--- a/.tickets/sl-qxkf.md
+++ b/.tickets/sl-qxkf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-qxkf
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-22T07:43:49Z

--- a/.tickets/sl-udpf.md
+++ b/.tickets/sl-udpf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-udpf
-status: open
+status: closed
 deps: []
 links: [sl-2usp]
 created: 2026-03-22T07:45:11Z
@@ -30,3 +30,12 @@ In the same file, ref `Opportunity` is reported at line 8. Actual location is li
 
 The nl command's own line numbers are correct. This bug is specific to nl-refs, suggesting the line calculation in nl-ref-extract.ts has a different off-by-one path than the one fixed in sl-djeo.
 
+
+## Notes
+
+**2026-03-22T09:39:44Z**
+
+**2026-03-22T12:00:00Z**
+
+Cause: Two issues: (1) nl-refs JSON output used 0-indexed line from tree-sitter without converting to 1-indexed. (2) Triple-quoted string text was `.trim()`ed, stripping the leading newline after `"""`, which caused newline counting to be off by 1 additional line for multiline strings.
+Fix: Removed `.trim()` from all `.slice(3, -3)` calls in nl-ref-extract.ts to preserve leading newline for accurate offset calculation. Added `line: r.line + 1` conversion in nl-refs.ts JSON output path.

--- a/tooling/satsuma-cli/src/commands/nl-refs.ts
+++ b/tooling/satsuma-cli/src/commands/nl-refs.ts
@@ -56,7 +56,8 @@ export function register(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(refs, null, 2));
+        const out = refs.map((r) => ({ ...r, line: r.line + 1 }));
+        console.log(JSON.stringify(out, null, 2));
         if (refs.length === 0) process.exit(1);
         return;
       }

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -158,7 +158,7 @@ function printJson(entry: SchemaRecord, schemaNode: SyntaxNode | null, index: Wo
     name: entry.name,
     ...(entry.namespace ? { namespace: entry.namespace } : {}),
     file: entry.file,
-    row: entry.row,
+    row: entry.row + 1,
     fields: allFields,
   };
 

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -234,7 +234,7 @@ function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | n
       const innerNode = step.namedChildren[0];
       if (innerNode && (innerNode.type === "nl_string" || innerNode.type === "multiline_string")) {
         const text = innerNode.type === "multiline_string"
-          ? innerNode.text.slice(3, -3).trim()
+          ? innerNode.text.slice(3, -3)
           : innerNode.text.slice(1, -1);
         if (text.includes("`")) {
           results.push({
@@ -260,7 +260,7 @@ function extractStandaloneNoteRefs(
   for (const inner of noteNode.namedChildren) {
     if (inner.type === "nl_string" || inner.type === "multiline_string") {
       const text = inner.type === "multiline_string"
-        ? inner.text.slice(3, -3).trim()
+        ? inner.text.slice(3, -3)
         : inner.text.slice(1, -1);
       if (text.includes("`")) {
         results.push({
@@ -312,7 +312,7 @@ function walkArrowsForNL(
       for (const inner of c.namedChildren) {
         if (inner.type === "nl_string" || inner.type === "multiline_string") {
           const text = inner.type === "multiline_string"
-            ? inner.text.slice(3, -3).trim()
+            ? inner.text.slice(3, -3)
             : inner.text.slice(1, -1);
           if (text.includes("`")) {
             results.push({
@@ -339,7 +339,7 @@ function walkArrowsForNL(
             const innerNode = step.namedChildren[0];
             if (innerNode && (innerNode.type === "nl_string" || innerNode.type === "multiline_string")) {
               const text = innerNode.type === "multiline_string"
-                ? innerNode.text.slice(3, -3).trim()
+                ? innerNode.text.slice(3, -3)
                 : innerNode.text.slice(1, -1);
               if (text.includes("`")) {
                 results.push({

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -145,6 +145,13 @@ describe("satsuma schema", () => {
     assert.ok(Array.isArray(data.fields));
   });
 
+  it("--json row is 1-indexed (sl-2usp)", async () => {
+    const { stdout, code } = await run("schema", "country_codes", "--json", EXAMPLES);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.row, 4, "country_codes starts on line 4 (1-indexed)");
+  });
+
   it("exits 1 for unknown schema", async () => {
     const { code, stderr } = await run("schema", "no_such_schema_xyz", EXAMPLES);
     assert.equal(code, 1);
@@ -2398,12 +2405,12 @@ describe("satsuma nl-refs", () => {
     assert.equal(code, 0);
     const refs = JSON.parse(stdout);
     assert.equal(refs.length, 4, "should find 4 backtick refs");
-    // First two refs are on the first line of the multiline string (line 14, 0-indexed)
-    assert.equal(refs[0].line, 14, "first ref should be on line 14");
-    assert.equal(refs[1].line, 14, "second ref should be on line 14");
-    // Last two refs are on the third line of the multiline string (line 16, 0-indexed)
-    assert.equal(refs[2].line, 16, "third ref should be on line 16");
-    assert.equal(refs[3].line, 16, "fourth ref should be on line 16");
+    // First two refs are on the first line of the multiline string (line 15, 1-indexed)
+    assert.equal(refs[0].line, 15, "first ref should be on line 15");
+    assert.equal(refs[1].line, 15, "second ref should be on line 15");
+    // Last two refs are on the third line of the multiline string (line 17, 1-indexed)
+    assert.equal(refs[2].line, 17, "third ref should be on line 17");
+    assert.equal(refs[3].line, 17, "fourth ref should be on line 17");
   });
 });
 


### PR DESCRIPTION
## Summary
- **schema --json**: `row` field was 0-indexed (raw tree-sitter value) instead of 1-indexed — added `+ 1` conversion
- **nl-refs --json**: line numbers off by 1 for single-line strings and off by 2 for triple-quoted strings — fixed by removing `.trim()` from multiline string text extraction (which stripped the leading newline needed for accurate offset counting) and adding `+ 1` conversion in JSON output
- Closes epic sl-qxkf (Line number indexing residual bugs), sl-2usp, sl-udpf

## Test plan
- [x] New test: `--json row is 1-indexed (sl-2usp)` verifies schema row matches actual file line
- [x] Updated test: `sl-djeo` multiline line number expectations updated from 0-indexed to 1-indexed
- [x] Verified against ticket reproduction cases (`fx_spot_rates` at line 76, `Opportunity` at line 10)
- [x] All 624 tests pass, all pre-commit hooks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)