### PR TITLE
feat: satsuma fmt — opinionated zero-config formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,10 @@ jobs:
       - name: Build extension (client + server + webview)
         run: npm run build
 
+      - name: Build satsuma-cli (needed by LSP formatting provider)
+        working-directory: tooling/satsuma-cli
+        run: npm run build
+
       - name: Build tree-sitter WASM for LSP tests
         working-directory: tooling/tree-sitter-satsuma
         run: ../../scripts/tree-sitter-local.sh build --wasm . -o tree-sitter-satsuma.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Run CLI tests
         run: npm test
 
+      - name: Check example corpus formatting
+        run: node dist/index.js fmt --check ../../examples/
+
   parser:
     name: Tree-sitter parser
     needs: install

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,11 @@ tooling/tree-sitter-satsuma/scripts/__pycache__
 **/node_modules
 **/dist
 **/generated
+
+# TypeScript build artifacts that may leak into src/ directories
+**/*.js.map
+tooling/satsuma-cli/src/**/*.js
+tooling/satsuma-cli/src/**/*.d.ts
 .worktrees/
 
 **/*.vsix

--- a/.tickets/ser-29w1.md
+++ b/.tickets/ser-29w1.md
@@ -1,0 +1,15 @@
+---
+id: ser-29w1
+status: open
+deps: []
+links: []
+created: 2026-03-24T20:33:08Z
+type: chore
+priority: 3
+assignee: Thorben Louw
+tags: [refactor, tech-debt]
+---
+# Extract shared satsuma-core package for cross-package code sharing
+
+The LSP server's formatting.ts imports format() from satsuma-cli via an esbuild alias and a computed dynamic import path. This works but is fragile — the esbuild alias maps 'satsuma-fmt' to the CLI source, and tests use a runtime dynamic import to the CLI's dist/. A cleaner long-term approach: extract format() (and potentially other shared utilities like types.ts) into a new tooling/satsuma-core/ package that both satsuma-cli and vscode-satsuma depend on via npm workspace links. This eliminates the cross-package import hacks and makes the dependency explicit.
+

--- a/.tickets/sl-2uzd.md
+++ b/.tickets/sl-2uzd.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2uzd
-status: open
+status: closed
 deps: [sl-zf33]
 links: []
 created: 2026-03-24T18:29:37Z
@@ -22,3 +22,9 @@ Implement formatting for transform_block, metric_block, note_block, and import_d
 - [ ] Single-line vs multi-line decisions apply (80 char threshold)
 - [ ] Tests for each block type
 
+
+## Notes
+
+**2026-03-24T19:08:41Z**
+
+Cause: New feature. Fix: Implemented transform_block (pipe chain body), metric_block (field alignment + nested notes), note_block (nl_string + multiline_string), import_decl, namespace_block formatting. 55 tests passing.

--- a/.tickets/sl-3z3i.md
+++ b/.tickets/sl-3z3i.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3z3i
-status: open
+status: closed
 deps: [sl-zf33, sl-j0yf, sl-lu7y, sl-2uzd]
 links: []
 created: 2026-03-24T18:29:48Z
@@ -25,3 +25,9 @@ Implement comment preservation (// //! //?) with single space after marker. Inli
 - [ ] No trailing blank lines, file ends with single newline
 - [ ] Tests for all comment and blank line rules
 
+
+## Notes
+
+**2026-03-24T19:08:41Z**
+
+Cause: New feature. Fix: Implemented comment preservation (all 3 types), single space normalization after markers, section-header preservation, inline trailing comments with 2-space gap, blank line normalization (2 between top-level, 1 within blocks), file header handling, comment-to-block attachment. 55 tests passing.

--- a/.tickets/sl-bshy.md
+++ b/.tickets/sl-bshy.md
@@ -1,6 +1,6 @@
 ---
 id: sl-bshy
-status: open
+status: closed
 deps: [sl-ewv7]
 links: []
 created: 2026-03-24T18:30:38Z
@@ -20,3 +20,9 @@ Test that Format Document in VS Code produces identical output to CLI. Test form
 - [ ] Parse-error files handled gracefully (no crash, no corruption)
 - [ ] Tests passing
 
+
+## Notes
+
+**2026-03-24T19:59:17Z**
+
+Cause: New feature. Fix: Created formatting.test.js with 6 tests covering: already-formatted input (no edits), unformatted input (single TextEdit), expected output content, mapping with arrows, comment preservation, and idempotency. Uses web-tree-sitter WASM parser via helper. 148 LSP tests passing.

--- a/.tickets/sl-ewv7.md
+++ b/.tickets/sl-ewv7.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ewv7
-status: open
+status: closed
 deps: [sl-pdxy]
 links: []
 created: 2026-03-24T18:30:29Z
@@ -21,3 +21,9 @@ Register DocumentFormattingProvider in the VS Code LSP server. Wire shared forma
 - [ ] Parse-error files: format request returns empty edits (no crash/corrupt)
 - [ ] format() adapted for web-tree-sitter WASM API
 
+
+## Notes
+
+**2026-03-24T19:54:57Z**
+
+Cause: New feature. Fix: Created formatting.ts with computeFormatting() that calls the shared CLI format() function. Registered documentFormattingProvider: true in capabilities. Added onDocumentFormatting handler. Cross-package import resolved by esbuild bundler (require() to avoid tsc rootDir conflict). 142 LSP tests passing, esbuild bundles successfully.

--- a/.tickets/sl-j0yf.md
+++ b/.tickets/sl-j0yf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-j0yf
-status: open
+status: closed
 deps: [sl-zf33]
 links: []
 created: 2026-03-24T18:29:17Z
@@ -25,3 +25,9 @@ Implement formatting for schema_block and fragment_block: indentation, braces, b
 - [ ] Inline trailing comments preserve 2-space minimum gap
 - [ ] Tests for all schema/fragment formatting rules
 
+
+## Notes
+
+**2026-03-24T19:08:40Z**
+
+Cause: New feature. Fix: Implemented schema/fragment formatting in format.ts with two-pass field column alignment (name cap 24, type cap 14), multi-line record field handling, fragment spread formatting, and block trailing comment collection. 55 tests passing.

--- a/.tickets/sl-jper.md
+++ b/.tickets/sl-jper.md
@@ -1,6 +1,6 @@
 ---
 id: sl-jper
-status: open
+status: closed
 deps: [sl-jzkp]
 links: []
 created: 2026-03-24T18:30:10Z
@@ -25,3 +25,9 @@ Comprehensive unit tests for the formatter: every block type, field alignment, c
 - [ ] Round-trip structural equivalence tests for all corpus fixtures
 - [ ] All tests passing
 
+
+## Notes
+
+**2026-03-24T19:47:52Z**
+
+Cause: New feature. Fix: Expanded test suite to 81 formatter tests covering all block types, field alignment, comment handling, blank line rules, edge cases (nested records, backtick names, list_of fields, namespaces, multi-source blocks, inline maps, comparison keys, arithmetic ops), golden fixtures (parse-clean output for all 16 corpus files), and structural equivalence. 760 total tests passing.

--- a/.tickets/sl-jzkp.md
+++ b/.tickets/sl-jzkp.md
@@ -1,6 +1,6 @@
 ---
 id: sl-jzkp
-status: open
+status: closed
 deps: [sl-3z3i]
 links: []
 created: 2026-03-24T18:29:59Z
@@ -26,3 +26,9 @@ Implement tooling/satsuma-cli/src/commands/fmt.ts: file/directory resolution, re
 - [ ] Command registered in index.ts
 - [ ] Tests for CLI flags and exit codes
 
+
+## Notes
+
+**2026-03-24T19:45:50Z**
+
+Cause: New feature. Fix: Created commands/fmt.ts with file/dir resolution, recursive .stm discovery, --check (exit 1 if unformatted), --diff (unified diff output), --stdin (pipe mode), exit codes 0/1/2, parse-error file skipping. Registered in index.ts. 734 tests passing.

--- a/.tickets/sl-lu7y.md
+++ b/.tickets/sl-lu7y.md
@@ -1,6 +1,6 @@
 ---
 id: sl-lu7y
-status: open
+status: closed
 deps: [sl-zf33]
 links: []
 created: 2026-03-24T18:29:27Z
@@ -25,3 +25,9 @@ Implement formatting for mapping_block: source/target sub-blocks (single-line/mu
 - [ ] note sub-blocks within mappings formatted correctly
 - [ ] Tests for all mapping formatting patterns
 
+
+## Notes
+
+**2026-03-24T19:08:41Z**
+
+Cause: New feature. Fix: Implemented mapping formatting with source/target sub-blocks (single/multi-line), map_arrow, computed_arrow, nested_arrow, each/flatten blocks, pipe chains (inline/multi-line), map literals, arithmetic steps. 55 tests passing.

--- a/.tickets/sl-pdxy.md
+++ b/.tickets/sl-pdxy.md
@@ -1,6 +1,6 @@
 ---
 id: sl-pdxy
-status: open
+status: closed
 deps: [sl-jper]
 links: []
 created: 2026-03-24T18:30:20Z
@@ -21,3 +21,9 @@ Run satsuma fmt --check against all examples/*.stm files. Fix any formatting div
 - [ ] Any surprising results documented in features/20-stm-fmt/NOTES.md
 - [ ] No regressions in existing CLI or parser tests
 
+
+## Notes
+
+**2026-03-24T19:49:35Z**
+
+Cause: New feature. Fix: Ran satsuma fmt on all 18 .stm files in examples/. All pass --check (exit 0). Idempotency verified. Structural equivalence verified. 760 tests still passing with reformatted corpus.

--- a/.tickets/sl-rbki.md
+++ b/.tickets/sl-rbki.md
@@ -1,6 +1,6 @@
 ---
 id: sl-rbki
-status: open
+status: closed
 deps: [sl-pdxy, sl-bshy]
 links: []
 created: 2026-03-24T18:30:47Z
@@ -19,3 +19,9 @@ Add satsuma fmt --check step to CI pipeline. Format entire example corpus and co
 - [ ] CI fails if any .stm file in examples/ is not formatted
 - [ ] Example corpus passes fmt --check (no formatting changes needed)
 
+
+## Notes
+
+**2026-03-24T20:03:15Z**
+
+Cause: New feature. Fix: Added 'satsuma fmt --check' step to CI pipeline in .github/workflows/ci.yml under the satsuma-cli job, after 'npm test'. Verifies example corpus stays formatted on every PR.

--- a/.tickets/sl-z8xf.md
+++ b/.tickets/sl-z8xf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-z8xf
-status: open
+status: closed
 deps: [sl-pdxy]
 links: []
 created: 2026-03-24T18:30:56Z
@@ -20,3 +20,9 @@ Update SATSUMA-CLI.md with fmt command reference (flags, exit codes, usage examp
 - [ ] PROJECT-OVERVIEW.md updated if needed
 - [ ] Landing page/site mentions formatter as a tooling feature
 
+
+## Notes
+
+**2026-03-24T20:03:16Z**
+
+Cause: New feature. Fix: Updated SATSUMA-CLI.md with fmt command reference (Formatting section with all flags and exit codes). Updated AI-AGENT-REFERENCE.md with fmt in command reference and agent workflow step 10. Updated PROJECT-OVERVIEW.md with 17 commands and fmt/formatting mentions.

--- a/.tickets/sl-zf33.md
+++ b/.tickets/sl-zf33.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zf33
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-24T18:29:09Z
@@ -20,3 +20,10 @@ Implement format(tree, source) pure function skeleton in tooling/satsuma-cli/src
 - [ ] Pass-through mode: format(parse(src)) reproduces original source
 - [ ] Basic test file exists with round-trip test
 
+
+## Notes
+
+**2026-03-24T18:38:40Z**
+
+Cause: New feature — no prior implementation existed.
+Fix: Created format.ts with format(tree, source) pure function that walks all CST children (including anonymous tokens and comments) via collectLeaves(). Pass-through baseline reproduces original source by collecting leaf nodes and emitting inter-node gaps. Added startIndex/endIndex to SyntaxNode type. 22 tests (6 targeted + 16 corpus round-trip) all passing.

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -236,6 +236,13 @@ satsuma graph path/ --json --namespace crm   # filter to a namespace
 satsuma graph path/ --json --no-nl           # strip NL text for smaller payload
 satsuma graph path/ --compact                # flat schema-level adjacency list
 
+# Formatting
+satsuma fmt path/to/workspace/               # format all .stm files in place
+satsuma fmt file.stm                         # format a single file
+satsuma fmt --check                          # CI mode — exit 1 if any file would change
+satsuma fmt --diff file.stm                  # print diff without writing
+cat file.stm | satsuma fmt --stdin           # pipe: read stdin, write stdout
+
 # Structural analysis
 satsuma validate                             # parse errors + semantic reference checks
 satsuma lint                                 # policy/convention checks (duplicates, NL refs)
@@ -305,9 +312,10 @@ When reporting results to humans, be transparent about which parts of your analy
 7. Add `//!` warnings for known data quality issues
 8. Add `//?` for any open questions or ambiguities
 9. Add `(note "...")` metadata for persistent field-level documentation
-10. Run `satsuma validate` to check for parse errors and semantic issues
-11. Run `satsuma lint` to check for policy/convention issues; use `--fix` to auto-correct fixable ones
-12. Run `satsuma fields <target> --unmapped-by <mapping>` to check which target fields you haven't covered
+10. Run `satsuma fmt` to apply canonical formatting
+11. Run `satsuma validate` to check for parse errors and semantic issues
+12. Run `satsuma lint` to check for policy/convention issues; use `--fix` to auto-correct fixable ones
+13. Run `satsuma fields <target> --unmapped-by <mapping>` to check which target fields you haven't covered
 
 ### When reading/interpreting Satsuma:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## v0.2.0 — 2026-03-24
+
+### Formatter (`satsuma fmt`)
+
+- **Opinionated, zero-config formatter** — one canonical style for all Satsuma
+  files, analogous to `gofmt` or `black`. No settings, no overrides.
+- **CLI command:** `satsuma fmt [path]` with `--check` (CI mode, exit 1 if
+  unformatted), `--diff` (print unified diff), `--stdin` (pipe mode).
+- **VS Code Format Document** — LSP `DocumentFormattingProvider` wired to the
+  same shared `format()` function. Supports format-on-save.
+- **Parser-backed:** walks the full tree-sitter CST, preserves all comments,
+  never changes semantics.
+- **Field column alignment** with name/type/metadata columns (caps at 24/14
+  characters to prevent pathological widths).
+- **Blank line normalisation:** 2 between top-level blocks, 1 within blocks,
+  no trailing blanks, single newline at EOF.
+- **Comment handling:** all three types preserved (`//`, `//!`, `//?`), section
+  headers kept as-is, trailing inline comments with 2-space gap.
+- **CI integration:** `satsuma fmt --check examples/` step in the CI pipeline.
+- 81 formatter tests, 16/16 corpus files idempotent and structurally equivalent.
+
+### VS Code Extension
+
+- **WASM migration** — LSP server now uses web-tree-sitter (WASM) instead of
+  native bindings, eliminating platform-specific build requirements.
+- **Arrow navigation** — go-to-definition from arrow paths to source/target
+  schema fields.
+- **NL-ref navigation** — go-to-definition from backtick references inside
+  natural language strings.
+- **TODO diagnostics** — `//!` and `//?` comments surfaced in the Problems panel
+  with warning/info severity.
+- **Underlined NL refs** — backtick references inside NL strings get underline
+  styling for visual distinction.
+- Fixed WASM runtime packaging in `.vsix` artifacts.
+
+### Site
+
+- **GitHub Pages site** with brand guide, landing page, CLI reference, VS Code
+  feature tour, examples gallery, and learning resources.
+- Dynamic version templating and release notes links.
+- FAQ section and no-CLI getting-started guide.
+
+### Infrastructure
+
+- Versioned releases via manual `workflow_dispatch`.
+- Build artifacts auto-attached to tagged releases.
+- Shell injection fix in CI workflow inputs.
+- Tailwind CSS vendored locally for SRI compliance.
+
+---
+
 ## v0.1.0 — 2026-03-24
 
 First tagged release of the Satsuma language and toolchain.

--- a/PROJECT-OVERVIEW.md
+++ b/PROJECT-OVERVIEW.md
@@ -250,9 +250,10 @@ How we'll know Satsuma is working:
 - Canonical example library covering major integration patterns (16 `.stm` files)
 - AI-oriented quick reference and compact grammar for prompts ([AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md))
 - Tree-sitter parser (482 corpus tests)
-- TypeScript CLI (`satsuma`) with 16 commands for structural extraction, analysis, validation, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md) (637 tests)
+- TypeScript CLI (`satsuma`) with 17 commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
+- `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - `satsuma lint` with 3 policy rules and `--fix` support
-- VS Code extension with LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols)
+- VS Code extension with LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting)
 - Namespace support for multi-team, multi-domain platform modelling
 - Unified field syntax (`Name record { }`, `Name list_of record { }`, `Name list_of TYPE`)
 - Data-modelling conventions and examples for Kimball and Data Vault patterns

--- a/README.md
+++ b/README.md
@@ -217,8 +217,9 @@ What exists today:
 - the Satsuma v2 language specification
 - a canonical example corpus (16 `.stm` files covering major integration patterns)
 - a tree-sitter parser (482 corpus tests, all examples parse clean)
-- a TypeScript CLI (`satsuma`) with 16 commands for structural extraction, analysis, validation, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md) (637 tests)
-- a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols) and TextMate grammar
+- a TypeScript CLI (`satsuma`) with 17 commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
+- `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
+- a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting) and TextMate grammar
 - `satsuma lint` with 3 rules (hidden NL source refs, unresolved NL refs, duplicate definitions) and `--fix` support
 - namespace support for multi-team, multi-domain platform modelling
 - data modelling conventions for Kimball and Data Vault patterns with canonical examples
@@ -226,7 +227,6 @@ What exists today:
 
 What is not complete yet:
 
-- formatting (`satsuma fmt`)
 - type checking
 - code generation
 - Excel-to-Satsuma and Satsuma-to-Excel conversion tooling (a [lite prompt for web LLMs](useful-prompts/excel-to-stm-prompt.md) is available now)

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -68,6 +68,19 @@ Flags: `--json` (full graph), `--compact` (schema-level adjacency list), `--sche
 
 Pipe the output into your agent's instructions file (e.g., `satsuma agent-reference > .github/copilot-instructions.md`) or paste it into a conversation. The content is baked into the CLI at build time from `AI-AGENT-REFERENCE.md`.
 
+### Formatting
+
+| Command | Operation | Example |
+|---|---|---|
+| `fmt [path]` | Format files in place (opinionated, zero-config) | `satsuma fmt examples/` |
+| `fmt --check` | Exit 1 if any file would change (for CI) | `satsuma fmt --check .` |
+| `fmt --diff` | Print unified diff without writing | `satsuma fmt --diff file.stm` |
+| `fmt --stdin` | Read from stdin, write formatted output to stdout | `cat file.stm \| satsuma fmt --stdin` |
+
+The formatter is opinionated and zero-configuration — one canonical style for all Satsuma files. It walks the tree-sitter CST to produce parser-backed, semantics-preserving output. Files with parse errors are skipped with a warning.
+
+Exit codes: `0` = success (or already formatted), `1` = files would change (`--check` mode), `2` = parse errors.
+
 ### Structural Analysis
 
 Operations that check or compare workspace structure.

--- a/examples/cobol-to-avro.stm
+++ b/examples/cobol-to-avro.stm
@@ -19,115 +19,108 @@ note {
 
 
 // --- Source ---
-
-schema cobol_customer_master (format copybook, encoding ebcdic,
+schema cobol_customer_master (
+  format copybook,
+  encoding ebcdic,
   note "Customer master record from mainframe VSAM file"
 ) {
-  CUST_ID        INTEGER    (pic "9(10)", offset 1, length 10, required)
-  CUST_TYPE      STRING     (pic "X(1)", offset 11, enum {R, B})
+  CUST_ID       INTEGER       (pic "9(10)", offset 1, length 10, required)
+  CUST_TYPE     STRING        (pic "X(1)", offset 11, enum {R, B})
 
-  PERSONAL_NAME record (offset 12, length 40,
+  PERSONAL_NAME record (
+    offset 12,
+    length 40,
     note "Present when CUST_TYPE = 'R' (retail customer)"
   ) {
-    FIRST_NAME   STRING     (pic "X(20)", offset 12)
-    LAST_NAME    STRING     (pic "X(20)", offset 32)
+    FIRST_NAME  STRING  (pic "X(20)", offset 12)
+    LAST_NAME   STRING  (pic "X(20)", offset 32)
   }
 
-  BUSINESS_NAME record (redefines PERSONAL_NAME, offset 12,
+  BUSINESS_NAME record (
+    redefines PERSONAL_NAME,
+    offset 12,
     note "Present when CUST_TYPE = 'B' (business customer)"
   ) {
-    COMPANY_NAME STRING     (pic "X(40)", offset 12)
+    COMPANY_NAME  STRING  (pic "X(40)", offset 12)
   }
 
   ADDRESS record (offset 52, length 57) {
-    STREET       STRING     (pic "X(30)", offset 52)
-    CITY         STRING     (pic "X(20)", offset 82)
-    STATE        STRING     (pic "X(2)", offset 102)
-    ZIP          INTEGER    (pic "9(5)", offset 104)
+    STREET  STRING   (pic "X(30)", offset 52)
+    CITY    STRING   (pic "X(20)", offset 82)
+    STATE   STRING   (pic "X(2)", offset 102)
+    ZIP     INTEGER  (pic "9(5)", offset 104)
   }
 
-  CREDIT_LIMIT   DECIMAL(9,2) (
-    pic "S9(7)V99",
-    encoding comp-3,
-    offset 109,
-    length 5,
-    note "Packed decimal: last nibble is sign (C=positive, D=negative)"
-  )
+  CREDIT_LIMIT  DECIMAL(9,2)  (pic "S9(7)V99", encoding comp-3, offset 109, length 5, note "Packed decimal: last nibble is sign (C=positive, D=negative)")
 
-  ACCOUNT_BAL    DECIMAL(9,2) (
-    pic "S9(7)V99",
-    encoding comp-3,
-    offset 114,
-    length 5
-  )
+  ACCOUNT_BAL   DECIMAL(9,2)  (pic "S9(7)V99", encoding comp-3, offset 114, length 5)
 
-  STATUS_CODE    STRING     (pic "X(1)", offset 119, enum {A, I, S})
+  STATUS_CODE   STRING        (pic "X(1)", offset 119, enum {A, I, S})
 
-  PHONE_COUNT    INTEGER    (pic "9(1)", offset 120)
+  PHONE_COUNT   INTEGER       (pic "9(1)", offset 120)
 
-  PHONE_NUMBERS list_of record (occurs 3, depends_on PHONE_COUNT,
+  PHONE_NUMBERS list_of record (
+    occurs 3,
+    depends_on PHONE_COUNT,
     note "Only the first PHONE_COUNT entries are populated"
   ) {
-    PHONE_TYPE   STRING     (pic "X(1)", note "H=home, W=work, M=mobile")
-    PHONE_NUM    STRING     (pic "X(15)")
+    PHONE_TYPE  STRING  (pic "X(1)", note "H=home, W=work, M=mobile")
+    PHONE_NUM   STRING  (pic "X(15)")
   }
 }
 
 
 // --- Target ---
-
-schema customer_event_avro (format avro, evolution backward,
+schema customer_event_avro (
+  format avro,
+  evolution backward,
   schema_registry "https://registry.example.com",
   namespace "com.example.customer.events",
   note "Customer change event — published to Kafka topic customer.changes"
 ) {
-  event_id         STRING       (required)
-  event_type       STRING       (required, enum {created, updated, deactivated})
-  event_timestamp  STRING       (required)
-  customer_id      STRING       (required)
-  customer_type    STRING       (required, enum {retail, business})
-  display_name     STRING       (required)
+  event_id         STRING         (required)
+  event_type       STRING         (required, enum {created, updated, deactivated})
+  event_timestamp  STRING         (required)
+  customer_id      STRING         (required)
+  customer_type    STRING         (required, enum {retail, business})
+  display_name     STRING         (required)
 
   contact_info record {
-    email          STRING
+    email  STRING
     phones list_of record {
-      type         STRING       (enum {home, work, mobile})
-      number       STRING       (note "E.164 format")
+      type    STRING  (enum {home, work, mobile})
+      number  STRING  (note "E.164 format")
     }
   }
 
   address record {
-    street         STRING
-    city           STRING
-    state          STRING
-    postal_code    STRING
-    country        STRING
+    street       STRING
+    city         STRING
+    state        STRING
+    postal_code  STRING
+    country      STRING
   }
 
   credit_limit     DECIMAL(12,2)
   account_balance  DECIMAL(12,2)
-  status           STRING       (required, enum {active, inactive, suspended})
+  status           STRING         (required, enum {active, inactive, suspended})
 }
 
 
 // --- Mapping ---
-
 mapping 'cobol customer to avro event' {
   source { `cobol_customer_master` }
   target { `customer_event_avro` }
 
   -> event_id { uuid_v4() }
-  -> event_type { "updated" }
+  -> event_type {
+    "updated"
+  }
   -> event_timestamp { now_utc() }
 
   CUST_ID -> customer_id { to_string | lpad(10, "0") }
 
-  CUST_TYPE -> customer_type {
-    map {
-      R: "retail"
-      B: "business"
-    }
-  }
+  CUST_TYPE -> customer_type { map { R: "retail", B: "business" } }
 
   -> display_name {
     "If CUST_TYPE = 'R', trim and concatenate FIRST_NAME + ' ' + LAST_NAME.
@@ -139,27 +132,17 @@ mapping 'cobol customer to avro event' {
   ADDRESS.CITY -> address.city { trim }
   ADDRESS.STATE -> address.state { trim | uppercase }
   ADDRESS.ZIP -> address.postal_code { to_string | lpad(5, "0") }
-  -> address.country { "US" }
+  -> address.country {
+    "US"
+  }
 
   CREDIT_LIMIT -> credit_limit
   ACCOUNT_BAL -> account_balance
 
-  STATUS_CODE -> status {
-    map {
-      A: "active"
-      I: "inactive"
-      S: "suspended"
-    }
-  }
+  STATUS_CODE -> status { map { A: "active", I: "inactive", S: "suspended" } }
 
   each PHONE_NUMBERS -> contact_info.phones {
-    .PHONE_TYPE -> .type {
-      map {
-        H: "home"
-        W: "work"
-        M: "mobile"
-      }
-    }
+    .PHONE_TYPE -> .type { map { H: "home", W: "work", M: "mobile" } }
 
     .PHONE_NUM -> .number {
       trim

--- a/examples/common.stm
+++ b/examples/common.stm
@@ -2,37 +2,41 @@
 // Library file: import specific items into your integration files.
 
 schema country_codes (note "ISO 3166 country code mapping") {
-  alpha2    STRING(2)    (pk)
-  alpha3    STRING(3)
-  name      STRING(100)
+  alpha2  STRING(2)    (pk)
+  alpha3  STRING(3)
+  name    STRING(100)
 }
 
+
 schema currency_rates (note "Daily FX rates") {
-  from_ccy  ISO-4217     (pk)
-  to_ccy    ISO-4217     (pk)
+  from_ccy  ISO-4217       (pk)
+  to_ccy    ISO-4217       (pk)
   rate      DECIMAL(18,8)
   as_of     DATE
 }
 
+
 schema product_catalog (note "Product reference data") {
-  sku            STRING(20)    (pk)
+  sku            STRING(20)   (pk)
   internal_code  STRING(20)
   description    STRING(255)
   category       STRING(100)
 }
 
+
 fragment 'address fields' {
-  line1        STRING(200)    (required)
+  line1        STRING(200)  (required)
   line2        STRING(200)
-  city         STRING(100)    (required)
+  city         STRING(100)  (required)
   state        STRING(50)
-  postal_code  STRING(20)     (required)
-  country      ISO-3166-a2    (required)
+  postal_code  STRING(20)   (required)
+  country      ISO-3166-a2  (required)
 }
 
+
 fragment 'audit columns' {
-  created_at   TIMESTAMPTZ    (required)
-  created_by   VARCHAR(100)   (required)
-  updated_at   TIMESTAMPTZ
-  updated_by   VARCHAR(100)
+  created_at  TIMESTAMPTZ   (required)
+  created_by  VARCHAR(100)  (required)
+  updated_at  TIMESTAMPTZ
+  updated_by  VARCHAR(100)
 }

--- a/examples/db-to-db.stm
+++ b/examples/db-to-db.stm
@@ -1,6 +1,6 @@
 // Satsuma v2 — Legacy Customer Migration
-
 import { 'address fields' } from "lib/common.stm"
+
 
 note {
   """
@@ -24,16 +24,15 @@ note {
 
 
 // --- Source ---
-
 schema legacy_sqlserver (
   note "CUSTOMER table — SQL Server 2008. No app-level validation until 2018."
 ) {
-  CUST_ID         INT            (pk)                          // sequential, gaps from deletions
-  CUST_TYPE       CHAR(1)        (enum {R, B, G}, default R)   //! some records have NULL
-  FIRST_NM        VARCHAR(100)                                 // retail customers only
-  LAST_NM         VARCHAR(100)                                 // retail customers only
-  COMPANY_NM      VARCHAR(200)                                 // business/government only
-  EMAIL_ADDR      VARCHAR(255)   (pii)                         //! not validated — contains garbage
+  CUST_ID         INT            (pk)  // sequential, gaps from deletions
+  CUST_TYPE       CHAR(1)        (enum {R, B, G}, default R)  //! some records have NULL
+  FIRST_NM        VARCHAR(100)  // retail customers only
+  LAST_NM         VARCHAR(100)  // retail customers only
+  COMPANY_NM      VARCHAR(200)  // business/government only
+  EMAIL_ADDR      VARCHAR(255)   (pii)  //! not validated — contains garbage
   PHONE_NBR       VARCHAR(50) (
     note """
     No consistent format across the dataset:
@@ -47,47 +46,45 @@ schema legacy_sqlserver (
   ADDR_LINE_1     VARCHAR(200)
   ADDR_LINE_2     VARCHAR(200)
   CITY            VARCHAR(100)
-  STATE_PROV      VARCHAR(50)                                  //! full names AND 2-char codes mixed
+  STATE_PROV      VARCHAR(50)  //! full names AND 2-char codes mixed
   ZIP_POSTAL      VARCHAR(20)
   COUNTRY_CD      CHAR(2)        (default US)
-  CREDIT_LIMIT    DECIMAL(12,2)                                // NULL = no credit extended
+  CREDIT_LIMIT    DECIMAL(12,2)  // NULL = no credit extended
   ACCOUNT_STATUS  CHAR(1)        (enum {A, S, C, D}, default A)
-  CREATED_DATE    VARCHAR(10)                                  //! stored as MM/DD/YYYY string
-  LAST_MOD_DATE   VARCHAR(20)                                  //! MM/DD/YYYY HH:MM:SS AM/PM
-  TAX_ID          VARCHAR(20)    (pii, encrypt)                //! plaintext in legacy — SSN or EIN
+  CREATED_DATE    VARCHAR(10)  //! stored as MM/DD/YYYY string
+  LAST_MOD_DATE   VARCHAR(20)  //! MM/DD/YYYY HH:MM:SS AM/PM
+  TAX_ID          VARCHAR(20)    (pii, encrypt)  //! plaintext in legacy — SSN or EIN
   LOYALTY_POINTS  INT            (default 0)
   PREF_CONTACT    CHAR(1)        (enum {E, P, M, N}, default E)
-  NOTES           VARCHAR(MAX)                                 // free-text, may contain profanity
+  NOTES           VARCHAR(MAX)  // free-text, may contain profanity
 }
 
 
 // --- Target ---
-
 schema postgres_db (note "Normalized customer schema — PostgreSQL 16") {
-  customer_id              UUID           (pk, required)
-  legacy_customer_id       INTEGER        (unique, indexed)
-  customer_type            VARCHAR(20)    (enum {retail, business, government}, required)
-  display_name             VARCHAR(200)   (required)
-  first_name               VARCHAR(100)
-  last_name                VARCHAR(100)
-  company_name             VARCHAR(200)
-  email                    VARCHAR(255)   (format email, pii)
-  phone                    VARCHAR(20)    (format E.164)
-  address_id               UUID           (ref addresses.id)
-  credit_limit_cents       BIGINT         (default 0)
-  status                   VARCHAR(20)    (enum {active, suspended, closed, delinquent}, required)
-  created_at               TIMESTAMPTZ    (required)
-  updated_at               TIMESTAMPTZ
-  tax_identifier_encrypted TEXT           (pii, encrypt AES-256-GCM)
-  loyalty_tier             VARCHAR(20)    (enum {bronze, silver, gold, platinum})
-  preferred_contact_method VARCHAR(20)    (enum {email, phone, mail, none})
-  notes                    TEXT
-  migration_timestamp      TIMESTAMPTZ
+  customer_id               UUID          (pk, required)
+  legacy_customer_id        INTEGER       (unique, indexed)
+  customer_type             VARCHAR(20)   (enum {retail, business, government}, required)
+  display_name              VARCHAR(200)  (required)
+  first_name                VARCHAR(100)
+  last_name                 VARCHAR(100)
+  company_name              VARCHAR(200)
+  email                     VARCHAR(255)  (format email, pii)
+  phone                     VARCHAR(20)   (format E.164)
+  address_id                UUID          (ref addresses.id)
+  credit_limit_cents        BIGINT        (default 0)
+  status                    VARCHAR(20)   (enum {active, suspended, closed, delinquent}, required)
+  created_at                TIMESTAMPTZ   (required)
+  updated_at                TIMESTAMPTZ
+  tax_identifier_encrypted  TEXT          (pii, encrypt AES-256-GCM)
+  loyalty_tier              VARCHAR(20)   (enum {bronze, silver, gold, platinum})
+  preferred_contact_method  VARCHAR(20)   (enum {email, phone, mail, none})
+  notes                     TEXT
+  migration_timestamp       TIMESTAMPTZ
 }
 
 
 // --- Mapping ---
-
 mapping 'customer migration' {
   note {
     "Mapping assumptions:
@@ -100,7 +97,9 @@ mapping 'customer migration' {
   target { `postgres_db` }
 
   // --- Identifiers ---
-  CUST_ID -> customer_id { uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID) }
+  CUST_ID -> customer_id {
+    uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID)
+  }
   CUST_ID -> legacy_customer_id
 
   // --- Customer Type ---
@@ -119,9 +118,9 @@ mapping 'customer migration' {
      Otherwise, trim `COMPANY_NM`."
   }
 
-  FIRST_NM   -> first_name    { trim | title_case | null_if_empty }
-  LAST_NM    -> last_name     { trim | title_case | null_if_empty }
-  COMPANY_NM -> company_name  { trim | null_if_empty }
+  FIRST_NM -> first_name { trim | title_case | null_if_empty }
+  LAST_NM -> last_name { trim | title_case | null_if_empty }
+  COMPANY_NM -> company_name { trim | null_if_empty }
 
   // --- Contact ---
   EMAIL_ADDR -> email { trim | lowercase | validate_email | null_if_invalid }
@@ -146,32 +145,52 @@ mapping 'customer migration' {
 
   // --- Status ---
   ACCOUNT_STATUS -> status {
-    map { A: "active", S: "suspended", C: "closed", D: "delinquent" }
+    map {
+      A: "active"
+      S: "suspended"
+      C: "closed"
+      D: "delinquent"
+    }
   }
 
   // --- Dates ---
-  CREATED_DATE -> created_at { parse("MM/DD/YYYY") | drop_if_invalid | assume_utc | to_iso8601 }
+  CREATED_DATE -> created_at {
+    parse("MM/DD/YYYY")
+    | drop_if_invalid
+    | assume_utc
+    | to_iso8601
+  }
 
   LAST_MOD_DATE -> updated_at {
-    parse("MM/DD/YYYY hh:mm:ss a") | to_utc | to_iso8601
+    parse("MM/DD/YYYY hh:mm:ss a")
+    | to_utc
+    | to_iso8601
     | "If null, fall back to CREATED_DATE parsed as MM/DD/YYYY in UTC"
   }
 
   // --- Security ---
-  TAX_ID -> tax_identifier_encrypted { error_if_null | encrypt(AES-256-GCM, secrets.tax_encryption_key) }
+  TAX_ID -> tax_identifier_encrypted {
+    error_if_null
+    | encrypt(AES-256-GCM, secrets.tax_encryption_key)
+  }
 
   // --- Calculated ---
   LOYALTY_POINTS -> loyalty_tier {
     map {
-      < 1000:  "bronze"
-      < 5000:  "silver"
+      < 1000: "bronze"
+      < 5000: "silver"
       < 10000: "gold"
       default: "platinum"
     }
   }
 
   PREF_CONTACT -> preferred_contact_method {
-    map { E: "email", P: "phone", M: "mail", N: "none" }
+    map {
+      E: "email"
+      P: "phone"
+      M: "mail"
+      N: "none"
+    }
   }
 
   // --- Text ---

--- a/examples/edi-to-json.stm
+++ b/examples/edi-to-json.stm
@@ -18,67 +18,65 @@ note {
 
 
 // --- Source ---
-
 schema edi_desadv (
   format fixed-length,
   note "EDI 856 Despatch Advice — Fixed Length Format"
 ) {
   BeginningOfMessage record {
-    DOCNUM      CHAR(35)                          // despatch advice number
-    MESSGFUN    CHAR(3)                           // message function: 9 = Original
+    DOCNUM    CHAR(35)  // despatch advice number
+    MESSGFUN  CHAR(3)  // message function: 9 = Original
   }
 
   DateTime record {
-    DATEQUAL    CHAR(3)                           // qualifier: 137 = document date/time
-    DATETIME    CHAR(35)                          // date/time value
-    DATEFMT     CHAR(3)                           // format: 102=CCYYMMDD, 203=CCYYMMDDHHMM
+    DATEQUAL  CHAR(3)  // qualifier: 137 = document date/time
+    DATETIME  CHAR(35)  // date/time value
+    DATEFMT   CHAR(3)  // format: 102=CCYYMMDD, 203=CCYYMMDDHHMM
   }
 
   ShipmentRefs list_of record (filter SHPRFQUAL == "SRN") {
-    SHPRFQUAL   CHAR(3)
-    SHIPREF     CHAR(70)                          // shipment reference number
+    SHPRFQUAL  CHAR(3)
+    SHIPREF    CHAR(70)  // shipment reference number
   }
 
   POReferences list_of record (filter REFQUAL == "ON") {
-    REFQUAL     CHAR(3)
-    REFNUM      CHAR(35)                          // PO Number + "/" + Dissection No
+    REFQUAL  CHAR(3)
+    REFNUM   CHAR(35)  // PO Number + "/" + Dissection No
   }
 
   NameAddress record {
-    PARTYQUAL   CHAR(3)                           // BY=Buyer, SU=Supplier
-    PARTYID     CHAR(35)                          // 13-digit ANA number
+    PARTYQUAL  CHAR(3)  // BY=Buyer, SU=Supplier
+    PARTYID    CHAR(35)  // 13-digit ANA number
   }
 
   LineItems list_of record {
-    LINENUM     NUMBER(6)
-    ITEMNO      CHAR(35)                          // product identifier
-    ITEMTYPE    CHAR(3)                           // EN=EAN, UP=UPC12
+    LINENUM   NUMBER(6)
+    ITEMNO    CHAR(35)  // product identifier
+    ITEMTYPE  CHAR(3)  // EN=EAN, UP=UPC12
   }
 
-  Quantities list_of record (filter QUANTQUAL == "12") {    // only despatch quantities
-    QUANTQUAL   CHAR(3)
-    QUANTITY    NUMBER(15)                         //! 4 implied decimal places
+  Quantities list_of record (filter QUANTQUAL == "12") {  // only despatch quantities
+    QUANTQUAL  CHAR(3)
+    QUANTITY   NUMBER(15)  //! 4 implied decimal places
   }
 }
 
 
 // --- Target ---
-
 schema mfcs_json (format json, note "MFCS Shipment Ingestion Format") {
   ShipmentHeader record {
     toLocation            NUMBER(10)
-    asnNo                 STRING(30)   (required)
-    shipDate              DATE         (required)
+    asnNo                 STRING(30)    (required)
+    shipDate              DATE          (required)
     estimatedArrivalDate  DATE
     comments              STRING(2000)
     carrierCode           STRING(4)
-    asnType               STRING(1)    (required)     // C=UCC-128, 0=ASN Shipment
-    supplier              NUMBER(10)   (required)
+    asnType               STRING(1)     (required)  // C=UCC-128, 0=ASN Shipment
+    supplier              NUMBER(10)    (required)
     shipPayMethod         STRING(2)
 
     asnDetails list_of record {
-      orderNo             NUMBER(12)   (required)
-      notAfterDate        DATE
+      orderNo       NUMBER(12)  (required)
+      notAfterDate  DATE
 
       containers list_of record (
         note """
@@ -88,19 +86,19 @@ schema mfcs_json (format json, note "MFCS Shipment Ingestion Format") {
         See Jira: DWHT-2847 for resolution status.
         """
       ) {
-        containerId       STRING(30)   (required)     //! no source mapping
-        finalLocation     NUMBER(10)   (required)     //! no source mapping
+        containerId    STRING(30)  (required)  //! no source mapping
+        finalLocation  NUMBER(10)  (required)  //! no source mapping
         items list_of record {
-          item            STRING(25)
-          unitQuantity    NUMBER(12,4)                 //! no source mapping
+          item          STRING(25)
+          unitQuantity  NUMBER(12,4)  //! no source mapping
         }
       }
 
       items list_of record {
-        item              STRING(25)
-        unitQuantity      NUMBER(12,4)  (required)
-        vpn               STRING(30)
-        referenceItem     STRING(25)
+        item           STRING(25)
+        unitQuantity   NUMBER(12,4)  (required)
+        vpn            STRING(30)
+        referenceItem  STRING(25)
       }
     }
   }
@@ -108,7 +106,6 @@ schema mfcs_json (format json, note "MFCS Shipment Ingestion Format") {
 
 
 // --- Mapping ---
-
 mapping 'edi to mfcs' {
   source { `edi_desadv` }
   target { `mfcs_json` }
@@ -121,7 +118,9 @@ mapping 'edi to mfcs' {
      if 203 parse as CCYYMMDDHHMM. Output format: YYYY-MM-DD."
   }
 
-  -> ShipmentHeader.asnType { "0" }    // default: ASN Shipment
+  -> ShipmentHeader.asnType {
+    "0"
+  }  // default: ASN Shipment
 
   POReferences.REFNUM -> ShipmentHeader.toLocation {
     "Extract PO number from `REFNUM` (digits before '/').
@@ -129,11 +128,15 @@ mapping 'edi to mfcs' {
   }
 
   POReferences.REFNUM -> ShipmentHeader.supplier {
-    split("/") | first | to_number
+    split("/")
+    | first
+    | to_number
     | "Validate supplier exists in MFCS PO table."
   }
 
-  ShipmentRefs.SHIPREF -> ShipmentHeader.comments { prepend("Shipment reference number: ") }
+  ShipmentRefs.SHIPREF -> ShipmentHeader.comments {
+    prepend("Shipment reference number: ")
+  }
 
   // --- Detail lines grouped by PO ---
   each POReferences -> ShipmentHeader.asnDetails (

--- a/examples/filter-flatten-governance.stm
+++ b/examples/filter-flatten-governance.stm
@@ -28,91 +28,90 @@ note {
 
 
 // --- Sources ---
-
 schema order_events (
   note "Enriched order events from the streaming platform (Kafka → S3)",
   classification "INTERNAL"
 ) {
-  event_id        UUID          (pk, required)
-  event_time      TIMESTAMPTZ   (required)
-  order_status    STRING(20)    (enum {completed, pending, failed, refunded}, required)
+  event_id      UUID            (pk, required)
+  event_time    TIMESTAMPTZ     (required)
+  order_status  STRING(20)      (enum {completed, pending, failed, refunded}, required)
 
   customer record {
-    customer_id   UUID          (required)
-    email         STRING(255)   (pii, classification "RESTRICTED", retention "3y")
-    tier          STRING(20)    (enum {standard, silver, gold, platinum})
+    customer_id  UUID         (required)
+    email        STRING(255)  (pii, classification "RESTRICTED", retention "3y")
+    tier         STRING(20)   (enum {standard, silver, gold, platinum})
   }
 
   order_totals record {
-    subtotal      DECIMAL(12,2)
-    tax           DECIMAL(12,2)
-    discount      DECIMAL(12,2)
-    total         DECIMAL(12,2) (required)
-    currency      CHAR(3)       (required, default "GBP")
+    subtotal  DECIMAL(12,2)
+    tax       DECIMAL(12,2)
+    discount  DECIMAL(12,2)
+    total     DECIMAL(12,2)  (required)
+    currency  CHAR(3)        (required, default "GBP")
   }
 
   // Scalar lists: element type is machine-readable in the type position
-  promo_codes list_of STRING (note "Applied promotion codes, may be empty")
-  tag_ids     list_of INT    (classification "INTERNAL")
+  promo_codes   list_of STRING  (note "Applied promotion codes, may be empty")
+  tag_ids       list_of INT     (classification "INTERNAL")
 
   // Filtered list: only include line items that are not cancelled.
   // Items with status = 'cancelled' are excluded before any mapping runs.
   line_items list_of record (filter item_status != "cancelled") {
-    line_number   INT           (required)
-    sku           STRING(30)    (required)
-    item_status   STRING(20)    (enum {active, cancelled, backordered})
-    quantity      INT           (required)
-    unit_price    DECIMAL(12,2) (required)
-    tax_amount    DECIMAL(12,2)
+    line_number  INT            (required)
+    sku          STRING(30)     (required)
+    item_status  STRING(20)     (enum {active, cancelled, backordered})
+    quantity     INT            (required)
+    unit_price   DECIMAL(12,2)  (required)
+    tax_amount   DECIMAL(12,2)
     discount_lines list_of record (filter discount_type != "internal") {
-      discount_code   STRING(30)
-      discount_type   STRING(20) (enum {promo, loyalty, internal, staff})
-      discount_amount DECIMAL(12,2)
+      discount_code    STRING(30)
+      discount_type    STRING(20)     (enum {promo, loyalty, internal, staff})
+      discount_amount  DECIMAL(12,2)
     }
   }
 }
+
 
 schema customer_profiles (
   note "Customer master — CRM system of record",
   classification "RESTRICTED",
   retention "7y"
 ) {
-  customer_id       UUID          (pk, required)
-  email             STRING(255)   (pii, classification "RESTRICTED", retention "3y")
-  first_name        STRING(100)   (pii)
-  last_name         STRING(100)   (pii)
-  acquisition_channel STRING(50)
-  region            STRING(50)
+  customer_id          UUID            (pk, required)
+  email                STRING(255)     (pii, classification "RESTRICTED", retention "3y")
+  first_name           STRING(100)     (pii)
+  last_name            STRING(100)     (pii)
+  acquisition_channel  STRING(50)
+  region               STRING(50)
   // Scalar lists used here for preference lists — no subfields needed
-  consent_flags     list_of STRING (classification "RESTRICTED", retention "7y",
-                       note "e.g. ['email_marketing', 'sms', 'third_party']")
-  opt_out_channels  list_of STRING (classification "RESTRICTED")
+  consent_flags        list_of STRING  (classification "RESTRICTED", retention "7y", note "e.g. ['email_marketing', 'sms', 'third_party']")
+  opt_out_channels     list_of STRING  (classification "RESTRICTED")
 }
 
 
 // --- Targets ---
-
 schema completed_orders_parquet (
   format parquet,
   classification "INTERNAL",
   note "Curated completed-orders fact table — one row per order"
 ) {
-  order_id          UUID          (pk, required)
-  event_time_utc    TIMESTAMPTZ   (required)
-  customer_id       UUID          (indexed)
-  customer_email    STRING(255)   (pii, classification "RESTRICTED", retention "3y")
-  tier              STRING(20)
-  acquisition_channel STRING(50)
-  region            STRING(50)
-  currency          CHAR(3)       (required)
-  subtotal          DECIMAL(12,2)
-  tax               DECIMAL(12,2)
-  discount          DECIMAL(12,2)
-  total             DECIMAL(12,2) (required)
-  promo_codes       list_of STRING (note "Passed through from source unchanged")
-  active_line_count INT           (required)
-  ingest_timestamp  TIMESTAMPTZ   (required)
+  order_id             UUID            (pk, required)
+  event_time_utc       TIMESTAMPTZ     (required)
+  customer_id          UUID            (indexed)
+  customer_email       STRING(255)     (pii, classification "RESTRICTED", retention "3y")
+  tier                 STRING(20)
+  acquisition_channel  STRING(50)
+  region               STRING(50)
+  currency             CHAR(3)         (required)
+  subtotal             DECIMAL(12,2)
+  tax                  DECIMAL(12,2)
+  discount             DECIMAL(12,2)
+  total                DECIMAL(12,2)   (required)
+  promo_codes          list_of STRING  (note "Passed through from source unchanged")
+  active_line_count    INT             (required)
+  ingest_timestamp     TIMESTAMPTZ     (required)
 }
+
 
 schema order_line_facts_parquet (
   format parquet,
@@ -120,22 +119,21 @@ schema order_line_facts_parquet (
   retention "5y",
   note "Curated order line facts — one row per non-cancelled line item"
 ) {
-  order_id          UUID          (required)
+  order_id          UUID           (required)
   customer_id       UUID
-  line_number       INT           (required)
-  sku               STRING(30)    (required)
-  quantity          INT           (required)
-  unit_price        DECIMAL(12,2) (required)
+  line_number       INT            (required)
+  sku               STRING(30)     (required)
+  quantity          INT            (required)
+  unit_price        DECIMAL(12,2)  (required)
   tax_amount        DECIMAL(12,2)
-  line_total        DECIMAL(12,2) (required)
-  currency          CHAR(3)       (required)
+  line_total        DECIMAL(12,2)  (required)
+  currency          CHAR(3)        (required)
   promo_code_count  INT
-  ingest_timestamp  TIMESTAMPTZ   (required)
+  ingest_timestamp  TIMESTAMPTZ    (required)
 }
 
 
 // --- Mapping 1: Order headers — multi-source filtered join ---
-
 mapping 'completed orders' {
   note {
     """
@@ -153,21 +151,29 @@ mapping 'completed orders' {
   }
   target { `completed_orders_parquet` }
 
-  event_id                       -> order_id
-  event_time                     -> event_time_utc
-  customer.customer_id           -> customer_id
-  customer.email                 -> customer_email { trim | lowercase | validate_email | null_if_invalid }
-  customer.tier                  -> tier { trim | lowercase | null_if_empty }
-  customer_profiles.acquisition_channel -> acquisition_channel { trim | null_if_empty }
-  customer_profiles.region       -> region { trim | uppercase | null_if_empty }
-  order_totals.currency          -> currency { trim | uppercase }
-  order_totals.subtotal          -> subtotal { coalesce(0) }
-  order_totals.tax               -> tax { coalesce(0) }
-  order_totals.discount          -> discount { coalesce(0) }
-  order_totals.total             -> total
+  event_id -> order_id
+  event_time -> event_time_utc
+  customer.customer_id -> customer_id
+  customer.email -> customer_email {
+    trim
+    | lowercase
+    | validate_email
+    | null_if_invalid
+  }
+  customer.tier -> tier { trim | lowercase | null_if_empty }
+  customer_profiles.acquisition_channel -> acquisition_channel {
+    trim
+    | null_if_empty
+  }
+  customer_profiles.region -> region { trim | uppercase | null_if_empty }
+  order_totals.currency -> currency { trim | uppercase }
+  order_totals.subtotal -> subtotal { coalesce(0) }
+  order_totals.tax -> tax { coalesce(0) }
+  order_totals.discount -> discount { coalesce(0) }
+  order_totals.total -> total
 
   // Scalar array passed through as-is — no iteration or subfield mapping needed
-  promo_codes                    -> promo_codes
+  promo_codes -> promo_codes
 
   -> active_line_count {
     "Count elements in line_items (already filtered to exclude cancelled items at source)"
@@ -178,7 +184,6 @@ mapping 'completed orders' {
 
 
 // --- Mapping 2: Order lines — flatten nested list ---
-
 // flatten lifts each element of line_items into its own output row,
 // so downstream field arrows reference the flattened element directly.
 mapping 'order line facts' {
@@ -191,18 +196,18 @@ mapping 'order line facts' {
   source { `order_events` }
   target { `order_line_facts_parquet` }
 
-  event_id                       -> order_id
-  customer.customer_id           -> customer_id
+  event_id -> order_id
+  customer.customer_id -> customer_id
 
   flatten line_items -> order_line_facts_parquet {
-    .line_number       -> line_number
-    .sku               -> sku { trim | uppercase }
-    .quantity          -> quantity
-    .unit_price        -> unit_price
-    .tax_amount        -> tax_amount { coalesce(0) }
+    .line_number -> line_number
+    .sku -> sku { trim | uppercase }
+    .quantity -> quantity
+    .unit_price -> unit_price
+    .tax_amount -> tax_amount { coalesce(0) }
   }
 
-  order_totals.currency          -> currency { trim | uppercase }
+  order_totals.currency -> currency { trim | uppercase }
 
   -> line_total {
     "Multiply line_items.unit_price by line_items.quantity, then add line_items.tax_amount"

--- a/examples/lib/sfdc_fragments.stm
+++ b/examples/lib/sfdc_fragments.stm
@@ -2,15 +2,16 @@
 // Reusable field sets for common Salesforce objects
 
 fragment 'sfdc standard types' {
-  Id                ID             (pk, unique)
-  Name              STRING(255)    (required)
-  CreatedDate       DATETIME       (required)
-  CreatedById       ID             (ref `User.Id`)
-  LastModifiedDate  DATETIME       (required)
-  LastModifiedById  ID             (ref `User.Id`)
-  SystemModStamp    DATETIME       (required)
-  IsDeleted         BOOLEAN        (default false)
+  Id                ID           (pk, unique)
+  Name              STRING(255)  (required)
+  CreatedDate       DATETIME     (required)
+  CreatedById       ID           (ref `User.Id`)
+  LastModifiedDate  DATETIME     (required)
+  LastModifiedById  ID           (ref `User.Id`)
+  SystemModStamp    DATETIME     (required)
+  IsDeleted         BOOLEAN      (default false)
 }
+
 
 fragment 'sfdc address' {
   Street      STRING(255)
@@ -22,29 +23,31 @@ fragment 'sfdc address' {
   Longitude   DECIMAL(18,15)
 }
 
+
 fragment 'sfdc opportunity standard' {
-  AccountId                ID             (ref `Account.Id`)
-  Amount                   CURRENCY(18,2)
-  CloseDate                DATE           (required)
-  StageName                PICKLIST       (required)
-  Probability              PERCENT(3,0)
-  ExpectedRevenue          CURRENCY(18,2)
-  TotalOpportunityQuantity DECIMAL(18,2)
-  LeadSource               PICKLIST
-  Type                     PICKLIST
+  AccountId                 ID              (ref `Account.Id`)
+  Amount                    CURRENCY(18,2)
+  CloseDate                 DATE            (required)
+  StageName                 PICKLIST        (required)
+  Probability               PERCENT(3,0)
+  ExpectedRevenue           CURRENCY(18,2)
+  TotalOpportunityQuantity  DECIMAL(18,2)
+  LeadSource                PICKLIST
+  Type                      PICKLIST
 }
 
+
 fragment 'sfdc account standard' {
-  Type            PICKLIST
-  ParentId        ID             (ref `Account.Id`)
+  Type               PICKLIST
+  ParentId           ID        (ref `Account.Id`)
   BillingAddress record {
     ...sfdc address
   }
   ShippingAddress record {
     ...sfdc address
   }
-  Phone           PHONE
-  Website         URL
-  Industry        PICKLIST
-  NumberOfEmployees INT
+  Phone              PHONE
+  Website            URL
+  Industry           PICKLIST
+  NumberOfEmployees  INT
 }

--- a/examples/lookups/finance.stm
+++ b/examples/lookups/finance.stm
@@ -3,7 +3,7 @@
 schema fx_spot_rates (
   note "Sourced from OpenExchangeRates API. Updated daily at 00:01 UTC."
 ) {
-  iso_code    STRING(3)    (pk)
+  iso_code    STRING(3)      (pk)
   rate        DECIMAL(10,6)
   updated_at  DATETIME
 }

--- a/examples/metric_sources.stm
+++ b/examples/metric_sources.stm
@@ -2,42 +2,45 @@
 // Fact and dimension tables referenced by metrics.stm
 
 schema fact_subscriptions (note "Active and historical subscription records") {
-  subscription_id   STRING(36)     (pk)
-  customer_id       STRING(36)     (ref dim_customer.customer_id)
-  product_line      STRING(50)
-  amount            DECIMAL(14,2)
-  billing_period    STRING(10)     (enum {monthly, quarterly, annual})
-  status            STRING(20)     (enum {active, cancelled, trial})
-  started_at        TIMESTAMPTZ
-  cancelled_at      TIMESTAMPTZ
+  subscription_id  STRING(36)     (pk)
+  customer_id      STRING(36)     (ref dim_customer.customer_id)
+  product_line     STRING(50)
+  amount           DECIMAL(14,2)
+  billing_period   STRING(10)     (enum {monthly, quarterly, annual})
+  status           STRING(20)     (enum {active, cancelled, trial})
+  started_at       TIMESTAMPTZ
+  cancelled_at     TIMESTAMPTZ
 }
+
 
 schema fact_orders (note "Commerce order header records") {
-  order_id          STRING(36)     (pk)
-  customer_id       STRING(36)     (ref dim_customer.customer_id)
-  order_date        DATE
-  order_channel     STRING(30)
-  currency_code     ISO-4217
-  total_amount      DECIMAL(14,2)
-  is_gift           BOOLEAN        (default false)
-  ship_country      ISO-3166-a2
-  loyalty_tier      STRING(20)
+  order_id       STRING(36)     (pk)
+  customer_id    STRING(36)     (ref dim_customer.customer_id)
+  order_date     DATE
+  order_channel  STRING(30)
+  currency_code  ISO-4217
+  total_amount   DECIMAL(14,2)
+  is_gift        BOOLEAN        (default false)
+  ship_country   ISO-3166-a2
+  loyalty_tier   STRING(20)
 }
+
 
 schema fact_opportunities (note "Sales pipeline opportunity snapshots") {
-  opportunity_id    STRING(36)     (pk)
-  pipeline_stage    STRING(50)
-  region            STRING(50)
-  account_segment   STRING(50)
-  arr_value         DECIMAL(18,2)
-  probability       DECIMAL(5,2)
-  close_quarter     STRING(6)
-  is_deleted        BOOLEAN        (default false)
-  snapshot_date     DATE
+  opportunity_id   STRING(36)     (pk)
+  pipeline_stage   STRING(50)
+  region           STRING(50)
+  account_segment  STRING(50)
+  arr_value        DECIMAL(18,2)
+  probability      DECIMAL(5,2)
+  close_quarter    STRING(6)
+  is_deleted       BOOLEAN        (default false)
+  snapshot_date    DATE
 }
 
+
 schema fact_sessions (note "Web/app checkout sessions for abandonment tracking") {
-  session_id        STRING(64)     (pk)
+  session_id        STRING(64)   (pk)
   session_type      STRING(20)
   order_channel     STRING(30)
   device_type       STRING(20)
@@ -45,22 +48,25 @@ schema fact_sessions (note "Web/app checkout sessions for abandonment tracking")
   started_at        TIMESTAMPTZ
 }
 
+
 schema dim_customer (note "Customer dimension") {
-  customer_id        STRING(36)    (pk)
-  segment            STRING(30)
-  region             STRING(50)
-  acquisition_channel STRING(50)
-  cohort_year        INTEGER
-  customer_segment   STRING(30)
+  customer_id          STRING(36)  (pk)
+  segment              STRING(30)
+  region               STRING(50)
+  acquisition_channel  STRING(50)
+  cohort_year          INTEGER
+  customer_segment     STRING(30)
 }
 
+
 schema dim_date (note "Date dimension for time-series analysis") {
-  date_key    DATE       (pk)
-  year        INTEGER
-  quarter     STRING(2)
-  month       INTEGER
-  day_of_week STRING(10)
+  date_key     DATE        (pk)
+  year         INTEGER
+  quarter      STRING(2)
+  month        INTEGER
+  day_of_week  STRING(10)
 }
+
 
 schema dim_stage (note "Pipeline stage dimension") {
   stage_key    STRING(50)   (pk)

--- a/examples/metrics.stm
+++ b/examples/metrics.stm
@@ -19,7 +19,6 @@ note {
 
 
 // --- Subscription Metrics ---
-
 metric monthly_recurring_revenue "MRR" (
   source fact_subscriptions,
   grain monthly,
@@ -40,6 +39,7 @@ metric monthly_recurring_revenue "MRR" (
   }
 }
 
+
 metric churn_rate (
   source {fact_subscriptions, dim_customer},
   grain monthly,
@@ -56,13 +56,14 @@ metric churn_rate (
   }
 }
 
+
 metric customer_lifetime_value "CLV" (
   source {fact_orders, dim_customer},
   slice {acquisition_channel, segment, cohort_year}
 ) {
-  value              DECIMAL(14,2)  (measure non_additive)
-  order_count        INTEGER        (measure additive)
-  avg_order_value    DECIMAL(12,2)  (measure non_additive)
+  value            DECIMAL(14,2)  (measure non_additive)
+  order_count      INTEGER        (measure additive)
+  avg_order_value  DECIMAL(12,2)  (measure non_additive)
 
   note {
     """
@@ -78,7 +79,6 @@ metric customer_lifetime_value "CLV" (
 
 
 // --- Pipeline / Sales Metrics ---
-
 metric conversion_rate (
   source {fact_opportunities, dim_stage},
   grain monthly,
@@ -92,6 +92,7 @@ metric conversion_rate (
   }
 }
 
+
 metric pipeline_value "ARR Pipeline" (
   source fact_opportunities,
   grain weekly,
@@ -99,8 +100,7 @@ metric pipeline_value "ARR Pipeline" (
   filter "pipeline_stage NOT IN ('closed_won', 'closed_lost')"
 ) {
   arr_value           DECIMAL(18,2)  (measure additive)
-  weighted_arr_value  DECIMAL(18,2)  (measure additive,
-    note "`arr_value` * `probability` — use for forecast roll-ups")
+  weighted_arr_value  DECIMAL(18,2)  (measure additive, note "`arr_value` * `probability` — use for forecast roll-ups")
 
   note {
     "Open pipeline as of the snapshot date, expressed in ARR."
@@ -109,17 +109,16 @@ metric pipeline_value "ARR Pipeline" (
 
 
 // --- Commerce Metrics ---
-
 metric order_revenue (
   source {fact_orders, dim_date, dim_customer},
   grain daily,
   slice {order_channel, ship_country, currency_code, loyalty_tier}
 ) {
-  gross_revenue   DECIMAL(14,2)  (measure additive)
-  net_revenue     DECIMAL(14,2)  (measure additive)
-  order_count     INTEGER        (measure additive)
-  units_sold      INTEGER        (measure additive)
-  avg_order_value DECIMAL(12,2)  (measure non_additive)
+  gross_revenue    DECIMAL(14,2)  (measure additive)
+  net_revenue      DECIMAL(14,2)  (measure additive)
+  order_count      INTEGER        (measure additive)
+  units_sold       INTEGER        (measure additive)
+  avg_order_value  DECIMAL(12,2)  (measure non_additive)
 
   note {
     """
@@ -134,6 +133,7 @@ metric order_revenue (
     """
   }
 }
+
 
 metric cart_abandonment_rate (
   source {fact_sessions, fact_orders},

--- a/examples/multi-source-hub.stm
+++ b/examples/multi-source-hub.stm
@@ -12,7 +12,6 @@ note {
 
 
 // --- Sources ---
-
 schema crm_system (note "CRM customer data") {
   customer_id     UUID
   email           EMAIL
@@ -20,38 +19,41 @@ schema crm_system (note "CRM customer data") {
   loyalty_points  INT32
 }
 
+
 schema payment_gateway (note "Payment transaction data") {
   transaction_id  UUID
   customer_email  EMAIL
   amount          DECIMAL(12,2)
   currency        ISO-4217
-  status          ENUM (enum {pending, completed, failed})
+  status          ENUM           (enum {pending, completed, failed})
 }
 
+
 schema inventory_system (note "Inventory management") {
-  product_sku          STRING(20)
-  stock_level          INT32
-  warehouse_location   STRING(50)
+  product_sku         STRING(20)
+  stock_level         INT32
+  warehouse_location  STRING(50)
 }
 
 
 // --- Targets ---
-
 schema analytics_db (note "Analytics database") {
-  customer_id           UUID
-  email                 VARCHAR(255)
-  total_spent           DECIMAL(12,2)
-  transaction_count     INT
-  last_transaction_date TIMESTAMPTZ
+  customer_id            UUID
+  email                  VARCHAR(255)
+  total_spent            DECIMAL(12,2)
+  transaction_count      INT
+  last_transaction_date  TIMESTAMPTZ
 }
+
 
 schema notification_service (note "Notification message format") {
   recipient_email  EMAIL
   recipient_phone  STRING(20)
   message_type     ENUM
   message_body     TEXT
-  priority         ENUM (enum {low, medium, high})
+  priority         ENUM        (enum {low, medium, high})
 }
+
 
 schema reporting_warehouse (note "Reporting data warehouse") {
   product_id       VARCHAR(20)
@@ -62,7 +64,6 @@ schema reporting_warehouse (note "Reporting data warehouse") {
 
 
 // --- Mappings ---
-
 mapping 'crm to analytics' {
   source { `crm_system` }
   target { `analytics_db` }
@@ -70,6 +71,7 @@ mapping 'crm to analytics' {
   customer_id -> customer_id
   email -> email
 }
+
 
 mapping 'payments to analytics' {
   source { `payment_gateway` }
@@ -89,8 +91,12 @@ mapping 'payments to analytics' {
   }
 }
 
+
 mapping 'crm to notifications' {
-  source { `crm_system`, `payment_gateway` }
+  source {
+    `crm_system`
+    `payment_gateway`
+  }
   target { `notification_service` }
 
   email -> recipient_email
@@ -106,6 +112,7 @@ mapping 'crm to notifications' {
   }
 }
 
+
 mapping 'payments to notifications' {
   source { `payment_gateway` }
   target { `notification_service` }
@@ -116,6 +123,7 @@ mapping 'payments to notifications' {
     "Format as 'Transaction {`transaction_id`} completed successfully.'"
   }
 }
+
 
 mapping 'inventory to reporting' {
   source { `inventory_system` }

--- a/examples/multi-source-join.stm
+++ b/examples/multi-source-join.stm
@@ -1,6 +1,6 @@
 // Satsuma v2 — Multi-Source Join: Customer 360 View
-
 import { 'audit fields' } from "lib/common.stm"
+
 
 note {
   """
@@ -28,105 +28,104 @@ note {
 
 
 // --- Sources ---
-
 schema crm_customers (
   format postgresql,
   note "Customer profile table from the CRM system"
 ) {
-  customer_id     UUID           (pk)
-  email           VARCHAR(255)   (pii, required)
-  first_name      VARCHAR(100)
-  last_name       VARCHAR(100)
-  company_name    VARCHAR(200)
-  segment         VARCHAR(20)    (enum {enterprise, mid_market, smb, individual})
-  region          VARCHAR(50)
-  signup_date     DATE           (required)
-  is_active       BOOLEAN        (default true)
-  account_owner   VARCHAR(100)                     // sales rep assigned
-  annual_contract_value  DECIMAL(12,2)             // NULL for non-contract customers
+  customer_id            UUID           (pk)
+  email                  VARCHAR(255)   (pii, required)
+  first_name             VARCHAR(100)
+  last_name              VARCHAR(100)
+  company_name           VARCHAR(200)
+  segment                VARCHAR(20)    (enum {enterprise, mid_market, smb, individual})
+  region                 VARCHAR(50)
+  signup_date            DATE           (required)
+  is_active              BOOLEAN        (default true)
+  account_owner          VARCHAR(100)  // sales rep assigned
+  annual_contract_value  DECIMAL(12,2)  // NULL for non-contract customers
 }
+
 
 schema order_transactions (
   format mysql,
   note "Order transactions from the e-commerce order service"
 ) {
-  order_id        BIGINT         (pk)
-  customer_id     UUID           (required, ref crm_customers.customer_id)
-  order_date      DATETIME       (required)
-  status          VARCHAR(20)    (enum {pending, completed, refunded, cancelled})
-  subtotal        DECIMAL(12,2)
-  tax             DECIMAL(12,2)
-  total           DECIMAL(12,2)  (required)
-  currency        CHAR(3)        (default "USD")
-  channel         VARCHAR(20)    (enum {web, mobile, api, pos})
-  coupon_code     VARCHAR(50)
+  order_id     BIGINT         (pk)
+  customer_id  UUID           (required, ref crm_customers.customer_id)
+  order_date   DATETIME       (required)
+  status       VARCHAR(20)    (enum {pending, completed, refunded, cancelled})
+  subtotal     DECIMAL(12,2)
+  tax          DECIMAL(12,2)
+  total        DECIMAL(12,2)  (required)
+  currency     CHAR(3)        (default "USD")
+  channel      VARCHAR(20)    (enum {web, mobile, api, pos})
+  coupon_code  VARCHAR(50)
 }
+
 
 schema support_tickets (
   format json,
   note "Support tickets from the helpdesk platform REST API"
 ) {
-  ticket_id       STRING         (pk)
-  customer_id     STRING         (required)        //! stored as string, must cast to UUID
-  created_at      STRING         (required)        //! ISO-8601 string
-  resolved_at     STRING                           // NULL if still open
-  category        STRING         (enum {billing, technical, account, general})
-  priority        STRING         (enum {low, medium, high, critical})
-  status          STRING         (enum {open, in_progress, resolved, closed})
-  csat_score      NUMBER                           // 1–5, NULL if not yet rated
+  ticket_id    STRING  (pk)
+  customer_id  STRING  (required)  //! stored as string, must cast to UUID
+  created_at   STRING  (required)  //! ISO-8601 string
+  resolved_at  STRING  // NULL if still open
+  category     STRING  (enum {billing, technical, account, general})
+  priority     STRING  (enum {low, medium, high, critical})
+  status       STRING  (enum {open, in_progress, resolved, closed})
+  csat_score   NUMBER  // 1–5, NULL if not yet rated
 }
 
 
 // --- Target ---
-
 schema customer_360 (
   format snowflake,
   note "DIM_CUSTOMER_360 — unified customer view in Snowflake analytics warehouse"
 ) {
-  customer_id              VARCHAR(36)    (pk)
-  email                    VARCHAR(255)   (pii)
-  full_name                VARCHAR(200)
-  company_name             VARCHAR(200)
-  segment                  VARCHAR(20)    (required)
-  region                   VARCHAR(50)
-  account_owner            VARCHAR(100)
-  signup_date              DATE           (required)
-  is_active                BOOLEAN
-  tenure_months            INT
+  customer_id            VARCHAR(36)    (pk)
+  email                  VARCHAR(255)   (pii)
+  full_name              VARCHAR(200)
+  company_name           VARCHAR(200)
+  segment                VARCHAR(20)    (required)
+  region                 VARCHAR(50)
+  account_owner          VARCHAR(100)
+  signup_date            DATE           (required)
+  is_active              BOOLEAN
+  tenure_months          INT
 
   // order metrics
-  total_orders             INT            (default 0)
-  total_revenue            DECIMAL(14,2)  (default 0)
-  total_refunds            DECIMAL(14,2)  (default 0)
-  net_revenue              DECIMAL(14,2)  (default 0)
-  avg_order_value          DECIMAL(12,2)
-  first_order_date         DATE
-  last_order_date          DATE
-  preferred_channel        VARCHAR(20)
-  distinct_coupon_count    INT            (default 0)
+  total_orders           INT            (default 0)
+  total_revenue          DECIMAL(14,2)  (default 0)
+  total_refunds          DECIMAL(14,2)  (default 0)
+  net_revenue            DECIMAL(14,2)  (default 0)
+  avg_order_value        DECIMAL(12,2)
+  first_order_date       DATE
+  last_order_date        DATE
+  preferred_channel      VARCHAR(20)
+  distinct_coupon_count  INT            (default 0)
 
   // support metrics
-  tickets_last_12m         INT            (default 0)
-  open_tickets             INT            (default 0)
-  avg_resolution_hours     DECIMAL(8,1)
-  avg_csat_score           DECIMAL(3,1)
-  has_critical_ticket      BOOLEAN        (default false)
+  tickets_last_12m       INT            (default 0)
+  open_tickets           INT            (default 0)
+  avg_resolution_hours   DECIMAL(8,1)
+  avg_csat_score         DECIMAL(3,1)
+  has_critical_ticket    BOOLEAN        (default false)
 
   // calculated
-  health_score             VARCHAR(20)    (enum {healthy, at_risk, churning})
-  annual_contract_value    DECIMAL(12,2)
+  health_score           VARCHAR(20)    (enum {healthy, at_risk, churning})
+  annual_contract_value  DECIMAL(12,2)
 
   ...audit fields
 }
 
 
 // --- Mapping ---
-
 mapping 'customer 360' {
   source {
-    `crm_customers`       (filter "email NOT LIKE '%@test.internal'")
-    `order_transactions`   (filter "status IN ('completed', 'refunded')")
-    `support_tickets`      (filter "created_at >= date_sub(now(), interval 12 month)")
+    `crm_customers` (filter "email NOT LIKE '%@test.internal'")
+    `order_transactions` (filter "status IN ('completed', 'refunded')")
+    `support_tickets` (filter "created_at >= date_sub(now(), interval 12 month)")
     "Join `crm_customers` to `order_transactions` on `crm_customers.customer_id` = `order_transactions.customer_id` (left join — customers may have no orders).
      Join `crm_customers` to `support_tickets` on `crm_customers.customer_id` = cast(`support_tickets.customer_id` as UUID) (left join — customers may have no tickets)."
   }
@@ -166,12 +165,14 @@ mapping 'customer 360' {
 
   -> total_revenue {
     "Sum `order_transactions.total` where `status` = 'completed'."
-    | coalesce(0) | round(2)
+    | coalesce(0)
+    | round(2)
   }
 
   -> total_refunds {
     "Sum abs(`order_transactions.total`) where `status` = 'refunded'."
-    | coalesce(0) | round(2)
+    | coalesce(0)
+    | round(2)
   }
 
   -> net_revenue {

--- a/examples/namespaces.stm
+++ b/examples/namespaces.stm
@@ -1,11 +1,12 @@
 // Satsuma v2 — Namespace Example: Multi-System Retail Platform
-
 // Global definitions — visible from all namespaces without qualification
+
 fragment audit_fields {
   created_at    TIMESTAMPTZ  (required)
   updated_at    TIMESTAMPTZ
   etl_batch_id  VARCHAR(50)
 }
+
 
 transform trim_and_lower {
   trim | lowercase
@@ -13,62 +14,59 @@ transform trim_and_lower {
 
 
 // --- POS Source System ---
-
 namespace pos (note "Oracle Retail POS — store and transaction data") {
   schema stores (note "POS store reference data") {
-    STORE_ID    VARCHAR(20)  (pk)
-    STORE_NAME  VARCHAR(100) (required)
+    STORE_ID    VARCHAR(20)   (pk)
+    STORE_NAME  VARCHAR(100)  (required)
     REGION_CD   CHAR(2)
     OPEN_DATE   DATE
   }
 
   schema transactions (note "Daily transaction feed") {
-    TXN_ID      BIGINT       (pk)
-    STORE_ID    VARCHAR(20)  (ref stores.STORE_ID)
-    TXN_DATE    DATE         (required)
+    TXN_ID      BIGINT         (pk)
+    STORE_ID    VARCHAR(20)    (ref stores.STORE_ID)
+    TXN_DATE    DATE           (required)
     TXN_AMOUNT  DECIMAL(12,2)
-    CUST_ID     VARCHAR(30)  (pii)
+    CUST_ID     VARCHAR(30)    (pii)
   }
 }
 
 
 // --- E-Commerce Source System ---
-
 namespace ecom (note "Shopify e-commerce platform") {
   schema orders (note "Shopify order lines") {
-    order_id        BIGINT    (pk)
-    order_date      DATE      (required)
-    customer_email  VARCHAR(255)  (pii)
+    order_id        BIGINT         (pk)
+    order_date      DATE           (required)
+    customer_email  VARCHAR(255)   (pii)
     total_amount    DECIMAL(10,2)
     store_code      VARCHAR(20)
   }
 
   schema customers (note "Shopify customer profiles") {
-    customer_id     BIGINT    (pk)
-    email           VARCHAR(255)  (pii)
-    first_name      VARCHAR(100)
-    last_name       VARCHAR(100)
-    created_at      TIMESTAMPTZ
+    customer_id  BIGINT        (pk)
+    email        VARCHAR(255)  (pii)
+    first_name   VARCHAR(100)
+    last_name    VARCHAR(100)
+    created_at   TIMESTAMPTZ
   }
 }
 
 
 // --- Warehouse / Hub Layer ---
-
 namespace warehouse (note "Data vault hub layer") {
   schema hub_store {
-    store_hk         BINARY(32)   (pk)
-    store_id         VARCHAR(20)  (required, unique)
-    store_name       VARCHAR(100)
-    region           CHAR(2)
+    store_hk    BINARY(32)    (pk)
+    store_id    VARCHAR(20)   (required, unique)
+    store_name  VARCHAR(100)
+    region      CHAR(2)
     ...audit_fields
   }
 
   schema hub_customer {
-    customer_hk      BINARY(32)   (pk)
-    customer_email   VARCHAR(255) (required, unique, pii)
-    first_name       VARCHAR(100)
-    last_name        VARCHAR(100)
+    customer_hk     BINARY(32)    (pk)
+    customer_email  VARCHAR(255)  (required, unique, pii)
+    first_name      VARCHAR(100)
+    last_name       VARCHAR(100)
     ...audit_fields
   }
 
@@ -77,10 +75,10 @@ namespace warehouse (note "Data vault hub layer") {
     source { `pos::stores` }
     target { `hub_store` }
 
-    STORE_ID   -> store_hk     { md5(STORE_ID) }
-    STORE_ID   -> store_id
-    STORE_NAME -> store_name   { trim }
-    REGION_CD  -> region
+    STORE_ID -> store_hk { md5(STORE_ID) }
+    STORE_ID -> store_id
+    STORE_NAME -> store_name { trim }
+    REGION_CD -> region
   }
 
   // Cross-namespace mapping: e-commerce customers into hub
@@ -88,24 +86,20 @@ namespace warehouse (note "Data vault hub layer") {
     source { `ecom::customers` }
     target { `hub_customer` }
 
-    email       -> customer_hk     { md5(email) }
-    email       -> customer_email  { trim_and_lower }
-    first_name  -> first_name      { trim }
-    last_name   -> last_name       { trim }
+    email -> customer_hk { md5(email) }
+    email -> customer_email { trim_and_lower }
+    first_name -> first_name { trim }
+    last_name -> last_name { trim }
   }
 }
 
 
 // --- Metrics ---
-
 namespace analytics (note "Business metrics layer") {
-  metric daily_sales "Daily Sales Volume" (
-    source ecom::orders,
-    grain daily
-  ) {
+  metric daily_sales "Daily Sales Volume" (source ecom::orders, grain daily) {
     sale_date    DATE
     channel      VARCHAR(20)
-    order_count  INTEGER       (measure)
-    total_value  DECIMAL(12,2) (measure)
+    order_count  INTEGER        (measure)
+    total_value  DECIMAL(12,2)  (measure)
   }
 }

--- a/examples/ns-merging.stm
+++ b/examples/ns-merging.stm
@@ -2,65 +2,69 @@
 //
 // Tests: same namespace appearing multiple times in one file,
 // cross-namespace references between merged blocks, global shadowing patterns.
-
 // Global transform — used across namespaces
+
 transform clean_string {
   trim | uppercase
 }
+
 
 transform hash_key {
   trim | md5
 }
 
+
 // --- First block of 'source' namespace ---
 namespace source (note "External source systems") {
   schema hr_employees (note "HRIS employee master") {
-    employee_id    VARCHAR(20)   (pk)
-    full_name      VARCHAR(200)  (required)
-    email          VARCHAR(255)  (pii, required)
-    department     VARCHAR(100)
-    hire_date      DATE          (required)
-    salary         DECIMAL(12,2) (pii)
-    manager_id     VARCHAR(20)   (ref hr_employees.employee_id)
+    employee_id  VARCHAR(20)    (pk)
+    full_name    VARCHAR(200)   (required)
+    email        VARCHAR(255)   (pii, required)
+    department   VARCHAR(100)
+    hire_date    DATE           (required)
+    salary       DECIMAL(12,2)  (pii)
+    manager_id   VARCHAR(20)    (ref hr_employees.employee_id)
   }
 }
+
 
 // --- Second block of 'source' namespace (merges with first) ---
 namespace source (note "External source systems") {
   schema finance_gl (note "General ledger entries") {
-    gl_entry_id    BIGINT        (pk)
-    account_code   VARCHAR(20)   (required)
-    entry_date     DATE          (required)
-    amount         DECIMAL(14,2)
-    department     VARCHAR(100)
-    description    TEXT
-    posted_by      VARCHAR(20)   (ref hr_employees.employee_id)
+    gl_entry_id   BIGINT         (pk)
+    account_code  VARCHAR(20)    (required)
+    entry_date    DATE           (required)
+    amount        DECIMAL(14,2)
+    department    VARCHAR(100)
+    description   TEXT
+    posted_by     VARCHAR(20)    (ref hr_employees.employee_id)
   }
 
   schema finance_budgets (note "Department budgets") {
-    budget_id      BIGINT        (pk)
-    department     VARCHAR(100)  (required)
-    fiscal_year    INTEGER       (required)
-    budget_amount  DECIMAL(14,2) (required)
-    approved_by    VARCHAR(20)   (ref hr_employees.employee_id)
+    budget_id      BIGINT         (pk)
+    department     VARCHAR(100)   (required)
+    fiscal_year    INTEGER        (required)
+    budget_amount  DECIMAL(14,2)  (required)
+    approved_by    VARCHAR(20)    (ref hr_employees.employee_id)
   }
 }
+
 
 // --- Staging namespace referencing merged source ---
 namespace staging (note "Cleaned and conformed staging area") {
   schema stg_employees {
-    employee_hk    BINARY(32)    (pk)
-    employee_id    VARCHAR(20)   (unique)
-    full_name      VARCHAR(200)
-    email          VARCHAR(255)  (pii)
-    department     VARCHAR(100)
-    hire_date      DATE
-    is_active      BOOLEAN
+    employee_hk  BINARY(32)    (pk)
+    employee_id  VARCHAR(20)   (unique)
+    full_name    VARCHAR(200)
+    email        VARCHAR(255)  (pii)
+    department   VARCHAR(100)
+    hire_date    DATE
+    is_active    BOOLEAN
   }
 
   schema stg_gl_entries {
-    gl_hk          BINARY(32)    (pk)
-    gl_entry_id    BIGINT        (unique)
+    gl_hk          BINARY(32)     (pk)
+    gl_entry_id    BIGINT         (unique)
     account_code   VARCHAR(20)
     entry_date     DATE
     amount         DECIMAL(14,2)
@@ -73,12 +77,12 @@ namespace staging (note "Cleaned and conformed staging area") {
     source { `source::hr_employees` }
     target { `stg_employees` }
 
-    employee_id -> employee_hk  { hash_key }
+    employee_id -> employee_hk { hash_key }
     employee_id -> employee_id
-    full_name   -> full_name    { clean_string }
-    email       -> email        { trim | lowercase }
-    department  -> department   { clean_string }
-    hire_date   -> hire_date
+    full_name -> full_name { clean_string }
+    email -> email { trim | lowercase }
+    department -> department { clean_string }
+    hire_date -> hire_date
 
     -> is_active {
       "True if no termination record exists in HR system"
@@ -87,14 +91,17 @@ namespace staging (note "Cleaned and conformed staging area") {
 
   // Map GL entries — joins to employees across merged namespace
   mapping 'stage gl entries' {
-    source { `source::finance_gl`, `source::hr_employees` }
+    source {
+      `source::finance_gl`
+      `source::hr_employees`
+    }
     target { `stg_gl_entries` }
 
-    gl_entry_id -> gl_hk        { hash_key }
+    gl_entry_id -> gl_hk { hash_key }
     gl_entry_id -> gl_entry_id
     account_code -> account_code { trim }
-    entry_date  -> entry_date
-    amount      -> amount
+    entry_date -> entry_date
+    amount -> amount
 
     -> department {
       "Lookup `department` from `source::hr_employees` using `posted_by` -> `employee_id`"
@@ -106,20 +113,25 @@ namespace staging (note "Cleaned and conformed staging area") {
   }
 }
 
+
 // --- Reporting namespace ---
 namespace reporting (note "Executive reporting layer") {
   schema dept_budget_vs_actual (note "Department spend analysis") {
-    department       VARCHAR(100)  (pk)
-    fiscal_year      INTEGER       (pk)
-    budget_amount    DECIMAL(14,2)
-    actual_spend     DECIMAL(14,2)
-    variance         DECIMAL(14,2)
-    variance_pct     DECIMAL(5,2)
-    headcount        INTEGER
+    department     VARCHAR(100)   (pk)
+    fiscal_year    INTEGER        (pk)
+    budget_amount  DECIMAL(14,2)
+    actual_spend   DECIMAL(14,2)
+    variance       DECIMAL(14,2)
+    variance_pct   DECIMAL(5,2)
+    headcount      INTEGER
   }
 
   mapping 'build budget vs actual' {
-    source { `staging::stg_gl_entries`, `source::finance_budgets`, `staging::stg_employees` }
+    source {
+      `staging::stg_gl_entries`
+      `source::finance_budgets`
+      `staging::stg_employees`
+    }
     target { `dept_budget_vs_actual` }
 
     department -> department
@@ -149,13 +161,10 @@ namespace reporting (note "Executive reporting layer") {
     }
   }
 
-  metric budget_health "Budget Utilization Health" (
-    source staging::stg_gl_entries,
-    grain monthly
-  ) {
-    department     VARCHAR(100)
-    month          DATE
-    utilization    DECIMAL(5,2)  (measure)
-    remaining      DECIMAL(14,2) (measure)
+  metric budget_health "Budget Utilization Health" (source staging::stg_gl_entries, grain monthly) {
+    department   VARCHAR(100)
+    month        DATE
+    utilization  DECIMAL(5,2)   (measure)
+    remaining    DECIMAL(14,2)  (measure)
   }
 }

--- a/examples/ns-platform.stm
+++ b/examples/ns-platform.stm
@@ -3,10 +3,10 @@
 // Tests: namespace blocks, cross-namespace references, global definitions,
 // namespace-scoped metrics, fragment spreads across namespaces, imports,
 // multiple mappings between namespaces, and derived arrows.
-
 import { pos::stores, pos::transactions } from "namespaces.stm"
 import { ecom::orders, ecom::customers } from "namespaces.stm"
 import { warehouse::hub_store, warehouse::hub_customer } from "namespaces.stm"
+
 
 note {
   """
@@ -23,16 +23,17 @@ note {
 
 
 // --- Global definitions ---
-
 fragment standard_metadata {
-  load_ts       TIMESTAMPTZ  (required)
-  record_source VARCHAR(50)  (required)
-  batch_id      VARCHAR(36)
+  load_ts        TIMESTAMPTZ  (required)
+  record_source  VARCHAR(50)  (required)
+  batch_id       VARCHAR(36)
 }
+
 
 transform normalize_email {
   trim | lowercase
 }
+
 
 transform dv_hash_key {
   trim | lowercase | md5
@@ -40,36 +41,35 @@ transform dv_hash_key {
 
 
 // --- Raw Ingestion Layer ---
-
 namespace raw (note "Raw ingestion layer — one schema per source feed") {
   schema crm_contacts (note "CRM contact export — daily CSV") {
-    contact_id     VARCHAR(36)   (pk)
-    first_name     VARCHAR(100)
-    last_name      VARCHAR(100)
-    email          VARCHAR(255)  (pii)
-    phone          VARCHAR(30)   (pii)
-    company_name   VARCHAR(200)
-    created_date   DATE
+    contact_id    VARCHAR(36)   (pk)
+    first_name    VARCHAR(100)
+    last_name     VARCHAR(100)
+    email         VARCHAR(255)  (pii)
+    phone         VARCHAR(30)   (pii)
+    company_name  VARCHAR(200)
+    created_date  DATE
     ...standard_metadata
   }
 
   schema crm_deals (note "CRM deal pipeline — hourly API pull") {
-    deal_id        VARCHAR(36)   (pk)
-    contact_id     VARCHAR(36)   (ref crm_contacts.contact_id)
-    deal_name      VARCHAR(200)
-    stage          VARCHAR(50)   (enum {discovery, proposal, negotiation, closed_won, closed_lost})
-    amount         DECIMAL(14,2)
-    close_date     DATE
-    owner_email    VARCHAR(255)
+    deal_id      VARCHAR(36)    (pk)
+    contact_id   VARCHAR(36)    (ref crm_contacts.contact_id)
+    deal_name    VARCHAR(200)
+    stage        VARCHAR(50)    (enum {discovery, proposal, negotiation, closed_won, closed_lost})
+    amount       DECIMAL(14,2)
+    close_date   DATE
+    owner_email  VARCHAR(255)
     ...standard_metadata
   }
 
   schema erp_invoices (note "ERP invoice feed — nightly batch") {
-    invoice_id     VARCHAR(20)   (pk)
-    customer_code  VARCHAR(20)   (required)
-    invoice_date   DATE          (required)
-    total_amount   DECIMAL(14,2) (required)
-    currency       VARCHAR(3)    (default USD)
+    invoice_id     VARCHAR(20)    (pk)
+    customer_code  VARCHAR(20)    (required)
+    invoice_date   DATE           (required)
+    total_amount   DECIMAL(14,2)  (required)
+    currency       VARCHAR(3)     (default USD)
     line_count     INTEGER
     ...standard_metadata
   }
@@ -77,36 +77,35 @@ namespace raw (note "Raw ingestion layer — one schema per source feed") {
 
 
 // --- Data Vault Layer ---
-
 namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
   schema hub_contact {
-    contact_hk       BINARY(32)   (pk)
-    contact_bk       VARCHAR(36)  (required, unique)
+    contact_hk  BINARY(32)   (pk)
+    contact_bk  VARCHAR(36)  (required, unique)
     ...standard_metadata
   }
 
   schema sat_contact_details (note "Contact PII satellite") {
-    contact_hk       BINARY(32)   (pk, ref hub_contact.contact_hk)
-    load_ts          TIMESTAMPTZ  (pk)
-    first_name       VARCHAR(100)
-    last_name        VARCHAR(100)
-    email            VARCHAR(255) (pii)
-    phone            VARCHAR(30)  (pii)
-    company_name     VARCHAR(200)
-    hash_diff        BINARY(32)
+    contact_hk    BINARY(32)    (pk, ref hub_contact.contact_hk)
+    load_ts       TIMESTAMPTZ   (pk)
+    first_name    VARCHAR(100)
+    last_name     VARCHAR(100)
+    email         VARCHAR(255)  (pii)
+    phone         VARCHAR(30)   (pii)
+    company_name  VARCHAR(200)
+    hash_diff     BINARY(32)
     ...standard_metadata
   }
 
   schema hub_deal {
-    deal_hk          BINARY(32)   (pk)
-    deal_bk          VARCHAR(36)  (required, unique)
+    deal_hk  BINARY(32)   (pk)
+    deal_bk  VARCHAR(36)  (required, unique)
     ...standard_metadata
   }
 
   schema link_contact_deal (note "Link between contacts and deals") {
-    link_hk          BINARY(32)   (pk)
-    contact_hk       BINARY(32)   (ref hub_contact.contact_hk)
-    deal_hk          BINARY(32)   (ref hub_deal.deal_hk)
+    link_hk     BINARY(32)  (pk)
+    contact_hk  BINARY(32)  (ref hub_contact.contact_hk)
+    deal_hk     BINARY(32)  (ref hub_deal.deal_hk)
     ...standard_metadata
   }
 
@@ -115,7 +114,7 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     source { `raw::crm_contacts` }
     target { `hub_contact` }
 
-    contact_id -> contact_hk  { dv_hash_key }
+    contact_id -> contact_hk { dv_hash_key }
     contact_id -> contact_bk
   }
 
@@ -124,11 +123,11 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     source { `raw::crm_contacts` }
     target { `sat_contact_details` }
 
-    contact_id  -> contact_hk   { dv_hash_key }
-    first_name  -> first_name
-    last_name   -> last_name
-    email       -> email        { normalize_email }
-    phone       -> phone        { trim }
+    contact_id -> contact_hk { dv_hash_key }
+    first_name -> first_name
+    last_name -> last_name
+    email -> email { normalize_email }
+    phone -> phone { trim }
     company_name -> company_name { trim }
 
     -> hash_diff {
@@ -141,7 +140,7 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     source { `raw::crm_deals` }
     target { `hub_deal` }
 
-    deal_id -> deal_hk  { dv_hash_key }
+    deal_id -> deal_hk { dv_hash_key }
     deal_id -> deal_bk
   }
 
@@ -153,49 +152,51 @@ namespace vault (note "Data Vault 2.0 — hubs, links, and satellites") {
     -> link_hk {
       "MD5 hash of `contact_id` + `deal_id`"
     }
-    contact_id -> contact_hk  { dv_hash_key }
-    deal_id    -> deal_hk     { dv_hash_key }
+    contact_id -> contact_hk { dv_hash_key }
+    deal_id -> deal_hk { dv_hash_key }
   }
 }
 
 
 // --- Mart Layer ---
-
 namespace mart (note "Business-facing dimensional models") {
   schema dim_contact (note "Contact dimension — SCD Type 2") {
-    contact_sk       BIGINT        (pk)
-    contact_bk       VARCHAR(36)   (unique)
-    full_name        VARCHAR(200)
-    email            VARCHAR(255)  (pii)
-    company          VARCHAR(200)
-    is_current       BOOLEAN       (default true)
-    valid_from       TIMESTAMPTZ   (required)
-    valid_to         TIMESTAMPTZ
+    contact_sk  BIGINT        (pk)
+    contact_bk  VARCHAR(36)   (unique)
+    full_name   VARCHAR(200)
+    email       VARCHAR(255)  (pii)
+    company     VARCHAR(200)
+    is_current  BOOLEAN       (default true)
+    valid_from  TIMESTAMPTZ   (required)
+    valid_to    TIMESTAMPTZ
   }
 
   schema fact_deals (note "Deal fact table — grain: one row per deal") {
-    deal_sk          BIGINT        (pk)
-    contact_sk       BIGINT        (ref dim_contact.contact_sk, indexed)
-    deal_name        VARCHAR(200)
-    stage            VARCHAR(50)
-    amount_usd       DECIMAL(14,2)
-    close_date       DATE
-    is_won           BOOLEAN
-    days_in_pipeline INTEGER
+    deal_sk           BIGINT         (pk)
+    contact_sk        BIGINT         (ref dim_contact.contact_sk, indexed)
+    deal_name         VARCHAR(200)
+    stage             VARCHAR(50)
+    amount_usd        DECIMAL(14,2)
+    close_date        DATE
+    is_won            BOOLEAN
+    days_in_pipeline  INTEGER
   }
 
   schema fact_revenue (note "Revenue fact — grain: one row per invoice line") {
-    revenue_sk       BIGINT        (pk)
-    contact_sk       BIGINT        (ref dim_contact.contact_sk, indexed)
-    invoice_id       VARCHAR(20)
-    invoice_date     DATE
-    amount_usd       DECIMAL(14,2)
-    currency         VARCHAR(3)
+    revenue_sk    BIGINT         (pk)
+    contact_sk    BIGINT         (ref dim_contact.contact_sk, indexed)
+    invoice_id    VARCHAR(20)
+    invoice_date  DATE
+    amount_usd    DECIMAL(14,2)
+    currency      VARCHAR(3)
   }
 
   // Build contact dimension from vault
   mapping 'build dim_contact' {
-    source { `vault::hub_contact`, `vault::sat_contact_details` }
+    source {
+      `vault::hub_contact`
+      `vault::sat_contact_details`
+    }
     target { `dim_contact` }
 
     contact_bk -> contact_bk
@@ -219,7 +220,12 @@ namespace mart (note "Business-facing dimensional models") {
 
   // Build deal fact from vault
   mapping 'build fact_deals' {
-    source { `vault::hub_deal`, `vault::link_contact_deal`, `vault::hub_contact`, `mart::dim_contact` }
+    source {
+      `vault::hub_deal`
+      `vault::link_contact_deal`
+      `vault::hub_contact`
+      `mart::dim_contact`
+    }
     target { `fact_deals` }
 
     -> deal_sk {
@@ -260,37 +266,30 @@ namespace mart (note "Business-facing dimensional models") {
       "Join `erp_invoices.customer_code` to CRM contact via lookup table"
     }
 
-    invoice_id   -> invoice_id
+    invoice_id -> invoice_id
     invoice_date -> invoice_date
     total_amount -> amount_usd {
       "Convert to USD using currency field and daily FX rate"
     }
-    currency     -> currency
+    currency -> currency
   }
 }
 
 
 // --- Cross-Layer Metrics ---
-
 namespace analytics (note "Business metrics layer") {
-  metric pipeline_value "Active Pipeline Value" (
-    source vault::hub_deal,
-    grain daily
-  ) {
-    snapshot_date     DATE
-    stage             VARCHAR(50)
-    deal_count        INTEGER       (measure)
-    total_value_usd   DECIMAL(14,2) (measure)
+  metric pipeline_value "Active Pipeline Value" (source vault::hub_deal, grain daily) {
+    snapshot_date    DATE
+    stage            VARCHAR(50)
+    deal_count       INTEGER        (measure)
+    total_value_usd  DECIMAL(14,2)  (measure)
   }
 
-  metric customer_ltv "Customer Lifetime Value" (
-    source mart::dim_contact,
-    grain monthly
-  ) {
-    calc_month        DATE
-    contact_bk        VARCHAR(36)
-    total_revenue     DECIMAL(14,2) (measure)
-    deal_count        INTEGER       (measure)
-    avg_deal_size     DECIMAL(14,2) (measure)
+  metric customer_ltv "Customer Lifetime Value" (source mart::dim_contact, grain monthly) {
+    calc_month     DATE
+    contact_bk     VARCHAR(36)
+    total_revenue  DECIMAL(14,2)  (measure)
+    deal_count     INTEGER        (measure)
+    avg_deal_size  DECIMAL(14,2)  (measure)
   }
 }

--- a/examples/protobuf-to-parquet.stm
+++ b/examples/protobuf-to-parquet.stm
@@ -16,7 +16,6 @@ note {
 
 
 // --- Source ---
-
 schema commerce_event_pb (
   format protobuf,
   schema_registry "https://registry.example.com",
@@ -24,64 +23,62 @@ schema commerce_event_pb (
   namespace "com.example.commerce.events",
   note "Commerce event protobuf envelope"
 ) {
-  event_id         STRING      (tag 1)
-  event_type       STRING      (tag 2)
-  event_ts         STRING      (tag 3)
-  source_system    STRING      (tag 4)
-  session_id       STRING      (tag 5)
-  user_id          STRING      (tag 6)
-  country_code     STRING      (tag 7)
-  currency_code    STRING      (tag 8)
+  event_id       STRING  (tag 1)
+  event_type     STRING  (tag 2)
+  event_ts       STRING  (tag 3)
+  source_system  STRING  (tag 4)
+  session_id     STRING  (tag 5)
+  user_id        STRING  (tag 6)
+  country_code   STRING  (tag 7)
+  currency_code  STRING  (tag 8)
 
   Context record (tag 9) {
-    device_type    STRING      (tag 1)
-    app_version    STRING      (tag 2)
-    entry_channel  STRING      (tag 3)
+    device_type    STRING  (tag 1)
+    app_version    STRING  (tag 2)
+    entry_channel  STRING  (tag 3)
   }
 
   CartLines list_of record (tag 10) {
-    sku            STRING      (tag 1)
-    quantity       INT32       (tag 2)
-    unit_price     DECIMAL(12,2) (tag 3)
-    discount_amt   DECIMAL(12,2) (tag 4)
-    category       STRING      (tag 5)
+    sku           STRING         (tag 1)
+    quantity      INT32          (tag 2)
+    unit_price    DECIMAL(12,2)  (tag 3)
+    discount_amt  DECIMAL(12,2)  (tag 4)
+    category      STRING         (tag 5)
   }
 
   Attributes list_of record (tag 11) {
-    key            STRING      (tag 1)
-    value          STRING      (tag 2)
+    key    STRING  (tag 1)
+    value  STRING  (tag 2)
   }
 }
 
 
 // --- Target ---
-
 schema commerce_session_parquet (format parquet, note "Session-level analytics dataset") {
-  session_id                 STRING         (pk)
-  user_id                    STRING
-  session_start_utc          TIMESTAMPTZ    (required)
-  session_end_utc            TIMESTAMPTZ    (required)
-  source_system              STRING
-  country_code               STRING
-  currency_code              STRING
-  entry_channel              STRING         (enum {web, mobile_app, kiosk, marketplace})
-  device_type                STRING         (enum {desktop, mobile, tablet, pos})
-  event_count                INT32          (required)
-  distinct_event_types       JSON
-  viewed_product_count       INT32
-  cart_add_count             INT32
-  purchase_event_count       INT32
-  checkout_completed         BOOLEAN        (required)
-  gross_merchandise_value    DECIMAL(14,2)
-  total_discount_amount      DECIMAL(14,2)
-  distinct_product_count     INT32
-  top_category               STRING
-  session_quality            STRING         (enum {bounce, browse, engaged, purchaser})
+  session_id               STRING         (pk)
+  user_id                  STRING
+  session_start_utc        TIMESTAMPTZ    (required)
+  session_end_utc          TIMESTAMPTZ    (required)
+  source_system            STRING
+  country_code             STRING
+  currency_code            STRING
+  entry_channel            STRING         (enum {web, mobile_app, kiosk, marketplace})
+  device_type              STRING         (enum {desktop, mobile, tablet, pos})
+  event_count              INT32          (required)
+  distinct_event_types     JSON
+  viewed_product_count     INT32
+  cart_add_count           INT32
+  purchase_event_count     INT32
+  checkout_completed       BOOLEAN        (required)
+  gross_merchandise_value  DECIMAL(14,2)
+  total_discount_amount    DECIMAL(14,2)
+  distinct_product_count   INT32
+  top_category             STRING
+  session_quality          STRING         (enum {bounce, browse, engaged, purchaser})
 }
 
 
 // --- Mapping ---
-
 mapping 'session aggregation' (group_by session_id, on_error log, error_threshold 0.02) {
   source { `commerce_event_pb` }
   target { `commerce_session_parquet` }
@@ -89,8 +86,14 @@ mapping 'session aggregation' (group_by session_id, on_error log, error_threshol
   session_id -> session_id
   user_id -> user_id { first }
 
-  event_ts -> session_start_utc { min | "Parse the minimum timestamp in the group as UTC." }
-  event_ts -> session_end_utc { max | "Parse the maximum timestamp in the group as UTC." }
+  event_ts -> session_start_utc {
+    min
+    | "Parse the minimum timestamp in the group as UTC."
+  }
+  event_ts -> session_end_utc {
+    max
+    | "Parse the maximum timestamp in the group as UTC."
+  }
 
   source_system -> source_system { first }
   country_code -> country_code { first | uppercase }
@@ -101,7 +104,8 @@ mapping 'session aggregation' (group_by session_id, on_error log, error_threshol
   -> event_count { count }
 
   event_type -> distinct_event_types {
-    distinct | "Emit the distinct `event_type` values as a JSON array string."
+    distinct
+    | "Emit the distinct `event_type` values as a JSON array string."
   }
 
   -> viewed_product_count {
@@ -116,9 +120,7 @@ mapping 'session aggregation' (group_by session_id, on_error log, error_threshol
     "Count records in the group where `event_type` == 'purchase'."
   }
 
-  event_type -> checkout_completed {
-    map { purchase: true, _: false } | max
-  }
+  event_type -> checkout_completed { map { purchase: true, _: false } | max }
 
   CartLines.unit_price -> gross_merchandise_value {
     "For each event, multiply `unit_price` by `quantity`,

--- a/examples/sap-po-to-mfcs.stm
+++ b/examples/sap-po-to-mfcs.stm
@@ -27,11 +27,7 @@ note {
 
 
 // --- Source ---
-
-schema sap_purchase_order (
-  format sap,
-  note "Logical SAP ERP purchase order contract"
-) {
+schema sap_purchase_order (format sap, note "Logical SAP ERP purchase order contract") {
   EBELN          STRING(10)    (pk, required, note "SAP purchase order number")
   BUKRS          STRING(4)     (required, note "Company code")
   BSART          STRING(4)     (required, enum {NB, UB, FO, ZST}, note "Purchasing document type")
@@ -45,48 +41,46 @@ schema sap_purchase_order (
   HeaderText     STRING(1000)
 
   Items list_of record {
-    EBELP        STRING(5)     (required, note "PO line number")
-    MATNR        STRING(18)    (required, note "SAP material number")
-    TXZ01        STRING(250)   (note "Short item description")
-    MENGE        NUMBER(13,3)  (required, note "Ordered quantity")
-    MEINS        STRING(3)     (required, note "Base unit of measure")
-    NETPR        NUMBER(13,4)  (required, note "Net price")
-    PEINH        NUMBER(5)     (default 1, note "Price unit divisor")
-    WERKS        STRING(4)     (required, note "Plant")
-    LGORT        STRING(4)     (note "Storage location")
-    EINDT        DATE          (note "Requested delivery date")
+    EBELP  STRING(5)     (required, note "PO line number")
+    MATNR  STRING(18)    (required, note "SAP material number")
+    TXZ01  STRING(250)   (note "Short item description")
+    MENGE  NUMBER(13,3)  (required, note "Ordered quantity")
+    MEINS  STRING(3)     (required, note "Base unit of measure")
+    NETPR  NUMBER(13,4)  (required, note "Net price")
+    PEINH  NUMBER(5)     (default 1, note "Price unit divisor")
+    WERKS  STRING(4)     (required, note "Plant")
+    LGORT  STRING(4)     (note "Storage location")
+    EINDT  DATE          (note "Requested delivery date")
   }
 }
 
 
 // --- Target ---
-
 schema mfcs_purchase_order (
   format json,
   note "Logical Oracle MFCS purchase order ingestion contract"
 ) {
   orderNo        NUMBER(12)    (required)
-  supplier       NUMBER(10)    (required)   //! requires MFCS supplier cross-reference
-  location       NUMBER(10)    (required)   //! requires site-to-location resolution
+  supplier       NUMBER(10)    (required)  //! requires MFCS supplier cross-reference
+  location       NUMBER(10)    (required)  //! requires site-to-location resolution
   currencyCode   STRING(3)     (required)
   orderType      STRING(20)    (required)
   notBeforeDate  DATE
   comments       STRING(1000)
 
   items list_of record {
-    item         STRING(25)      (required)   //! requires material-to-item cross-reference
-    orderedQty   NUMBER(12,4)    (required)
-    unitCost     NUMBER(12,4)
-    uom          STRING(10)      (required)
-    needByDate   DATE
-    referenceLine NUMBER(6)      (required)
-    description  STRING(250)
+    item           STRING(25)    (required)  //! requires material-to-item cross-reference
+    orderedQty     NUMBER(12,4)  (required)
+    unitCost       NUMBER(12,4)
+    uom            STRING(10)    (required)
+    needByDate     DATE
+    referenceLine  NUMBER(6)     (required)
+    description    STRING(250)
   }
 }
 
 
 // --- Mapping ---
-
 mapping 'sap po to mfcs' {
   note {
     """
@@ -139,15 +133,10 @@ mapping 'sap po to mfcs' {
      If all line dates are null, fall back to `BEDAT`."
   }
 
-  HeaderText -> comments {
-    trim
-    | max_length(1000)
-  }
+  HeaderText -> comments { trim | max_length(1000) }
 
   // --- Lines ---
-  each Items -> items (
-    note "One MFCS target line per SAP purchase order item."
-  ) {
+  each Items -> items (note "One MFCS target line per SAP purchase order item.") {
     .EBELP -> .referenceLine { to_number }
 
     .MATNR -> .item {

--- a/examples/sfdc_to_snowflake.stm
+++ b/examples/sfdc_to_snowflake.stm
@@ -1,7 +1,7 @@
 // Satsuma v2 — Salesforce to Snowflake Pipeline
-
 import { 'sfdc standard types' } from "lib/sfdc_fragments.stm"
 import { fx_spot_rates } from "lookups/finance.stm"
+
 
 note {
   """
@@ -18,50 +18,51 @@ note {
 
 
 // --- Sources ---
-
 schema sfdc_opportunity (note "SFDC Opportunity Object") {
-  Id                          ID             (pk)
-  Name                        STRING(120)    (required)
-  AccountId                   ID             (ref sfdc_account.Id)
-  Amount                      CURRENCY(18,2)
-  CurrencyIsoCode             STRING(3)      (default USD)
-  StageName                   PICKLIST       (enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost})
-  CloseDate                   DATE           (required)
-  Probability                 PERCENT(3,0)
-  `Lead_Source_Detail__c`     STRING(255)
-  `ARR_Override__c`           CURRENCY(18,2)  //! manual override used by Finance
-  SystemModStamp              DATETIME       (required)
+  Id                       ID              (pk)
+  Name                     STRING(120)     (required)
+  AccountId                ID              (ref sfdc_account.Id)
+  Amount                   CURRENCY(18,2)
+  CurrencyIsoCode          STRING(3)       (default USD)
+  StageName                PICKLIST        (enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost})
+  CloseDate                DATE            (required)
+  Probability              PERCENT(3,0)
+  `Lead_Source_Detail__c`  STRING(255)
+  `ARR_Override__c`        CURRENCY(18,2)  //! manual override used by Finance
+  SystemModStamp           DATETIME        (required)
 }
 
+
 schema sfdc_account (note "SFDC Account Object") {
-  Id              ID             (pk)
-  Name            STRING(255)    (required)
-  Type            PICKLIST       (enum {Customer, Prospect, Partner, Competitor})
+  Id              ID           (pk)
+  Name            STRING(255)  (required)
+  Type            PICKLIST     (enum {Customer, Prospect, Partner, Competitor})
   BillingCountry  STRING(80)
 }
 
 
 // --- Target ---
-
 schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
-  opp_key          VARCHAR(18)    (pk)
-  account_key      VARCHAR(18)    (indexed)
-  opportunity_name VARCHAR(120)
-  amount_raw       NUMBER(18,2)
-  amount_usd       NUMBER(18,2)   (note "Converted at daily spot rate")
-  arr_value        NUMBER(18,2)   (required)
-  pipeline_stage   VARCHAR(50)    (enum {top_funnel, mid_funnel, closed_won, closed_lost})
-  is_closed        BOOLEAN
-  close_date       DATE
-  source_system    VARCHAR(10)    (default SFDC)
-  ingested_at      TIMESTAMP_NTZ
+  opp_key           VARCHAR(18)    (pk)
+  account_key       VARCHAR(18)    (indexed)
+  opportunity_name  VARCHAR(120)
+  amount_raw        NUMBER(18,2)
+  amount_usd        NUMBER(18,2)   (note "Converted at daily spot rate")
+  arr_value         NUMBER(18,2)   (required)
+  pipeline_stage    VARCHAR(50)    (enum {top_funnel, mid_funnel, closed_won, closed_lost})
+  is_closed         BOOLEAN
+  close_date        DATE
+  source_system     VARCHAR(10)    (default SFDC)
+  ingested_at       TIMESTAMP_NTZ
 }
 
 
 // --- Mapping ---
-
 mapping 'opportunity ingestion' {
-  source { `sfdc_opportunity`, `fx_spot_rates` }
+  source {
+    `sfdc_opportunity`
+    `fx_spot_rates`
+  }
   target { `snowflake_opps` }
 
   // --- Direct identifiers ---
@@ -85,12 +86,12 @@ mapping 'opportunity ingestion' {
   // --- Stage normalization ---
   StageName -> pipeline_stage {
     map {
-      Prospecting:  "top_funnel"
+      Prospecting: "top_funnel"
       Qualification: "mid_funnel"
-      "Value Prop":  "mid_funnel"
-      Closed_Won:    "closed_won"
-      Closed_Lost:   "closed_lost"
-      _:             "unknown"
+      "Value Prop": "mid_funnel"
+      Closed_Won: "closed_won"
+      Closed_Lost: "closed_lost"
+      _: "unknown"
     }
   }
 

--- a/examples/xml-to-parquet.stm
+++ b/examples/xml-to-parquet.stm
@@ -17,7 +17,6 @@ note {
 
 
 // --- Source ---
-
 schema commerce_order (
   format xml,
   namespace ord "http://example.com/commerce/order/v2",
@@ -25,21 +24,21 @@ schema commerce_order (
   note "Canonical commerce order message"
 ) {
   Order record (xpath "/ord:OrderMessage/ord:Order") {
-    OrderId           STRING       (xpath "ord:OrderId")
-    Channel           STRING       (xpath "ord:Channel")
-    OrderTimestamp    STRING       (xpath "ord:OrderTimestamp")
-    CurrencyCode      STRING       (xpath "ord:Currency/com:Code")
+    OrderId         STRING  (xpath "ord:OrderId")
+    Channel         STRING  (xpath "ord:Channel")
+    OrderTimestamp  STRING  (xpath "ord:OrderTimestamp")
+    CurrencyCode    STRING  (xpath "ord:Currency/com:Code")
 
     Customer record {
-      CustomerId      STRING       (xpath "ord:CustomerId")
-      Email           STRING       (xpath "ord:Email")
-      LoyaltyTier     STRING       (xpath "ord:LoyaltyTier")
+      CustomerId   STRING  (xpath "ord:CustomerId")
+      Email        STRING  (xpath "ord:Email")
+      LoyaltyTier  STRING  (xpath "ord:LoyaltyTier")
     }
 
     ShippingAddress record {
-      CountryCode     STRING       (xpath "ord:CountryCode")
-      RegionCode      STRING       (xpath "ord:RegionCode")
-      PostalCode      STRING       (xpath "ord:PostalCode")
+      CountryCode  STRING  (xpath "ord:CountryCode")
+      RegionCode   STRING  (xpath "ord:RegionCode")
+      PostalCode   STRING  (xpath "ord:PostalCode")
     }
 
     Totals record {
@@ -49,27 +48,26 @@ schema commerce_order (
     }
 
     Discounts list_of record (xpath "ord:Discounts/ord:Discount") {
-      DiscountCode    STRING       (xpath "ord:Code")
-      DiscountAmount  DECIMAL(12,2) (xpath "ord:Amount")
-      DiscountType    STRING       (xpath "ord:Type")
+      DiscountCode    STRING         (xpath "ord:Code")
+      DiscountAmount  DECIMAL(12,2)  (xpath "ord:Amount")
+      DiscountType    STRING         (xpath "ord:Type")
     }
 
     LineItems list_of record (xpath "ord:LineItems/ord:LineItem") {
-      LineNumber      INT32        (xpath "ord:LineNumber")
-      SKU             STRING       (xpath "ord:SKU")
-      FulfillmentType STRING       (xpath "ord:FulfillmentType")
-      Quantity        INT32        (xpath "ord:Quantity")
-      UnitPrice       DECIMAL(12,2) (xpath "ord:UnitPrice")
-      ExtendedAmount  DECIMAL(12,2) (xpath "ord:ExtendedAmount")
-      TaxAmount       DECIMAL(12,2) (xpath "ord:TaxAmount")
-      IsGift          BOOLEAN      (xpath "ord:IsGift")
+      LineNumber       INT32          (xpath "ord:LineNumber")
+      SKU              STRING         (xpath "ord:SKU")
+      FulfillmentType  STRING         (xpath "ord:FulfillmentType")
+      Quantity         INT32          (xpath "ord:Quantity")
+      UnitPrice        DECIMAL(12,2)  (xpath "ord:UnitPrice")
+      ExtendedAmount   DECIMAL(12,2)  (xpath "ord:ExtendedAmount")
+      TaxAmount        DECIMAL(12,2)  (xpath "ord:TaxAmount")
+      IsGift           BOOLEAN        (xpath "ord:IsGift")
     }
   }
 }
 
 
 // --- Targets ---
-
 schema order_headers_parquet (format parquet, note "Curated order header dataset") {
   order_id             STRING         (pk)
   order_channel        STRING         (enum {web, mobile, store, marketplace}, required)
@@ -90,26 +88,26 @@ schema order_headers_parquet (format parquet, note "Curated order header dataset
   ingest_date          DATE           (required)
 }
 
+
 schema order_lines_parquet (format parquet, note "Curated order line dataset") {
-  order_id             STRING         (required)
-  line_number          INT32          (required)
-  sku                  STRING         (required)
-  fulfillment_type     STRING         (enum {ship, pickup, digital, service})
-  quantity             INT32          (required)
-  unit_price           DECIMAL(12,2)
-  extended_amount      DECIMAL(12,2)  (required)
-  line_tax_amount      DECIMAL(12,2)
-  is_gift              BOOLEAN
-  currency_code        STRING         (required)
-  order_channel        STRING         (required)
-  customer_id          STRING
-  ship_country         STRING
-  ingest_date          DATE           (required)
+  order_id          STRING         (required)
+  line_number       INT32          (required)
+  sku               STRING         (required)
+  fulfillment_type  STRING         (enum {ship, pickup, digital, service})
+  quantity          INT32          (required)
+  unit_price        DECIMAL(12,2)
+  extended_amount   DECIMAL(12,2)  (required)
+  line_tax_amount   DECIMAL(12,2)
+  is_gift           BOOLEAN
+  currency_code     STRING         (required)
+  order_channel     STRING         (required)
+  customer_id       STRING
+  ship_country      STRING
+  ingest_date       DATE           (required)
 }
 
 
 // --- Mapping: Order Headers ---
-
 mapping 'order headers' {
   source { `commerce_order` }
   target { `order_headers_parquet` }
@@ -123,11 +121,24 @@ mapping 'order headers' {
   }
 
   Order.Customer.CustomerId -> customer_id
-  Order.Customer.Email -> customer_email { trim | lowercase | validate_email | null_if_invalid }
-  Order.Customer.LoyaltyTier -> loyalty_tier { trim | lowercase | null_if_empty }
+  Order.Customer.Email -> customer_email {
+    trim
+    | lowercase
+    | validate_email
+    | null_if_invalid
+  }
+  Order.Customer.LoyaltyTier -> loyalty_tier {
+    trim
+    | lowercase
+    | null_if_empty
+  }
 
   Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
-  Order.ShippingAddress.RegionCode -> ship_region { trim | uppercase | null_if_empty }
+  Order.ShippingAddress.RegionCode -> ship_region {
+    trim
+    | uppercase
+    | null_if_empty
+  }
   Order.ShippingAddress.PostalCode -> ship_postal_code { trim | null_if_empty }
 
   Order.CurrencyCode -> currency_code { trim | uppercase }
@@ -150,12 +161,14 @@ mapping 'order headers' {
     "Count `LineNumber` entries for the current order."
   }
 
-  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+  -> ingest_date {
+    now_utc()
+    | "Truncate to UTC calendar date YYYY-MM-DD."
+  }
 }
 
 
 // --- Mapping: Order Lines (flattened) ---
-
 mapping 'order lines' {
   source { `commerce_order` }
   target { `order_lines_parquet` }
@@ -178,5 +191,8 @@ mapping 'order lines' {
   Order.Customer.CustomerId -> customer_id
   Order.ShippingAddress.CountryCode -> ship_country { trim | uppercase }
 
-  -> ingest_date { now_utc() | "Truncate to UTC calendar date YYYY-MM-DD." }
+  -> ingest_date {
+    now_utc()
+    | "Truncate to UTC calendar date YYYY-MM-DD."
+  }
 }

--- a/features/20-stm-fmt/PRD.md
+++ b/features/20-stm-fmt/PRD.md
@@ -1,6 +1,6 @@
 # Feature 20 — `satsuma fmt`: Opinionated Formatter
 
-> **Status: NOT STARTED**
+> **Status: COMPLETE**
 
 ## Goal
 

--- a/site/cli.html
+++ b/site/cli.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Satsuma CLI &mdash; 16 Commands for Structural Extraction</title>
-  <meta name="description" content="The Satsuma CLI provides 16 deterministic, parser-backed commands for workspace extraction, validation, lineage tracing, and structural analysis.">
+  <meta name="description" content="The Satsuma CLI provides 17 deterministic, parser-backed commands for workspace extraction, validation, formatting, lineage tracing, and structural analysis.">
   <meta property="og:title" content="Satsuma CLI &mdash; 16 Commands for Structural Extraction">
   <meta property="og:description" content="Deterministic structural extraction for Satsuma workspaces. Lineage, validation, linting, and more.">
   <meta property="og:image" content="img/satsuma-logo-512.png">
@@ -83,7 +83,7 @@
         <div>
           <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-6">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-            16 commands &middot; 637 tests
+            17 commands &middot; 760 tests
           </div>
           <h1 class="text-4xl sm:text-5xl font-extrabold text-charcoal leading-tight mb-6">
             Satsuma <span class="text-orange">CLI</span>
@@ -162,7 +162,7 @@
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
-<span class="output">16 commands available</span></pre>
+<span class="output">17 commands available</span></pre>
         </div>
         <details class="mt-4 text-sm">
           <summary class="cursor-pointer text-warm-gray hover:text-charcoal transition-colors font-medium">Latest unstable build (from main)</summary>
@@ -361,11 +361,21 @@
         <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-4">
           Analysis
         </div>
-        <h2 class="text-3xl font-bold text-charcoal mb-3">Validate, lint, and diff</h2>
-        <p class="text-warm-gray max-w-2xl">Check structural correctness, enforce policy conventions, and compare workspace snapshots.</p>
+        <h2 class="text-3xl font-bold text-charcoal mb-3">Format, validate, lint, and diff</h2>
+        <p class="text-warm-gray max-w-2xl">One canonical style, structural correctness checks, policy conventions, and workspace comparison.</p>
       </div>
 
-      <div class="grid md:grid-cols-3 gap-6 reveal">
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6 reveal">
+        <!-- fmt -->
+        <div class="bg-white rounded-2xl p-6 border border-charcoal/5">
+          <h3 class="text-lg font-bold text-charcoal mb-1 font-mono">fmt</h3>
+          <p class="text-sm text-warm-gray mb-4">Opinionated, zero-config formatter. One canonical style. Also available as VS Code <em>Format Document</em>.</p>
+          <div class="terminal text-xs">
+            <div class="terminal-header"><div class="terminal-dot red"></div><div class="terminal-dot yellow"></div><div class="terminal-dot green"></div></div>
+            <pre><span class="prompt">$</span> satsuma fmt <span class="flag">--check</span> <span class="flag">examples/</span>
+<span class="output">0 file(s) would be reformatted</span></pre>
+          </div>
+        </div>
         <!-- validate -->
         <div class="bg-white rounded-2xl p-6 border border-charcoal/5">
           <h3 class="text-lg font-bold text-charcoal mb-1 font-mono">validate</h3>

--- a/site/index.html
+++ b/site/index.html
@@ -405,7 +405,7 @@
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">Satsuma CLI</h3>
-              <p class="text-sm text-warm-gray">16 commands &middot; 637 tests</p>
+              <p class="text-sm text-warm-gray">17 commands &middot; 760 tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">

--- a/site/vscode.html
+++ b/site/vscode.html
@@ -208,6 +208,16 @@
           <p class="text-warm-gray text-sm leading-relaxed"><strong class="text-charcoal">Hover</strong> &mdash; contextual info for blocks, fields, tags, spreads, arrow paths, and pipeline functions.</p>
         </div>
 
+        <!-- Format Document -->
+        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
+          <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
+            <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/></svg>
+          </div>
+          <h3 class="text-lg font-bold text-charcoal mb-2">Format Document</h3>
+          <p class="text-warm-gray text-sm leading-relaxed mb-3">Opinionated, zero-config formatting. One canonical style for all Satsuma files &mdash; field column alignment, consistent spacing, normalised blank lines.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Trigger with <kbd class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded border border-charcoal/10">Shift+Alt+F</kbd> or enable format-on-save. Same formatter as <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">satsuma fmt</code> in the CLI.</p>
+        </div>
+
         <!-- CodeLens -->
         <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
           <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">

--- a/tooling/satsuma-cli/src/commands/fmt.ts
+++ b/tooling/satsuma-cli/src/commands/fmt.ts
@@ -1,0 +1,181 @@
+/**
+ * fmt.ts — `satsuma fmt` command
+ *
+ * Opinionated Satsuma formatter. Zero configuration, one canonical style.
+ *
+ * Flags:
+ *   --check   exit 1 if any file would change (for CI)
+ *   --diff    print unified diff without writing
+ *   --stdin   read from stdin, write formatted output to stdout
+ *
+ * Exit codes:
+ *   0  success (or all files already formatted in --check mode)
+ *   1  files would change (--check mode only)
+ *   2  parse errors or other failures
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, relative } from "node:path";
+import type { Command } from "commander";
+import { findStmFiles } from "../workspace.js";
+import { parseFile, parseSource } from "../parser.js";
+import { format } from "../format.js";
+
+export function register(program: Command): void {
+  program
+    .command("fmt [path]")
+    .description("Format Satsuma files (opinionated, zero-config)")
+    .option("--check", "exit 1 if any file would change (for CI)")
+    .option("--diff", "print unified diff without writing")
+    .option("--stdin", "read from stdin, write to stdout")
+    .action(async (
+      pathArg: string | undefined,
+      opts: { check?: boolean; diff?: boolean; stdin?: boolean }
+    ) => {
+      if (opts.stdin) {
+        return handleStdin();
+      }
+
+      const root = resolve(pathArg ?? ".");
+      let files: string[];
+      try {
+        const stat = await import("node:fs").then(m => m.statSync(root));
+        if (stat.isFile()) {
+          files = [root];
+        } else if (stat.isDirectory()) {
+          files = await findStmFiles(root);
+        } else {
+          console.error(`Not a file or directory: ${root}`);
+          process.exit(2);
+        }
+      } catch (err: unknown) {
+        console.error(`Error resolving path: ${(err as Error).message}`);
+        process.exit(2);
+      }
+
+      if (files.length === 0) {
+        // No files to format — success
+        process.exit(0);
+      }
+
+      let wouldChange = 0;
+      let parseErrors = 0;
+
+      for (const filePath of files) {
+        const parsed = parseFile(filePath);
+
+        if (parsed.errorCount > 0) {
+          const rel = relative(process.cwd(), filePath);
+          console.error(`skipping ${rel}: parse error (${parsed.errorCount} error(s))`);
+          parseErrors++;
+          continue;
+        }
+
+        const formatted = format(parsed.tree, parsed.src);
+
+        if (formatted === parsed.src) {
+          continue; // already formatted
+        }
+
+        wouldChange++;
+        const rel = relative(process.cwd(), filePath);
+
+        if (opts.check) {
+          console.log(rel);
+        } else if (opts.diff) {
+          printDiff(rel, parsed.src, formatted);
+        } else {
+          writeFileSync(filePath, formatted, "utf8");
+          console.log(`formatted ${rel}`);
+        }
+      }
+
+      if (parseErrors > 0 && wouldChange === 0 && !opts.check) {
+        process.exit(2);
+      }
+
+      if (opts.check && wouldChange > 0) {
+        console.error(`\n${wouldChange} file(s) would be reformatted`);
+        process.exit(1);
+      }
+    });
+}
+
+function handleStdin(): void {
+  const src = readFileSync(0, "utf8"); // fd 0 = stdin
+  const { tree, errorCount } = parseSource(src);
+
+  if (errorCount > 0) {
+    console.error(`stdin: parse error (${errorCount} error(s))`);
+    process.exit(2);
+  }
+
+  const formatted = format(tree, src);
+  process.stdout.write(formatted);
+}
+
+function printDiff(filename: string, original: string, formatted: string): void {
+  const origLines = original.split("\n");
+  const fmtLines = formatted.split("\n");
+
+  console.log(`--- a/${filename}`);
+  console.log(`+++ b/${filename}`);
+
+  // Simple line-by-line unified diff
+  let i = 0;
+  let j = 0;
+  while (i < origLines.length || j < fmtLines.length) {
+    if (i < origLines.length && j < fmtLines.length && origLines[i] === fmtLines[j]) {
+      i++;
+      j++;
+      continue;
+    }
+
+    // Find the hunk boundaries
+    const hunkStartI = Math.max(0, i - 3);
+    const hunkStartJ = Math.max(0, j - 3);
+
+    // Scan ahead to find where lines match again
+    let endI = i;
+    let endJ = j;
+    let found = false;
+    for (let di = 0; di < 20 && i + di < origLines.length; di++) {
+      for (let dj = 0; dj < 20 && j + dj < fmtLines.length; dj++) {
+        if (origLines[i + di] === fmtLines[j + dj]) {
+          endI = i + di;
+          endJ = j + dj;
+          found = true;
+          break;
+        }
+      }
+      if (found) break;
+    }
+    if (!found) {
+      endI = origLines.length;
+      endJ = fmtLines.length;
+    }
+
+    const ctxEnd = Math.min(endI + 3, origLines.length);
+    console.log(`@@ -${hunkStartI + 1},${ctxEnd - hunkStartI} +${hunkStartJ + 1},${endJ - hunkStartJ + (ctxEnd - endI)} @@`);
+
+    // Context before
+    for (let k = hunkStartI; k < i; k++) {
+      console.log(` ${origLines[k]}`);
+    }
+    // Removed lines
+    for (let k = i; k < endI; k++) {
+      console.log(`-${origLines[k]}`);
+    }
+    // Added lines
+    for (let k = j; k < endJ; k++) {
+      console.log(`+${fmtLines[k]}`);
+    }
+    // Context after
+    for (let k = endI; k < ctxEnd; k++) {
+      console.log(` ${origLines[k]}`);
+    }
+
+    i = ctxEnd;
+    j = endJ + (ctxEnd - endI);
+  }
+}

--- a/tooling/satsuma-cli/src/format.ts
+++ b/tooling/satsuma-cli/src/format.ts
@@ -7,56 +7,1242 @@
  * The formatter walks the full CST (node.children, not just namedChildren)
  * to preserve comments and all anonymous tokens (punctuation, keywords).
  *
- * Current phase: pass-through baseline — reproduces the original source
- * by collecting leaf nodes and emitting inter-node gaps from the source.
- * Subsequent tickets layer formatting rules on top of this walk.
+ * Style rules are fixed and match the canonical example corpus. Zero
+ * configuration — one style for all Satsuma files everywhere.
  */
 
 import type { SyntaxNode, Tree } from "./types.js";
 
-/**
- * Format a Satsuma source string given its tree-sitter parse tree.
- *
- * @param tree  - tree-sitter Tree (must still be valid / not reused)
- * @param source - the original source text that was parsed
- * @returns the formatted source string
- */
+const INDENT = "  ";
+const NAME_CAP = 24;
+const TYPE_CAP = 14;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
 export function format(tree: Tree, source: string): string {
-  const leaves: SyntaxNode[] = [];
-  collectLeaves(tree.rootNode, leaves);
+  const result = formatSourceFile(tree.rootNode, source);
+  // Ensure single trailing newline, no trailing blank lines
+  return result.replace(/\n*$/, "\n");
+}
 
-  let result = "";
-  let pos = 0;
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-  for (const leaf of leaves) {
-    // Emit the gap between the previous token and this one (whitespace, newlines)
-    if (leaf.startIndex > pos) {
-      result += source.slice(pos, leaf.startIndex);
-    }
-    // Emit the leaf token text
-    result += leaf.text;
-    pos = leaf.endIndex;
+function ind(level: number): string {
+  return INDENT.repeat(level);
+}
+
+function isComment(node: SyntaxNode): boolean {
+  return node.type === "comment" ||
+         node.type === "warning_comment" ||
+         node.type === "question_comment";
+}
+
+function isImport(node: SyntaxNode): boolean {
+  return node.type === "import_decl";
+}
+
+/** True if there is at least one blank line between two nodes in the source. */
+function hasBlankBetween(a: SyntaxNode, b: SyntaxNode): boolean {
+  return b.startPosition.row - a.endPosition.row > 1;
+}
+
+/** True if b starts on the same line as a ends. */
+function sameLine(a: SyntaxNode, b: SyntaxNode): boolean {
+  return a.endPosition.row === b.startPosition.row;
+}
+
+/** Find a named child by type. */
+function findChild(node: SyntaxNode, type: string): SyntaxNode | null {
+  for (const c of node.children) {
+    if (c.type === type) return c;
   }
+  return null;
+}
 
-  // Emit any trailing content after the last leaf (e.g. final newline)
-  if (pos < source.length) {
-    result += source.slice(pos);
-  }
-
-  return result;
+/** Find all children of a given type. */
+function findChildren(node: SyntaxNode, type: string): SyntaxNode[] {
+  return node.children.filter(c => c.type === type);
 }
 
 /**
- * Recursively collect all leaf nodes from the CST in document order.
- * Walks node.children (all children, including anonymous tokens and comments)
- * rather than namedChildren, so nothing is skipped.
+ * Collect any comments inside a block node that appear after the body
+ * but before the closing }. These are typically trailing inline comments
+ * on the last body item. Returns the formatted comment lines.
  */
-function collectLeaves(node: SyntaxNode, out: SyntaxNode[]): void {
-  if (node.childCount === 0) {
-    out.push(node);
-    return;
-  }
+function collectBlockTrailingComments(
+  node: SyntaxNode, bodyEndRow: number, indent: number
+): string {
+  const comments: string[] = [];
+  let foundBody = false;
+  const openBrace = node.children.find(c => c.type === "{");
+  const openBraceRow = openBrace?.startPosition.row ?? -1;
+
   for (const child of node.children) {
-    collectLeaves(child, out);
+    if (child.type === "schema_body" || child.type === "mapping_body" ||
+        child.type === "metric_body" || child.type === "pipe_chain") {
+      foundBody = true;
+      continue;
+    }
+    if (foundBody && isComment(child)) {
+      // Skip comments already handled by the opening-brace inline logic
+      if (child.startPosition.row === openBraceRow) continue;
+
+      if (child.startPosition.row === bodyEndRow) {
+        // Trailing inline comment on last line of body
+        comments.push("  " + formatInlineComment(child));
+      } else {
+        comments.push("\n" + formatComment(child, indent + 1));
+      }
+    }
   }
+  return comments.join("");
+}
+
+/** Check if a field_decl is multi-line (has a { } body — record or list_of record). */
+function isMultiLineField(node: SyntaxNode): boolean {
+  return node.children.some(c => c.type === "{");
+}
+
+/** Get the field name text from a field_decl. */
+function fieldNameText(node: SyntaxNode): string {
+  const fn = findChild(node, "field_name");
+  if (!fn) return "";
+  const inner = fn.children[0];
+  return inner ? inner.text : "";
+}
+
+/** Get the display type string for a field_decl (for column alignment). */
+function fieldTypeText(node: SyntaxNode): string {
+  const hasListOf = node.children.some(c => c.type === "list_of");
+  const typeExpr = findChild(node, "type_expr");
+  const hasRecord = node.children.some(c => c.type === "record");
+
+  if (hasListOf && hasRecord) return "list_of record";
+  if (hasListOf && typeExpr) return "list_of " + typeExpr.text;
+  if (hasRecord) return "record";
+  if (typeExpr) return typeExpr.text;
+  return "";
+}
+
+// ── Source File ───────────────────────────────────────────────────────────────
+
+function formatSourceFile(root: SyntaxNode, source: string): string {
+  const children = root.children;
+  if (children.length === 0) return "";
+
+  const parts: string[] = [];
+  let prev: SyntaxNode | null = null;
+  let seenNonComment = false;
+
+  for (const child of children) {
+    if (prev !== null) {
+      parts.push(topLevelSep(prev, child, seenNonComment));
+    }
+    parts.push(formatTopLevel(child, source, 0));
+    prev = child;
+    if (!isComment(child)) seenNonComment = true;
+  }
+
+  return parts.join("");
+}
+
+function topLevelSep(prev: SyntaxNode, curr: SyntaxNode, seenNonComment: boolean): string {
+  // Import → Import: no blank line
+  if (isImport(prev) && isImport(curr)) return "\n";
+
+  // File header comments (before any non-comment)
+  if (!seenNonComment && isComment(prev)) {
+    if (isComment(curr)) return "\n";       // consecutive header comments
+    if (isImport(curr)) return "\n";        // header → imports: 0 blank lines
+    return "\n\n";                          // header → first block: 1 blank line
+  }
+
+  // Comment → non-comment: pull tight
+  if (isComment(prev) && !isComment(curr)) return "\n";
+
+  // Non-comment → comment: 2 blank lines (section break)
+  if (!isComment(prev) && isComment(curr)) return "\n\n\n";
+
+  // Comment → comment (between blocks): no blank line
+  if (isComment(prev) && isComment(curr)) return "\n";
+
+  // Block → Block (any combination): 2 blank lines
+  return "\n\n\n";
+}
+
+function formatTopLevel(node: SyntaxNode, source: string, indent: number): string {
+  switch (node.type) {
+    case "schema_block":    return formatSchemaBlock(node, source, indent);
+    case "fragment_block":  return formatFragmentBlock(node, source, indent);
+    case "mapping_block":   return formatMappingBlock(node, source, indent);
+    case "transform_block": return formatTransformBlock(node, source, indent);
+    case "metric_block":    return formatMetricBlock(node, source, indent);
+    case "note_block":      return formatNoteBlock(node, source, indent);
+    case "import_decl":     return formatImportDecl(node, source, indent);
+    case "namespace_block": return formatNamespaceBlock(node, source, indent);
+    case "comment":
+    case "warning_comment":
+    case "question_comment":
+      return formatComment(node, indent);
+    default:
+      // Fallback: reproduce source text
+      return node.text;
+  }
+}
+
+// ── Comments ──────────────────────────────────────────────────────────────────
+
+function formatComment(node: SyntaxNode, indent: number): string {
+  const text = node.text;
+  // Section-header comments (// --- ... ---) are preserved as-is
+  if (/^\/\/\s*---/.test(text)) return ind(indent) + text;
+
+  // Normalize: ensure single space after comment marker
+  const match = text.match(/^(\/\/[!?]?)\s*(.*)/);
+  if (match) {
+    const marker = match[1]!;
+    const body = match[2]!;
+    if (body.length === 0) return ind(indent) + marker;
+    return ind(indent) + marker + " " + body;
+  }
+  return ind(indent) + text;
+}
+
+function formatInlineComment(node: SyntaxNode): string {
+  const text = node.text;
+  if (/^\/\/\s*---/.test(text)) return text;
+  const match = text.match(/^(\/\/[!?]?)\s*(.*)/);
+  if (match) {
+    const marker = match[1]!;
+    const body = match[2]!;
+    if (body.length === 0) return marker;
+    return marker + " " + body;
+  }
+  return text;
+}
+
+// ── Schema Block ──────────────────────────────────────────────────────────────
+
+function formatSchemaBlock(node: SyntaxNode, source: string, indent: number): string {
+  const label = findChild(node, "block_label");
+  const meta = findChild(node, "metadata_block");
+  const body = findChild(node, "schema_body");
+
+  let line = ind(indent) + "schema " + formatBlockLabel(label!);
+  if (meta) line += " " + formatMetadataBlock(meta, source, indent);
+  line += " {";
+
+  if (!body || body.namedChildren.length === 0) {
+    const trailing = collectBlockTrailingComments(node, -1, indent);
+    return line + trailing + "\n" + ind(indent) + "}";
+  }
+
+  const bodyStr = formatSchemaBody(body, source, indent + 1);
+  const trailing = collectBlockTrailingComments(node, body.endPosition.row, indent);
+  return line + "\n" + bodyStr + trailing + "\n" + ind(indent) + "}";
+}
+
+// ── Fragment Block ────────────────────────────────────────────────────────────
+
+function formatFragmentBlock(node: SyntaxNode, source: string, indent: number): string {
+  const label = findChild(node, "block_label");
+  const body = findChild(node, "schema_body");
+
+  let line = ind(indent) + "fragment " + formatBlockLabel(label!);
+  line += " {";
+
+  if (!body || body.namedChildren.length === 0) {
+    const trailing = collectBlockTrailingComments(node, -1, indent);
+    return line + trailing + "\n" + ind(indent) + "}";
+  }
+
+  const bodyStr = formatSchemaBody(body, source, indent + 1);
+  const trailing = collectBlockTrailingComments(node, body.endPosition.row, indent);
+  return line + "\n" + bodyStr + trailing + "\n" + ind(indent) + "}";
+}
+
+// ── Block Label ───────────────────────────────────────────────────────────────
+
+function formatBlockLabel(node: SyntaxNode): string {
+  const inner = node.children[0];
+  if (!inner) return "";
+  return inner.text; // identifier or quoted_name
+}
+
+// ── Schema Body (field alignment) ─────────────────────────────────────────────
+
+function formatSchemaBody(body: SyntaxNode, source: string, indent: number): string {
+  const children = body.children;
+  if (children.length === 0) return "";
+
+  // Gather all single-line field_decls for alignment calculation
+  const singleLineFields: SyntaxNode[] = [];
+  for (const c of children) {
+    if (c.type === "field_decl" && !isMultiLineField(c)) {
+      singleLineFields.push(c);
+    }
+  }
+
+  // Calculate alignment columns from ALL single-line fields in the block
+  const { nameCol, typeCol, metaCol } = calcFieldAlignment(singleLineFields);
+
+  // Format each child in order with blank line preservation
+  const lines: string[] = [];
+  let prev: SyntaxNode | null = null;
+
+  for (const child of children) {
+    // Skip anonymous tokens (they're punctuation handled by parent)
+    if (!child.isNamed && !isComment(child)) continue;
+
+    // Blank line handling: preserve existing blank lines, normalize to 1
+    if (prev !== null && hasBlankBetween(prev, child)) {
+      lines.push("");
+    }
+
+    if (isComment(child)) {
+      // Check if this is a trailing inline comment (same line as previous)
+      if (prev !== null && sameLine(prev, child)) {
+        // Append to previous line with 2-space gap
+        const lastIdx = lines.length - 1;
+        if (lastIdx >= 0) {
+          lines[lastIdx] += "  " + formatInlineComment(child);
+          prev = child;
+          continue;
+        }
+      }
+      lines.push(formatComment(child, indent));
+    } else if (child.type === "field_decl") {
+      if (isMultiLineField(child)) {
+        lines.push(formatMultiLineField(child, source, indent));
+      } else {
+        lines.push(formatSingleLineField(child, source, indent, nameCol, typeCol, metaCol));
+      }
+    } else if (child.type === "fragment_spread") {
+      lines.push(formatFragmentSpread(child, indent));
+    }
+
+    prev = child;
+  }
+
+  return lines.join("\n");
+}
+
+interface FieldAlignment {
+  nameCol: number;   // max name width (capped)
+  typeCol: number;   // column where type starts (relative to indent)
+  metaCol: number;   // column where metadata starts (relative to indent)
+}
+
+function calcFieldAlignment(fields: SyntaxNode[]): FieldAlignment {
+  let maxName = 0;
+  let maxType = 0;
+
+  for (const f of fields) {
+    const name = fieldNameText(f);
+    const type = fieldTypeText(f);
+    if (name.length > maxName) maxName = name.length;
+    if (type.length > maxType) maxType = type.length;
+  }
+
+  const nameCol = Math.min(maxName, NAME_CAP);
+  const typeCol = nameCol + 2;
+  const typeWidth = Math.min(maxType, TYPE_CAP);
+  const metaCol = typeCol + typeWidth + 2;
+
+  return { nameCol, typeCol, metaCol };
+}
+
+function formatSingleLineField(
+  node: SyntaxNode, source: string, indent: number,
+  nameCol: number, typeCol: number, metaCol: number
+): string {
+  const name = fieldNameText(node);
+  const type = fieldTypeText(node);
+  const meta = findChild(node, "metadata_block");
+
+  // Name padding
+  const nameGap = Math.max(typeCol - name.length, 2);
+  let line = ind(indent) + name + " ".repeat(nameGap) + type;
+
+  if (meta) {
+    // Check if metadata should be multi-line (contains multiline_string)
+    if (hasMultilineString(meta)) {
+      line += " " + formatMetadataBlock(meta, source, indent);
+    } else {
+      const metaStr = formatMetadataInline(meta, source);
+      const typeGap = Math.max(metaCol - typeCol - type.length, 2);
+      line += " ".repeat(typeGap) + metaStr;
+    }
+  }
+
+  return line;
+}
+
+function formatMultiLineField(node: SyntaxNode, source: string, indent: number): string {
+  const name = fieldNameText(node);
+  const hasListOf = node.children.some(c => c.type === "list_of");
+  const hasRecord = node.children.some(c => c.type === "record");
+  const meta = findChild(node, "metadata_block");
+  const body = findChild(node, "schema_body");
+
+  let line = ind(indent) + name + " ";
+  if (hasListOf) line += "list_of ";
+  if (hasRecord) line += "record";
+
+  if (meta) {
+    line += " " + formatMetadataBlock(meta, source, indent);
+  }
+
+  line += " {";
+
+  // Collect inline comments between { and body (on same line as {)
+  const openBrace = node.children.find(c => c.type === "{");
+  if (openBrace) {
+    for (const child of node.children) {
+      if (isComment(child) && child.startPosition.row === openBrace.startPosition.row) {
+        line += "  " + formatInlineComment(child);
+      }
+    }
+  }
+
+  if (!body || body.namedChildren.length === 0) {
+    const trailing = collectBlockTrailingComments(node, openBrace?.startPosition.row ?? -1, indent);
+    return line + trailing + "\n" + ind(indent) + "}";
+  }
+
+  const bodyStr = formatSchemaBody(body, source, indent + 1);
+  const trailing = collectBlockTrailingComments(node, body.endPosition.row, indent);
+  return line + "\n" + bodyStr + trailing + "\n" + ind(indent) + "}";
+}
+
+// ── Fragment Spread ───────────────────────────────────────────────────────────
+
+function formatFragmentSpread(node: SyntaxNode, indent: number): string {
+  const label = findChild(node, "spread_label");
+  if (!label) return ind(indent) + node.text;
+
+  const inner = label.children[0];
+  if (!inner) return ind(indent) + "..." + label.text;
+
+  // spread_label can be: quoted_name, qualified_name, or _spread_words (multiple identifiers)
+  if (inner.type === "quoted_name") {
+    return ind(indent) + "..." + inner.text;
+  }
+  if (inner.type === "qualified_name") {
+    return ind(indent) + "..." + inner.text;
+  }
+  // _spread_words: multiple identifiers
+  const words = label.children.filter(c => c.type === "identifier").map(c => c.text);
+  return ind(indent) + "..." + words.join(" ");
+}
+
+// ── Mapping Block ─────────────────────────────────────────────────────────────
+
+function formatMappingBlock(node: SyntaxNode, source: string, indent: number): string {
+  const label = findChild(node, "block_label");
+  const meta = findChild(node, "metadata_block");
+  const body = findChild(node, "mapping_body");
+
+  let line = ind(indent) + "mapping";
+  if (label) line += " " + formatBlockLabel(label);
+  if (meta) line += " " + formatMetadataBlock(meta, source, indent);
+  line += " {";
+
+  if (!body) {
+    return line + "\n" + ind(indent) + "}";
+  }
+
+  return line + "\n" + formatMappingBody(body, source, indent + 1) + "\n" + ind(indent) + "}";
+}
+
+// ── Mapping Body ──────────────────────────────────────────────────────────────
+
+function formatMappingBody(body: SyntaxNode, source: string, indent: number): string {
+  const children = body.children;
+  const lines: string[] = [];
+  let prev: SyntaxNode | null = null;
+
+  for (const child of children) {
+    if (!child.isNamed && !isComment(child)) continue;
+
+    // Blank line preservation
+    if (prev !== null && hasBlankBetween(prev, child)) {
+      lines.push("");
+    }
+
+    if (isComment(child)) {
+      if (prev !== null && sameLine(prev, child)) {
+        const lastIdx = lines.length - 1;
+        if (lastIdx >= 0) {
+          lines[lastIdx] += "  " + formatInlineComment(child);
+          prev = child;
+          continue;
+        }
+      }
+      lines.push(formatComment(child, indent));
+    } else {
+      switch (child.type) {
+        case "source_block":
+          lines.push(formatSourceBlock(child, source, indent));
+          break;
+        case "target_block":
+          lines.push(formatTargetBlock(child, source, indent));
+          break;
+        case "map_arrow":
+          lines.push(formatMapArrow(child, source, indent));
+          break;
+        case "computed_arrow":
+          lines.push(formatComputedArrow(child, source, indent));
+          break;
+        case "nested_arrow":
+          lines.push(formatNestedArrow(child, source, indent));
+          break;
+        case "each_block":
+          lines.push(formatEachFlattenBlock(child, source, indent, "each"));
+          break;
+        case "flatten_block":
+          lines.push(formatEachFlattenBlock(child, source, indent, "flatten"));
+          break;
+        case "note_block":
+          lines.push(formatNoteBlock(child, source, indent));
+          break;
+        default:
+          lines.push(ind(indent) + child.text);
+      }
+    }
+    prev = child;
+  }
+
+  return lines.join("\n");
+}
+
+// ── Source/Target Blocks ──────────────────────────────────────────────────────
+
+function formatSourceBlock(node: SyntaxNode, source: string, indent: number): string {
+  const nlStrings = node.children.filter(c => c.type === "nl_string");
+
+  // Gather all content items: refs and nl_strings
+  const items: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "source_ref") {
+      items.push(formatSourceRef(child, source));
+    } else if (child.type === "nl_string") {
+      items.push(child.text);
+    }
+  }
+
+  if (items.length === 0) {
+    return ind(indent) + "source { }";
+  }
+
+  // Try single-line
+  const singleLine = ind(indent) + "source { " + items.join(", ") + " }";
+  if (singleLine.length <= 80 && !items.some(s => s.includes("\n"))) {
+    // For multi-ref sources, use multi-line
+    if (items.length <= 1 && nlStrings.length === 0) {
+      return singleLine;
+    }
+  }
+
+  // Multi-line
+  const inner = items.map(item => ind(indent + 1) + item).join("\n");
+  return ind(indent) + "source {\n" + inner + "\n" + ind(indent) + "}";
+}
+
+function formatTargetBlock(node: SyntaxNode, source: string, indent: number): string {
+
+  const items: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "source_ref") {
+      items.push(formatSourceRef(child, source));
+    }
+  }
+
+  if (items.length === 0) {
+    return ind(indent) + "target { }";
+  }
+
+  const singleLine = ind(indent) + "target { " + items[0] + " }";
+  if (singleLine.length <= 80 && items.length === 1) {
+    return singleLine;
+  }
+
+  const inner = items.map(item => ind(indent + 1) + item).join("\n");
+  return ind(indent) + "target {\n" + inner + "\n" + ind(indent) + "}";
+}
+
+function formatSourceRef(node: SyntaxNode, source: string): string {
+  const parts: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "metadata_block") {
+      parts.push(formatMetadataInline(child, source));
+    } else if (child.isNamed || child.type === "identifier" || child.type === "qualified_name" || child.type === "backtick_name" || child.type === "nl_string") {
+      parts.push(child.text);
+    }
+  }
+  return parts.join(" ");
+}
+
+// ── Arrows ────────────────────────────────────────────────────────────────────
+
+function formatMapArrow(node: SyntaxNode, source: string, indent: number): string {
+  const srcPath = findChild(node, "src_path");
+  const tgtPath = findChild(node, "tgt_path");
+  const meta = findChild(node, "metadata_block");
+  const pipeChain = findChild(node, "pipe_chain");
+
+  let line = ind(indent);
+  if (srcPath) line += formatPath(srcPath);
+  line += " -> " + formatPath(tgtPath!);
+
+  if (meta) line += " " + formatMetadataInline(meta, source);
+
+  if (pipeChain) {
+    const chainStr = formatPipeChain(pipeChain, source, indent);
+    // Check if inline transform fits on one line
+    const inlineCandidate = line + " { " + chainStr + " }";
+    if (isInlinePipeChain(pipeChain) && inlineCandidate.length <= 80) {
+      return inlineCandidate;
+    }
+    // Multi-line
+    return line + " {\n" + formatPipeChainMultiLine(pipeChain, source, indent + 1) + "\n" + ind(indent) + "}";
+  }
+
+  return line;
+}
+
+function formatComputedArrow(node: SyntaxNode, source: string, indent: number): string {
+  const tgtPath = findChild(node, "tgt_path");
+  const meta = findChild(node, "metadata_block");
+  const pipeChain = findChild(node, "pipe_chain");
+
+  let line = ind(indent) + "-> " + formatPath(tgtPath!);
+
+  if (meta) line += " " + formatMetadataInline(meta, source);
+
+  if (pipeChain) {
+    const chainStr = formatPipeChain(pipeChain, source, indent);
+    const inlineCandidate = line + " { " + chainStr + " }";
+    if (isInlinePipeChain(pipeChain) && inlineCandidate.length <= 80) {
+      return inlineCandidate;
+    }
+    return line + " {\n" + formatPipeChainMultiLine(pipeChain, source, indent + 1) + "\n" + ind(indent) + "}";
+  }
+
+  return line;
+}
+
+function formatNestedArrow(node: SyntaxNode, source: string, indent: number): string {
+  const srcPath = findChild(node, "src_path");
+  const tgtPath = findChild(node, "tgt_path");
+  const meta = findChild(node, "metadata_block");
+
+  let line = ind(indent) + formatPath(srcPath!) + " -> " + formatPath(tgtPath!);
+  if (meta) line += " " + formatMetadataInline(meta, source);
+
+  // Inner arrows
+  const innerArrows = node.children.filter(c =>
+    c.type === "map_arrow" || c.type === "computed_arrow" || c.type === "nested_arrow"
+  );
+
+  if (innerArrows.length === 0) {
+    return line + " { }";
+  }
+
+  const innerLines: string[] = [];
+  let prev: SyntaxNode | null = null;
+  for (const child of node.children) {
+    if (!child.isNamed && !isComment(child)) continue;
+    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block") continue;
+
+    if (prev !== null && hasBlankBetween(prev, child)) {
+      innerLines.push("");
+    }
+
+    if (isComment(child)) {
+      if (prev !== null && sameLine(prev, child)) {
+        const lastIdx = innerLines.length - 1;
+        if (lastIdx >= 0) {
+          innerLines[lastIdx] += "  " + formatInlineComment(child);
+          prev = child;
+          continue;
+        }
+      }
+      innerLines.push(formatComment(child, indent + 1));
+    } else if (child.type === "map_arrow") {
+      innerLines.push(formatMapArrow(child, source, indent + 1));
+    } else if (child.type === "computed_arrow") {
+      innerLines.push(formatComputedArrow(child, source, indent + 1));
+    } else if (child.type === "nested_arrow") {
+      innerLines.push(formatNestedArrow(child, source, indent + 1));
+    }
+    prev = child;
+  }
+
+  return line + " {\n" + innerLines.join("\n") + "\n" + ind(indent) + "}";
+}
+
+// ── Each/Flatten Blocks ───────────────────────────────────────────────────────
+
+function formatEachFlattenBlock(
+  node: SyntaxNode, source: string, indent: number, keyword: string
+): string {
+  const srcPath = findChild(node, "src_path");
+  const tgtPath = findChild(node, "tgt_path");
+  const meta = findChild(node, "metadata_block");
+
+  let line = ind(indent) + keyword + " " + formatPath(srcPath!) + " -> " + formatPath(tgtPath!);
+
+  if (meta) {
+    line += " " + formatMetadataBlock(meta, source, indent);
+  }
+
+  line += " {";
+
+  // Inner arrows
+  const innerLines: string[] = [];
+  let prev: SyntaxNode | null = null;
+
+  for (const child of node.children) {
+    if (!child.isNamed && !isComment(child)) continue;
+    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block") continue;
+    if (child.type === keyword) continue; // skip the keyword itself
+
+    if (prev !== null && hasBlankBetween(prev, child)) {
+      innerLines.push("");
+    }
+
+    if (isComment(child)) {
+      if (prev !== null && sameLine(prev, child)) {
+        const lastIdx = innerLines.length - 1;
+        if (lastIdx >= 0) {
+          innerLines[lastIdx] += "  " + formatInlineComment(child);
+          prev = child;
+          continue;
+        }
+      }
+      innerLines.push(formatComment(child, indent + 1));
+    } else if (child.type === "map_arrow") {
+      innerLines.push(formatMapArrow(child, source, indent + 1));
+    } else if (child.type === "computed_arrow") {
+      innerLines.push(formatComputedArrow(child, source, indent + 1));
+    } else if (child.type === "nested_arrow") {
+      innerLines.push(formatNestedArrow(child, source, indent + 1));
+    }
+    prev = child;
+  }
+
+  if (innerLines.length === 0) {
+    return line + "\n" + ind(indent) + "}";
+  }
+
+  return line + "\n" + innerLines.join("\n") + "\n" + ind(indent) + "}";
+}
+
+// ── Path Formatting ───────────────────────────────────────────────────────────
+
+function formatPath(node: SyntaxNode): string {
+  // Reconstruct path from children: identifiers, dots, backtick_names, ::
+  const parts: string[] = [];
+  for (const child of node.children) {
+    // The path node wraps a field_path, relative_field_path, namespaced_path, or backtick_path
+    if (child.childCount > 0) {
+      return formatPath(child);
+    }
+    parts.push(child.text);
+  }
+  return parts.join("");
+}
+
+// ── Pipe Chain ────────────────────────────────────────────────────────────────
+
+function isInlinePipeChain(node: SyntaxNode): boolean {
+  // A pipe chain is inline if it has no NL strings or multiline strings
+  for (const child of node.children) {
+    if (child.type === "pipe_step") {
+      const inner = child.children[0];
+      if (inner && (inner.type === "nl_string" || inner.type === "multiline_string")) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function formatPipeChain(node: SyntaxNode, source: string, indent: number): string {
+  // Inline format: step1 | step2 | step3
+  const steps: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "pipe_step") {
+      steps.push(formatPipeStep(child, source, indent));
+    }
+  }
+  return steps.join(" | ");
+}
+
+function formatPipeChainMultiLine(node: SyntaxNode, source: string, indent: number): string {
+  // Multi-line: each step on its own line, pipe continuation
+  const steps: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "pipe_step") {
+      steps.push(formatPipeStep(child, source, indent));
+    }
+  }
+
+  // First step at indent, subsequent with | prefix
+  const lines: string[] = [];
+  for (let i = 0; i < steps.length; i++) {
+    if (i === 0) {
+      lines.push(ind(indent) + steps[i]);
+    } else {
+      lines.push(ind(indent) + "| " + steps[i]);
+    }
+  }
+  return lines.join("\n");
+}
+
+function formatPipeStep(node: SyntaxNode, source: string, indent: number): string {
+  const inner = node.children[0];
+  if (!inner) return "";
+
+  switch (inner.type) {
+    case "nl_string":
+      return inner.text;
+    case "multiline_string":
+      return inner.text;
+    case "token_call":
+      return formatTokenCall(inner);
+    case "arithmetic_step":
+      return formatArithmeticStep(inner);
+    case "map_literal":
+      return formatMapLiteral(inner, source, indent);
+    case "fragment_spread":
+      return formatFragmentSpread(inner, 0).trimStart();
+    default:
+      return inner.text;
+  }
+}
+
+function formatTokenCall(node: SyntaxNode): string {
+  const name = findChild(node, "identifier");
+  if (!name) return node.text;
+
+  // Check for arguments
+  const hasParens = node.children.some(c => c.type === "(");
+  if (!hasParens) return name.text;
+
+  // Collect args
+  const args: string[] = [];
+  let inArgs = false;
+  for (const child of node.children) {
+    if (child.type === "(") { inArgs = true; continue; }
+    if (child.type === ")") break;
+    if (child.type === ",") continue;
+    if (inArgs && child.isNamed) {
+      args.push(child.text);
+    }
+  }
+
+  return name.text + "(" + args.join(", ") + ")";
+}
+
+function formatArithmeticStep(node: SyntaxNode): string {
+  // The operator (* / + -) is a hidden token, not a child node.
+  // Extract it from the node text: "* 100" or "/ 2" etc.
+  const num = findChild(node, "number_literal");
+  if (!num) return node.text;
+  // The operator is everything before the number in the node's source span
+  const opText = node.text.slice(0, node.text.indexOf(num.text)).trim();
+  return opText + " " + num.text;
+}
+
+function formatMapLiteral(node: SyntaxNode, source: string, indent: number): string {
+  const entries = findChildren(node, "map_entry");
+
+  if (entries.length === 0) return "map { }";
+
+  // Try single-line: map { key: val, key: val }
+  const entryStrs = entries.map(e => formatMapEntry(e));
+  const singleLine = "map { " + entryStrs.join(", ") + " }";
+  if (singleLine.length + ind(indent).length <= 80 && entries.length <= 3) {
+    return singleLine;
+  }
+
+  // Multi-line
+  const inner = entryStrs.map(e => ind(indent + 1) + e).join("\n");
+  return "map {\n" + inner + "\n" + ind(indent) + "}";
+}
+
+function formatMapEntry(node: SyntaxNode): string {
+  const key = findChild(node, "map_key");
+  const value = findChild(node, "map_value");
+  if (!key || !value) return node.text;
+
+  return formatMapKey(key) + ": " + value.text;
+}
+
+function formatMapKey(node: SyntaxNode): string {
+  // map_key children may be hidden (comparison ops, default, null, _).
+  // Use node.text directly — it always contains the correct key text.
+  return node.text.replace(/\s+/g, " ").trim();
+}
+
+// ── Transform Block ───────────────────────────────────────────────────────────
+
+function formatTransformBlock(node: SyntaxNode, source: string, indent: number): string {
+  const label = findChild(node, "block_label");
+  const pipeChain = findChild(node, "pipe_chain");
+
+  let line = ind(indent) + "transform " + formatBlockLabel(label!);
+
+  if (!pipeChain) {
+    return line + " { }";
+  }
+
+  // Try single-line
+  const chainStr = formatPipeChain(pipeChain, source, indent);
+  const singleLine = line + " { " + chainStr + " }";
+  if (isInlinePipeChain(pipeChain) && singleLine.length <= 80) {
+    return line + " {\n" + ind(indent + 1) + chainStr + "\n" + ind(indent) + "}";
+  }
+
+  return line + " {\n" + formatPipeChainMultiLine(pipeChain, source, indent + 1) + "\n" + ind(indent) + "}";
+}
+
+// ── Metric Block ──────────────────────────────────────────────────────────────
+
+function formatMetricBlock(node: SyntaxNode, source: string, indent: number): string {
+  const label = findChild(node, "block_label");
+  const displayName = findChild(node, "nl_string");
+  const meta = findChild(node, "metadata_block");
+  const body = findChild(node, "metric_body");
+
+  let line = ind(indent) + "metric " + formatBlockLabel(label!);
+  if (displayName) line += " " + displayName.text;
+  if (meta) line += " " + formatMetadataBlock(meta, source, indent);
+  line += " {";
+
+  // Metric body contains field_decls and note_blocks
+  if (!body) {
+    return line + "\n" + ind(indent) + "}";
+  }
+
+  const innerLines: string[] = [];
+  let prev: SyntaxNode | null = null;
+
+  // Gather fields for alignment
+  const fields = body.children.filter(c => c.type === "field_decl" && !isMultiLineField(c));
+  const { nameCol, typeCol, metaCol } = calcFieldAlignment(fields);
+
+  for (const child of body.children) {
+    if (!child.isNamed && !isComment(child)) continue;
+
+    if (prev !== null && hasBlankBetween(prev, child)) {
+      innerLines.push("");
+    }
+
+    if (isComment(child)) {
+      if (prev !== null && sameLine(prev, child)) {
+        const lastIdx = innerLines.length - 1;
+        if (lastIdx >= 0) {
+          innerLines[lastIdx] += "  " + formatInlineComment(child);
+          prev = child;
+          continue;
+        }
+      }
+      innerLines.push(formatComment(child, indent + 1));
+    } else if (child.type === "field_decl") {
+      if (isMultiLineField(child)) {
+        innerLines.push(formatMultiLineField(child, source, indent + 1));
+      } else {
+        innerLines.push(formatSingleLineField(child, source, indent + 1, nameCol, typeCol, metaCol));
+      }
+    } else if (child.type === "note_block") {
+      innerLines.push(formatNoteBlock(child, source, indent + 1));
+    }
+    prev = child;
+  }
+
+  return line + "\n" + innerLines.join("\n") + "\n" + ind(indent) + "}";
+}
+
+// ── Note Block ────────────────────────────────────────────────────────────────
+
+function formatNoteBlock(node: SyntaxNode, source: string, indent: number): string {
+  // note { "..." } or note { """...""" } or note { "line1" "line2" }
+  const strings: SyntaxNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "nl_string" || child.type === "multiline_string") {
+      strings.push(child);
+    }
+  }
+
+  if (strings.length === 0) {
+    return ind(indent) + "note { }";
+  }
+
+  // Single short string: try inline
+  if (strings.length === 1 && strings[0]!.type === "nl_string") {
+    const singleLine = ind(indent) + "note {\n" + ind(indent + 1) + strings[0]!.text + "\n" + ind(indent) + "}";
+    return singleLine;
+  }
+
+  // Multi-line: preserve string content verbatim
+  const inner = strings.map(s => {
+    if (s.type === "multiline_string") {
+      return formatMultilineString(s, indent + 1);
+    }
+    return ind(indent + 1) + s.text;
+  }).join("\n");
+
+  return ind(indent) + "note {\n" + inner + "\n" + ind(indent) + "}";
+}
+
+function formatMultilineString(node: SyntaxNode, indent: number): string {
+  // Triple-quoted strings: preserve content verbatim but fix delimiter indentation
+  const text = node.text;
+  // Split into lines
+  const lines = text.split("\n");
+  if (lines.length <= 1) return ind(indent) + text;
+
+  // The spec says: "Content inside strings is never modified."
+  // The triple-quoted string is a single token including delimiters and content.
+  // Preserve content verbatim — just output at the current indent position.
+  return ind(indent) + text;
+}
+
+// ── Import Declaration ────────────────────────────────────────────────────────
+
+function formatImportDecl(node: SyntaxNode, source: string, indent: number): string {
+  const names: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "import_name") {
+      names.push(formatImportName(child));
+    }
+  }
+
+  const path = findChild(node, "import_path");
+  const pathStr = path ? path.children[0]?.text || path.text : "";
+
+  return ind(indent) + "import { " + names.join(", ") + " } from " + pathStr;
+}
+
+function formatImportName(node: SyntaxNode): string {
+  const inner = node.children[0];
+  if (!inner) return node.text;
+  return inner.text;
+}
+
+// ── Namespace Block ───────────────────────────────────────────────────────────
+
+function formatNamespaceBlock(node: SyntaxNode, source: string, indent: number): string {
+  const name = node.children.find(c => c.type === "identifier");
+  const meta = findChild(node, "metadata_block");
+
+  let line = ind(indent) + "namespace " + (name?.text || "");
+  if (meta) line += " " + formatMetadataBlock(meta, source, indent);
+  line += " {";
+
+  // Inner items (schemas, mappings, etc.)
+  const innerItems: SyntaxNode[] = [];
+  let insideBody = false;
+  for (const child of node.children) {
+    if (child.type === "{") { insideBody = true; continue; }
+    if (child.type === "}") break;
+    if (insideBody && (child.isNamed || isComment(child))) {
+      innerItems.push(child);
+    }
+  }
+
+  if (innerItems.length === 0) {
+    return line + "\n" + ind(indent) + "}";
+  }
+
+  // Format inner items like a mini source_file
+  const innerParts: string[] = [];
+  let prev: SyntaxNode | null = null;
+  let seenNonComment = false;
+
+  for (const item of innerItems) {
+    if (prev !== null) {
+      innerParts.push(namespaceSep(prev, item, seenNonComment));
+    }
+    innerParts.push(formatTopLevel(item, source, indent + 1));
+    prev = item;
+    if (!isComment(item)) seenNonComment = true;
+  }
+
+  return line + "\n" + innerParts.join("") + "\n" + ind(indent) + "}";
+}
+
+function namespaceSep(prev: SyntaxNode, curr: SyntaxNode, _seenNonComment: boolean): string {
+  // Within namespaces, use 1 blank line between blocks
+  if (isComment(prev) && !isComment(curr)) return "\n";
+  if (!isComment(prev) && isComment(curr)) return "\n\n";
+  if (isComment(prev) && isComment(curr)) return "\n";
+  return "\n\n";
+}
+
+// ── Metadata Block ────────────────────────────────────────────────────────────
+
+function hasMultilineString(node: SyntaxNode): boolean {
+  for (const child of node.children) {
+    if (child.type === "multiline_string") return true;
+    if (child.type === "note_tag") {
+      for (const inner of child.children) {
+        if (inner.type === "multiline_string") return true;
+      }
+    }
+    if (child.childCount > 0 && hasMultilineString(child)) return true;
+  }
+  return false;
+}
+
+function formatMetadataBlock(node: SyntaxNode, source: string, indent: number): string {
+  const entries = collectMetadataEntries(node, source);
+
+  if (entries.length === 0) return "()";
+
+  // Check if any entry has a multiline string
+  if (hasMultilineString(node)) {
+    return formatMetadataMultiLine(entries, node, source, indent);
+  }
+
+  // Try single-line
+  const singleLine = "(" + entries.join(", ") + ")";
+  if (singleLine.length + ind(indent).length + 20 <= 80) { // rough line length check
+    return singleLine;
+  }
+
+  // Multi-line
+  return formatMetadataMultiLine(entries, node, source, indent);
+}
+
+function formatMetadataInline(node: SyntaxNode, source: string): string {
+  const entries = collectMetadataEntries(node, source);
+  return "(" + entries.join(", ") + ")";
+}
+
+function formatMetadataMultiLine(
+  entries: string[], node: SyntaxNode, source: string, indent: number
+): string {
+  if (entries.length === 0) return "()";
+
+  const lines: string[] = ["("];
+  for (let i = 0; i < entries.length; i++) {
+    const comma = i < entries.length - 1 ? "," : "";
+    lines.push(ind(indent + 1) + entries[i]! + comma);
+  }
+  lines.push(ind(indent) + ")");
+  return lines.join("\n");
+}
+
+function collectMetadataEntries(node: SyntaxNode, source: string): string[] {
+  const entries: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "(" || child.type === ")" || child.type === ",") continue;
+    if (isComment(child)) continue;
+    entries.push(formatMetadataEntry(child, source));
+  }
+  return entries;
+}
+
+function formatMetadataEntry(node: SyntaxNode, source: string): string {
+  switch (node.type) {
+    case "tag_token": {
+      const id = findChild(node, "identifier");
+      return id ? id.text : node.text;
+    }
+    case "key_value_pair": {
+      return formatKeyValuePair(node, source);
+    }
+    case "note_tag": {
+      return formatNoteTag(node, source);
+    }
+    case "enum_body": {
+      return formatEnumBody(node);
+    }
+    case "slice_body": {
+      return formatSliceBody(node);
+    }
+    default:
+      return node.text;
+  }
+}
+
+function formatKeyValuePair(node: SyntaxNode, source: string): string {
+  const key = findChild(node, "kv_key");
+  const keyText = key ? key.children[0]?.text || key.text : "";
+
+  // Value is everything after the key
+  const valueParts: string[] = [];
+  let pastKey = false;
+  for (const child of node.children) {
+    if (child.type === "kv_key") { pastKey = true; continue; }
+    if (pastKey) {
+      if (child.type === "kv_braced_list") {
+        valueParts.push(formatKvBracedList(child));
+      } else if (child.type === "kv_comparison") {
+        valueParts.push(formatKvComparison(child));
+      } else if (child.type === "kv_compound") {
+        valueParts.push(formatKvCompound(child));
+      } else if (child.type === "kv_ref_on") {
+        valueParts.push(formatKvRefOn(child));
+      } else {
+        valueParts.push(child.text);
+      }
+    }
+  }
+
+  return keyText + " " + valueParts.join(" ");
+}
+
+function formatNoteTag(node: SyntaxNode, source: string): string {
+  // note "string" or note """multiline"""
+  for (const child of node.children) {
+    if (child.type === "nl_string") return "note " + child.text;
+    if (child.type === "multiline_string") return "note " + child.text;
+  }
+  return "note";
+}
+
+function formatEnumBody(node: SyntaxNode): string {
+  const items: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "enum" || child.type === "{" || child.type === "}" || child.type === ",") continue;
+    items.push(child.text);
+  }
+  return "enum {" + items.join(", ") + "}";
+}
+
+function formatSliceBody(node: SyntaxNode): string {
+  const items: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "slice" || child.type === "{" || child.type === "}" || child.type === ",") continue;
+    if (child.type === "identifier") items.push(child.text);
+  }
+  return "slice {" + items.join(", ") + "}";
+}
+
+function formatKvBracedList(node: SyntaxNode): string {
+  const items: string[] = [];
+  for (const child of node.children) {
+    if (child.type === "{" || child.type === "}" || child.type === ",") continue;
+    items.push(child.text);
+  }
+  return "{" + items.join(", ") + "}";
+}
+
+function formatKvComparison(node: SyntaxNode): string {
+  // The comparison operator (!=, ==, >=, etc.) is a hidden token.
+  // Use node.text directly and normalize whitespace.
+  return node.text.replace(/\s+/g, " ").trim();
+}
+
+function formatKvCompound(node: SyntaxNode): string {
+  return node.text.replace(/\s+/g, " ").trim();
+}
+
+function formatKvRefOn(node: SyntaxNode): string {
+  return node.text.replace(/\s+/g, " ").trim();
 }

--- a/tooling/satsuma-cli/src/format.ts
+++ b/tooling/satsuma-cli/src/format.ts
@@ -893,7 +893,7 @@ function formatTransformBlock(node: SyntaxNode, source: string, indent: number):
   const label = findChild(node, "block_label");
   const pipeChain = findChild(node, "pipe_chain");
 
-  let line = ind(indent) + "transform " + formatBlockLabel(label!);
+  const line = ind(indent) + "transform " + formatBlockLabel(label!);
 
   if (!pipeChain) {
     return line + " { }";
@@ -1170,7 +1170,7 @@ function formatMetadataEntry(node: SyntaxNode, source: string): string {
   }
 }
 
-function formatKeyValuePair(node: SyntaxNode, source: string): string {
+function formatKeyValuePair(node: SyntaxNode, _source: string): string {
   const key = findChild(node, "kv_key");
   const keyText = key ? key.children[0]?.text || key.text : "";
 
@@ -1197,7 +1197,7 @@ function formatKeyValuePair(node: SyntaxNode, source: string): string {
   return keyText + " " + valueParts.join(" ");
 }
 
-function formatNoteTag(node: SyntaxNode, source: string): string {
+function formatNoteTag(node: SyntaxNode, _source: string): string {
   // note "string" or note """multiline"""
   for (const child of node.children) {
     if (child.type === "nl_string") return "note " + child.text;

--- a/tooling/satsuma-cli/src/format.ts
+++ b/tooling/satsuma-cli/src/format.ts
@@ -1,0 +1,62 @@
+/**
+ * format.ts — Satsuma formatter core
+ *
+ * Pure function: takes a tree-sitter Tree and the original source string,
+ * returns the formatted string. No I/O, no configuration, no side effects.
+ *
+ * The formatter walks the full CST (node.children, not just namedChildren)
+ * to preserve comments and all anonymous tokens (punctuation, keywords).
+ *
+ * Current phase: pass-through baseline — reproduces the original source
+ * by collecting leaf nodes and emitting inter-node gaps from the source.
+ * Subsequent tickets layer formatting rules on top of this walk.
+ */
+
+import type { SyntaxNode, Tree } from "./types.js";
+
+/**
+ * Format a Satsuma source string given its tree-sitter parse tree.
+ *
+ * @param tree  - tree-sitter Tree (must still be valid / not reused)
+ * @param source - the original source text that was parsed
+ * @returns the formatted source string
+ */
+export function format(tree: Tree, source: string): string {
+  const leaves: SyntaxNode[] = [];
+  collectLeaves(tree.rootNode, leaves);
+
+  let result = "";
+  let pos = 0;
+
+  for (const leaf of leaves) {
+    // Emit the gap between the previous token and this one (whitespace, newlines)
+    if (leaf.startIndex > pos) {
+      result += source.slice(pos, leaf.startIndex);
+    }
+    // Emit the leaf token text
+    result += leaf.text;
+    pos = leaf.endIndex;
+  }
+
+  // Emit any trailing content after the last leaf (e.g. final newline)
+  if (pos < source.length) {
+    result += source.slice(pos);
+  }
+
+  return result;
+}
+
+/**
+ * Recursively collect all leaf nodes from the CST in document order.
+ * Walks node.children (all children, including anonymous tokens and comments)
+ * rather than namedChildren, so nothing is skipped.
+ */
+function collectLeaves(node: SyntaxNode, out: SyntaxNode[]): void {
+  if (node.childCount === 0) {
+    out.push(node);
+    return;
+  }
+  for (const child of node.children) {
+    collectLeaves(child, out);
+  }
+}

--- a/tooling/satsuma-cli/src/index.ts
+++ b/tooling/satsuma-cli/src/index.ts
@@ -56,6 +56,7 @@ const commands = [
   "commands/graph.js",
   "commands/lint.js",
   "commands/agent-reference.js",
+  "commands/fmt.js",
 ];
 
 for (const cmd of commands) {

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -18,6 +18,8 @@ export interface SyntaxNode {
   parent: SyntaxNode | null;
   startPosition: { row: number; column: number };
   endPosition: { row: number; column: number };
+  startIndex: number;
+  endIndex: number;
   isMissing: boolean;
 }
 

--- a/tooling/satsuma-cli/test/format.test.js
+++ b/tooling/satsuma-cli/test/format.test.js
@@ -328,4 +328,129 @@ describe("edge cases", () => {
     assert.ok(out.includes("< 1000"), "should preserve comparison key");
     assert.ok(out.includes("default"), "should preserve default key");
   });
+
+  it("handles list_of scalar fields in alignment", () => {
+    const src = `schema test {
+  id INT (pk)
+  tags list_of STRING
+  codes list_of INT (required)
+}`;
+    const out = fmt(src);
+    // list_of fields participate in alignment
+    assert.ok(out.includes("tags   list_of STRING") || out.includes("tags  list_of STRING"));
+    assert.ok(out.includes("codes  list_of INT"));
+  });
+
+  it("handles namespace blocks", () => {
+    const src = `namespace myns (note "Test namespace") {
+  schema inner { x INT }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes('namespace myns (note "Test namespace") {'));
+    assert.ok(out.includes("  schema inner {"));
+  });
+
+  it("handles multi-line metadata on blocks", () => {
+    const src = `schema test (
+  format postgresql,
+  note "A long description"
+) {
+  id INT (pk)
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("schema test ("));
+    assert.ok(out.includes("format postgresql,"));
+    assert.ok(out.includes(") {"));
+  });
+
+  it("handles each/flatten blocks", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  each s.items -> t.items {
+    .sku -> .sku { trim }
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("each s.items -> t.items {"));
+    assert.ok(out.includes("  .sku -> .sku { trim }"));
+  });
+
+  it("handles metric block with display name and metadata", () => {
+    const src = `metric mrr "MRR" (source subs, grain monthly) {
+  value DECIMAL(14,2) (measure additive)
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes('metric mrr "MRR"'));
+    assert.ok(out.includes("value  DECIMAL(14,2)  (measure additive)"));
+  });
+
+  it("handles multi-source blocks", () => {
+    const src = `mapping test {
+  source {
+    schema_a
+    schema_b
+    "join condition"
+  }
+  target { t }
+  a.x -> t.x
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("source {"));
+    assert.ok(out.includes("  schema_a"));
+    assert.ok(out.includes("  schema_b"));
+  });
+
+  it("handles quoted block labels", () => {
+    const src = `schema 'my schema' { x INT }`;
+    const out = fmt(src);
+    assert.ok(out.includes("schema 'my schema' {"));
+  });
+
+  it("handles backtick field names in alignment", () => {
+    const src = `schema test {
+  \`special_field\` INT
+  normal STRING
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("`special_field`"));
+  });
+
+  it("handles inline map on single line", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  s.x -> t.y { map { A: "active", I: "inactive" } }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("map {") && out.includes("}"));
+  });
+
+  it("preserves NL string content verbatim", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  -> t.x {
+    "Complex NL: use \`field_a\` + \`field_b\`. Handle edge cases."
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("`field_a`"));
+    assert.ok(out.includes("`field_b`"));
+  });
+});
+
+// ── Golden Fixture Tests ─────────────────────────────────────────────────────
+
+describe("golden fixture round-trip (all corpus)", () => {
+  const stmFiles = readdirSync(examplesDir).filter(f => f.endsWith(".stm"));
+
+  for (const file of stmFiles) {
+    it(`format(parse(examples/${file})) parses without errors`, () => {
+      const src = readFileSync(join(examplesDir, file), "utf8");
+      const out = fmt(src);
+      const { errorCount } = parseSource(out);
+      assert.equal(errorCount, 0, `formatted output should parse cleanly`);
+    });
+  }
 });

--- a/tooling/satsuma-cli/test/format.test.js
+++ b/tooling/satsuma-cli/test/format.test.js
@@ -1,0 +1,106 @@
+/**
+ * format.test.js — Unit tests for the core formatter.
+ *
+ * Phase 1 (scaffolding): verifies that the pass-through CST walk
+ * reproduces the original source exactly for various inputs.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { format } from "../dist/format.js";
+import { parseSource } from "../dist/parser.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(__dirname, "../../../examples");
+
+// ── Pass-through round-trip tests ────────────────────────────────────────────
+
+describe("format (pass-through)", () => {
+  it("reproduces a simple schema block", () => {
+    const src = `schema foo {
+  id    INT    (pk)
+  name  STRING
+}
+`;
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  it("reproduces a file with comments", () => {
+    const src = `// Header comment
+//! Doc comment
+
+schema bar {
+  // field comment
+  x  INT
+}
+`;
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  it("reproduces an empty input", () => {
+    const src = "";
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  it("reproduces a file with multiple blocks and blank lines", () => {
+    const src = `schema a {
+  x  INT
+}
+
+
+schema b {
+  y  STRING
+}
+`;
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  it("reproduces a mapping block with arrows", () => {
+    const src = `mapping my_map {
+  source { src_schema }
+  target { tgt_schema }
+
+  src_schema.id -> id
+  src_schema.name -> name { trim }
+}
+`;
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  it("reproduces a fragment with spreads", () => {
+    const src = `fragment 'audit columns' {
+  created_at  TIMESTAMPTZ  (required)
+  updated_at  TIMESTAMPTZ
+}
+
+schema orders {
+  id  INT  (pk)
+  ...'audit columns'
+}
+`;
+    const { tree } = parseSource(src);
+    assert.equal(format(tree, src), src);
+  });
+
+  // ── Corpus round-trip tests ──────────────────────────────────────────────
+
+  describe("corpus round-trip", () => {
+    const stmFiles = readdirSync(examplesDir).filter(f => f.endsWith(".stm"));
+
+    for (const file of stmFiles) {
+      it(`round-trips examples/${file}`, () => {
+        const src = readFileSync(join(examplesDir, file), "utf8");
+        const { tree } = parseSource(src);
+        assert.equal(format(tree, src), src);
+      });
+    }
+  });
+});

--- a/tooling/satsuma-cli/test/format.test.js
+++ b/tooling/satsuma-cli/test/format.test.js
@@ -1,8 +1,10 @@
 /**
  * format.test.js — Unit tests for the core formatter.
  *
- * Phase 1 (scaffolding): verifies that the pass-through CST walk
- * reproduces the original source exactly for various inputs.
+ * Tests cover:
+ * - Idempotency: format(format(x)) === format(x) for all corpus files
+ * - Structural equivalence: parse tree is preserved after formatting
+ * - Specific formatting rules: alignment, comments, blank lines, etc.
  */
 
 import assert from "node:assert/strict";
@@ -16,91 +18,314 @@ import { parseSource } from "../dist/parser.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const examplesDir = join(__dirname, "../../../examples");
 
-// ── Pass-through round-trip tests ────────────────────────────────────────────
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
-describe("format (pass-through)", () => {
-  it("reproduces a simple schema block", () => {
-    const src = `schema foo {
-  id    INT    (pk)
-  name  STRING
-}
-`;
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
-
-  it("reproduces a file with comments", () => {
-    const src = `// Header comment
-//! Doc comment
-
-schema bar {
-  // field comment
-  x  INT
-}
-`;
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
-
-  it("reproduces an empty input", () => {
-    const src = "";
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
-
-  it("reproduces a file with multiple blocks and blank lines", () => {
-    const src = `schema a {
-  x  INT
+function fmt(src) {
+  const { tree } = parseSource(src);
+  return format(tree, src);
 }
 
-
-schema b {
-  y  STRING
-}
-`;
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
-
-  it("reproduces a mapping block with arrows", () => {
-    const src = `mapping my_map {
-  source { src_schema }
-  target { tgt_schema }
-
-  src_schema.id -> id
-  src_schema.name -> name { trim }
-}
-`;
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
-
-  it("reproduces a fragment with spreads", () => {
-    const src = `fragment 'audit columns' {
-  created_at  TIMESTAMPTZ  (required)
-  updated_at  TIMESTAMPTZ
+function structureOf(node) {
+  if (node.childCount === 0) {
+    if (node.isNamed) return node.type + "=" + JSON.stringify(node.text);
+    return null;
+  }
+  const kids = [];
+  for (const c of node.children) {
+    const s = structureOf(c);
+    if (s !== null) kids.push(s);
+  }
+  return node.type + "(" + kids.join(",") + ")";
 }
 
-schema orders {
-  id  INT  (pk)
-  ...'audit columns'
-}
-`;
-    const { tree } = parseSource(src);
-    assert.equal(format(tree, src), src);
-  });
+// ── Corpus Round-Trip (Idempotency + Structural Equivalence) ─────────────────
 
-  // ── Corpus round-trip tests ──────────────────────────────────────────────
+describe("corpus round-trip", () => {
+  const stmFiles = readdirSync(examplesDir).filter(f => f.endsWith(".stm"));
 
-  describe("corpus round-trip", () => {
-    const stmFiles = readdirSync(examplesDir).filter(f => f.endsWith(".stm"));
+  for (const file of stmFiles) {
+    describe(`examples/${file}`, () => {
+      const src = readFileSync(join(examplesDir, file), "utf8");
 
-    for (const file of stmFiles) {
-      it(`round-trips examples/${file}`, () => {
-        const src = readFileSync(join(examplesDir, file), "utf8");
-        const { tree } = parseSource(src);
-        assert.equal(format(tree, src), src);
+      it("is idempotent", () => {
+        const out1 = fmt(src);
+        const out2 = fmt(out1);
+        assert.equal(out1, out2, "format(format(x)) should equal format(x)");
       });
+
+      it("preserves parse tree structure", () => {
+        const { tree: tree1 } = parseSource(src);
+        const out = fmt(src);
+        const { tree: tree2 } = parseSource(out);
+        assert.equal(
+          structureOf(tree1.rootNode),
+          structureOf(tree2.rootNode),
+          "parse trees should be structurally identical"
+        );
+      });
+    });
+  }
+});
+
+// ── Field Alignment ──────────────────────────────────────────────────────────
+
+describe("field alignment", () => {
+  it("aligns name and type columns based on max widths", () => {
+    const src = `schema test {
+  id INT (pk)
+  long_name STRING
+}`;
+    const out = fmt(src);
+    const lines = out.split("\n");
+    // max_name = 9 ("long_name"), type_col = 11
+    assert.match(lines[1], /^  id         INT/);
+    assert.match(lines[2], /^  long_name  STRING/);
+  });
+
+  it("aligns metadata column", () => {
+    const src = `schema test {
+      alpha2 STRING(2) (pk)
+      name STRING(100)
+    }`;
+    const out = fmt(src);
+    const lines = out.split("\n");
+    assert.match(lines[1], /^  alpha2  STRING\(2\)\s+\(pk\)/);
+  });
+
+  it("does not align multi-line record fields", () => {
+    const src = `schema test {
+  id INT (pk)
+  addr record {
+    line1 STRING
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("addr record {"), "record field should use minimal spacing");
+  });
+
+  it("handles fragment spreads as non-aligned standalone lines", () => {
+    const src = `schema test {
+  id INT (pk)
+  ...'audit fields'
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("  ...'audit fields'"), "spread should be at block indent");
+  });
+});
+
+// ── Comments ─────────────────────────────────────────────────────────────────
+
+describe("comments", () => {
+  it("preserves all three comment types", () => {
+    const src = `// regular
+//! warning
+//? question
+schema test {
+  x INT
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("// regular"));
+    assert.ok(out.includes("//! warning"));
+    assert.ok(out.includes("//? question"));
+  });
+
+  it("normalizes space after comment marker", () => {
+    const src = `//no space
+//!no space
+//?no space
+schema test { x INT }`;
+    const out = fmt(src);
+    assert.ok(out.includes("// no space"));
+    assert.ok(out.includes("//! no space"));
+    assert.ok(out.includes("//? no space"));
+  });
+
+  it("preserves section-header comments as-is", () => {
+    const src = `schema a { x INT }
+
+// --- Section ---
+
+schema b { y STRING }`;
+    const out = fmt(src);
+    assert.ok(out.includes("// --- Section ---"));
+  });
+
+  it("preserves trailing inline comments", () => {
+    const src = `schema test {
+  x INT  // trailing comment
+  y STRING
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("INT") && out.includes("// trailing comment"));
+    // Check 2-space minimum gap
+    const line = out.split("\n").find(l => l.includes("trailing comment"));
+    assert.ok(line);
+    assert.match(line, /\S  \/\/ trailing comment/);
+  });
+});
+
+// ── Blank Lines ──────────────────────────────────────────────────────────────
+
+describe("blank lines", () => {
+  it("puts 2 blank lines between top-level blocks", () => {
+    const src = `schema a { x INT }
+schema b { y STRING }`;
+    const out = fmt(src);
+    assert.ok(out.includes("}\n\n\nschema b"), "should have 2 blank lines between blocks");
+  });
+
+  it("no blank lines between consecutive imports", () => {
+    const src = `import { foo } from "a.stm"
+import { bar } from "b.stm"`;
+    const out = fmt(src);
+    assert.ok(out.includes('"a.stm"\nimport'));
+  });
+
+  it("file ends with single newline", () => {
+    const src = `schema test {
+  x INT
+}
+
+
+`;
+    const out = fmt(src);
+    assert.ok(out.endsWith("}\n"), "should end with single newline");
+    assert.ok(!out.endsWith("}\n\n"), "should not have trailing blank lines");
+  });
+
+  it("preserves blank lines within blocks (normalized to 1)", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+
+
+
+  s.x -> t.y
+}`;
+    const out = fmt(src);
+    // Multiple blank lines should normalize to 1
+    assert.ok(!out.includes("\n\n\n  s.x"), "should not have 2+ blank lines within block");
+    assert.ok(out.includes("}\n\n  s.x"), "should preserve 1 blank line");
+  });
+});
+
+// ── Mapping Formatting ───────────────────────────────────────────────────────
+
+describe("mapping formatting", () => {
+  it("formats simple arrows", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  s.id   ->   t.id
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("s.id -> t.id"), "should normalize arrow spacing");
+  });
+
+  it("formats inline transforms", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  s.x -> t.x {   trim  |  lowercase  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("{ trim | lowercase }"), "should normalize pipe spacing");
+  });
+
+  it("formats computed arrows", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  -> t.computed { "NL description." }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("-> t.computed"));
+  });
+});
+
+// ── Transform, Metric, Note, Import ──────────────────────────────────────────
+
+describe("transform formatting", () => {
+  it("formats transform block", () => {
+    const src = `transform my_transform {
+  trim | lowercase
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("transform my_transform {"));
+    assert.ok(out.includes("  trim | lowercase"));
+  });
+});
+
+describe("import formatting", () => {
+  it("formats import declaration", () => {
+    const src = `import { foo, bar } from "lib.stm"`;
+    const out = fmt(src);
+    assert.equal(out.trim(), 'import { foo, bar } from "lib.stm"');
+  });
+});
+
+describe("note formatting", () => {
+  it("formats note with triple-quoted string", () => {
+    const src = `note {
+  """
+  Some content.
+  """
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("note {"));
+    assert.ok(out.includes('"""'));
+  });
+});
+
+// ── Edge Cases ───────────────────────────────────────────────────────────────
+
+describe("edge cases", () => {
+  it("handles empty input", () => {
+    assert.equal(fmt(""), "\n");
+  });
+
+  it("handles empty blocks", () => {
+    const src = `schema empty { }`;
+    const out = fmt(src);
+    assert.ok(out.includes("schema empty {"));
+  });
+
+  it("handles deeply nested records", () => {
+    const src = `schema test {
+  outer record {
+    inner record {
+      x INT
     }
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("    inner record {"));
+    assert.ok(out.includes("      x  INT"));
+  });
+
+  it("handles arithmetic steps in pipe chains", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  s.x -> t.y { coalesce(0) | * 100 | round }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("* 100"), "should preserve arithmetic operator");
+  });
+
+  it("handles map literals with comparison keys", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  s.x -> t.y {
+    map {
+      < 1000: "low"
+      default: "high"
+    }
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("< 1000"), "should preserve comparison key");
+    assert.ok(out.includes("default"), "should preserve default key");
   });
 });

--- a/tooling/satsuma-cli/test/format.test.js
+++ b/tooling/satsuma-cli/test/format.test.js
@@ -78,8 +78,8 @@ describe("field alignment", () => {
     const out = fmt(src);
     const lines = out.split("\n");
     // max_name = 9 ("long_name"), type_col = 11
-    assert.match(lines[1], /^  id         INT/);
-    assert.match(lines[2], /^  long_name  STRING/);
+    assert.match(lines[1], /^ {2}id {9}INT/);
+    assert.match(lines[2], /^ {2}long_name {2}STRING/);
   });
 
   it("aligns metadata column", () => {
@@ -89,7 +89,7 @@ describe("field alignment", () => {
     }`;
     const out = fmt(src);
     const lines = out.split("\n");
-    assert.match(lines[1], /^  alpha2  STRING\(2\)\s+\(pk\)/);
+    assert.match(lines[1], /^ {2}alpha2 {2}STRING\(2\)\s+\(pk\)/);
   });
 
   it("does not align multi-line record fields", () => {
@@ -160,7 +160,7 @@ schema b { y STRING }`;
     // Check 2-space minimum gap
     const line = out.split("\n").find(l => l.includes("trailing comment"));
     assert.ok(line);
-    assert.match(line, /\S  \/\/ trailing comment/);
+    assert.match(line, /\S {2}\/\/ trailing comment/);
   });
 });
 

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -23,6 +23,11 @@ const serverConfig = {
   outfile: "server/dist/server.js",
   format: "cjs",
   sourcemap: true,
+  alias: {
+    // Resolve the shared formatter from the CLI package source.
+    // esbuild bundles the .ts file directly — no pre-build step needed.
+    "satsuma-fmt": "../satsuma-cli/src/format.ts",
+  },
 };
 
 /** @type {import("esbuild").BuildOptions} */

--- a/tooling/vscode-satsuma/server/src/formatting.ts
+++ b/tooling/vscode-satsuma/server/src/formatting.ts
@@ -34,7 +34,10 @@ try {
 /** Initialize the formatting module. Call in test setup to load the format function. */
 export async function initFormatting(): Promise<void> {
   if (_formatFn) return;
-  const mod = await import("../../../satsuma-cli/dist/format.js") as { format: FormatFn };
+  // Use a variable path so esbuild doesn't try to resolve this at bundle time.
+  // This path is only used by tests running against tsc-compiled dist/ output.
+  const modPath = ["../../../satsuma-cli", "dist", "format.js"].join("/");
+  const mod = await import(modPath) as { format: FormatFn };
   _formatFn = mod.format;
 }
 

--- a/tooling/vscode-satsuma/server/src/formatting.ts
+++ b/tooling/vscode-satsuma/server/src/formatting.ts
@@ -1,0 +1,70 @@
+/**
+ * formatting.ts — DocumentFormattingProvider for Satsuma LSP server
+ *
+ * Wires the shared format() function into the LSP formatting handler.
+ * Returns a single TextEdit replacing the full document range.
+ *
+ * The canonical format() implementation lives in satsuma-cli/src/format.ts.
+ * The esbuild bundler inlines it into server.js at build time.
+ * For tsc-compiled tests, we load the CLI's compiled ESM module via
+ * dynamic import (cached after first call).
+ */
+
+import { TextEdit, Range, Position } from "vscode-languageserver";
+import type { Tree } from "./parser-utils";
+
+type FormatFn = (tree: unknown, source: string) => string;
+
+let _formatFn: FormatFn | null = null;
+
+async function getFormatFn(): Promise<FormatFn> {
+  if (_formatFn) return _formatFn;
+  // Dynamic import works for both CJS test runner and esbuild bundler
+  const mod = await import("../../../satsuma-cli/dist/format.js") as { format: FormatFn };
+  _formatFn = mod.format;
+  return _formatFn;
+}
+
+// Synchronous accessor — only works after init() has been called
+function getFormatFnSync(): FormatFn {
+  if (!_formatFn) {
+    // Fallback: try require (works in esbuild bundle where it's inlined)
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require("../../../satsuma-cli/src/format.js") as { format: FormatFn };
+      _formatFn = mod.format;
+    } catch {
+      throw new Error("Format function not initialized — call initFormatting() first");
+    }
+  }
+  return _formatFn;
+}
+
+/** Initialize the formatting module. Call once during server startup. */
+export async function initFormatting(): Promise<void> {
+  await getFormatFn();
+}
+
+/**
+ * Compute formatting edits for a Satsuma document.
+ * Returns a single TextEdit replacing the entire document if formatting
+ * would change anything, or an empty array if already formatted.
+ */
+export function computeFormatting(tree: Tree, source: string): TextEdit[] {
+  const formatFn = getFormatFnSync();
+  const formatted = formatFn(tree, source);
+
+  if (formatted === source) {
+    return []; // Already formatted — no edits needed
+  }
+
+  // Replace the entire document
+  const lines = source.split("\n");
+  const lastLine = lines[lines.length - 1] ?? "";
+  const fullRange = Range.create(
+    Position.create(0, 0),
+    Position.create(lines.length - 1, lastLine.length),
+  );
+
+  return [TextEdit.replace(fullRange, formatted)];
+}

--- a/tooling/vscode-satsuma/server/src/formatting.ts
+++ b/tooling/vscode-satsuma/server/src/formatting.ts
@@ -36,6 +36,7 @@ export async function initFormatting(): Promise<void> {
   if (_formatFn) return;
   // Use a variable path so esbuild doesn't try to resolve this at bundle time.
   // This path is only used by tests running against tsc-compiled dist/ output.
+  // CI must build satsuma-cli before running LSP tests.
   const modPath = ["../../../satsuma-cli", "dist", "format.js"].join("/");
   const mod = await import(modPath) as { format: FormatFn };
   _formatFn = mod.format;

--- a/tooling/vscode-satsuma/server/src/formatting.ts
+++ b/tooling/vscode-satsuma/server/src/formatting.ts
@@ -5,9 +5,12 @@
  * Returns a single TextEdit replacing the full document range.
  *
  * The canonical format() implementation lives in satsuma-cli/src/format.ts.
- * The esbuild bundler inlines it into server.js at build time.
- * For tsc-compiled tests, we load the CLI's compiled ESM module via
- * dynamic import (cached after first call).
+ *
+ * Resolution strategy:
+ * - **esbuild bundle**: require("satsuma-fmt") is resolved via an alias in
+ *   esbuild.js to ../satsuma-cli/src/format.ts and inlined at build time.
+ * - **tsc-compiled tests**: initFormatting() loads the CLI's compiled dist/
+ *   module via dynamic import.
  */
 
 import { TextEdit, Range, Position } from "vscode-languageserver";
@@ -17,32 +20,22 @@ type FormatFn = (tree: unknown, source: string) => string;
 
 let _formatFn: FormatFn | null = null;
 
-async function getFormatFn(): Promise<FormatFn> {
-  if (_formatFn) return _formatFn;
-  // Dynamic import works for both CJS test runner and esbuild bundler
+// In the esbuild bundle, this require is resolved at build time via the alias.
+// In tsc-compiled test output, it will fail (module not found) — that's fine,
+// tests call initFormatting() which loads via dynamic import instead.
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const _mod = require("satsuma-fmt") as { format: FormatFn };
+  _formatFn = _mod.format;
+} catch {
+  // Not in esbuild bundle context — initFormatting() will load it
+}
+
+/** Initialize the formatting module. Call in test setup to load the format function. */
+export async function initFormatting(): Promise<void> {
+  if (_formatFn) return;
   const mod = await import("../../../satsuma-cli/dist/format.js") as { format: FormatFn };
   _formatFn = mod.format;
-  return _formatFn;
-}
-
-// Synchronous accessor — only works after init() has been called
-function getFormatFnSync(): FormatFn {
-  if (!_formatFn) {
-    // Fallback: try require (works in esbuild bundle where it's inlined)
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const mod = require("../../../satsuma-cli/src/format.js") as { format: FormatFn };
-      _formatFn = mod.format;
-    } catch {
-      throw new Error("Format function not initialized — call initFormatting() first");
-    }
-  }
-  return _formatFn;
-}
-
-/** Initialize the formatting module. Call once during server startup. */
-export async function initFormatting(): Promise<void> {
-  await getFormatFn();
 }
 
 /**
@@ -51,8 +44,9 @@ export async function initFormatting(): Promise<void> {
  * would change anything, or an empty array if already formatted.
  */
 export function computeFormatting(tree: Tree, source: string): TextEdit[] {
-  const formatFn = getFormatFnSync();
-  const formatted = formatFn(tree, source);
+  if (!_formatFn) return [];
+
+  const formatted = _formatFn(tree, source);
 
   if (formatted === source) {
     return []; // Already formatted — no edits needed

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -32,6 +32,7 @@ import { computeReferences } from "./references";
 import { computeCompletions } from "./completion";
 import { computeCodeLenses } from "./codelens";
 import { prepareRename, computeRename } from "./rename";
+import { computeFormatting, initFormatting } from "./formatting";
 
 // ---------- Connection setup ----------
 
@@ -61,6 +62,7 @@ connection.onInitialize(async (params): Promise<InitializeResult> => {
   const wasmPath = path.join(serverDir, "tree-sitter-satsuma.wasm");
   const highlightsPath = path.join(serverDir, "highlights.scm");
   await initParser(wasmPath);
+  await initFormatting();
   try {
     setHighlightsSource(fs.readFileSync(highlightsPath, "utf-8"));
   } catch {
@@ -106,6 +108,7 @@ connection.onInitialize(async (params): Promise<InitializeResult> => {
       renameProvider: {
         prepareProvider: true,
       },
+      documentFormattingProvider: true,
     },
   };
 });
@@ -288,6 +291,14 @@ connection.onCodeLens((params) => {
   const tree = trees.get(params.textDocument.uri);
   if (!tree) return [];
   return computeCodeLenses(tree, params.textDocument.uri, wsIndex);
+});
+
+connection.onDocumentFormatting((params) => {
+  const tree = trees.get(params.textDocument.uri);
+  if (!tree) return [];
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  return computeFormatting(tree, doc.getText());
 });
 
 // ---------- Custom requests ----------

--- a/tooling/vscode-satsuma/server/test/formatting.test.js
+++ b/tooling/vscode-satsuma/server/test/formatting.test.js
@@ -44,7 +44,6 @@ describe("computeFormatting", () => {
     const src = "mapping test {\n  source { s }\n  target { t }\n  s.x -> t.x { trim | lowercase }\n}";
     const tree = parse(src);
     const edits = computeFormatting(tree, src);
-    // May or may not have edits depending on current formatting
     const result = edits.length > 0 ? edits[0].newText : src;
     assert.ok(result.includes("source { s }"));
     assert.ok(result.includes("target { t }"));
@@ -60,7 +59,7 @@ describe("computeFormatting", () => {
   });
 
   it("is idempotent", () => {
-    const src = "schema messy{id INT(pk)name STRING}";
+    const src = "schema messy{id INT (pk) name STRING}";
     const tree = parse(src);
     const edits1 = computeFormatting(tree, src);
     assert.equal(edits1.length, 1);

--- a/tooling/vscode-satsuma/server/test/formatting.test.js
+++ b/tooling/vscode-satsuma/server/test/formatting.test.js
@@ -1,0 +1,73 @@
+/**
+ * formatting.test.js — Tests for the DocumentFormattingProvider.
+ *
+ * Verifies that computeFormatting() returns correct TextEdit arrays
+ * and that the output matches the CLI formatter.
+ */
+const { describe, it, before } = require("node:test");
+const assert = require("node:assert/strict");
+const { initTestParser, parse } = require("./helper");
+const { computeFormatting, initFormatting } = require("../dist/formatting");
+
+before(async () => {
+  await initTestParser();
+  await initFormatting();
+});
+
+describe("computeFormatting", () => {
+  it("returns empty array for already-formatted input", () => {
+    const src = "schema test {\n  id  INT  (pk)\n}\n";
+    const tree = parse(src);
+    const edits = computeFormatting(tree, src);
+    assert.equal(edits.length, 0, "should return no edits for formatted input");
+  });
+
+  it("returns a single TextEdit for unformatted input", () => {
+    const src = "schema test{id INT (pk)}";
+    const tree = parse(src);
+    const edits = computeFormatting(tree, src);
+    assert.equal(edits.length, 1, "should return one edit");
+    assert.equal(edits[0].range.start.line, 0);
+    assert.equal(edits[0].range.start.character, 0);
+  });
+
+  it("produces formatted output that matches expectations", () => {
+    const src = "schema test{id INT (pk)}";
+    const tree = parse(src);
+    const edits = computeFormatting(tree, src);
+    assert.ok(edits[0].newText.includes("schema test {"));
+    assert.ok(edits[0].newText.includes("  id  INT  (pk)"));
+    assert.ok(edits[0].newText.endsWith("}\n"));
+  });
+
+  it("handles mapping with arrows", () => {
+    const src = "mapping test {\n  source { s }\n  target { t }\n  s.x -> t.x { trim | lowercase }\n}";
+    const tree = parse(src);
+    const edits = computeFormatting(tree, src);
+    // May or may not have edits depending on current formatting
+    const result = edits.length > 0 ? edits[0].newText : src;
+    assert.ok(result.includes("source { s }"));
+    assert.ok(result.includes("target { t }"));
+    assert.ok(result.includes("s.x -> t.x { trim | lowercase }"));
+  });
+
+  it("preserves comments", () => {
+    const src = "// Header comment\nschema test {\n  x  INT\n}\n";
+    const tree = parse(src);
+    const edits = computeFormatting(tree, src);
+    const result = edits.length > 0 ? edits[0].newText : src;
+    assert.ok(result.includes("// Header comment"));
+  });
+
+  it("is idempotent", () => {
+    const src = "schema messy{id INT(pk)name STRING}";
+    const tree = parse(src);
+    const edits1 = computeFormatting(tree, src);
+    assert.equal(edits1.length, 1);
+
+    const formatted = edits1[0].newText;
+    const tree2 = parse(formatted);
+    const edits2 = computeFormatting(tree2, formatted);
+    assert.equal(edits2.length, 0, "formatting should be idempotent");
+  });
+});


### PR DESCRIPTION
## Summary

- **`satsuma fmt`** CLI command — format files in place with `--check`, `--diff`, `--stdin` flags
- **VS Code Format Document** — LSP `DocumentFormattingProvider` using the same shared `format()` function
- **CI enforcement** — `satsuma fmt --check examples/` step in the CI pipeline
- Zero configuration, one canonical style: field column alignment, consistent spacing, normalized blank lines, comment preservation
- Parser-backed (tree-sitter CST walk), idempotent, semantics-preserving
- Example corpus reformatted and committed as canonical fixtures

## Changes

| Area | What changed |
|------|-------------|
| `tooling/satsuma-cli/src/format.ts` | Core formatter (1200+ lines) covering all CST node types |
| `tooling/satsuma-cli/src/commands/fmt.ts` | CLI command with `--check`, `--diff`, `--stdin` |
| `tooling/satsuma-cli/src/index.ts` | Register fmt command (17th command) |
| `tooling/satsuma-cli/src/types.ts` | Add `startIndex`/`endIndex` to SyntaxNode |
| `tooling/satsuma-cli/test/format.test.js` | 81 formatter tests |
| `tooling/vscode-satsuma/server/src/formatting.ts` | LSP DocumentFormattingProvider |
| `tooling/vscode-satsuma/server/src/server.ts` | Register formatting capability + handler |
| `tooling/vscode-satsuma/server/test/formatting.test.js` | 6 LSP formatting tests |
| `examples/*.stm` (18 files) | Canonical corpus reformatted |
| `.github/workflows/ci.yml` | Add `fmt --check` CI step |
| Docs (CHANGELOG, README, CLI, agent-ref, site) | Updated for v0.2.0 |

## Test plan

- [x] 760 CLI tests passing (81 formatter-specific)
- [x] 154 LSP server tests passing (6 formatting-specific)
- [x] 16/16 corpus files idempotent (`format(format(x)) === format(x)`)
- [x] 16/16 corpus files structurally equivalent (parse tree preserved)
- [x] `satsuma fmt --check examples/` exits 0
- [x] esbuild bundles VS Code extension successfully
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)