### PR TITLE
ci: build .vsix release artefact and add LSP tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             tooling/tree-sitter-satsuma/node_modules
             tooling/tree-sitter-satsuma/build
             tooling/vscode-satsuma/node_modules
+            tooling/vscode-satsuma/server/node_modules
           key: workspace-${{ github.sha }}
 
   lint:
@@ -52,6 +53,7 @@ jobs:
             tooling/tree-sitter-satsuma/node_modules
             tooling/tree-sitter-satsuma/build
             tooling/vscode-satsuma/node_modules
+            tooling/vscode-satsuma/server/node_modules
           key: workspace-${{ github.sha }}
 
       - run: npm run lint
@@ -79,6 +81,7 @@ jobs:
             tooling/tree-sitter-satsuma/node_modules
             tooling/tree-sitter-satsuma/build
             tooling/vscode-satsuma/node_modules
+            tooling/vscode-satsuma/server/node_modules
           key: workspace-${{ github.sha }}
 
       - name: Run CLI tests
@@ -111,6 +114,7 @@ jobs:
             tooling/tree-sitter-satsuma/node_modules
             tooling/tree-sitter-satsuma/build
             tooling/vscode-satsuma/node_modules
+            tooling/vscode-satsuma/server/node_modules
           key: workspace-${{ github.sha }}
 
       - name: Generate parser
@@ -172,6 +176,7 @@ jobs:
             tooling/tree-sitter-satsuma/node_modules
             tooling/tree-sitter-satsuma/build
             tooling/vscode-satsuma/node_modules
+            tooling/vscode-satsuma/server/node_modules
           key: workspace-${{ github.sha }}
 
       - name: Validate manifest and grammar
@@ -179,6 +184,12 @@ jobs:
 
       - name: Run fixture and golden tests
         run: npm test
+
+      - name: Build extension (client + server + webview)
+        run: npm run build
+
+      - name: Run LSP server tests
+        run: npm run test:lsp
 
       - name: Audit npm dependencies
         run: npm audit --omit=dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,40 @@ jobs:
           name: satsuma-cli-${{ matrix.platform }}
           path: tooling/satsuma-cli/satsuma-cli-${{ matrix.platform }}.tgz
 
+  vsix:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tooling/vscode-satsuma
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install all dependencies
+        working-directory: .
+        run: npm run ci:all
+
+      - name: Build and package .vsix
+        run: |
+          # Build the LSP server (needed for the extension)
+          cd server && npx tsc && cd ..
+
+          # Build client + server + webview bundles
+          npm run build
+
+          # Package the extension
+          npx @vscode/vsce package --no-dependencies -o vscode-satsuma.vsix
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vscode-satsuma-vsix
+          path: tooling/vscode-satsuma/vscode-satsuma.vsix
+
   release:
-    needs: build
+    needs: [build, vsix]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -75,7 +107,7 @@ jobs:
           cat > notes.md <<'EOF'
           Auto-built from the latest `main` branch.
 
-          **Install:**
+          **Install CLI:**
           ```bash
           # macOS (Apple Silicon)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-darwin-arm64.tgz
@@ -83,10 +115,17 @@ jobs:
           # Linux (x64)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-linux-x64.tgz
           ```
+
+          **Install VS Code Extension:**
+          Download `vscode-satsuma.vsix` and install via:
+          ```bash
+          code --install-extension vscode-satsuma.vsix
+          ```
           EOF
 
           gh release create latest \
             --title "Latest build" \
             --notes-file notes.md \
             --prerelease \
-            satsuma-cli-*.tgz
+            satsuma-cli-*.tgz \
+            vscode-satsuma.vsix

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean:all": "rm -rf node_modules tooling/satsuma-cli/node_modules tooling/tree-sitter-satsuma/node_modules tooling/vscode-satsuma/node_modules",
     "install:all": "npm install && npm --prefix tooling/satsuma-cli install && npm --prefix tooling/tree-sitter-satsuma install && npm --prefix tooling/vscode-satsuma install",
-    "ci:all": "npm ci && npm ci --prefix tooling/tree-sitter-satsuma && npm ci --prefix tooling/satsuma-cli && npm ci --prefix tooling/vscode-satsuma",
+    "ci:all": "npm ci && npm ci --prefix tooling/tree-sitter-satsuma && npm ci --prefix tooling/satsuma-cli && npm ci --prefix tooling/vscode-satsuma && npm ci --prefix tooling/vscode-satsuma/server",
     "reinstall": "npm run clean:all && npm run install:all",
     "lint": "npm run lint:js",
     "lint:js": "eslint .",

--- a/tooling/vscode-satsuma/.vscodeignore
+++ b/tooling/vscode-satsuma/.vscodeignore
@@ -1,0 +1,16 @@
+**/.git/**
+**/node_modules/**
+**/test/**
+**/src/**
+**/*.ts
+**/*.map
+.eslintrc*
+tsconfig.json
+esbuild.js
+server/src/**
+server/test/**
+server/tsconfig.json
+server/node_modules/**
+server/dist/**
+!server/dist/server.js
+!dist/**

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -1,112 +1,181 @@
 # VS Code Satsuma Extension
 
-Language support for the Satsuma data mapping language: syntax highlighting (TextMate) plus a Language Server providing document symbols, diagnostics, and code folding.
+Full language support for the [Satsuma](../../SATSUMA-V2-SPEC.md) data mapping language: syntax highlighting, an LSP server with navigation and completions, and interactive workspace visualization.
 
-## Prerequisites
+## Install
 
-- **Node.js** 20+ (native tree-sitter bindings require compilation)
-- **VS Code** 1.85+
+### From GitHub Release (recommended)
 
-## Installation (local development)
+Download `vscode-satsuma.vsix` from the [latest release](https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest) and install:
+
+```bash
+code --install-extension vscode-satsuma.vsix
+```
+
+### From Source
 
 ```bash
 cd tooling/vscode-satsuma
-
-# Install client dependencies
 npm install
-
-# Install and build the language server
-cd server
-npm install
+cd server && npm install && cd ..
 npm run build
-cd ..
-
-# Build the extension client
-npm run build
+npx @vscode/vsce package --no-dependencies -o vscode-satsuma.vsix
+code --install-extension vscode-satsuma.vsix
 ```
 
-### Running in VS Code
+### Extension Development Host
 
 1. Open the repo root in VS Code.
 2. Press **F5** to launch the Extension Development Host.
-3. Open any `.stm` file — the language server activates automatically.
+3. Open any `.stm` file — the extension activates automatically.
 
-### Installing from `.vsix`
+## Prerequisites
 
-```bash
-cd tooling/vscode-satsuma
-npx @vscode/vsce package --no-dependencies
-code --install-extension vscode-satsuma-0.3.0.vsix
-```
+- **VS Code** 1.85+
+- **Node.js** 20+ (for building from source)
+- **`satsuma` CLI** on PATH (for validation diagnostics, commands, and webviews). Install from the [latest release](https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest).
 
 ## Features
 
-### TextMate Syntax Highlighting
+### Syntax Highlighting
 
-Regex-based syntax colouring for all Satsuma constructs. Works immediately, no build step.
+TextMate grammar for all Satsuma constructs (keywords, types, metadata, strings, comments, operators). Works immediately with no dependencies.
 
-### Language Server (Phase 1)
+Semantic tokens from the LSP server override TextMate scopes for context-sensitive constructs (`source`/`target` as keyword vs. field name, `map` as keyword vs. identifier, vocabulary tokens, etc.).
 
-Parser-backed features using tree-sitter:
+### Diagnostics
 
-- **Document Symbols / Outline** — schemas, mappings, fragments, transforms, metrics, namespaces, and notes appear in the Outline panel. Fields appear as children. Nested record/list structures appear as nested entries.
-- **Diagnostics** — parse errors show as red squiggles in real time. `//!` warning comments appear as warnings in the Problems panel. `//?` question comments appear as information.
-- **Code Folding** — all block types (schema, mapping, fragment, transform, metric, note, namespace, each, flatten, map literal, metadata, nested arrow) are foldable.
+- **Parse errors** — red squiggles in real time as you type (tree-sitter ERROR/MISSING nodes).
+- **Semantic warnings** — yellow squiggles on save via `satsuma validate` (undefined schemas, duplicate names, broken imports).
+- **Warning comments** (`//!`) — appear as warnings in the Problems panel.
+- **Question comments** (`//?`) — appear as information in the Problems panel.
+
+### Navigation
+
+- **Go-to-Definition** (Ctrl+Click / F12) — jump from schema name in `source`/`target` to its definition, fragment spread to fragment block, import name to imported definition, import path to file.
+- **Find References** (Shift+F12) — find all usages of a schema, fragment, or transform across the workspace.
+- **Rename Symbol** (F2) — rename a schema, fragment, transform, or mapping across all files. Refuses duplicate names. Handles namespace-qualified references.
+
+### IntelliSense
+
+- **Completions** — context-aware suggestions:
+  - Schema names inside `source { }` / `target { }`
+  - Fragment and transform names after `...`
+  - Field names from source/target schemas in arrow paths
+  - Metadata vocabulary tokens inside `( )` (pk, pii, scd, required, etc.)
+  - Transform functions in pipe chains (trim, lowercase, coalesce, etc.)
+  - Block names in `import { }` declarations
+
+### Document Structure
+
+- **Outline Panel** — schemas, mappings, fragments, transforms, metrics, namespaces, and notes with nested fields and children.
+- **Breadcrumbs** — automatic from document symbols.
+- **Code Folding** — all block types foldable (schema, mapping, fragment, transform, metric, note, namespace, each, flatten, map literal, metadata, nested arrow).
+- **Hover** — contextual markdown info for blocks, fields, tags, spreads, arrow paths, and pipeline functions.
+
+### CodeLens
+
+Inline annotations above blocks:
+
+- **Schema** — `N fields | used in M mappings`
+- **Mapping** — `source → target | N arrows`
+- **Fragment** — `spread in N places`
+- **Transform** — `used in N places`
+- **Metric** — `sources: schema1, schema2`
+
+### Command Palette
+
+Nine commands available via `Ctrl+Shift+P`:
+
+| Command | Description |
+|---|---|
+| **Satsuma: Validate Workspace** | Run `satsuma validate` and populate the Problems panel |
+| **Satsuma: Show Lineage From...** | Pick a schema and trace its downstream lineage |
+| **Satsuma: Where Used** | Find all references to the symbol under cursor |
+| **Satsuma: Show Warnings** | Show all `//!` warnings in the Problems panel |
+| **Satsuma: Show Workspace Summary** | Display workspace statistics |
+| **Satsuma: Show Arrows for Field** | Show all arrows involving a field |
+| **Satsuma: Show Workspace Graph** | Open interactive workspace graph webview |
+| **Satsuma: Trace Field Lineage** | Open field-level lineage webview |
+| **Satsuma: Show Mapping Coverage** | Show mapped/unmapped fields with gutter markers |
+
+### Workspace Graph
+
+`Satsuma: Show Workspace Graph` opens an interactive SVG diagram of your workspace:
+
+- **Nodes** by block type: schemas (rectangles), mappings (diamonds), metrics (circles), fragments (rounded rectangles)
+- **Edges** show data flow between schemas and mappings
+- **Click** a node to jump to its definition
+- **Namespace filter** dropdown to focus on a single namespace
+- **Auto-refreshes** on file save
+
+### Field-Level Lineage
+
+`Satsuma: Trace Field Lineage` traces a field through the entire data pipeline:
+
+- Multi-hop chain tracing via `satsuma arrows`
+- Horizontal flow: `source.field → [transform] → target.field`
+- NL transforms displayed with distinct styling
+- Click any node to navigate to the definition
+
+### Mapping Coverage
+
+`Satsuma: Show Mapping Coverage` shows which target fields are mapped:
+
+- Green gutter markers for mapped fields
+- Red gutter markers for unmapped fields
+- Status bar shows coverage percentage
+- Works from cursor position inside any mapping block
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `satsuma.cliPath` | `"satsuma"` | Path to the `satsuma` CLI executable |
 
 ## Running Tests
 
-From `tooling/vscode-satsuma/`:
-
 ```bash
-# Run all tests (TextMate + LSP)
+cd tooling/vscode-satsuma
+
+# All tests (TextMate + LSP)
 npm run check
 
 # TextMate grammar tests only
 npm test
 
-# LSP server tests only
+# LSP server tests only (142 tests)
 npm run test:lsp
 
-# Focused fixture tests only
-npm run test:fixtures
-
-# Golden fixture tests only
-npm run test:golden
-
-# Validate manifest + grammar JSON
-npm run validate
+# Build .vsix locally
+npm run package
 ```
 
-TextMate tests use [`vscode-tmgrammar-test`](https://github.com/nicolo-ribaudo/vscode-tmgrammar-test) (CI-safe, no VS Code instance needed). LSP tests use Node's built-in test runner against the tree-sitter parser directly.
+## Architecture
 
-## Grammar Authoring
-
-The TextMate grammar is in `syntaxes/satsuma.tmLanguage.json` — plain JSON, no build step. Edit it directly; reload the Extension Development Host to preview changes.
-
-## Known Approximation Limits
-
-The TextMate grammar handles several constructs approximately due to regex-only matching. The Language Server's semantic tokens (planned for a future phase) will resolve these:
-
-- **`source` / `target` as keywords vs. field names** — both scoped as keywords everywhere.
-- **`map` as keyword vs. field name** — highlighted as keyword everywhere.
-- **`list` / `record` as keywords vs. field names** — highlighted as keywords inside schema bodies.
-- **Pipeline tokens as field names** — `trim`, `filter`, `format` etc. only highlighted inside `{}` arrow bodies.
-- **Vocabulary tokens as field names** — constraint/format tokens only matched inside `()` metadata blocks.
-
-## Theme Verification
-
-Before releases, verify highlighting in:
-
-- **Dark+** (VS Code default dark)
-- **Light+** (VS Code default light)
-- **One Dark Pro** (popular community theme)
-
-Checklist:
-
-- [ ] Keywords coloured distinctly from identifiers
-- [ ] `import` / `from` coloured as control-flow keywords
-- [ ] Strings (double-quoted NL, triple-quoted Markdown, single-quoted labels, backtick identifiers) each coloured
-- [ ] Comments visually de-emphasised
-- [ ] Vocabulary tokens in `()` metadata distinguishable from field names
-- [ ] Pipeline function tokens highlighted inside `{}` bodies
-- [ ] `//!` and `//?` fall back gracefully in themes that don't distinguish them
+```
+tooling/vscode-satsuma/
+  src/
+    extension.ts              Client: LSP lifecycle, commands, webview panels
+    commands/                 Command handlers (CLI integration)
+    webview/graph/            Workspace graph webview (SVG + D3-free layout)
+    webview/lineage/          Field lineage webview (horizontal chain)
+  server/
+    src/
+      server.ts               LSP server: connection, capabilities, handlers
+      workspace-index.ts      Cross-file symbol table
+      definition.ts           Go-to-definition
+      references.ts           Find references
+      completion.ts           Context-aware completions
+      codelens.ts             Inline annotations
+      rename.ts               Workspace-wide rename
+      diagnostics.ts          Parse error diagnostics
+      validate-diagnostics.ts Semantic diagnostics (CLI integration)
+      symbols.ts              Document symbols / outline
+      folding.ts              Code folding
+      semantic-tokens.ts      Parser-backed semantic highlighting
+      hover.ts                Contextual hover information
+      parser-utils.ts         Tree-sitter helpers
+  syntaxes/
+    satsuma.tmLanguage.json   TextMate grammar
+```

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -70,7 +70,8 @@
     "validate:manifest": "node -e \"JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')\"",
     "validate:grammar": "node -e \"const g=JSON.parse(require('fs').readFileSync('syntaxes/satsuma.tmLanguage.json','utf8')); if(!g.scopeName)throw new Error('missing scopeName'); console.log('grammar OK, scopeName='+g.scopeName)\"",
     "validate": "npm run validate:manifest && npm run validate:grammar",
-    "check": "npm run validate && npm test && npm run test:lsp"
+    "check": "npm run validate && npm test && npm run test:lsp",
+    "package": "npm run build && npx @vscode/vsce package --no-dependencies -o vscode-satsuma.vsix"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"


### PR DESCRIPTION
## Summary

- **Release workflow**: new `vsix` job builds and packages the VS Code extension as `vscode-satsuma.vsix`, uploaded alongside CLI tarballs in the `latest` release
- **CI workflow**: `vscode-extension` job now builds the full extension (client + server + webview) and runs 142 LSP server tests. Server `node_modules` added to workspace cache
- **Root `ci:all`**: now installs `tooling/vscode-satsuma/server` dependencies
- **Extension packaging**: `.vscodeignore` produces lean 435KB `.vsix` (no source maps, no TS source, no test files). `npm run package` script for local builds

## Test plan

- [x] `npm run package` produces valid `.vsix` locally (435KB, 17 files)
- [ ] CI `vscode-extension` job builds extension and runs LSP tests
- [ ] Release `vsix` job produces `vscode-satsuma.vsix` artefact
- [ ] `vscode-satsuma.vsix` included in `latest` GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)