### PR TITLE
feat: dynamic version templating and release links for site

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [main]
     paths: ['site/**']
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
   pages: write
   id-token: write
+  contents: read
 
 concurrency:
   group: pages
@@ -22,6 +25,22 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve latest tagged version
+        id: version
+        run: |
+          TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo 'v0.0.0')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $TAG"
+
+      - name: Inject version into site HTML
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          find site -name '*.html' -exec sed -i "s|__VERSION_TAG__|${TAG}|g" {} +
+          find site -name '*.html' -exec sed -i "s|__VERSION__|${TAG}|g" {} +
+
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/site/cli.html
+++ b/site/cli.html
@@ -142,15 +142,38 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 reveal">
       <div class="max-w-3xl mx-auto">
         <h2 class="text-3xl font-bold text-charcoal mb-3">Installation</h2>
-        <p class="text-warm-gray mb-8">Download a prebuilt package from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">latest GitHub release</a> and install globally with npm.</p>
+        <p class="text-warm-gray mb-8">Download a prebuilt package from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="text-orange hover:underline">__VERSION__ release</a> and install globally with npm.</p>
         <div class="terminal">
           <div class="terminal-header">
             <div class="terminal-dot red"></div>
             <div class="terminal-dot yellow"></div>
             <div class="terminal-dot green"></div>
-            <span class="text-xs text-gray-400 ml-2 font-mono">terminal</span>
+            <span class="text-xs text-gray-400 ml-2 font-mono">terminal — stable (__VERSION__)</span>
           </div>
           <pre>
+<span class="output"># macOS (Apple Silicon)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/__VERSION_TAG__/satsuma-cli-darwin-arm64.tgz
+
+<span class="output"># macOS (Intel)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/__VERSION_TAG__/satsuma-cli-darwin-x64.tgz
+
+<span class="output"># Linux (x64)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/__VERSION_TAG__/satsuma-cli-linux-x64.tgz
+
+<span class="prompt">$</span> satsuma <span class="flag">--help</span>
+<span class="output">satsuma &lt;command&gt; [options]</span>
+<span class="output">16 commands available</span></pre>
+        </div>
+        <details class="mt-4 text-sm">
+          <summary class="cursor-pointer text-warm-gray hover:text-charcoal transition-colors font-medium">Latest unstable build (from main)</summary>
+          <div class="terminal mt-3">
+            <div class="terminal-header">
+              <div class="terminal-dot red"></div>
+              <div class="terminal-dot yellow"></div>
+              <div class="terminal-dot green"></div>
+              <span class="text-xs text-gray-400 ml-2 font-mono">terminal — unstable (latest)</span>
+            </div>
+            <pre>
 <span class="output"># macOS (Apple Silicon)</span>
 <span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz
 
@@ -158,12 +181,9 @@
 <span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-x64.tgz
 
 <span class="output"># Linux (x64)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz
-
-<span class="prompt">$</span> satsuma <span class="flag">--help</span>
-<span class="output">satsuma &lt;command&gt; [options]</span>
-<span class="output">16 commands available</span></pre>
-        </div>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz</pre>
+          </div>
+        </details>
         <div class="mt-6 flex items-start gap-3 p-4 bg-peach rounded-xl">
           <svg class="w-5 h-5 text-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           <p class="text-sm text-charcoal">
@@ -723,13 +743,14 @@
           <h4 class="font-semibold text-charcoal mb-3">Community</h4>
           <ul class="space-y-2 text-sm text-warm-gray">
             <li><a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" class="hover:text-orange transition-colors">GitHub Repository</a></li>
+            <li><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">Release Notes (__VERSION__)</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/CHANGELOG.md" target="_blank" class="hover:text-orange transition-colors">Changelog</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/AGENT-CONTRIBUTIONS.md" target="_blank" class="hover:text-orange transition-colors">Contributing</a></li>
           </ul>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center justify-between pt-8 border-t border-charcoal/5 text-sm text-warm-gray">
-        <p>v0.1.0 &middot; MIT License</p>
+        <p><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">__VERSION__</a> &middot; MIT License</p>
         <p class="mt-2 sm:mt-0">Made with care for the data community</p>
       </div>
     </div>

--- a/site/examples.html
+++ b/site/examples.html
@@ -970,13 +970,14 @@
           <h4 class="font-semibold text-charcoal mb-3">Community</h4>
           <ul class="space-y-2 text-sm text-warm-gray">
             <li><a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" class="hover:text-orange transition-colors">GitHub Repository</a></li>
+            <li><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">Release Notes (__VERSION__)</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/CHANGELOG.md" target="_blank" class="hover:text-orange transition-colors">Changelog</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/AGENT-CONTRIBUTIONS.md" target="_blank" class="hover:text-orange transition-colors">Contributing</a></li>
           </ul>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center justify-between pt-8 border-t border-charcoal/5 text-sm text-warm-gray">
-        <p>v0.1.0 &middot; MIT License</p>
+        <p><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">__VERSION__</a> &middot; MIT License</p>
         <p class="mt-2 sm:mt-0">Made with care for the data community</p>
       </div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -680,13 +680,14 @@
           <h4 class="font-semibold text-charcoal mb-3">Community</h4>
           <ul class="space-y-2 text-sm text-warm-gray">
             <li><a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" class="hover:text-orange transition-colors">GitHub Repository</a></li>
+            <li><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">Release Notes (__VERSION__)</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/CHANGELOG.md" target="_blank" class="hover:text-orange transition-colors">Changelog</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/AGENT-CONTRIBUTIONS.md" target="_blank" class="hover:text-orange transition-colors">Contributing</a></li>
           </ul>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center justify-between pt-8 border-t border-charcoal/5 text-sm text-warm-gray">
-        <p>v0.1.0 &middot; MIT License</p>
+        <p><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">__VERSION__</a> &middot; MIT License</p>
         <p class="mt-2 sm:mt-0">Made with care for the data community</p>
       </div>
     </div>

--- a/site/learn.html
+++ b/site/learn.html
@@ -117,10 +117,10 @@
           <div class="absolute -top-4 left-8 w-8 h-8 gradient-orange rounded-full flex items-center justify-center text-white font-bold text-sm">1</div>
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the CLI</h3>
           <div class="code-block text-sm mb-4">
-            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># macOS (Apple Silicon)</span>
-npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz</code></pre>
+            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># macOS (Apple Silicon) — stable (__VERSION__)</span>
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/__VERSION_TAG__/satsuma-cli-darwin-arm64.tgz</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. Prebuilt packages for macOS, Linux, and Windows are on the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">latest release</a>.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. Prebuilt packages for macOS, Linux, and Windows are on the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="text-orange hover:underline">__VERSION__ release</a>. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>.</p>
         </div>
 
         <!-- Step 2 -->
@@ -131,7 +131,7 @@ npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/lat
             <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># Download from the latest release, then:</span>
 code --install-extension vscode-satsuma.vsix</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the latest release. Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-3">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the __VERSION__ release. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>. Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more.</p>
           <a href="vscode.html" class="text-green text-sm font-semibold hover:underline">See all extension features &rarr;</a>
         </div>
 
@@ -711,13 +711,14 @@ code --install-extension vscode-satsuma.vsix</code></pre>
           <h4 class="font-semibold text-charcoal mb-3">Community</h4>
           <ul class="space-y-2 text-sm text-warm-gray">
             <li><a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" class="hover:text-orange transition-colors">GitHub Repository</a></li>
+            <li><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">Release Notes (__VERSION__)</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/CHANGELOG.md" target="_blank" class="hover:text-orange transition-colors">Changelog</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/AGENT-CONTRIBUTIONS.md" target="_blank" class="hover:text-orange transition-colors">Contributing</a></li>
           </ul>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center justify-between pt-8 border-t border-charcoal/5 text-sm text-warm-gray">
-        <p>v0.1.0 &middot; MIT License</p>
+        <p><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">__VERSION__</a> &middot; MIT License</p>
         <p class="mt-2 sm:mt-0">Made with care for the data community</p>
       </div>
     </div>

--- a/site/vscode.html
+++ b/site/vscode.html
@@ -94,10 +94,14 @@
           Full language support for Satsuma: syntax highlighting, an LSP server with navigation and completions, real-time diagnostics, and interactive workspace visualization. All parser-backed.
         </p>
         <div class="flex flex-wrap gap-4">
-          <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" rel="noopener"
+          <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" rel="noopener"
              class="inline-flex items-center gap-2 px-6 py-3 gradient-green text-white font-semibold rounded-xl shadow-lg shadow-green/25 hover:shadow-xl hover:shadow-green/30 transition-all">
-            Download .vsix
+            Download .vsix (__VERSION__)
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
+          </a>
+          <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" rel="noopener"
+             class="inline-flex items-center gap-2 px-6 py-3 bg-warm-gray/10 text-warm-gray font-medium rounded-xl border border-charcoal/10 hover:border-charcoal/20 transition-all text-sm">
+            Latest unstable
           </a>
           <a href="https://github.com/thorbenlouw/satsuma-lang/tree/main/tooling/vscode-satsuma" target="_blank" rel="noopener"
              class="inline-flex items-center gap-2 px-6 py-3 bg-cream text-charcoal font-semibold rounded-xl border border-charcoal/10 hover:border-charcoal/20 transition-all">
@@ -455,7 +459,7 @@
             <h3 class="text-lg font-bold text-charcoal">From GitHub Release</h3>
             <span class="px-2 py-0.5 bg-green/10 text-green-dark text-xs font-semibold rounded-full">Recommended</span>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/latest" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the latest GitHub release, then install:</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the __VERSION__ release (or <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable</a>), then install:</p>
           <div class="terminal">
             <div class="terminal-header">
               <span class="terminal-dot red"></span>
@@ -529,7 +533,7 @@
             </div>
             <div>
               <h3 class="font-semibold text-charcoal"><code class="font-mono text-sm">satsuma</code> CLI on PATH</h3>
-              <p class="text-warm-gray text-sm mt-1">Required for validation diagnostics, workspace commands, and webview panels. <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-orange hover:underline">Download from the latest release</a> or <a href="cli.html" class="text-orange hover:underline">see the CLI page</a>.</p>
+              <p class="text-warm-gray text-sm mt-1">Required for validation diagnostics, workspace commands, and webview panels. <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="text-orange hover:underline">Download from the __VERSION__ release</a> or <a href="cli.html" class="text-orange hover:underline">see the CLI page</a>.</p>
             </div>
           </div>
         </div>
@@ -599,13 +603,14 @@
           <h4 class="font-semibold text-charcoal mb-3">Community</h4>
           <ul class="space-y-2 text-sm text-warm-gray">
             <li><a href="https://github.com/thorbenlouw/satsuma-lang" target="_blank" class="hover:text-orange transition-colors">GitHub Repository</a></li>
+            <li><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">Release Notes (__VERSION__)</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/CHANGELOG.md" target="_blank" class="hover:text-orange transition-colors">Changelog</a></li>
             <li><a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/AGENT-CONTRIBUTIONS.md" target="_blank" class="hover:text-orange transition-colors">Contributing</a></li>
           </ul>
         </div>
       </div>
       <div class="flex flex-col sm:flex-row items-center justify-between pt-8 border-t border-charcoal/5 text-sm text-warm-gray">
-        <p>v0.1.0 &middot; MIT License</p>
+        <p><a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/__VERSION_TAG__" target="_blank" class="hover:text-orange transition-colors">__VERSION__</a> &middot; MIT License</p>
         <p class="mt-2 sm:mt-0">Made with care for the data community</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded `v0.1.0` across all site pages with `__VERSION__` / `__VERSION_TAG__` placeholders, injected at deploy time from the latest `v*` git tag
- CLI binary and .vsix download links now point to the **tagged release**; separate "latest unstable" links added for builds off main
- "Release Notes" link added to footer on all pages
- Site auto-redeploys on `release: published` events so version stays current

## Test plan
- [ ] Verify `deploy-site.yml` resolves the correct tag and substitutes all placeholders (check no `__VERSION__` literals remain in deployed HTML)
- [ ] Confirm stable download URLs resolve to the tagged release assets
- [ ] Confirm "latest unstable" links still point to `releases/tag/latest`
- [ ] Verify site redeploys when a new GitHub release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)