### PR TITLE
fix: resolve backtick refs in standalone notes (sl-xrc8)

### DIFF
--- a/.tickets/sl-xrc8.md
+++ b/.tickets/sl-xrc8.md
@@ -1,0 +1,32 @@
+---
+id: sl-xrc8
+status: open
+deps: []
+links: []
+created: 2026-03-23T12:34:19Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, validate, nl-refs]
+---
+# Standalone note backtick refs fail to resolve against file-level schemas and fields
+
+Backtick references inside standalone `note { }` blocks (top-level or inside schemas) do not resolve correctly, producing false `nl-ref-unresolved` and `nl-ref-not-in-source` warnings even when the referenced schemas and fields are defined in the same file.
+
+Root cause: standalone notes get a pseudo-mapping key of `note:` (or `note:<parent>`) which has no entry in the workspace index's mappings map. When `resolveAllNLRefs()` looks up this key, it gets `undefined`, so the mapping context has empty sources/targets arrays. This means:
+
+1. Bare field refs (e.g. \`user_id\`) cannot resolve — they need source/target schemas to search through.
+2. Schema refs (e.g. \`source_system\`) resolve globally but then get flagged by `nl-ref-not-in-source` because the empty pseudo-mapping has no source/target list.
+3. Dotted field refs (e.g. \`source_system.email_addr\`) resolve via the global fallback but also get the false `not-in-source` warning.
+
+Reproduces on the canonical `examples/db-to-db.stm` where \`tax_encryption_key\` in the top-level note is reported as unresolved.
+
+## Acceptance Criteria
+
+- Backtick refs in standalone notes that reference schemas defined in the same file resolve without warnings
+- Backtick refs in standalone notes that reference fields of schemas in the same file resolve without warnings (bare refs should search all file-level schemas)
+- The `nl-ref-not-in-source` rule is either skipped or adapted for standalone notes (they have no mapping context)
+- `satsuma validate examples/db-to-db.stm` no longer warns about \`tax_encryption_key\` as unresolved (this one is a non-schema ref, so it should either resolve or the note context should suppress the warning)
+- Existing mapping-scoped NL ref validation is unchanged
+- Tests added covering standalone note ref resolution
+

--- a/.tickets/sl-xrc8.md
+++ b/.tickets/sl-xrc8.md
@@ -1,6 +1,6 @@
 ---
 id: sl-xrc8
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-23T12:34:19Z
@@ -30,3 +30,9 @@ Reproduces on the canonical `examples/db-to-db.stm` where \`tax_encryption_key\`
 - Existing mapping-scoped NL ref validation is unchanged
 - Tests added covering standalone note ref resolution
 
+## Notes
+
+**2026-03-23T12:40:00Z**
+
+Cause: Standalone `note { }` blocks get a pseudo-mapping key `"note:"` with no entry in the workspace index, so bare field refs have no schemas to search and all resolved refs get false `not-in-source` warnings.
+Fix: (1) In `resolveRef()`, added fallback for bare refs to search all workspace schemas when sources/targets are empty. (2) In `validate.ts`, skip both `nl-ref-unresolved` and `nl-ref-not-in-source` diagnostics for note-context entries (`mappingKey.startsWith("note:")`). Added 8 new unit tests.

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -128,6 +128,16 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
     }
   }
 
+  // When there is no mapping context (e.g. standalone notes), fall back to
+  // searching all workspace schemas for the bare field name.
+  if (allSchemaNames.length === 0) {
+    for (const [key, schema] of index.schemas) {
+      if (hasFieldWithSpreads(schema, ref, index)) {
+        return { resolved: true, resolvedTo: { kind: "field", name: `${key}.${ref}` } };
+      }
+    }
+  }
+
   // Try namespace-qualified lookup from mapping's namespace BEFORE global
   if (mappingContext.namespace) {
     const nsRef = `${mappingContext.namespace}::${ref}`;

--- a/tooling/satsuma-cli/src/validate.ts
+++ b/tooling/satsuma-cli/src/validate.ts
@@ -264,20 +264,27 @@ export function collectSemanticWarnings(index: WorkspaceIndex): LintDiagnostic[]
         namespace: item.namespace,
       };
 
+      // Standalone notes (mapping key starts with "note:") have no mapping
+      // context, so skip both unresolved and not-in-source checks — they are
+      // free-form documentation that may reference external concepts.
+      const isNoteContext = mappingKey.startsWith("note:");
+
       for (const { ref, offset } of refs) {
         const classification = classifyRef(ref);
         const resolution = resolveRef(ref, mappingContext, index);
 
         if (!resolution.resolved) {
-          diagnostics.push({
-            file: item.file,
-            line: item.line + 1,
-            column: item.column + offset + 1,
-            severity: "warning",
-            rule: "nl-ref-unresolved",
-            message: `NL reference \`${ref}\` in mapping '${mappingKey}' does not resolve to any known identifier`,
-            fixable: false,
-          });
+          if (!isNoteContext) {
+            diagnostics.push({
+              file: item.file,
+              line: item.line + 1,
+              column: item.column + offset + 1,
+              severity: "warning",
+              rule: "nl-ref-unresolved",
+              message: `NL reference \`${ref}\` in mapping '${mappingKey}' does not resolve to any known identifier`,
+              fixable: false,
+            });
+          }
         } else {
           // Determine the schema name being referenced
           let referencedSchema: string | null = null;
@@ -292,7 +299,7 @@ export function collectSemanticWarnings(index: WorkspaceIndex): LintDiagnostic[]
               if (lastDot > 0) referencedSchema = fieldPath.slice(0, lastDot);
             }
           }
-          if (referencedSchema && !isSchemaInMappingSources(referencedSchema, mapping)) {
+          if (referencedSchema && !isNoteContext && !isSchemaInMappingSources(referencedSchema, mapping)) {
             diagnostics.push({
               file: item.file,
               line: item.line + 1,

--- a/tooling/satsuma-cli/test/nl-ref-extract.test.js
+++ b/tooling/satsuma-cli/test/nl-ref-extract.test.js
@@ -145,6 +145,27 @@ describe("resolveRef", () => {
     assert.equal(result.resolved, false);
   });
 
+  it("resolves bare field against all workspace schemas when sources/targets are empty", () => {
+    const index = makeIndex({
+      my_schema: { fields: [{ name: "user_id" }, { name: "email" }] },
+    });
+    const context = { sources: [], targets: [] };
+    const result = resolveRef("user_id", context, index);
+    assert.equal(result.resolved, true);
+    assert.equal(result.resolvedTo.kind, "field");
+    assert.equal(result.resolvedTo.name, "my_schema.user_id");
+  });
+
+  it("does not fall back to all schemas when sources/targets are provided", () => {
+    const index = makeIndex({
+      other_schema: { fields: [{ name: "secret_field" }] },
+      "source::src": { fields: [{ name: "known_field" }] },
+    });
+    const context = { sources: ["source::src"], targets: [] };
+    const result = resolveRef("secret_field", context, index);
+    assert.equal(result.resolved, false, "should not search schemas outside mapping context");
+  });
+
   it("resolves nested field names", () => {
     const index = makeIndex({
       "source::orders": {

--- a/tooling/satsuma-cli/test/nl-ref-validate.test.js
+++ b/tooling/satsuma-cli/test/nl-ref-validate.test.js
@@ -246,6 +246,141 @@ describe("NL ref validation: fragment spread fields", () => {
   });
 });
 
+describe("NL ref validation: standalone notes (sl-xrc8)", () => {
+  it("does not warn for bare schema refs in standalone notes", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source_system", fields: [{ name: "user_id" }] },
+        { name: "target_system", fields: [{ name: "id" }] },
+      ],
+      nlRefData: [{
+        text: "Converts `source_system` records into `target_system`",
+        mapping: "note:",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Schema refs in standalone notes should not warn");
+  });
+
+  it("does not warn for bare field refs in standalone notes", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "my_schema", fields: [{ name: "user_id" }, { name: "email" }] },
+      ],
+      nlRefData: [{
+        text: "The `user_id` field is the primary key",
+        mapping: "note:",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Bare field refs in standalone notes should resolve without warnings");
+  });
+
+  it("does not warn for unresolvable refs in standalone notes", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "my_schema", fields: [{ name: "user_id" }] },
+      ],
+      nlRefData: [{
+        text: "Needs `external_config_key` to be provisioned",
+        mapping: "note:",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Unresolvable refs in standalone notes should not warn");
+  });
+
+  it("does not warn for dotted field refs in standalone notes", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source_system", fields: [{ name: "email_addr" }] },
+      ],
+      nlRefData: [{
+        text: "See `source_system.email_addr` for details",
+        mapping: "note:",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Dotted field refs in standalone notes should not warn");
+  });
+
+  it("does not warn for refs in schema-scoped notes (note:<parent>)", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "my_schema", fields: [{ name: "user_id" }] },
+      ],
+      nlRefData: [{
+        text: "The `user_id` is sequential",
+        mapping: "note:my_schema",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule.startsWith("nl-ref-"));
+    assert.equal(nlWarnings.length, 0, "Refs in schema-scoped notes should not warn");
+  });
+
+  it("still warns for unresolved refs inside mapping notes", () => {
+    const index = makeIndex({
+      schemas: [
+        { name: "source::src", fields: [{ name: "amount" }] },
+        { name: "target::tgt", fields: [] },
+      ],
+      mappings: [{
+        name: "my_mapping",
+        sources: ["source::src"],
+        targets: ["target::tgt"],
+      }],
+      nlRefData: [{
+        text: "Check `nonexistent_field` before proceeding",
+        mapping: "my_mapping",
+        namespace: null,
+        targetField: null,
+        file: "test.stm",
+        line: 10,
+        column: 6,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const unresolvedWarnings = warnings.filter((w) => w.rule === "nl-ref-unresolved");
+    assert.equal(unresolvedWarnings.length, 1, "Mapping notes should still warn for unresolved refs");
+  });
+});
+
 describe("NL ref validation: bare field matching", () => {
   it("does not warn for bare field that matches a source schema field", () => {
     const index = makeIndex({


### PR DESCRIPTION
## Summary
- Standalone `note { }` blocks with backtick references produced false `nl-ref-unresolved` and `nl-ref-not-in-source` warnings because the pseudo-mapping key `"note:"` has no entry in the workspace index
- Added fallback in `resolveRef()` to search all workspace schemas for bare field refs when no mapping context exists
- Skip both `nl-ref-unresolved` and `nl-ref-not-in-source` diagnostics for standalone notes (free-form docs that may reference external concepts)
- 8 new unit tests; 675 tests pass

## Test plan
- [x] `satsuma validate examples/db-to-db.stm` no longer warns about `tax_encryption_key`
- [x] Bare field, schema, and dotted-field refs in standalone notes resolve correctly
- [x] Mapping-scoped NL ref validation unchanged (guarded by new test)
- [x] All 675 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)