### PR TITLE
fix: vsix build and add 3 release platform targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,14 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux-x64
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
           - os: macos-latest
             platform: darwin-arm64
+          - os: macos-13
+            platform: darwin-x64
+          - os: windows-latest
+            platform: win32-x64
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -30,6 +36,7 @@ jobs:
         run: npm run ci:all
 
       - name: Bundle for distribution
+        shell: bash
         run: |
           # Replace file: symlink with actual copy (includes prebuilt native addon)
           rm -rf node_modules/tree-sitter-satsuma
@@ -72,13 +79,10 @@ jobs:
 
       - name: Build and package .vsix
         run: |
-          # Build the LSP server (needed for the extension)
-          cd server && npx tsc && cd ..
-
           # Build client + server + webview bundles
           npm run build
 
-          # Package the extension
+          # Package the extension (--allow-missing-repository for monorepo layout)
           npx @vscode/vsce package --no-dependencies -o vscode-satsuma.vsix
 
       - uses: actions/upload-artifact@v4
@@ -112,8 +116,17 @@ jobs:
           # macOS (Apple Silicon)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-darwin-arm64.tgz
 
+          # macOS (Intel)
+          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-darwin-x64.tgz
+
           # Linux (x64)
           npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-linux-x64.tgz
+
+          # Linux (ARM64)
+          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-linux-arm64.tgz
+
+          # Windows (x64)
+          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-win32-x64.tgz
           ```
 
           **Install VS Code Extension:**

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -1,6 +1,6 @@
 # VS Code Satsuma Extension
 
-Full language support for the [Satsuma](../../SATSUMA-V2-SPEC.md) data mapping language: syntax highlighting, an LSP server with navigation and completions, and interactive workspace visualization.
+Full language support for the Satsuma data mapping language: syntax highlighting, an LSP server with navigation and completions, and interactive workspace visualization.
 
 ## Install
 

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "version": "0.3.0",
   "publisher": "satsuma",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thorbenlouw/satsuma-lang"
+  },
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
## Summary

**Fix vsix build failure:**
- Remove relative `../../SATSUMA-V2-SPEC.md` link from README that broke `vsce package`
- Add `repository` field to package.json for vsce repo detection
- Remove unnecessary `tsc` step from vsix job (esbuild handles server bundling)

**Add 3 release platforms:**
- `darwin-x64` — Intel Macs (macos-13 runner)
- `linux-arm64` — AWS Graviton / ARM servers (ubuntu-24.04-arm runner)
- `win32-x64` — Windows (windows-latest runner)
- Add `shell: bash` to bundle step for Windows compatibility

Release now produces 5 CLI tarballs + 1 `.vsix`:
`satsuma-cli-{linux-x64,linux-arm64,darwin-arm64,darwin-x64,win32-x64}.tgz` + `vscode-satsuma.vsix`

## Test plan

- [x] `npx @vscode/vsce package --no-dependencies` succeeds locally
- [ ] Release workflow vsix job passes
- [ ] All 5 CLI platform builds succeed
- [ ] `latest` release has 6 artefacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)