### PR TITLE
feat: VS Code navigation enhancements and TODO diagnostics

### DIFF
--- a/tooling/vscode-satsuma/.vscodeignore
+++ b/tooling/vscode-satsuma/.vscodeignore
@@ -13,6 +13,7 @@ server/tsconfig.json
 server/node_modules/**
 server/dist/**
 !server/dist/server.js
+!server/dist/tree-sitter.wasm
 !server/dist/tree-sitter-satsuma.wasm
 !server/dist/highlights.scm
 !dist/**

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -63,6 +63,8 @@ function copyAssets() {
   pairs.push(
     [path.join(treeSitterDir, "tree-sitter-satsuma.wasm"), "server/dist/tree-sitter-satsuma.wasm"],
     [path.join(treeSitterDir, "queries/highlights.scm"), "server/dist/highlights.scm"],
+    // web-tree-sitter runtime WASM — loaded by the web-tree-sitter module at init
+    ["server/node_modules/web-tree-sitter/tree-sitter.wasm", "server/dist/tree-sitter.wasm"],
   );
 
   for (const [src, dst] of pairs) {

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -53,6 +53,21 @@
         { "command": "satsuma.showCoverage", "when": "editorLangId == satsuma" }
       ]
     },
+    "semanticTokenModifiers": [
+      {
+        "id": "nlRef",
+        "description": "A backtick reference inside a natural language string"
+      }
+    ],
+    "configurationDefaults": {
+      "editor.semanticTokenColorCustomizations": {
+        "rules": {
+          "variable.nlRef:satsuma": {
+            "fontStyle": "underline"
+          }
+        }
+      }
+    },
     "configuration": {
       "title": "Satsuma",
       "properties": {

--- a/tooling/vscode-satsuma/server/src/definition.ts
+++ b/tooling/vscode-satsuma/server/src/definition.ts
@@ -1,10 +1,9 @@
 import { Location } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { child, labelText } from "./parser-utils";
+import { child, children, labelText } from "./parser-utils";
 import {
   WorkspaceIndex,
   resolveDefinition,
-  getFields,
   FieldInfo,
 } from "./workspace-index";
 
@@ -25,6 +24,10 @@ export function computeDefinition(
   });
   if (!node) return null;
 
+  // Check if cursor is on a backtick reference inside an NL string
+  const nlRef = tryNlRefContext(node, line, character);
+  if (nlRef) return resolveContext(nlRef, uri, index);
+
   const ctx = findNodeContext(node);
   if (!ctx) return null;
 
@@ -42,6 +45,9 @@ export interface NodeContext {
     | "import_path"
     | "block_label"
     | "field_name"
+    | "arrow_source"
+    | "arrow_target"
+    | "nl_ref"
     | "unknown";
   name: string;
   namespace: string | null;
@@ -122,6 +128,34 @@ function tryContext(node: SyntaxNode): NodeContext | null {
       return { kind: "field_name", name, namespace: ns, node };
     }
 
+    case "src_path": {
+      const pathText = extractPathFieldName(node);
+      if (!pathText) return null;
+      const mapping = findEnclosingMapping(node);
+      return {
+        kind: "arrow_source",
+        name: pathText,
+        namespace: ns,
+        node,
+        mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
+        mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
+      };
+    }
+
+    case "tgt_path": {
+      const pathText = extractPathFieldName(node);
+      if (!pathText) return null;
+      const mapping = findEnclosingMapping(node);
+      return {
+        kind: "arrow_target",
+        name: pathText,
+        namespace: ns,
+        node,
+        mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
+        mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
+      };
+    }
+
     // Handle identifiers and backtick_names that are inside source_ref, spread, etc.
     case "identifier":
     case "backtick_name":
@@ -185,9 +219,47 @@ function resolveContext(
       if (!blockName) return null;
       const ns = findEnclosingNamespace(ctx.node);
       const qualName = ns ? `${ns}::${blockName}` : blockName;
-      const fields = getFields(index, qualName, ns);
-      const fieldLoc = findFieldLocation(fields, ctx.name);
+      const defs = resolveDefinition(index, qualName, ns);
+      for (const def of defs) {
+        const loc = findFieldInDef(def, ctx.name);
+        if (loc) return loc;
+      }
+      return null;
+    }
+
+    case "arrow_source": {
+      // Look up field in source schemas of the enclosing mapping
+      const schemas = ctx.mappingSources ?? [];
+      return resolveFieldInSchemas(index, schemas, ctx.name, ctx.namespace);
+    }
+
+    case "arrow_target": {
+      // Look up field in target schemas of the enclosing mapping
+      const schemas = ctx.mappingTargets ?? [];
+      return resolveFieldInSchemas(index, schemas, ctx.name, ctx.namespace);
+    }
+
+    case "nl_ref": {
+      // Try as a block name first (schema, fragment, etc.)
+      const blockDefs = resolveDefinition(index, ctx.name, ctx.namespace);
+      if (blockDefs.length > 0) return defsToLocations(blockDefs);
+
+      // Try as a field name in the enclosing mapping's source/target schemas
+      const allSchemas = [
+        ...(ctx.mappingSources ?? []),
+        ...(ctx.mappingTargets ?? []),
+      ];
+      const fieldLoc = resolveFieldInSchemas(index, allSchemas, ctx.name, ctx.namespace);
       if (fieldLoc) return fieldLoc;
+
+      // Try as a dotted path (e.g., "schema.field")
+      if (ctx.name.includes(".")) {
+        const parts = ctx.name.split(".");
+        const schemaName = parts[0]!;
+        const fieldName = parts[parts.length - 1]!;
+        return resolveFieldInSchemas(index, [schemaName], fieldName, ctx.namespace);
+      }
+
       return null;
     }
 
@@ -206,17 +278,39 @@ function defsToLocations(
   return defs.map((d) => Location.create(d.uri, d.selectionRange));
 }
 
-function findFieldLocation(
-  fields: FieldInfo[],
-  name: string,
+function findFieldInDef(
+  def: { uri: string; fields: FieldInfo[] },
+  fieldName: string,
 ): Location | null {
+  const match = findFieldRecursive(def.fields, fieldName);
+  if (match) {
+    return Location.create(def.uri, match.range);
+  }
+  return null;
+}
+
+function findFieldRecursive(fields: FieldInfo[], name: string): FieldInfo | null {
   for (const f of fields) {
-    if (f.name === name) {
-      // FieldInfo.range points to the field_name node
-      return null; // We don't have the URI in FieldInfo — caller handles
-    }
-    const nested = findFieldLocation(f.children, name);
+    if (f.name === name) return f;
+    const nested = findFieldRecursive(f.children, name);
     if (nested) return nested;
+  }
+  return null;
+}
+
+/** Resolve a field name by searching across multiple schema definitions. */
+function resolveFieldInSchemas(
+  index: WorkspaceIndex,
+  schemaNames: string[],
+  fieldName: string,
+  namespace: string | null,
+): Location | null {
+  for (const schemaName of schemaNames) {
+    const defs = resolveDefinition(index, schemaName, namespace);
+    for (const def of defs) {
+      const loc = findFieldInDef(def, fieldName);
+      if (loc) return loc;
+    }
   }
   return null;
 }
@@ -303,4 +397,121 @@ function fieldNameTextDef(node: SyntaxNode): string | null {
   if (!inner) return node.text;
   if (inner.type === "backtick_name") return inner.text.slice(1, -1);
   return inner.text;
+}
+
+// ---------- Arrow field helpers ----------
+
+/** Find the enclosing mapping_block node. */
+function findEnclosingMapping(node: SyntaxNode): SyntaxNode | null {
+  let current: SyntaxNode | null = node.parent;
+  while (current) {
+    if (current.type === "mapping_block") return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+/** Extract the first segment of a path (the field name before any dots). */
+function extractPathFieldName(pathNode: SyntaxNode): string | null {
+  // src_path / tgt_path wraps a _path_expr which can be:
+  //   field_path (identifier.identifier...), relative_field_path (.identifier...),
+  //   backtick_path, namespaced_path
+  const text = pathNode.text;
+  if (!text) return null;
+
+  // Handle backtick paths: `field name`
+  if (text.startsWith("`") && text.endsWith("`")) {
+    return text.slice(1, -1).split(".")[0] ?? null;
+  }
+
+  // Handle dotted paths: take the first segment
+  const firstSegment = text.split(".")[0]!;
+  // Handle namespaced: ns::field → take field part
+  if (firstSegment.includes("::")) {
+    return firstSegment.split("::").pop() ?? null;
+  }
+  return firstSegment;
+}
+
+/** Get schema names referenced in a mapping's source or target block. */
+function getMappingSchemaRefs(
+  mappingNode: SyntaxNode,
+  blockType: "source_block" | "target_block",
+): string[] {
+  const body = child(mappingNode, "mapping_body");
+  if (!body) return [];
+
+  const names: string[] = [];
+  for (const ch of body.namedChildren) {
+    if (ch.type === blockType) {
+      for (const ref of children(ch, "source_ref")) {
+        const name = sourceRefText(ref);
+        if (name) names.push(name);
+      }
+    }
+  }
+  return names;
+}
+
+// ---------- NL reference detection ----------
+
+const BACKTICK_REF_RE = /`([^`\\]*(?:\\.[^`\\]*)*)`/g;
+
+/**
+ * Check if the cursor is on a backtick reference inside an NL string.
+ * Returns a NodeContext with kind "nl_ref" if so.
+ */
+function tryNlRefContext(
+  node: SyntaxNode,
+  line: number,
+  character: number,
+): NodeContext | null {
+  // The node itself might be the nl_string, or it might be a descendant.
+  // Walk up to find the nl_string or multiline_string node.
+  let nlNode: SyntaxNode | null = node;
+  while (nlNode) {
+    if (nlNode.type === "nl_string" || nlNode.type === "multiline_string") break;
+    nlNode = nlNode.parent;
+  }
+  if (!nlNode) return null;
+
+  const text = nlNode.text;
+  const nodeStartRow = nlNode.startPosition.row;
+  const nodeStartCol = nlNode.startPosition.column;
+
+  // Calculate cursor offset within the node text
+  let cursorOffset: number;
+  if (line === nodeStartRow) {
+    cursorOffset = character - nodeStartCol;
+  } else {
+    const lines = text.split("\n");
+    let offset = 0;
+    for (let i = 0; i < line - nodeStartRow; i++) {
+      offset += (lines[i]?.length ?? 0) + 1; // +1 for newline
+    }
+    cursorOffset = offset + character;
+  }
+
+  // Find which backtick ref (if any) the cursor is within
+  BACKTICK_REF_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BACKTICK_REF_RE.exec(text)) !== null) {
+    const refStart = match.index;
+    const refEnd = refStart + match[0].length;
+    if (cursorOffset >= refStart && cursorOffset < refEnd) {
+      const refName = match[1]!;
+      const ns = findEnclosingNamespace(nlNode);
+      const mapping = findEnclosingMapping(nlNode);
+      return {
+        kind: "nl_ref",
+        name: refName,
+        namespace: ns,
+        node: nlNode,
+        mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
+        mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
+      };
+    }
+  }
+
+  return null;
 }

--- a/tooling/vscode-satsuma/server/src/diagnostics.ts
+++ b/tooling/vscode-satsuma/server/src/diagnostics.ts
@@ -1,6 +1,7 @@
 import {
   Diagnostic,
   DiagnosticSeverity,
+  DiagnosticTag,
 } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange } from "./parser-utils";
@@ -65,9 +66,10 @@ function walkComments(node: SyntaxNode, out: Diagnostic[]): void {
     } else if (child.type === "question_comment") {
       out.push({
         range: nodeRange(child),
-        severity: DiagnosticSeverity.Information,
+        severity: DiagnosticSeverity.Hint,
         source: "satsuma",
-        message: child.text.replace(/^\/\/\?\s*/, ""),
+        message: `TODO: ${child.text.replace(/^\/\/\?\s*/, "")}`,
+        tags: [DiagnosticTag.Unnecessary],
       });
     }
 

--- a/tooling/vscode-satsuma/server/src/semantic-tokens.ts
+++ b/tooling/vscode-satsuma/server/src/semantic-tokens.ts
@@ -32,6 +32,7 @@ const tokenModifiers: string[] = [
   SemanticTokenModifiers.declaration,   // 1
   SemanticTokenModifiers.readonly,      // 2
   SemanticTokenModifiers.defaultLibrary,// 3
+  "nlRef",                              // 4 — backtick reference inside NL string
 ];
 
 export const semanticTokensLegend: SemanticTokensLegend = {
@@ -278,8 +279,10 @@ function emitSplitStringTokens(
   }
 
   // Emit each segment, splitting across lines as needed
+  const nlRefBit = 1 << 4;  // nlRef modifier bitmask
   for (const seg of segments) {
     const typeIndex = seg.isRef ? 3 : 5;  // variable or string
+    const modBits = seg.isRef ? nlRefBit : 0;
     const segText = text.slice(seg.offset, seg.offset + seg.length);
     const segLines = segText.split("\n");
 
@@ -302,7 +305,7 @@ function emitSplitStringTokens(
       }
       const len = segLines[i]!.length;
       if (len > 0) {
-        builder.push(row, col, len, typeIndex, 0);
+        builder.push(row, col, len, typeIndex, modBits);
       }
     }
   }

--- a/tooling/vscode-satsuma/server/test/definition.test.js
+++ b/tooling/vscode-satsuma/server/test/definition.test.js
@@ -180,4 +180,102 @@ mapping 'test' {
     const loc = Array.isArray(result) ? result[0] : result;
     assert.equal(loc.uri, "file:///a.stm");
   });
+
+  it("jumps from arrow source field to schema field definition", () => {
+    const result = definition(
+      {
+        "file:///a.stm": `schema src {
+  email VARCHAR(255)
+  name VARCHAR
+}
+schema tgt {
+  email_addr VARCHAR
+}
+mapping 'test' {
+  source { src }
+  target { tgt }
+  email -> email_addr
+}`,
+      },
+      "file:///a.stm",
+      10,
+      2, // cursor on "email" in "email -> email_addr"
+    );
+    assert.ok(result, "Expected definition for arrow source field");
+    const loc = Array.isArray(result) ? result[0] : result;
+    assert.equal(loc.uri, "file:///a.stm");
+    assert.equal(loc.range.start.line, 1); // email field in src schema
+  });
+
+  it("jumps from arrow target field to schema field definition", () => {
+    const result = definition(
+      {
+        "file:///a.stm": `schema src {
+  email VARCHAR(255)
+}
+schema tgt {
+  email_addr VARCHAR
+}
+mapping 'test' {
+  source { src }
+  target { tgt }
+  email -> email_addr
+}`,
+      },
+      "file:///a.stm",
+      9,
+      12, // cursor on "email_addr" in "email -> email_addr"
+    );
+    assert.ok(result, "Expected definition for arrow target field");
+    const loc = Array.isArray(result) ? result[0] : result;
+    assert.equal(loc.uri, "file:///a.stm");
+    assert.equal(loc.range.start.line, 4); // email_addr field in tgt schema
+  });
+
+  it("jumps from backtick ref in NL string to block definition", () => {
+    // Line 6: "  -> display { "Look up `customers` table" }"
+    //                         ^col15            ^col24 = start of `customers`
+    const result = definition(
+      {
+        "file:///a.stm": `schema customers {
+  id UUID
+}
+mapping 'test' {
+  source { customers }
+  target { dim }
+  -> display { "Look up \`customers\` table" }
+}`,
+      },
+      "file:///a.stm",
+      6,
+      26, // cursor inside backtick ref `customers` (col 15 + offset 11)
+    );
+    assert.ok(result, "Expected definition for backtick ref");
+    const loc = Array.isArray(result) ? result[0] : result;
+    assert.equal(loc.range.start.line, 0); // schema customers on line 0
+  });
+
+  it("jumps from backtick ref in NL string to schema field", () => {
+    // Line 7: "  -> full_name { "Concat `customer_id` with name" }"
+    //                           ^col17           ^col26 = start of `customer_id`
+    const result = definition(
+      {
+        "file:///a.stm": `schema src {
+  customer_id UUID (pk)
+  name VARCHAR
+}
+mapping 'test' {
+  source { src }
+  target { dim }
+  -> full_name { "Concat \`customer_id\` with name" }
+}`,
+      },
+      "file:///a.stm",
+      7,
+      28, // cursor inside backtick ref `customer_id` (col 17 + offset 11)
+    );
+    assert.ok(result, "Expected definition for field backtick ref");
+    const loc = Array.isArray(result) ? result[0] : result;
+    assert.equal(loc.range.start.line, 1); // customer_id field on line 1
+  });
 });

--- a/tooling/vscode-satsuma/server/test/diagnostics.test.js
+++ b/tooling/vscode-satsuma/server/test/diagnostics.test.js
@@ -33,14 +33,15 @@ describe("computeDiagnostics", () => {
     assert.match(warnings[0].message, /known issue/);
   });
 
-  it("reports question comments as Information severity", () => {
+  it("reports question comments as Hint severity with TODO prefix", () => {
     const tree = parse(`schema foo {
   bar STRING //? should this be INT?
 }`);
     const diags = computeDiagnostics(tree);
-    const infos = diags.filter((d) => d.severity === 3); // Information
-    assert.equal(infos.length, 1);
-    assert.match(infos[0].message, /should this be INT/);
+    const hints = diags.filter((d) => d.severity === 4); // Hint
+    assert.equal(hints.length, 1);
+    assert.match(hints[0].message, /^TODO: /);
+    assert.match(hints[0].message, /should this be INT/);
   });
 
   it("sets source to 'satsuma' on all diagnostics", () => {

--- a/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
+++ b/tooling/vscode-satsuma/server/test/semantic-tokens.test.js
@@ -249,4 +249,31 @@ describe("computeSemanticTokens", () => {
     assert.ok(semanticTokensLegend.tokenTypes.includes("variable"));
     assert.ok(semanticTokensLegend.tokenTypes.includes("property"));
   });
+
+  it("applies nlRef modifier to backtick references in nl_string", () => {
+    const tree = parse(
+      'note { "Check `balance` field." }',
+    );
+    const tokens = decodeTokens(computeSemanticTokens(tree).data);
+
+    const varTokens = tokens.filter((t) => t.type === "variable");
+    assert.equal(varTokens.length, 1, "should have 1 variable token");
+    // nlRef modifier is at bit index 4 (1 << 4 = 16)
+    assert.equal(varTokens[0].mods & 16, 16, "should have nlRef modifier set");
+
+    // String parts should NOT have the nlRef modifier
+    const stringTokens = tokens.filter(
+      (t) => t.type === "string" && t.line === 0 && t.col >= 7,
+    );
+    for (const st of stringTokens) {
+      assert.equal(st.mods & 16, 0, "string segments should not have nlRef modifier");
+    }
+  });
+
+  it("legend includes nlRef modifier", () => {
+    assert.ok(
+      semanticTokensLegend.tokenModifiers.includes("nlRef"),
+      "should include nlRef modifier in legend",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- **`//? comments` → TODO diagnostics**: Show as Hint severity with "TODO:" prefix in the Problems panel, making open questions easy to track
- **Arrow field navigation**: Ctrl+click on `email` in `email -> email_addr` jumps to the field definition in the source/target schema
- **NL-ref navigation**: Ctrl+click on backtick references inside NL strings (e.g., `` `customer_id` `` in `"Concat `customer_id` with name"`) resolves to block or field definitions
- **Underlined NL-refs**: Backtick references in NL strings are now rendered with underline styling via a custom `nlRef` semantic token modifier
- **WASM packaging fix**: Include `tree-sitter.wasm` (web-tree-sitter runtime) in the vsix — previously missing, causing init failure when installed from package

## Test plan
- [x] 148 LSP server tests passing (6 new)
- [x] 21 TM grammar fixture/golden tests passing
- [ ] Install vsix and verify extension initializes without WASM errors
- [ ] Verify `//? comment` shows as TODO hint in Problems panel
- [ ] Verify Ctrl+click on arrow source/target fields jumps to schema field
- [ ] Verify Ctrl+click on backtick ref in NL string jumps to definition
- [ ] Verify backtick refs in NL strings appear underlined

🤖 Generated with [Claude Code](https://claude.com/claude-code)