### PR TITLE
feat: LSP Phase 3 — CodeLens, Rename, Commands, Graph/Lineage Webviews, Coverage

### DIFF
--- a/.tickets/sl-oz1t.md
+++ b/.tickets/sl-oz1t.md
@@ -1,6 +1,6 @@
 ---
 id: sl-oz1t
-status: open
+status: done
 deps: [sl-t7mg]
 links: []
 created: 2026-03-23T09:55:41Z
@@ -15,3 +15,25 @@ tags: [feature-16, lsp, vscode]
 
 Outline panel shows schemas/mappings/metrics hierarchy. Breadcrumbs work. Code actions for common fixes. Lineage visualization webview using satsuma graph.
 
+
+## Notes
+
+**2026-03-23T20:00:00Z**
+
+Cause: Phase 3 required advanced VS Code extension features beyond the core LSP server.
+Fix: Implemented full PRD Phase 2+3 scope across 3 commits:
+
+Commit 1 — Server-side features:
+- CodeLens: inline annotations on all block types (field counts, mapping usage, spread counts, source→target, metric sources)
+- Rename Symbol: F2 workspace-wide rename with duplicate detection
+- 17 new tests (142 total)
+
+Commit 2 — Command palette + CLI integration:
+- 9 commands: validate, lineage, where-used, warnings, summary, arrows, graph, field-lineage, coverage
+- Shared CLI runner, custom LSP requests (satsuma/blockNames, satsuma/fieldLocations)
+
+Commit 3 — Visualization + coverage:
+- Workspace Graph webview (SVG DAG layout, namespace filter, click-to-navigate, auto-refresh on save)
+- Field-Level Lineage webview (multi-hop chain tracing via satsuma arrows, NL badges)
+- Mapping Coverage Heatmap (gutter decorations, status bar percentage)
+- esbuild webview bundling

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -26,19 +26,65 @@ const serverConfig = {
   sourcemap: true,
 };
 
+/** @type {import("esbuild").BuildOptions} */
+const webviewGraphConfig = {
+  entryPoints: ["src/webview/graph/graph.ts"],
+  bundle: true,
+  platform: "browser",
+  target: "es2020",
+  outfile: "dist/webview/graph/graph.js",
+  format: "iife",
+  sourcemap: true,
+};
+
+/** @type {import("esbuild").BuildOptions} */
+const webviewLineageConfig = {
+  entryPoints: ["src/webview/lineage/lineage.ts"],
+  bundle: true,
+  platform: "browser",
+  target: "es2020",
+  outfile: "dist/webview/lineage/lineage.js",
+  format: "iife",
+  sourcemap: true,
+};
+
+// Copy CSS to dist
+const { copyFileSync, mkdirSync, existsSync } = require("fs");
+
+function copyCss() {
+  const pairs = [
+    ["src/webview/graph/graph.css", "dist/webview/graph/graph.css"],
+    ["src/webview/lineage/lineage.css", "dist/webview/lineage/lineage.css"],
+  ];
+  for (const [src, dst] of pairs) {
+    try {
+      const dir = require("path").dirname(dst);
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+      copyFileSync(src, dst);
+    } catch {
+      // CSS file may not exist yet
+    }
+  }
+}
+
 async function build() {
+  const configs = [clientConfig, serverConfig, webviewGraphConfig];
+
+  // Only include lineage config if the entry point exists
+  try {
+    require("fs").accessSync("src/webview/lineage/lineage.ts");
+    configs.push(webviewLineageConfig);
+  } catch {
+    // Lineage webview not yet created
+  }
+
   if (watch) {
-    const [clientCtx, serverCtx] = await Promise.all([
-      esbuild.context(clientConfig),
-      esbuild.context(serverConfig),
-    ]);
-    await Promise.all([clientCtx.watch(), serverCtx.watch()]);
+    const contexts = await Promise.all(configs.map((c) => esbuild.context(c)));
+    await Promise.all(contexts.map((ctx) => ctx.watch()));
     console.log("Watching for changes...");
   } else {
-    await Promise.all([
-      esbuild.build(clientConfig),
-      esbuild.build(serverConfig),
-    ]);
+    await Promise.all(configs.map((c) => esbuild.build(c)));
+    copyCss();
     console.log("Build complete.");
   }
 }

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -29,6 +29,25 @@
         "path": "./syntaxes/satsuma.tmLanguage.json"
       }
     ],
+    "commands": [
+      { "command": "satsuma.validateWorkspace", "title": "Satsuma: Validate Workspace" },
+      { "command": "satsuma.showLineage", "title": "Satsuma: Show Lineage From..." },
+      { "command": "satsuma.whereUsed", "title": "Satsuma: Where Used" },
+      { "command": "satsuma.showWarnings", "title": "Satsuma: Show Warnings" },
+      { "command": "satsuma.showSummary", "title": "Satsuma: Show Workspace Summary" },
+      { "command": "satsuma.showArrows", "title": "Satsuma: Show Arrows for Field" },
+      { "command": "satsuma.showGraph", "title": "Satsuma: Show Workspace Graph" },
+      { "command": "satsuma.traceFieldLineage", "title": "Satsuma: Trace Field Lineage" },
+      { "command": "satsuma.showCoverage", "title": "Satsuma: Show Mapping Coverage" }
+    ],
+    "menus": {
+      "commandPalette": [
+        { "command": "satsuma.whereUsed", "when": "editorLangId == satsuma" },
+        { "command": "satsuma.showArrows", "when": "editorLangId == satsuma" },
+        { "command": "satsuma.traceFieldLineage", "when": "editorLangId == satsuma" },
+        { "command": "satsuma.showCoverage", "when": "editorLangId == satsuma" }
+      ]
+    },
     "configuration": {
       "title": "Satsuma",
       "properties": {

--- a/tooling/vscode-satsuma/server/src/codelens.ts
+++ b/tooling/vscode-satsuma/server/src/codelens.ts
@@ -1,0 +1,218 @@
+import {
+  CodeLens,
+  Command,
+  Range,
+} from "vscode-languageserver";
+import type { SyntaxNode, Tree } from "tree-sitter";
+import { nodeRange, child, children, labelText } from "./parser-utils";
+import {
+  WorkspaceIndex,
+  findReferences,
+  findMappingsUsing,
+} from "./workspace-index";
+
+/**
+ * Compute CodeLens annotations for all top-level blocks in a file.
+ * Uses the workspace index for counts — no CLI calls.
+ */
+export function computeCodeLenses(
+  tree: Tree,
+  uri: string,
+  index: WorkspaceIndex,
+): CodeLens[] {
+  const lenses: CodeLens[] = [];
+  for (const node of tree.rootNode.namedChildren) {
+    collectLenses(node, null, uri, index, lenses);
+  }
+  return lenses;
+}
+
+function collectLenses(
+  node: SyntaxNode,
+  namespace: string | null,
+  uri: string,
+  index: WorkspaceIndex,
+  lenses: CodeLens[],
+): void {
+  if (node.type === "namespace_block") {
+    const nsName = node.childForFieldName("name")?.text ?? null;
+    for (const ch of node.namedChildren) {
+      collectLenses(ch, nsName, uri, index, lenses);
+    }
+    return;
+  }
+
+  const name = labelText(node);
+  if (!name) return;
+
+  const qualName = namespace ? `${namespace}::${name}` : name;
+  const lblNode = child(node, "block_label");
+  const range = lblNode ? nodeRange(lblNode) : lineRange(node);
+
+  switch (node.type) {
+    case "schema_block":
+      lenses.push(schemaLens(node, qualName, range, index));
+      break;
+    case "fragment_block":
+      lenses.push(fragmentLens(qualName, range, index));
+      break;
+    case "mapping_block":
+      lenses.push(mappingLens(node, range));
+      break;
+    case "metric_block":
+      lenses.push(metricLens(node, range));
+      break;
+    case "transform_block":
+      lenses.push(transformLens(qualName, range, index));
+      break;
+  }
+}
+
+// ---------- Per-block-type lenses ----------
+
+function schemaLens(
+  node: SyntaxNode,
+  qualName: string,
+  range: Range,
+  index: WorkspaceIndex,
+): CodeLens {
+  const body = child(node, "schema_body");
+  const fieldCount = body ? children(body, "field_decl").length : 0;
+  const mappingCount = findMappingsUsing(index, qualName).length;
+
+  let title = `${fieldCount} field(s)`;
+  if (mappingCount > 0) {
+    title += ` | used in ${mappingCount} mapping(s)`;
+  }
+
+  return { range, command: makeCommand(title) };
+}
+
+function fragmentLens(
+  qualName: string,
+  range: Range,
+  index: WorkspaceIndex,
+): CodeLens {
+  const spreadRefs = findReferences(index, qualName).filter(
+    (r) => r.context === "spread",
+  );
+  const title = `spread in ${spreadRefs.length} place(s)`;
+  return { range, command: makeCommand(title) };
+}
+
+function mappingLens(node: SyntaxNode, range: Range): CodeLens {
+  const body = child(node, "mapping_body");
+  if (!body) return { range, command: makeCommand("mapping") };
+
+  const sources = extractRefNames(body, "source_block");
+  const targets = extractRefNames(body, "target_block");
+  const arrowCount = countArrows(body);
+
+  const srcText = sources.length > 0 ? sources.join(", ") : "?";
+  const tgtText = targets.length > 0 ? targets.join(", ") : "?";
+  const title = `${srcText} → ${tgtText} | ${arrowCount} arrow(s)`;
+
+  return { range, command: makeCommand(title) };
+}
+
+function metricLens(node: SyntaxNode, range: Range): CodeLens {
+  const meta = child(node, "metadata_block");
+  const sourceNames: string[] = [];
+
+  if (meta) {
+    walkDescendants(meta, (n) => {
+      if (n.type === "key_value_pair") {
+        const key = n.namedChildren[0];
+        const val = n.namedChildren[1];
+        if (key?.text === "source" && val) {
+          sourceNames.push(val.text);
+        }
+      }
+    });
+  }
+
+  const title =
+    sourceNames.length > 0
+      ? `sources: ${sourceNames.join(", ")}`
+      : "metric";
+
+  return { range, command: makeCommand(title) };
+}
+
+function transformLens(
+  qualName: string,
+  range: Range,
+  index: WorkspaceIndex,
+): CodeLens {
+  const spreadRefs = findReferences(index, qualName).filter(
+    (r) => r.context === "spread",
+  );
+  const title = `used in ${spreadRefs.length} place(s)`;
+  return { range, command: makeCommand(title) };
+}
+
+// ---------- Helpers ----------
+
+function makeCommand(title: string): Command {
+  return { title, command: "" };
+}
+
+function extractRefNames(body: SyntaxNode, blockType: string): string[] {
+  const names: string[] = [];
+  for (const block of body.namedChildren) {
+    if (block.type !== blockType) continue;
+    for (const ref of block.namedChildren) {
+      if (ref.type === "source_ref") {
+        const text = sourceRefText(ref);
+        if (text) names.push(text);
+      }
+    }
+  }
+  return names;
+}
+
+function countArrows(body: SyntaxNode): number {
+  let count = 0;
+  for (const ch of body.namedChildren) {
+    if (
+      ch.type === "map_arrow" ||
+      ch.type === "nested_arrow" ||
+      ch.type === "computed_arrow" ||
+      ch.type === "each_block" ||
+      ch.type === "flatten_block"
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+function sourceRefText(ref: SyntaxNode): string | null {
+  const qn = child(ref, "qualified_name");
+  if (qn) {
+    const ids = qn.namedChildren.filter((c) => c.type === "identifier");
+    if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
+    return qn.text;
+  }
+  const bn = child(ref, "backtick_name");
+  if (bn) return bn.text.slice(1, -1);
+  const id = child(ref, "identifier");
+  if (id) return id.text;
+  return null;
+}
+
+function lineRange(node: SyntaxNode): Range {
+  return Range.create(
+    node.startPosition.row,
+    node.startPosition.column,
+    node.startPosition.row,
+    node.startPosition.column,
+  );
+}
+
+function walkDescendants(node: SyntaxNode, fn: (n: SyntaxNode) => void): void {
+  for (const ch of node.namedChildren) {
+    fn(ch);
+    walkDescendants(ch, fn);
+  }
+}

--- a/tooling/vscode-satsuma/server/src/rename.ts
+++ b/tooling/vscode-satsuma/server/src/rename.ts
@@ -1,0 +1,134 @@
+import {
+  Range,
+  WorkspaceEdit,
+  TextEdit,
+} from "vscode-languageserver";
+import type { Tree } from "tree-sitter";
+import { nodeRange } from "./parser-utils";
+import { findNodeContext, NodeContext } from "./definition";
+import {
+  WorkspaceIndex,
+  resolveDefinition,
+  findReferences,
+} from "./workspace-index";
+
+/**
+ * Validate that the cursor is on a renameable symbol and return its range.
+ */
+export function prepareRename(
+  tree: Tree,
+  line: number,
+  character: number,
+  _uri: string,
+  _index: WorkspaceIndex,
+): { range: Range; placeholder: string } | null {
+  const node = tree.rootNode.descendantForPosition({
+    row: line,
+    column: character,
+  });
+  if (!node) return null;
+
+  const ctx = findNodeContext(node);
+  if (!ctx) return null;
+
+  // Only allow rename on these context types
+  const renameable = new Set<NodeContext["kind"]>([
+    "block_label",
+    "source_ref",
+    "target_ref",
+    "spread",
+    "import_name",
+  ]);
+
+  if (!renameable.has(ctx.kind)) return null;
+
+  return {
+    range: nodeRange(ctx.node),
+    placeholder: ctx.name,
+  };
+}
+
+/**
+ * Compute a workspace-wide rename for the symbol at the cursor position.
+ */
+export function computeRename(
+  tree: Tree,
+  line: number,
+  character: number,
+  _uri: string,
+  index: WorkspaceIndex,
+  newName: string,
+): WorkspaceEdit | null {
+  const node = tree.rootNode.descendantForPosition({
+    row: line,
+    column: character,
+  });
+  if (!node) return null;
+
+  const ctx = findNodeContext(node);
+  if (!ctx) return null;
+
+  const oldName = ctx.name;
+  if (!oldName || oldName === newName) return null;
+
+  // Check for duplicate: if newName already exists as a definition, refuse
+  const existingDefs = resolveDefinition(index, newName, ctx.namespace);
+  if (existingDefs.length > 0) {
+    // Name collision — return null (server will send error to client)
+    return null;
+  }
+
+  // Collect all edit locations
+  const changes: Record<string, TextEdit[]> = {};
+
+  // 1. Rename the definition site(s)
+  const defs = resolveDefinition(index, oldName, ctx.namespace);
+  for (const def of defs) {
+    addEdit(changes, def.uri, def.selectionRange, newName);
+  }
+
+  // 2. Rename all reference sites
+  const refs = findReferences(index, oldName);
+  for (const ref of refs) {
+    // For qualified references like "ns::oldName", only replace the name part
+    if (ref.name.includes("::") && !oldName.includes("::")) {
+      // The reference is qualified but the old name is bare — this ref
+      // might match via namespace fallback. Compute the sub-range for just
+      // the name part after "::"
+      const colonIdx = ref.name.indexOf("::");
+      const bareInRef = ref.name.slice(colonIdx + 2);
+      if (bareInRef === oldName) {
+        // Adjust range to only cover the part after "::"
+        const prefixLen = colonIdx + 2;
+        const adjusted: Range = {
+          start: {
+            line: ref.range.start.line,
+            character: ref.range.start.character + prefixLen,
+          },
+          end: ref.range.end,
+        };
+        addEdit(changes, ref.uri, adjusted, newName);
+        continue;
+      }
+    }
+    addEdit(changes, ref.uri, ref.range, newName);
+  }
+
+  if (Object.keys(changes).length === 0) return null;
+
+  return { changes };
+}
+
+// ---------- Helpers ----------
+
+function addEdit(
+  changes: Record<string, TextEdit[]>,
+  uri: string,
+  range: Range,
+  newText: string,
+): void {
+  if (!changes[uri]) {
+    changes[uri] = [];
+  }
+  changes[uri].push(TextEdit.replace(range, newText));
+}

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -23,6 +23,8 @@ import {
   createWorkspaceIndex,
   indexFile,
   removeFile,
+  allBlockNames,
+  resolveDefinition,
 } from "./workspace-index";
 import { computeDefinition } from "./definition";
 import { computeReferences } from "./references";
@@ -275,6 +277,32 @@ connection.onCodeLens((params) => {
   if (!tree) return [];
   return computeCodeLenses(tree, params.textDocument.uri, wsIndex);
 });
+
+// ---------- Custom requests ----------
+
+/** Return all block names from the workspace index (for command QuickPicks). */
+connection.onRequest("satsuma/blockNames", () => {
+  return allBlockNames(wsIndex).map(({ name, entry }) => ({
+    name,
+    kind: entry.kind,
+    uri: entry.uri,
+  }));
+});
+
+/** Return field locations for a schema/fragment (for coverage decorations). */
+connection.onRequest(
+  "satsuma/fieldLocations",
+  (params: { name: string }) => {
+    const defs = resolveDefinition(wsIndex, params.name, null);
+    if (defs.length === 0) return [];
+    const def = defs[0]!;
+    return def.fields.map((f) => ({
+      name: f.name,
+      uri: def.uri,
+      line: f.range.start.line,
+    }));
+  },
+);
 
 // ---------- Helpers ----------
 

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -27,6 +27,8 @@ import {
 import { computeDefinition } from "./definition";
 import { computeReferences } from "./references";
 import { computeCompletions } from "./completion";
+import { computeCodeLenses } from "./codelens";
+import { prepareRename, computeRename } from "./rename";
 
 // ---------- Connection setup ----------
 
@@ -83,6 +85,12 @@ connection.onInitialize((params): InitializeResult => {
       completionProvider: {
         triggerCharacters: ["|", ".", ":", "{"],
         resolveProvider: false,
+      },
+      codeLensProvider: {
+        resolveProvider: false,
+      },
+      renameProvider: {
+        prepareProvider: true,
       },
     },
   };
@@ -235,6 +243,37 @@ connection.onCompletion((params) => {
     params.textDocument.uri,
     wsIndex,
   );
+});
+
+connection.onPrepareRename((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return null;
+  return prepareRename(
+    tree,
+    params.position.line,
+    params.position.character,
+    params.textDocument.uri,
+    wsIndex,
+  );
+});
+
+connection.onRenameRequest((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return null;
+  return computeRename(
+    tree,
+    params.position.line,
+    params.position.character,
+    params.textDocument.uri,
+    wsIndex,
+    params.newName,
+  );
+});
+
+connection.onCodeLens((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return [];
+  return computeCodeLenses(tree, params.textDocument.uri, wsIndex);
 });
 
 // ---------- Helpers ----------

--- a/tooling/vscode-satsuma/server/src/workspace-index.ts
+++ b/tooling/vscode-satsuma/server/src/workspace-index.ts
@@ -186,6 +186,34 @@ export function getFields(
   return [];
 }
 
+/** Count unique references to a name, optionally filtered by context. */
+export function countReferences(
+  index: WorkspaceIndex,
+  name: string,
+  contextFilter?: ReferenceEntry["context"][],
+): number {
+  const refs = index.references.get(name) ?? [];
+  if (!contextFilter) return refs.length;
+  return refs.filter((r) => contextFilter.includes(r.context)).length;
+}
+
+/** Find distinct mapping names that reference a given schema as source or target. */
+export function findMappingsUsing(
+  index: WorkspaceIndex,
+  schemaName: string,
+): string[] {
+  const refs = findReferences(index, schemaName);
+  const mappingRefs = refs.filter(
+    (r) => r.context === "source" || r.context === "target",
+  );
+  // Deduplicate by URI + parent mapping (approximate: use URI since each mapping body is in one file)
+  const seen = new Set<string>();
+  for (const ref of mappingRefs) {
+    seen.add(`${ref.uri}:${ref.range.start.line}`);
+  }
+  return [...seen];
+}
+
 // ---------- Extraction (per file) ----------
 
 const BLOCK_KINDS: Record<string, DefinitionEntry["kind"]> = {

--- a/tooling/vscode-satsuma/server/test/codelens.test.js
+++ b/tooling/vscode-satsuma/server/test/codelens.test.js
@@ -1,0 +1,156 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { computeCodeLenses } = require("../dist/codelens");
+const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+function buildIndex(files) {
+  const idx = createWorkspaceIndex();
+  const trees = {};
+  for (const [uri, source] of Object.entries(files)) {
+    const tree = parse(source);
+    trees[uri] = tree;
+    indexFile(idx, uri, tree);
+  }
+  return { index: idx, trees };
+}
+
+/** Get CodeLens items for a given file in a multi-file workspace. */
+function lenses(files, uri) {
+  const { index, trees } = buildIndex(files);
+  return computeCodeLenses(trees[uri], uri, index);
+}
+
+describe("computeCodeLenses", () => {
+  it("returns empty for empty files", () => {
+    const result = lenses({ "file:///a.stm": "" }, "file:///a.stm");
+    assert.equal(result.length, 0);
+  });
+
+  it("shows field count for schema", () => {
+    const result = lenses(
+      { "file:///a.stm": "schema customers {\n  id UUID (pk)\n  name VARCHAR\n  email VARCHAR\n}" },
+      "file:///a.stm",
+    );
+    assert.equal(result.length, 1);
+    assert.ok(result[0].command.title.includes("3 field(s)"));
+  });
+
+  it("shows mapping count for schema used in mappings", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": "schema customers {\n  id UUID\n}",
+        "file:///b.stm": "mapping 'a' {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+        "file:///c.stm": "mapping 'b' {\n  source { customers }\n  target { fact }\n  id -> id\n}",
+      },
+      "file:///a.stm",
+    );
+    assert.equal(result.length, 1);
+    assert.ok(result[0].command.title.includes("used in 2 mapping(s)"));
+  });
+
+  it("shows spread count for fragments", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": `fragment audit_fields {
+  ts TIMESTAMP
+}
+schema customers {
+  id UUID
+  ...audit_fields
+}
+schema orders {
+  id UUID
+  ...audit_fields
+}`,
+      },
+      "file:///a.stm",
+    );
+    const fragLens = result.find((l) => l.command.title.includes("spread in"));
+    assert.ok(fragLens);
+    assert.ok(fragLens.command.title.includes("2 place(s)"));
+  });
+
+  it("shows source → target for mappings", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": `mapping 'migrate' {
+  source { customers }
+  target { dim_customers }
+  id -> id
+  name -> name
+}`,
+      },
+      "file:///a.stm",
+    );
+    assert.equal(result.length, 1);
+    assert.ok(result[0].command.title.includes("customers"));
+    assert.ok(result[0].command.title.includes("dim_customers"));
+    assert.ok(result[0].command.title.includes("2 arrow(s)"));
+  });
+
+  it("shows source info for metrics", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": `metric monthly_revenue "MRR" (source orders) {\n  amount DECIMAL\n}`,
+      },
+      "file:///a.stm",
+    );
+    assert.equal(result.length, 1);
+    assert.ok(result[0].command.title.includes("sources: orders"));
+  });
+
+  it("shows usage count for transforms", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": `transform 'clean email' {
+  trim | lowercase
+}
+mapping 'test' {
+  source { src }
+  target { tgt }
+  email -> email { ...clean email }
+}`,
+      },
+      "file:///a.stm",
+    );
+    const transformLens = result.find((l) =>
+      l.command.title.includes("used in"),
+    );
+    assert.ok(transformLens);
+  });
+
+  it("handles namespaced blocks", () => {
+    const result = lenses(
+      {
+        "file:///a.stm": `namespace crm {
+  schema customers {
+    id UUID
+  }
+}`,
+      },
+      "file:///a.stm",
+    );
+    // Should have a lens for the schema inside the namespace
+    assert.ok(result.length >= 1);
+    assert.ok(result.some((l) => l.command.title.includes("1 field(s)")));
+  });
+
+  it("lens range points to block label", () => {
+    const result = lenses(
+      { "file:///a.stm": "schema customers {\n  id UUID\n}" },
+      "file:///a.stm",
+    );
+    assert.equal(result.length, 1);
+    // block_label "customers" is on line 0
+    assert.equal(result[0].range.start.line, 0);
+  });
+});

--- a/tooling/vscode-satsuma/server/test/rename.test.js
+++ b/tooling/vscode-satsuma/server/test/rename.test.js
@@ -1,0 +1,184 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const Parser = require("tree-sitter");
+const Satsuma = require("tree-sitter-satsuma");
+const { prepareRename, computeRename } = require("../dist/rename");
+const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
+
+const parser = new Parser();
+parser.setLanguage(Satsuma);
+
+function parse(source) {
+  return parser.parse(source);
+}
+
+function buildIndex(files) {
+  const idx = createWorkspaceIndex();
+  const trees = {};
+  for (const [uri, source] of Object.entries(files)) {
+    const tree = parse(source);
+    trees[uri] = tree;
+    indexFile(idx, uri, tree);
+  }
+  return { index: idx, trees };
+}
+
+describe("prepareRename", () => {
+  it("returns range for schema block label", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+    });
+    const result = prepareRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+    );
+    assert.ok(result);
+    assert.equal(result.placeholder, "customers");
+  });
+
+  it("returns range for source ref", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm":
+        "mapping 'test' {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+    });
+    const result = prepareRename(
+      trees["file:///a.stm"],
+      1,
+      12,
+      "file:///a.stm",
+      index,
+    );
+    assert.ok(result);
+    assert.equal(result.placeholder, "customers");
+  });
+
+  it("returns null for non-renameable positions", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+    });
+    // Cursor on "schema" keyword (not a renameable node)
+    const result = prepareRename(
+      trees["file:///a.stm"],
+      0,
+      2,
+      "file:///a.stm",
+      index,
+    );
+    assert.equal(result, null);
+  });
+});
+
+describe("computeRename", () => {
+  it("renames schema definition and all references", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+      "file:///b.stm":
+        "mapping 'test' {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    assert.ok(edit.changes);
+    // Should have edits in both files
+    assert.ok(edit.changes["file:///a.stm"]);
+    assert.ok(edit.changes["file:///b.stm"]);
+    // Definition edit
+    assert.ok(
+      edit.changes["file:///a.stm"].some(
+        (e) => e.newText === "clients",
+      ),
+    );
+    // Reference edit
+    assert.ok(
+      edit.changes["file:///b.stm"].some(
+        (e) => e.newText === "clients",
+      ),
+    );
+  });
+
+  it("renames fragment and all spread sites", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": `fragment audit_fields {
+  ts TIMESTAMP
+}
+schema customers {
+  id UUID
+  ...audit_fields
+}`,
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      10,
+      "file:///a.stm",
+      index,
+      "tracking_fields",
+    );
+    assert.ok(edit);
+    const edits = edit.changes["file:///a.stm"];
+    assert.ok(edits);
+    // Should rename both the definition and the spread
+    assert.ok(edits.length >= 2);
+    assert.ok(edits.every((e) => e.newText === "tracking_fields"));
+  });
+
+  it("refuses rename to existing name", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm":
+        "schema customers {\n  id UUID\n}\nschema orders {\n  id UUID\n}",
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "orders", // already exists
+    );
+    assert.equal(edit, null);
+  });
+
+  it("returns null for same name", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "customers",
+    );
+    assert.equal(edit, null);
+  });
+
+  it("renames from a reference site", () => {
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+      "file:///b.stm":
+        "mapping 'test' {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+    });
+    const edit = computeRename(
+      trees["file:///b.stm"],
+      1,
+      12,
+      "file:///b.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    // Should still rename in both files
+    assert.ok(edit.changes["file:///a.stm"]);
+    assert.ok(edit.changes["file:///b.stm"]);
+  });
+});

--- a/tooling/vscode-satsuma/src/commands/arrows.ts
+++ b/tooling/vscode-satsuma/src/commands/arrows.ts
@@ -1,0 +1,78 @@
+import * as vscode from "vscode";
+import { runCli } from "./cli-runner";
+
+export function registerArrowsCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+  outputChannel: vscode.OutputChannel,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showArrows", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || editor.document.languageId !== "satsuma") return;
+
+      // Try to determine the field path from cursor context
+      const wordRange = editor.document.getWordRangeAtPosition(
+        editor.selection.active,
+      );
+      if (!wordRange) return;
+
+      // Ask user for the full schema.field reference
+      const word = editor.document.getText(wordRange);
+      const fieldPath = await vscode.window.showInputBox({
+        prompt: "Enter field reference (schema.field)",
+        value: word.includes(".") ? word : `${word}.`,
+        placeHolder: "customers.email",
+      });
+      if (!fieldPath) return;
+
+      const result = await runCli(cliPath, [
+        "arrows",
+        fieldPath,
+        "--json",
+      ]);
+
+      if (result.exitCode !== 0) {
+        vscode.window.showWarningMessage(
+          `Arrows failed: ${result.stderr.trim() || "not found"}`,
+        );
+        return;
+      }
+
+      try {
+        const arrows = JSON.parse(result.stdout);
+        if (!Array.isArray(arrows) || arrows.length === 0) {
+          vscode.window.showInformationMessage(
+            `No arrows found for '${fieldPath}'.`,
+          );
+          return;
+        }
+
+        outputChannel.clear();
+        outputChannel.appendLine(`Arrows for ${fieldPath}:`);
+        outputChannel.appendLine("");
+
+        for (const a of arrows) {
+          const cls = a.classification ? `[${a.classification}]` : "";
+          const src = a.source_qualified ?? a.source ?? "?";
+          const tgt = a.target_qualified ?? a.target ?? "?";
+          const mapping = a.mapping ?? "";
+          const transform = a.transform_raw ?? "";
+
+          outputChannel.appendLine(
+            `  ${src} → ${tgt} ${cls} in ${mapping}`,
+          );
+          if (transform) {
+            outputChannel.appendLine(`    transform: ${transform}`);
+          }
+        }
+
+        outputChannel.show();
+      } catch {
+        outputChannel.clear();
+        outputChannel.appendLine(result.stdout);
+        outputChannel.show();
+      }
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/commands/cli-runner.ts
+++ b/tooling/vscode-satsuma/src/commands/cli-runner.ts
@@ -1,0 +1,36 @@
+import { execFile } from "child_process";
+import { workspace } from "vscode";
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Run a satsuma CLI command and return the result.
+ * Resolves even on non-zero exit (caller checks exitCode).
+ */
+export function runCli(
+  cliPath: string,
+  args: string[],
+  cwd?: string,
+): Promise<CliResult> {
+  const workDir =
+    cwd ?? workspace.workspaceFolders?.[0]?.uri.fsPath ?? ".";
+
+  return new Promise((resolve) => {
+    execFile(
+      cliPath,
+      args,
+      { cwd: workDir, timeout: 15_000, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        resolve({
+          stdout: stdout ?? "",
+          stderr: stderr ?? "",
+          exitCode: error?.code ? Number(error.code) : error ? 1 : 0,
+        });
+      },
+    );
+  });
+}

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -1,0 +1,191 @@
+import * as vscode from "vscode";
+import { join } from "path";
+import { LanguageClient } from "vscode-languageclient/node";
+import { runCli } from "./cli-runner";
+
+let mappedDecoration: vscode.TextEditorDecorationType | undefined;
+let unmappedDecoration: vscode.TextEditorDecorationType | undefined;
+let coverageBar: vscode.StatusBarItem | undefined;
+let _activeTargetUri: string | undefined;
+
+export function registerCoverageCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+  client: LanguageClient,
+): void {
+  mappedDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: join(context.extensionPath, "src", "icons", "mapped.svg"),
+    gutterIconSize: "80%",
+    overviewRulerColor: "#4caf50",
+    overviewRulerLane: vscode.OverviewRulerLane.Left,
+  });
+
+  unmappedDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: join(context.extensionPath, "src", "icons", "unmapped.svg"),
+    gutterIconSize: "80%",
+    overviewRulerColor: "#f44336",
+    overviewRulerLane: vscode.OverviewRulerLane.Left,
+  });
+
+  coverageBar = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  context.subscriptions.push(mappedDecoration, unmappedDecoration, coverageBar);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showCoverage", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || editor.document.languageId !== "satsuma") return;
+
+      // Find the mapping name and target schema from the document
+      const text = editor.document.getText();
+      const info = extractMappingInfo(text, editor.selection.active.line);
+
+      if (!info) {
+        vscode.window.showWarningMessage(
+          "Place cursor inside a mapping block to show coverage.",
+        );
+        return;
+      }
+
+      const { mappingName, targetSchema } = info;
+
+      // Get unmapped fields via CLI
+      const result = await runCli(cliPath, [
+        "fields",
+        targetSchema,
+        "--unmapped-by",
+        mappingName,
+        "--json",
+      ]);
+
+      let unmappedFields: string[];
+      try {
+        const fields = JSON.parse(result.stdout);
+        if (!Array.isArray(fields)) {
+          vscode.window.showWarningMessage("Unexpected CLI output format.");
+          return;
+        }
+        unmappedFields = fields.map((f: { name: string }) => f.name);
+      } catch {
+        vscode.window.showWarningMessage(
+          `Coverage failed: ${result.stderr.trim() || "unknown error"}`,
+        );
+        return;
+      }
+
+      // Get field locations from LSP
+      let fieldLocations: Array<{ name: string; uri: string; line: number }>;
+      try {
+        fieldLocations = await client.sendRequest("satsuma/fieldLocations", {
+          name: targetSchema,
+        });
+      } catch {
+        vscode.window.showWarningMessage("Could not locate target schema fields.");
+        return;
+      }
+
+      if (fieldLocations.length === 0) {
+        vscode.window.showInformationMessage(
+          `No fields found for schema '${targetSchema}'.`,
+        );
+        return;
+      }
+
+      // Open the target schema file if not already open
+      const targetUri = fieldLocations[0]!.uri;
+      _activeTargetUri = targetUri;
+      const targetDoc = await vscode.workspace.openTextDocument(
+        vscode.Uri.parse(targetUri),
+      );
+      const targetEditor = await vscode.window.showTextDocument(
+        targetDoc,
+        { preserveFocus: true },
+      );
+
+      // Apply decorations
+      const unmappedSet = new Set(unmappedFields);
+      const mappedRanges: vscode.DecorationOptions[] = [];
+      const unmappedRanges: vscode.DecorationOptions[] = [];
+
+      for (const field of fieldLocations) {
+        const range = new vscode.Range(field.line, 0, field.line, 0);
+        if (unmappedSet.has(field.name)) {
+          unmappedRanges.push({
+            range,
+            hoverMessage: `**${field.name}** — unmapped`,
+          });
+        } else {
+          mappedRanges.push({
+            range,
+            hoverMessage: `**${field.name}** — mapped`,
+          });
+        }
+      }
+
+      targetEditor.setDecorations(mappedDecoration!, mappedRanges);
+      targetEditor.setDecorations(unmappedDecoration!, unmappedRanges);
+
+      // Update status bar
+      const total = fieldLocations.length;
+      const mapped = total - unmappedFields.length;
+      const pct = total > 0 ? Math.round((mapped / total) * 100) : 0;
+      coverageBar!.text = `$(check) Coverage: ${pct}%`;
+      coverageBar!.tooltip = `${mapped}/${total} fields mapped by '${mappingName}'`;
+      coverageBar!.show();
+    }),
+  );
+
+  // Clear decorations when switching editors
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(() => {
+      if (coverageBar) coverageBar.hide();
+    }),
+  );
+}
+
+/** Extract mapping name and target schema from document text near cursor. */
+function extractMappingInfo(
+  text: string,
+  cursorLine: number,
+): { mappingName: string; targetSchema: string } | null {
+  const lines = text.split("\n");
+
+  // Walk backwards from cursor to find "mapping" keyword
+  let mappingName: string | null = null;
+  for (let i = cursorLine; i >= 0; i--) {
+    const match = lines[i]?.match(/^mapping\s+(?:'([^']+)'|(\S+))/);
+    if (match) {
+      mappingName = match[1] ?? match[2] ?? null;
+      break;
+    }
+  }
+  if (!mappingName) return null;
+
+  // Find target block within the mapping
+  let targetSchema: string | null = null;
+  let inMapping = false;
+  let braceDepth = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (line.match(/^mapping\s/)) {
+      inMapping = line.includes(mappingName);
+      braceDepth = 0;
+    }
+    if (inMapping) {
+      for (const ch of line) {
+        if (ch === "{") braceDepth++;
+        if (ch === "}") braceDepth--;
+      }
+      const targetMatch = line.match(/target\s*\{\s*(?:`([^`]+)`|(\S+))/);
+      if (targetMatch) {
+        targetSchema = targetMatch[1] ?? targetMatch[2] ?? null;
+      }
+      if (braceDepth <= 0 && i > cursorLine) break;
+    }
+  }
+
+  if (!targetSchema) return null;
+  return { mappingName, targetSchema };
+}

--- a/tooling/vscode-satsuma/src/commands/lineage.ts
+++ b/tooling/vscode-satsuma/src/commands/lineage.ts
@@ -1,0 +1,74 @@
+import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { runCli } from "./cli-runner";
+
+export function registerLineageCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+  client: LanguageClient,
+  outputChannel: vscode.OutputChannel,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showLineage", async () => {
+      // Get block names from the LSP server
+      let names: Array<{ name: string; kind: string }>;
+      try {
+        names = await client.sendRequest("satsuma/blockNames");
+      } catch {
+        names = [];
+      }
+
+      const schemaNames = names
+        .filter((n) => n.kind === "schema")
+        .map((n) => n.name);
+
+      if (schemaNames.length === 0) {
+        vscode.window.showInformationMessage("No schemas found in workspace.");
+        return;
+      }
+
+      const selected = await vscode.window.showQuickPick(schemaNames, {
+        placeHolder: "Select a schema to trace lineage from",
+      });
+      if (!selected) return;
+
+      const result = await runCli(cliPath, [
+        "lineage",
+        "--from",
+        selected,
+        "--json",
+      ]);
+
+      if (result.exitCode !== 0) {
+        vscode.window.showWarningMessage(
+          `Lineage failed: ${result.stderr.trim() || "unknown error"}`,
+        );
+        return;
+      }
+
+      try {
+        const dag = JSON.parse(result.stdout);
+        outputChannel.clear();
+        outputChannel.appendLine(`Lineage from ${selected}:`);
+        outputChannel.appendLine("");
+        if (dag.nodes) {
+          for (const node of dag.nodes) {
+            outputChannel.appendLine(`  ${node.name}${node.type ? ` (${node.type})` : ""}`);
+          }
+        }
+        if (dag.edges) {
+          outputChannel.appendLine("");
+          outputChannel.appendLine("Edges:");
+          for (const edge of dag.edges) {
+            outputChannel.appendLine(`  ${edge.src} → ${edge.tgt}`);
+          }
+        }
+        outputChannel.show();
+      } catch {
+        outputChannel.clear();
+        outputChannel.appendLine(result.stdout);
+        outputChannel.show();
+      }
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/commands/summary.ts
+++ b/tooling/vscode-satsuma/src/commands/summary.ts
@@ -1,0 +1,60 @@
+import * as vscode from "vscode";
+import { runCli } from "./cli-runner";
+
+export function registerSummaryCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+  outputChannel: vscode.OutputChannel,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showSummary", async () => {
+      const result = await runCli(cliPath, ["summary", "--json"]);
+
+      if (result.exitCode !== 0) {
+        vscode.window.showWarningMessage(
+          `Summary failed: ${result.stderr.trim() || "unknown error"}`,
+        );
+        return;
+      }
+
+      try {
+        const data = JSON.parse(result.stdout);
+        outputChannel.clear();
+        outputChannel.appendLine("Satsuma Workspace Summary");
+        outputChannel.appendLine("=".repeat(40));
+        outputChannel.appendLine("");
+
+        if (data.files !== undefined) {
+          outputChannel.appendLine(`Files: ${data.files}`);
+        }
+        if (data.schemas !== undefined) {
+          outputChannel.appendLine(`Schemas: ${data.schemas}`);
+        }
+        if (data.mappings !== undefined) {
+          outputChannel.appendLine(`Mappings: ${data.mappings}`);
+        }
+        if (data.fragments !== undefined) {
+          outputChannel.appendLine(`Fragments: ${data.fragments}`);
+        }
+        if (data.transforms !== undefined) {
+          outputChannel.appendLine(`Transforms: ${data.transforms}`);
+        }
+        if (data.metrics !== undefined) {
+          outputChannel.appendLine(`Metrics: ${data.metrics}`);
+        }
+        if (data.notes !== undefined) {
+          outputChannel.appendLine(`Notes: ${data.notes}`);
+        }
+        if (data.arrows !== undefined) {
+          outputChannel.appendLine(`Arrows: ${data.arrows}`);
+        }
+
+        outputChannel.show();
+      } catch {
+        outputChannel.clear();
+        outputChannel.appendLine(result.stdout);
+        outputChannel.show();
+      }
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/commands/validate.ts
+++ b/tooling/vscode-satsuma/src/commands/validate.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import { runCli } from "./cli-runner";
+
+export function registerValidateCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+): void {
+  const diagnostics = vscode.languages.createDiagnosticCollection("satsuma-validate-cmd");
+  context.subscriptions.push(diagnostics);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.validateWorkspace", async () => {
+      const result = await runCli(cliPath, ["validate", "--json"]);
+      diagnostics.clear();
+
+      let entries: Array<{
+        file: string;
+        line: number;
+        column: number;
+        severity: string;
+        rule: string;
+        message: string;
+      }>;
+
+      try {
+        entries = JSON.parse(result.stdout);
+        if (!Array.isArray(entries)) return;
+      } catch {
+        if (result.stderr) {
+          vscode.window.showWarningMessage(`Satsuma validate: ${result.stderr.trim()}`);
+        }
+        return;
+      }
+
+      const grouped = new Map<string, vscode.Diagnostic[]>();
+      for (const e of entries) {
+        const uri = vscode.Uri.file(e.file).toString();
+        const diag = new vscode.Diagnostic(
+          new vscode.Range(
+            Math.max(0, e.line - 1),
+            Math.max(0, e.column - 1),
+            Math.max(0, e.line - 1),
+            Math.max(0, e.column - 1),
+          ),
+          e.message,
+          e.severity === "error"
+            ? vscode.DiagnosticSeverity.Error
+            : vscode.DiagnosticSeverity.Warning,
+        );
+        diag.source = "satsuma-validate";
+        diag.code = e.rule;
+        if (!grouped.has(uri)) grouped.set(uri, []);
+        grouped.get(uri)!.push(diag);
+      }
+
+      for (const [uriStr, diags] of grouped) {
+        diagnostics.set(vscode.Uri.parse(uriStr), diags);
+      }
+
+      vscode.window.showInformationMessage(
+        `Satsuma: ${entries.length} diagnostic(s) found.`,
+      );
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/commands/warnings.ts
+++ b/tooling/vscode-satsuma/src/commands/warnings.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+import { runCli } from "./cli-runner";
+
+export function registerWarningsCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+): void {
+  const diagnostics = vscode.languages.createDiagnosticCollection("satsuma-warnings-cmd");
+  context.subscriptions.push(diagnostics);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showWarnings", async () => {
+      const result = await runCli(cliPath, ["warnings", "--json"]);
+      diagnostics.clear();
+
+      try {
+        const data = JSON.parse(result.stdout);
+        if (!data.items || data.items.length === 0) {
+          vscode.window.showInformationMessage("No warnings found.");
+          return;
+        }
+
+        const grouped = new Map<string, vscode.Diagnostic[]>();
+        for (const item of data.items) {
+          if (!item.file) continue;
+          const uri = vscode.Uri.file(item.file).toString();
+          const diag = new vscode.Diagnostic(
+            new vscode.Range(item.row ?? 0, 0, item.row ?? 0, 0),
+            item.text,
+            vscode.DiagnosticSeverity.Warning,
+          );
+          diag.source = "satsuma-warnings";
+          if (!grouped.has(uri)) grouped.set(uri, []);
+          grouped.get(uri)!.push(diag);
+        }
+
+        for (const [uriStr, diags] of grouped) {
+          diagnostics.set(vscode.Uri.parse(uriStr), diags);
+        }
+
+        vscode.window.showInformationMessage(
+          `Satsuma: ${data.count} warning(s) found.`,
+        );
+      } catch {
+        if (result.stderr) {
+          vscode.window.showWarningMessage(result.stderr.trim());
+        }
+      }
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/commands/where-used.ts
+++ b/tooling/vscode-satsuma/src/commands/where-used.ts
@@ -1,0 +1,62 @@
+import * as vscode from "vscode";
+import { runCli } from "./cli-runner";
+
+export function registerWhereUsedCommand(
+  context: vscode.ExtensionContext,
+  cliPath: string,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.whereUsed", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || editor.document.languageId !== "satsuma") return;
+
+      const wordRange = editor.document.getWordRangeAtPosition(
+        editor.selection.active,
+      );
+      if (!wordRange) return;
+      const word = editor.document.getText(wordRange);
+
+      const result = await runCli(cliPath, [
+        "where-used",
+        word,
+        "--json",
+      ]);
+
+      if (result.exitCode !== 0) {
+        vscode.window.showWarningMessage(
+          `Where-used failed: ${result.stderr.trim() || "not found"}`,
+        );
+        return;
+      }
+
+      try {
+        const data = JSON.parse(result.stdout);
+        if (!data.refs || data.refs.length === 0) {
+          vscode.window.showInformationMessage(
+            `No references found for '${word}'.`,
+          );
+          return;
+        }
+
+        const locations: vscode.Location[] = data.refs
+          .filter((r: { file?: string }) => r.file)
+          .map(
+            (r: { file: string; row?: number }) =>
+              new vscode.Location(
+                vscode.Uri.file(r.file),
+                new vscode.Position(r.row ?? 0, 0),
+              ),
+          );
+
+        await vscode.commands.executeCommand(
+          "editor.action.showReferences",
+          editor.document.uri,
+          editor.selection.active,
+          locations,
+        );
+      } catch {
+        vscode.window.showWarningMessage("Failed to parse where-used results.");
+      }
+    }),
+  );
+}

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -1,11 +1,17 @@
 import { join } from "path";
-import { ExtensionContext, workspace } from "vscode";
+import { ExtensionContext, window, workspace } from "vscode";
 import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
+import { registerValidateCommand } from "./commands/validate";
+import { registerLineageCommand } from "./commands/lineage";
+import { registerWhereUsedCommand } from "./commands/where-used";
+import { registerWarningsCommand } from "./commands/warnings";
+import { registerSummaryCommand } from "./commands/summary";
+import { registerArrowsCommand } from "./commands/arrows";
 
 let client: LanguageClient | undefined;
 
@@ -45,6 +51,21 @@ export function activate(context: ExtensionContext): void {
 
   client.start();
   context.subscriptions.push({ dispose: () => client?.stop() });
+
+  // Output channel for command results
+  const outputChannel = window.createOutputChannel("Satsuma");
+  context.subscriptions.push(outputChannel);
+
+  // Register commands
+  registerValidateCommand(context, cliPath);
+  registerLineageCommand(context, cliPath, client, outputChannel);
+  registerWhereUsedCommand(context, cliPath);
+  registerWarningsCommand(context, cliPath);
+  registerSummaryCommand(context, cliPath, outputChannel);
+  registerArrowsCommand(context, cliPath, outputChannel);
+
+  // Graph and lineage webview commands are registered in later steps
+  // (satsuma.showGraph, satsuma.traceFieldLineage, satsuma.showCoverage)
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import * as vscode from "vscode";
 import { ExtensionContext, window, workspace } from "vscode";
 import {
   LanguageClient,
@@ -12,6 +13,9 @@ import { registerWhereUsedCommand } from "./commands/where-used";
 import { registerWarningsCommand } from "./commands/warnings";
 import { registerSummaryCommand } from "./commands/summary";
 import { registerArrowsCommand } from "./commands/arrows";
+import { registerCoverageCommand } from "./commands/coverage";
+import { GraphPanel } from "./webview/graph/panel";
+import { LineagePanel } from "./webview/lineage/panel";
 
 let client: LanguageClient | undefined;
 
@@ -64,8 +68,35 @@ export function activate(context: ExtensionContext): void {
   registerSummaryCommand(context, cliPath, outputChannel);
   registerArrowsCommand(context, cliPath, outputChannel);
 
-  // Graph and lineage webview commands are registered in later steps
-  // (satsuma.showGraph, satsuma.traceFieldLineage, satsuma.showCoverage)
+  registerCoverageCommand(context, cliPath, client);
+
+  // Graph webview
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.showGraph", () => {
+      GraphPanel.createOrShow(context.extensionUri, cliPath);
+    }),
+  );
+
+  // Lineage webview
+  context.subscriptions.push(
+    vscode.commands.registerCommand("satsuma.traceFieldLineage", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || editor.document.languageId !== "satsuma") return;
+
+      const word = editor.document.getText(
+        editor.document.getWordRangeAtPosition(editor.selection.active),
+      );
+
+      const fieldPath = await vscode.window.showInputBox({
+        prompt: "Enter field reference (schema.field)",
+        value: word?.includes(".") ? word : `${word ?? ""}.`,
+        placeHolder: "customers.email",
+      });
+      if (!fieldPath) return;
+
+      LineagePanel.createOrShow(context.extensionUri, cliPath, fieldPath);
+    }),
+  );
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/tooling/vscode-satsuma/src/icons/mapped.svg
+++ b/tooling/vscode-satsuma/src/icons/mapped.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5" fill="#4caf50" opacity="0.8"/>
+</svg>

--- a/tooling/vscode-satsuma/src/icons/unmapped.svg
+++ b/tooling/vscode-satsuma/src/icons/unmapped.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="5" fill="#f44336" opacity="0.8"/>
+</svg>

--- a/tooling/vscode-satsuma/src/webview/graph/graph.css
+++ b/tooling/vscode-satsuma/src/webview/graph/graph.css
@@ -1,0 +1,88 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--vscode-font-family, sans-serif);
+  background: var(--vscode-editor-background, #1e1e1e);
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  overflow: hidden;
+}
+
+#controls {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 10;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+#controls select {
+  background: var(--vscode-dropdown-background, #3c3c3c);
+  color: var(--vscode-dropdown-foreground, #d4d4d4);
+  border: 1px solid var(--vscode-dropdown-border, #555);
+  padding: 4px 8px;
+  border-radius: 2px;
+  font-size: 12px;
+}
+
+#stats {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+#graph {
+  width: 100vw;
+  height: 100vh;
+}
+
+/* Node shapes */
+.node rect, .node circle, .node polygon {
+  stroke-width: 1.5;
+  cursor: pointer;
+}
+
+.node text {
+  font-size: 11px;
+  fill: var(--vscode-editor-foreground, #d4d4d4);
+  pointer-events: none;
+  text-anchor: middle;
+  dominant-baseline: central;
+}
+
+.node:hover rect, .node:hover circle, .node:hover polygon {
+  stroke-width: 3;
+}
+
+/* Node kind colors */
+.node-schema rect { fill: #264f78; stroke: #4fc1ff; }
+.node-mapping polygon { fill: #4e3a1e; stroke: #dcdcaa; }
+.node-metric circle { fill: #1e3a2e; stroke: #6a9955; }
+.node-fragment rect { fill: #3a1e3a; stroke: #c586c0; rx: 8; ry: 8; }
+.node-transform rect { fill: #3a2e1e; stroke: #ce9178; rx: 4; ry: 4; }
+
+/* Edge styles */
+.edge { fill: none; stroke-width: 1.5; }
+.edge-structural { stroke: #569cd6; }
+.edge-nl { stroke: #ce9178; stroke-dasharray: 6 3; }
+.edge-mixed { stroke: #dcdcaa; stroke-dasharray: 3 3; }
+.edge-none { stroke: #555; }
+
+.edge-label {
+  font-size: 9px;
+  fill: var(--vscode-editor-foreground, #d4d4d4);
+  opacity: 0.6;
+}
+
+/* Tooltip */
+.tooltip {
+  position: fixed;
+  background: var(--vscode-editorHoverWidget-background, #2d2d2d);
+  border: 1px solid var(--vscode-editorHoverWidget-border, #454545);
+  padding: 6px 10px;
+  border-radius: 3px;
+  font-size: 12px;
+  pointer-events: none;
+  z-index: 100;
+  max-width: 300px;
+}

--- a/tooling/vscode-satsuma/src/webview/graph/graph.ts
+++ b/tooling/vscode-satsuma/src/webview/graph/graph.ts
@@ -1,0 +1,294 @@
+/**
+ * Webview-side graph rendering for Satsuma workspace graph.
+ * Uses vanilla SVG — no D3 dependency needed for this DAG layout.
+ */
+
+// @ts-nocheck — runs in webview context, no node/vscode types
+
+const vscode = acquireVsCodeApi();
+
+interface GraphNode {
+  id: string;
+  kind: string;
+  namespace: string | null;
+  file: string;
+  line: number;
+  fields?: Array<{ name: string }>;
+  sources?: string[];
+  targets?: string[];
+}
+
+interface SchemaEdge {
+  from: string;
+  to: string;
+  role: string;
+}
+
+interface GraphData {
+  stats?: Record<string, number>;
+  nodes: GraphNode[];
+  schema_edges: SchemaEdge[];
+}
+
+let currentData: GraphData | null = null;
+let currentFilter = "";
+
+// Listen for messages from extension
+window.addEventListener("message", (event) => {
+  const msg = event.data;
+  if (msg.type === "graphData") {
+    currentData = msg.payload;
+    render(currentData!, currentFilter);
+  } else if (msg.type === "error") {
+    showError(msg.message);
+  }
+});
+
+// Namespace filter
+document.getElementById("namespace-filter")?.addEventListener("change", (e) => {
+  currentFilter = (e.target as HTMLSelectElement).value;
+  if (currentData) render(currentData, currentFilter);
+});
+
+function render(data: GraphData, nsFilter: string): void {
+  updateNamespaceDropdown(data.nodes);
+  updateStats(data.stats);
+
+  // Filter nodes by namespace
+  let nodes = data.nodes;
+  if (nsFilter) {
+    nodes = nodes.filter((n) => n.namespace === nsFilter);
+  }
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const edges = (data.schema_edges ?? []).filter(
+    (e) => nodeIds.has(e.from) && nodeIds.has(e.to),
+  );
+
+  // Simple layer-based layout
+  const layout = computeLayout(nodes, edges);
+
+  const svg = document.getElementById("graph") as unknown as SVGSVGElement;
+  svg.innerHTML = "";
+
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+  // Draw edges first (behind nodes)
+  for (const edge of edges) {
+    const from = layout.get(edge.from);
+    const to = layout.get(edge.to);
+    if (!from || !to) continue;
+
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    line.setAttribute("x1", String(from.x));
+    line.setAttribute("y1", String(from.y));
+    line.setAttribute("x2", String(to.x));
+    line.setAttribute("y2", String(to.y));
+    line.setAttribute("class", `edge edge-${classForRole(edge.role)}`);
+    line.setAttribute("marker-end", "url(#arrowhead)");
+    svg.appendChild(line);
+  }
+
+  // Arrow marker
+  const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+  defs.innerHTML = `<marker id="arrowhead" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+    <polygon points="0 0, 8 3, 0 6" fill="#888"/>
+  </marker>`;
+  svg.prepend(defs);
+
+  // Draw nodes
+  for (const node of nodes) {
+    const pos = layout.get(node.id);
+    if (!pos) continue;
+    const g = createNodeElement(node, pos.x, pos.y);
+    svg.appendChild(g);
+  }
+}
+
+function computeLayout(
+  nodes: GraphNode[],
+  edges: SchemaEdge[],
+): Map<string, { x: number; y: number }> {
+  // Topological layering: sources on left, targets on right
+  const inDegree = new Map<string, number>();
+  const outEdges = new Map<string, string[]>();
+
+  for (const n of nodes) {
+    inDegree.set(n.id, 0);
+    outEdges.set(n.id, []);
+  }
+  for (const e of edges) {
+    inDegree.set(e.to, (inDegree.get(e.to) ?? 0) + 1);
+    outEdges.get(e.from)?.push(e.to);
+  }
+
+  // Assign layers via BFS from roots
+  const layers = new Map<string, number>();
+  const queue: string[] = [];
+  for (const [id, deg] of inDegree) {
+    if (deg === 0) {
+      queue.push(id);
+      layers.set(id, 0);
+    }
+  }
+
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const layer = layers.get(id) ?? 0;
+    for (const next of outEdges.get(id) ?? []) {
+      const nextLayer = Math.max(layers.get(next) ?? 0, layer + 1);
+      layers.set(next, nextLayer);
+      // Only enqueue if all predecessors assigned
+      const allPredAssigned = edges
+        .filter((e) => e.to === next)
+        .every((e) => layers.has(e.from));
+      if (allPredAssigned && !queue.includes(next)) {
+        queue.push(next);
+      }
+    }
+  }
+
+  // Assign unplaced nodes to layer 0
+  for (const n of nodes) {
+    if (!layers.has(n.id)) layers.set(n.id, 0);
+  }
+
+  // Group by layer
+  const maxLayer = Math.max(0, ...layers.values());
+  const layerGroups: string[][] = Array.from({ length: maxLayer + 1 }, () => []);
+  for (const [id, layer] of layers) {
+    layerGroups[layer]?.push(id);
+  }
+
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  const layerWidth = width / (maxLayer + 2);
+  const positions = new Map<string, { x: number; y: number }>();
+
+  for (let l = 0; l <= maxLayer; l++) {
+    const group = layerGroups[l] ?? [];
+    const layerHeight = height / (group.length + 1);
+    for (let i = 0; i < group.length; i++) {
+      positions.set(group[i]!, {
+        x: (l + 1) * layerWidth,
+        y: (i + 1) * layerHeight,
+      });
+    }
+  }
+
+  return positions;
+}
+
+function createNodeElement(node: GraphNode, x: number, y: number): SVGGElement {
+  const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  g.setAttribute("class", `node node-${node.kind}`);
+  g.setAttribute("transform", `translate(${x},${y})`);
+  g.style.cursor = "pointer";
+
+  const label = node.id.length > 20 ? node.id.slice(0, 18) + "…" : node.id;
+  const w = Math.max(80, label.length * 7 + 20);
+  const h = 30;
+
+  if (node.kind === "mapping") {
+    // Diamond shape
+    const points = `0,${-h / 2} ${w / 2},0 0,${h / 2} ${-w / 2},0`;
+    const poly = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+    poly.setAttribute("points", points);
+    g.appendChild(poly);
+  } else if (node.kind === "metric") {
+    // Circle
+    const circ = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    circ.setAttribute("r", String(Math.max(w, h) / 2));
+    g.appendChild(circ);
+  } else {
+    // Rectangle (schema, fragment, transform)
+    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect.setAttribute("x", String(-w / 2));
+    rect.setAttribute("y", String(-h / 2));
+    rect.setAttribute("width", String(w));
+    rect.setAttribute("height", String(h));
+    if (node.kind === "fragment") {
+      rect.setAttribute("rx", "8");
+      rect.setAttribute("ry", "8");
+    }
+    g.appendChild(rect);
+  }
+
+  const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  text.textContent = label;
+  g.appendChild(text);
+
+  // Click to navigate
+  g.addEventListener("click", () => {
+    vscode.postMessage({
+      type: "navigate",
+      uri: node.file,
+      line: Math.max(0, (node.line ?? 1) - 1),
+    });
+  });
+
+  // Hover tooltip
+  g.addEventListener("mouseenter", (e: MouseEvent) => {
+    showTooltip(e, node);
+  });
+  g.addEventListener("mouseleave", () => {
+    hideTooltip();
+  });
+
+  return g;
+}
+
+function classForRole(role: string): string {
+  if (role === "source" || role === "target") return "structural";
+  if (role === "fragment_spread") return "nl";
+  return "none";
+}
+
+function updateNamespaceDropdown(nodes: GraphNode[]): void {
+  const select = document.getElementById("namespace-filter") as HTMLSelectElement;
+  const namespaces = [...new Set(nodes.map((n) => n.namespace).filter(Boolean))].sort();
+  // Keep existing selection
+  const current = select.value;
+  select.innerHTML = '<option value="">All namespaces</option>';
+  for (const ns of namespaces) {
+    const opt = document.createElement("option");
+    opt.value = ns!;
+    opt.textContent = ns!;
+    select.appendChild(opt);
+  }
+  select.value = current;
+}
+
+function updateStats(stats?: Record<string, number>): void {
+  const el = document.getElementById("stats");
+  if (!el || !stats) return;
+  const parts: string[] = [];
+  if (stats.schemas) parts.push(`${stats.schemas} schemas`);
+  if (stats.mappings) parts.push(`${stats.mappings} mappings`);
+  if (stats.metrics) parts.push(`${stats.metrics} metrics`);
+  el.textContent = parts.join(" · ");
+}
+
+// Tooltip helpers
+let tooltipEl: HTMLDivElement | null = null;
+
+function showTooltip(e: MouseEvent, node: GraphNode): void {
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  const lines: string[] = [`<b>${node.kind}</b> ${node.id}`];
+  if (node.fields) lines.push(`${node.fields.length} field(s)`);
+  if (node.sources) lines.push(`sources: ${node.sources.join(", ")}`);
+  if (node.targets) lines.push(`targets: ${node.targets.join(", ")}`);
+  tooltipEl.innerHTML = lines.join("<br>");
+  tooltipEl.style.left = `${e.clientX + 12}px`;
+  tooltipEl.style.top = `${e.clientY + 12}px`;
+  tooltipEl.style.display = "block";
+}
+
+function hideTooltip(): void {
+  if (tooltipEl) tooltipEl.style.display = "none";
+}

--- a/tooling/vscode-satsuma/src/webview/graph/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/graph/panel.ts
@@ -1,0 +1,147 @@
+import * as vscode from "vscode";
+import { join } from "path";
+import { runCli } from "../../commands/cli-runner";
+
+export class GraphPanel {
+  static currentPanel: GraphPanel | undefined;
+  private readonly panel: vscode.WebviewPanel;
+  private readonly extensionUri: vscode.Uri;
+  private readonly cliPath: string;
+  private disposables: vscode.Disposable[] = [];
+
+  static createOrShow(
+    extensionUri: vscode.Uri,
+    cliPath: string,
+  ): void {
+    if (GraphPanel.currentPanel) {
+      GraphPanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
+      GraphPanel.currentPanel.refresh();
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "satsumaGraph",
+      "Satsuma: Workspace Graph",
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview"))],
+      },
+    );
+
+    GraphPanel.currentPanel = new GraphPanel(panel, extensionUri, cliPath);
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    cliPath: string,
+  ) {
+    this.panel = panel;
+    this.extensionUri = extensionUri;
+    this.cliPath = cliPath;
+
+    this.panel.webview.html = this.getHtml();
+
+    // Handle messages from webview
+    this.panel.webview.onDidReceiveMessage(
+      (msg) => this.handleMessage(msg),
+      null,
+      this.disposables,
+    );
+
+    // Refresh on save
+    const saveWatcher = vscode.workspace.onDidSaveTextDocument((doc) => {
+      if (doc.fileName.endsWith(".stm")) {
+        this.refresh();
+      }
+    });
+    this.disposables.push(saveWatcher);
+
+    // Clean up on dispose
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+    // Initial data load
+    this.refresh();
+  }
+
+  async refresh(): Promise<void> {
+    const result = await runCli(this.cliPath, ["graph", "--json"]);
+    if (result.exitCode !== 0 && !result.stdout.trim()) {
+      this.panel.webview.postMessage({
+        type: "error",
+        message: result.stderr.trim() || "Failed to load graph data",
+      });
+      return;
+    }
+
+    try {
+      const data = JSON.parse(result.stdout);
+      this.panel.webview.postMessage({ type: "graphData", payload: data });
+    } catch {
+      this.panel.webview.postMessage({
+        type: "error",
+        message: "Failed to parse graph data",
+      });
+    }
+  }
+
+  private handleMessage(message: { type: string; uri?: string; line?: number }): void {
+    if (message.type === "navigate" && message.uri) {
+      const uri = vscode.Uri.file(message.uri);
+      const line = message.line ?? 0;
+      vscode.window.showTextDocument(uri, {
+        selection: new vscode.Range(line, 0, line, 0),
+      });
+    }
+  }
+
+  dispose(): void {
+    GraphPanel.currentPanel = undefined;
+    this.panel.dispose();
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables = [];
+  }
+
+  private getHtml(): string {
+    const scriptUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "graph", "graph.js")),
+    );
+    const styleUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "graph", "graph.css")),
+    );
+    const nonce = getNonce();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${this.panel.webview.cspSource}; script-src 'nonce-${nonce}';">
+  <link rel="stylesheet" href="${styleUri}">
+  <title>Satsuma Graph</title>
+</head>
+<body>
+  <div id="controls">
+    <select id="namespace-filter">
+      <option value="">All namespaces</option>
+    </select>
+    <span id="stats"></span>
+  </div>
+  <svg id="graph"></svg>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+}
+
+function getNonce(): string {
+  let text = "";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}

--- a/tooling/vscode-satsuma/src/webview/lineage/lineage.css
+++ b/tooling/vscode-satsuma/src/webview/lineage/lineage.css
@@ -1,0 +1,97 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--vscode-font-family, sans-serif);
+  background: var(--vscode-editor-background, #1e1e1e);
+  color: var(--vscode-editor-foreground, #d4d4d4);
+  padding: 24px;
+  overflow-x: auto;
+}
+
+#lineage {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  min-height: 80px;
+  padding: 20px;
+}
+
+.field-node {
+  background: var(--vscode-editor-background, #1e1e1e);
+  border: 1.5px solid #569cd6;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.field-node:hover {
+  border-color: #4fc1ff;
+  background: #264f78;
+}
+
+.field-node .schema {
+  font-size: 10px;
+  opacity: 0.6;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.field-node .name {
+  font-weight: 600;
+}
+
+.arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 8px;
+  min-width: 60px;
+}
+
+.arrow-line {
+  width: 100%;
+  height: 2px;
+  background: #569cd6;
+  position: relative;
+}
+
+.arrow-line::after {
+  content: "";
+  position: absolute;
+  right: -1px;
+  top: -4px;
+  border: 5px solid transparent;
+  border-left: 6px solid #569cd6;
+}
+
+.arrow-label {
+  font-size: 10px;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: #333;
+  white-space: nowrap;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.arrow-label.nl {
+  background: #4e3a1e;
+  color: #ce9178;
+}
+
+.arrow-label.nl::before {
+  content: "NL ";
+  font-weight: 700;
+  font-size: 9px;
+}
+
+.empty-message {
+  opacity: 0.5;
+  font-style: italic;
+  padding: 40px;
+}

--- a/tooling/vscode-satsuma/src/webview/lineage/lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/lineage/lineage.ts
@@ -1,0 +1,142 @@
+/**
+ * Webview-side lineage rendering for Satsuma field-level lineage.
+ * Renders a horizontal chain of field nodes connected by arrow edges.
+ */
+
+// @ts-nocheck — runs in webview context
+
+const vscode = acquireVsCodeApi();
+
+interface ArrowEntry {
+  source: string;
+  target: string;
+  classification: string;
+  transform: string;
+  file: string;
+  line: number;
+}
+
+window.addEventListener("message", (event) => {
+  const msg = event.data;
+  if (msg.type === "lineageData") {
+    render(msg.payload);
+  }
+});
+
+function render(arrows: ArrowEntry[]): void {
+  const container = document.getElementById("lineage")!;
+  container.innerHTML = "";
+
+  if (arrows.length === 0) {
+    container.innerHTML = '<div class="empty-message">No lineage found for this field.</div>';
+    return;
+  }
+
+  // Build ordered chain from arrows
+  const chain = buildChain(arrows);
+
+  for (let i = 0; i < chain.length; i++) {
+    const step = chain[i]!;
+
+    // Source node (only for the first step)
+    if (i === 0) {
+      container.appendChild(createFieldNode(step.source, step.file, step.line));
+    }
+
+    // Arrow with transform label
+    container.appendChild(createArrow(step.transform, step.classification));
+
+    // Target node
+    container.appendChild(createFieldNode(step.target, step.file, step.line));
+  }
+}
+
+function buildChain(arrows: ArrowEntry[]): ArrowEntry[] {
+  if (arrows.length === 0) return [];
+
+  // Simple ordering: follow source → target chain
+  const bySource = new Map<string, ArrowEntry>();
+  const allTargets = new Set<string>();
+
+  for (const a of arrows) {
+    bySource.set(a.source, a);
+    allTargets.add(a.target);
+  }
+
+  // Find the root (a source that's not any target)
+  let start: ArrowEntry | undefined;
+  for (const a of arrows) {
+    if (!allTargets.has(a.source)) {
+      start = a;
+      break;
+    }
+  }
+  if (!start) start = arrows[0];
+
+  // Follow the chain
+  const chain: ArrowEntry[] = [];
+  const visited = new Set<string>();
+  let current: ArrowEntry | undefined = start;
+
+  while (current && !visited.has(current.source)) {
+    visited.add(current.source);
+    chain.push(current);
+    current = bySource.get(current.target);
+  }
+
+  // Add any remaining arrows not in the chain
+  for (const a of arrows) {
+    if (!visited.has(a.source)) {
+      chain.push(a);
+    }
+  }
+
+  return chain;
+}
+
+function createFieldNode(fieldPath: string, file: string, line: number): HTMLDivElement {
+  const div = document.createElement("div");
+  div.className = "field-node";
+
+  const parts = fieldPath.split(".");
+  const schema = parts.length > 1 ? parts.slice(0, -1).join(".") : "";
+  const field = parts[parts.length - 1] ?? fieldPath;
+
+  if (schema) {
+    const schemaEl = document.createElement("span");
+    schemaEl.className = "schema";
+    schemaEl.textContent = schema;
+    div.appendChild(schemaEl);
+  }
+
+  const nameEl = document.createElement("span");
+  nameEl.className = "name";
+  nameEl.textContent = field;
+  div.appendChild(nameEl);
+
+  div.addEventListener("click", () => {
+    vscode.postMessage({ type: "navigate", uri: file, line: Math.max(0, line - 1) });
+  });
+
+  return div;
+}
+
+function createArrow(transform: string, classification: string): HTMLDivElement {
+  const div = document.createElement("div");
+  div.className = "arrow";
+
+  const line = document.createElement("div");
+  line.className = "arrow-line";
+  div.appendChild(line);
+
+  if (transform) {
+    const label = document.createElement("div");
+    const isNl = classification === "nl" || classification === "nl-derived";
+    label.className = `arrow-label${isNl ? " nl" : ""}`;
+    label.textContent = transform.length > 30 ? transform.slice(0, 28) + "…" : transform;
+    label.title = transform;
+    div.appendChild(label);
+  }
+
+  return div;
+}

--- a/tooling/vscode-satsuma/src/webview/lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/lineage/panel.ts
@@ -1,0 +1,170 @@
+import * as vscode from "vscode";
+import { join } from "path";
+import { runCli } from "../../commands/cli-runner";
+
+export class LineagePanel {
+  static currentPanel: LineagePanel | undefined;
+  private readonly panel: vscode.WebviewPanel;
+  private readonly extensionUri: vscode.Uri;
+  private readonly cliPath: string;
+  private disposables: vscode.Disposable[] = [];
+
+  static createOrShow(
+    extensionUri: vscode.Uri,
+    cliPath: string,
+    fieldPath: string,
+  ): void {
+    if (LineagePanel.currentPanel) {
+      LineagePanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
+      LineagePanel.currentPanel.refresh(fieldPath);
+      return;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      "satsumaLineage",
+      `Satsuma: Lineage — ${fieldPath}`,
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview"))],
+      },
+    );
+
+    LineagePanel.currentPanel = new LineagePanel(panel, extensionUri, cliPath, fieldPath);
+  }
+
+  private constructor(
+    panel: vscode.WebviewPanel,
+    extensionUri: vscode.Uri,
+    cliPath: string,
+    fieldPath: string,
+  ) {
+    this.panel = panel;
+    this.extensionUri = extensionUri;
+    this.cliPath = cliPath;
+
+    this.panel.webview.html = this.getHtml();
+
+    this.panel.webview.onDidReceiveMessage(
+      (msg) => this.handleMessage(msg),
+      null,
+      this.disposables,
+    );
+
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+    this.refresh(fieldPath);
+  }
+
+  async refresh(fieldPath: string): Promise<void> {
+    this.panel.title = `Satsuma: Lineage — ${fieldPath}`;
+
+    // Trace multi-hop lineage
+    const chain = await this.traceLineage(fieldPath, 10);
+
+    this.panel.webview.postMessage({ type: "lineageData", payload: chain });
+  }
+
+  private async traceLineage(
+    fieldPath: string,
+    maxHops: number,
+  ): Promise<Array<{ source: string; target: string; classification: string; transform: string; file: string; line: number }>> {
+    const visited = new Set<string>();
+    const allArrows: Array<{ source: string; target: string; classification: string; transform: string; file: string; line: number }> = [];
+    const queue = [fieldPath];
+
+    for (let hop = 0; hop < maxHops && queue.length > 0; hop++) {
+      const current = queue.shift()!;
+      if (visited.has(current)) continue;
+      visited.add(current);
+
+      const result = await runCli(this.cliPath, [
+        "arrows",
+        current,
+        "--as-source",
+        "--json",
+      ]);
+
+      if (result.exitCode !== 0 || !result.stdout.trim()) continue;
+
+      try {
+        const arrows = JSON.parse(result.stdout);
+        if (!Array.isArray(arrows)) continue;
+
+        for (const a of arrows) {
+          const src = a.source_qualified ?? `${current.split(".")[0]}.${a.source}`;
+          const tgt = a.target_qualified ?? `${a.target_schema ?? "?"}.${a.target}`;
+
+          allArrows.push({
+            source: src,
+            target: tgt,
+            classification: a.classification ?? "none",
+            transform: a.transform_raw ?? "",
+            file: a.file ?? "",
+            line: a.line ?? 0,
+          });
+
+          // Follow the target for next hop
+          if (!visited.has(tgt)) {
+            queue.push(tgt);
+          }
+        }
+      } catch {
+        // Parse error — skip
+      }
+    }
+
+    return allArrows;
+  }
+
+  private handleMessage(message: { type: string; uri?: string; line?: number }): void {
+    if (message.type === "navigate" && message.uri) {
+      const uri = vscode.Uri.file(message.uri);
+      const line = message.line ?? 0;
+      vscode.window.showTextDocument(uri, {
+        selection: new vscode.Range(line, 0, line, 0),
+      });
+    }
+  }
+
+  dispose(): void {
+    LineagePanel.currentPanel = undefined;
+    this.panel.dispose();
+    for (const d of this.disposables) d.dispose();
+    this.disposables = [];
+  }
+
+  private getHtml(): string {
+    const scriptUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "lineage", "lineage.js")),
+    );
+    const styleUri = this.panel.webview.asWebviewUri(
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "lineage", "lineage.css")),
+    );
+    const nonce = getNonce();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${this.panel.webview.cspSource}; script-src 'nonce-${nonce}';">
+  <link rel="stylesheet" href="${styleUri}">
+  <title>Satsuma Lineage</title>
+</head>
+<body>
+  <div id="lineage"></div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+  }
+}
+
+function getNonce(): string {
+  let text = "";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (let i = 0; i < 32; i++) {
+    text += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return text;
+}


### PR DESCRIPTION
## Summary

Full PRD Phase 2+3 scope for the Satsuma VS Code extension:

- **CodeLens**: inline annotations on all block types — field counts, mapping usage, spread counts, source→target arrows, metric sources
- **Rename Symbol**: F2 workspace-wide rename for schemas, fragments, transforms, mappings. Duplicate detection, qualified name handling
- **9 Command Palette entries**: Validate Workspace, Show Lineage, Where Used, Show Warnings, Show Summary, Show Arrows, Show Graph, Trace Field Lineage, Show Coverage
- **Workspace Graph Webview**: SVG DAG layout with namespace filter, click-to-navigate, auto-refresh on save. Nodes by block type, schema-level edges
- **Field-Level Lineage Webview**: multi-hop chain tracing via `satsuma arrows`, horizontal flow with NL transform badges
- **Mapping Coverage Heatmap**: gutter decorations (green/red) on target schema fields, status bar coverage percentage
- **Custom LSP requests**: `satsuma/blockNames` and `satsuma/fieldLocations` for command QuickPicks and coverage
- 17 new server tests (142 total LSP tests passing), full extension check passing

Closes sl-oz1t.

## Test plan

- [x] `npm run check` passes (manifest + grammar + TextMate + golden + 142 LSP tests)
- [x] `npm run build` bundles client + server + graph webview + lineage webview
- [ ] CodeLens visible above schema/mapping/fragment/metric blocks
- [ ] F2 rename updates definition + all references across files
- [ ] Command palette shows all 9 `Satsuma:` commands
- [ ] `Satsuma: Show Workspace Graph` opens interactive SVG diagram
- [ ] Click graph node → navigates to definition
- [ ] `Satsuma: Trace Field Lineage` shows multi-hop chain
- [ ] `Satsuma: Show Mapping Coverage` shows gutter markers + status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)