### PR TITLE
fix: resolve 18 CLI bugs and close 6 epics (batch 3)

### DIFF
--- a/.tickets/cbh-2y8p.md
+++ b/.tickets/cbh-2y8p.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-2y8p
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-so1o, cbh-kyv3, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s]
 created: 2026-03-25T11:16:52Z

--- a/.tickets/cbh-394k.md
+++ b/.tickets/cbh-394k.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-394k
-status: open
+status: closed
 deps: []
 links: [cbh-zybb, cbh-xj0m, cbh-vgka, cbh-0lhj, cbh-qwyg, cbh-ya9k]
 created: 2026-03-25T11:20:25Z

--- a/.tickets/cbh-5lzd.md
+++ b/.tickets/cbh-5lzd.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-5lzd
-status: open
+status: closed
 deps: []
 links: [cbh-5tvk, cbh-mpz2, cbh-rkia]
 created: 2026-03-25T11:17:34Z

--- a/.tickets/cbh-5tvk.md
+++ b/.tickets/cbh-5tvk.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-5tvk
-status: open
+status: closed
 deps: []
 links: [cbh-mpz2, cbh-5lzd, cbh-rkia]
 created: 2026-03-25T11:24:11Z

--- a/.tickets/cbh-7ji8.md
+++ b/.tickets/cbh-7ji8.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-7ji8
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-so1o, cbh-kyv3, cbh-2y8p, cbh-9cqh, cbh-b0w8, cbh-e01s]
 created: 2026-03-25T11:17:11Z

--- a/.tickets/cbh-9cqh.md
+++ b/.tickets/cbh-9cqh.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-9cqh
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-so1o, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-b0w8, cbh-e01s, sl-kutf]
 created: 2026-03-25T11:17:55Z

--- a/.tickets/cbh-b0w8.md
+++ b/.tickets/cbh-b0w8.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-b0w8
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-so1o, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-e01s]
 created: 2026-03-25T11:16:05Z

--- a/.tickets/cbh-cyl0.md
+++ b/.tickets/cbh-cyl0.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-cyl0
-status: open
+status: closed
 deps: []
 links: [cbh-y5og, cbh-h0or, cbh-n4vm]
 created: 2026-03-25T11:18:53Z

--- a/.tickets/cbh-fmtb.md
+++ b/.tickets/cbh-fmtb.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-fmtb
-status: open
+status: closed
 deps: []
 links: [cbh-7rvo, cbh-gz2v, cbh-s9w6, cbh-myj2]
 created: 2026-03-25T11:24:08Z

--- a/.tickets/cbh-h0or.md
+++ b/.tickets/cbh-h0or.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-h0or
-status: open
+status: closed
 deps: []
 links: [cbh-cyl0, cbh-y5og, cbh-n4vm, cbh-sttt]
 created: 2026-03-25T11:24:14Z

--- a/.tickets/cbh-kyv3.md
+++ b/.tickets/cbh-kyv3.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-kyv3
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-so1o, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s]
 created: 2026-03-25T11:17:04Z

--- a/.tickets/cbh-mpz2.md
+++ b/.tickets/cbh-mpz2.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-mpz2
-status: open
+status: closed
 deps: []
 links: [cbh-5tvk, cbh-5lzd, cbh-rkia]
 created: 2026-03-25T11:16:27Z

--- a/.tickets/cbh-myj2.md
+++ b/.tickets/cbh-myj2.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-myj2
-status: open
+status: closed
 deps: []
 links: [cbh-fmtb, cbh-7rvo, cbh-gz2v, cbh-s9w6]
 created: 2026-03-25T11:20:43Z

--- a/.tickets/cbh-n4vm.md
+++ b/.tickets/cbh-n4vm.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-n4vm
-status: open
+status: closed
 deps: []
 links: [cbh-cyl0, cbh-y5og, cbh-h0or, cbh-ekvb, sl-xj4p]
 created: 2026-03-25T11:17:18Z

--- a/.tickets/cbh-ocid.md
+++ b/.tickets/cbh-ocid.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-ocid
-status: open
+status: closed
 deps: []
 links: [cbh-z5dy, cbh-djny]
 created: 2026-03-25T11:24:15Z

--- a/.tickets/cbh-qwyg.md
+++ b/.tickets/cbh-qwyg.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-qwyg
-status: open
+status: closed
 deps: []
 links: [cbh-zybb, cbh-xj0m, cbh-vgka, cbh-0lhj, cbh-394k, cbh-ya9k]
 created: 2026-03-25T11:20:30Z

--- a/.tickets/cbh-rkia.md
+++ b/.tickets/cbh-rkia.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-rkia
-status: open
+status: closed
 deps: []
 links: [cbh-5tvk, cbh-mpz2, cbh-5lzd]
 created: 2026-03-25T11:18:41Z

--- a/.tickets/cbh-so1o.md
+++ b/.tickets/cbh-so1o.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-so1o
-status: open
+status: closed
 deps: []
 links: [cbh-ukcx, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s, sl-kutf]
 created: 2026-03-25T11:17:46Z

--- a/.tickets/cbh-ukcx.md
+++ b/.tickets/cbh-ukcx.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-ukcx
-status: open
+status: closed
 deps: []
 links: [cbh-so1o, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s, sl-d9hi]
 created: 2026-03-25T11:24:02Z

--- a/.tickets/cbh-xj0m.md
+++ b/.tickets/cbh-xj0m.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-xj0m
-status: open
+status: closed
 deps: []
 links: [cbh-zybb, cbh-vgka, cbh-0lhj, cbh-394k, cbh-qwyg, cbh-ya9k]
 created: 2026-03-25T11:20:39Z

--- a/.tickets/cbh-y5og.md
+++ b/.tickets/cbh-y5og.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-y5og
-status: open
+status: closed
 deps: []
 links: [cbh-cyl0, cbh-h0or, cbh-n4vm]
 created: 2026-03-25T11:18:20Z

--- a/.tickets/cbh-ya9k.md
+++ b/.tickets/cbh-ya9k.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-ya9k
-status: open
+status: closed
 deps: []
 links: [cbh-zybb, cbh-xj0m, cbh-vgka, cbh-0lhj, cbh-394k, cbh-qwyg]
 created: 2026-03-25T11:20:21Z

--- a/.tickets/cbh-z5dy.md
+++ b/.tickets/cbh-z5dy.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-z5dy
-status: open
+status: closed
 deps: []
 links: [cbh-ocid, cbh-djny]
 created: 2026-03-25T11:16:16Z

--- a/.tickets/cbh-zybb.md
+++ b/.tickets/cbh-zybb.md
@@ -1,6 +1,6 @@
 ---
 id: cbh-zybb
-status: open
+status: closed
 deps: []
 links: [cbh-xj0m, cbh-vgka, cbh-0lhj, cbh-394k, cbh-qwyg, cbh-ya9k]
 created: 2026-03-25T11:24:09Z

--- a/examples/cobol-to-avro.stm
+++ b/examples/cobol-to-avro.stm
@@ -50,9 +50,15 @@ schema cobol_customer_master (
     ZIP     INTEGER  (pic "9(5)", offset 104)
   }
 
-  CREDIT_LIMIT  DECIMAL(9,2)  (pic "S9(7)V99", encoding comp-3, offset 109, length 5, note "Packed decimal: last nibble is sign (C=positive, D=negative)")
+  CREDIT_LIMIT  DECIMAL(9,2) (
+    pic "S9(7)V99",
+    encoding comp-3,
+    offset 109,
+    length 5,
+    note "Packed decimal: last nibble is sign (C=positive, D=negative)"
+  )
 
-  ACCOUNT_BAL   DECIMAL(9,2)  (pic "S9(7)V99", encoding comp-3, offset 114, length 5)
+  ACCOUNT_BAL   DECIMAL(9,2) (pic "S9(7)V99", encoding comp-3, offset 114, length 5)
 
   STATUS_CODE   STRING        (pic "X(1)", offset 119, enum {A, I, S})
 
@@ -77,7 +83,7 @@ schema customer_event_avro (
   note "Customer change event — published to Kafka topic customer.changes"
 ) {
   event_id         STRING         (required)
-  event_type       STRING         (required, enum {created, updated, deactivated})
+  event_type       STRING (required, enum {created, updated, deactivated})
   event_timestamp  STRING         (required)
   customer_id      STRING         (required)
   customer_type    STRING         (required, enum {retail, business})

--- a/examples/db-to-db.stm
+++ b/examples/db-to-db.stm
@@ -61,7 +61,7 @@ schema legacy_sqlserver (
 schema postgres_db (note "Normalized customer schema — PostgreSQL 16") {
   customer_id               UUID          (pk, required)
   legacy_customer_id        INTEGER       (unique, indexed)
-  customer_type             VARCHAR(20)   (enum {retail, business, government}, required)
+  customer_type             VARCHAR(20) (enum {retail, business, government}, required)
   display_name              VARCHAR(200)  (required)
   first_name                VARCHAR(100)
   last_name                 VARCHAR(100)
@@ -70,11 +70,11 @@ schema postgres_db (note "Normalized customer schema — PostgreSQL 16") {
   phone                     VARCHAR(20)   (format E.164)
   address_id                UUID          (ref addresses.id)
   credit_limit_cents        BIGINT        (default 0)
-  status                    VARCHAR(20)   (enum {active, suspended, closed, delinquent}, required)
+  status                    VARCHAR(20) (enum {active, suspended, closed, delinquent}, required)
   created_at                TIMESTAMPTZ   (required)
   updated_at                TIMESTAMPTZ
   tax_identifier_encrypted  TEXT          (pii, encrypt AES-256-GCM)
-  loyalty_tier              VARCHAR(20)   (enum {bronze, silver, gold, platinum})
+  loyalty_tier              VARCHAR(20) (enum {bronze, silver, gold, platinum})
   preferred_contact_method  VARCHAR(20)   (enum {email, phone, mail, none})
   notes                     TEXT
   migration_timestamp       TIMESTAMPTZ

--- a/examples/filter-flatten-governance.stm
+++ b/examples/filter-flatten-governance.stm
@@ -33,7 +33,7 @@ schema order_events (
 ) {
   event_id      UUID            (pk, required)
   event_time    TIMESTAMPTZ     (required)
-  order_status  STRING(20)      (enum {completed, pending, failed, refunded}, required)
+  order_status  STRING(20) (enum {completed, pending, failed, refunded}, required)
 
   customer record {
     customer_id  UUID         (required)
@@ -76,13 +76,17 @@ schema customer_profiles (
   retention "7y"
 ) {
   customer_id          UUID            (pk, required)
-  email                STRING(255)     (pii, classification "RESTRICTED", retention "3y")
+  email                STRING(255) (pii, classification "RESTRICTED", retention "3y")
   first_name           STRING(100)     (pii)
   last_name            STRING(100)     (pii)
   acquisition_channel  STRING(50)
   region               STRING(50)
   // Scalar lists used here for preference lists — no subfields needed
-  consent_flags        list_of STRING  (classification "RESTRICTED", retention "7y", note "e.g. ['email_marketing', 'sms', 'third_party']")
+  consent_flags        list_of STRING (
+    classification "RESTRICTED",
+    retention "7y",
+    note "e.g. ['email_marketing', 'sms', 'third_party']"
+  )
   opt_out_channels     list_of STRING  (classification "RESTRICTED")
 }
 
@@ -95,7 +99,7 @@ schema completed_orders_parquet (
   order_id             UUID            (pk, required)
   event_time_utc       TIMESTAMPTZ     (required)
   customer_id          UUID            (indexed)
-  customer_email       STRING(255)     (pii, classification "RESTRICTED", retention "3y")
+  customer_email       STRING(255) (pii, classification "RESTRICTED", retention "3y")
   tier                 STRING(20)
   acquisition_channel  STRING(50)
   region               STRING(50)
@@ -104,7 +108,7 @@ schema completed_orders_parquet (
   tax                  DECIMAL(12,2)
   discount             DECIMAL(12,2)
   total                DECIMAL(12,2)   (required)
-  promo_codes          list_of STRING  (note "Passed through from source unchanged")
+  promo_codes          list_of STRING (note "Passed through from source unchanged")
   active_line_count    INT             (required)
   ingest_timestamp     TIMESTAMPTZ     (required)
 }

--- a/examples/governance.stm
+++ b/examples/governance.stm
@@ -38,23 +38,47 @@ schema crm_customers (
         Retention clock starts when account_closure_date is populated."
 ) {
   customer_id           UUID         (pk, required)
-  email                 STRING(255)  (pii, classification "RESTRICTED", encrypt AES-256-GCM, mask partial_email, retention "3y", note "Email has a 3-year retention override per GDPR Art. 17 right-to-erasure.
+  email                 STRING(255) (
+    pii,
+    classification "RESTRICTED",
+    encrypt AES-256-GCM,
+    mask partial_email,
+    retention "3y",
+    note "Email has a 3-year retention override per GDPR Art. 17 right-to-erasure.
           Encrypted at rest with AES-256-GCM. Masked as j***@domain.com for
-          non-privileged consumers.")
-  first_name            STRING(100)  (pii, classification "CONFIDENTIAL", mask redact)
-  last_name             STRING(100)  (pii, classification "CONFIDENTIAL", mask redact)
-  phone                 STRING(20)   (pii, classification "RESTRICTED", encrypt AES-256-GCM, mask last_four)
-  date_of_birth         DATE         (pii, classification "RESTRICTED", mask redact, note "DOB is one of the HIPAA Safe Harbor 18 identifiers. Masked completely
-          for non-privileged consumers.")
+          non-privileged consumers."
+  )
+  first_name            STRING(100) (pii, classification "CONFIDENTIAL", mask redact)
+  last_name             STRING(100) (pii, classification "CONFIDENTIAL", mask redact)
+  phone                 STRING(20) (
+    pii,
+    classification "RESTRICTED",
+    encrypt AES-256-GCM,
+    mask last_four
+  )
+  date_of_birth         DATE (
+    pii,
+    classification "RESTRICTED",
+    mask redact,
+    note "DOB is one of the HIPAA Safe Harbor 18 identifiers. Masked completely
+          for non-privileged consumers."
+  )
   loyalty_tier          STRING(20)   (enum {bronze, silver, gold, platinum})
   acquisition_channel   STRING(50)
   region                STRING(50)
-  account_closure_date  DATE         (note "Null while the account is active. Retention clock starts when populated.")
+  account_closure_date  DATE (
+    note "Null while the account is active. Retention clock starts when populated."
+  )
 
   consent record (note "Consent state — governs downstream marketing use") {
     email_marketing    BOOLEAN  (required, default false)
     sms_marketing      BOOLEAN  (required, default false)
-    third_party_share  BOOLEAN  (required, default false, classification "RESTRICTED", note "Must be checked before any data sharing with external partners.")
+    third_party_share  BOOLEAN (
+      required,
+      default false,
+      classification "RESTRICTED",
+      note "Must be checked before any data sharing with external partners."
+    )
   }
 }
 
@@ -76,8 +100,11 @@ schema finance_transactions (
   transaction_date  DATE           (required)
   amount            DECIMAL(15,2)  (required, audit_level critical)
   currency          CHAR(3)        (required, default "USD")
-  payment_method    STRING(30)     (classification "CONFIDENTIAL", note "Payment method reveals financial behaviour — classified CONFIDENTIAL
-          even though it is not PII by itself.")
+  payment_method    STRING(30) (
+    classification "CONFIDENTIAL",
+    note "Payment method reveals financial behaviour — classified CONFIDENTIAL
+          even though it is not PII by itself."
+  )
 
   card_details record (
     classification "RESTRICTED",
@@ -97,8 +124,10 @@ schema finance_transactions (
     country      CHAR(2)
   }
 
-  gl_account        STRING(20)     (required, ref "chart_of_accounts.account_code")
-  cost_center       STRING(10)     (note "Inherited from schema-level cost_center for per-row allocation overrides")
+  gl_account        STRING(20) (required, ref "chart_of_accounts.account_code")
+  cost_center       STRING(10) (
+    note "Inherited from schema-level cost_center for per-row allocation overrides"
+  )
 }
 
 // --- Target: Unified Customer View ---
@@ -115,9 +144,20 @@ schema customer_360_view (
         Retention clock anchored to last_activity_date."
 ) {
   customer_id            UUID           (pk, required)
-  email                  STRING(255)    (pii, classification "RESTRICTED", encrypt AES-256-GCM, mask partial_email, retention "3y")
-  full_name              STRING(200)    (pii, classification "CONFIDENTIAL", mask redact)
-  phone                  STRING(20)     (pii, classification "RESTRICTED", encrypt AES-256-GCM, mask last_four)
+  email                  STRING(255) (
+    pii,
+    classification "RESTRICTED",
+    encrypt AES-256-GCM,
+    mask partial_email,
+    retention "3y"
+  )
+  full_name              STRING(200) (pii, classification "CONFIDENTIAL", mask redact)
+  phone                  STRING(20) (
+    pii,
+    classification "RESTRICTED",
+    encrypt AES-256-GCM,
+    mask last_four
+  )
   loyalty_tier           STRING(20)
   region                 STRING(50)
   acquisition_channel    STRING(50)
@@ -125,8 +165,10 @@ schema customer_360_view (
   total_transaction_amt  DECIMAL(15,2)
   transaction_count      INT
   last_transaction_date  DATE
-  last_activity_date     DATE           (note "Most recent of: last login, last transaction, last profile update.
-                                              Used as the retention anchor for this schema.")
+  last_activity_date     DATE (
+    note "Most recent of: last login, last transaction, last profile update.
+                                              Used as the retention anchor for this schema."
+  )
   consent_email          BOOLEAN
   consent_sms            BOOLEAN
   consent_third_party    BOOLEAN        (classification "RESTRICTED")

--- a/examples/json-api-to-parquet.stm
+++ b/examples/json-api-to-parquet.stm
@@ -58,14 +58,17 @@ schema api_order_response (format json, note "Commerce REST API v2 order respons
       IsGift           BOOLEAN        (jsonpath ".is_gift")
     }
 
-    OrderMetadata   JSON    (jsonpath "$.order.metadata", note "Preserved as raw JSON — contains variable vendor-specific fields")
+    OrderMetadata   JSON (
+      jsonpath "$.order.metadata",
+      note "Preserved as raw JSON — contains variable vendor-specific fields"
+    )
   }
 }
 
 // --- Targets ---
 schema order_headers_parquet (format parquet, note "Curated order header dataset") {
   order_id             STRING         (pk)
-  order_channel        STRING         (enum {web, mobile, store, marketplace}, required)
+  order_channel        STRING (enum {web, mobile, store, marketplace}, required)
   order_timestamp_utc  TIMESTAMPTZ    (required)
   customer_id          STRING
   customer_email       STRING         (format email, pii)

--- a/examples/metrics.stm
+++ b/examples/metrics.stm
@@ -95,7 +95,10 @@ metric pipeline_value "ARR Pipeline" (
   filter "pipeline_stage NOT IN ('closed_won', 'closed_lost')"
 ) {
   arr_value           DECIMAL(18,2)  (measure additive)
-  weighted_arr_value  DECIMAL(18,2)  (measure additive, note "`arr_value` * `probability` — use for forecast roll-ups")
+  weighted_arr_value  DECIMAL(18,2) (
+    measure additive,
+    note "`arr_value` * `probability` — use for forecast roll-ups"
+  )
 
   note {
     "Open pipeline as of the snapshot date, expressed in ARR."

--- a/examples/multi-source-join.stm
+++ b/examples/multi-source-join.stm
@@ -35,7 +35,7 @@ schema crm_customers (
   first_name             VARCHAR(100)
   last_name              VARCHAR(100)
   company_name           VARCHAR(200)
-  segment                VARCHAR(20)    (enum {enterprise, mid_market, smb, individual})
+  segment                VARCHAR(20) (enum {enterprise, mid_market, smb, individual})
   region                 VARCHAR(50)
   signup_date            DATE           (required)
   is_active              BOOLEAN        (default true)

--- a/examples/ns-platform.stm
+++ b/examples/ns-platform.stm
@@ -52,7 +52,9 @@ namespace raw (note "Raw ingestion layer — one schema per source feed") {
     deal_id      VARCHAR(36)    (pk)
     contact_id   VARCHAR(36)    (ref crm_contacts.contact_id)
     deal_name    VARCHAR(200)
-    stage        VARCHAR(50)    (enum {discovery, proposal, negotiation, closed_won, closed_lost})
+    stage        VARCHAR(50) (
+      enum {discovery, proposal, negotiation, closed_won, closed_lost}
+    )
     amount       DECIMAL(14,2)
     close_date   DATE
     owner_email  VARCHAR(255)

--- a/examples/protobuf-to-parquet.stm
+++ b/examples/protobuf-to-parquet.stm
@@ -60,7 +60,7 @@ schema commerce_session_parquet (format parquet, note "Session-level analytics d
   source_system            STRING
   country_code             STRING
   currency_code            STRING
-  entry_channel            STRING         (enum {web, mobile_app, kiosk, marketplace})
+  entry_channel            STRING (enum {web, mobile_app, kiosk, marketplace})
   device_type              STRING         (enum {desktop, mobile, tablet, pos})
   event_count              INT32          (required)
   distinct_event_types     JSON
@@ -72,7 +72,7 @@ schema commerce_session_parquet (format parquet, note "Session-level analytics d
   total_discount_amount    DECIMAL(14,2)
   distinct_product_count   INT32
   top_category             STRING
-  session_quality          STRING         (enum {bounce, browse, engaged, purchaser})
+  session_quality          STRING (enum {bounce, browse, engaged, purchaser})
 }
 
 // --- Mapping ---

--- a/examples/reports-and-models.stm
+++ b/examples/reports-and-models.stm
@@ -62,11 +62,11 @@ schema weekly_sales_dashboard (
   owner "analytics-team",
   note "Executive weekly sales overview — filters default to current quarter"
 ) {
-  total_revenue     DECIMAL(14,2)  (note "Sum of fact_orders.net_amount for the period")
+  total_revenue     DECIMAL(14,2) (note "Sum of fact_orders.net_amount for the period")
   units_sold        INTEGER        (note "Count of fact_orders.quantity")
-  avg_order_value   DECIMAL(10,2)  (note "total_revenue / number of distinct orders")
-  top_product       VARCHAR(200)   (note "Product with highest revenue in the period")
-  region            VARCHAR(50)    (note "Dimension slicer from dim_product.region")
+  avg_order_value   DECIMAL(10,2) (note "total_revenue / number of distinct orders")
+  top_product       VARCHAR(200) (note "Product with highest revenue in the period")
+  region            VARCHAR(50) (note "Dimension slicer from dim_product.region")
   week_ending_date  DATE           (note "Last day of the reporting week")
 }
 
@@ -79,11 +79,13 @@ schema churn_predictor (
   refresh schedule "Sunday 02:00 UTC",
   note "Binary classifier predicting 90-day churn. Retrained weekly; promoted to production only if AUC > 0.82."
 ) {
-  customer_tenure_days   INTEGER        (note "Days since dim_customer.signup_date")
-  order_count_30d        INTEGER        (note "Orders in the last 30 days from fact_orders")
-  avg_order_value        DECIMAL(10,2)  (note "Mean net_amount over customer lifetime")
-  days_since_last_order  INTEGER        (note "Recency signal — days since most recent order")
-  churn_probability      DECIMAL(5,4)   (note "Model output: probability of churn in next 90 days")
+  customer_tenure_days   INTEGER (note "Days since dim_customer.signup_date")
+  order_count_30d        INTEGER (note "Orders in the last 30 days from fact_orders")
+  avg_order_value        DECIMAL(10,2) (note "Mean net_amount over customer lifetime")
+  days_since_last_order  INTEGER (note "Recency signal — days since most recent order")
+  churn_probability      DECIMAL(5,4) (
+    note "Model output: probability of churn in next 90 days"
+  )
 }
 
 // --- Report with Governance Tokens ---
@@ -100,8 +102,10 @@ schema customer_risk_report (
   customer_id        UUID           (required)
   customer_name      VARCHAR(200)   (pii)
   churn_probability  DECIMAL(5,4)   (note "From churn_predictor model output")
-  lifetime_revenue   DECIMAL(14,2)  (note "Sum of all historical orders from fact_orders")
-  risk_tier          VARCHAR(20)    (note "High / Medium / Low based on churn probability and LTV")
+  lifetime_revenue   DECIMAL(14,2) (note "Sum of all historical orders from fact_orders")
+  risk_tier          VARCHAR(20) (
+    note "High / Medium / Low based on churn probability and LTV"
+  )
 }
 
 // --- Minimal Report ---

--- a/examples/sap-po-to-mfcs.stm
+++ b/examples/sap-po-to-mfcs.stm
@@ -29,14 +29,25 @@ note {
 schema sap_purchase_order (format sap, note "Logical SAP ERP purchase order contract") {
   EBELN          STRING(10)    (pk, required, note "SAP purchase order number")
   BUKRS          STRING(4)     (required, note "Company code")
-  BSART          STRING(4)     (required, enum {NB, UB, FO, ZST}, note "Purchasing document type")
-  BSTYP          STRING(1)     (required, enum {F}, note "Document category: purchase order")
+  BSART          STRING(4) (
+    required,
+    enum {NB, UB, FO, ZST},
+    note "Purchasing document type"
+  )
+  BSTYP          STRING(1) (
+    required,
+    enum {F},
+    note "Document category: purchase order"
+  )
   LIFNR          STRING(10)    (required, note "Vendor account number")
   EKORG          STRING(4)     (required, note "Purchasing organization")
   EKGRP          STRING(3)     (note "Purchasing group")
   WAERS          STRING(3)     (required, note "Document currency")
   BEDAT          DATE          (required, note "PO document date")
-  ReceivingSite  STRING(10)    (required, note "Business receiving site used for MFCS location resolution")
+  ReceivingSite  STRING(10) (
+    required,
+    note "Business receiving site used for MFCS location resolution"
+  )
   HeaderText     STRING(1000)
 
   Items list_of record {

--- a/examples/sfdc_to_snowflake.stm
+++ b/examples/sfdc_to_snowflake.stm
@@ -22,7 +22,9 @@ schema sfdc_opportunity (note "SFDC Opportunity Object") {
   AccountId                ID              (ref sfdc_account.Id)
   Amount                   CURRENCY(18,2)
   CurrencyIsoCode          STRING(3)       (default USD)
-  StageName                PICKLIST        (enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost})
+  StageName                PICKLIST (
+    enum {Prospecting, Qualification, "Value Prop", Closed_Won, Closed_Lost}
+  )
   CloseDate                DATE            (required)
   Probability              PERCENT(3,0)
   `Lead_Source_Detail__c`  STRING(255)
@@ -45,7 +47,7 @@ schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
   amount_raw        NUMBER(18,2)
   amount_usd        NUMBER(18,2)   (note "Converted at daily spot rate")
   arr_value         NUMBER(18,2)   (required)
-  pipeline_stage    VARCHAR(50)    (enum {top_funnel, mid_funnel, closed_won, closed_lost})
+  pipeline_stage    VARCHAR(50) (enum {top_funnel, mid_funnel, closed_won, closed_lost})
   is_closed         BOOLEAN
   close_date        DATE
   source_system     VARCHAR(10)    (default SFDC)

--- a/examples/xml-to-parquet.stm
+++ b/examples/xml-to-parquet.stm
@@ -68,7 +68,7 @@ schema commerce_order (
 // --- Targets ---
 schema order_headers_parquet (format parquet, note "Curated order header dataset") {
   order_id             STRING         (pk)
-  order_channel        STRING         (enum {web, mobile, store, marketplace}, required)
+  order_channel        STRING (enum {web, mobile, store, marketplace}, required)
   order_timestamp_utc  TIMESTAMPTZ    (required)
   customer_id          STRING
   customer_email       STRING         (format email, pii)

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -196,6 +196,13 @@ Examples:
           const qualifyPath = (path: string | null, schema: string): string | null => {
             if (!path) return null;
             if (path.startsWith(schema + ".") || path === schema) return path;
+            // If path is already schema-qualified (contains a dot and the prefix
+            // is a known schema), don't double-qualify
+            const dotIdx = path.indexOf(".");
+            if (dotIdx > 0) {
+              const prefix = path.slice(0, dotIdx);
+              if (index.schemas.has(prefix)) return path;
+            }
             return `${schema}.${path}`;
           };
 

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -24,7 +24,8 @@ import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
 import { extractBacktickRefs } from "../nl-ref-extract.js";
 import { extractNLContent } from "../nl-extract.js";
-import type { WorkspaceIndex, ParsedFile, SyntaxNode } from "../types.js";
+import { expandEntityFields } from "../spread-expand.js";
+import type { WorkspaceIndex, ParsedFile, SyntaxNode, FieldDecl } from "../types.js";
 
 interface ScoredCandidate {
   name: string;
@@ -252,8 +253,11 @@ function renderBlock(index: WorkspaceIndex, candidate: ScoredCandidate, compact?
     const s = index.schemas.get(name);
     const note = s?.note && !compact ? `  (note "${s.note}")` : "";
     lines.push(`schema ${name}${note} {`);
-    const maxLen = Math.max(24, ...((s?.fields ?? []).map((f) => f.name.length + 1)));
-    for (const f of s?.fields ?? []) lines.push(`  ${f.name.padEnd(maxLen)}${f.type}`);
+    // Include fields from fragment spreads
+    const spreadFields = s ? expandEntityFields(s, s.namespace ?? null, index) : [];
+    const allFields: FieldDecl[] = [...(s?.fields ?? []), ...spreadFields];
+    const maxLen = Math.max(24, ...allFields.map((f) => f.name.length + 1));
+    for (const f of allFields) lines.push(`  ${f.name.padEnd(maxLen)}${f.type}`);
     lines.push("}");
   } else if (type === "metric") {
     const m = index.metrics.get(name);

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -280,12 +280,13 @@ function collectSpreadFieldMatches(
     if (!body) continue;
 
     // Search the fragment's body for matching fields, but report under the consuming schema
+    // Use the consuming schema's file and row, not the fragment's
     const fragMatches: Match[] = [];
     collectFieldMatches(body, "schema", schemaName, fragment.file, tag, fragMatches);
     for (const m of fragMatches) {
       if (!existing.has(m.field)) {
         existing.add(m.field);
-        acc.push(m);
+        acc.push({ ...m, file: schema.file, line: schema.row + 1 });
       }
     }
 

--- a/tooling/satsuma-cli/src/commands/fmt.ts
+++ b/tooling/satsuma-cli/src/commands/fmt.ts
@@ -65,7 +65,7 @@ export function register(program: Command): void {
         const parsed = parseFile(filePath);
 
         if (parsed.errorCount > 0) {
-          const rel = relative(process.cwd(), filePath);
+          const rel = displayPath(filePath);
           console.error(`skipping ${rel}: parse error (${parsed.errorCount} error(s))`);
           parseErrors++;
           continue;
@@ -78,7 +78,7 @@ export function register(program: Command): void {
         }
 
         wouldChange++;
-        const rel = relative(process.cwd(), filePath);
+        const rel = displayPath(filePath);
 
         if (opts.check) {
           console.log(rel);
@@ -101,6 +101,14 @@ export function register(program: Command): void {
     });
 }
 
+/** Return the shorter of the relative and absolute path. */
+function displayPath(filePath: string): string {
+  const rel = relative(process.cwd(), filePath);
+  // If relative path starts with excessive ../, prefer absolute
+  if (rel.startsWith("..") && filePath.length < rel.length) return filePath;
+  return rel;
+}
+
 function handleStdin(): void {
   const src = readFileSync(0, "utf8"); // fd 0 = stdin
   const { tree, errorCount } = parseSource(src);
@@ -121,61 +129,171 @@ function printDiff(filename: string, original: string, formatted: string): void 
   console.log(`--- a/${filename}`);
   console.log(`+++ b/${filename}`);
 
-  // Simple line-by-line unified diff
+  // Build edit script using Myers-style diff (O(ND) but simple)
+  const ops = diffLines(origLines, fmtLines);
+
+  // Group into hunks with 3 lines of context
+  const CTX = 3;
+  const hunks: Array<{ origStart: number; origLen: number; fmtStart: number; fmtLen: number; lines: string[] }> = [];
+  let hunk: typeof hunks[0] | null = null;
+  let oi = 0;
+  let fi = 0;
+
+  for (let k = 0; k < ops.length; k++) {
+    const op = ops[k]!;
+    if (op === "equal") {
+      // Check if we need to start or extend a hunk (look ahead for changes within CTX*2+1)
+      const inRange = hunk && (oi - (hunk.origStart + hunk.origLen) < CTX * 2 + 1);
+      if (hunk && inRange) {
+        hunk.lines.push(` ${origLines[oi]}`);
+        hunk.origLen = oi - hunk.origStart + 1;
+        hunk.fmtLen = fi - hunk.fmtStart + 1;
+      }
+      oi++;
+      fi++;
+    } else if (op === "delete") {
+      if (!hunk) {
+        const ctxStart = Math.max(0, oi - CTX);
+        hunk = { origStart: ctxStart, origLen: 0, fmtStart: Math.max(0, fi - CTX + (oi - ctxStart) - (oi - ctxStart)), fmtLen: 0, lines: [] };
+        hunk.fmtStart = fi - (oi - ctxStart);
+        for (let c = ctxStart; c < oi; c++) {
+          hunk.lines.push(` ${origLines[c]}`);
+        }
+        hunk.origLen = oi - ctxStart;
+        hunk.fmtLen = fi - hunk.fmtStart;
+      }
+      hunk.lines.push(`-${origLines[oi]}`);
+      hunk.origLen = oi - hunk.origStart + 1;
+      oi++;
+    } else if (op === "insert") {
+      if (!hunk) {
+        const ctxStart = Math.max(0, oi - CTX);
+        hunk = { origStart: ctxStart, origLen: 0, fmtStart: 0, fmtLen: 0, lines: [] };
+        hunk.fmtStart = fi - (oi - ctxStart);
+        for (let c = ctxStart; c < oi; c++) {
+          hunk.lines.push(` ${origLines[c]}`);
+        }
+        hunk.origLen = oi - ctxStart;
+        hunk.fmtLen = fi - hunk.fmtStart;
+      }
+      hunk.lines.push(`+${fmtLines[fi]}`);
+      hunk.fmtLen = fi - hunk.fmtStart + 1;
+      fi++;
+    }
+
+    // Check if the next operation is far enough away to flush the hunk
+    const nextChange = findNextChange(ops, k + 1);
+    if (hunk && (nextChange === -1 || isNextChangeFar(ops, k + 1, oi, CTX))) {
+      // Add trailing context
+      const trailEnd = Math.min(oi + CTX, origLines.length);
+      for (let c = oi; c < trailEnd; c++) {
+        hunk.lines.push(` ${origLines[c]}`);
+      }
+      hunk.origLen = (oi + Math.min(CTX, origLines.length - oi)) - hunk.origStart;
+      hunk.fmtLen = (fi + Math.min(CTX, fmtLines.length - fi)) - hunk.fmtStart;
+      hunks.push(hunk);
+      hunk = null;
+    }
+  }
+  if (hunk) hunks.push(hunk);
+
+  for (const h of hunks) {
+    console.log(`@@ -${h.origStart + 1},${h.origLen} +${h.fmtStart + 1},${h.fmtLen} @@`);
+    for (const l of h.lines) console.log(l);
+  }
+}
+
+type DiffOp = "equal" | "delete" | "insert";
+
+function diffLines(a: string[], b: string[]): DiffOp[] {
+  // Simple LCS-based diff for reasonable file sizes
+  const n = a.length;
+  const m = b.length;
+
+  // For large files, use a faster greedy approach
+  if (n + m > 10000) return greedyDiff(a, b);
+
+  // Build LCS table
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i]![j] = dp[i - 1]![j - 1]! + 1;
+      } else {
+        dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+      }
+    }
+  }
+
+  // Backtrack to build edit script
+  const ops: DiffOp[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      ops.push("equal");
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i]![j - 1]! >= dp[i - 1]![j]!)) {
+      ops.push("insert");
+      j--;
+    } else {
+      ops.push("delete");
+      i--;
+    }
+  }
+  ops.reverse();
+  return ops;
+}
+
+function greedyDiff(a: string[], b: string[]): DiffOp[] {
+  const ops: DiffOp[] = [];
   let i = 0;
   let j = 0;
-  while (i < origLines.length || j < fmtLines.length) {
-    if (i < origLines.length && j < fmtLines.length && origLines[i] === fmtLines[j]) {
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      ops.push("equal");
       i++;
       j++;
-      continue;
-    }
-
-    // Find the hunk boundaries
-    const hunkStartI = Math.max(0, i - 3);
-    const hunkStartJ = Math.max(0, j - 3);
-
-    // Scan ahead to find where lines match again
-    let endI = i;
-    let endJ = j;
-    let found = false;
-    for (let di = 0; di < 20 && i + di < origLines.length; di++) {
-      for (let dj = 0; dj < 20 && j + dj < fmtLines.length; dj++) {
-        if (origLines[i + di] === fmtLines[j + dj]) {
-          endI = i + di;
-          endJ = j + dj;
-          found = true;
-          break;
-        }
+    } else {
+      // Look ahead for a match
+      let foundI = -1;
+      let foundJ = -1;
+      for (let d = 1; d < 50; d++) {
+        if (i + d < a.length && a[i + d] === b[j]) { foundI = i + d; break; }
+        if (j + d < b.length && a[i] === b[j + d]) { foundJ = j + d; break; }
       }
-      if (found) break;
+      if (foundI >= 0 && (foundJ < 0 || foundI - i <= foundJ - j)) {
+        while (i < foundI) { ops.push("delete"); i++; }
+      } else if (foundJ >= 0) {
+        while (j < foundJ) { ops.push("insert"); j++; }
+      } else {
+        ops.push("delete");
+        i++;
+      }
     }
-    if (!found) {
-      endI = origLines.length;
-      endJ = fmtLines.length;
-    }
-
-    const ctxEnd = Math.min(endI + 3, origLines.length);
-    console.log(`@@ -${hunkStartI + 1},${ctxEnd - hunkStartI} +${hunkStartJ + 1},${endJ - hunkStartJ + (ctxEnd - endI)} @@`);
-
-    // Context before
-    for (let k = hunkStartI; k < i; k++) {
-      console.log(` ${origLines[k]}`);
-    }
-    // Removed lines
-    for (let k = i; k < endI; k++) {
-      console.log(`-${origLines[k]}`);
-    }
-    // Added lines
-    for (let k = j; k < endJ; k++) {
-      console.log(`+${fmtLines[k]}`);
-    }
-    // Context after
-    for (let k = endI; k < ctxEnd; k++) {
-      console.log(` ${origLines[k]}`);
-    }
-
-    i = ctxEnd;
-    j = endJ + (ctxEnd - endI);
   }
+  while (i < a.length) { ops.push("delete"); i++; }
+  while (j < b.length) { ops.push("insert"); j++; }
+  return ops;
+}
+
+function findNextChange(ops: DiffOp[], from: number): number {
+  for (let i = from; i < ops.length; i++) {
+    if (ops[i] !== "equal") return i;
+  }
+  return -1;
+}
+
+function isNextChangeFar(ops: DiffOp[], from: number, currentOi: number, ctx: number): boolean {
+  let equalsInARow = 0;
+  for (let i = from; i < ops.length; i++) {
+    if (ops[i] === "equal") {
+      equalsInARow++;
+      if (equalsInARow > ctx * 2) return true;
+    } else {
+      return false;
+    }
+  }
+  return true; // end of file
 }

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -125,7 +125,30 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: W
       const metaNode = node.namedChildren.find(
         (c) => c.type === "metadata_block",
       );
-      return { scope: blockName, entries: extractMetadata(metaNode) };
+      const entries = extractMetadata(metaNode);
+
+      // Also extract note blocks from the body (mapping_body, metric_body)
+      const bodyNode = node.namedChildren.find(
+        (c) => c.type === "mapping_body" || c.type === "metric_body",
+      );
+      if (bodyNode) {
+        for (const child of bodyNode.namedChildren) {
+          if (child.type === "note_block") {
+            const strNodes = child.namedChildren.filter(
+              (x: SyntaxNode) => x.type === "nl_string" || x.type === "multiline_string",
+            );
+            if (strNodes.length > 0) {
+              const text = strNodes.map((s: SyntaxNode) => {
+                if (s.type === "multiline_string") return s.text.slice(3, -3).trim();
+                return s.text.slice(1, -1);
+              }).join("\n");
+              entries.push({ kind: "note" as const, text });
+            }
+          }
+        }
+      }
+
+      return { scope: blockName, entries };
     }
   }
 
@@ -323,10 +346,7 @@ function printDefault(result: MetaResult): void {
     } else if (entry.kind === "enum") {
       console.log(`  enum { ${entry.values.join(", ")} }`);
     } else if (entry.kind === "note") {
-      const text = entry.text.length > 100
-        ? entry.text.slice(0, 97) + "..."
-        : entry.text;
-      console.log(`  note: ${text}`);
+      console.log(`  note: ${entry.text}`);
     } else if (entry.kind === "slice") {
       console.log(`  slice { ${entry.values.join(", ")} }`);
     }

--- a/tooling/satsuma-cli/src/commands/metric.ts
+++ b/tooling/satsuma-cli/src/commands/metric.ts
@@ -188,7 +188,7 @@ function printDefault(entry: MetricRecord, metricNode: SyntaxNode | null, compac
         const metaDecl = c.namedChildren.find((x) => x.type === "metadata_block");
         const inner = nameNode?.namedChildren[0];
         const fname = inner?.text ?? "";
-        const metaDeclText = metaDecl && !compact ? ` ${metaDecl.text}` : "";
+        const metaDeclText = metaDecl ? ` ${metaDecl.text}` : "";
         console.log(`  ${fname.padEnd(20)}${typeNode?.text ?? ""}${metaDeclText}`);
       } else if (c.type === "note_block" && !compact) {
         console.log(`  note { ... }`);

--- a/tooling/satsuma-cli/src/commands/nl-refs.ts
+++ b/tooling/satsuma-cli/src/commands/nl-refs.ts
@@ -92,7 +92,22 @@ function printDefault(refs: ResolvedNLRef[]): void {
   }
 
   for (const [mapping, mappingRefs] of byMapping) {
-    console.log(`  mapping '${mapping}':`);
+    // Format the label: "mapping 'name'", "metric 'name'", "schema 'name'", etc.
+    let label: string;
+    if (mapping.startsWith("note:metric:")) {
+      label = `metric '${mapping.slice(12)}'`;
+    } else if (mapping.startsWith("note:schema:")) {
+      label = `schema '${mapping.slice(12)}'`;
+    } else if (mapping.startsWith("note:fragment:")) {
+      label = `fragment '${mapping.slice(14)}'`;
+    } else if (mapping.startsWith("note:")) {
+      label = `note '${mapping.slice(5)}'`;
+    } else if (mapping.startsWith("transform:")) {
+      label = `transform '${mapping.slice(10)}'`;
+    } else {
+      label = `mapping '${mapping}'`;
+    }
+    console.log(`  ${label}:`);
     for (const ref of mappingRefs) {
       const status = ref.resolved
         ? `-> ${ref.resolvedTo?.name ?? "?"}`

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -200,7 +200,9 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
     );
     if (!mBody) continue;
 
-    for (const arrow of mBody.namedChildren) {
+    const bodyChildren = mBody.namedChildren;
+    for (let idx = 0; idx < bodyChildren.length; idx++) {
+      const arrow = bodyChildren[idx]!;
       if (arrow.type !== "map_arrow" && arrow.type !== "computed_arrow")
         continue;
       const src = arrow.namedChildren.find((c) => c.type === "src_path");
@@ -209,10 +211,21 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
       const tgtText = tgt?.namedChildren[0]?.text ?? null;
       if (srcText !== leafName && tgtText !== leafName) continue;
 
-      for (const item of extractNLContent(
-        arrow,
-        `${getBlockName(mappingNode) ?? "?"}`,
-      )) {
+      const parentName = getBlockName(mappingNode) ?? "?";
+
+      // Include warning/question comments immediately preceding this arrow
+      for (let ci = idx - 1; ci >= 0; ci--) {
+        const prev = bodyChildren[ci]!;
+        if (prev.type === "warning_comment" || prev.type === "question_comment") {
+          for (const item of extractNLContent(prev, parentName)) {
+            items.push({ ...item, file: mapping.file });
+          }
+        } else {
+          break; // stop at first non-comment
+        }
+      }
+
+      for (const item of extractNLContent(arrow, parentName)) {
         items.push({ ...item, file: mapping.file });
       }
     }

--- a/tooling/satsuma-cli/src/commands/summary.ts
+++ b/tooling/satsuma-cli/src/commands/summary.ts
@@ -17,23 +17,12 @@ import type { Command } from "commander";
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
-import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
+import { expandEntityFields } from "../spread-expand.js";
 import type { FieldDecl, WorkspaceIndex } from "../types.js";
 
-function countFieldsDeep(fields: FieldDecl[]): number {
-  let count = 0;
-  for (const f of fields) {
-    count++;
-    if (f.children) count += countFieldsDeep(f.children);
-  }
-  return count;
-}
-
 function totalFieldCount(schema: { fields: FieldDecl[]; namespace?: string | null }, index: WorkspaceIndex): number {
-  const fieldsCopy: FieldDecl[] = JSON.parse(JSON.stringify(schema.fields)) as FieldDecl[];
-  expandNestedSpreads(fieldsCopy, schema.namespace ?? null, index);
   const expanded = expandEntityFields(schema as Parameters<typeof expandEntityFields>[0], schema.namespace ?? null, index);
-  return countFieldsDeep([...fieldsCopy, ...expanded]);
+  return schema.fields.length + expanded.length;
 }
 
 export function register(program: Command): void {
@@ -161,7 +150,8 @@ function printDefault(index: WorkspaceIndex, fileCount: number): void {
   if (schemas.length > 0) {
     console.log(`Schemas (${schemas.length}):`);
     for (const s of schemas) {
-      const note = s.note ? `  — ${s.note}` : "";
+      const noteText = s.note?.split("\n")[0]?.trim() ?? null;
+      const note = noteText ? `  — ${noteText}` : "";
       console.log(`  ${displayName(s)}  [${plural(totalFieldCount(s, index), "field")}]${note}`);
     }
     console.log();

--- a/tooling/satsuma-cli/src/commands/validate.ts
+++ b/tooling/satsuma-cli/src/commands/validate.ts
@@ -127,7 +127,14 @@ export function register(program: Command): void {
       }
 
       if (opts.json) {
-        console.log(JSON.stringify(diagnostics, null, 2));
+        console.log(JSON.stringify({
+          findings: diagnostics,
+          summary: {
+            files: extracted.length,
+            errors: errorCount,
+            warnings: warnCount,
+          },
+        }, null, 2));
         process.exit(errorCount > 0 ? 2 : 0);
       }
 

--- a/tooling/satsuma-cli/src/format.ts
+++ b/tooling/satsuma-cli/src/format.ts
@@ -368,13 +368,19 @@ function formatSingleLineField(
   let line = ind(indent) + name + " ".repeat(nameGap) + type;
 
   if (meta) {
-    // Check if metadata should be multi-line (contains multiline_string)
+    // Check if metadata should be multi-line (contains multiline_string or too long)
     if (hasMultilineString(meta)) {
       line += " " + formatMetadataBlock(meta, source, indent);
     } else {
       const metaStr = formatMetadataInline(meta, source);
       const typeGap = Math.max(metaCol - typeCol - type.length, 2);
-      line += " ".repeat(typeGap) + metaStr;
+      const candidateLine = line + " ".repeat(typeGap) + metaStr;
+      if (candidateLine.length > 80) {
+        // Too long for one line — use multi-line metadata
+        line += " " + formatMetadataBlock(meta, source, indent);
+      } else {
+        line += " ".repeat(typeGap) + metaStr;
+      }
     }
   }
 
@@ -452,10 +458,13 @@ function formatMappingBlock(node: SyntaxNode, source: string, indent: number): s
   line += " {";
 
   if (!body) {
-    return line + "\n" + ind(indent) + "}";
+    const trailing = collectBlockTrailingComments(node, -1, indent);
+    return line + trailing + "\n" + ind(indent) + "}";
   }
 
-  return line + "\n" + formatMappingBody(body, source, indent + 1) + "\n" + ind(indent) + "}";
+  const bodyStr = formatMappingBody(body, source, indent + 1);
+  const trailing = collectBlockTrailingComments(node, body.endPosition.row, indent);
+  return line + "\n" + bodyStr + trailing + "\n" + ind(indent) + "}";
 }
 
 // ── Mapping Body ──────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/graph-builder.ts
+++ b/tooling/satsuma-cli/src/graph-builder.ts
@@ -4,7 +4,6 @@
  * Shared by `satsuma lineage` and `satsuma graph` commands.
  */
 
-import { extractBacktickRefs, classifyRef } from "./nl-ref-extract.js";
 import type { WorkspaceIndex } from "./types.js";
 
 export interface GraphNode {
@@ -59,45 +58,11 @@ export function buildFullGraph(index: WorkspaceIndex): FullGraph {
     }
   }
 
-  // NL backtick references
-  if (index.nlRefData) {
-    for (const item of index.nlRefData) {
-      // Skip note blocks — they are not real mappings
-      if (item.mapping.startsWith("note:")) continue;
-
-      const refs = extractBacktickRefs(item.text);
-      const mappingKey = item.namespace
-        ? `${item.namespace}::${item.mapping}`
-        : item.mapping;
-
-      for (const { ref } of refs) {
-        const classification = classifyRef(ref);
-        if (classification === "namespace-qualified-schema" && index.schemas.has(ref)) {
-          addNode(ref, "schema");
-          addEdge(ref, mappingKey);
-        } else if (classification === "namespace-qualified-field") {
-          const dotIdx = ref.indexOf(".", ref.indexOf("::") + 2);
-          const schemaRef = ref.slice(0, dotIdx);
-          if (index.schemas.has(schemaRef)) {
-            addNode(schemaRef, "schema");
-            addEdge(schemaRef, mappingKey);
-          }
-        } else if (classification === "bare" && item.namespace) {
-          const nsRef = `${item.namespace}::${ref}`;
-          if (index.schemas.has(nsRef)) {
-            addNode(nsRef, "schema");
-            addEdge(nsRef, mappingKey);
-          } else if (index.schemas.has(ref)) {
-            addNode(ref, "schema");
-            addEdge(ref, mappingKey);
-          }
-        } else if (classification === "bare" && index.schemas.has(ref)) {
-          addNode(ref, "schema");
-          addEdge(ref, mappingKey);
-        }
-      }
-    }
-  }
+  // NL backtick references — only create field-level edges, NOT schema-level
+  // edges. Schema refs in NL text are informational references, not real
+  // source/target declarations. Creating schema edges from NL text would
+  // produce phantom lineage paths (cbh-y5og).
+  // Schema-level edges are already created above from declared source/target blocks.
 
   return { nodes, edges };
 }

--- a/tooling/satsuma-cli/src/nl-extract.ts
+++ b/tooling/satsuma-cli/src/nl-extract.ts
@@ -59,6 +59,18 @@ function walkNL(node: SyntaxNode, parent: string | null, items: NLItem[]): void 
           line: c.startPosition.row + 1,
         });
       }
+    } else if (c.type === "source_block") {
+      // Extract NL strings from source blocks (join descriptions)
+      for (const sc of c.namedChildren) {
+        if (sc.type === "nl_string" || sc.type === "multiline_string") {
+          items.push({
+            text: stripDelimiters(sc.text, sc.type),
+            kind: "note",
+            parent,
+            line: sc.startPosition.row + 1,
+          });
+        }
+      }
     } else if (c.type === "pipe_step") {
       const inner = c.namedChildren[0];
       if (

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -350,14 +350,23 @@ function extractBlockNoteRefs(
   let blockName = inner?.text ?? "";
   if (inner?.type === "quoted_name") blockName = blockName.slice(1, -1);
 
+  // extractStandaloneNoteRefs prepends "note:" to the parentLabel, so we just pass
+  // a type-prefixed block name so downstream can distinguish metric vs mapping notes.
+  // Result: "note:metric:monthly_revenue" for metrics, "note:schema:foo" for schemas.
+  const blockTypePrefix = blockNode.type === "metric_block" ? "metric:"
+    : blockNode.type === "schema_block" ? "schema:"
+    : blockNode.type === "fragment_block" ? "fragment:"
+    : "";
+  const parentLabel = `${blockTypePrefix}${blockName}`;
+
   const bodyTypes = ["schema_body", "metric_body"];
   for (const child of blockNode.namedChildren) {
     if (child.type === "note_block") {
-      extractStandaloneNoteRefs(child, namespace, blockName, results);
+      extractStandaloneNoteRefs(child, namespace, parentLabel, results);
     } else if (bodyTypes.includes(child.type)) {
       for (const bodyChild of child.namedChildren) {
         if (bodyChild.type === "note_block") {
-          extractStandaloneNoteRefs(bodyChild, namespace, blockName, results);
+          extractStandaloneNoteRefs(bodyChild, namespace, parentLabel, results);
         }
       }
     }

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1774,13 +1774,18 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", "--json", BAD);
     assert.equal(code, 2);
     const data = JSON.parse(stdout);
-    assert.ok(Array.isArray(data));
-    assert.ok(data.length > 0);
-    assert.ok(data[0].file);
-    assert.ok(data[0].line);
-    assert.ok(data[0].severity);
-    assert.ok(data[0].rule);
-    assert.ok(data[0].message);
+    assert.ok(data.findings, "should have findings key");
+    assert.ok(Array.isArray(data.findings));
+    assert.ok(data.findings.length > 0);
+    assert.ok(data.findings[0].file);
+    assert.ok(data.findings[0].line);
+    assert.ok(data.findings[0].severity);
+    assert.ok(data.findings[0].rule);
+    assert.ok(data.findings[0].message);
+    assert.ok(data.summary, "should have summary key");
+    assert.equal(typeof data.summary.files, "number");
+    assert.equal(typeof data.summary.errors, "number");
+    assert.equal(typeof data.summary.warnings, "number");
   });
 
   it("expands fragment spreads — no false field-not-in-schema warnings", async () => {
@@ -1836,7 +1841,7 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", BAD, "--json");
     assert.equal(code, 0, "missing import is a warning, not an error");
     const data = JSON.parse(stdout);
-    assert.ok(data.some((d) => d.rule === "missing-import"), "should have missing-import diagnostic");
+    assert.ok(data.findings.some((d) => d.rule === "missing-import"), "should have missing-import diagnostic");
   });
 
   it("warns on undefined import name (sl-t5k4)", async () => {
@@ -1844,7 +1849,7 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", dir, "--json");
     assert.equal(code, 0, "undefined import is a warning, not an error");
     const data = JSON.parse(stdout);
-    const undefinedImport = data.find((d) => d.rule === "undefined-import");
+    const undefinedImport = data.findings.find((d) => d.rule === "undefined-import");
     assert.ok(undefinedImport, "should have undefined-import diagnostic");
     assert.match(undefinedImport.message, /totally_fake_name/);
   });
@@ -1854,10 +1859,10 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", F, "--json");
     assert.equal(code, 0, "ref warning is not an error");
     const data = JSON.parse(stdout);
-    const refWarning = data.find((d) => d.rule === "undefined-ref" && d.message.includes("nonexistent_table"));
+    const refWarning = data.findings.find((d) => d.rule === "undefined-ref" && d.message.includes("nonexistent_table"));
     assert.ok(refWarning, "should warn about ref to nonexistent_table");
     // Valid ref to customers should NOT produce a warning
-    assert.ok(!data.some((d) => d.message.includes("customers")), "valid ref should not warn");
+    assert.ok(!data.findings.some((d) => d.message.includes("customers")), "valid ref should not warn");
   });
 
   it("target-only mapping parses without errors (sl-icqz)", async () => {
@@ -2306,8 +2311,9 @@ describe("satsuma validate (namespaces)", () => {
     const { stdout, code } = await run("validate", "--json", DUP);
     assert.notEqual(code, 0);
     const data = JSON.parse(stdout);
-    assert.ok(Array.isArray(data));
-    const dupError = data.find((d) => d.rule === "duplicate-definition");
+    assert.ok(data.findings, "should have findings key");
+    assert.ok(Array.isArray(data.findings));
+    const dupError = data.findings.find((d) => d.rule === "duplicate-definition");
     assert.ok(dupError, "Should contain a duplicate-definition diagnostic");
     assert.ok(dupError.message.includes("pos::stores"));
   });
@@ -2731,7 +2737,7 @@ describe("satsuma nl-refs", () => {
     const fixture = resolve(import.meta.dirname, "fixtures", "transform-nl-refs.stm");
     const { stdout, code } = await run("nl-refs", fixture);
     assert.equal(code, 0);
-    assert.match(stdout, /transform:build_fullname/);
+    assert.match(stdout, /transform 'build_fullname'/);
     assert.match(stdout, /first_name/);
     assert.match(stdout, /last_name/);
     assert.match(stdout, /region_code/);
@@ -2804,7 +2810,7 @@ describe("satsuma where-used (NL refs)", () => {
     const result = JSON.parse(stdout);
     const nlRefs = result.refs.filter((r) => r.kind === "nl_ref");
     assert.ok(nlRefs.length >= 1, "should find NL ref in metric note block");
-    assert.ok(nlRefs.some((r) => r.name === "note:order_count"), "should attribute to metric");
+    assert.ok(nlRefs.some((r) => r.name === "note:metric:order_count"), "should attribute to metric");
   });
 
   it("text output uses 'Referenced in NL text' label", async () => {


### PR DESCRIPTION
## Summary
- **18 individual bugs fixed** across 14 command files (meta, fmt, nl, nl-refs, arrows, summary, validate, context, find, metric, lineage, graph-builder, nl-extract, nl-ref-extract)
- **6 epics closed** (all children resolved): cbh-zybb, cbh-ukcx, cbh-h0or, cbh-fmtb, cbh-5tvk, cbh-ocid
- **24 tickets closed total**
- All 789 CLI tests pass, 13 example files reformatted to match new multi-line metadata wrapping

### Bug fixes by area
- **meta**: Remove note truncation; extract body note blocks from mappings and metrics (cbh-2y8p, cbh-7ji8, cbh-kyv3)
- **fmt**: Preserve trailing comments in mapping blocks; wrap long metadata to multi-line; use cleaner paths; rewrite diff with LCS algorithm (cbh-394k, cbh-qwyg, cbh-xj0m, cbh-ya9k)
- **nl**: Extract NL from source block joins; include arrow-adjacent warning comments in field queries (cbh-so1o, cbh-9cqh)
- **nl-refs**: Attribute metric note backtick refs to metric type, not mapping (cbh-cyl0)
- **arrows**: Prevent double-qualifying already schema-qualified NL-derived paths (cbh-n4vm)
- **summary**: Truncate multi-line notes to first line; use top-level field count consistent with schema --json (cbh-b0w8, cbh-mpz2)
- **validate**: Wrap --json output in `{findings, summary}` structure consistent with lint (cbh-myj2)
- **context**: Expand fragment spread fields in schema rendering (cbh-rkia)
- **find**: Report consuming schema file/line for spread fields (cbh-5lzd)
- **metric**: Keep field metadata visible in --compact mode (cbh-z5dy)
- **lineage**: Remove phantom schema edges from NL backtick references (cbh-y5og)

## Test plan
- [x] All 789 existing CLI tests pass
- [x] Updated tests for validate --json structure change
- [x] Updated tests for nl-refs metric/transform label formatting
- [x] All pre-commit hooks pass (lint, fmt --check, vscode, tree-sitter, Python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)