### PR TITLE
fix: deeply nested paths in nl/arrows + remove nl truncation

### DIFF
--- a/.tickets/sl-d9hi.md
+++ b/.tickets/sl-d9hi.md
@@ -1,6 +1,6 @@
 ---
 id: sl-d9hi
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx]
 created: 2026-03-24T08:14:41Z

--- a/.tickets/sl-kutf.md
+++ b/.tickets/sl-kutf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kutf
-status: open
+status: closed
 deps: []
 links: [cbh-so1o, cbh-9cqh]
 created: 2026-03-24T08:18:27Z

--- a/.tickets/sl-xj4p.md
+++ b/.tickets/sl-xj4p.md
@@ -1,6 +1,6 @@
 ---
 id: sl-xj4p
-status: open
+status: closed
 deps: []
 links: [cbh-ekvb, cbh-n4vm]
 created: 2026-03-24T08:15:14Z

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -113,6 +113,15 @@ Examples:
         }
       }
 
+      // When the user specifies a deeply nested path (e.g. CdtTrfTxInf.DbtrAgt.BIC),
+      // filter out arrows whose source/target path doesn't match the requested path.
+      // This allows disambiguating fields that share a leaf name at different nesting levels.
+      if (fieldName.includes(".")) {
+        arrows = arrows.filter((a) => {
+          return arrowPathMatches(a.source, fieldName) || arrowPathMatches(a.target, fieldName);
+        });
+      }
+
       // Add NL-derived arrows for this field
       const nlRefs = resolveAllNLRefs(index);
       for (const nlRef of nlRefs) {
@@ -212,6 +221,27 @@ Examples:
 
       printDefault(fieldRef, arrows, index);
     });
+}
+
+/**
+ * Check if an arrow's source/target path matches the user's requested nested path.
+ * For example, if the arrow source is "CdtTrfTxInf.DbtrAgt.BIC" and the user
+ * requested "CdtTrfTxInf.DbtrAgt.BIC", this returns true.
+ * Also matches if the arrow path ends with the requested path (suffix match).
+ */
+function arrowPathMatches(arrowPath: string | null, requestedPath: string): boolean {
+  if (!arrowPath) return false;
+  if (arrowPath === requestedPath) return true;
+  // Suffix match: arrow path ends with the requested path
+  if (arrowPath.endsWith(`.${requestedPath}`)) return true;
+  // The requested path ends with the arrow path (arrow has shorter dotted path)
+  if (requestedPath.endsWith(`.${arrowPath}`)) return true;
+  // Exact match on leaf only when the full path also has matching intermediate segments
+  if (requestedPath.endsWith(arrowPath) && arrowPath === requestedPath.split(".").pop()) {
+    // Leaf-only match — only accept if no deeper path was specified
+    return false;
+  }
+  return false;
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -138,7 +138,10 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: W
 function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: WorkspaceIndex): NLItemWithFile[] {
   const dot = fieldRef.indexOf(".");
   const schemaName = fieldRef.slice(0, dot);
-  const fieldName = fieldRef.slice(dot + 1);
+  const fieldPath = fieldRef.slice(dot + 1);
+  // Support nested paths like schema.record.nested.field
+  const pathSegments = fieldPath.split(".");
+  const leafName = pathSegments[pathSegments.length - 1]!;
 
   const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
   if (!resolvedSchema) {
@@ -147,9 +150,13 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
   }
 
   const schema = resolvedSchema.entry;
-  if (!schemaHasField(schema.fields, fieldName)) {
+  // For multi-segment paths, require exact path match; for single-segment, use flat search
+  const fieldExists = pathSegments.length > 1
+    ? schemaHasFieldByPath(schema.fields, pathSegments)
+    : schemaHasField(schema.fields, leafName);
+  if (!fieldExists) {
     console.error(
-      `Field '${fieldName}' not found in schema '${schemaName}'.`,
+      `Field '${fieldPath}' not found in schema '${schemaName}'.`,
     );
     process.exit(1);
   }
@@ -159,8 +166,10 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
   const schemaNode = parsed ? findBlockNode(parsed.tree.rootNode, "schema_block", resolvedSchema.key) : null;
   const body = schemaNode?.namedChildren.find((c) => c.type === "schema_body");
   if (body) {
-    for (const fieldDecl of findFieldDecls(body, fieldName)) {
-      for (const item of extractNLContent(fieldDecl, fieldName)) {
+    // Navigate to the nested body for intermediate path segments, then find the leaf field
+    const targetBody = navigateToNestedBody(body, pathSegments.slice(0, -1));
+    for (const fieldDecl of findFieldDecls(targetBody, leafName)) {
+      for (const item of extractNLContent(fieldDecl, leafName)) {
         items.push({ ...item, file: schema.file });
       }
     }
@@ -198,7 +207,7 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
       const tgt = arrow.namedChildren.find((c) => c.type === "tgt_path");
       const srcText = src?.namedChildren[0]?.text ?? null;
       const tgtText = tgt?.namedChildren[0]?.text ?? null;
-      if (srcText !== fieldName && tgtText !== fieldName) continue;
+      if (srcText !== leafName && tgtText !== leafName) continue;
 
       for (const item of extractNLContent(
         arrow,
@@ -230,6 +239,39 @@ function schemaHasField(fields: FieldDecl[], fieldName: string): boolean {
   return false;
 }
 
+function schemaHasFieldByPath(fields: FieldDecl[], segments: string[]): boolean {
+  if (segments.length === 0) return false;
+  const [head, ...rest] = segments;
+  for (const field of fields) {
+    if (field.name === head) {
+      if (rest.length === 0) return true;
+      if (field.children) return schemaHasFieldByPath(field.children, rest);
+    }
+  }
+  return false;
+}
+
+function navigateToNestedBody(body: SyntaxNode, intermediateSegments: string[]): SyntaxNode {
+  let current = body;
+  for (const seg of intermediateSegments) {
+    let found = false;
+    for (const c of current.namedChildren) {
+      if (c.type === "field_decl") {
+        if (getFieldDeclName(c) === seg) {
+          const nested = c.namedChildren.find((x) => x.type === "schema_body");
+          if (nested) {
+            current = nested;
+            found = true;
+            break;
+          }
+        }
+      }
+    }
+    if (!found) break;
+  }
+  return current;
+}
+
 function findFieldDecls(bodyNode: SyntaxNode, fieldName: string, acc: SyntaxNode[] = []): SyntaxNode[] {
   for (const child of bodyNode.namedChildren) {
     if (child.type === "field_decl") {
@@ -252,9 +294,6 @@ function printDefault(items: NLItemWithFile[]): void {
         item.kind === "transform" ? "[transform] " :
           "[note] ";
     const parent = item.parent ? ` (${item.parent})` : "";
-    const text = item.text.length > 120
-      ? item.text.slice(0, 117) + "..."
-      : item.text;
-    console.log(`${prefix}${text}${parent}`);
+    console.log(`${prefix}${item.text}${parent}`);
   }
 }

--- a/tooling/satsuma-cli/test/fixtures/deep-nested-bugs.stm
+++ b/tooling/satsuma-cli/test/fixtures/deep-nested-bugs.stm
@@ -1,0 +1,45 @@
+// Fixture for testing deeply nested field paths in nl, arrows, and meta commands
+// Related tickets: sl-d9hi, sl-kutf, sl-xj4p
+
+schema pacs008 {
+  GrpHdr record {
+    MsgId STRING
+    InstgAgt record {
+      //! BIC may need SWIFT validation
+      BIC STRING
+    }
+    InstdAgt record {
+      BIC STRING
+    }
+  }
+  CdtTrfTxInf record {
+    PmtId record {
+      UETR STRING
+        note { "Unique end-to-end transaction reference (UUID v4). Used for tracking across the entire payment chain." }
+    }
+    DbtrAgt record {
+      BIC STRING
+    }
+    CdtrAgt record {
+      BIC STRING
+    }
+  }
+}
+
+schema iso_target {
+  payment_id STRING
+  debtor_bic STRING
+  creditor_bic STRING
+  instructing_bic STRING
+}
+
+mapping 'pacs008 to iso_target' {
+  source { pacs008 }
+  target { iso_target }
+
+  //! Validate all BIC fields before mapping
+  CdtTrfTxInf.PmtId.UETR -> payment_id { uppercase }
+  GrpHdr.InstgAgt.BIC -> instructing_bic { trim }
+  CdtTrfTxInf.DbtrAgt.BIC -> debtor_bic { trim }
+  CdtTrfTxInf.CdtrAgt.BIC -> creditor_bic { trim }
+}

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -3395,6 +3395,79 @@ describe("satsuma where-used — fragment-to-fragment spreads (sl-307v)", () => 
 // ---------------------------------------------------------------------------
 // Bug fix: nl/meta field syntax (sg-95gr) — dot-separated scope works
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Bug fix: nl text output no longer truncates (sl-d9hi)
+// ---------------------------------------------------------------------------
+const DEEP_NESTED = resolve(__dirname, "fixtures", "deep-nested-bugs.stm");
+
+describe("satsuma nl — no truncation (sl-d9hi)", () => {
+  it("text output shows full NL content without truncation", async () => {
+    const { stdout, code } = await run("nl", "pacs008", DEEP_NESTED);
+    assert.equal(code, 0);
+    // The note is >100 chars — should NOT be truncated with "..."
+    assert.match(stdout, /Used for tracking across the entire payment chain\./);
+    assert.ok(!stdout.includes("..."), "should not truncate with ellipsis");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix: nl supports deeply nested field paths (sl-kutf)
+// ---------------------------------------------------------------------------
+describe("satsuma nl — deeply nested paths (sl-kutf)", () => {
+  it("3-level nested path finds NL on record scope", async () => {
+    const { stdout, code } = await run("nl", "pacs008.CdtTrfTxInf.PmtId", DEEP_NESTED);
+    assert.equal(code, 0);
+    assert.match(stdout, /Unique end-to-end transaction reference/);
+  });
+
+  it("3-level nested path finds warnings", async () => {
+    const { stdout, code } = await run("nl", "pacs008.GrpHdr.InstgAgt", DEEP_NESTED);
+    assert.equal(code, 0);
+    assert.match(stdout, /BIC may need SWIFT validation/);
+  });
+
+  it("exits 1 for invalid nested path", async () => {
+    const { stderr, code } = await run("nl", "pacs008.GrpHdr.Nonexistent.BIC", DEEP_NESTED);
+    assert.equal(code, 1);
+    assert.match(stderr, /not found/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug fix: arrows supports deeply nested field paths (sl-xj4p)
+// ---------------------------------------------------------------------------
+describe("satsuma arrows — deeply nested paths (sl-xj4p)", () => {
+  it("deeply nested path returns only matching arrow", async () => {
+    const { stdout, code } = await run("arrows", "pacs008.CdtTrfTxInf.DbtrAgt.BIC", DEEP_NESTED);
+    assert.equal(code, 0);
+    assert.match(stdout, /1 arrow/);
+    assert.match(stdout, /DbtrAgt\.BIC -> debtor_bic/);
+    // Should NOT include other BIC arrows
+    assert.ok(!stdout.includes("instructing_bic"), "should not include InstgAgt.BIC arrow");
+    assert.ok(!stdout.includes("creditor_bic"), "should not include CdtrAgt.BIC arrow");
+  });
+
+  it("leaf-name query still returns all matching arrows", async () => {
+    const { stdout, code } = await run("arrows", "pacs008.BIC", DEEP_NESTED);
+    assert.equal(code, 0);
+    assert.match(stdout, /3 arrow/);
+  });
+
+  it("--json includes full nested path for source", async () => {
+    const { stdout, code } = await run("arrows", "pacs008.CdtTrfTxInf.DbtrAgt.BIC", "--json", DEEP_NESTED);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.length, 1);
+    assert.match(data[0].source, /pacs008\.CdtTrfTxInf\.DbtrAgt\.BIC/);
+  });
+
+  it("exits 1 for invalid deeply nested path", async () => {
+    const { stderr, code } = await run("arrows", "pacs008.Nonexistent.BIC", DEEP_NESTED);
+    assert.equal(code, 1);
+    assert.match(stderr, /not found/i);
+  });
+});
+
 describe("satsuma nl/meta field syntax (sg-95gr)", () => {
   it("nl accepts schema.field without 'field' keyword", async () => {
     const { code } = await run("nl", "mart::dim_contact.email", NS_PLATFORM);


### PR DESCRIPTION
## Summary
- **sl-d9hi**: Remove 120-char truncation from `nl` text output — full NL content is now always shown
- **sl-kutf**: Support deeply nested field paths in `nl` command (e.g. `pacs008.CdtTrfTxInf.PmtId`), consistent with `meta` command
- **sl-xj4p**: Support deeply nested field paths in `arrows` command (e.g. `pacs008.CdtTrfTxInf.DbtrAgt.BIC`) to disambiguate fields sharing a leaf name; leaf-name queries still return all matches

## Test plan
- [x] 8 new integration tests covering all three bugs
- [x] All 780 tests pass (772 existing + 8 new)
- [x] Manual verification of nl truncation removal, nested path resolution, and arrows path filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)