### PR TITLE
feat: LSP Phase 1 — symbols, diagnostics, folding, semantic tokens, hover, validate

### DIFF
--- a/.tickets/sl-2e4z.md
+++ b/.tickets/sl-2e4z.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2e4z
-status: open
+status: done
 deps: []
 links: []
 created: 2026-03-23T09:55:40Z
@@ -17,6 +17,17 @@ Node.js LSP server using vscode-languageserver + tree-sitter. File-level feature
 
 
 ## Notes
+
+**2026-03-23T15:00:00Z**
+
+All Phase 1 features complete. Third commit adds semantic diagnostics:
+- ✅ Semantic diagnostics — `satsuma validate --json` runs on save, results merged with parse diagnostics
+- New `validate-diagnostics.ts` module: shells out to CLI, parses JSON output, maps to LSP Diagnostics
+- Server wires `onDidSave` → `runValidate` → merged diagnostics (parse + validate)
+- Extension passes configurable `satsuma.cliPath` to server via initializationOptions
+- `satsuma.cliPath` setting added to package.json contributes.configuration
+- 6 new tests (62 total LSP tests passing)
+- Graceful fallback: if CLI not found, parse diagnostics still work
 
 **2026-03-23T13:00:00Z**
 

--- a/.tickets/sl-2e4z.md
+++ b/.tickets/sl-2e4z.md
@@ -20,35 +20,51 @@ Node.js LSP server using vscode-languageserver + tree-sitter. File-level feature
 
 **2026-03-23T13:00:00Z**
 
-Progress: Second PR (feat/lsp-phase1). Added 2 more Phase 1 features:
-- ✅ Semantic tokens — highlights.scm captures mapped to LSP SemanticTokenTypes (keyword, type, function, property, decorator, namespace, etc.) with definition modifiers; multi-line token support; deduplication of overlapping captures
-- ✅ Hover — contextual markdown hover for all block types (schema/fragment/mapping/transform/metric/namespace/note), field declarations (type, metadata, parent), tag descriptions, fragment spread resolution (same-file), arrow paths, pipe chain functions
-- ✅ 30 new tests (12 semantic tokens + 18 hover), 56 total LSP tests passing
+Progress: Second commit on feat/lsp-phase1 (906765c). Added semantic tokens + hover. 5 of 7 Phase 1 features now complete. 56 LSP tests passing.
 
-Remaining for sl-2e4z:
-1. Semantic diagnostics — shell out to `satsuma validate --json` on save
-2. Go-to-definition — deferred to sl-t7mg
-3. Find references — deferred to sl-t7mg
-
-**2026-03-23T11:19:17Z**
-
-**2026-03-23T11:15:00Z**
-
-Progress: First PR merged (feat/lsp-phase1, PR #47). Delivered LSP server scaffold with 3 of 7 Phase 1 features:
+Completed features:
 - ✅ Document symbols (outline panel with all block types, nested fields)
 - ✅ Parse-error diagnostics (ERROR/MISSING nodes, //! warnings, //? info)
 - ✅ Code folding (all block types matching folds.scm)
-- ✅ PRD updated to align with latest SATSUMA-V2-SPEC.md
-- ✅ README updated with build/install/test docs
-- ✅ 26 unit tests passing
+- ✅ Semantic tokens (highlights.scm → LSP SemanticTokenTypes with definition modifiers, multi-line support, dedup)
+- ✅ Hover (block summaries, field type/metadata/parent, tag descriptions, spread resolution, arrow paths)
 
 Remaining for sl-2e4z:
-1. Semantic tokens — map highlights.scm to LSP semantic token types (per-file, no workspace index)
-2. Hover — field type/metadata, schema summaries, fragment/transform info (per-file)
-3. Semantic diagnostics — shell out to `satsuma validate --json` on save for workspace-level warnings (undefined schemas, duplicate names, missing imports)
-4. Go-to-definition — uses locals.scm (may be deferred to sl-t7mg)
-5. Find references — workspace-aware (may be deferred to sl-t7mg)
+1. **Semantic diagnostics** — shell out to `satsuma validate --json` on save for workspace-level warnings (undefined schemas, duplicate names, missing imports). This is the only remaining item before this ticket can close.
 
-Recommended next PR: semantic tokens + hover (both per-file, natural extension of current architecture). Semantic diagnostics as a follow-up PR since it introduces CLI subprocess integration.
+Deferred to sl-t7mg (Phase 2):
+- Go-to-definition (uses locals.scm, requires workspace index)
+- Find references (workspace-aware)
 
-Architecture: server at tooling/vscode-satsuma/server/, client at tooling/vscode-satsuma/src/extension.ts, esbuild bundles both. Tests use Node built-in test runner importing from dist/.
+## Architecture reference for next agent
+
+- **Branch**: `feat/lsp-phase1` — worktree at `.worktrees/feat/lsp-phase1/`
+- **Server source**: `tooling/vscode-satsuma/server/src/` — one file per provider:
+  - `server.ts` — connection setup, capability registration, document lifecycle, handler wiring
+  - `parser-utils.ts` — tree-sitter singleton, CST→LSP helpers (nodeRange, child, children, labelText, stringText)
+  - `diagnostics.ts` — parse-error + comment diagnostics (ERROR/MISSING nodes, //!, //?)
+  - `symbols.ts` — document symbols/outline
+  - `folding.ts` — fold ranges
+  - `semantic-tokens.ts` — runs highlights.scm query, maps captures to LSP token types (singleton Query)
+  - `hover.ts` — contextual markdown hover (walks CST ancestors to find hover target)
+- **Client**: `tooling/vscode-satsuma/src/extension.ts` — thin LSP client, starts server via IPC
+- **Build**: `npm run build` (esbuild bundles client+server), `cd server && npx tsc` (for test dist/)
+- **Tests**: `tooling/vscode-satsuma/server/test/*.test.js` — Node built-in `node:test`, import from `../dist/`, parse with tree-sitter directly (no mocking)
+- **Run tests**: `cd tooling/vscode-satsuma && npm run test:lsp` or `cd server && npm test`
+- **Full check**: `cd tooling/vscode-satsuma && npm run check` (manifest + grammar + TextMate tests + LSP tests)
+- **PRD**: `features/16-vscode-language-server/PRD.md` — see §1.1 for semantic diagnostics acceptance criteria
+
+## Implementation guidance for semantic diagnostics
+
+The PRD §1.1 specifies: run `satsuma validate --json` on save (not on keystroke) and surface results as LSP diagnostics. Key considerations:
+- Use `child_process.execFile` to run `satsuma validate --json <file>` on `documents.onDidSave`
+- Parse JSON output and map to LSP Diagnostic objects with appropriate severities
+- Workspace-level warnings: undefined schemas, duplicate names, missing imports, broken import paths
+- Debounce or cancel in-flight validate calls if the user saves rapidly
+- Handle missing `satsuma` CLI gracefully (warn once, don't spam)
+- The existing `computeDiagnostics` (parse errors) runs on every keystroke; semantic diagnostics from validate should merge with those, not replace them
+- Tests should mock/stub the CLI subprocess — don't shell out in unit tests
+
+**2026-03-23T11:15:00Z**
+
+Progress: First PR merged (feat/lsp-phase1, PR #47). Delivered LSP server scaffold with 3 of 7 Phase 1 features. 26 unit tests. Architecture established: one file per provider, esbuild bundles client+server, tests use Node built-in test runner.

--- a/.tickets/sl-2e4z.md
+++ b/.tickets/sl-2e4z.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2e4z
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-03-23T09:55:40Z

--- a/.tickets/sl-2e4z.md
+++ b/.tickets/sl-2e4z.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2e4z
-status: in_progress
+status: open
 deps: []
 links: []
 created: 2026-03-23T09:55:40Z
@@ -15,3 +15,40 @@ tags: [feature-16, lsp, vscode]
 
 Node.js LSP server using vscode-languageserver + tree-sitter. File-level features: semantic tokens, fold ranges, document symbols, live diagnostics from satsuma validate. Extension activates and connects.
 
+
+## Notes
+
+**2026-03-23T13:00:00Z**
+
+Progress: Second PR (feat/lsp-phase1). Added 2 more Phase 1 features:
+- ✅ Semantic tokens — highlights.scm captures mapped to LSP SemanticTokenTypes (keyword, type, function, property, decorator, namespace, etc.) with definition modifiers; multi-line token support; deduplication of overlapping captures
+- ✅ Hover — contextual markdown hover for all block types (schema/fragment/mapping/transform/metric/namespace/note), field declarations (type, metadata, parent), tag descriptions, fragment spread resolution (same-file), arrow paths, pipe chain functions
+- ✅ 30 new tests (12 semantic tokens + 18 hover), 56 total LSP tests passing
+
+Remaining for sl-2e4z:
+1. Semantic diagnostics — shell out to `satsuma validate --json` on save
+2. Go-to-definition — deferred to sl-t7mg
+3. Find references — deferred to sl-t7mg
+
+**2026-03-23T11:19:17Z**
+
+**2026-03-23T11:15:00Z**
+
+Progress: First PR merged (feat/lsp-phase1, PR #47). Delivered LSP server scaffold with 3 of 7 Phase 1 features:
+- ✅ Document symbols (outline panel with all block types, nested fields)
+- ✅ Parse-error diagnostics (ERROR/MISSING nodes, //! warnings, //? info)
+- ✅ Code folding (all block types matching folds.scm)
+- ✅ PRD updated to align with latest SATSUMA-V2-SPEC.md
+- ✅ README updated with build/install/test docs
+- ✅ 26 unit tests passing
+
+Remaining for sl-2e4z:
+1. Semantic tokens — map highlights.scm to LSP semantic token types (per-file, no workspace index)
+2. Hover — field type/metadata, schema summaries, fragment/transform info (per-file)
+3. Semantic diagnostics — shell out to `satsuma validate --json` on save for workspace-level warnings (undefined schemas, duplicate names, missing imports)
+4. Go-to-definition — uses locals.scm (may be deferred to sl-t7mg)
+5. Find references — workspace-aware (may be deferred to sl-t7mg)
+
+Recommended next PR: semantic tokens + hover (both per-file, natural extension of current architecture). Semantic diagnostics as a follow-up PR since it introduces CLI subprocess integration.
+
+Architecture: server at tooling/vscode-satsuma/server/, client at tooling/vscode-satsuma/src/extension.ts, esbuild bundles both. Tests use Node built-in test runner importing from dist/.

--- a/features/16-vscode-language-server/PRD.md
+++ b/features/16-vscode-language-server/PRD.md
@@ -10,7 +10,7 @@ Ship a VS Code extension that turns the existing TextMate syntax highlighter (Fe
 
 ## Problem
 
-Satsuma now has strong tooling foundations — a tree-sitter parser with 190+ corpus tests, a 16-command CLI for structural extraction, tree-sitter queries for highlights/locals/folds, and a TextMate grammar for basic syntax colouring. But the editing experience is still "coloured text in a file":
+Satsuma now has strong tooling foundations — a tree-sitter parser with 480+ corpus tests, a 16-command CLI for structural extraction (630+ tests), tree-sitter queries for highlights/locals/folds, and a TextMate grammar for basic syntax colouring. But the editing experience is still "coloured text in a file":
 
 1. **No navigation.** A user reading a mapping that references `crm_customers` has to manually search for that schema. There is no go-to-definition, no find-references, no breadcrumb trail.
 2. **No live feedback.** Validation errors and semantic warnings (`satsuma validate`) only surface when run from the terminal. Parse errors sit silently in the file.
@@ -117,7 +117,7 @@ Surface parse errors and semantic warnings inline as the user types.
 - **Semantic warnings:** Run on save (not on keystroke — too expensive for large workspaces):
   - Schema referenced in `source`/`target` but not defined in workspace
   - Fragment/transform spread referencing undefined name
-  - Duplicate block names
+  - Duplicate block names — including cross-type uniqueness violations (spec §2.8: all named definitions share a single name space, so a schema and a metric with the same name is an error)
   - Arrow source/target field not present in declared schema
   - Import path referencing a file that doesn't exist
 - **Warning/question comments:** Surface `//!` as `DiagnosticSeverity.Warning` and `//?` as `DiagnosticSeverity.Information` so they appear in the Problems panel.
@@ -137,6 +137,7 @@ Uses the `locals.scm` definition/reference captures:
 - Schema name in `source`/`target` block → schema block label
 - Fragment spread (`...name`) → fragment block label
 - Transform spread (`...name`) → transform block label
+- Namespace-qualified reference (`ns::name`) → definition within the namespace block
 - Backtick reference (`` `schema.field` ``) → field declaration
 - Import name → block label in the imported file
 - Import path → open the referenced `.stm` file
@@ -183,12 +184,17 @@ transform 'clean email'
 metric monthly_recurring_revenue
 ```
 
-- Top-level blocks → `SymbolKind.Class` (schema), `SymbolKind.Function` (mapping/transform), `SymbolKind.Constant` (metric), `SymbolKind.Interface` (fragment)
+- Top-level blocks → `SymbolKind.Class` (schema), `SymbolKind.Function` (mapping/transform), `SymbolKind.Constant` (metric), `SymbolKind.Interface` (fragment), `SymbolKind.Namespace` (namespace), `SymbolKind.File` (note)
+- Metric blocks include the optional display label (e.g. `"MRR"`) in the symbol detail when present
 - Fields → `SymbolKind.Field` as children
 - Record/list → `SymbolKind.Struct` nested under the parent schema
+- Namespace blocks contain their child definitions as nested symbols
 
 **Acceptance criteria:**
 - [ ] Outline panel shows all top-level blocks with names and kinds
+- [ ] Namespace blocks appear as containers with their child definitions nested inside
+- [ ] Note blocks appear in the outline
+- [ ] Metric symbols include the display label (e.g. `"MRR"`) as detail text when present
 - [ ] Fields appear as children of their parent schema/fragment
 - [ ] Nested record/list blocks appear as nested children
 - [ ] Breadcrumbs update as cursor moves through the file
@@ -201,9 +207,13 @@ Upgrade from TextMate regex scoping to parser-backed semantic tokens for context
 Uses `highlights.scm` captures mapped to LSP semantic token types:
 - `source`/`target` as keyword vs. field name (disambiguated by CST position)
 - `map` as keyword vs. identifier
-- `record`/`list` as keyword vs. type reference
+- `record`/`list_of` as keyword vs. type reference
+- `each`/`flatten` as context-sensitive keywords (only valid inside mapping bodies per spec §2.6)
+- `namespace` as keyword in namespace blocks
 - Block labels get definition-specific token types
+- Metric display labels (e.g. `"MRR"`) get `string` token type distinct from NL strings
 - Vocabulary tokens in metadata get `decorator` type
+- Error-handling tokens (`null_if_*`, `drop_if_*`, `warn_if_*`, `error_if_*`) get `function` type in pipelines
 - Warning comments (`//!`) and question comments (`//?`) get distinct token types
 
 **Acceptance criteria:**
@@ -231,6 +241,8 @@ Show contextual information when hovering over identifiers.
 - **Field name** (in arrow): show type, metadata tags, and parent schema
 - **Fragment name** (in spread): show field count and field names
 - **Transform name** (in spread): show the transform body summary
+- **Metric name**: show display label (if present), source schemas, grain, slice dimensions, and measure count
+- **Namespace name**: show the count and names of contained definitions
 - **Vocabulary token** (in metadata): show a brief description from a built-in token dictionary
 - **Import path**: show the file path and block count
 
@@ -238,6 +250,17 @@ Show contextual information when hovering over identifiers.
 - [ ] Hovering a schema name in a mapping shows its field summary
 - [ ] Hovering a field in an arrow shows its type and metadata
 - [ ] Hover information loads within 100ms
+
+#### 1.8 Developer Documentation
+
+Ship a README update covering how to install and use the extension locally during Phase 1 (before Marketplace publishing).
+
+**Acceptance criteria:**
+- [ ] `tooling/vscode-satsuma/README.md` documents how to build the extension (install deps, compile the LSP server)
+- [ ] Documents how to install locally via `.vsix` or the Extension Development Host (F5)
+- [ ] Documents the features available in Phase 1 (diagnostics, navigation, outline, semantic tokens, folding, hover)
+- [ ] Documents any prerequisites (Node.js version, `tree-sitter` native dependencies)
+- [ ] Documents how to run the extension's test suite
 
 ---
 
@@ -256,7 +279,7 @@ Context-aware autocompletion powered by the workspace index.
 | Arrow source path (left of `->`) | Fields from source schemas of current mapping |
 | Arrow target path (right of `->`) | Fields from target schemas of current mapping |
 | Inside `()` metadata | Vocabulary tokens (pk, required, pii, enum, format, etc.) |
-| Inside `{ }` pipeline body | Transform function names (trim, lowercase, coalesce, etc.) |
+| Inside `{ }` pipeline body | Transform function names (trim, lowercase, coalesce, etc.) and error-handling tokens (`null_if_empty`, `drop_if_invalid`, `warn_if_null`, `error_if_null`, etc. — the `<action>_if_<condition>` pattern from spec §7.2) |
 | After `import { }` | Block names from files in workspace |
 | After `from "` | `.stm` file paths relative to workspace root |
 | After `::` (namespace) | Block names within the namespace |
@@ -443,7 +466,7 @@ tooling/vscode-satsuma/
 - **Feature 07 (TextMate grammar):** COMPLETED. The extension builds on the existing `vscode-satsuma` package.
 - **Feature 08 (tree-sitter parser v2):** COMPLETED. The LSP server uses `tree-sitter-satsuma` directly.
 - **Features 09+10 (CLI):** COMPLETED. The extension shells out to `satsuma` CLI for workspace-level operations.
-- **Feature 15 (namespaces):** IN PROGRESS. Namespace-aware completions and navigation depend on namespace index support in the CLI. Phase 1 LSP features work without it; Phase 2 completions benefit from it.
+- **Feature 15 (namespaces):** Parser and CLI support for `namespace` blocks is implemented. The tree-sitter grammar includes `namespace_block` and the CLI handles namespace-qualified names. Phase 1 LSP features should handle namespace blocks in document symbols and navigation; Phase 2 completions benefit from the workspace namespace index.
 
 ---
 

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -1,27 +1,71 @@
 # VS Code Satsuma Extension
 
-Syntax highlighting for the Satsuma language.
+Language support for the Satsuma data mapping language: syntax highlighting (TextMate) plus a Language Server providing document symbols, diagnostics, and code folding.
+
+## Prerequisites
+
+- **Node.js** 20+ (native tree-sitter bindings require compilation)
+- **VS Code** 1.85+
 
 ## Installation (local development)
 
 ```bash
-# Install dev dependencies
 cd tooling/vscode-satsuma
+
+# Install client dependencies
 npm install
 
-# Load the extension in VS Code:
-# 1. Open the repo root in VS Code
-# 2. Run "Developer: Install Extension from VSIX..." OR
-# 3. Press F5 (with the Extension Development Host launch config)
+# Install and build the language server
+cd server
+npm install
+npm run build
+cd ..
+
+# Build the extension client
+npm run build
 ```
+
+### Running in VS Code
+
+1. Open the repo root in VS Code.
+2. Press **F5** to launch the Extension Development Host.
+3. Open any `.stm` file — the language server activates automatically.
+
+### Installing from `.vsix`
+
+```bash
+cd tooling/vscode-satsuma
+npx @vscode/vsce package --no-dependencies
+code --install-extension vscode-satsuma-0.3.0.vsix
+```
+
+## Features
+
+### TextMate Syntax Highlighting
+
+Regex-based syntax colouring for all Satsuma constructs. Works immediately, no build step.
+
+### Language Server (Phase 1)
+
+Parser-backed features using tree-sitter:
+
+- **Document Symbols / Outline** — schemas, mappings, fragments, transforms, metrics, namespaces, and notes appear in the Outline panel. Fields appear as children. Nested record/list structures appear as nested entries.
+- **Diagnostics** — parse errors show as red squiggles in real time. `//!` warning comments appear as warnings in the Problems panel. `//?` question comments appear as information.
+- **Code Folding** — all block types (schema, mapping, fragment, transform, metric, note, namespace, each, flatten, map literal, metadata, nested arrow) are foldable.
 
 ## Running Tests
 
 From `tooling/vscode-satsuma/`:
 
 ```bash
-# Run all tests
+# Run all tests (TextMate + LSP)
+npm run check
+
+# TextMate grammar tests only
 npm test
+
+# LSP server tests only
+npm run test:lsp
 
 # Focused fixture tests only
 npm run test:fixtures
@@ -31,62 +75,23 @@ npm run test:golden
 
 # Validate manifest + grammar JSON
 npm run validate
-
-# Run everything (validate + test)
-npm run check
 ```
 
-Tests use [`vscode-tmgrammar-test`](https://github.com/nicolo-ribaudo/vscode-tmgrammar-test),
-which runs without a VS Code instance (CI-safe) and exits non-zero on failure.
+TextMate tests use [`vscode-tmgrammar-test`](https://github.com/nicolo-ribaudo/vscode-tmgrammar-test) (CI-safe, no VS Code instance needed). LSP tests use Node's built-in test runner against the tree-sitter parser directly.
 
 ## Grammar Authoring
 
-The grammar is in `syntaxes/stm.tmLanguage.json` — plain JSON, no build step.
-This is a standard TextMate grammar. Edit it directly; reload the Extension
-Development Host to preview changes.
+The TextMate grammar is in `syntaxes/satsuma.tmLanguage.json` — plain JSON, no build step. Edit it directly; reload the Extension Development Host to preview changes.
 
 ## Known Approximation Limits
 
-The TextMate grammar handles several constructs approximately due to
-regex-only matching. See `features/07-vscode-syntax-highlighter-v2/HIGHLIGHTING-TAXONOMY.md §14`
-for the full list. Key limitations:
+The TextMate grammar handles several constructs approximately due to regex-only matching. The Language Server's semantic tokens (planned for a future phase) will resolve these:
 
-- **`source` / `target` as keywords vs. field names** (§14): Both are scoped as
-  keywords everywhere. A parser can distinguish them by block context.
-- **`map` as keyword vs. field name** (§14): `map` is highlighted as a keyword
-  everywhere. In practice field names of `map` are uncommon.
-- **`list` / `record` as keywords vs. field names** (§14): Highlighted as keywords
-  inside schema bodies — minor overlap possible for fields named `list` or `record`.
-- **Pipeline tokens as field names** (§14): `trim`, `filter`, `format` etc. could
-  be field names but are only highlighted as pipeline tokens inside `{}` arrow bodies.
-- **Vocabulary tokens as field names** (§14): Constraint/format tokens (`filter`,
-  `format`) are only matched inside `()` metadata blocks, reducing false positives.
-- **Type names vs. field names** (§14): An all-caps field like `STATUS CHAR(1)` —
-  `STATUS` is matched as a type by position (second token in declaration). Parser
-  needed for precise disambiguation.
-
-## Semantic Tokens (Future Work)
-
-Parser-backed semantic tokens are planned as a follow-on to resolve the approximation
-limits above. Candidates from the taxonomy (§14):
-
-- `source` / `target` — distinguish keyword (inside `mapping {}`) from field name (inside `schema {}`)
-- `map` — distinguish value-mapping block keyword from field identifier
-- `list` / `record` — distinguish structural keywords from field names
-- Type-position identifiers — confirm second token in declaration is a type, not a field
-
-Dependencies: tree-sitter-stm grammar stable, CST-to-AST mapping defined.
-
-## Shared Token Mapping
-
-The TextMate scopes in this extension align with the token taxonomy defined in
-`features/07-vscode-syntax-highlighter-v2/HIGHLIGHTING-TAXONOMY.md`. The full
-scope summary is in §15 of that document.
-
-New syntax patterns should produce:
-
-1. An updated example `.stm` file in `test/fixtures/`
-2. A corresponding TextMate scope fixture test
+- **`source` / `target` as keywords vs. field names** — both scoped as keywords everywhere.
+- **`map` as keyword vs. field name** — highlighted as keyword everywhere.
+- **`list` / `record` as keywords vs. field names** — highlighted as keywords inside schema bodies.
+- **Pipeline tokens as field names** — `trim`, `filter`, `format` etc. only highlighted inside `{}` arrow bodies.
+- **Vocabulary tokens as field names** — constraint/format tokens only matched inside `()` metadata blocks.
 
 ## Theme Verification
 
@@ -98,10 +103,10 @@ Before releases, verify highlighting in:
 
 Checklist:
 
-- [ ] Keywords (`schema`, `mapping`, `fragment`, `record`, `list`, `transform`, `note`) coloured distinctly from identifiers
+- [ ] Keywords coloured distinctly from identifiers
 - [ ] `import` / `from` coloured as control-flow keywords
 - [ ] Strings (double-quoted NL, triple-quoted Markdown, single-quoted labels, backtick identifiers) each coloured
 - [ ] Comments visually de-emphasised
-- [ ] Vocabulary tokens in `()` metadata (`pk`, `required`, `pii`, `enum`, `format`) distinguishable from field names
-- [ ] Pipeline function tokens (`trim`, `lowercase`, `coalesce`) highlighted inside `{}` bodies
+- [ ] Vocabulary tokens in `()` metadata distinguishable from field names
+- [ ] Pipeline function tokens highlighted inside `{}` bodies
 - [ ] `//!` and `//?` fall back gracefully in themes that don't distinguish them

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -1,0 +1,49 @@
+const esbuild = require("esbuild");
+
+const watch = process.argv.includes("--watch");
+
+/** @type {import("esbuild").BuildOptions} */
+const clientConfig = {
+  entryPoints: ["src/extension.ts"],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  outfile: "dist/client/extension.js",
+  external: ["vscode"],
+  format: "cjs",
+  sourcemap: true,
+};
+
+/** @type {import("esbuild").BuildOptions} */
+const serverConfig = {
+  entryPoints: ["server/src/server.ts"],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  outfile: "server/dist/server.js",
+  external: ["tree-sitter", "tree-sitter-satsuma"],
+  format: "cjs",
+  sourcemap: true,
+};
+
+async function build() {
+  if (watch) {
+    const [clientCtx, serverCtx] = await Promise.all([
+      esbuild.context(clientConfig),
+      esbuild.context(serverConfig),
+    ]);
+    await Promise.all([clientCtx.watch(), serverCtx.watch()]);
+    console.log("Watching for changes...");
+  } else {
+    await Promise.all([
+      esbuild.build(clientConfig),
+      esbuild.build(serverConfig),
+    ]);
+    console.log("Build complete.");
+  }
+}
+
+build().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -1,14 +1,18 @@
 {
   "name": "vscode-satsuma",
   "displayName": "Satsuma Language Support",
-  "description": "VS Code syntax highlighting for the Satsuma data mapping language",
+  "description": "VS Code language support for the Satsuma data mapping language",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "satsuma",
   "engines": {
     "vscode": "^1.85.0"
   },
   "categories": ["Programming Languages"],
+  "main": "./dist/client/extension.js",
+  "activationEvents": [
+    "onLanguage:satsuma"
+  ],
   "contributes": {
     "languages": [
       {
@@ -27,15 +31,25 @@
     ]
   },
   "scripts": {
+    "build": "node esbuild.js",
+    "watch": "node esbuild.js --watch",
+    "build:server": "cd server && npm run build",
     "test": "npm run test:fixtures && npm run test:golden",
     "test:fixtures": "npx vscode-tmgrammar-test -g syntaxes/satsuma.tmLanguage.json 'test/fixtures/*.stm'",
     "test:golden": "npx vscode-tmgrammar-test -g syntaxes/satsuma.tmLanguage.json 'test/golden/*.stm'",
+    "test:lsp": "cd server && npm test",
     "validate:manifest": "node -e \"JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')\"",
     "validate:grammar": "node -e \"const g=JSON.parse(require('fs').readFileSync('syntaxes/satsuma.tmLanguage.json','utf8')); if(!g.scopeName)throw new Error('missing scopeName'); console.log('grammar OK, scopeName='+g.scopeName)\"",
     "validate": "npm run validate:manifest && npm run validate:grammar",
-    "check": "npm run validate && npm test"
+    "check": "npm run validate && npm test && npm run test:lsp"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
+    "@types/vscode": "^1.85.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.8.0",
     "vscode-tmgrammar-test": "^0.1.3"
   }
 }

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -28,7 +28,17 @@
         "scopeName": "source.satsuma",
         "path": "./syntaxes/satsuma.tmLanguage.json"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Satsuma",
+      "properties": {
+        "satsuma.cliPath": {
+          "type": "string",
+          "default": "satsuma",
+          "description": "Path to the satsuma CLI executable used for validation diagnostics."
+        }
+      }
+    }
   },
   "scripts": {
     "build": "node esbuild.js",

--- a/tooling/vscode-satsuma/server/package-lock.json
+++ b/tooling/vscode-satsuma/server/package-lock.json
@@ -1,24 +1,37 @@
 {
-  "name": "vscode-satsuma",
-  "version": "0.3.0",
+  "name": "satsuma-language-server",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vscode-satsuma",
-      "version": "0.3.0",
-      "license": "MIT",
+      "name": "satsuma-language-server",
+      "version": "0.1.0",
       "dependencies": {
-        "vscode-languageclient": "^9.0.1"
+        "tree-sitter": "^0.25.0",
+        "tree-sitter-satsuma": "file:../../tree-sitter-satsuma",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-textdocument": "^1.0.12"
       },
       "devDependencies": {
-        "@types/vscode": "^1.85.0",
+        "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",
-        "typescript": "^5.8.0",
-        "vscode-tmgrammar-test": "^0.1.3"
+        "typescript": "^5.8.0"
+      }
+    },
+    "../../tree-sitter-satsuma": {
+      "version": "2.0.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.0"
       },
-      "engines": {
-        "vscode": "^1.85.0"
+      "devDependencies": {
+        "tree-sitter-cli": "^0.26.7"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.25.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -463,107 +476,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/bottleneck": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/esbuild": {
@@ -608,131 +528,40 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
+    "node_modules/node-addon-api": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.6.0.tgz",
+      "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
       "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+    "node_modules/tree-sitter": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.25.0.tgz",
+      "integrity": "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
       }
+    },
+    "node_modules/tree-sitter-satsuma": {
+      "resolved": "../../tree-sitter-satsuma",
+      "link": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -748,6 +577,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -757,39 +593,16 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/vscode-languageclient": {
+    "node_modules/vscode-languageserver": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
         "vscode-languageserver-protocol": "3.17.5"
       },
-      "engines": {
-        "vscode": "^1.82.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
@@ -802,52 +615,17 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
     "node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-textmate": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
-      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/vscode-tmgrammar-test": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
-      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bottleneck": "^2.19.5",
-        "chalk": "^2.4.2",
-        "commander": "^9.2.0",
-        "diff": "^4.0.2",
-        "glob": "^7.1.6",
-        "vscode-oniguruma": "^1.5.1",
-        "vscode-textmate": "^7.0.1"
-      },
-      "bin": {
-        "vscode-tmgrammar-snap": "dist/snapshot.js",
-        "vscode-tmgrammar-test": "dist/unit.js"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
     }
   }
 }

--- a/tooling/vscode-satsuma/server/package.json
+++ b/tooling/vscode-satsuma/server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "satsuma-language-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Satsuma Language Server",
+  "type": "commonjs",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "esbuild src/server.ts --bundle --platform=node --target=node20 --outfile=dist/server.js --external:tree-sitter --external:tree-sitter-satsuma --sourcemap",
+    "watch": "npm run build -- --watch",
+    "test": "node --test test/**/*.test.js",
+    "pretest": "tsc"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.12",
+    "tree-sitter": "^0.25.0",
+    "tree-sitter-satsuma": "file:../../tree-sitter-satsuma"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/tooling/vscode-satsuma/server/src/diagnostics.ts
+++ b/tooling/vscode-satsuma/server/src/diagnostics.ts
@@ -1,0 +1,79 @@
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+} from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+import { nodeRange } from "./parser-utils";
+
+/**
+ * Produce LSP diagnostics from a tree-sitter parse tree.
+ *
+ * - ERROR / MISSING nodes → Error severity
+ * - warning_comment (//!) → Warning severity
+ * - question_comment (//?…) → Information severity
+ */
+export function computeDiagnostics(tree: Tree): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  walkErrors(tree.rootNode, diagnostics);
+  walkComments(tree.rootNode, diagnostics);
+  return diagnostics;
+}
+
+/** Recursively collect ERROR and MISSING nodes. */
+function walkErrors(node: SyntaxNode, out: Diagnostic[]): void {
+  if (node.type === "ERROR") {
+    out.push({
+      range: nodeRange(node),
+      severity: DiagnosticSeverity.Error,
+      source: "satsuma",
+      message: "Syntax error",
+    });
+    // Don't recurse into ERROR children — the parent ERROR is enough context
+    return;
+  }
+
+  if (node.isMissing) {
+    out.push({
+      range: nodeRange(node),
+      severity: DiagnosticSeverity.Error,
+      source: "satsuma",
+      message: `Expected ${node.type}`,
+    });
+    return;
+  }
+
+  for (const child of node.namedChildren) {
+    walkErrors(child, out);
+  }
+}
+
+/** Collect //! and //? comments as diagnostics. */
+function walkComments(node: SyntaxNode, out: Diagnostic[]): void {
+  // Comments are "extra" nodes in tree-sitter — they can appear at any level.
+  // Walk all children (not just named) to find them.
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+
+    if (child.type === "warning_comment") {
+      out.push({
+        range: nodeRange(child),
+        severity: DiagnosticSeverity.Warning,
+        source: "satsuma",
+        message: child.text.replace(/^\/\/!\s*/, ""),
+      });
+    } else if (child.type === "question_comment") {
+      out.push({
+        range: nodeRange(child),
+        severity: DiagnosticSeverity.Information,
+        source: "satsuma",
+        message: child.text.replace(/^\/\/\?\s*/, ""),
+      });
+    }
+
+    // Recurse into structural nodes to find nested comments
+    if (child.namedChildCount > 0) {
+      walkComments(child, out);
+    }
+  }
+}

--- a/tooling/vscode-satsuma/server/src/folding.ts
+++ b/tooling/vscode-satsuma/server/src/folding.ts
@@ -1,0 +1,50 @@
+import { FoldingRange, FoldingRangeKind } from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+
+/**
+ * Foldable node types — mirrors folds.scm.
+ *
+ * These are the CST node types that define foldable regions in VS Code.
+ */
+const FOLDABLE_TYPES = new Set([
+  "schema_block",
+  "fragment_block",
+  "transform_block",
+  "mapping_block",
+  "metric_block",
+  "note_block",
+  "namespace_block",
+  "each_block",
+  "flatten_block",
+  "metadata_block",
+  "nested_arrow",
+  "map_literal",
+]);
+
+/**
+ * Compute folding ranges from a tree-sitter parse tree.
+ * Only multi-line nodes produce fold ranges.
+ */
+export function computeFoldingRanges(tree: Tree): FoldingRange[] {
+  const ranges: FoldingRange[] = [];
+  walk(tree.rootNode, ranges);
+  return ranges;
+}
+
+function walk(node: SyntaxNode, out: FoldingRange[]): void {
+  if (FOLDABLE_TYPES.has(node.type)) {
+    const startLine = node.startPosition.row;
+    const endLine = node.endPosition.row;
+    if (endLine > startLine) {
+      out.push({
+        startLine,
+        endLine,
+        kind: FoldingRangeKind.Region,
+      });
+    }
+  }
+
+  for (const child of node.namedChildren) {
+    walk(child, out);
+  }
+}

--- a/tooling/vscode-satsuma/server/src/hover.ts
+++ b/tooling/vscode-satsuma/server/src/hover.ts
@@ -1,0 +1,376 @@
+import { Hover, MarkupKind } from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
+
+/**
+ * Compute hover information for the node at the given position.
+ *
+ * Per-file only — no workspace index.  Shows structural information
+ * derived from the CST: block summaries, field types, metadata, etc.
+ */
+export function computeHover(
+  tree: Tree,
+  line: number,
+  character: number,
+): Hover | null {
+  const node = tree.rootNode.descendantForPosition({
+    row: line,
+    column: character,
+  });
+  if (!node) return null;
+
+  // Walk up the tree to find a meaningful hover target
+  const result = hoverForNode(node, tree);
+  if (!result) return null;
+
+  return {
+    contents: { kind: MarkupKind.Markdown, value: result.markdown },
+    range: nodeRange(result.node),
+  };
+}
+
+interface HoverResult {
+  markdown: string;
+  node: SyntaxNode;
+}
+
+function hoverForNode(node: SyntaxNode, tree: Tree): HoverResult | null {
+  // Try the node itself and ancestors until we find something useful
+  let current: SyntaxNode | null = node;
+  while (current) {
+    const result = tryHover(current, tree);
+    if (result) return result;
+    current = current.parent;
+  }
+  return null;
+}
+
+function tryHover(node: SyntaxNode, tree: Tree): HoverResult | null {
+  switch (node.type) {
+    case "block_label":
+      return hoverBlockLabel(node);
+
+    case "field_name":
+      return hoverFieldName(node);
+
+    case "field_decl":
+      return hoverFieldDecl(node);
+
+    case "type_expr":
+      return hoverTypeExpr(node);
+
+    case "tag_token":
+      return hoverTag(node);
+
+    case "key_value_pair":
+      return hoverKeyValue(node);
+
+    case "fragment_spread":
+      return hoverSpread(node, tree);
+
+    case "spread_label":
+      return hoverSpread(node.parent!, tree);
+
+    case "src_path":
+    case "tgt_path":
+      return hoverArrowPath(node);
+
+    case "token_call":
+      return hoverTokenCall(node);
+
+    case "schema_block":
+    case "fragment_block":
+    case "mapping_block":
+    case "transform_block":
+    case "metric_block":
+    case "namespace_block":
+    case "note_block":
+      return hoverBlock(node);
+
+    default:
+      return null;
+  }
+}
+
+// ---------- Hover generators ----------
+
+function hoverBlockLabel(node: SyntaxNode): HoverResult | null {
+  const block = node.parent;
+  if (!block) return null;
+  return hoverBlock(block);
+}
+
+function hoverBlock(node: SyntaxNode): HoverResult | null {
+  const name = labelText(node) ?? "(anonymous)";
+  const blockType = node.type.replace("_block", "");
+
+  const lines: string[] = [];
+
+  switch (node.type) {
+    case "schema_block":
+    case "fragment_block": {
+      lines.push(`**${blockType}** \`${name}\``);
+      const body = child(node, "schema_body");
+      if (body) {
+        const fields = children(body, "field_decl");
+        const spreads = children(body, "fragment_spread");
+        lines.push(`${fields.length} field(s)${spreads.length > 0 ? `, ${spreads.length} spread(s)` : ""}`);
+        // Show field summary (first 8 fields)
+        const fieldSummary = fields.slice(0, 8).map((f) => {
+          const fn = child(f, "field_name");
+          const te = child(f, "type_expr");
+          const meta = collectMetadata(f);
+          let line = `- \`${fn?.text ?? "?"}\``;
+          if (te) line += ` ${te.text}`;
+          if (meta) line += ` *(${meta})*`;
+          return line;
+        });
+        if (fieldSummary.length > 0) {
+          lines.push("", ...fieldSummary);
+        }
+        if (fields.length > 8) {
+          lines.push(`- *…${fields.length - 8} more*`);
+        }
+      }
+      break;
+    }
+
+    case "mapping_block": {
+      lines.push(`**mapping** \`${name}\``);
+      const body = child(node, "mapping_body");
+      if (body) {
+        const sources = children(body, "source_block");
+        const targets = children(body, "target_block");
+        if (sources.length > 0 || targets.length > 0) {
+          const srcNames = sources.map((s) => backtickText(s)).filter(Boolean);
+          const tgtNames = targets.map((t) => backtickText(t)).filter(Boolean);
+          if (srcNames.length > 0) lines.push(`Source: ${srcNames.map((n) => `\`${n}\``).join(", ")}`);
+          if (tgtNames.length > 0) lines.push(`Target: ${tgtNames.map((n) => `\`${n}\``).join(", ")}`);
+        }
+      }
+      break;
+    }
+
+    case "transform_block": {
+      lines.push(`**transform** \`${name}\``);
+      // Transform body is a pipe_chain (not a named "transform_body")
+      const pipeChain = child(node, "pipe_chain");
+      if (pipeChain) {
+        const bodyText = pipeChain.text.trim();
+        if (bodyText.length > 0 && bodyText.length < 200) {
+          lines.push("```satsuma", bodyText, "```");
+        }
+      }
+      break;
+    }
+
+    case "metric_block": {
+      lines.push(`**metric** \`${name}\``);
+      const displayLabel = child(node, "nl_string");
+      if (displayLabel) {
+        lines.push(`Display: "${stringText(displayLabel)}"`);
+      }
+      const meta = child(node, "metadata_block");
+      if (meta) {
+        lines.push(`Metadata: ${meta.text.trim()}`);
+      }
+      break;
+    }
+
+    case "namespace_block": {
+      const nsName = node.childForFieldName("name");
+      lines.push(`**namespace** \`${nsName?.text ?? name}\``);
+      const blockChildren = node.namedChildren.filter((c) => c.type.endsWith("_block"));
+      if (blockChildren.length > 0) {
+        lines.push(`${blockChildren.length} block(s)`);
+      }
+      break;
+    }
+
+    case "note_block": {
+      lines.push("**note**");
+      const nlStr = child(node, "nl_string");
+      const mlStr = child(node, "multiline_string");
+      const text = stringText(nlStr) ?? stringText(mlStr);
+      if (text && text.length < 300) {
+        lines.push(text);
+      }
+      break;
+    }
+
+    default:
+      return null;
+  }
+
+  return { markdown: lines.join("\n"), node };
+}
+
+function hoverFieldName(node: SyntaxNode): HoverResult | null {
+  const fieldDecl = node.parent;
+  if (!fieldDecl || fieldDecl.type !== "field_decl") return null;
+  return hoverFieldDecl(fieldDecl);
+}
+
+function hoverFieldDecl(node: SyntaxNode): HoverResult | null {
+  const nameNode = child(node, "field_name");
+  const typeExpr = child(node, "type_expr");
+  const meta = collectMetadata(node);
+
+  const name = nameNode?.text ?? "?";
+  const lines: string[] = [];
+  lines.push(`**field** \`${name}\``);
+  if (typeExpr) lines.push(`Type: \`${typeExpr.text}\``);
+
+  // Check for record / list_of
+  const isList = node.children.some((c) => c.type === "list_of");
+  const isRecord = node.children.some((c) => c.type === "record");
+  if (isList && isRecord) lines.push("Structure: `list_of record`");
+  else if (isRecord) lines.push("Structure: `record`");
+  else if (isList) lines.push("Structure: `list_of`");
+
+  if (meta) lines.push(`Metadata: ${meta}`);
+
+  // Show parent schema/fragment name
+  const parent = findAncestorBlock(node);
+  if (parent) {
+    const parentName = labelText(parent) ?? "(anonymous)";
+    const parentType = parent.type.replace("_block", "");
+    lines.push(`In: \`${parentType} ${parentName}\``);
+  }
+
+  return { markdown: lines.join("\n"), node: nameNode ?? node };
+}
+
+function hoverTypeExpr(node: SyntaxNode): HoverResult | null {
+  return {
+    markdown: `**type** \`${node.text}\``,
+    node,
+  };
+}
+
+function hoverTag(node: SyntaxNode): HoverResult | null {
+  const tag = node.text;
+  const desc = TAG_DESCRIPTIONS[tag];
+  const lines = [`**tag** \`${tag}\``];
+  if (desc) lines.push(desc);
+  return { markdown: lines.join("\n"), node };
+}
+
+function hoverKeyValue(node: SyntaxNode): HoverResult | null {
+  const key = child(node, "kv_key");
+  const val = node.namedChildren.find((c) => c.type !== "kv_key");
+  if (!key) return null;
+  const lines = [`**metadata** \`${key.text}\``];
+  if (val) lines.push(`Value: \`${val.text}\``);
+  return { markdown: lines.join("\n"), node };
+}
+
+function hoverSpread(node: SyntaxNode, tree: Tree): HoverResult | null {
+  const label = child(node, "spread_label");
+  if (!label) return null;
+  const name = label.text;
+
+  // Try to find the fragment/transform definition in the same file
+  const root = tree.rootNode;
+  for (const block of root.namedChildren) {
+    if (block.type === "fragment_block" || block.type === "transform_block") {
+      const blockName = labelText(block);
+      if (blockName === name) {
+        const result = hoverBlock(block);
+        if (result) {
+          return { markdown: `**spread** \`...${name}\`\n\n${result.markdown}`, node: label };
+        }
+      }
+    }
+    // Check inside namespaces
+    if (block.type === "namespace_block") {
+      for (const nested of block.namedChildren) {
+        if (nested.type === "fragment_block" || nested.type === "transform_block") {
+          const blockName = labelText(nested);
+          if (blockName === name) {
+            const result = hoverBlock(nested);
+            if (result) {
+              return { markdown: `**spread** \`...${name}\`\n\n${result.markdown}`, node: label };
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return { markdown: `**spread** \`...${name}\``, node: label };
+}
+
+function hoverArrowPath(node: SyntaxNode): HoverResult | null {
+  const side = node.type === "src_path" ? "source" : "target";
+  return {
+    markdown: `**${side} path** \`${node.text}\``,
+    node,
+  };
+}
+
+function hoverTokenCall(node: SyntaxNode): HoverResult | null {
+  const name = child(node, "identifier");
+  if (!name) return null;
+  return {
+    markdown: `**transform function** \`${name.text}\``,
+    node,
+  };
+}
+
+// ---------- Helpers ----------
+
+/** Walk up from a node to find the enclosing schema/fragment/mapping block. */
+function findAncestorBlock(node: SyntaxNode): SyntaxNode | null {
+  let current = node.parent;
+  while (current) {
+    if (
+      current.type === "schema_block" ||
+      current.type === "fragment_block" ||
+      current.type === "mapping_block" ||
+      current.type === "transform_block" ||
+      current.type === "metric_block"
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+/** Collect metadata tags and key-value pairs from a field_decl. */
+function collectMetadata(node: SyntaxNode): string | null {
+  const meta = child(node, "metadata_block");
+  if (!meta) return null;
+  const parts: string[] = [];
+  for (const ch of meta.namedChildren) {
+    if (ch.type === "tag_token") parts.push(ch.text);
+    else if (ch.type === "key_value_pair") parts.push(ch.text);
+  }
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+/** Extract the reference name from a source/target block. */
+function backtickText(node: SyntaxNode): string | null {
+  for (const ch of node.namedChildren) {
+    if (ch.type === "source_ref" || ch.type === "backtick_name") return ch.text;
+  }
+  return null;
+}
+
+/** Built-in tag descriptions for hover. */
+const TAG_DESCRIPTIONS: Record<string, string> = {
+  pk: "Primary key — uniquely identifies each record",
+  pii: "Personally identifiable information — requires special handling",
+  required: "Field must not be null",
+  optional: "Field may be null",
+  unique: "Values must be unique across all records",
+  indexed: "Field is indexed for fast lookup",
+  deprecated: "Field is deprecated and should not be used in new mappings",
+  scd: "Slowly changing dimension — tracks historical changes",
+  scd2: "SCD Type 2 — maintains full history with start/end dates",
+  immutable: "Value cannot change after initial creation",
+  sensitive: "Contains sensitive data requiring access controls",
+  computed: "Value is derived/calculated, not directly sourced",
+  nullable: "Field explicitly allows null values",
+};

--- a/tooling/vscode-satsuma/server/src/parser-utils.ts
+++ b/tooling/vscode-satsuma/server/src/parser-utils.ts
@@ -1,0 +1,63 @@
+import {
+  Range,
+  Position,
+} from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+
+// ---------- tree-sitter initialisation ----------
+
+let _parser: InstanceType<typeof import("tree-sitter")> | null = null;
+
+export function getParser(): InstanceType<typeof import("tree-sitter")> {
+  if (_parser) return _parser;
+  // tree-sitter and tree-sitter-satsuma are CJS-only native addons
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Parser = require("tree-sitter");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Satsuma = require("tree-sitter-satsuma");
+  _parser = new Parser();
+  _parser!.setLanguage(Satsuma);
+  return _parser!;
+}
+
+export function parseSource(source: string): Tree {
+  return getParser().parse(source);
+}
+
+// ---------- CST → LSP helpers ----------
+
+/** Convert a tree-sitter node span to an LSP Range. */
+export function nodeRange(node: SyntaxNode): Range {
+  return Range.create(
+    Position.create(node.startPosition.row, node.startPosition.column),
+    Position.create(node.endPosition.row, node.endPosition.column),
+  );
+}
+
+/** First named child of the given type. */
+export function child(node: SyntaxNode, type: string): SyntaxNode | null {
+  return node.namedChildren.find((c) => c.type === type) ?? null;
+}
+
+/** All named children of the given type. */
+export function children(node: SyntaxNode, type: string): SyntaxNode[] {
+  return node.namedChildren.filter((c) => c.type === type);
+}
+
+/** Extract the display text from a block_label node. */
+export function labelText(node: SyntaxNode): string | null {
+  const lbl = child(node, "block_label");
+  if (!lbl) return null;
+  const inner = lbl.namedChildren[0];
+  if (!inner) return null;
+  if (inner.type === "quoted_name") return inner.text.slice(1, -1);
+  return inner.text;
+}
+
+/** Strip delimiters from an NL string or multiline string node. */
+export function stringText(node: SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  if (node.type === "multiline_string") return node.text.slice(3, -3).trim();
+  if (node.type === "nl_string") return node.text.slice(1, -1);
+  return node.text;
+}

--- a/tooling/vscode-satsuma/server/src/semantic-tokens.ts
+++ b/tooling/vscode-satsuma/server/src/semantic-tokens.ts
@@ -127,6 +127,10 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
   const query = getHighlightsQuery();
   const captures = query.captures(tree.rootNode);
 
+  // Pre-scan: identify nl_string/multiline_string nodes that contain backtick refs.
+  // These need split tokenisation instead of a single string token.
+  const nlRefNodes = collectNlRefNodes(tree.rootNode);
+
   // Sort captures by position (row, then column) — tree-sitter captures
   // should already be ordered, but ensure it for the delta encoding.
   captures.sort((a: { node: SyntaxNode }, b: { node: SyntaxNode }) => {
@@ -149,6 +153,12 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
     if (seen.has(key)) continue;
     seen.add(key);
 
+    // For NL strings with backtick refs, emit split tokens instead of one big string.
+    if (nlRefNodes.has(nodeId(node))) {
+      emitSplitStringTokens(node, builder);
+      continue;
+    }
+
     // Semantic tokens are single-line in the LSP protocol.
     // For multi-line nodes (like multiline strings), emit one token per line.
     const startRow = node.startPosition.row;
@@ -166,9 +176,7 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
         );
       }
     } else {
-      // Multi-line token: emit first line from start to end-of-line,
-      // and last line from 0 to end column.  We skip interior lines
-      // for simplicity — they'll fall back to TextMate scoping.
+      // Multi-line token: emit one token per source line.
       const sourceLines = node.text.split("\n");
       for (let i = 0; i < sourceLines.length; i++) {
         const line = startRow + i;
@@ -181,11 +189,6 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
     }
   }
 
-  // Emit extra tokens for backtick references inside NL strings.
-  // The grammar treats nl_string and multiline_string as atomic tokens,
-  // so we scan their text for `…` patterns and emit variable tokens.
-  emitNlRefTokens(tree.rootNode, builder, seen);
-
   return builder.build();
 }
 
@@ -193,74 +196,111 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
 
 const BACKTICK_REF_RE = /`([^`\\]*(?:\\.[^`\\]*)*)`/g;
 
+/** Unique identity for a CST node (by position). */
+function nodeId(node: SyntaxNode): string {
+  return `${node.startPosition.row}:${node.startPosition.column}:${node.endPosition.row}:${node.endPosition.column}`;
+}
+
 /**
- * Walk all nl_string and multiline_string nodes and emit semantic tokens
- * for backtick-quoted references within them.
+ * Pre-scan the tree and return the set of nodeId()s for nl_string and
+ * multiline_string nodes that contain at least one backtick reference.
  */
-function emitNlRefTokens(
-  root: SyntaxNode,
-  builder: SemanticTokensBuilder,
-  seen: Set<string>,
-): void {
+function collectNlRefNodes(root: SyntaxNode): Set<string> {
+  const result = new Set<string>();
   const cursor = root.walk();
   let reachedRoot = false;
 
   do {
     const node = cursor.currentNode;
     if (node.type === "nl_string" || node.type === "multiline_string") {
-      const text = node.text;
-      const startRow = node.startPosition.row;
-      const startCol = node.startPosition.column;
-
-      // Build a line offset map for multi-line strings
-      const lineOffsets: number[] = [0];
-      for (let i = 0; i < text.length; i++) {
-        if (text[i] === "\n") lineOffsets.push(i + 1);
-      }
-
       BACKTICK_REF_RE.lastIndex = 0;
-      let match: RegExpExecArray | null;
-      while ((match = BACKTICK_REF_RE.exec(text)) !== null) {
-        const offset = match.index;
-        // Find which line this offset falls on
-        let lineIdx = 0;
-        for (let l = lineOffsets.length - 1; l >= 0; l--) {
-          if (offset >= lineOffsets[l]!) {
-            lineIdx = l;
-            break;
-          }
-        }
-
-        const row = startRow + lineIdx;
-        const col =
-          lineIdx === 0
-            ? startCol + offset
-            : offset - lineOffsets[lineIdx]!;
-        const length = match[0].length;
-
-        const key = `${row}:${col}:${row}:${col + length}`;
-        if (!seen.has(key)) {
-          seen.add(key);
-          builder.push(
-            row,
-            col,
-            length,
-            3,  // variable
-            0,
-          );
-        }
+      if (BACKTICK_REF_RE.test(node.text)) {
+        result.add(nodeId(node));
       }
     }
-
-    // Depth-first traversal
     if (cursor.gotoFirstChild()) continue;
     if (cursor.gotoNextSibling()) continue;
     while (true) {
-      if (!cursor.gotoParent()) {
-        reachedRoot = true;
-        break;
-      }
+      if (!cursor.gotoParent()) { reachedRoot = true; break; }
       if (cursor.gotoNextSibling()) break;
     }
   } while (!reachedRoot);
+
+  return result;
+}
+
+/** Segment type for split string tokenisation. */
+interface Segment {
+  offset: number;    // byte offset within node text
+  length: number;
+  isRef: boolean;    // true = backtick ref (variable), false = string
+}
+
+/**
+ * For an nl_string or multiline_string that contains backtick refs,
+ * emit interleaved string and variable tokens instead of one big string token.
+ */
+function emitSplitStringTokens(
+  node: SyntaxNode,
+  builder: SemanticTokensBuilder,
+): void {
+  const text = node.text;
+  const startRow = node.startPosition.row;
+  const startCol = node.startPosition.column;
+
+  // Build line offset map for position calculation
+  const lineOffsets: number[] = [0];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === "\n") lineOffsets.push(i + 1);
+  }
+
+  // Build segments: alternating string and ref parts
+  const segments: Segment[] = [];
+  let lastEnd = 0;
+
+  BACKTICK_REF_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BACKTICK_REF_RE.exec(text)) !== null) {
+    // String part before this ref
+    if (match.index > lastEnd) {
+      segments.push({ offset: lastEnd, length: match.index - lastEnd, isRef: false });
+    }
+    // The backtick ref itself
+    segments.push({ offset: match.index, length: match[0].length, isRef: true });
+    lastEnd = match.index + match[0].length;
+  }
+  // Trailing string part
+  if (lastEnd < text.length) {
+    segments.push({ offset: lastEnd, length: text.length - lastEnd, isRef: false });
+  }
+
+  // Emit each segment, splitting across lines as needed
+  for (const seg of segments) {
+    const typeIndex = seg.isRef ? 3 : 5;  // variable or string
+    const segText = text.slice(seg.offset, seg.offset + seg.length);
+    const segLines = segText.split("\n");
+
+    // Find starting line for this segment
+    let segLineIdx = 0;
+    for (let l = lineOffsets.length - 1; l >= 0; l--) {
+      if (seg.offset >= lineOffsets[l]!) { segLineIdx = l; break; }
+    }
+
+    for (let i = 0; i < segLines.length; i++) {
+      const row = startRow + segLineIdx + i;
+      let col: number;
+      if (segLineIdx + i === 0) {
+        // First line of the node — offset relative to node start column
+        col = startCol + (i === 0 ? seg.offset : 0);
+      } else {
+        // Subsequent lines — offset from start of that line
+        const lineStartOffset = lineOffsets[segLineIdx + i]!;
+        col = (i === 0 ? seg.offset : lineStartOffset) - lineStartOffset;
+      }
+      const len = segLines[i]!.length;
+      if (len > 0) {
+        builder.push(row, col, len, typeIndex, 0);
+      }
+    }
+  }
 }

--- a/tooling/vscode-satsuma/server/src/semantic-tokens.ts
+++ b/tooling/vscode-satsuma/server/src/semantic-tokens.ts
@@ -181,5 +181,86 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
     }
   }
 
+  // Emit extra tokens for backtick references inside NL strings.
+  // The grammar treats nl_string and multiline_string as atomic tokens,
+  // so we scan their text for `…` patterns and emit variable tokens.
+  emitNlRefTokens(tree.rootNode, builder, seen);
+
   return builder.build();
+}
+
+// ---------- NL reference extraction ----------
+
+const BACKTICK_REF_RE = /`([^`\\]*(?:\\.[^`\\]*)*)`/g;
+
+/**
+ * Walk all nl_string and multiline_string nodes and emit semantic tokens
+ * for backtick-quoted references within them.
+ */
+function emitNlRefTokens(
+  root: SyntaxNode,
+  builder: SemanticTokensBuilder,
+  seen: Set<string>,
+): void {
+  const cursor = root.walk();
+  let reachedRoot = false;
+
+  do {
+    const node = cursor.currentNode;
+    if (node.type === "nl_string" || node.type === "multiline_string") {
+      const text = node.text;
+      const startRow = node.startPosition.row;
+      const startCol = node.startPosition.column;
+
+      // Build a line offset map for multi-line strings
+      const lineOffsets: number[] = [0];
+      for (let i = 0; i < text.length; i++) {
+        if (text[i] === "\n") lineOffsets.push(i + 1);
+      }
+
+      BACKTICK_REF_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = BACKTICK_REF_RE.exec(text)) !== null) {
+        const offset = match.index;
+        // Find which line this offset falls on
+        let lineIdx = 0;
+        for (let l = lineOffsets.length - 1; l >= 0; l--) {
+          if (offset >= lineOffsets[l]!) {
+            lineIdx = l;
+            break;
+          }
+        }
+
+        const row = startRow + lineIdx;
+        const col =
+          lineIdx === 0
+            ? startCol + offset
+            : offset - lineOffsets[lineIdx]!;
+        const length = match[0].length;
+
+        const key = `${row}:${col}:${row}:${col + length}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          builder.push(
+            row,
+            col,
+            length,
+            3,  // variable
+            0,
+          );
+        }
+      }
+    }
+
+    // Depth-first traversal
+    if (cursor.gotoFirstChild()) continue;
+    if (cursor.gotoNextSibling()) continue;
+    while (true) {
+      if (!cursor.gotoParent()) {
+        reachedRoot = true;
+        break;
+      }
+      if (cursor.gotoNextSibling()) break;
+    }
+  } while (!reachedRoot);
 }

--- a/tooling/vscode-satsuma/server/src/semantic-tokens.ts
+++ b/tooling/vscode-satsuma/server/src/semantic-tokens.ts
@@ -1,0 +1,185 @@
+import {
+  SemanticTokensBuilder,
+  SemanticTokenTypes,
+  SemanticTokenModifiers,
+  SemanticTokensLegend,
+} from "vscode-languageserver";
+import type { Tree, SyntaxNode } from "tree-sitter";
+
+// ---------- Legend ----------
+
+/** Ordered token types — index positions are referenced by the builder. */
+const tokenTypes: string[] = [
+  SemanticTokenTypes.keyword,       // 0
+  SemanticTokenTypes.type,          // 1
+  SemanticTokenTypes.function,      // 2
+  SemanticTokenTypes.variable,      // 3
+  SemanticTokenTypes.property,      // 4
+  SemanticTokenTypes.string,        // 5
+  SemanticTokenTypes.comment,       // 6
+  SemanticTokenTypes.decorator,     // 7
+  SemanticTokenTypes.namespace,     // 8
+  SemanticTokenTypes.operator,      // 9
+  SemanticTokenTypes.enumMember,    // 10
+  SemanticTokenTypes.number,        // 11 (unused, but standard)
+];
+
+/** Ordered token modifiers — bitmask positions. */
+const tokenModifiers: string[] = [
+  SemanticTokenModifiers.definition,    // 0
+  SemanticTokenModifiers.declaration,   // 1
+  SemanticTokenModifiers.readonly,      // 2
+  SemanticTokenModifiers.defaultLibrary,// 3
+];
+
+export const semanticTokensLegend: SemanticTokensLegend = {
+  tokenTypes,
+  tokenModifiers,
+};
+
+// ---------- Capture name → token type/modifier mapping ----------
+
+interface TokenMapping {
+  typeIndex: number;
+  modifierBits: number;
+}
+
+/**
+ * Map highlights.scm capture names to LSP semantic token type indices
+ * and modifier bitmasks.
+ */
+const CAPTURE_MAP: Record<string, TokenMapping> = {
+  // Keywords
+  "keyword":            { typeIndex: 0, modifierBits: 0 },
+  "keyword.import":     { typeIndex: 0, modifierBits: 0 },
+  "keyword.context":    { typeIndex: 0, modifierBits: 0 },
+  "keyword.operator":   { typeIndex: 0, modifierBits: 0 },
+
+  // Block labels — definitions
+  "type.definition":    { typeIndex: 1, modifierBits: 1 << 0 },  // type + definition
+  "function.definition":{ typeIndex: 2, modifierBits: 1 << 0 },  // function + definition
+  "module":             { typeIndex: 8, modifierBits: 0 },        // namespace
+
+  // Fields and variables
+  "variable.field":     { typeIndex: 4, modifierBits: 0 },        // property
+  "variable":           { typeIndex: 3, modifierBits: 0 },        // variable
+
+  // Types
+  "type":               { typeIndex: 1, modifierBits: 0 },
+
+  // Metadata / decorators
+  "attribute":          { typeIndex: 7, modifierBits: 0 },        // decorator
+
+  // Strings
+  "string":             { typeIndex: 5, modifierBits: 0 },
+  "string.special":     { typeIndex: 5, modifierBits: 0 },
+  "string.multiline":   { typeIndex: 5, modifierBits: 0 },
+  "string.path":        { typeIndex: 5, modifierBits: 0 },
+
+  // Comments
+  "comment":            { typeIndex: 6, modifierBits: 0 },
+  "comment.warning":    { typeIndex: 6, modifierBits: 0 },
+  "comment.question":   { typeIndex: 6, modifierBits: 0 },
+
+  // Constants (enum values, map keys/values, builtins)
+  "constant":           { typeIndex: 10, modifierBits: 0 },       // enumMember
+  "constant.builtin":   { typeIndex: 10, modifierBits: 1 << 3 },  // enumMember + defaultLibrary
+
+  // Operators / punctuation
+  "operator":           { typeIndex: 9, modifierBits: 0 },
+  "punctuation.bracket":{ typeIndex: 9, modifierBits: 0 },
+  "punctuation.delimiter":{ typeIndex: 9, modifierBits: 0 },
+
+  // Function calls (pipe chain tokens)
+  "function.call":      { typeIndex: 2, modifierBits: 0 },
+};
+
+// ---------- Query loading ----------
+
+let _query: InstanceType<typeof import("tree-sitter").Query> | null = null;
+
+function getHighlightsQuery(): InstanceType<typeof import("tree-sitter").Query> {
+  if (_query) return _query;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Parser = require("tree-sitter");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Satsuma = require("tree-sitter-satsuma");
+  const fs = require("fs");
+  const path = require("path");
+
+  // Resolve highlights.scm relative to tree-sitter-satsuma package
+  const satsumaDir = path.dirname(require.resolve("tree-sitter-satsuma/package.json"));
+  const queryPath = path.join(satsumaDir, "queries", "highlights.scm");
+  const querySource = fs.readFileSync(queryPath, "utf8");
+
+  _query = new Parser.Query(Satsuma, querySource);
+  return _query!;
+}
+
+// ---------- Public API ----------
+
+/**
+ * Compute semantic tokens from a tree-sitter parse tree using highlights.scm.
+ *
+ * Returns encoded tokens suitable for the LSP semanticTokens/full response.
+ */
+export function computeSemanticTokens(tree: Tree): { data: number[] } {
+  const query = getHighlightsQuery();
+  const captures = query.captures(tree.rootNode);
+
+  // Sort captures by position (row, then column) — tree-sitter captures
+  // should already be ordered, but ensure it for the delta encoding.
+  captures.sort((a: { node: SyntaxNode }, b: { node: SyntaxNode }) => {
+    const rowDiff = a.node.startPosition.row - b.node.startPosition.row;
+    if (rowDiff !== 0) return rowDiff;
+    return a.node.startPosition.column - b.node.startPosition.column;
+  });
+
+  // Deduplicate: when multiple captures match the same span, keep the first
+  // (most specific due to highlights.scm ordering).
+  const seen = new Set<string>();
+  const builder = new SemanticTokensBuilder();
+
+  for (const capture of captures as Array<{ name: string; node: SyntaxNode }>) {
+    const mapping = CAPTURE_MAP[capture.name];
+    if (!mapping) continue;
+
+    const node = capture.node;
+    const key = `${node.startPosition.row}:${node.startPosition.column}:${node.endPosition.row}:${node.endPosition.column}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    // Semantic tokens are single-line in the LSP protocol.
+    // For multi-line nodes (like multiline strings), emit one token per line.
+    const startRow = node.startPosition.row;
+    const endRow = node.endPosition.row;
+
+    if (startRow === endRow) {
+      const length = node.endPosition.column - node.startPosition.column;
+      if (length > 0) {
+        builder.push(
+          startRow,
+          node.startPosition.column,
+          length,
+          mapping.typeIndex,
+          mapping.modifierBits,
+        );
+      }
+    } else {
+      // Multi-line token: emit first line from start to end-of-line,
+      // and last line from 0 to end column.  We skip interior lines
+      // for simplicity — they'll fall back to TextMate scoping.
+      const sourceLines = node.text.split("\n");
+      for (let i = 0; i < sourceLines.length; i++) {
+        const line = startRow + i;
+        const col = i === 0 ? node.startPosition.column : 0;
+        const len = sourceLines[i]!.length;
+        if (len > 0) {
+          builder.push(line, col, len, mapping.typeIndex, mapping.modifierBits);
+        }
+      }
+    }
+  }
+
+  return builder.build();
+}

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -11,6 +11,8 @@ import { getParser } from "./parser-utils";
 import { computeDiagnostics } from "./diagnostics";
 import { computeDocumentSymbols } from "./symbols";
 import { computeFoldingRanges } from "./folding";
+import { computeSemanticTokens, semanticTokensLegend } from "./semantic-tokens";
+import { computeHover } from "./hover";
 
 // ---------- Connection setup ----------
 
@@ -28,6 +30,11 @@ connection.onInitialize((): InitializeResult => {
       textDocumentSync: TextDocumentSyncKind.Full,
       documentSymbolProvider: true,
       foldingRangeProvider: true,
+      semanticTokensProvider: {
+        legend: semanticTokensLegend,
+        full: true,
+      },
+      hoverProvider: true,
     },
   };
 });
@@ -63,6 +70,18 @@ connection.onFoldingRanges((params) => {
   const tree = trees.get(params.textDocument.uri);
   if (!tree) return [];
   return computeFoldingRanges(tree);
+});
+
+connection.onRequest("textDocument/semanticTokens/full", (params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return { data: [] };
+  return computeSemanticTokens(tree);
+});
+
+connection.onHover((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return null;
+  return computeHover(tree, params.position.line, params.position.character);
 });
 
 // ---------- Helpers ----------

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -1,0 +1,78 @@
+import {
+  createConnection,
+  ProposedFeatures,
+  TextDocuments,
+  TextDocumentSyncKind,
+  InitializeResult,
+} from "vscode-languageserver/node";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import type { Tree } from "tree-sitter";
+import { getParser } from "./parser-utils";
+import { computeDiagnostics } from "./diagnostics";
+import { computeDocumentSymbols } from "./symbols";
+import { computeFoldingRanges } from "./folding";
+
+// ---------- Connection setup ----------
+
+const connection = createConnection(ProposedFeatures.all);
+const documents = new TextDocuments(TextDocument);
+
+// Per-document parse tree cache
+const trees = new Map<string, Tree>();
+
+// ---------- Initialisation ----------
+
+connection.onInitialize((): InitializeResult => {
+  return {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Full,
+      documentSymbolProvider: true,
+      foldingRangeProvider: true,
+    },
+  };
+});
+
+// ---------- Document lifecycle ----------
+
+documents.onDidChangeContent((change) => {
+  const tree = parseDocument(change.document);
+  trees.set(change.document.uri, tree);
+
+  const diagnostics = computeDiagnostics(tree);
+  connection.sendDiagnostics({
+    uri: change.document.uri,
+    diagnostics,
+  });
+});
+
+documents.onDidClose((event) => {
+  trees.delete(event.document.uri);
+  // Clear diagnostics for closed documents
+  connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+});
+
+// ---------- Feature handlers ----------
+
+connection.onDocumentSymbol((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return [];
+  return computeDocumentSymbols(tree);
+});
+
+connection.onFoldingRanges((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return [];
+  return computeFoldingRanges(tree);
+});
+
+// ---------- Helpers ----------
+
+function parseDocument(doc: TextDocument): Tree {
+  const parser = getParser();
+  return parser.parse(doc.getText());
+}
+
+// ---------- Start ----------
+
+documents.listen(connection);
+connection.listen();

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -13,6 +13,7 @@ import { computeDocumentSymbols } from "./symbols";
 import { computeFoldingRanges } from "./folding";
 import { computeSemanticTokens, semanticTokensLegend } from "./semantic-tokens";
 import { computeHover } from "./hover";
+import { runValidate } from "./validate-diagnostics";
 
 // ---------- Connection setup ----------
 
@@ -22,12 +23,28 @@ const documents = new TextDocuments(TextDocument);
 // Per-document parse tree cache
 const trees = new Map<string, Tree>();
 
+// Per-document validate diagnostics cache (keyed by URI)
+const validateDiagCache = new Map<string, import("vscode-languageserver").Diagnostic[]>();
+
+// CLI path resolved at initialization
+let cliPath = "satsuma";
+
 // ---------- Initialisation ----------
 
-connection.onInitialize((): InitializeResult => {
+connection.onInitialize((params): InitializeResult => {
+  // Accept CLI path from client initialization options
+  const initOptions = params.initializationOptions;
+  if (initOptions?.cliPath && typeof initOptions.cliPath === "string") {
+    cliPath = initOptions.cliPath;
+  }
+
   return {
     capabilities: {
-      textDocumentSync: TextDocumentSyncKind.Full,
+      textDocumentSync: {
+        openClose: true,
+        change: TextDocumentSyncKind.Full,
+        save: true,
+      },
       documentSymbolProvider: true,
       foldingRangeProvider: true,
       semanticTokensProvider: {
@@ -45,17 +62,44 @@ documents.onDidChangeContent((change) => {
   const tree = parseDocument(change.document);
   trees.set(change.document.uri, tree);
 
-  const diagnostics = computeDiagnostics(tree);
-  connection.sendDiagnostics({
-    uri: change.document.uri,
-    diagnostics,
-  });
+  // Recompute parse diagnostics and merge with cached validate diagnostics
+  sendMergedDiagnostics(change.document.uri, tree);
 });
 
 documents.onDidClose((event) => {
   trees.delete(event.document.uri);
+  validateDiagCache.delete(event.document.uri);
   // Clear diagnostics for closed documents
   connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+});
+
+// Run satsuma validate on save
+documents.onDidSave(async (event) => {
+  try {
+    const diagsByUri = await runValidate(event.document.uri, cliPath);
+
+    // Update cache: clear stale entries for files no longer reporting
+    // Only clear for the saved file — other files keep their cached diagnostics
+    validateDiagCache.delete(event.document.uri);
+
+    for (const [uri, diags] of diagsByUri) {
+      validateDiagCache.set(uri, diags);
+
+      // For the currently open document, merge with parse diagnostics
+      const tree = trees.get(uri);
+      if (tree) {
+        sendMergedDiagnostics(uri, tree);
+      }
+    }
+
+    // If saved file had validate diagnostics before but now has none, refresh
+    const tree = trees.get(event.document.uri);
+    if (tree && !diagsByUri.has(event.document.uri)) {
+      sendMergedDiagnostics(event.document.uri, tree);
+    }
+  } catch {
+    // CLI not available or errored — parse diagnostics still work
+  }
 });
 
 // ---------- Feature handlers ----------
@@ -89,6 +133,16 @@ connection.onHover((params) => {
 function parseDocument(doc: TextDocument): Tree {
   const parser = getParser();
   return parser.parse(doc.getText());
+}
+
+/** Send parse diagnostics merged with cached validate diagnostics. */
+function sendMergedDiagnostics(uri: string, tree: Tree): void {
+  const parseDiags = computeDiagnostics(tree);
+  const validateDiags = validateDiagCache.get(uri) ?? [];
+  connection.sendDiagnostics({
+    uri,
+    diagnostics: [...parseDiags, ...validateDiags],
+  });
 }
 
 // ---------- Start ----------

--- a/tooling/vscode-satsuma/server/src/symbols.ts
+++ b/tooling/vscode-satsuma/server/src/symbols.ts
@@ -1,0 +1,232 @@
+import {
+  DocumentSymbol,
+  SymbolKind,
+} from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
+
+/** Map of CST block type → LSP SymbolKind. */
+const BLOCK_SYMBOL_KIND: Record<string, SymbolKind> = {
+  schema_block: SymbolKind.Class,
+  fragment_block: SymbolKind.Interface,
+  mapping_block: SymbolKind.Function,
+  transform_block: SymbolKind.Function,
+  metric_block: SymbolKind.Constant,
+  namespace_block: SymbolKind.Namespace,
+  note_block: SymbolKind.File,
+  import_decl: SymbolKind.Package,
+};
+
+/** Block types whose bodies contain field declarations. */
+const FIELD_BEARING_BLOCKS = new Set(["schema_block", "fragment_block"]);
+
+/**
+ * Build a DocumentSymbol tree from the parse tree.
+ * Returns top-level symbols with fields/nested blocks as children.
+ */
+export function computeDocumentSymbols(tree: Tree): DocumentSymbol[] {
+  return symbolsFromNodes(tree.rootNode.namedChildren);
+}
+
+function symbolsFromNodes(nodes: SyntaxNode[]): DocumentSymbol[] {
+  const symbols: DocumentSymbol[] = [];
+  for (const node of nodes) {
+    const kind = BLOCK_SYMBOL_KIND[node.type];
+    if (kind === undefined) continue;
+
+    const sym = blockSymbol(node, kind);
+    if (sym) symbols.push(sym);
+  }
+  return symbols;
+}
+
+function blockSymbol(node: SyntaxNode, kind: SymbolKind): DocumentSymbol | null {
+  const name = symbolName(node);
+  if (!name) return null;
+
+  const lblNode = child(node, "block_label");
+  const selectionRange = lblNode ? nodeRange(lblNode) : nodeRange(node);
+  const detail = symbolDetail(node);
+
+  const sym: DocumentSymbol = {
+    name,
+    kind,
+    range: nodeRange(node),
+    selectionRange,
+    children: [],
+  };
+
+  if (detail) {
+    sym.detail = detail;
+  }
+
+  // Namespace blocks contain nested definitions
+  if (node.type === "namespace_block") {
+    sym.children = symbolsFromNodes(node.namedChildren);
+  }
+
+  // Schema and fragment blocks contain field declarations
+  if (FIELD_BEARING_BLOCKS.has(node.type)) {
+    const body = child(node, "schema_body");
+    if (body) {
+      sym.children = fieldSymbols(body);
+    }
+  }
+
+  // Mapping blocks — show source/target/arrow structure as children
+  if (node.type === "mapping_block") {
+    const body = child(node, "mapping_body");
+    if (body) {
+      sym.children = mappingChildSymbols(body);
+    }
+  }
+
+  return sym;
+}
+
+/** Extract field declarations as DocumentSymbol children. */
+function fieldSymbols(body: SyntaxNode): DocumentSymbol[] {
+  const symbols: DocumentSymbol[] = [];
+  for (const fieldNode of children(body, "field_decl")) {
+    const nameNode = child(fieldNode, "field_name");
+    if (!nameNode) continue;
+
+    const fieldName = fieldNameText(nameNode);
+    if (!fieldName) continue;
+
+    const typeExpr = child(fieldNode, "type_expr");
+    const nestedBody = child(fieldNode, "schema_body");
+
+    // Determine if this is a record/list_of record (nested structure)
+    const isNested = nestedBody !== null;
+    const isList = fieldNode.children.some((c) => c.type === "list_of");
+    const isRecord = fieldNode.children.some(
+      (c) => c.type === "record" || (c.type === "list_of" && fieldNode.children.some((d) => d.type === "record")),
+    );
+
+    let detail: string | undefined;
+    if (isList && isRecord) {
+      detail = "list_of record";
+    } else if (isRecord) {
+      detail = "record";
+    } else if (isList && typeExpr) {
+      detail = `list_of ${typeExpr.text}`;
+    } else if (typeExpr) {
+      detail = typeExpr.text;
+    }
+
+    const sym: DocumentSymbol = {
+      name: fieldName,
+      kind: isNested ? SymbolKind.Struct : SymbolKind.Field,
+      range: nodeRange(fieldNode),
+      selectionRange: nodeRange(nameNode),
+      children: [],
+    };
+
+    if (detail) {
+      sym.detail = detail;
+    }
+
+    // Recurse into nested record bodies
+    if (nestedBody) {
+      sym.children = fieldSymbols(nestedBody);
+    }
+
+    symbols.push(sym);
+  }
+
+  // Fragment spreads
+  for (const spread of children(body, "fragment_spread")) {
+    const spreadLabel = child(spread, "spread_label");
+    const spreadName = spreadLabel ? spreadLabelText(spreadLabel) : null;
+    if (spreadName) {
+      symbols.push({
+        name: `...${spreadName}`,
+        kind: SymbolKind.Field,
+        range: nodeRange(spread),
+        selectionRange: nodeRange(spread),
+        children: [],
+        detail: "spread",
+      });
+    }
+  }
+
+  return symbols;
+}
+
+/** Extract mapping body children as symbols (source, target blocks). */
+function mappingChildSymbols(body: SyntaxNode): DocumentSymbol[] {
+  const symbols: DocumentSymbol[] = [];
+
+  for (const ch of body.namedChildren) {
+    if (ch.type === "source_block") {
+      symbols.push({
+        name: "source",
+        kind: SymbolKind.Property,
+        range: nodeRange(ch),
+        selectionRange: nodeRange(ch),
+        children: [],
+      });
+    } else if (ch.type === "target_block") {
+      symbols.push({
+        name: "target",
+        kind: SymbolKind.Property,
+        range: nodeRange(ch),
+        selectionRange: nodeRange(ch),
+        children: [],
+      });
+    } else if (ch.type === "note_block") {
+      symbols.push({
+        name: "note",
+        kind: SymbolKind.File,
+        range: nodeRange(ch),
+        selectionRange: nodeRange(ch),
+        children: [],
+      });
+    }
+  }
+
+  return symbols;
+}
+
+// ---------- Name extraction helpers ----------
+
+function symbolName(node: SyntaxNode): string | null {
+  switch (node.type) {
+    case "note_block":
+      return "note";
+    case "import_decl": {
+      const pathNode = child(node, "import_path");
+      const pathStr = pathNode ? stringText(pathNode.namedChildren[0]) : null;
+      return pathStr ? `import "${pathStr}"` : "import";
+    }
+    default:
+      return labelText(node) ?? "(anonymous)";
+  }
+}
+
+function symbolDetail(node: SyntaxNode): string | undefined {
+  if (node.type === "metric_block") {
+    // Metric display label is the nl_string directly under the metric block
+    const displayLabel = child(node, "nl_string");
+    if (displayLabel) {
+      return stringText(displayLabel) ?? undefined;
+    }
+  }
+  return undefined;
+}
+
+function fieldNameText(nameNode: SyntaxNode): string | null {
+  const inner = nameNode.namedChildren[0];
+  if (!inner) return nameNode.text;
+  if (inner.type === "backtick_name") return inner.text;
+  return inner.text;
+}
+
+function spreadLabelText(node: SyntaxNode): string | null {
+  // spread_label can contain identifier, quoted_name, or qualified_name
+  const inner = node.namedChildren[0];
+  if (!inner) return node.text;
+  if (inner.type === "quoted_name") return inner.text.slice(1, -1);
+  return inner.text;
+}

--- a/tooling/vscode-satsuma/server/src/validate-diagnostics.ts
+++ b/tooling/vscode-satsuma/server/src/validate-diagnostics.ts
@@ -1,0 +1,101 @@
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  Range,
+  Position,
+} from "vscode-languageserver";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+/** Shape of a single entry from `satsuma validate --json`. */
+interface ValidateEntry {
+  file: string;
+  line: number;
+  column: number;
+  severity: "error" | "warning" | "info";
+  rule: string;
+  message: string;
+  fixable: boolean;
+}
+
+const SEVERITY_MAP: Record<string, DiagnosticSeverity> = {
+  error: DiagnosticSeverity.Error,
+  warning: DiagnosticSeverity.Warning,
+  info: DiagnosticSeverity.Information,
+};
+
+/**
+ * Run `satsuma validate --json` on the directory containing the given file
+ * and return LSP diagnostics grouped by file URI.
+ *
+ * The CLI validates at directory scope so cross-file checks (undefined refs,
+ * missing imports) work correctly.
+ */
+export async function runValidate(
+  fileUri: string,
+  cliPath: string,
+): Promise<Map<string, Diagnostic[]>> {
+  const filePath = fileURLToPath(fileUri);
+
+  return new Promise((resolve) => {
+    execFile(
+      cliPath,
+      ["validate", "--json", filePath],
+      { timeout: 15_000 },
+      (_error, stdout, _stderr) => {
+        const result = new Map<string, Diagnostic[]>();
+        // Parse stdout even on non-zero exit (validate returns 2 on errors)
+        const raw = stdout.trim();
+        if (!raw) {
+          resolve(result);
+          return;
+        }
+
+        let entries: ValidateEntry[];
+        try {
+          entries = JSON.parse(raw);
+        } catch {
+          resolve(result);
+          return;
+        }
+
+        if (!Array.isArray(entries)) {
+          resolve(result);
+          return;
+        }
+
+        for (const entry of entries) {
+          const uri = pathToFileUri(entry.file);
+          // validate lines are 1-based; LSP is 0-based
+          const line = Math.max(0, entry.line - 1);
+          const col = Math.max(0, entry.column - 1);
+
+          const diag: Diagnostic = {
+            range: Range.create(
+              Position.create(line, col),
+              Position.create(line, col),
+            ),
+            severity: SEVERITY_MAP[entry.severity] ?? DiagnosticSeverity.Warning,
+            source: "satsuma-validate",
+            code: entry.rule,
+            message: entry.message,
+          };
+
+          const existing = result.get(uri);
+          if (existing) {
+            existing.push(diag);
+          } else {
+            result.set(uri, [diag]);
+          }
+        }
+
+        resolve(result);
+      },
+    );
+  });
+}
+
+function pathToFileUri(fsPath: string): string {
+  // Use a simple conversion — the file paths from validate are absolute
+  return "file://" + encodeURI(fsPath).replace(/#/g, "%23");
+}

--- a/tooling/vscode-satsuma/server/test/diagnostics.test.js
+++ b/tooling/vscode-satsuma/server/test/diagnostics.test.js
@@ -1,0 +1,77 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { computeDiagnostics } = require("../dist/diagnostics");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+describe("computeDiagnostics", () => {
+  it("returns empty diagnostics for valid input", () => {
+    const tree = parse(`schema customers {
+  customer_id UUID (pk)
+  name VARCHAR(200)
+}`);
+    const diags = computeDiagnostics(tree);
+    const errors = diags.filter((d) => d.severity === 1); // Error
+    assert.equal(errors.length, 0);
+  });
+
+  it("reports syntax errors for invalid input", () => {
+    const tree = parse("schema { }"); // missing block label
+    const diags = computeDiagnostics(tree);
+    const errors = diags.filter((d) => d.severity === 1); // Error
+    assert.ok(errors.length > 0, "Expected at least one error diagnostic");
+  });
+
+  it("reports warning comments as Warning severity", () => {
+    const tree = parse(`schema foo {
+  bar STRING //! known issue with this field
+}`);
+    const diags = computeDiagnostics(tree);
+    const warnings = diags.filter((d) => d.severity === 2); // Warning
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0].message, /known issue/);
+  });
+
+  it("reports question comments as Information severity", () => {
+    const tree = parse(`schema foo {
+  bar STRING //? should this be INT?
+}`);
+    const diags = computeDiagnostics(tree);
+    const infos = diags.filter((d) => d.severity === 3); // Information
+    assert.equal(infos.length, 1);
+    assert.match(infos[0].message, /should this be INT/);
+  });
+
+  it("sets source to 'satsuma' on all diagnostics", () => {
+    const tree = parse(`schema { }
+//! warning
+//? question`);
+    const diags = computeDiagnostics(tree);
+    assert.ok(diags.length > 0);
+    for (const d of diags) {
+      assert.equal(d.source, "satsuma");
+    }
+  });
+
+  it("handles files with no blocks gracefully", () => {
+    const tree = parse("");
+    const diags = computeDiagnostics(tree);
+    assert.deepEqual(diags, []);
+  });
+
+  it("includes correct line/column range for errors", () => {
+    const tree = parse("schema { }");
+    const diags = computeDiagnostics(tree);
+    const errors = diags.filter((d) => d.severity === 1);
+    assert.ok(errors.length > 0);
+    // Error should be on line 0
+    assert.equal(errors[0].range.start.line, 0);
+  });
+});

--- a/tooling/vscode-satsuma/server/test/folding.test.js
+++ b/tooling/vscode-satsuma/server/test/folding.test.js
@@ -1,0 +1,105 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { computeFoldingRanges } = require("../dist/folding");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+describe("computeFoldingRanges", () => {
+  it("returns fold ranges for schema blocks", () => {
+    const tree = parse(`schema customers {
+  id UUID (pk)
+  name VARCHAR(200)
+}`);
+    const ranges = computeFoldingRanges(tree);
+    assert.ok(ranges.length >= 1);
+    const schemaFold = ranges.find((r) => r.startLine === 0);
+    assert.ok(schemaFold, "Expected a fold starting at line 0");
+    assert.equal(schemaFold.endLine, 3);
+  });
+
+  it("returns fold ranges for multiple block types", () => {
+    const tree = parse(`schema foo {
+  a STRING
+}
+
+fragment 'bar' {
+  b INT
+}
+
+mapping 'baz' {
+  source { \`foo\` }
+  target { \`foo\` }
+  a -> a
+}`);
+    const ranges = computeFoldingRanges(tree);
+    // At least 3 top-level blocks
+    const topLevelFolds = ranges.filter((r) => r.startLine === 0 || r.startLine === 4 || r.startLine === 8);
+    assert.ok(topLevelFolds.length >= 3, `Expected 3+ top-level folds, got ${topLevelFolds.length}`);
+  });
+
+  it("returns fold ranges for nested structures", () => {
+    const tree = parse(`schema order {
+  customer record {
+    id STRING
+    email STRING
+  }
+}`);
+    const ranges = computeFoldingRanges(tree);
+    // Should have at least schema fold and no separate record fold (record is part of field_decl)
+    assert.ok(ranges.length >= 1);
+  });
+
+  it("does not fold single-line blocks", () => {
+    // A single-line construct should not produce a fold
+    const tree = parse("schema foo { a STRING }");
+    const ranges = computeFoldingRanges(tree);
+    const singleLine = ranges.filter((r) => r.startLine === r.endLine);
+    assert.equal(singleLine.length, 0, "Single-line blocks should not be foldable");
+  });
+
+  it("handles empty files", () => {
+    const tree = parse("");
+    const ranges = computeFoldingRanges(tree);
+    assert.deepEqual(ranges, []);
+  });
+
+  it("folds each/flatten blocks inside mappings", () => {
+    const tree = parse(`mapping {
+  source { \`src\` }
+  target { \`tgt\` }
+
+  each items -> target_items {
+    .sku -> .sku
+    .qty -> .qty
+  }
+}`);
+    const ranges = computeFoldingRanges(tree);
+    // Should have fold for mapping and for each block
+    const eachFold = ranges.find((r) => r.startLine === 4);
+    assert.ok(eachFold, "Expected a fold for the each block");
+  });
+
+  it("folds map literal blocks", () => {
+    const tree = parse(`mapping {
+  source { \`src\` }
+  target { \`tgt\` }
+
+  status -> status {
+    map {
+      A: "active"
+      S: "suspended"
+    }
+  }
+}`);
+    const ranges = computeFoldingRanges(tree);
+    const mapFold = ranges.find((r) => r.startLine === 5);
+    assert.ok(mapFold, "Expected a fold for the map literal");
+  });
+});

--- a/tooling/vscode-satsuma/server/test/hover.test.js
+++ b/tooling/vscode-satsuma/server/test/hover.test.js
@@ -1,0 +1,202 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { computeHover } = require("../dist/hover");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+/** Shorthand: get the markdown hover text at a position. */
+function hover(source, line, col) {
+  const tree = parse(source);
+  const result = computeHover(tree, line, col);
+  return result?.contents?.value ?? null;
+}
+
+describe("computeHover", () => {
+  it("returns null for empty files", () => {
+    assert.equal(hover("", 0, 0), null);
+  });
+
+  it("shows schema summary on block label", () => {
+    const md = hover(
+      "schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}",
+      0,
+      8,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**schema** `customers`"));
+    assert.ok(md.includes("2 field(s)"));
+    assert.ok(md.includes("`id`"));
+    assert.ok(md.includes("UUID"));
+    assert.ok(md.includes("*(pk)*"));
+  });
+
+  it("shows fragment summary on block label", () => {
+    const md = hover(
+      "fragment audit {\n  created_at TIMESTAMPTZ\n  updated_at TIMESTAMPTZ\n}",
+      0,
+      10,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**fragment** `audit`"));
+    assert.ok(md.includes("2 field(s)"));
+  });
+
+  it("shows field info with type and parent", () => {
+    const md = hover(
+      "schema customers {\n  email VARCHAR(255) (pii)\n}",
+      1,
+      3,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**field** `email`"));
+    assert.ok(md.includes("Type: `VARCHAR(255)`"));
+    assert.ok(md.includes("Metadata: pii"));
+    assert.ok(md.includes("In: `schema customers`"));
+  });
+
+  it("shows type info on type expression", () => {
+    const md = hover("schema foo {\n  id UUID\n}", 1, 6);
+    assert.ok(md);
+    assert.ok(md.includes("**type** `UUID`"));
+  });
+
+  it("shows tag description for known tags", () => {
+    const md = hover("schema foo {\n  id UUID (pk)\n}", 1, 12);
+    assert.ok(md);
+    assert.ok(md.includes("**tag** `pk`"));
+    assert.ok(md.includes("Primary key"));
+  });
+
+  it("shows mapping summary with source and target", () => {
+    const md = hover(
+      "mapping migrate {\n  source { `legacy` }\n  target { `new_db` }\n  old_id -> new_id\n}",
+      0,
+      9,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**mapping** `migrate`"));
+    assert.ok(md.includes("Source:"));
+    assert.ok(md.includes("Target:"));
+  });
+
+  it("shows transform summary with body", () => {
+    const md = hover(
+      "transform clean {\n  trim | lowercase\n}",
+      0,
+      11,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**transform** `clean`"));
+    assert.ok(md.includes("trim"));
+  });
+
+  it("shows metric summary with display label", () => {
+    const md = hover(
+      'metric mrr "MRR" (source fact_sub, grain monthly) {\n  value DECIMAL\n}',
+      0,
+      8,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**metric** `mrr`"));
+    assert.ok(md.includes('Display: "MRR"'));
+  });
+
+  it("shows spread info with resolved fragment", () => {
+    const source = [
+      "fragment audit {",
+      "  created_at TIMESTAMPTZ",
+      "  updated_at TIMESTAMPTZ",
+      "}",
+      "",
+      "schema orders {",
+      "  id UUID (pk)",
+      "  ...audit",
+      "}",
+    ].join("\n");
+    const md = hover(source, 7, 5);
+    assert.ok(md);
+    assert.ok(md.includes("**spread** `...audit`"));
+    assert.ok(md.includes("**fragment** `audit`"));
+    assert.ok(md.includes("2 field(s)"));
+  });
+
+  it("shows spread label for unresolved fragment", () => {
+    const md = hover("schema foo {\n  ...unknown\n}", 1, 5);
+    assert.ok(md);
+    assert.ok(md.includes("**spread** `...unknown`"));
+  });
+
+  it("shows arrow path info", () => {
+    const md = hover(
+      "mapping m {\n  source { `src` }\n  target { `tgt` }\n  old_id -> new_id\n}",
+      3,
+      3,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**source path**"));
+  });
+
+  it("shows target arrow path info", () => {
+    const md = hover(
+      "mapping m {\n  source { `src` }\n  target { `tgt` }\n  old_id -> new_id\n}",
+      3,
+      14,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**target path**"));
+  });
+
+  it("shows namespace info", () => {
+    const md = hover(
+      "namespace crm {\n  schema customers {\n    id UUID\n  }\n}",
+      0,
+      11,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**namespace** `crm`"));
+  });
+
+  it("shows note block info", () => {
+    const md = hover('note {\n  "This is documentation"\n}', 0, 1);
+    assert.ok(md);
+    assert.ok(md.includes("**note**"));
+  });
+
+  it("returns hover range pointing to the target node", () => {
+    const tree = parse("schema customers {\n  id UUID\n}");
+    const result = computeHover(tree, 0, 8);
+    assert.ok(result);
+    assert.ok(result.range);
+    // Range should cover the schema_block
+    assert.equal(result.range.start.line, 0);
+  });
+
+  it("handles nested record fields", () => {
+    const md = hover(
+      "schema order {\n  address record {\n    street STRING\n    city STRING\n  }\n}",
+      1,
+      3,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**field** `address`"));
+    assert.ok(md.includes("Structure: `record`"));
+  });
+
+  it("handles list_of record fields", () => {
+    const md = hover(
+      "schema order {\n  items list_of record {\n    sku STRING\n  }\n}",
+      1,
+      3,
+    );
+    assert.ok(md);
+    assert.ok(md.includes("**field** `items`"));
+    assert.ok(md.includes("Structure: `list_of record`"));
+  });
+});

--- a/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
+++ b/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
@@ -1,0 +1,187 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const {
+  computeSemanticTokens,
+  semanticTokensLegend,
+} = require("../dist/semantic-tokens");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+/**
+ * Decode the delta-encoded semantic tokens data into readable objects.
+ * Each token is 5 ints: deltaLine, deltaStartChar, length, tokenType, tokenModifiers.
+ */
+function decodeTokens(data) {
+  const tokens = [];
+  let line = 0;
+  let col = 0;
+  for (let i = 0; i < data.length; i += 5) {
+    const dLine = data[i];
+    const dCol = data[i + 1];
+    const len = data[i + 2];
+    const typeIdx = data[i + 3];
+    const mods = data[i + 4];
+
+    if (dLine > 0) {
+      line += dLine;
+      col = dCol;
+    } else {
+      col += dCol;
+    }
+
+    tokens.push({
+      line,
+      col,
+      length: len,
+      type: semanticTokensLegend.tokenTypes[typeIdx],
+      mods,
+    });
+  }
+  return tokens;
+}
+
+describe("computeSemanticTokens", () => {
+  it("returns empty data for empty files", () => {
+    const tree = parse("");
+    const result = computeSemanticTokens(tree);
+    assert.deepEqual(result.data, []);
+  });
+
+  it("tokenizes schema keyword and label", () => {
+    const tree = parse("schema customers {}");
+    const result = computeSemanticTokens(tree);
+    const tokens = decodeTokens(result.data);
+
+    // First token: "schema" keyword
+    assert.equal(tokens[0].line, 0);
+    assert.equal(tokens[0].col, 0);
+    assert.equal(tokens[0].length, 6);
+    assert.equal(tokens[0].type, "keyword");
+
+    // Second token: "customers" — type with definition modifier
+    assert.equal(tokens[1].line, 0);
+    assert.equal(tokens[1].col, 7);
+    assert.equal(tokens[1].length, 9);
+    assert.equal(tokens[1].type, "type");
+    assert.equal(tokens[1].mods & 1, 1); // definition modifier bit
+  });
+
+  it("tokenizes field declarations with types", () => {
+    const tree = parse("schema foo {\n  id UUID\n}");
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    // Find the field name token
+    const fieldToken = tokens.find(
+      (t) => t.type === "property" && t.line === 1,
+    );
+    assert.ok(fieldToken, "should have a property token for field name");
+    assert.equal(fieldToken.length, 2); // "id"
+
+    // Find the type token
+    const typeToken = tokens.find((t) => t.type === "type" && t.line === 1);
+    assert.ok(typeToken, "should have a type token for UUID");
+    assert.equal(typeToken.length, 4); // "UUID"
+  });
+
+  it("tokenizes mapping keyword and label as function definition", () => {
+    const tree = parse(
+      "mapping migrate {\n  source { `s` }\n  target { `t` }\n  a -> b\n}",
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const keyword = tokens.find((t) => t.type === "keyword");
+    assert.ok(keyword);
+    assert.equal(keyword.length, 7); // "mapping"
+
+    const label = tokens.find((t) => t.type === "function");
+    assert.ok(label);
+    assert.equal(label.mods & 1, 1); // definition modifier
+  });
+
+  it("tokenizes namespace labels as namespace type", () => {
+    const tree = parse("namespace crm {}");
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const nsToken = tokens.find((t) => t.type === "namespace");
+    assert.ok(nsToken, "should have a namespace token");
+    assert.equal(nsToken.length, 3); // "crm"
+  });
+
+  it("tokenizes metadata tags as decorators", () => {
+    const tree = parse("schema foo {\n  id UUID (pk, pii)\n}");
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const decorators = tokens.filter((t) => t.type === "decorator");
+    assert.ok(decorators.length >= 2, "should have decorator tokens for pk and pii");
+  });
+
+  it("tokenizes comments", () => {
+    const tree = parse("// regular comment\n//! warning\n//? question");
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const comments = tokens.filter((t) => t.type === "comment");
+    assert.equal(comments.length, 3, "should have 3 comment tokens");
+  });
+
+  it("tokenizes pipe chain function calls", () => {
+    const tree = parse(
+      "transform clean {\n  trim | lowercase | validate_email\n}",
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const funcCalls = tokens.filter((t) => t.type === "function");
+    // Should have 'clean' as function.definition and trim/lowercase/validate_email as function calls
+    assert.ok(funcCalls.length >= 1, "should have function tokens");
+  });
+
+  it("tokenizes import keywords", () => {
+    const tree = parse('import { customers } from "crm.stm"');
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const keywords = tokens.filter((t) => t.type === "keyword");
+    assert.ok(
+      keywords.length >= 2,
+      "should have keyword tokens for import and from",
+    );
+  });
+
+  it("tokenizes operators and punctuation", () => {
+    const tree = parse("schema foo {\n  a STRING\n}");
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const operators = tokens.filter((t) => t.type === "operator");
+    assert.ok(operators.length >= 2, "should have operator tokens for { and }");
+  });
+
+  it("deduplicates overlapping captures", () => {
+    // nl_string captures can overlap with other string captures in highlights.scm
+    const tree = parse('metric mrr "MRR" {}');
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    // Check no two tokens share the same position
+    const positions = tokens.map((t) => `${t.line}:${t.col}`);
+    const unique = new Set(positions);
+    assert.equal(
+      positions.length,
+      unique.size,
+      "no duplicate token positions",
+    );
+  });
+
+  it("has a valid legend with standard token types", () => {
+    assert.ok(semanticTokensLegend.tokenTypes.length > 0);
+    assert.ok(semanticTokensLegend.tokenModifiers.length > 0);
+    assert.ok(semanticTokensLegend.tokenTypes.includes("keyword"));
+    assert.ok(semanticTokensLegend.tokenTypes.includes("type"));
+    assert.ok(semanticTokensLegend.tokenTypes.includes("function"));
+    assert.ok(semanticTokensLegend.tokenTypes.includes("variable"));
+    assert.ok(semanticTokensLegend.tokenTypes.includes("property"));
+  });
+});

--- a/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
+++ b/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
@@ -185,6 +185,15 @@ describe("computeSemanticTokens", () => {
     assert.equal(varTokens.length, 2, "should have 2 variable tokens for backtick refs");
     assert.equal(varTokens[0].length, "`src_accounts`".length);
     assert.equal(varTokens[1].length, "`tgt_accounts`".length);
+
+    // The string should be split — string parts before/between/after the refs
+    const stringTokens = tokens.filter(
+      (t) => t.type === "string" && t.line === 0 && t.col >= 7,
+    );
+    assert.ok(
+      stringTokens.length >= 2,
+      `should have string segments between refs, got ${stringTokens.length}`,
+    );
   });
 
   it("tokenizes backtick references inside multiline_string as variable", () => {

--- a/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
+++ b/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
@@ -175,6 +175,50 @@ describe("computeSemanticTokens", () => {
     );
   });
 
+  it("tokenizes backtick references inside nl_string as variable", () => {
+    const tree = parse(
+      'note { "This maps `src_accounts` to `tgt_accounts`." }',
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const varTokens = tokens.filter((t) => t.type === "variable");
+    assert.equal(varTokens.length, 2, "should have 2 variable tokens for backtick refs");
+    assert.equal(varTokens[0].length, "`src_accounts`".length);
+    assert.equal(varTokens[1].length, "`tgt_accounts`".length);
+  });
+
+  it("tokenizes backtick references inside multiline_string as variable", () => {
+    const tree = parse(
+      'note {\n  """\n  Check `balance` and `status` fields.\n  """\n}',
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const varTokens = tokens.filter((t) => t.type === "variable");
+    assert.equal(varTokens.length, 2, "should have 2 variable tokens in multiline string");
+    assert.equal(varTokens[0].length, "`balance`".length);
+    assert.equal(varTokens[1].length, "`status`".length);
+  });
+
+  it("does not emit variable tokens for strings without backtick refs", () => {
+    const tree = parse('note { "No refs here." }');
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const varTokens = tokens.filter((t) => t.type === "variable");
+    assert.equal(varTokens.length, 0, "should have no variable tokens");
+  });
+
+  it("handles backtick refs on note block with multiple nl_strings", () => {
+    const tree = parse(
+      'note {\n  "First `alpha` ref."\n  "Second `beta` ref."\n}',
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const varTokens = tokens.filter((t) => t.type === "variable");
+    assert.equal(varTokens.length, 2, "one ref per line");
+    // Check they're on different lines
+    assert.notEqual(varTokens[0].line, varTokens[1].line);
+  });
+
   it("has a valid legend with standard token types", () => {
     assert.ok(semanticTokensLegend.tokenTypes.length > 0);
     assert.ok(semanticTokensLegend.tokenModifiers.length > 0);

--- a/tooling/vscode-satsuma/server/test/symbols.test.js
+++ b/tooling/vscode-satsuma/server/test/symbols.test.js
@@ -1,0 +1,184 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { computeDocumentSymbols } = require("../dist/symbols");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+// SymbolKind constants from LSP spec
+const SymbolKind = {
+  Class: 5,
+  Interface: 11,
+  Function: 12,
+  Constant: 14,
+  Field: 8,
+  Struct: 23,
+  Namespace: 3,
+  File: 1,
+  Package: 4,
+  Property: 7,
+};
+
+describe("computeDocumentSymbols", () => {
+  it("returns schema as Class with fields as children", () => {
+    const tree = parse(`schema customers {
+  customer_id UUID (pk)
+  name VARCHAR(200)
+  email VARCHAR(255) (pii)
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "customers");
+    assert.equal(symbols[0].kind, SymbolKind.Class);
+    assert.equal(symbols[0].children.length, 3);
+    assert.equal(symbols[0].children[0].name, "customer_id");
+    assert.equal(symbols[0].children[0].kind, SymbolKind.Field);
+  });
+
+  it("returns fragment as Interface", () => {
+    const tree = parse(`fragment 'audit fields' {
+  created_at TIMESTAMPTZ
+  updated_at TIMESTAMPTZ
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "audit fields");
+    assert.equal(symbols[0].kind, SymbolKind.Interface);
+    assert.equal(symbols[0].children.length, 2);
+  });
+
+  it("returns mapping as Function", () => {
+    const tree = parse(`mapping 'customer migration' {
+  source { \`legacy_db\` }
+  target { \`new_db\` }
+  old_id -> new_id
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "customer migration");
+    assert.equal(symbols[0].kind, SymbolKind.Function);
+  });
+
+  it("returns transform as Function", () => {
+    const tree = parse(`transform 'clean email' {
+  trim | lowercase | validate_email
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "clean email");
+    assert.equal(symbols[0].kind, SymbolKind.Function);
+  });
+
+  it("returns metric as Constant with display label", () => {
+    const tree = parse(`metric monthly_recurring_revenue "MRR" (
+  source fact_subscriptions,
+  grain monthly
+) {
+  value DECIMAL(14,2)
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "monthly_recurring_revenue");
+    assert.equal(symbols[0].kind, SymbolKind.Constant);
+    assert.equal(symbols[0].detail, "MRR");
+  });
+
+  it("handles nested record fields as Struct", () => {
+    const tree = parse(`schema order {
+  order_id STRING (pk)
+  customer record {
+    id STRING
+    email STRING (pii)
+  }
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    const fields = symbols[0].children;
+    assert.equal(fields.length, 2);
+    assert.equal(fields[0].name, "order_id");
+    assert.equal(fields[0].kind, SymbolKind.Field);
+    assert.equal(fields[1].name, "customer");
+    assert.equal(fields[1].kind, SymbolKind.Struct);
+    assert.equal(fields[1].children.length, 2);
+    assert.equal(fields[1].children[0].name, "id");
+  });
+
+  it("handles list_of record fields", () => {
+    const tree = parse(`schema order {
+  line_items list_of record {
+    sku STRING
+    quantity INT
+  }
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    const field = symbols[0].children[0];
+    assert.equal(field.name, "line_items");
+    assert.equal(field.kind, SymbolKind.Struct);
+    assert.equal(field.detail, "list_of record");
+    assert.equal(field.children.length, 2);
+  });
+
+  it("handles note blocks", () => {
+    const tree = parse(`note {
+  "Some documentation here"
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "note");
+    assert.equal(symbols[0].kind, SymbolKind.File);
+  });
+
+  it("handles anonymous mappings", () => {
+    const tree = parse(`mapping {
+  source { \`foo\` }
+  target { \`bar\` }
+  a -> b
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 1);
+    assert.equal(symbols[0].name, "(anonymous)");
+    assert.equal(symbols[0].kind, SymbolKind.Function);
+  });
+
+  it("handles multiple top-level blocks", () => {
+    const tree = parse(`schema foo {
+  a STRING
+}
+
+schema bar {
+  b INT
+}
+
+mapping 'migrate' {
+  source { \`foo\` }
+  target { \`bar\` }
+  a -> b
+}`);
+    const symbols = computeDocumentSymbols(tree);
+    assert.equal(symbols.length, 3);
+    assert.equal(symbols[0].name, "foo");
+    assert.equal(symbols[1].name, "bar");
+    assert.equal(symbols[2].name, "migrate");
+  });
+
+  it("handles empty files", () => {
+    const tree = parse("");
+    const symbols = computeDocumentSymbols(tree);
+    assert.deepEqual(symbols, []);
+  });
+
+  it("selectionRange points to the block label", () => {
+    const tree = parse("schema customers {\n  id UUID\n}");
+    const symbols = computeDocumentSymbols(tree);
+    const sel = symbols[0].selectionRange;
+    // "customers" starts at col 7 on line 0
+    assert.equal(sel.start.line, 0);
+    assert.equal(sel.start.character, 7);
+  });
+});

--- a/tooling/vscode-satsuma/server/test/validate-diagnostics.test.js
+++ b/tooling/vscode-satsuma/server/test/validate-diagnostics.test.js
@@ -1,0 +1,122 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { runValidate } = require("../dist/validate-diagnostics");
+
+describe("runValidate", () => {
+  it("returns empty map when CLI produces no output", async () => {
+    // Use a non-existent CLI to exercise the error/empty path
+    const result = await runValidate(
+      "file:///tmp/nonexistent.stm",
+      "/nonexistent/satsuma-cli",
+    );
+    assert.ok(result instanceof Map);
+    assert.equal(result.size, 0);
+  });
+
+  it("returns empty map when CLI produces invalid JSON", async () => {
+    // echo outputs non-JSON text
+    const result = await runValidate(
+      "file:///tmp/test.stm",
+      "echo",
+    );
+    assert.ok(result instanceof Map);
+    assert.equal(result.size, 0);
+  });
+
+  it("parses valid satsuma validate --json output", async () => {
+    // Use the real satsuma CLI against a fixture with known warnings
+    const fixtureDir = require("path").resolve(
+      __dirname,
+      "../../../../examples/db-to-db.stm",
+    );
+    const fixtureUri = "file://" + encodeURI(fixtureDir);
+
+    const result = await runValidate(fixtureUri, "satsuma");
+
+    // db-to-db.stm should have warnings (missing-import, undefined-ref, etc.)
+    // If satsuma CLI is not available, this effectively tests graceful fallback
+    if (result.size > 0) {
+      for (const [uri, diags] of result) {
+        assert.ok(uri.startsWith("file://"), `URI should be file:// got ${uri}`);
+        assert.ok(diags.length > 0, "Should have diagnostics");
+        for (const d of diags) {
+          assert.equal(d.source, "satsuma-validate");
+          assert.ok(d.message, "Diagnostic should have a message");
+          assert.ok(d.code, "Diagnostic should have a rule code");
+          assert.ok(d.range, "Diagnostic should have a range");
+          // Lines should be 0-based (converted from 1-based)
+          assert.ok(
+            d.range.start.line >= 0,
+            "Line should be non-negative",
+          );
+        }
+      }
+    }
+  });
+
+  it("returns diagnostics with correct severity mapping", async () => {
+    const fixtureDir = require("path").resolve(
+      __dirname,
+      "../../../../examples/db-to-db.stm",
+    );
+    const fixtureUri = "file://" + encodeURI(fixtureDir);
+
+    const result = await runValidate(fixtureUri, "satsuma");
+
+    if (result.size > 0) {
+      for (const [, diags] of result) {
+        for (const d of diags) {
+          // DiagnosticSeverity: Error=1, Warning=2, Information=3, Hint=4
+          assert.ok(
+            [1, 2, 3, 4].includes(d.severity),
+            `Severity should be a valid LSP value, got ${d.severity}`,
+          );
+        }
+      }
+    }
+  });
+
+  it("groups diagnostics by file URI", async () => {
+    // Validate the examples directory — should have multiple files
+    const examplesDir = require("path").resolve(
+      __dirname,
+      "../../../../examples",
+    );
+    // Pick a file that imports from another file
+    const fixtureUri = "file://" + encodeURI(
+      require("path").join(examplesDir, "db-to-db.stm"),
+    );
+
+    const result = await runValidate(fixtureUri, "satsuma");
+
+    if (result.size > 0) {
+      // All URIs should be properly formatted
+      for (const [uri] of result) {
+        assert.ok(
+          uri.startsWith("file://"),
+          `URI should start with file://, got: ${uri}`,
+        );
+      }
+    }
+  });
+
+  it("converts 1-based line/column to 0-based", async () => {
+    const fixtureDir = require("path").resolve(
+      __dirname,
+      "../../../../examples/db-to-db.stm",
+    );
+    const fixtureUri = "file://" + encodeURI(fixtureDir);
+
+    const result = await runValidate(fixtureUri, "satsuma");
+
+    if (result.size > 0) {
+      for (const [, diags] of result) {
+        for (const d of diags) {
+          // 0-based lines: line 3 in CLI output → line 2 in LSP
+          assert.ok(d.range.start.line >= 0, "Line must be 0-based");
+          assert.ok(d.range.start.character >= 0, "Character must be 0-based");
+        }
+      }
+    }
+  });
+});

--- a/tooling/vscode-satsuma/server/tsconfig.json
+++ b/tooling/vscode-satsuma/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -1,0 +1,43 @@
+import * as path from "path";
+import { ExtensionContext } from "vscode";
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+export function activate(context: ExtensionContext): void {
+  const serverModule = context.asAbsolutePath(
+    path.join("server", "dist", "server.js"),
+  );
+
+  const serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.ipc },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: { execArgv: ["--nolazy", "--inspect=6009"] },
+    },
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: "file", language: "satsuma" }],
+  };
+
+  client = new LanguageClient(
+    "satsumaLanguageServer",
+    "Satsuma Language Server",
+    serverOptions,
+    clientOptions,
+  );
+
+  client.start();
+  context.subscriptions.push({ dispose: () => client?.stop() });
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import { ExtensionContext } from "vscode";
+import { join } from "path";
+import { ExtensionContext, workspace } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -11,7 +11,7 @@ let client: LanguageClient | undefined;
 
 export function activate(context: ExtensionContext): void {
   const serverModule = context.asAbsolutePath(
-    path.join("server", "dist", "server.js"),
+    join("server", "dist", "server.js"),
   );
 
   const serverOptions: ServerOptions = {
@@ -23,8 +23,14 @@ export function activate(context: ExtensionContext): void {
     },
   };
 
+  const config = workspace.getConfiguration("satsuma");
+  const cliPath = config.get<string>("cliPath") || "satsuma";
+
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ scheme: "file", language: "satsuma" }],
+    initializationOptions: {
+      cliPath,
+    },
   };
 
   client = new LanguageClient(

--- a/tooling/vscode-satsuma/src/tsconfig.json
+++ b/tooling/vscode-satsuma/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "strict": true,
+    "outDir": "../dist/client",
+    "rootDir": ".",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary

- LSP server for the VS Code Satsuma extension with six parser-backed features
- Architecture: Node.js server (`vscode-languageserver` + `tree-sitter-satsuma`), VS Code client (`vscode-languageclient` with IPC transport), esbuild bundling
- 62 unit tests across all feature modules using Node's built-in test runner

### Features

| Feature | Trigger | Source |
|---------|---------|--------|
| **Document symbols** | Outline panel | tree-sitter CST walk |
| **Parse-error diagnostics** | On keystroke | ERROR/MISSING nodes, `//!` warnings, `//?` info |
| **Code folding** | Editor gutter | Block types matching `folds.scm` |
| **Semantic tokens** | Syntax highlighting | `highlights.scm` captures → LSP token types |
| **Hover** | Mouse hover | Block summaries, field info, tag descriptions, spread resolution |
| **Semantic diagnostics** | On save | `satsuma validate --json` (missing imports, undefined refs, etc.) |

### New files

| Path | Purpose |
|------|------------|
| `server/src/server.ts` | LSP entry point — connection, sync, capability registration |
| `server/src/parser-utils.ts` | tree-sitter init, CST→LSP helpers |
| `server/src/diagnostics.ts` | Parse-error + comment diagnostics |
| `server/src/symbols.ts` | Document symbols for all block types |
| `server/src/folding.ts` | Fold ranges matching `folds.scm` |
| `server/src/semantic-tokens.ts` | highlights.scm → LSP semantic token types |
| `server/src/hover.ts` | Contextual markdown hover for all constructs |
| `server/src/validate-diagnostics.ts` | Shells out to `satsuma validate --json`, maps to LSP diagnostics |
| `src/extension.ts` | VS Code client, passes `satsuma.cliPath` config |
| `esbuild.js` | Builds both client and server bundles |

### Configuration

- `satsuma.cliPath` — path to the `satsuma` CLI (defaults to `satsuma` on PATH)

## Test plan

- [x] 62 LSP unit tests pass (`npm run test:lsp`)
- [x] 21 TextMate grammar tests pass (`npm test`)
- [x] Full check passes (`npm run check`)
- [ ] Manual: F5 in VS Code → open `.stm` file → verify all six features

Refs: sl-2e4z

🤖 Generated with [Claude Code](https://claude.com/claude-code)