### PR TITLE
ci: auto-attach build artifacts to tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -110,7 +111,19 @@ jobs:
         with:
           merge-multiple: true
 
+      - name: Upload artifacts to tagged release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            satsuma-cli-*.tgz \
+            vscode-satsuma.vsix \
+            --clobber
+
       - name: Update latest release
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Add `tags: ["v*"]` trigger to the Release workflow
- When a version tag is pushed, build artifacts (4 CLI platform tarballs + VS Code .vsix) are uploaded to the existing GitHub release for that tag
- The rolling `latest` prerelease on main push is unchanged

This means future releases only need `gh release create vX.Y.Z ...` followed by a tag push — artifacts attach automatically.

## Test plan

- [ ] Verify workflow syntax is valid (CI will check this)
- [ ] Next tagged release should have artifacts attached without manual upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)