### PR TITLE
fix: diff shows removals when file B imports from file A

### DIFF
--- a/.tickets/sl-pzgv.md
+++ b/.tickets/sl-pzgv.md
@@ -1,0 +1,49 @@
+---
+id: sl-pzgv
+status: closed
+deps: []
+links: []
+created: 2026-03-24T08:13:57Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [cli, diff]
+---
+# diff command does not show removals (things in A but not B)
+
+When comparing two files/directories, `satsuma diff` only shows additions (things in B but not A). Schemas, fragments, and other definitions that exist in file A but not in file B are not shown as removals.
+
+Repro:
+```bash
+satsuma diff bug-hunt/scenario-02-trading-lib.stm bug-hunt/scenario-02-trading-flow.stm --json
+# JSON output:
+# schemas.removed: []    ← WRONG
+# fragments.removed: []  ← WRONG
+# But scenario-02-trading-lib.stm has venue_codes, instrument_ref schemas
+# and party_id, money_fields, timestamps fragments that are NOT in the flow file
+```
+
+Text output also shows only `+` additions, no `-` removals.
+
+## Acceptance Criteria
+
+1. Schemas/fragments/mappings/metrics in A but not B appear in the 'removed' list
+2. Both JSON and text output show removals
+3. Removals are shown with `-` prefix in text output
+4. Works for cross-directory diffs too
+
+
+## Notes
+
+**2026-03-24T08:19:59Z**
+
+Follow-up testing shows diff removals DO work for single-file comparisons (lib.stm where schemas were removed shows correct - prefix). The original test compared files with import relationships (lib imports flow), where imported definitions may be resolved and considered part of both files. The bug may be limited to: (1) directory-to-directory diff behavior, or (2) diff doesn't handle the import relationship correctly when definitions exist in the first file but are imported into the second.
+
+**2026-03-24T10:00:00Z**
+
+Confirmed: `diff examples/common.stm examples/db-to-db.stm --json` correctly shows `schemas.removed: [country_codes, currency_rates, product_catalog]` and `fragments.removed: [address fields, audit columns]`. The bug is specifically when file B imports from file A — the import-resolved definitions from A appear in B's workspace, making them not count as "removed". This is an import-resolution scoping issue in diff, not a general removals bug. Narrowing title and scope accordingly.
+
+**2026-03-24T09:34:43Z**
+
+Cause: `resolveInput()` follows import declarations when resolving single files. When file B imports from file A, both files end up in B's index, so definitions from A never appear as 'removed'.
+Fix: Added `followImports` option to `resolveInput()` (defaults to `true`). The diff command now passes `{ followImports: false }` so it compares only definitions directly in each file/directory, not import-resolved workspaces.

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -35,8 +35,8 @@ Examples:
     .action(async (pathA: string, pathB: string, opts: { json?: boolean; namesOnly?: boolean; stat?: boolean }) => {
       let filesA: string[], filesB: string[];
       try {
-        filesA = await resolveInput(pathA);
-        filesB = await resolveInput(pathB);
+        filesA = await resolveInput(pathA, { followImports: false });
+        filesB = await resolveInput(pathB, { followImports: false });
       } catch (err: unknown) {
         console.error(`Error resolving paths: ${(err as Error).message}`);
         process.exit(2);

--- a/tooling/satsuma-cli/src/workspace.ts
+++ b/tooling/satsuma-cli/src/workspace.ts
@@ -122,11 +122,14 @@ function followImports(entryFile: string): string[] {
  * When given a single file, follows import declarations to discover
  * referenced files recursively.
  */
-export async function resolveInput(pathArg: string): Promise<string[]> {
+export async function resolveInput(pathArg: string, opts?: { followImports?: boolean }): Promise<string[]> {
   const abs = resolve(pathArg);
   const s = await stat(abs);
   if (s.isDirectory()) {
     return findStmFiles(abs);
+  }
+  if (opts?.followImports === false) {
+    return [abs];
   }
   return followImports(abs);
 }

--- a/tooling/satsuma-cli/test/fixtures/diff-import-consumer.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-import-consumer.stm
@@ -1,0 +1,8 @@
+// Consumer file that imports from the library
+import { audit_fields, ref_data } from "diff-import-lib.stm"
+
+schema orders {
+  order_id  UUID   (pk, required)
+  amount    DECIMAL(18,2)
+  ...audit_fields
+}

--- a/tooling/satsuma-cli/test/fixtures/diff-import-lib.stm
+++ b/tooling/satsuma-cli/test/fixtures/diff-import-lib.stm
@@ -1,0 +1,10 @@
+// Library file with shared definitions
+fragment audit_fields {
+  created_at  TIMESTAMPTZ (required)
+  updated_at  TIMESTAMPTZ
+}
+
+schema ref_data {
+  code   STRING(10) (pk)
+  label  STRING(100)
+}

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -2088,6 +2088,27 @@ describe("satsuma diff", () => {
     assert.equal(data.notes.added.length, 0, "metric notes should not leak to top-level");
     assert.equal(data.notes.removed.length, 0, "metric notes should not leak to top-level");
   });
+
+  it("shows removals when file B imports from file A (sl-pzgv)", async () => {
+    const lib = resolve(import.meta.dirname, "fixtures", "diff-import-lib.stm");
+    const consumer = resolve(import.meta.dirname, "fixtures", "diff-import-consumer.stm");
+    const { stdout, code } = await run("diff", lib, consumer);
+    assert.equal(code, 0);
+    assert.match(stdout, /- ref_data/, "schema from lib not in consumer should appear as removed");
+    assert.match(stdout, /- audit_fields/, "fragment from lib not in consumer should appear as removed");
+    assert.match(stdout, /\+ orders/, "schema only in consumer should appear as added");
+  });
+
+  it("--json shows removals when file B imports from file A (sl-pzgv)", async () => {
+    const lib = resolve(import.meta.dirname, "fixtures", "diff-import-lib.stm");
+    const consumer = resolve(import.meta.dirname, "fixtures", "diff-import-consumer.stm");
+    const { stdout, code } = await run("diff", "--json", lib, consumer);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.schemas.removed.includes("ref_data"), "ref_data should be in schemas.removed");
+    assert.ok(data.schemas.added.includes("orders"), "orders should be in schemas.added");
+    assert.ok(data.fragments.removed.includes("audit_fields"), "audit_fields should be in fragments.removed");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `satsuma diff` was not showing removals when the second file (B) imported from the first file (A), because `resolveInput()` followed imports — merging A's definitions into B's index
- Added `followImports` option to `resolveInput()` and set it to `false` in the diff command so it compares only directly-defined content
- Added integration tests with import-aware fixture files

Fixes sl-pzgv

## Test plan

- [x] Verified `satsuma diff lib.stm flow.stm --json` now shows `schemas.removed` and `fragments.removed` correctly
- [x] Text output shows `-` prefix for removed items
- [x] All 677 existing + 2 new tests pass
- [x] Pre-commit hooks pass (lint, tests, tree-sitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)