### PR TITLE
docs: add namespace rules to EBNF and strengthen backtick guidance

### DIFF
--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -10,13 +10,17 @@
 ### Grammar (compact EBNF, ~500 tokens)
 
 ```ebnf
-file             = { import_stmt | note_block | schema | fragment | transform | mapping | metric } ;
+file             = { import_stmt | note_block | namespace | schema | fragment | transform | mapping | metric } ;
 
 import_stmt      = "import" "{" name_list "}" "from" STRING ;
 name_list        = name {"," name} ;
-name             = IDENT | "'" ANY "'" ;
+name             = qualified_name | IDENT | "'" ANY "'" ;
+qualified_name   = IDENT "::" IDENT ;
 
 note_block       = "note" "{" (STRING | TRIPLESTRING) "}" ;
+
+namespace        = "namespace" IDENT ["(" metadata ")"] "{" namespace_body "}" ;
+namespace_body   = { note_block | schema | fragment | transform | mapping | metric } ;
 
 schema           = "schema" label ["(" metadata ")"] "{" schema_body "}" ;
 fragment         = "fragment" label "{" schema_body "}" ;
@@ -36,7 +40,7 @@ transform_body   = { STRING | pipe_step {"|" pipe_step} } ;
 
 metric           = "metric" label [STRING] ["(" metric_meta ")"] "{" metric_body "}" ;
 metric_meta      = metric_entry {"," metric_entry} ;
-metric_entry     = "source" (IDENT | "{" name_list "}") | "grain" IDENT
+metric_entry     = "source" (namespaced_name | IDENT | "{" name_list "}") | "grain" IDENT
                  | "slice" "{" name_list "}" | "filter" STRING ;
 metric_body      = { field | note_block | COMMENT } ;
 
@@ -55,7 +59,8 @@ pipe_step        = IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries
 map_entries      = { map_key ":" value } ;
 map_key          = value | "<" NUMBER | "default" | "_" | "null" ;
 
-field_path       = segment {"." segment} ;
+field_path       = namespaced_path | segment {"." segment} ;
+namespaced_path  = IDENT "::" segment {"." segment} ;
 segment          = IDENT | BACKTICK_IDENT ;
 
 IDENT            = LETTER {LETTER | DIGIT | "_" | "-"} ;
@@ -95,7 +100,19 @@ Metadata tokens (in parens):  pk, required, unique, indexed, pii, encrypt,
   ref table.field, note "...", xpath "...", namespace prefix "uri", filter COND
 
 Reserved keywords: schema, fragment, mapping, transform, metric, note,
-  source, target, import, from, record, list_of, each, flatten
+  source, target, import, from, record, list_of, each, flatten, namespace
+
+## Namespace blocks
+namespace <name> (<metadata>) {
+  schema ...
+  mapping ...
+  // any top-level block except import and other namespaces
+}
+
+Cross-namespace references use :: syntax:
+  source { `ns::schema_ref` }          // in mapping source/target
+  source ns::schema_name               // in metric metadata
+  import { ns::name } from "file.stm"  // in imports
 
 ## Mapping blocks
 mapping <name> (<metadata>) {
@@ -139,6 +156,7 @@ mapping <name> (<metadata>) {
 fragment <name> { fields... }              (spread with ...name)
 transform <name> { pipeline or NL... }     (spread with ...name)
 import { name1, name2 } from "file.stm"
+import { ns::name1, ns::name2 } from "other.stm"  // namespace-qualified
 
 ## Metric blocks
 metric <name> ["display label"] (<metric_meta>) {
@@ -149,7 +167,7 @@ metric <name> ["display label"] (<metric_meta>) {
 }
 
 Metric metadata tokens (in parens):
-  source schema_name | source {schema_a, schema_b}
+  source schema_name | source ns::schema_name | source {schema_a, schema_b}
   grain monthly | grain daily | grain weekly
   slice {dim_a, dim_b, dim_c}
   filter "sql_condition"
@@ -168,6 +186,13 @@ note { "standalone documentation block" }
 note { """multiline **Markdown** content""" }
 (note "inline on a field or schema")       // in metadata parens
 // info   //! warning   //? question/todo
+
+## Backtick References in NL Strings (IMPORTANT)
+ALWAYS backtick field and schema names inside "..." NL strings:
+  -> total { "Sum `line_amount` grouped by `order_id`" }
+  (note "Derived from `customer.email` after dedup")
+This is NOT optional — tooling extracts backticked references for
+deterministic lineage tracing. Bare names in NL are invisible to tools.
 ```
 
 ---

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -221,8 +221,9 @@ satsuma context "customer mapping"           # keyword-ranked block extraction (
 
 # Structural primitives — slice below block level
 satsuma arrows loyalty_sfdc.LoyaltyTier      # all arrows involving this field + classification
-satsuma nl 'demographics to mart'              # NL content in this mapping (notes, transforms)
-satsuma nl mart_customer_360.email            # NL content on this specific field
+satsuma nl 'demographics to mart'              # NL content in a mapping
+satsuma nl mart_customer_360.email            # NL content on a specific field
+satsuma nl all path/to/workspace/             # all NL across the workspace
 satsuma meta loyalty_sfdc.Email              # metadata entries (tags, type, constraints)
 satsuma fields sat_customer_demographics     # field list with types
 satsuma fields mart_customer_360 --unmapped-by 'demographics to mart'  # fields with no arrows

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -26,6 +26,16 @@ export function register(program: Command): void {
     .option("--as-source", "only arrows where the field is the source")
     .option("--as-target", "only arrows where the field is the target")
     .option("--json", "structured JSON output")
+    .addHelpText("after", `
+The field reference is <schema>.<field> — the schema name followed by a
+dot and the field name. Namespace-qualified names work (e.g. pos::stores.STORE_ID).
+
+Each arrow is classified: [structural], [nl], [mixed], [none], or [nl-derived].
+
+Examples:
+  satsuma arrows hub_customer.email                  # all arrows for this field
+  satsuma arrows hub_customer.email --as-source      # only outbound arrows
+  satsuma arrows pos::stores.STORE_ID --json         # namespace-qualified`)
     .action(async (fieldRef: string, pathArg: string | undefined, opts: { asSource?: boolean; asTarget?: boolean; json?: boolean }) => {
       const dot = fieldRef.indexOf(".");
       if (dot === -1) {

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -41,6 +41,16 @@ export function register(program: Command): void {
     .option("--budget <n>", "token budget", (v: string) => parseInt(v, 10), 4000)
     .option("--compact", "omit notes and transform bodies")
     .option("--json", "emit ranked JSON list")
+    .addHelpText("after", `
+Scores blocks by keyword relevance: block name (+10), field names (+5),
+notes (+2), metadata (+1). Emits highest-scoring blocks within the token
+budget (~4 chars per token). --json bypasses the budget and emits all scores.
+
+Examples:
+  satsuma context "customer mapping"                 # blocks about customers
+  satsuma context "loyalty tier" --budget 8000       # larger context window
+  satsuma context "pii email" --compact              # compact output
+  satsuma context "order" --json                     # all scores as JSON`)
     .action(async (query: string, pathArg: string | undefined, opts: { budget: number; compact?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -23,6 +23,15 @@ export function register(program: Command): void {
     .option("--json", "structured JSON output")
     .option("--names-only", "list changed block names only")
     .option("--stat", "summary counts only")
+    .addHelpText("after", `
+Compares two Satsuma snapshots structurally (not text diff). Both <a> and
+<b> should be the same type — both files or both directories.
+
+Examples:
+  satsuma diff v1/pipeline.stm v2/pipeline.stm      # file-to-file
+  satsuma diff old/ new/ --stat                      # directory summary
+  satsuma diff old/ new/ --json                      # full structural delta
+  satsuma diff old/ new/ --names-only                # just changed block names`)
     .action(async (pathA: string, pathB: string, opts: { json?: boolean; namesOnly?: boolean; stat?: boolean }) => {
       let filesA: string[], filesB: string[];
       try {

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -28,6 +28,15 @@ export function register(program: Command): void {
     .option("--with-meta", "include metadata tags")
     .option("--unmapped-by <mapping>", "only unmapped fields relative to a mapping")
     .option("--json", "structured JSON output")
+    .addHelpText("after", `
+Looks up <name> in schemas first, then fragments, then metrics.
+Names can be namespace-qualified (e.g. pos::stores).
+
+Examples:
+  satsuma fields hub_customer                                    # list all fields
+  satsuma fields hub_customer --with-meta                        # include tags
+  satsuma fields hub_customer --unmapped-by 'load hub_customer'  # coverage gaps
+  satsuma fields pos::stores --json                              # namespace-qualified`)
     .action(async (schemaName: string, pathArg: string | undefined, opts: { withMeta?: boolean; unmappedBy?: string; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -42,6 +42,15 @@ export function register(program: Command): void {
     .option("--in <scope>", "scope: schema|metric|fragment|all", "all")
     .option("--compact", "one match per line")
     .option("--json", "output JSON")
+    .addHelpText("after", `
+Searches all field metadata for the given tag token or key-value key.
+Common tags: pk, required, unique, pii, encrypt, indexed, measure, ref, enum.
+
+Examples:
+  satsuma find --tag pii                     # all PII-tagged fields
+  satsuma find --tag measure --in metric     # measure fields in metrics only
+  satsuma find --tag ref --json              # all foreign key refs as JSON
+  satsuma find --tag enum --compact          # compact one-per-line output`)
     .action(async (pathArg: string | undefined, opts: { tag: string; in?: string; compact?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/graph.ts
+++ b/tooling/satsuma-cli/src/commands/graph.ts
@@ -79,6 +79,22 @@ export function register(program: Command): void {
     .option("--schema-only", "omit field-level edges and field arrays")
     .option("--namespace <ns>", "filter to a namespace")
     .option("--no-nl", "strip NL text from edges")
+    .addHelpText("after", `
+Output modes (pick one):
+  --json          nodes, field-level edges, schema-level edges, warnings, unresolved NL
+  --compact       flat schema-level adjacency list (minimal tokens)
+  (default)       human-readable summary
+
+Modifiers (combine with --json):
+  --schema-only   drop field arrays and field-level edges (topology only)
+  --no-nl         strip NL text from edges (smaller payload)
+  --namespace     filter to nodes within a single namespace
+
+Examples:
+  satsuma graph ./workspace --json                   # full graph
+  satsuma graph ./workspace --json --schema-only     # topology only
+  satsuma graph ./workspace --json --namespace crm   # one namespace
+  satsuma graph ./workspace --compact                # minimal output`)
     .action(async (pathArg: string | undefined, opts: GraphOpts) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -47,6 +47,16 @@ export function register(program: Command): void {
     .option("--depth <n>", "maximum recursion depth", (v: string) => parseInt(v, 10), 10)
     .option("--compact", "print names only")
     .option("--json", "emit {nodes, edges} DAG")
+    .addHelpText("after", `
+One of --from or --to is required (not both).
+  --from  traces downstream: schema → mappings → target schemas → metrics
+  --to    traces upstream: BFS path from any source back to the target
+
+Examples:
+  satsuma lineage --from hub_customer              # what does hub_customer feed?
+  satsuma lineage --to mart_customer_360           # what feeds mart_customer_360?
+  satsuma lineage --from pos::stores --depth 3     # namespace-qualified, limited depth
+  satsuma lineage --from hub_customer --json       # DAG as JSON`)
     .action(async (pathArg: string | undefined, opts: { from?: string; to?: string; depth: number; compact?: boolean; json?: boolean }) => {
       if (!opts.from && !opts.to) {
         console.error("Provide --from <name> or --to <name>.");

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -26,6 +26,14 @@ export function register(program: Command): void {
     .option("--compact", "omit transform bodies and notes")
     .option("--arrows-only", "print src → tgt table")
     .option("--json", "output JSON")
+    .addHelpText("after", `
+Names can be namespace-qualified (e.g. warehouse::'load hub_store').
+Quote names with spaces (e.g. 'load hub_customer').
+
+Examples:
+  satsuma mapping 'load hub_customer'                # full mapping
+  satsuma mapping 'load hub_customer' --arrows-only  # just src → tgt
+  satsuma mapping 'load hub_customer' --json         # structured output`)
     .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; arrowsOnly?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/match-fields.ts
+++ b/tooling/satsuma-cli/src/commands/match-fields.ts
@@ -26,6 +26,14 @@ export function register(program: Command): void {
     .option("--matched-only", "show only matched pairs")
     .option("--unmatched-only", "show only unmatched fields")
     .option("--json", "structured JSON output")
+    .addHelpText("after", `
+Both --source and --target are required. Matching is case-insensitive with
+underscores, hyphens, and spaces normalized. Names can be namespace-qualified.
+
+Examples:
+  satsuma match-fields --source crm --target warehouse
+  satsuma match-fields --source pos::stores --target hub_store --matched-only
+  satsuma match-fields --source crm --target warehouse --json`)
     .action(async (pathArg: string | undefined, opts: { source: string; target: string; matchedOnly?: boolean; unmatchedOnly?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -31,6 +31,19 @@ export function register(program: Command): void {
     .description("Extract metadata for a schema, field, mapping, or metric")
     .option("--tags-only", "only output tag tokens, one per line")
     .option("--json", "structured JSON output")
+    .addHelpText("after", `
+Scope formats:
+  <block-name>     metadata on a schema, mapping, metric, or transform
+  <schema.field>   metadata on a specific field (type, tags, constraints)
+
+Names can be namespace-qualified (e.g. pos::stores).
+
+Examples:
+  satsuma meta hub_customer                  # schema-level metadata
+  satsuma meta hub_customer.email            # field-level metadata
+  satsuma meta 'load hub_store'              # mapping metadata
+  satsuma meta hub_customer --tags-only      # just tag tokens
+  satsuma meta pos::stores.STORE_ID --json   # namespace-qualified`)
     .action(async (scope: string, pathArg: string | undefined, opts: { tagsOnly?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/metric.ts
+++ b/tooling/satsuma-cli/src/commands/metric.ts
@@ -22,8 +22,15 @@ export function register(program: Command): void {
     .command("metric <name> [path]")
     .description("Show a metric definition")
     .option("--compact", "suppress note text")
-    .option("--sources", "print source names only")
+    .option("--sources", "print source schema names only (one per line)")
     .option("--json", "output JSON")
+    .addHelpText("after", `
+Names can be namespace-qualified (e.g. analytics::daily_sales).
+
+Examples:
+  satsuma metric daily_sales                         # full metric
+  satsuma metric daily_sales --sources               # just source schemas
+  satsuma metric analytics::daily_sales --json       # namespace-qualified`)
     .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; sources?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/nl-refs.ts
+++ b/tooling/satsuma-cli/src/commands/nl-refs.ts
@@ -25,6 +25,15 @@ export function register(program: Command): void {
     .option("--mapping <name>", "scope to a specific mapping")
     .option("--json", "structured JSON output")
     .option("--unresolved", "show only unresolved references")
+    .addHelpText("after", `
+Backtick references are \`field_name\` or \`schema.field\` inside "..." NL
+strings. Each ref is checked against the workspace index — "resolved" means
+the referenced field or schema exists, "unresolved" means it was not found.
+
+Examples:
+  satsuma nl-refs ./workspace                        # all refs across workspace
+  satsuma nl-refs --mapping 'load hub_customer'      # refs in one mapping
+  satsuma nl-refs --unresolved --json                # broken refs as JSON`)
     .action(async (pathArg: string | undefined, opts: { mapping?: string; json?: boolean; unresolved?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -25,9 +25,22 @@ interface NLItemWithFile extends NLItem {
 export function register(program: Command): void {
   program
     .command("nl <scope> [path]")
-    .description("Extract NL content from a scope (schema, mapping, field, or all)")
+    .description("Extract NL content (notes, transforms, comments) from a scope")
     .option("--kind <type>", "filter by kind: note, warning, question, transform")
     .option("--json", "structured JSON output")
+    .addHelpText("after", `
+Scope formats:
+  <block-name>     NL in a schema, mapping, metric, or transform by name
+  <schema.field>   NL on a specific field and arrows referencing it
+  all              NL across the entire workspace
+
+Examples:
+  satsuma nl 'demographics to mart'          # NL in a mapping
+  satsuma nl hub_customer                    # NL in a schema
+  satsuma nl mart_customer_360.email         # NL on a field
+  satsuma nl all ./workspace                 # all NL in a directory
+  satsuma nl all --kind warning              # only //! warnings
+  satsuma nl hub_customer --json             # structured output`)
     .action(async (scope: string, pathArg: string | undefined, opts: { kind?: string; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -26,6 +26,14 @@ export function register(program: Command): void {
     .option("--compact", "omit notes and inline strings")
     .option("--fields-only", "one line per field")
     .option("--json", "output JSON")
+    .addHelpText("after", `
+Names can be namespace-qualified (e.g. pos::stores). Quote names with
+spaces (e.g. 'my schema').
+
+Examples:
+  satsuma schema hub_customer                        # full schema
+  satsuma schema hub_customer --fields-only          # one field per line
+  satsuma schema pos::stores --json                  # namespace-qualified`)
     .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; fieldsOnly?: boolean; json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -32,6 +32,14 @@ export function register(program: Command): void {
     .command("where-used <name> [path]")
     .description("Find all references to a schema, fragment, or transform")
     .option("--json", "output JSON")
+    .addHelpText("after", `
+Searches mappings (source/target refs), metrics (source refs), schemas
+(fragment spreads, ref metadata), and NL backtick references.
+
+Examples:
+  satsuma where-used hub_customer                    # who references this schema?
+  satsuma where-used audit_fields                    # where is this fragment spread?
+  satsuma where-used trim_and_lower --json           # transform refs as JSON`)
     .action(async (name: string, pathArg: string | undefined, opts: { json?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];

--- a/useful-prompts/excel-to-stm-prompt.md
+++ b/useful-prompts/excel-to-stm-prompt.md
@@ -7,13 +7,17 @@ You are a Satsuma (Source-to-Target Mapping) conversion specialist. The user wil
 ## Satsuma Grammar (compact EBNF)
 
 ```ebnf
-file             = { import_stmt | note_block | schema | fragment | transform | mapping | metric } ;
+file             = { import_stmt | note_block | namespace | schema | fragment | transform | mapping | metric } ;
 
 import_stmt      = "import" "{" name_list "}" "from" STRING ;
 name_list        = name {"," name} ;
-name             = IDENT | "'" ANY "'" ;
+name             = qualified_name | IDENT | "'" ANY "'" ;
+qualified_name   = IDENT "::" IDENT ;
 
 note_block       = "note" "{" (STRING | TRIPLESTRING) "}" ;
+
+namespace        = "namespace" IDENT ["(" metadata ")"] "{" namespace_body "}" ;
+namespace_body   = { note_block | schema | fragment | transform | mapping | metric } ;
 
 schema           = "schema" label ["(" metadata ")"] "{" schema_body "}" ;
 fragment         = "fragment" label "{" schema_body "}" ;
@@ -33,7 +37,7 @@ transform_body   = { STRING | pipe_step {"|" pipe_step} } ;
 
 metric           = "metric" label [STRING] ["(" metric_meta ")"] "{" metric_body "}" ;
 metric_meta      = metric_entry {"," metric_entry} ;
-metric_entry     = "source" (IDENT | "{" name_list "}") | "grain" IDENT
+metric_entry     = "source" (namespaced_name | IDENT | "{" name_list "}") | "grain" IDENT
                  | "slice" "{" name_list "}" | "filter" STRING ;
 metric_body      = { field | note_block | COMMENT } ;
 
@@ -52,7 +56,8 @@ pipe_step        = IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries
 map_entries      = { map_key ":" value } ;
 map_key          = value | "<" NUMBER | "default" | "_" | "null" ;
 
-field_path       = segment {"." segment} ;
+field_path       = namespaced_path | segment {"." segment} ;
+namespaced_path  = IDENT "::" segment {"." segment} ;
 segment          = IDENT | BACKTICK_IDENT ;
 
 IDENT            = LETTER {LETTER | DIGIT | "_" | "-"} ;
@@ -90,7 +95,19 @@ Metadata tokens (in parens):  pk, required, unique, indexed, pii, encrypt,
   ref table.field, note "...", xpath "...", namespace prefix "uri", filter COND
 
 Reserved keywords: schema, fragment, mapping, transform, metric, note,
-  source, target, import, from, record, list_of, each, flatten
+  source, target, import, from, record, list_of, each, flatten, namespace
+
+## Namespace blocks
+namespace <name> (<metadata>) {
+  schema ...
+  mapping ...
+  // any top-level block except import and other namespaces
+}
+
+Cross-namespace references use :: syntax:
+  source { `ns::schema_ref` }          // in mapping source/target
+  source ns::schema_name               // in metric metadata
+  import { ns::name } from "file.stm"  // in imports
 
 ## Mapping blocks
 mapping <name> (<metadata>) {
@@ -134,6 +151,7 @@ mapping <name> (<metadata>) {
 fragment <name> { fields... }              (spread with ...name)
 transform <name> { pipeline or NL... }     (spread with ...name)
 import { name1, name2 } from "file.stm"
+import { ns::name1, ns::name2 } from "other.stm"  // namespace-qualified
 
 ## Metric blocks
 metric <name> ["display label"] (<metric_meta>) {
@@ -144,7 +162,7 @@ metric <name> ["display label"] (<metric_meta>) {
 }
 
 Metric metadata tokens (in parens):
-  source schema_name | source {schema_a, schema_b}
+  source schema_name | source ns::schema_name | source {schema_a, schema_b}
   grain monthly | grain daily | grain weekly
   slice {dim_a, dim_b, dim_c}
   filter "sql_condition"
@@ -159,6 +177,13 @@ note { "standalone documentation block" }
 note { """multiline **Markdown** content""" }
 (note "inline on a field or schema")       // in metadata parens
 // info   //! warning   //? question/todo
+
+## Backtick References in NL Strings (IMPORTANT)
+ALWAYS backtick field and schema names inside "..." NL strings:
+  -> total { "Sum `line_amount` grouped by `order_id`" }
+  (note "Derived from `customer.email` after dedup")
+This is NOT optional — tooling extracts backticked references for
+deterministic lineage tracing. Bare names in NL are invisible to tools.
 ```
 
 ---
@@ -184,7 +209,8 @@ Follow these steps in order:
 - Use `Name record { }` for nested objects and `Name list_of record { }` for repeated / array structures. Use `Name list_of TYPE` for scalar lists.
 - Use `fragment` for any field pattern that appears 2+ times across schemas.
 - Write transforms inside `{ }` braces after the arrow — **not** after a `:` colon.
-- Use bare `"..."` strings in `{ }` for any transformation described in prose that you can't express as a pipeline. Backtick any field or schema names referenced inside the NL string (e.g. `` "Sum `amount` grouped by `customer_id`" ``).
+- Use bare `"..."` strings in `{ }` for any transformation described in prose that you can't express as a pipeline.
+- **Always backtick field and schema names** referenced inside `"..."` NL strings (e.g. `` "Sum `amount` grouped by `customer_id`" ``). This is required — tooling extracts backticked references for deterministic lineage tracing. Bare names in NL strings are invisible to tools.
 - For conditional value mapping, use `map { key: "value", _: "fallback" }`. For complex conditions involving multiple fields or logic, use a `"..."` NL string.
 - For derived / computed fields with no source, use `-> target { ... }` with no left-hand side.
 - Represent lookup/reference/code tables found in the spreadsheet as `schema` blocks with fields.


### PR DESCRIPTION
## Summary
- **Added namespace grammar rules** to the compact EBNF in both `AI-AGENT-REFERENCE.md` and `useful-prompts/excel-to-stm-prompt.md` — `namespace_block`, `namespace_body`, `qualified_name` (`ns::name`), and `namespaced_path` were all missing despite being fully implemented in the tree-sitter grammar and CLI
- **Updated cheat sheets** in both files with namespace block syntax, cross-namespace `::` reference examples, namespace-qualified imports, and `namespace` in reserved keywords
- **Added prominent "Backtick References in NL Strings" section** to both cheat sheets, emphasising that backticking field/schema names in NL strings is required for deterministic lineage extraction by tooling
- **Strengthened backtick guidance** in the Excel prompt's Generation Rules as a standalone bullet point

## Test plan
- [x] Pre-commit hooks pass (lint + 637 CLI tests)
- [ ] Verify `satsuma agent-reference` output includes namespace rules after rebuild
- [ ] Spot-check EBNF rules against `tooling/tree-sitter-satsuma/grammar.js` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)