### PR TITLE
fix: 17 CLI bug fixes across commands

### DIFF
--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -240,9 +240,13 @@ function collectAllFieldNames(fields: FieldDecl[]): string[] {
 }
 
 function printDefault(fieldRef: string, arrows: ArrowRecord[], _index: WorkspaceIndex): void {
-  const fieldName = fieldRef.split(".").pop();
-  const asSource = arrows.filter((a) => a.source === fieldName);
-  const asTarget = arrows.filter((a) => a.target === fieldName);
+  const dot = fieldRef.indexOf(".");
+  const fieldPath = dot >= 0 ? fieldRef.slice(dot + 1) : fieldRef;
+  const leafName = fieldPath.split(".").pop();
+  const matchesField = (val: string | null) =>
+    val === fieldPath || val === leafName;
+  const asSource = arrows.filter((a) => matchesField(a.source));
+  const asTarget = arrows.filter((a) => matchesField(a.target));
 
   const parts: string[] = [];
   if (asSource.length > 0) parts.push(`${asSource.length} as source`);

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -139,8 +139,11 @@ function scoreAll(index: WorkspaceIndex, terms: string[], parsedFiles: ParsedFil
 
   // Collect metadata text (tags, kv pairs) grouped by parent block name
   const metaByParent = new Map<string, string[]>();
+  // Collect raw block text for full-text keyword search
+  const rawTextByBlock = new Map<string, string>();
   for (const { tree } of parsedFiles) {
     collectMetadataText(tree.rootNode, null, metaByParent);
+    collectRawBlockText(tree.rootNode, null, rawTextByBlock);
   }
 
   const scoreEntry = (name: string, type: string, entry: { note?: string | null; fields?: Array<{ name: string; type: string }>; sources?: string[]; targets?: string[]; file: string; row: number }) => {
@@ -169,6 +172,11 @@ function scoreAll(index: WorkspaceIndex, terms: string[], parsedFiles: ParsedFil
     const metaTexts = metaByParent.get(name) ?? metaByParent.get(bareName) ?? [];
     for (const text of metaTexts) {
       score += scoreText(text, terms);
+    }
+    // Score raw block text (catches language keywords like flatten, list_of, governance)
+    const rawText = rawTextByBlock.get(name) ?? rawTextByBlock.get(bareName) ?? "";
+    if (rawText) {
+      score += scoreText(rawText, terms);
     }
     if (score > 0) {
       results.push({ name, type, score, file: entry.file, row: entry.row });
@@ -282,6 +290,24 @@ function getBlockName(node: SyntaxNode): string | null {
     return ids.map((id) => id.text).join("::");
   }
   return inner.text;
+}
+
+/**
+ * Walk the CST and collect raw block text grouped by block name.
+ * Used for full-text keyword search (flatten, list_of, governance, etc.).
+ */
+function collectRawBlockText(node: SyntaxNode, _parent: string | null, result: Map<string, string>): void {
+  for (const c of node.namedChildren) {
+    if (BLOCK_TYPES.has(c.type)) {
+      const name = getBlockName(c);
+      if (name) {
+        result.set(name, c.text);
+      }
+    }
+    if (c.type === "namespace_block") {
+      collectRawBlockText(c, null, result);
+    }
+  }
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -14,7 +14,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
 import { diffIndex } from "../diff.js";
-import type { Delta, BlockDelta, SchemaChange, MappingChange } from "../types.js";
+import type { Delta, BlockDelta, SchemaChange, MappingChange, TransformChange } from "../types.js";
 
 export function register(program: Command): void {
   program
@@ -127,7 +127,7 @@ function printNotes(delta: Delta): void {
   console.log();
 }
 
-function printSection(label: string, section: BlockDelta<SchemaChange | MappingChange>): void {
+function printSection(label: string, section: BlockDelta<SchemaChange | MappingChange | TransformChange>): void {
   const total =
     section.added.length + section.removed.length + section.changed.length;
   if (total === 0) return;
@@ -165,10 +165,14 @@ function printSection(label: string, section: BlockDelta<SchemaChange | MappingC
       } else if (c.kind === "source-changed" || c.kind === "grain-changed" || c.kind === "slices-changed") {
         const label = c.kind.replace("-changed", "");
         console.log(`      ~ ${label}: ${String(c.from)} -> ${String(c.to)}`);
+      } else if (c.kind === "note-changed") {
+        console.log(`      ~ note: ${String(c.from)} -> ${String(c.to)}`);
       } else if (c.kind === "note-added") {
         console.log(`      + note ${JSON.stringify(String(c.from))}`);
       } else if (c.kind === "note-removed") {
         console.log(`      - note ${JSON.stringify(String(c.from))}`);
+      } else if (c.kind === "body-changed") {
+        console.log(`      ~ body: ${String(c.from)} -> ${String(c.to)}`);
       }
     }
   }

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -221,7 +221,10 @@ function collectAllTags(metaNode: SyntaxNode): string[] {
       const key = c.namedChildren.find((x) => x.type === "kv_key");
       const val = c.namedChildren.find((x) => x.type !== "kv_key");
       tags.push(val ? `${key?.text} ${val.text}` : (key?.text ?? ""));
-    } else if (c.type === "note_tag") tags.push("note");
+    } else if (c.type === "note_tag") {
+      const strNode = c.namedChildren.find((x) => x.type === "nl_string" || x.type === "multiline_string");
+      tags.push(strNode ? `note ${strNode.text}` : "note");
+    }
     else if (c.type === "enum_body") tags.push("enum {...}");
     else if (c.type === "slice_body") tags.push("slice {...}");
   }

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -103,11 +103,13 @@ function searchTag(index: WorkspaceIndex, parsedFiles: ParsedFile[], tag: string
     if (meta) {
       const matched = findTagInMeta(meta, tag);
       if (matched) {
+        const allTags = collectAllTags(meta);
         matches.push({
           blockType,
           block: blockName,
           field: "(schema)",
           tag: matched,
+          metadata: allTags.length > 0 ? allTags : undefined,
           file: blockEntry.file,
           line: blockNode.startPosition.row + 1,
         });

--- a/tooling/satsuma-cli/src/commands/graph.ts
+++ b/tooling/satsuma-cli/src/commands/graph.ts
@@ -162,7 +162,7 @@ function buildWorkspaceGraph(index: WorkspaceIndex, schemaGraph: FullGraph, root
       const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
       node.fields = [...schema.fields, ...spreadFields].map((f) => ({
         name: f.name,
-        type: f.type ?? null,
+        type: f.isList && f.type ? `list_of ${f.type}` : (f.type ?? null),
       }));
     }
     nodes.push(node);
@@ -210,7 +210,7 @@ function buildWorkspaceGraph(index: WorkspaceIndex, schemaGraph: FullGraph, root
     if (!schemaOnly) {
       fragNode.fields = fragment.fields.map((f) => ({
         name: f.name,
-        type: f.type ?? null,
+        type: f.isList && f.type ? `list_of ${f.type}` : (f.type ?? null),
       }));
     }
     nodes.push(fragNode);

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -133,7 +133,8 @@ function printJson(entry: MappingRecord, mappingNode: SyntaxNode | null): void {
     const pipeChain = arrowNode.namedChildren.find((x) => x.type === "pipe_chain");
     const pipeSteps = pipeChain ? [...pipeChain.namedChildren].filter((x) => x.type === "pipe_step") : [];
     const classification = classifyTransform(pipeSteps.length > 0 ? pipeSteps : null);
-    const arrowObj: Record<string, unknown> = { kind, src, tgt, hasTransform: hasBody, classification };
+    const hasTransform = hasBody && pipeChain != null;
+    const arrowObj: Record<string, unknown> = { kind, src, tgt, hasTransform, classification };
     if (hasBody) {
       if (pipeChain) arrowObj.transform = pipeChain.text;
     }

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -183,12 +183,12 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
               (c) => c.type === "metadata_block",
             );
             const entries = extractMetadata(metaNode);
-            return { scope: fieldRef, type: field.type ?? null, entries };
+            return { scope: fieldRef, type: displayType(field), entries };
           }
         }
       }
     }
-    return { scope: fieldRef, type: field.type ?? null, entries: [] };
+    return { scope: fieldRef, type: displayType(field), entries: [] };
   }
 
   const parsed = parsedFiles.find((p) => p.filePath === entity.file);
@@ -204,14 +204,19 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
         const entries = extractMetadata(metaNode);
         return {
             scope: fieldRef,
-            type: field?.type ?? null,
+            type: displayType(field),
             entries,
           };
         }
     }
   }
 
-  return { scope: fieldRef, type: field.type, entries: [] };
+  return { scope: fieldRef, type: displayType(field), entries: [] };
+}
+
+function displayType(field: FieldDecl): string | null {
+  if (!field.type) return null;
+  return field.isList ? `list_of ${field.type}` : field.type;
 }
 
 function getFieldDeclName(fieldDecl: SyntaxNode): string | null {

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -79,17 +79,19 @@ function extractFromAll(parsedFiles: ParsedFile[]): NLItemWithFile[] {
 }
 
 function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: WorkspaceIndex): NLItemWithFile[] {
-  // Check if it's a schema, mapping, or metric (resolving namespace-qualified keys)
+  // Check if it's a schema, mapping, metric, or transform (resolving namespace-qualified keys)
   const schemaResolved = resolveIndexKey(blockName, index.schemas);
   const mappingResolved = resolveIndexKey(blockName, index.mappings);
   const metricResolved = resolveIndexKey(blockName, index.metrics);
+  const transformResolved = resolveIndexKey(blockName, index.transforms);
 
-  if (!schemaResolved && !mappingResolved && !metricResolved) {
-    console.error(`'${blockName}' not found as a schema, mapping, or metric.`);
+  if (!schemaResolved && !mappingResolved && !metricResolved && !transformResolved) {
+    console.error(`'${blockName}' not found as a schema, mapping, metric, or transform.`);
     const allNames = [
       ...index.schemas.keys(),
       ...index.mappings.keys(),
       ...index.metrics.keys(),
+      ...index.transforms.keys(),
     ];
     const close = allNames.find(
       (k) => k.toLowerCase() === blockName.toLowerCase(),
@@ -98,13 +100,14 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: W
     process.exit(1);
   }
 
-  // Collect NL content from ALL matching blocks (schema, mapping, metric)
+  // Collect NL content from ALL matching blocks (schema, mapping, metric, transform)
   // to handle ambiguous names where a schema and mapping share a name
   const items: NLItemWithFile[] = [];
   const matches: Array<{ key: string; entry: { file: string }; blockType: string }> = [];
   if (schemaResolved) matches.push({ key: schemaResolved.key, entry: schemaResolved.entry, blockType: "schema_block" });
   if (mappingResolved) matches.push({ key: mappingResolved.key, entry: mappingResolved.entry, blockType: "mapping_block" });
   if (metricResolved) matches.push({ key: metricResolved.key, entry: metricResolved.entry, blockType: "metric_block" });
+  if (transformResolved) matches.push({ key: transformResolved.key, entry: transformResolved.entry, blockType: "transform_block" });
 
   for (const { key, entry, blockType } of matches) {
     const parsed = parsedFiles.find((p) => p.filePath === entry.file);

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -135,14 +135,15 @@ function collectFields(bodyNode: SyntaxNode, indent: number = 0): CollectedLine[
       const inner = nameNode?.namedChildren[0];
       const fname = inner?.text ?? "";
 
-      if (nested) {
-        // Nested structure: record or list_of record
+      const hasRecordKw = c.children?.some((ch: SyntaxNode) => !ch.isNamed && ch.text === "record");
+      if (nested || hasRecordKw) {
+        // Nested structure: record or list_of record (may have empty body)
         const isList = fieldHasListOf(c);
         const kind = isList ? "list_of record" : "record";
         const blockMeta = meta;
         const blockMetaText = blockMeta ? ` ${blockMeta.text}` : "";
         lines.push({ indent, text: `${pad}${fname} ${kind}${blockMetaText} {` });
-        lines.push(...collectFields(nested, indent + 1));
+        if (nested) lines.push(...collectFields(nested, indent + 1));
         lines.push({ indent, text: `${pad}}` });
       } else {
         // Scalar field (may be list_of scalar)

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -100,6 +100,28 @@ function fieldHasListOf(fd: SyntaxNode): boolean {
   return false;
 }
 
+/** Collect edge comments (before first field / after last field) from a block node. */
+function collectEdgeComments(blockNode: SyntaxNode, position: "before" | "after", bodyNode: SyntaxNode): CollectedLine[] {
+  const lines: CollectedLine[] = [];
+  const commentTypes = new Set(["comment", "warning_comment", "question_comment"]);
+  for (const c of blockNode.children) {
+    if (position === "before") {
+      // Comments between { and body start
+      if (c.startPosition.row >= bodyNode.startPosition.row) break;
+      if (commentTypes.has(c.type)) {
+        lines.push({ indent: 0, text: `  ${c.text}` });
+      }
+    } else {
+      // Comments between body end and }
+      if (c.startPosition.row <= bodyNode.endPosition.row) continue;
+      if (commentTypes.has(c.type)) {
+        lines.push({ indent: 0, text: `  ${c.text}` });
+      }
+    }
+  }
+  return lines;
+}
+
 /** Collect fields from schema_body, recursing into nested record/list_of fields. */
 function collectFields(bodyNode: SyntaxNode, indent: number = 0): CollectedLine[] {
   const lines: CollectedLine[] = [];
@@ -184,7 +206,11 @@ function printJson(entry: SchemaRecord, schemaNode: SyntaxNode | null, index: Wo
   if (schemaNode) {
     const body = schemaNode.namedChildren.find((c) => c.type === "schema_body");
     if (body) {
-      let fieldLines = collectFields(body).map((l) => l.text.trim());
+      let fieldLines = [
+        ...collectEdgeComments(schemaNode, "before", body),
+        ...collectFields(body),
+        ...collectEdgeComments(schemaNode, "after", body),
+      ].map((l) => l.text.trim());
       if (opts.compact) {
         fieldLines = fieldLines.filter((l) => !l.startsWith("//"));
       }
@@ -211,7 +237,12 @@ function printDefault(entry: SchemaRecord, schemaNode: SyntaxNode | null, compac
   if (schemaNode) {
     const body = schemaNode.namedChildren.find((c) => c.type === "schema_body");
     if (body) {
-      for (const { text } of collectFields(body, 1)) {
+      const allLines = [
+        ...collectEdgeComments(schemaNode, "before", body),
+        ...collectFields(body, 1),
+        ...collectEdgeComments(schemaNode, "after", body),
+      ];
+      for (const { text } of allLines) {
         if (compact) {
           // Strip comments and inline note text in compact mode
           if (text.trimStart().startsWith("//")) continue;

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -184,7 +184,11 @@ function printJson(entry: SchemaRecord, schemaNode: SyntaxNode | null, index: Wo
   if (schemaNode) {
     const body = schemaNode.namedChildren.find((c) => c.type === "schema_body");
     if (body) {
-      out.fieldLines = collectFields(body).map((l) => l.text.trim());
+      let fieldLines = collectFields(body).map((l) => l.text.trim());
+      if (opts.compact) {
+        fieldLines = fieldLines.filter((l) => !l.startsWith("//"));
+      }
+      out.fieldLines = fieldLines;
     }
   }
 

--- a/tooling/satsuma-cli/src/commands/validate.ts
+++ b/tooling/satsuma-cli/src/commands/validate.ts
@@ -32,7 +32,12 @@ export function register(program: Command): void {
       try {
         files = await resolveInput(root);
       } catch (err: unknown) {
-        console.error(`Error resolving path: ${(err as Error).message}`);
+        const msg = `Error resolving path: ${(err as Error).message}`;
+        if (opts.json) {
+          console.log(JSON.stringify([{ severity: "error", message: msg }], null, 2));
+        } else {
+          console.error(msg);
+        }
         process.exit(2);
       }
 

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -286,14 +286,8 @@ function walkForTransformCalls(node: SyntaxNode, transformName: string, mappingN
           results.push({ mapping: mappingName, row: c.startPosition.row });
         }
       }
-    }
-    // Also check for fragment_spread directly in arrow bodies
-    if (c.type === "fragment_spread") {
-      const lbl = c.namedChildren.find((x) => x.type === "spread_label");
-      const spreadName = getSpreadName(lbl);
-      if (spreadName === transformName) {
-        results.push({ mapping: mappingName, row: c.startPosition.row });
-      }
+      // Don't recurse into pipe_step — already checked its children above
+      continue;
     }
     walkForTransformCalls(c, transformName, mappingName, results);
   }

--- a/tooling/satsuma-cli/src/diff.ts
+++ b/tooling/satsuma-cli/src/diff.ts
@@ -47,7 +47,12 @@ export function diffIndex(indexA: WorkspaceIndex, indexB: WorkspaceIndex): Delta
       const notesB = noteTextsForParent(indexB, mappingKey);
       return diffMapping(a, b, arrowsA.get(mappingKey) ?? [], arrowsB.get(mappingKey) ?? [], notesA, notesB);
     }),
-    metrics: diffBlockMap(indexA.metrics, indexB.metrics, diffMetric),
+    metrics: diffBlockMap(indexA.metrics, indexB.metrics, (a, b) => {
+      const metricKey = [...indexA.metrics.entries()].find(([, v]) => v === a)?.[0] ?? "";
+      const notesA = noteTextsForParent(indexA, metricKey);
+      const notesB = noteTextsForParent(indexB, metricKey);
+      return diffMetric(a, b, notesA, notesB);
+    }),
     fragments: diffBlockMap(indexA.fragments, indexB.fragments, diffFragment),
     transforms: diffBlockMap(indexA.transforms, indexB.transforms, diffTransform),
     notes: diffNotes(indexA.notes ?? [], indexB.notes ?? []),
@@ -116,7 +121,7 @@ function diffSchema(a: SchemaRecord, b: SchemaRecord): SchemaChange[] {
   return changes;
 }
 
-function diffMetric(a: MetricRecord, b: MetricRecord): SchemaChange[] {
+function diffMetric(a: MetricRecord, b: MetricRecord, notesA: Set<string>, notesB: Set<string>): SchemaChange[] {
   const changes: SchemaChange[] = [];
 
   // Compare metric header attributes
@@ -136,6 +141,21 @@ function diffMetric(a: MetricRecord, b: MetricRecord): SchemaChange[] {
 
   // Compare fields
   changes.push(...diffFieldList(a.fields, b.fields));
+
+  // Compare notes inside the metric
+  for (const text of notesB) {
+    if (!notesA.has(text)) {
+      const preview = text.length > 60 ? text.slice(0, 60) + "..." : text;
+      changes.push({ kind: "note-added", field: "(note)", from: preview });
+    }
+  }
+  for (const text of notesA) {
+    if (!notesB.has(text)) {
+      const preview = text.length > 60 ? text.slice(0, 60) + "..." : text;
+      changes.push({ kind: "note-removed", field: "(note)", from: preview });
+    }
+  }
+
   return changes;
 }
 

--- a/tooling/satsuma-cli/src/diff.ts
+++ b/tooling/satsuma-cli/src/diff.ts
@@ -17,6 +17,8 @@ import type {
   NoteRecord,
   SchemaChange,
   SchemaRecord,
+  TransformChange,
+  TransformRecord,
   WorkspaceIndex,
 } from "./types.js";
 
@@ -47,7 +49,7 @@ export function diffIndex(indexA: WorkspaceIndex, indexB: WorkspaceIndex): Delta
     }),
     metrics: diffBlockMap(indexA.metrics, indexB.metrics, diffMetric),
     fragments: diffBlockMap(indexA.fragments, indexB.fragments, diffFragment),
-    transforms: diffBlockMap(indexA.transforms, indexB.transforms, () => []),
+    transforms: diffBlockMap(indexA.transforms, indexB.transforms, diffTransform),
     notes: diffNotes(indexA.notes ?? [], indexB.notes ?? []),
   };
 }
@@ -102,7 +104,16 @@ function diffBlockMap<T, C>(
 }
 
 function diffSchema(a: SchemaRecord, b: SchemaRecord): SchemaChange[] {
-  return diffFieldList(a.fields, b.fields);
+  const changes: SchemaChange[] = [];
+
+  // Compare schema-level note text
+  if ((a.note ?? "") !== (b.note ?? "")) {
+    changes.push({ kind: "note-changed", field: "(note)", from: a.note || "(none)", to: b.note || "(none)" });
+  }
+
+  // Compare fields
+  changes.push(...diffFieldList(a.fields, b.fields));
+  return changes;
 }
 
 function diffMetric(a: MetricRecord, b: MetricRecord): SchemaChange[] {
@@ -130,6 +141,14 @@ function diffMetric(a: MetricRecord, b: MetricRecord): SchemaChange[] {
 
 function diffFragment(a: FragmentRecord, b: FragmentRecord): SchemaChange[] {
   return diffFieldList(a.fields, b.fields);
+}
+
+function diffTransform(a: TransformRecord, b: TransformRecord): TransformChange[] {
+  const changes: TransformChange[] = [];
+  if ((a.body ?? "") !== (b.body ?? "")) {
+    changes.push({ kind: "body-changed", from: a.body || "(empty)", to: b.body || "(empty)" });
+  }
+  return changes;
 }
 
 function diffFieldList(aFields: FieldDecl[], bFields: FieldDecl[], prefix = ""): SchemaChange[] {

--- a/tooling/satsuma-cli/src/extract.ts
+++ b/tooling/satsuma-cli/src/extract.ts
@@ -451,6 +451,7 @@ export function extractFragments(rootNode: SyntaxNode): ExtractedFragment[] {
 
 interface ExtractedTransform {
   name: string | null;
+  body: string | null;
   namespace: string | null;
   row: number;
 }
@@ -459,11 +460,15 @@ interface ExtractedTransform {
  * Extract all transform_block definitions.
  */
 export function extractTransforms(rootNode: SyntaxNode): ExtractedTransform[] {
-  return collectFromNamespaces(rootNode, "transform_block").map(({ node, namespace }) => ({
-    name: labelText(node),
-    namespace,
-    row: node.startPosition.row,
-  }));
+  return collectFromNamespaces(rootNode, "transform_block").map(({ node, namespace }) => {
+    const pipeChain = child(node, "pipe_chain");
+    return {
+      name: labelText(node),
+      body: pipeChain ? pipeChain.text : null,
+      namespace,
+      row: node.startPosition.row,
+    };
+  });
 }
 
 const BLOCK_TYPES = new Set([

--- a/tooling/satsuma-cli/src/extract.ts
+++ b/tooling/satsuma-cli/src/extract.ts
@@ -148,10 +148,23 @@ function extractFieldTree(bodyNode: SyntaxNode): FieldTree {
       } else {
         // Scalar field or list_of scalar
         const isList = hasListOfKeyword(c);
-        const decl: FieldDecl = { name, type: typeNode?.text ?? "" };
-        if (isList) decl.isList = true;
-        if (meta.length > 0) decl.metadata = meta;
-        fields.push(decl);
+        // Handle empty record/list_of record bodies (no schema_body when { } is empty)
+        const hasRecordKeyword = c.children?.some((ch) => !ch.isNamed && ch.text === "record");
+        if (hasRecordKeyword) {
+          const decl: FieldDecl = {
+            name,
+            type: isList ? "list" : "record",
+            isList: isList || undefined,
+            children: [],
+          };
+          if (meta.length > 0) decl.metadata = meta;
+          fields.push(decl);
+        } else {
+          const decl: FieldDecl = { name, type: typeNode?.text ?? "" };
+          if (isList) decl.isList = true;
+          if (meta.length > 0) decl.metadata = meta;
+          fields.push(decl);
+        }
       }
     } else if (c.type === "fragment_spread") {
       hasSpreads = true;

--- a/tooling/satsuma-cli/src/graph-builder.ts
+++ b/tooling/satsuma-cli/src/graph-builder.ts
@@ -62,6 +62,9 @@ export function buildFullGraph(index: WorkspaceIndex): FullGraph {
   // NL backtick references
   if (index.nlRefData) {
     for (const item of index.nlRefData) {
+      // Skip note blocks — they are not real mappings
+      if (item.mapping.startsWith("note:")) continue;
+
       const refs = extractBacktickRefs(item.text);
       const mappingKey = item.namespace
         ? `${item.namespace}::${item.mapping}`

--- a/tooling/satsuma-cli/src/nl-extract.ts
+++ b/tooling/satsuma-cli/src/nl-extract.ts
@@ -51,7 +51,7 @@ function walkNL(node: SyntaxNode, parent: string | null, items: NLItem[]): void 
         (x) => x.type === "nl_string" || x.type === "multiline_string",
       );
       if (strNodes.length > 0) {
-        const text = strNodes.map((s) => stripDelimiters(s.text, s.type)).join("");
+        const text = strNodes.map((s) => stripDelimiters(s.text, s.type)).join("\n");
         items.push({
           text,
           kind: "note",

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -17,6 +17,7 @@ export interface SyntaxNode {
   child(index: number): SyntaxNode | null;
   parent: SyntaxNode | null;
   startPosition: { row: number; column: number };
+  endPosition: { row: number; column: number };
   isMissing: boolean;
 }
 

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -85,6 +85,7 @@ export interface FragmentRecord {
 
 export interface TransformRecord {
   name: string;
+  body: string | null;
   file: string;
   row: number;
   namespace?: string;
@@ -223,7 +224,7 @@ export type RegisterFn = (rule: LintRule) => void;
 // ── Diff types ──────────────────────────────────────────────────────────────
 
 export interface SchemaChange {
-  kind: "field-removed" | "field-added" | "type-changed" | "metadata-changed" | "source-changed" | "grain-changed" | "slices-changed";
+  kind: "field-removed" | "field-added" | "type-changed" | "metadata-changed" | "source-changed" | "grain-changed" | "slices-changed" | "note-changed";
   field: string;
   from?: string;
   to?: string;
@@ -247,12 +248,18 @@ export interface NoteDelta {
   removed: string[];
 }
 
+export interface TransformChange {
+  kind: "body-changed";
+  from: string;
+  to: string;
+}
+
 export interface Delta {
   schemas: BlockDelta<SchemaChange>;
   mappings: BlockDelta<MappingChange>;
   metrics: BlockDelta<SchemaChange>;
   fragments: BlockDelta<SchemaChange>;
-  transforms: BlockDelta<never>;
+  transforms: BlockDelta<TransformChange>;
   notes: NoteDelta;
 }
 

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -224,7 +224,7 @@ export type RegisterFn = (rule: LintRule) => void;
 // ── Diff types ──────────────────────────────────────────────────────────────
 
 export interface SchemaChange {
-  kind: "field-removed" | "field-added" | "type-changed" | "metadata-changed" | "source-changed" | "grain-changed" | "slices-changed" | "note-changed";
+  kind: "field-removed" | "field-added" | "type-changed" | "metadata-changed" | "source-changed" | "grain-changed" | "slices-changed" | "note-changed" | "note-added" | "note-removed";
   field: string;
   from?: string;
   to?: string;

--- a/tooling/satsuma-cli/test/diff.test.js
+++ b/tooling/satsuma-cli/test/diff.test.js
@@ -135,6 +135,49 @@ describe("diffIndex", () => {
     assert.equal(delta.notes.added.length, 0, "block-owned notes should not appear in top-level notes");
   });
 
+  it("detects schema-level note text changes (sl-4gio)", () => {
+    const a = makeIndex({ foo: { note: "Raw source data", fields: [{ name: "id", type: "INT" }] } });
+    const b = makeIndex({ foo: { note: "Updated description", fields: [{ name: "id", type: "INT" }] } });
+    const delta = diffIndex(a, b);
+    assert.equal(delta.schemas.changed.length, 1);
+    assert.equal(delta.schemas.changed[0].changes[0].kind, "note-changed");
+    assert.equal(delta.schemas.changed[0].changes[0].from, "Raw source data");
+    assert.equal(delta.schemas.changed[0].changes[0].to, "Updated description");
+  });
+
+  it("detects schema note added from null (sl-4gio)", () => {
+    const a = makeIndex({ foo: { note: null, fields: [] } });
+    const b = makeIndex({ foo: { note: "New note", fields: [] } });
+    const delta = diffIndex(a, b);
+    assert.equal(delta.schemas.changed.length, 1);
+    assert.equal(delta.schemas.changed[0].changes[0].kind, "note-changed");
+  });
+
+  it("identical schema notes produce no change", () => {
+    const a = makeIndex({ foo: { note: "Same note", fields: [] } });
+    const b = makeIndex({ foo: { note: "Same note", fields: [] } });
+    const delta = diffIndex(a, b);
+    assert.equal(delta.schemas.changed.length, 0);
+  });
+
+  it("detects transform body text changes (sl-7ow3)", () => {
+    const a = makeIndex({}, {}, { transforms: { "clean address": { body: "trim | lowercase" } } });
+    const b = makeIndex({}, {}, { transforms: { "clean address": { body: "trim | lowercase | capitalize" } } });
+    const delta = diffIndex(a, b);
+    assert.equal(delta.transforms.changed.length, 1);
+    assert.equal(delta.transforms.changed[0].name, "clean address");
+    assert.equal(delta.transforms.changed[0].changes[0].kind, "body-changed");
+    assert.equal(delta.transforms.changed[0].changes[0].from, "trim | lowercase");
+    assert.equal(delta.transforms.changed[0].changes[0].to, "trim | lowercase | capitalize");
+  });
+
+  it("identical transform bodies produce no change", () => {
+    const a = makeIndex({}, {}, { transforms: { "clean": { body: "trim" } } });
+    const b = makeIndex({}, {}, { transforms: { "clean": { body: "trim" } } });
+    const delta = diffIndex(a, b);
+    assert.equal(delta.transforms.changed.length, 0);
+  });
+
   it("detects arrow count changes in mappings", () => {
     const a = makeIndex({}, { m1: { sources: ["a"], targets: ["b"], arrowCount: 5 } });
     const b = makeIndex({}, { m1: { sources: ["a"], targets: ["b"], arrowCount: 8 } });

--- a/tooling/satsuma-cli/test/diff.test.js
+++ b/tooling/satsuma-cli/test/diff.test.js
@@ -178,6 +178,27 @@ describe("diffIndex", () => {
     assert.equal(delta.transforms.changed.length, 0);
   });
 
+  it("detects metric note changes attributed under metric, not top-level (sl-kf76)", () => {
+    const a = makeIndex({}, {}, {
+      metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
+      notes: [{ text: "Old note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
+    });
+    const b = makeIndex({}, {}, {
+      metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
+      notes: [{ text: "New note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
+    });
+    const delta = diffIndex(a, b);
+    // Should appear under metrics, not top-level notes
+    assert.equal(delta.metrics.changed.length, 1);
+    assert.equal(delta.metrics.changed[0].name, "rev");
+    const noteAdded = delta.metrics.changed[0].changes.find((c) => c.kind === "note-added");
+    const noteRemoved = delta.metrics.changed[0].changes.find((c) => c.kind === "note-removed");
+    assert.ok(noteAdded);
+    assert.ok(noteRemoved);
+    assert.equal(delta.notes.added.length, 0, "metric notes should not leak to top-level");
+    assert.equal(delta.notes.removed.length, 0, "metric notes should not leak to top-level");
+  });
+
   it("detects arrow count changes in mappings", () => {
     const a = makeIndex({}, { m1: { sources: ["a"], targets: ["b"], arrowCount: 5 } });
     const b = makeIndex({}, { m1: { sources: ["a"], targets: ["b"], arrowCount: 8 } });

--- a/tooling/satsuma-cli/test/fixtures/comment-edges.stm
+++ b/tooling/satsuma-cli/test/fixtures/comment-edges.stm
@@ -1,0 +1,6 @@
+schema comment_edges {
+  // comment before first field
+  id     INTEGER  (pk)
+  name   STRING
+  // comment after last field
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-metric-note-a.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-metric-note-a.stm
@@ -1,0 +1,5 @@
+schema orders { id INTEGER }
+metric daily_signups (source orders) {
+  note { "Counts new signups per day." }
+  signups INTEGER (measure additive)
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-metric-note-b.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-metric-note-b.stm
@@ -1,0 +1,5 @@
+schema orders { id INTEGER }
+metric daily_signups (source orders) {
+  note { "Counts new signups per day, excluding bots." }
+  signups INTEGER (measure additive)
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-schema-note-a.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-schema-note-a.stm
@@ -1,0 +1,3 @@
+schema source_data (note "Raw source data") {
+  id INTEGER (pk)
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-schema-note-b.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-schema-note-b.stm
@@ -1,0 +1,3 @@
+schema source_data (note "Updated raw source data description") {
+  id INTEGER (pk)
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-transform-body-a.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-transform-body-a.stm
@@ -1,0 +1,3 @@
+transform 'clean address' {
+  trim | lowercase | replace("  ", " ")
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-transform-body-b.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-transform-body-b.stm
@@ -1,0 +1,3 @@
+transform 'clean address' {
+  trim | lowercase | replace("  ", " ") | capitalize
+}

--- a/tooling/satsuma-cli/test/fixtures/empty-list-record.stm
+++ b/tooling/satsuma-cli/test/fixtures/empty-list-record.stm
@@ -1,0 +1,4 @@
+schema test {
+  items list_of record { }
+  id INT (pk)
+}

--- a/tooling/satsuma-cli/test/fixtures/nl-concat-note.stm
+++ b/tooling/satsuma-cli/test/fixtures/nl-concat-note.stm
@@ -1,0 +1,13 @@
+schema src { id INTEGER }
+schema tgt { id INTEGER }
+
+mapping 'order transform' {
+  source { `src` }
+  target { `tgt` }
+  note {
+    "First part of the note."
+    "Second part of the note."
+    "Third part with more detail."
+  }
+  id -> id
+}

--- a/tooling/satsuma-cli/test/fixtures/schema-compact-comment.stm
+++ b/tooling/satsuma-cli/test/fixtures/schema-compact-comment.stm
@@ -1,0 +1,7 @@
+schema comment_test {
+  id     INTEGER  (pk)
+  // regular comment between fields
+  //! warning between fields
+  //? question between fields
+  name   STRING
+}

--- a/tooling/satsuma-cli/test/fixtures/where-used-transform-spread.stm
+++ b/tooling/satsuma-cli/test/fixtures/where-used-transform-spread.stm
@@ -1,0 +1,11 @@
+schema src { field1 STRING; field2 STRING }
+schema tgt { field1 STRING; field2 STRING }
+
+transform my_xform { trim | lowercase }
+
+mapping 'test' {
+  source { `src` }
+  target { `tgt` }
+  field1 -> field1 { ...my_xform }
+  field2 -> field2 { my_xform }
+}

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -221,6 +221,25 @@ describe("satsuma schema", () => {
     assert.ok(data.fieldLines.some((l) => l.includes("comment after last field")));
   });
 
+  it("--json shows record type for empty list_of record (sc-r9gv)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "empty-list-record.stm");
+    const { stdout, code } = await run("schema", "test", "--json", F);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const items = data.fields.find((f) => f.name === "items");
+    assert.ok(items, "should have items field");
+    assert.equal(items.type, "list", "empty list_of record should have type 'list'");
+    assert.equal(items.isList, true);
+    assert.ok(Array.isArray(items.children), "should have children array");
+  });
+
+  it("text output shows list_of record for empty body (sc-r9gv)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "empty-list-record.stm");
+    const { stdout, code } = await run("schema", "test", F);
+    assert.equal(code, 0);
+    assert.match(stdout, /items list_of record/, "should show list_of record");
+  });
+
   it("--json --compact strips comments from fieldLines (sl-xtpd)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "schema-compact-comment.stm");
     const { stdout, code } = await run("schema", "comment_test", "--json", "--compact", F);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -585,6 +585,18 @@ describe("satsuma find", () => {
     assert.ok(schemaLevel.length > 0, "expected schema-level format matches");
   });
 
+  it("--json note metadata includes text value (sc-5s57)", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const cf = data.find((m) => m.field === "consent_flags");
+    assert.ok(cf, "should find consent_flags");
+    const noteEntry = cf.metadata.find((t) => t.startsWith("note"));
+    assert.ok(noteEntry, "should have note in metadata");
+    assert.match(noteEntry, /note "/, "note should include its text value");
+  });
+
   it("--json schema-level entries include metadata array (sc-h1wv)", async () => {
     const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
     const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -952,6 +952,19 @@ describe("satsuma context", () => {
     assert.ok(data.some((d) => d.name === "raw_orders"), "should match raw_orders via //! comment");
   });
 
+  it("finds blocks containing language keywords like flatten and list_of (sc-rj24)", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout: flattenOut, code: c1 } = await run("context", "flatten", FFG, "--json");
+    assert.equal(c1, 0);
+    const flattenData = JSON.parse(flattenOut);
+    assert.ok(flattenData.length > 0, "should find blocks containing flatten");
+
+    const { stdout: listOut, code: c2 } = await run("context", "list_of", FFG, "--json");
+    assert.equal(c2, 0);
+    const listData = JSON.parse(listOut);
+    assert.ok(listData.length > 0, "should find blocks containing list_of");
+  });
+
   it("searches metadata tags/values for query matches (sl-mdlr)", async () => {
     const { stdout, code } = await run("context", "pii", EXAMPLES, "--json");
     assert.equal(code, 0);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1686,6 +1686,16 @@ describe("satsuma validate", () => {
     assert.match(stdout, /no issues/i);
   });
 
+  it("--json produces JSON for filesystem errors (sl-5q6h)", async () => {
+    const { stdout, code } = await run("validate", "/nonexistent/path.stm", "--json");
+    assert.equal(code, 2);
+    const data = JSON.parse(stdout);
+    assert.ok(Array.isArray(data));
+    assert.equal(data.length, 1);
+    assert.equal(data[0].severity, "error");
+    assert.match(data[0].message, /ENOENT|resolving path/);
+  });
+
   it("unclosed schema at EOF reports missing-node error (sl-w6yu)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "unclosed-schema.stm");
     const { stdout, code } = await run("validate", F);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1337,6 +1337,15 @@ describe("satsuma nl", () => {
     assert.ok(data.length >= 2, "should have at least 2 NL items from both blocks");
   });
 
+  it("accepts standalone transform block names as scope (sl-egu3)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "nl-parent-test.stm");
+    const { stdout, code } = await run("nl", "nl transform", F, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.length > 0, "should find NL content in transform block");
+    assert.ok(data.some((d) => d.parent === "nl transform"), "parent should be transform name");
+  });
+
   it("unescapes escape sequences in NL strings (sl-j014)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "escape-test.stm");
     const { stdout, code } = await run("nl", "all", F, "--json");

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1387,6 +1387,14 @@ describe("satsuma meta", () => {
     assert.ok(data.entries.some((e) => e.kind === "note" && e.text === "Creation timestamp"));
   });
 
+  it("shows list_of prefix for scalar list fields (sc-5j7y)", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout, code } = await run("meta", "order_events.promo_codes", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.type, "list_of STRING");
+  });
+
   it("still finds direct fields on schemas with spreads", async () => {
     const FIXTURE = resolve(__dirname, "fixtures/spread-meta.stm");
     const { stdout, code } = await run("meta", "uses_fragment.id", FIXTURE);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -778,6 +778,14 @@ describe("satsuma where-used", () => {
     assert.equal(code, 0);
     assert.match(stdout, /transform_call|Invoked/);
   });
+
+  it("no duplicate refs for transform spread syntax (sl-b1h0)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "where-used-transform-spread.stm");
+    const { stdout, code } = await run("where-used", "my_xform", "--json", F);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.refs.length, 2, "should have exactly 2 refs (spread + bare), not 3");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -2911,6 +2911,19 @@ describe("satsuma graph: schema_edges excludes NL-referenced schemas (sl-n11t)",
   });
 });
 
+describe("satsuma graph: scalar list fields (sc-ebau)", () => {
+  it("--json shows list_of type for scalar list fields", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout, code } = await run("graph", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const allFields = data.nodes.flatMap((n) => n.fields || []);
+    const promoCodes = allFields.find((f) => f.name === "promo_codes");
+    assert.ok(promoCodes, "should have promo_codes field");
+    assert.equal(promoCodes.type, "list_of STRING", "scalar list field should show list_of type");
+  });
+});
+
 describe("satsuma graph: fragment fields (sl-yibt)", () => {
   it("fragment nodes include fields in --json output", async () => {
     const { stdout, code } = await run("graph", "--json", resolve(EXAMPLES, "common.stm"));

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -702,6 +702,17 @@ describe("satsuma lineage", () => {
     assert.ok(names.includes("target_d"), "should include target");
   });
 
+  it("--json has no phantom note: node from NL refs (sc-nk3v)", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout, code } = await run("lineage", "--from", "order_events", FFG, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const noteNode = data.nodes.find((n) => n.name === "note:");
+    assert.equal(noteNode, undefined, "should not have phantom note: node");
+    const noteEdge = data.edges.find((e) => e.src === "note:" || e.tgt === "note:");
+    assert.equal(noteEdge, undefined, "should not have edges to/from note:");
+  });
+
   it("--depth --json edges only reference nodes in the nodes array (sl-iliz)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "lineage-chain.stm");
     const { stdout, code } = await run("lineage", "--from", "source_a", "--depth", "1", "--json", F);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -204,6 +204,23 @@ describe("satsuma schema", () => {
     assert.doesNotMatch(stdout, /\/\/\?/);
   });
 
+  it("includes comments before first and after last field (sl-a0wf)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "comment-edges.stm");
+    const { stdout, code } = await run("schema", "comment_edges", F);
+    assert.equal(code, 0);
+    assert.match(stdout, /comment before first field/);
+    assert.match(stdout, /comment after last field/);
+  });
+
+  it("--json includes edge comments in fieldLines (sl-a0wf)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "comment-edges.stm");
+    const { stdout, code } = await run("schema", "comment_edges", "--json", F);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.fieldLines.some((l) => l.includes("comment before first field")));
+    assert.ok(data.fieldLines.some((l) => l.includes("comment after last field")));
+  });
+
   it("--json --compact strips comments from fieldLines (sl-xtpd)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "schema-compact-comment.stm");
     const { stdout, code } = await run("schema", "comment_test", "--json", "--compact", F);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1874,6 +1874,32 @@ describe("satsuma diff", () => {
     assert.match(bodyChange.from, /trim/);
     assert.match(bodyChange.to, /capitalize/);
   });
+
+  it("metric note change attributed under metric, not top-level (sl-kf76)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-metric-note-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-metric-note-b.stm");
+    const { stdout, code } = await run("diff", a, b);
+    assert.equal(code, 0);
+    assert.match(stdout, /Metrics:/);
+    assert.match(stdout, /daily_signups/);
+    assert.match(stdout, /note/);
+  });
+
+  it("--json metric note changes under metrics.changed, not notes (sl-kf76)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-metric-note-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-metric-note-b.stm");
+    const { stdout, code } = await run("diff", "--json", a, b);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const metricChange = data.metrics.changed.find((m) => m.name === "daily_signups");
+    assert.ok(metricChange, "should have changed metric");
+    const noteAdded = metricChange.changes.find((c) => c.kind === "note-added");
+    const noteRemoved = metricChange.changes.find((c) => c.kind === "note-removed");
+    assert.ok(noteAdded, "should have note-added");
+    assert.ok(noteRemoved, "should have note-removed");
+    assert.equal(data.notes.added.length, 0, "metric notes should not leak to top-level");
+    assert.equal(data.notes.removed.length, 0, "metric notes should not leak to top-level");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1282,6 +1282,18 @@ describe("satsuma nl", () => {
     assert.ok(transformItems.length >= 2, "should have transform-parented items");
   });
 
+  it("concatenated note strings joined with separators (sl-p0et)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "nl-concat-note.stm");
+    const { stdout, code } = await run("nl", "order transform", F, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const note = data.find((d) => d.kind === "note");
+    assert.ok(note, "should have a note item");
+    // Words at string boundaries should not run together
+    assert.doesNotMatch(note.text, /note\.Second/, "should not run words together at boundaries");
+    assert.match(note.text, /note\.\n?.*Second/, "should have separator between concatenated strings");
+  });
+
   it("concatenated note strings are fully extracted (sl-gu24)", async () => {
     const { stdout, code } = await run("nl", "cart_abandonment_rate", resolve(EXAMPLES, "metrics.stm"), "--json");
     assert.equal(code, 0);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1827,6 +1827,53 @@ describe("satsuma diff", () => {
     assert.match(String(transformChange.from), /title_case/);
     assert.match(String(transformChange.to), /uppercase/);
   });
+
+  it("detects schema-level note text changes (sl-4gio)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-schema-note-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-schema-note-b.stm");
+    const { stdout, code } = await run("diff", a, b);
+    assert.equal(code, 0);
+    assert.match(stdout, /note/);
+    assert.match(stdout, /Raw source data/);
+    assert.match(stdout, /Updated raw source data description/);
+  });
+
+  it("--json reports schema note-changed kind (sl-4gio)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-schema-note-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-schema-note-b.stm");
+    const { stdout, code } = await run("diff", "--json", a, b);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const schemaChange = data.schemas.changed.find((s) => s.name === "source_data");
+    assert.ok(schemaChange, "should have changed schema");
+    const noteChange = schemaChange.changes.find((c) => c.kind === "note-changed");
+    assert.ok(noteChange, "should have note-changed");
+    assert.equal(noteChange.from, "Raw source data");
+    assert.equal(noteChange.to, "Updated raw source data description");
+  });
+
+  it("detects transform body text changes (sl-7ow3)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-transform-body-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-transform-body-b.stm");
+    const { stdout, code } = await run("diff", a, b);
+    assert.equal(code, 0);
+    assert.match(stdout, /clean address/);
+    assert.match(stdout, /body/);
+  });
+
+  it("--json reports transform body-changed kind (sl-7ow3)", async () => {
+    const a = resolve(import.meta.dirname, "fixtures", "diff-transform-body-a.stm");
+    const b = resolve(import.meta.dirname, "fixtures", "diff-transform-body-b.stm");
+    const { stdout, code } = await run("diff", "--json", a, b);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const txChange = data.transforms.changed.find((t) => t.name === "clean address");
+    assert.ok(txChange, "should have changed transform");
+    const bodyChange = txChange.changes.find((c) => c.kind === "body-changed");
+    assert.ok(bodyChange, "should have body-changed");
+    assert.match(bodyChange.from, /trim/);
+    assert.match(bodyChange.to, /capitalize/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -478,6 +478,20 @@ describe("satsuma mapping", () => {
     assert.ok(data.arrows.some((a) => a.classification === "structural"), "expected at least one structural arrow");
   });
 
+  it("--json container arrows have hasTransform:false (sl-zfi0)", async () => {
+    const SAP = resolve(EXAMPLES, "sap-po-to-mfcs.stm");
+    const { stdout, code } = await run("mapping", "sap po to mfcs", "--json", SAP);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const containers = data.arrows.filter((a) => a.children && a.children.length > 0);
+    assert.ok(containers.length > 0, "should have container arrows");
+    for (const c of containers) {
+      if (!c.transform) {
+        assert.equal(c.hasTransform, false, `container arrow ${c.src}->${c.tgt} without pipe_chain should have hasTransform:false`);
+      }
+    }
+  });
+
   it("--json includes children for nested arrows (sl-wjb9)", async () => {
     const COBOL = resolve(EXAMPLES, "cobol-to-avro.stm");
     const { stdout, code } = await run("mapping", "cobol customer to avro event", "--json", COBOL);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -204,6 +204,16 @@ describe("satsuma schema", () => {
     assert.doesNotMatch(stdout, /\/\/\?/);
   });
 
+  it("--json --compact strips comments from fieldLines (sl-xtpd)", async () => {
+    const F = resolve(import.meta.dirname, "fixtures", "schema-compact-comment.stm");
+    const { stdout, code } = await run("schema", "comment_test", "--json", "--compact", F);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    for (const line of data.fieldLines ?? []) {
+      assert.doesNotMatch(line, /^\/\//, `fieldLines should not include comments: ${line}`);
+    }
+  });
+
   it("--json --compact omits note field (sl-5fbn)", async () => {
     const { stdout, code } = await run("schema", "country_codes", "--json", "--compact", EXAMPLES);
     assert.equal(code, 0);

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1022,6 +1022,14 @@ describe("satsuma arrows", () => {
     assert.ok(data[0].metadata.some((m) => m.kind === "tag" && m.tag === "pii"));
   });
 
+  it("text header shows correct count for nested field paths (sl-dvhm)", async () => {
+    const XML = resolve(EXAMPLES, "xml-to-parquet.stm");
+    const { stdout, code } = await run("arrows", "commerce_order.Order.Customer.Email", XML);
+    assert.equal(code, 0);
+    assert.match(stdout, /1 arrow/, "should show correct arrow count in header");
+    assert.match(stdout, /as source/, "should show direction in header");
+  });
+
   it("finds arrows for nested child by dotted path (sl-9gvb)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "nested-arrow-lookup.stm");
     const { stdout, code } = await run("arrows", "src_sys.addr.street", F, "--json");

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -571,6 +571,19 @@ describe("satsuma find", () => {
     assert.ok(schemaLevel.length > 0, "expected schema-level format matches");
   });
 
+  it("--json schema-level entries include metadata array (sc-h1wv)", async () => {
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance.stm");
+    const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const schemaLevel = data.filter((m) => m.field === "(schema)");
+    assert.ok(schemaLevel.length > 0, "expected schema-level matches");
+    for (const m of schemaLevel) {
+      assert.ok(Array.isArray(m.metadata), `schema-level entry for ${m.block} should include metadata array`);
+      assert.ok(m.metadata.some((t) => /classification/.test(t)), "metadata should include matched tag value");
+    }
+  });
+
   it("--tag note finds fields with note metadata (sl-amyh)", async () => {
     const { stdout, code } = await run("find", "--tag", "note", EXAMPLES);
     assert.equal(code, 0);


### PR DESCRIPTION
## Summary

- **arrows**: correct count for nested field paths in text header; report `hasTransform:false` when no pipe_chain in mapping containers
- **context**: find language keywords like `flatten` and `list_of`
- **diff**: attribute metric/mapping note changes to owning block; detect schema-level note and transform body text changes
- **find**: `--json` includes metadata array for schema-level entries; `--json` note metadata includes full text value
- **graph**: `--json` shows `list_of` type for scalar list fields
- **meta**: show `list_of` prefix for scalar list fields
- **nl**: concatenated note strings joined with newline separator; standalone transform block names accepted as scope
- **schema**: preserve record type for empty `list_of` record bodies; include comments before first and after last field; `--json --compact` strips comments from fieldLines
- **validate**: `--json` outputs JSON for filesystem errors
- **where-used**: no longer duplicates transform spread references
- **lineage**: exclude phantom `note:` nodes from NL ref processing

## Test plan

- [x] 17 new/updated integration tests covering each fix
- [x] New test fixtures for edge cases (empty list records, comment edges, concat notes, etc.)
- [x] All 637+ existing CLI tests still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)