### PR TITLE
feat: Feature 20 — satsuma fmt (PRD + tickets)

### DIFF
--- a/.tickets/sl-2uzd.md
+++ b/.tickets/sl-2uzd.md
@@ -1,0 +1,24 @@
+---
+id: sl-2uzd
+status: open
+deps: [sl-zf33]
+links: []
+created: 2026-03-24T18:29:37Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Transform, metric, note, and import formatting
+
+Implement formatting for transform_block, metric_block, note_block, and import_decl nodes. These follow standard brace/indentation rules. Imports grouped tightly (no blank lines between them).
+
+## Acceptance Criteria
+
+- [ ] transform_block formatted with correct indentation and brace rules
+- [ ] metric_block formatted with source references and expressions
+- [ ] note_block formatted, triple-quoted strings preserved verbatim
+- [ ] import_decl: no blank lines between consecutive imports
+- [ ] Single-line vs multi-line decisions apply (80 char threshold)
+- [ ] Tests for each block type
+

--- a/.tickets/sl-3z3i.md
+++ b/.tickets/sl-3z3i.md
@@ -1,0 +1,27 @@
+---
+id: sl-3z3i
+status: open
+deps: [sl-zf33, sl-j0yf, sl-lu7y, sl-2uzd]
+links: []
+created: 2026-03-24T18:29:48Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Comment and blank line handling
+
+Implement comment preservation (// //! //?) with single space after marker. Inline trailing comments with 2-space gap. Section-header comments preserved as-is. Comment-to-block attachment (pull tight). Blank line normalisation: 2 between top-level blocks, collapse consecutive to 1 within blocks, no trailing blanks, file ends with single newline.
+
+## Acceptance Criteria
+
+- [ ] All three comment types preserved in output
+- [ ] Single space after // //! //?
+- [ ] Section-header comments (// --- X ---) preserved as-is
+- [ ] Inline trailing comments: 2-space minimum gap from code
+- [ ] Comments pulled tight to the block they precede (no blank line between)
+- [ ] 2 blank lines between top-level blocks
+- [ ] Consecutive blank lines within blocks collapse to 1
+- [ ] No trailing blank lines, file ends with single newline
+- [ ] Tests for all comment and blank line rules
+

--- a/.tickets/sl-bshy.md
+++ b/.tickets/sl-bshy.md
@@ -1,0 +1,22 @@
+---
+id: sl-bshy
+status: open
+deps: [sl-ewv7]
+links: []
+created: 2026-03-24T18:30:38Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [feat-20, phase-2]
+---
+# VS Code formatting tests
+
+Test that Format Document in VS Code produces identical output to CLI. Test format-on-save. Test with parse-error files (no crash or corruption).
+
+## Acceptance Criteria
+
+- [ ] Format Document produces same output as satsuma fmt for same input
+- [ ] format-on-save integration works
+- [ ] Parse-error files handled gracefully (no crash, no corruption)
+- [ ] Tests passing
+

--- a/.tickets/sl-ewv7.md
+++ b/.tickets/sl-ewv7.md
@@ -1,0 +1,23 @@
+---
+id: sl-ewv7
+status: open
+deps: [sl-pdxy]
+links: []
+created: 2026-03-24T18:30:29Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [feat-20, phase-2]
+---
+# LSP DocumentFormattingProvider
+
+Register DocumentFormattingProvider in the VS Code LSP server. Wire shared format() function (adapted for web-tree-sitter WASM) into the handler. Return TextEdit[] replacing full document. Verify format-on-save works with standard VS Code settings.
+
+## Acceptance Criteria
+
+- [ ] DocumentFormattingProvider registered in LSP server capabilities
+- [ ] Format Document in VS Code produces identical output to CLI
+- [ ] format-on-save works when user enables editor.formatOnSave
+- [ ] Parse-error files: format request returns empty edits (no crash/corrupt)
+- [ ] format() adapted for web-tree-sitter WASM API
+

--- a/.tickets/sl-j0yf.md
+++ b/.tickets/sl-j0yf.md
@@ -1,0 +1,27 @@
+---
+id: sl-j0yf
+status: open
+deps: [sl-zf33]
+links: []
+created: 2026-03-24T18:29:17Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Schema and fragment block formatting
+
+Implement formatting for schema_block and fragment_block: indentation, braces, block metadata (single-line/multi-line), two-pass field column alignment (name/type/metadata caps at 24/14). Fragment spreads as non-aligned standalone lines.
+
+## Acceptance Criteria
+
+- [ ] Schema blocks formatted with correct indentation and brace placement
+- [ ] Multi-line metadata: opening ( on keyword line, entries indented, closing ) { together
+- [ ] Field names column-aligned (capped at 24 chars)
+- [ ] Type column-aligned (capped at 14 chars)
+- [ ] Metadata column-aligned with 2-space minimum gap
+- [ ] Fragment blocks use same field alignment rules
+- [ ] Fragment spreads (...name) not aligned, standalone at block indent
+- [ ] Inline trailing comments preserve 2-space minimum gap
+- [ ] Tests for all schema/fragment formatting rules
+

--- a/.tickets/sl-jper.md
+++ b/.tickets/sl-jper.md
@@ -1,0 +1,27 @@
+---
+id: sl-jper
+status: open
+deps: [sl-jzkp]
+links: []
+created: 2026-03-24T18:30:10Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Core formatter tests
+
+Comprehensive unit tests for the formatter: every block type, field alignment, comment handling, blank line rules, single-line vs multi-line decisions. Edge cases: deeply nested records, long metadata, inline comments at alignment boundaries, empty blocks. Use example corpus as golden fixtures. Round-trip structural equivalence tests (parse(format(src)) matches parse(src)).
+
+## Acceptance Criteria
+
+- [ ] Unit tests for schema, fragment, mapping, transform, metric, note, import formatting
+- [ ] Tests for field column alignment including cap overflow
+- [ ] Tests for all three comment types and positioning
+- [ ] Tests for blank line normalisation
+- [ ] Tests for single-line vs multi-line block decisions
+- [ ] Edge case tests: deeply nested records, long metadata, empty blocks
+- [ ] Golden fixture tests against examples/*.stm
+- [ ] Round-trip structural equivalence tests for all corpus fixtures
+- [ ] All tests passing
+

--- a/.tickets/sl-jzkp.md
+++ b/.tickets/sl-jzkp.md
@@ -1,0 +1,28 @@
+---
+id: sl-jzkp
+status: open
+deps: [sl-3z3i]
+links: []
+created: 2026-03-24T18:29:59Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# CLI fmt command
+
+Implement tooling/satsuma-cli/src/commands/fmt.ts: file/directory resolution, recursive .stm discovery, --check (exit 1 if unformatted), --diff (print unified diff), --stdin (read stdin, write stdout), exit codes 0/1/2, parse-error file skipping with warnings. Register in index.ts.
+
+## Acceptance Criteria
+
+- [ ] satsuma fmt file.stm formats in place
+- [ ] satsuma fmt dir/ recursively formats all .stm files
+- [ ] satsuma fmt (no args) formats .stm files in cwd
+- [ ] --check exits 0 if formatted, 1 if not, prints unformatted file list
+- [ ] --diff prints unified diff without writing
+- [ ] --stdin reads from stdin, writes to stdout
+- [ ] Exit code 2 on parse errors
+- [ ] Parse-error files skipped with warning message
+- [ ] Command registered in index.ts
+- [ ] Tests for CLI flags and exit codes
+

--- a/.tickets/sl-lu7y.md
+++ b/.tickets/sl-lu7y.md
@@ -1,0 +1,27 @@
+---
+id: sl-lu7y
+status: open
+deps: [sl-zf33]
+links: []
+created: 2026-03-24T18:29:27Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Mapping block formatting
+
+Implement formatting for mapping_block: source/target sub-blocks (single-line/multi-line), arrow declarations (simple, inline transform, computed with NL body), pipe chains, each/flatten nested structures, note sub-blocks within mappings.
+
+## Acceptance Criteria
+
+- [ ] source/target sub-blocks: single-line when short (<80 chars), multi-line otherwise
+- [ ] Simple arrows: single space around ->
+- [ ] Inline transform arrows: { trim | lowercase } with single spaces
+- [ ] Computed arrows: opening { on same line, body indented, closing } at arrow indent
+- [ ] Pipe chains: | with single space on each side
+- [ ] NL strings in computed arrows preserved verbatim
+- [ ] each/flatten nested blocks formatted recursively
+- [ ] note sub-blocks within mappings formatted correctly
+- [ ] Tests for all mapping formatting patterns
+

--- a/.tickets/sl-pdxy.md
+++ b/.tickets/sl-pdxy.md
@@ -1,0 +1,23 @@
+---
+id: sl-pdxy
+status: open
+deps: [sl-jper]
+links: []
+created: 2026-03-24T18:30:20Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Exploratory testing and corpus validation
+
+Run satsuma fmt --check against all examples/*.stm files. Fix any formatting divergence between the formatter output and the canonical corpus. Run against deliberately messy/agent-generated .stm files. Verify idempotency across full corpus. Document any surprising results.
+
+## Acceptance Criteria
+
+- [ ] satsuma fmt --check examples/ exits 0
+- [ ] Formatter is idempotent on all corpus files
+- [ ] Tested with deliberately messy .stm input (bad indentation, wrong alignment, extra blank lines)
+- [ ] Any surprising results documented in features/20-stm-fmt/NOTES.md
+- [ ] No regressions in existing CLI or parser tests
+

--- a/.tickets/sl-rbki.md
+++ b/.tickets/sl-rbki.md
@@ -1,0 +1,21 @@
+---
+id: sl-rbki
+status: open
+deps: [sl-pdxy, sl-bshy]
+links: []
+created: 2026-03-24T18:30:47Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [feat-20, phase-3]
+---
+# CI integration for fmt --check
+
+Add satsuma fmt --check step to CI pipeline. Format entire example corpus and commit (should be a no-op if style matches).
+
+## Acceptance Criteria
+
+- [ ] CI pipeline includes satsuma fmt --check step
+- [ ] CI fails if any .stm file in examples/ is not formatted
+- [ ] Example corpus passes fmt --check (no formatting changes needed)
+

--- a/.tickets/sl-z8xf.md
+++ b/.tickets/sl-z8xf.md
@@ -1,0 +1,22 @@
+---
+id: sl-z8xf
+status: open
+deps: [sl-pdxy]
+links: []
+created: 2026-03-24T18:30:56Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [feat-20, phase-3]
+---
+# Documentation updates
+
+Update SATSUMA-CLI.md with fmt command reference (flags, exit codes, usage examples). Update AI-AGENT-REFERENCE.md with formatter guidance for agents. Update PROJECT-OVERVIEW.md if architecture description changes. Update landing page/site to mention the formatter.
+
+## Acceptance Criteria
+
+- [ ] SATSUMA-CLI.md: fmt command documented with all flags and examples
+- [ ] AI-AGENT-REFERENCE.md: formatter guidance for agents (when to run, CI expectations)
+- [ ] PROJECT-OVERVIEW.md updated if needed
+- [ ] Landing page/site mentions formatter as a tooling feature
+

--- a/.tickets/sl-zf33.md
+++ b/.tickets/sl-zf33.md
@@ -1,0 +1,22 @@
+---
+id: sl-zf33
+status: open
+deps: []
+links: []
+created: 2026-03-24T18:29:09Z
+type: task
+priority: 1
+assignee: Thorben Louw
+tags: [feat-20, phase-1]
+---
+# Core formatter scaffolding
+
+Implement format(tree, source) pure function skeleton in tooling/satsuma-cli/src/format.ts. Set up CST walk over node.children (not just namedChildren). Emit pass-through as baseline.
+
+## Acceptance Criteria
+
+- [ ] format.ts exists with format(tree, source): string signature
+- [ ] Full CST walk visits all children including anonymous tokens and comments
+- [ ] Pass-through mode: format(parse(src)) reproduces original source
+- [ ] Basic test file exists with round-trip test
+

--- a/features/20-stm-fmt/PRD.md
+++ b/features/20-stm-fmt/PRD.md
@@ -1,0 +1,289 @@
+# Feature 20 — `satsuma fmt`: Opinionated Formatter
+
+> **Status: NOT STARTED**
+
+## Goal
+
+Ship a zero-config, opinionated Satsuma formatter — analogous to `black` for Python or `gofmt` for Go. One canonical style, no user overrides, no configuration. The formatter is available as a CLI command (`satsuma fmt`) and as the VS Code "Format Document" provider for `.stm` files.
+
+---
+
+## Problem
+
+Satsuma files are written by humans and AI agents, each with different spacing habits. The example corpus is manually kept consistent, but there is no automated way to enforce or apply the canonical style. This leads to:
+
+1. **Inconsistent formatting** across files in a workspace, especially when multiple contributors (human or agent) edit concurrently.
+2. **Noisy diffs** where whitespace and alignment changes obscure semantic changes.
+3. **Wasted effort** aligning columns and fixing indentation by hand.
+4. **No format-on-save** in VS Code — the LSP server (Feature 16) explicitly deferred formatting as a non-goal.
+
+A canonical formatter eliminates formatting as a decision. Contributors run `satsuma fmt` (or hit Format in VS Code) and move on.
+
+---
+
+## Design Principles
+
+1. **Zero configuration.** No `.satsumarc`, no flags to tweak style, no overrides. One style for all Satsuma files everywhere. This is non-negotiable — simplicity is the feature.
+2. **Parser-backed.** The formatter walks the tree-sitter CST. It does not use regex or line-oriented heuristics.
+3. **Comment-preserving.** All three comment types (`//`, `//!`, `//?`) are retained in their correct positions. Comments are never dropped or repositioned across blocks.
+4. **Idempotent.** Running the formatter twice produces the same output as running it once. `fmt(fmt(x)) == fmt(x)`.
+5. **Semantics-preserving.** The CST of formatted output is structurally identical to the CST of the input (ignoring whitespace tokens). Formatting never changes meaning.
+
+---
+
+## Non-Goals
+
+- Configuration, style options, or per-project overrides.
+- Sorting or reordering declarations (schemas, fields, imports, arrows). The formatter preserves declaration order.
+- Inserting or removing language constructs (e.g. adding missing metadata, removing unused imports).
+- Linting or diagnostics — that's `satsuma lint` (Feature 17).
+- Formatting embedded NL content inside `"..."` or `"""..."""` strings. Natural language string content is preserved verbatim.
+
+---
+
+## Style Specification
+
+The canonical style is derived from the conventions established in the example corpus (`examples/*.stm`). These rules are **fixed and not user-configurable**.
+
+### Indentation
+
+- **Unit:** 2 spaces. No tabs.
+- **Nesting:** Each block level (`{ }`) adds one indentation level.
+
+### Blank Lines
+
+- **Between top-level blocks:** 2 blank lines (between schemas, mappings, fragments, transforms, metrics, notes, and import groups).
+- **Between import statements:** 0 blank lines (consecutive imports are grouped tightly).
+- **Before the first import:** 0 blank lines after the file-level header comment(s), 1 blank line if no header comment.
+- **Within a block body:** 1 blank line to separate logical groups (e.g. between `source`/`target` sub-blocks and arrows, between groups of arrows separated by section comments). Existing blank-line groupings within a block body are preserved but normalised to exactly 1 blank line (consecutive blank lines collapse to 1).
+- **No trailing blank lines** at end of file. Files end with a single newline.
+
+### Field Alignment (in schemas, fragments, records)
+
+Fields within the same block body are **column-aligned** in up to three columns:
+
+```
+  name          TYPE           (metadata)
+```
+
+1. **Name column** — left-aligned, starts at the block's indentation level.
+2. **Type column** — left-aligned, starts at `(longest field name in block) + 2` spaces minimum gap, **capped at 24 characters** of name width. If the longest name exceeds 24 characters, longer names use a 2-space minimum gap instead of padding to the column.
+3. **Metadata column** — left-aligned, starts at `type column + (longest type in block) + 2` spaces minimum gap, **capped at 14 characters** of type width. If the longest type exceeds 14 characters, longer types use a 2-space minimum gap instead of padding to the column.
+
+The caps (24 for names, 14 for types) cover 100% of the existing example corpus. They prevent pathologically long names or types from pushing the entire block's alignment to absurd widths.
+
+If a field has a trailing inline comment, it appears after the metadata (or after the type if no metadata) with a 2-space minimum gap.
+
+Fragment spread lines (`...name`) are not aligned — they sit at the block indentation level and stand alone.
+
+### Arrows (in mappings)
+
+Arrow declarations are **not column-aligned** — each arrow stands on its own line with standard spacing:
+
+```
+  source.field -> target_field
+  source.field -> target_field { transform | chain }
+```
+
+- Single space around `->`.
+- Single space before `{` and after `}` in inline transform bodies.
+- Pipe operators `|` have a single space on each side.
+
+### Computed Arrows
+
+```
+  -> target_field {
+    "NL description."
+    | func1 | func2
+  }
+```
+
+- Opening `{` on same line as the arrow.
+- Body indented one level.
+- Pipe continuation lines indented to the same level as the NL string above.
+- Closing `}` on its own line at the arrow's indentation level.
+
+### Block Structure
+
+- **Opening brace** on the same line as the keyword: `schema name (...) {`
+- **Closing brace** on its own line at the keyword's indentation level.
+- **Single-line blocks** are allowed when the body is short enough (fits within 80 characters on the line): `target { \`name\` }`
+- **Metadata parentheses** on the same line as the keyword when short. When multi-line, the opening `(` stays on the keyword line, continuation lines are indented one level, and the closing `)` can be on the same line as the last metadata entry or on the `{` line:
+
+```
+schema name (
+  format postgresql,
+  note "description"
+) {
+  ...
+}
+```
+
+### Comments
+
+- A single space after `//`, `//!`, and `//?`.
+- Section-header comments (`// --- Section Name ---`) are preserved as-is.
+- Inline trailing comments maintain a 2-space minimum gap from code.
+- Block-preceding comments stay attached to the block they precede.
+- Blank lines between a comment and its block are removed (comment is pulled tight to the block).
+
+### Spacing
+
+- No trailing whitespace on any line.
+- Single space around `->`.
+- Single space around `|` in pipe chains.
+- Single space after `,` in metadata lists.
+- No space inside `( )` for metadata: `(pk, required)` not `( pk, required )`.
+- No space inside `{ }` for single-line bodies: `{ trim | lowercase }` not `{  trim | lowercase  }`.
+- Single space between name and `(` for block metadata: `schema name (...)`.
+
+### String Content
+
+- Content inside `"..."` and `"""..."""` is **never modified**. The formatter does not touch natural language string interiors.
+- Triple-quoted string delimiters (`"""`) are placed on their own lines when the string is multi-line.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  Shared Core                        │
+│                                                     │
+│  format(tree: Tree, source: string): string         │
+│                                                     │
+│  Pure function. CST in, formatted string out.       │
+│  No I/O, no config, no side effects.                │
+└──────────┬──────────────────────┬───────────────────┘
+           │                      │
+           ▼                      ▼
+┌──────────────────┐   ┌──────────────────────────────┐
+│  CLI Command     │   │  VS Code LSP Server          │
+│  satsuma fmt     │   │  DocumentFormattingProvider   │
+│                  │   │                               │
+│  - file/dir I/O  │   │  - receives document text     │
+│  - --check mode  │   │  - calls format()             │
+│  - exit codes    │   │  - returns TextEdit[]          │
+│  - glob support  │   │  - format-on-save via editor  │
+└──────────────────┘   └──────────────────────────────┘
+```
+
+### Core Formatter Module
+
+A single pure function: takes a tree-sitter `Tree` and the original source string, returns the formatted string. No I/O, no configuration, no side effects.
+
+**Location:** `tooling/satsuma-cli/src/format.ts` (or `format/` directory if it grows).
+
+The formatter walks the full CST (`node.children`, not just `namedChildren`) to preserve comments and punctuation. It reconstructs output by emitting each node with canonical spacing, indentation, and alignment.
+
+**Key implementation detail:** Field alignment requires a two-pass approach within each block — first pass measures column widths, second pass emits aligned output.
+
+### CLI Command
+
+```
+satsuma fmt [path]            # format file or directory (in place)
+satsuma fmt [path] --check    # exit 1 if any file would change (for CI)
+satsuma fmt [path] --diff     # print diff instead of writing
+```
+
+- **`[path]`** — a `.stm` file or directory. When given a directory, recursively formats all `.stm` files.
+- **`--check`** — dry-run mode. Exits 0 if all files are already formatted, 1 if any would change. Prints the list of unformatted files.
+- **`--diff`** — prints a unified diff of what would change, without writing.
+- **No path** — formats all `.stm` files in the current directory (recursive).
+- **Stdin/stdout** — when `--stdin` is passed, reads from stdin and writes formatted output to stdout (useful for editor integrations and pipes).
+- **Exit codes:** 0 = success (or already formatted), 1 = files would change (with `--check`), 2 = parse errors.
+
+Files with parse errors are **skipped** with a warning (the formatter only operates on valid CSTs). This matches `black`'s behaviour.
+
+### VS Code Integration
+
+The LSP server registers a `DocumentFormattingProvider`. When the user triggers Format Document (or format-on-save is enabled), the server:
+
+1. Parses the document with tree-sitter (already cached from live editing).
+2. Calls the shared `format()` function.
+3. Returns a single `TextEdit` replacing the full document range.
+
+No additional VS Code extension configuration is needed — `documentFormattingProvider` is a standard LSP capability that VS Code surfaces automatically.
+
+---
+
+## Success Criteria
+
+### Correctness
+1. `satsuma fmt file.stm` produces correctly formatted output for all files in `examples/`.
+2. Formatting is **idempotent**: `satsuma fmt` on an already-formatted file produces no changes.
+3. Formatting is **semantics-preserving**: the tree-sitter parse tree of formatted output matches the original (structurally, ignoring whitespace).
+4. `satsuma fmt --check examples/` exits 0 (the example corpus is the canonical style).
+5. All three comment types are preserved in correct positions.
+6. Parse-error files are skipped with a diagnostic message, not crashed on.
+7. VS Code "Format Document" on a `.stm` file uses the same formatter and produces identical output to the CLI.
+8. Round-trip test: for every corpus test fixture, `parse(format(source)) ≅ parse(source)`.
+9. Performance: formatting a 500-line file completes in under 100ms.
+10. No configuration files, flags, or settings alter the formatting style.
+
+### Testing
+11. Unit tests cover every block type (schema, fragment, mapping, transform, metric, note, import) and their formatting rules.
+12. Unit tests cover edge cases: deeply nested records, long metadata lines, inline comments at alignment boundaries, empty blocks, single-line vs multi-line decisions.
+13. Integration tests run `satsuma fmt --check` against the full example corpus.
+14. Round-trip structural equivalence tests for all corpus fixtures.
+15. Exploratory testing: manually run the formatter against real-world `.stm` files (including large, messy, or agent-generated files) and verify the output looks correct and readable. Document any surprising results.
+
+### Documentation
+16. `SATSUMA-CLI.md` updated with the `fmt` command, its flags, and usage examples.
+17. `AI-AGENT-REFERENCE.md` updated with formatter guidance (how agents should use `satsuma fmt`, when to run it, CI expectations).
+18. Landing page / site updated to mention the formatter as a tooling feature.
+19. `PROJECT-OVERVIEW.md` updated if the formatter changes the tooling architecture description.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Core Formatter + CLI Command
+
+- Implement `format()` as a pure function over the CST.
+- Handle all block types: schema, fragment, mapping, transform, metric, note, import.
+- Implement field column alignment within schema/fragment/record bodies.
+- Implement arrow formatting in mapping bodies.
+- Handle all comment types and positions.
+- Handle single-line vs multi-line block decisions.
+- Add `fmt` command to CLI with `--check`, `--diff`, and `--stdin` flags.
+- Add tests using the example corpus as golden fixtures.
+- Add targeted tests for edge cases (deeply nested records, long metadata, inline comments at alignment boundaries).
+
+### Phase 2 — VS Code Integration
+
+- Register `DocumentFormattingProvider` in the LSP server.
+- Wire the shared `format()` function into the LSP formatting handler.
+- Verify format-on-save works with standard VS Code settings.
+- Add `DocumentRangeFormattingProvider` if feasible (format selection).
+
+### Phase 3 — CI Integration
+
+- Add `satsuma fmt --check` to the project's CI pipeline.
+- Format the entire example corpus and commit (should be a no-op if the style matches).
+- Document the formatter in `SATSUMA-CLI.md`.
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Column alignment heuristics produce ugly output for extreme cases (very long names/types) | Low — rare in practice | Cap alignment at a maximum column; fall back to minimum-gap spacing beyond that |
+| Comment repositioning loses association with the code it describes | High — data loss | Conservative approach: comments stay attached to the next sibling node; never move comments across blank lines |
+| Multi-line metadata formatting edge cases (deeply nested `record` with metadata) | Medium | Test with all corpus fixtures; add targeted edge-case fixtures |
+| Shared core between CLI (Node) and VS Code (WASM) needs adaptation | Low | The formatter operates on the CST API, which is identical between bindings; only the tree construction differs |
+| Disagreement on style choices after shipping | Low | The `black` philosophy: ship an opinionated style and don't revisit it. Style is derived from the existing corpus, not invented |
+
+---
+
+## File Locations
+
+| Artifact | Path |
+|----------|------|
+| Feature PRD | `features/20-stm-fmt/PRD.md` |
+| Core formatter | `tooling/satsuma-cli/src/format.ts` |
+| CLI command | `tooling/satsuma-cli/src/commands/fmt.ts` |
+| Formatter tests | `tooling/satsuma-cli/src/__tests__/format.test.ts` |
+| LSP handler | `tooling/vscode-satsuma/server/src/formatting.ts` |
+| CLI docs update | `SATSUMA-CLI.md` |

--- a/features/20-stm-fmt/TODO.md
+++ b/features/20-stm-fmt/TODO.md
@@ -1,0 +1,43 @@
+# Feature 20 — `satsuma fmt` — Task Breakdown
+
+## Phase 1: Core Formatter + CLI Command
+
+### 1.1 Core formatter scaffolding
+Implement the `format(tree, source)` pure function skeleton in `tooling/satsuma-cli/src/format.ts`. Set up the CST walk over `node.children` (not just `namedChildren`) to handle all node types including anonymous tokens and comments. Emit unformatted source as a baseline (pass-through) and wire up basic tests proving round-trip works.
+
+### 1.2 Schema and fragment block formatting
+Implement formatting for `schema_block` and `fragment_block` nodes: indentation, opening/closing braces, block metadata (single-line and multi-line), and the two-pass field column alignment (name, type, metadata columns with caps at 24/14). Handle fragment spreads (`...name`) as non-aligned standalone lines.
+
+### 1.3 Mapping block formatting
+Implement formatting for `mapping_block` nodes: `source`/`target` sub-blocks (single-line and multi-line), arrow declarations (simple, with inline transform, computed with NL body), pipe chains, `each`/`flatten` nested structures, and `note` sub-blocks within mappings.
+
+### 1.4 Transform, metric, note, and import formatting
+Implement formatting for `transform_block`, `metric_block`, `note_block`, and `import_decl` nodes. These are simpler block types that follow the same brace/indentation rules.
+
+### 1.5 Comment and blank line handling
+Implement comment preservation (all three types: `//`, `//!`, `//?`), inline trailing comments with 2-space gap, section-header comment preservation, comment-to-block attachment (pull tight), and blank line normalisation (2 between top-level blocks, collapse consecutive blanks to 1 within blocks, no trailing blanks).
+
+### 1.6 CLI `fmt` command
+Implement `tooling/satsuma-cli/src/commands/fmt.ts`: file/directory resolution, recursive `.stm` discovery, `--check`, `--diff`, `--stdin` flags, exit codes (0/1/2), and parse-error file skipping with warnings.
+
+### 1.7 Core formatter tests
+Unit tests for every block type, field alignment, comment handling, blank line rules, single-line vs multi-line decisions, edge cases (deeply nested records, long metadata, inline comments at alignment boundaries, empty blocks). Use example corpus as golden fixtures. Add round-trip structural equivalence tests.
+
+### 1.8 Exploratory testing and corpus validation
+Run `satsuma fmt --check` against all `examples/*.stm` files. Fix any formatting divergence. Run the formatter against deliberately messy/agent-generated `.stm` files. Document any surprising results. Ensure idempotency across the full corpus.
+
+## Phase 2: VS Code Integration
+
+### 2.1 LSP DocumentFormattingProvider
+Register `DocumentFormattingProvider` in the VS Code LSP server. Wire the shared `format()` function (adapted for web-tree-sitter WASM) into the handler. Return `TextEdit[]` replacing the full document. Verify format-on-save works with standard VS Code settings.
+
+### 2.2 VS Code formatting tests
+Test that Format Document in VS Code produces identical output to the CLI. Test format-on-save. Test with parse-error files (should not crash or corrupt).
+
+## Phase 3: CI + Documentation
+
+### 3.1 CI integration
+Add `satsuma fmt --check` step to the CI pipeline. Format the entire example corpus and commit (should be a no-op).
+
+### 3.2 Documentation updates
+Update `SATSUMA-CLI.md` with the `fmt` command reference. Update `AI-AGENT-REFERENCE.md` with formatter guidance for agents. Update `PROJECT-OVERVIEW.md` if architecture description needs it. Update landing page / site to mention the formatter.


### PR DESCRIPTION
## Summary

- Adds PRD for `satsuma fmt` — an opinionated, zero-config Satsuma formatter (like `black` for Python)
- Adds TODO.md task breakdown across 3 phases: core formatter + CLI, VS Code integration, CI + docs
- Creates 12 dependency-linked `tk` tickets covering the full implementation

## Scope

This PR is **spec and planning only** — no implementation code. The formatter will:

- Ship as `satsuma fmt [path]` CLI command with `--check`, `--diff`, `--stdin` flags
- Integrate as VS Code "Format Document" via the LSP `DocumentFormattingProvider`
- Enforce one canonical style with no configuration (field column alignment, 2-space indent, blank line rules, comment preservation)
- Include CI `--check` gate and documentation updates (CLI docs, AI-AGENT-REFERENCE.md, landing page)

## Key design decisions

- **Column alignment caps**: field names at 24 chars, types at 14 chars (covers 100% of corpus)
- **Arrows not column-aligned** (source paths vary too much in length)
- **String content never modified** (NL content preserved verbatim)
- **Single-line blocks** when body fits within 80 chars

## Test plan

- [ ] PRD reviewed for completeness and style rule accuracy
- [ ] Ticket dependency chain verified (`tk dep tree sl-rbki`)
- [ ] TODO.md matches ticket breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)