### PR TITLE
Potential fix for code scanning alert no. 8: Client-side cross-site scripting

### DIFF
--- a/tooling/vscode-satsuma/src/webview/graph/graph.ts
+++ b/tooling/vscode-satsuma/src/webview/graph/graph.ts
@@ -279,11 +279,36 @@ function showTooltip(e: MouseEvent, node: GraphNode): void {
     tooltipEl.className = "tooltip";
     document.body.appendChild(tooltipEl);
   }
-  const lines: string[] = [`<b>${node.kind}</b> ${node.id}`];
-  if (node.fields) lines.push(`${node.fields.length} field(s)`);
-  if (node.sources) lines.push(`sources: ${node.sources.join(", ")}`);
-  if (node.targets) lines.push(`targets: ${node.targets.join(", ")}`);
-  tooltipEl.innerHTML = lines.join("<br>");
+  // Clear previous content safely
+  while (tooltipEl.firstChild) {
+    tooltipEl.removeChild(tooltipEl.firstChild);
+  }
+
+  // First line: bold kind, then id as plain text
+  const firstLine = document.createElement("div");
+  const kindEl = document.createElement("b");
+  kindEl.textContent = node.kind;
+  firstLine.appendChild(kindEl);
+  firstLine.appendChild(document.createTextNode(" " + node.id));
+  tooltipEl.appendChild(firstLine);
+
+  // Additional lines
+  if (node.fields) {
+    const line = document.createElement("div");
+    line.textContent = `${node.fields.length} field(s)`;
+    tooltipEl.appendChild(line);
+  }
+  if (node.sources) {
+    const line = document.createElement("div");
+    line.textContent = `sources: ${node.sources.join(", ")}`;
+    tooltipEl.appendChild(line);
+  }
+  if (node.targets) {
+    const line = document.createElement("div");
+    line.textContent = `targets: ${node.targets.join(", ")}`;
+    tooltipEl.appendChild(line);
+  }
+
   tooltipEl.style.left = `${e.clientX + 12}px`;
   tooltipEl.style.top = `${e.clientY + 12}px`;
   tooltipEl.style.display = "block";


### PR DESCRIPTION
Potential fix for [https://github.com/thorbenlouw/satsuma-lang/security/code-scanning/8](https://github.com/thorbenlouw/satsuma-lang/security/code-scanning/8)

In general, the fix is to avoid writing untrusted data into the DOM via `innerHTML`; instead, either (a) construct the DOM nodes programmatically and set only `textContent` on text nodes, or (b) apply robust HTML-encoding to all dynamic values before using `innerHTML`. The safest approach, which preserves functionality while removing XSS risk, is to build the tooltip from DOM elements and rely on `textContent` so that special characters in `node.id`, `sources`, `targets`, etc. are rendered as text, not interpreted as HTML.

For this codebase, the single best fix is to refactor `showTooltip` so that it no longer builds an HTML string array (`lines`) and no longer uses `tooltipEl.innerHTML`. Instead:
- Ensure `tooltipEl` exists as before.
- Clear any existing children, e.g. by `while (tooltipEl.firstChild) tooltipEl.removeChild(tooltipEl.firstChild);`.
- Create a first line container (e.g. a `<div>` or `<span>`) where `<b>${node.kind}</b> ${node.id}` is represented as a `<b>` element for `kind` and a text node for the space and `node.id`.
- For each subsequent line (`fields`, `sources`, `targets`), create a `<div>` (or `<span>`) and set its `textContent` to the corresponding string (`"${len} field(s)"`, `"sources: ..."`).
- Append these elements in order to `tooltipEl`. CSS can continue to handle line breaks via `display: block` or similar, replacing the previous `<br>` joins.

No changes are needed elsewhere; all behavior (what text shows in the tooltip, how it is positioned) remains the same, but user-controlled values are no longer interpreted as HTML. All required APIs (`createElement`, `createElementNS`, `textContent`, `appendChild`) are standard and already used in this file; no new imports or external libraries are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
