### PR TITLE
fix: use prebuilt release artifacts in site install instructions

### DIFF
--- a/site/cli.html
+++ b/site/cli.html
@@ -142,7 +142,7 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 reveal">
       <div class="max-w-3xl mx-auto">
         <h2 class="text-3xl font-bold text-charcoal mb-3">Installation</h2>
-        <p class="text-warm-gray mb-8">The CLI lives in the Satsuma repository. Install it globally with npm.</p>
+        <p class="text-warm-gray mb-8">Download a prebuilt package from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">latest GitHub release</a> and install globally with npm.</p>
         <div class="terminal">
           <div class="terminal-header">
             <div class="terminal-dot red"></div>
@@ -151,10 +151,14 @@
             <span class="text-xs text-gray-400 ml-2 font-mono">terminal</span>
           </div>
           <pre>
-<span class="prompt">$</span> git clone https://github.com/thorbenlouw/satsuma-lang.git
-<span class="prompt">$</span> cd satsuma-lang/tooling/satsuma-cli
-<span class="prompt">$</span> npm install
-<span class="prompt">$</span> npm link    <span class="output"># makes `satsuma` available globally</span>
+<span class="output"># macOS (Apple Silicon)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz
+
+<span class="output"># macOS (Intel)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-x64.tgz
+
+<span class="output"># Linux (x64)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>

--- a/site/learn.html
+++ b/site/learn.html
@@ -117,9 +117,10 @@
           <div class="absolute -top-4 left-8 w-8 h-8 gradient-orange rounded-full flex items-center justify-center text-white font-bold text-sm">1</div>
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the CLI</h3>
           <div class="code-block text-sm mb-4">
-            <pre><code class="font-mono text-charcoal">npm install -g satsuma-cli</code></pre>
+            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># macOS (Apple Silicon)</span>
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. The CLI includes the tree-sitter parser, all 16 commands, and the AI agent reference.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. Prebuilt packages for macOS, Linux, and Windows are on the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">latest release</a>.</p>
         </div>
 
         <!-- Step 2 -->
@@ -127,9 +128,10 @@
           <div class="absolute -top-4 left-8 w-8 h-8 gradient-green rounded-full flex items-center justify-center text-white font-bold text-sm">2</div>
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the VS Code extension</h3>
           <div class="code-block text-sm mb-4">
-            <pre><code class="font-mono text-charcoal">code --install-extension vscode-satsuma.vsix</code></pre>
+            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># Download from the latest release, then:</span>
+code --install-extension vscode-satsuma.vsix</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more. Download the <code class="font-mono text-orange">.vsix</code> from the latest GitHub release.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-3">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the latest release. Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more.</p>
           <a href="vscode.html" class="text-green text-sm font-semibold hover:underline">See all extension features &rarr;</a>
         </div>
 

--- a/site/vscode.html
+++ b/site/vscode.html
@@ -455,7 +455,7 @@
             <h3 class="text-lg font-bold text-charcoal">From GitHub Release</h3>
             <span class="px-2 py-0.5 bg-green/10 text-green-dark text-xs font-semibold rounded-full">Recommended</span>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download the pre-built <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">.vsix</code> from the latest release and install:</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the latest GitHub release, then install:</p>
           <div class="terminal">
             <div class="terminal-header">
               <span class="terminal-dot red"></span>


### PR DESCRIPTION
## Summary

- **CLI install** (`cli.html`): replaced `git clone` + `npm link` with `npm install -g` from platform-specific release tarballs
- **Quick start** (`learn.html`): step 1 shows prebuilt tarball install with link to latest release; step 2 links directly to `.vsix` download
- **VS Code install** (`vscode.html`): "From GitHub Release" section now includes direct download link

All Satsuma code examples across the site were also validated against the v2 spec — no issues found.

## Test plan

- [ ] Verify CLI install command on cli.html points to working release URL
- [ ] Verify learn.html quick start steps link to latest release page
- [ ] Verify vscode.html download link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)