### PR TITLE
ci: make versioned releases manual via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,10 +121,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.version }}
         run: |
-          tag="${{ inputs.version }}"
-          gh release create "$tag" \
-            --title "$tag" \
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_TAG" \
             --generate-notes \
             satsuma-cli-*.tgz \
             vscode-satsuma.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,12 @@ name: Release
 on:
   push:
     branches: [main]
-    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to create (e.g. v0.3.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -111,19 +116,21 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Upload artifacts to tagged release
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Create tagged release
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          gh release upload "${{ github.ref_name }}" \
+          tag="${{ inputs.version }}"
+          gh release create "$tag" \
+            --title "$tag" \
+            --generate-notes \
             satsuma-cli-*.tgz \
-            vscode-satsuma.vsix \
-            --clobber
+            vscode-satsuma.vsix
 
       - name: Update latest release
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Remove automatic tag-push trigger for versioned releases
- Add `workflow_dispatch` with a `version` input so tagged releases are created manually from the Actions UI or via `gh workflow run`
- Keep the "latest" prerelease updated on every push to `main` (unchanged)

## Test plan
- [ ] Verify "latest" release still updates on merge to main
- [ ] Trigger a manual release via Actions UI with a test version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)