### PR TITLE
feat: add FAQ, no-CLI guide section, and hero colors to landing page

### DIFF
--- a/site/css/custom.css
+++ b/site/css/custom.css
@@ -220,6 +220,24 @@ body { background-color: var(--cream); color: var(--charcoal); }
   border-color: var(--orange);
 }
 
+/* FAQ accordion */
+.faq-item summary {
+  list-style: none;
+}
+.faq-item summary::-webkit-details-marker {
+  display: none;
+}
+.faq-item {
+  transition: all 0.2s ease;
+}
+.faq-item:hover {
+  border-color: var(--orange-light);
+}
+.faq-item[open] {
+  border-color: var(--orange-light);
+  box-shadow: 0 4px 12px rgba(45, 42, 38, 0.06);
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }

--- a/site/index.html
+++ b/site/index.html
@@ -52,6 +52,7 @@
           <a href="vscode.html" class="nav-link text-sm font-medium">VS Code</a>
           <a href="examples.html" class="nav-link text-sm font-medium">Examples</a>
           <a href="learn.html" class="nav-link text-sm font-medium">Learn</a>
+          <a href="#faq" class="nav-link text-sm font-medium">FAQ</a>
           <a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" rel="noopener"
              class="inline-flex items-center gap-2 px-4 py-2 bg-charcoal text-white text-sm font-medium rounded-lg hover:bg-charcoal/90 transition-colors">
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -71,6 +72,7 @@
           <a href="vscode.html" class="block px-3 py-2 text-sm font-medium text-charcoal rounded-lg hover:bg-peach">VS Code</a>
           <a href="examples.html" class="block px-3 py-2 text-sm font-medium text-charcoal rounded-lg hover:bg-peach">Examples</a>
           <a href="learn.html" class="block px-3 py-2 text-sm font-medium text-charcoal rounded-lg hover:bg-peach">Learn</a>
+          <a href="#faq" class="block px-3 py-2 text-sm font-medium text-charcoal rounded-lg hover:bg-peach">FAQ</a>
         </div>
       </div>
     </div>
@@ -86,9 +88,11 @@
           </div>
           <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-charcoal leading-tight mb-6">
             The mapping language humans can
-            <span class="text-transparent bg-clip-text bg-gradient-to-r from-orange to-orange-dark">read</span>
-            and machines can
-            <span class="text-transparent bg-clip-text bg-gradient-to-r from-green to-green-dark">parse</span>
+            <span class="text-transparent bg-clip-text bg-gradient-to-r from-orange to-orange-dark">read</span>,
+            machines can
+            <span class="text-transparent bg-clip-text bg-gradient-to-r from-green to-green-dark">parse</span>,
+             and AIs can
+            <span class="text-transparent bg-clip-text" style="background-image: linear-gradient(to right, #8E5BB0, #7C6BAE);">reason</span> about.
           </h1>
           <p class="text-lg text-warm-gray leading-relaxed mb-8 max-w-lg">
             Replace spreadsheets and wikis with a single source of truth for source-to-target data mappings. Readable by business analysts, parseable by tooling, and AI-native by design.
@@ -178,7 +182,7 @@
             </div>
             <div class="flex items-start gap-3 text-warm-gray">
               <svg class="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
-              <span>AI can't generate or reason about freeform docs</span>
+              <span>AI can't reason well about human-optimised spreadsheets with free-form layouts or derive high-fidelity pipeline code</span>
             </div>
           </div>
         </div>
@@ -202,7 +206,7 @@
             </div>
             <div class="flex items-start gap-3 text-warm-gray">
               <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-              <span>LLMs generate valid Satsuma &gt;90% of the time</span>
+              <span>LLMs generate valid Satsuma using the parsing tools, and can generate high-fidelity pipeline implementations, DQ tests and sample data in your tech stack of choice, with areas of ambiguity made explicit.</span>
             </div>
           </div>
         </div>
@@ -244,7 +248,7 @@
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">40-60% Smaller</h3>
-          <p class="text-warm-gray text-sm leading-relaxed">More concise than equivalent YAML or JSON specs, and 3-8x less token usage than mapping spreadsheets. Less noise, more signal for both humans and AI.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">More concise than equivalent YAML or JSON specs, and <bold>3-8x less token usage</bold> than mapping spreadsheets. Less noise, more signal for both humans and AI.</p>
         </div>
       </div>
     </div>
@@ -346,7 +350,7 @@
             <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Data Engineers</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Define mapping contracts your pipelines can consume. Validate, lint, and trace lineage with 16 CLI commands.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Define mapping contracts that you can use with AI tools to create pipelines for your platform and tech stack. Write data quality tests, create sample test data, populate governance metadata. AI tools achieve much better implementation adherence to specs compared to loose spreadsheets. Use simple metadata extensions for data analytics modelling like Kimball or Data Vault.</p>
           <span class="text-green text-sm font-semibold">Explore the CLI &rarr;</span>
         </a>
         <a href="learn.html#integration-engineers" class="role-card bg-cream rounded-2xl p-6">
@@ -354,7 +358,7 @@
             <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Integration Engineers</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Replace proprietary ESB config with portable, version-controlled mapping specs. EDI, XML, COBOL &mdash; all supported.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Portable, version-controlled mapping specs. REST APIs, EDI, XML, COBOL, ESBs, database tables &mdash; all supported.</p>
           <span class="text-orange text-sm font-semibold">See examples &rarr;</span>
         </a>
         <a href="learn.html#governance" class="role-card bg-cream rounded-2xl p-6">
@@ -362,7 +366,7 @@
             <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Governance &amp; Audit</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Trace every field from source to target. PII tags, encryption markers, and lineage are structural &mdash; not comments.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Trace every field from source to target. PII tags, field descriptions, encryption markers, and lineage are structural &mdash; not comments.</p>
           <span class="text-green text-sm font-semibold">Learn about lineage &rarr;</span>
         </a>
         <a href="learn.html#ai-automation" class="role-card bg-cream rounded-2xl p-6">
@@ -451,6 +455,180 @@
     </div>
   </section>
 
+  <!-- No Tooling Required -->
+  <section class="py-20 lg:py-28 bg-white">
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="grid md:grid-cols-2 gap-12 lg:gap-20 items-center reveal">
+        <div>
+          <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-orange/10 text-orange-dark text-sm font-medium mb-4">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+            No installation required
+          </div>
+          <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Works without the CLI or VS Code extension</h2>
+          <p class="text-warm-gray leading-relaxed mb-6">
+            The best experience comes with the full toolchain, but Satsuma delivers real value even if you can't install anything. Locked-down laptop? Working through a web LLM? You still get the core benefits.
+          </p>
+          <div class="space-y-4 mb-8">
+            <div class="flex items-start gap-3 text-warm-gray">
+              <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              <span><strong class="text-charcoal">Token-efficient specs</strong> &mdash; 3&ndash;8x more compact than spreadsheets. Fits in any LLM context window.</span>
+            </div>
+            <div class="flex items-start gap-3 text-warm-gray">
+              <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              <span><strong class="text-charcoal">Plain text, version-controlled</strong> &mdash; <code>.stm</code> files diff cleanly and merge naturally in any Git workflow.</span>
+            </div>
+            <div class="flex items-start gap-3 text-warm-gray">
+              <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              <span><strong class="text-charcoal">Works with any LLM</strong> &mdash; paste the ~900-token grammar reference into ChatGPT, Gemini, or Claude.ai and start writing specs.</span>
+            </div>
+            <div class="flex items-start gap-3 text-warm-gray">
+              <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+              <span><strong class="text-charcoal">Graduate when ready</strong> &mdash; when your environment allows installation, the CLI and extension slot in without changing your files.</span>
+            </div>
+          </div>
+          <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/using-satsuma-without-cli.md" target="_blank" rel="noopener"
+             class="inline-flex items-center gap-2 text-orange font-semibold hover:underline">
+            Read the full guide &rarr;
+          </a>
+        </div>
+        <div class="bg-cream rounded-2xl p-8 border border-charcoal/5">
+          <h3 class="text-lg font-bold text-charcoal mb-4">Example workflows without tooling</h3>
+          <div class="space-y-4">
+            <div class="flex items-start gap-3">
+              <div class="w-7 h-7 gradient-orange rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span class="text-white text-xs font-bold">1</span>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-charcoal">Draft specs from requirements</p>
+                <p class="text-xs text-warm-gray">Upload a spreadsheet or requirements doc to any LLM and ask it to produce a <code>.stm</code> file.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="w-7 h-7 gradient-green rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span class="text-white text-xs font-bold">2</span>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-charcoal">Review and explain specs</p>
+                <p class="text-xs text-warm-gray">Paste a <code>.stm</code> file and ask for a walkthrough, risk assessment, or onboarding summary.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="w-7 h-7 bg-charcoal rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span class="text-white text-xs font-bold">3</span>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-charcoal">Generate implementation scaffolds</p>
+                <p class="text-xs text-warm-gray">Ask the LLM to produce dbt, PySpark, SQL, or pandas code from your mapping spec.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="w-7 h-7 bg-gradient-to-br from-orange to-green rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                <span class="text-white text-xs font-bold">4</span>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-charcoal">Convert from Excel</p>
+                <p class="text-xs text-warm-gray">Use the self-contained conversion prompt &mdash; no installation needed.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="py-20 lg:py-28">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16 reveal">
+        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Frequently asked questions</h2>
+        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Everything you need to know about adopting Satsuma.</p>
+      </div>
+      <div class="space-y-4 reveal">
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">Does Satsuma replace dbt, DBML, PySpark, or my existing data tools?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>No. Satsuma is not a pipeline engine or a schema modelling tool. It is a <strong>specification language</strong> that sits <em>upstream</em> of your implementation stack. You write your mapping intent in Satsuma, then use that spec to generate or validate implementations in dbt, PySpark, pandas, SQL, DuckDB, or whatever your team runs. Think of it as the blueprint, not the building.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">How does Satsuma work with AI coding agents?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>Satsuma is designed to be read and written by AI agents. Give your coding agent &mdash; GitHub Copilot, OpenAI Codex, Claude Code, Cursor, Windsurf, or any agentic coding tool &mdash; a <code>.stm</code> file and it can generate high-fidelity scaffolds for frameworks like <strong>dbt on Snowflake</strong>, <strong>Databricks Lakehouse Declarative Pipelines</strong>, <strong>pandas</strong>, <strong>dltHub</strong>, <strong>DuckDB</strong>, <strong>PySpark</strong>, and more. The structured syntax means the agent doesn't have to guess where a field name ends and a business rule begins &mdash; ambiguity is made explicit, so the generated code is better.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">What if I'm not allowed to install the CLI or don't have any agentic coding tools?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>You can still get real value. Satsuma files are plain text &mdash; write them in any editor and version them in Git. For AI assistance, paste the compact grammar reference (~900 tokens) into any web LLM like ChatGPT, Gemini, or Claude.ai. That's enough for the model to generate, review, and explain Satsuma specs. No CLI, no VS Code, no agent required. Read the <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/using-satsuma-without-cli.md" target="_blank" rel="noopener" class="text-orange hover:underline">full guide</a> for workflows and tips.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">Can AI agents generate entire pipeline implementations from a Satsuma spec?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>Yes &mdash; that's one of the core motivations, but in combination with human judgement and review. Because Satsuma separates deterministic structure (field mappings, types, value maps, pipe chains) from intentionally scoped natural language (complex business rules), an AI agent can generate correct code for the deterministic parts and leave clearly marked TODOs, or ask you for the parts that need human judgement. This is a dramatic improvement over trying to generate pipelines from spreadsheets, where the agent has to guess what's a field name, what's a comment, and what's a transformation rule.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">What tech stacks can I target from a Satsuma spec?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>Satsuma is stack-agnostic. The same <code>.stm</code> file can be used to generate implementations for <strong>dbt (Snowflake, BigQuery, Redshift)</strong>, <strong>Databricks Lakehouse Declarative Pipelines</strong>, <strong>PySpark</strong>, <strong>pandas</strong>, <strong>DuckDB</strong>, <strong>dltHub</strong>, <strong>SQL stored procedures</strong>, <strong>Apache Beam</strong>, and more. Integration teams can use Satsuma specs with AI assistance to build integrations in <strong>webMethods</strong>, <strong>MuleSoft</strong>, <strong>Azure Logic Apps</strong>, cloud microservices, and other middleware &mdash; the structured mapping format gives the agent exactly the context it needs to generate integration flows, not just data pipelines. Your mapping spec is the contract; the implementation target is a generation-time choice.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">Why not just use YAML, JSON, or a spreadsheet?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>YAML and JSON are verbose &mdash; a simple field mapping that takes one line in Satsuma becomes 5&ndash;7 lines of YAML. Spreadsheets are worse: inconsistent layouts, no version control, and AI tools struggle to parse free-form cell formats reliably. Satsuma is purpose-built for data mappings, so it's 40&ndash;60% smaller than YAML, diffs cleanly in Git, and gives both humans and AI a format that's unambiguous by design.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">How mature is Satsuma? Is it production-ready?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>Satsuma is in an <strong>early experimental stage</strong>. The language spec, parser, CLI, and VS Code extension are functional and well-tested, but the project is young and evolving. We're actively looking for feedback from data engineers, integration teams, and anyone who works with mapping specs. If you try it, we'd love to hear what works and what doesn't &mdash; <a href="https://github.com/thorbenlouw/satsuma-lang/issues" target="_blank" rel="noopener" class="text-orange hover:underline">open an issue</a> or start a discussion on GitHub.</p>
+          </div>
+        </details>
+
+        <details class="faq-item group bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
+          <summary class="flex items-center justify-between px-6 py-5 cursor-pointer select-none">
+            <span class="text-charcoal font-semibold pr-4">Can non-technical people read Satsuma?</span>
+            <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
+          </summary>
+          <div class="px-6 pb-5 text-warm-gray leading-relaxed">
+            <p>That's the primary design goal. The syntax reads like a structured document, not a programming language. Business analysts can follow the arrows (<code>source_field -> target_field</code>), understand metadata like <code>(pii, required)</code>, and read natural-language transform descriptions directly. No programming experience required &mdash; there's a dedicated <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/BA-TUTORIAL.md" target="_blank" rel="noopener" class="text-orange hover:underline">BA tutorial</a> to help non-technical readers get started in minutes.</p>
+          </div>
+        </details>
+
+      </div>
+    </div>
+  </section>
+
   <!-- CTA -->
   <section class="py-20 lg:py-28 bg-white">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center reveal">
@@ -480,7 +658,7 @@
             <img src="img/satsuma-logo-512.png" alt="Satsuma" class="h-7 w-7">
             <span class="text-lg font-bold text-charcoal">Satsuma</span>
           </div>
-          <p class="text-sm text-warm-gray leading-relaxed">The data mapping language that humans can read and machines can parse.</p>
+          <p class="text-sm text-warm-gray leading-relaxed">The data mapping language that humans can read, machines can parse, and AIs can reason about.</p>
         </div>
         <div>
           <h4 class="font-semibold text-charcoal mb-3">Tooling</h4>

--- a/site/learn.html
+++ b/site/learn.html
@@ -584,36 +584,6 @@ code --install-extension vscode-satsuma.vsix</code></pre>
           </ul>
         </div>
 
-        <!-- Technical Reference -->
-        <div class="bg-cream rounded-2xl p-8 border border-charcoal/5">
-          <div class="w-12 h-12 bg-charcoal rounded-xl flex items-center justify-center mb-5">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-          </div>
-          <h3 class="text-xl font-bold text-charcoal mb-4">Technical Reference</h3>
-          <ul class="space-y-3">
-            <li>
-              <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/ast-mapping.md" target="_blank" rel="noopener"
-                 class="flex items-center gap-2 text-sm text-warm-gray hover:text-charcoal transition-colors group">
-                <svg class="w-4 h-4 text-charcoal/40 group-hover:text-charcoal flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                AST Mapping
-              </a>
-            </li>
-            <li>
-              <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/tree-sitter-ambiguities.md" target="_blank" rel="noopener"
-                 class="flex items-center gap-2 text-sm text-warm-gray hover:text-charcoal transition-colors group">
-                <svg class="w-4 h-4 text-charcoal/40 group-hover:text-charcoal flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                Tree-sitter Ambiguities
-              </a>
-            </li>
-            <li>
-              <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/tree-sitter-precedence.md" target="_blank" rel="noopener"
-                 class="flex items-center gap-2 text-sm text-warm-gray hover:text-charcoal transition-colors group">
-                <svg class="w-4 h-4 text-charcoal/40 group-hover:text-charcoal flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
-                Tree-sitter Precedence
-              </a>
-            </li>
-          </ul>
-        </div>
 
         <!-- Schema Format Conventions -->
         <div class="bg-cream rounded-2xl p-8 border border-charcoal/5">


### PR DESCRIPTION
## Summary
- Add an 8-question FAQ accordion section covering: positioning vs dbt/DBML/PySpark, AI agent integration (Copilot, Codex, Claude Code, Cursor, etc.), no-tooling workflows, tech stack targeting (data platforms + integration platforms like webMethods, MuleSoft, Azure Logic Apps), maturity/feedback, and readability for non-technical users
- Add a "Works without the CLI or VS Code extension" section with workflow examples, linking to `docs/using-satsuma-without-cli.md`
- Update hero heading colors: **read**=orange, **parse**=green, **reason**=purple (matching the constraint/metadata syntax highlight color)
- Add FAQ link to desktop and mobile nav
- Remove stale Technical Reference card from learn page

## Test plan
- [ ] Verify FAQ accordion opens/closes correctly on desktop and mobile
- [ ] Verify nav FAQ link scrolls to the section
- [ ] Verify hero heading colors render correctly (orange, green, purple)
- [ ] Verify "Works without the CLI" section layout on mobile
- [ ] Check all external links in FAQ answers resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)