### PR TITLE
docs: discovered requirements audit + language simplification PRD

### DIFF
--- a/DISCOVERED-REQUIREMENTS.md
+++ b/DISCOVERED-REQUIREMENTS.md
@@ -1,0 +1,613 @@
+# Discovered Requirements
+
+Latent requirements and non-obvious behaviors discovered through exploratory testing, bug fixes, and feature work across 300+ tickets. These are behaviors that the spec and CLI docs don't explicitly call out but that users and tooling authors need to know about.
+
+Each entry links to the ticket(s) where the behavior was discovered.
+
+---
+
+## Table of Contents
+
+1. [Output Indexing](#1-output-indexing-all-line-numbers-must-be-1-indexed)
+2. [Exit Code Contract](#2-exit-code-contract)
+3. [Backtick-Quoted Identifiers](#3-backtick-quoted-identifiers-must-be-preserved-through-output)
+4. [Quoted Metadata Values](#4-quoted-metadata-values-must-round-trip-through-output)
+5. [Flatten/Each as Containers](#5-flatteneach-blocks-are-structural-containers-not-arrows)
+6. [Path Continuation Dots](#6-path-continuation-dots-must-not-cross-newlines)
+7. [Schema-Qualified Path Prefixing](#7-schema-qualified-paths-must-not-be-double-prefixed)
+8. [Anonymous Mapping Keys](#8-anonymous-mappings-use-anonfilerow-keys)
+9. [NL Refs Are Not Sources](#9-nl-backtick-references-are-not-structural-sources)
+10. [Lint --fix Quoting](#10-lint---fix-must-match-existing-quoting-style)
+11. [Recursive Field Rendering](#11-nested-fields-must-be-recursively-rendered)
+12. [Metric Block Context](#12-metric-blocks-are-first-class-citizens)
+13. [Container vs. Leaf Arrows](#13-container-arrows-vs-leaf-arrows)
+14. [nl-derived Classification](#14-the-nl-derived-arrow-classification-exists)
+15. [Standalone Note/Transform NL](#15-standalone-note-and-transform-blocks-need-nl-extraction)
+16. [Comments in Output](#16-comments-in-schema-bodies-are-part-of-the-output)
+17. [Formatter Conventions](#17-formatter-conventions)
+18. [find --in Validation](#18-find---in-must-validate-scope-values)
+19. [Multi-Source Validation](#19-validate-must-check-all-declared-sources-in-multi-source-mappings)
+20. [Convention Fields](#20-convention-fields-are-inferred-not-declared)
+21. [Import References](#21-import-statements-are-references)
+22. [Double-Dot Paths](#22-graph-double-dot-path-bug-pattern)
+23. [Compact/No-NL Stripping](#23---compact-and---no-nl-must-strip-all-nl-content)
+24. [Column Offsets](#24-column-offsets-must-account-for-quote-characters)
+25. [Warnings Block Context](#25-warnings-json-must-include-block-context)
+26. [Diff Attribution](#26-diff-command-must-attribute-changes-to-parent-blocks)
+27. [Version Sync](#27-version-must-be-synchronized-across-all-package-files)
+28. [Fragment Spread Expansion](#28-fragment-spreads-must-be-expanded-across-all-commands)
+29. [Namespace Resolution](#29-namespace-resolution-current-namespace-first-then-global)
+30. [Deeply Nested NL Paths](#30-deeply-nested-dotted-paths-in-nl-references)
+31. [Metadata Value Forms](#31-metadata-supports-rich-value-forms)
+32. [Trailing Comment Preservation](#32-trailing-comments-must-not-be-dropped)
+33. [Multi-Line Metadata](#33-multi-line-metadata-blocks-must-preserve-structure)
+34. [JSON Output Consistency](#34-json-output-consistency-contract)
+35. [Error Output Channel](#35-errors-and-warnings-must-use-stderr-not-stdout)
+36. [Import Resolution](#36-single-file-entry-points-must-resolve-imports-transitively)
+37. [Backtick Stripping in Index](#37-backtick-stripping-in-workspace-index)
+38. [NL String Escape Handling](#38-nl-string-escape-sequences-must-be-unescaped)
+39. [Lineage Completeness](#39-upstream-lineage-must-follow-all-branches)
+40. [Field Count Ambiguity](#40-field-count-meaning-depends-on-fragment-spreads)
+41. [Note Block Completeness](#41-note-blocks-must-be-extracted-from-all-parent-types)
+42. [Diff Completeness](#42-diff-must-detect-all-change-kinds)
+43. [Formatter Field Alignment](#43-formatter-field-alignment-rules)
+44. [Source Block NL Content](#44-source-block-join-descriptions-are-nl-content)
+45. [Arrow-Adjacent Comments](#45-arrow-adjacent-comments-are-field-scoped-nl)
+46. [Numeric Enum Values](#46-numeric-and-quoted-enum-values-are-valid)
+47. [Multi-Target Mappings](#47-multi-target-mapping-extraction)
+48. [Schema Label Quoting](#48-multi-word-schema-labels-must-be-quoted-in-output)
+
+---
+
+## 1. Output Indexing: All Line Numbers Must Be 1-Indexed
+
+**Tickets:** cbh-7rvo, cbh-gz2v, cbh-s9w6, sl-m02g, sl-2usp, sl-n96y, sl-z3eg, cbh-fmtb
+
+Tree-sitter internally uses 0-indexed row numbers. Every CLI command that emits a row/line number in JSON or text output must add `+1` to produce 1-indexed output. This applies to: `context`, `warnings`, `where-used`, `summary`, `mapping`, `metric`, `find`, `nl`, `graph`, `nl-refs`, `schema`, and `arrows`.
+
+Commands that mix 0-indexed and 1-indexed output in the same workspace are a source of silent downstream errors (e.g., an agent computing a diff between `graph` and `arrows` output gets off-by-one mismatches).
+
+---
+
+## 2. Exit Code Contract
+
+**Tickets:** sl-0ycs, sl-ht9n
+
+The CLI uses a three-tier exit code contract:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Results found and printed |
+| 1 | No results (query matched nothing, or entity exists with zero references) |
+| 2 | Structural error (parse failure, filesystem ENOENT/EACCES, invalid arguments) |
+
+Every query command must return exit code 1 when the query matches nothing — including when the named entity exists but has zero references. This is critical for scripting (`satsuma warnings examples/ || echo "clean"`).
+
+Commands affected: `warnings`, `context`, `arrows`, `where-used`, `nl-refs`, `graph`, `lineage`, `fields`.
+
+Mutually exclusive flags (e.g., `--from` and `--to` on `lineage`) must error immediately, not silently ignore one.
+
+---
+
+## 3. Backtick-Quoted Identifiers Must Be Preserved Through Output
+
+**Tickets:** cbh-sttt
+
+Field names wrapped in backticks (e.g., `` `Lead_Source_Detail__c` ``) must retain their backticks in both text and JSON output. The CLI must never strip backticks — they indicate that the identifier contains special characters and stripping them changes the semantics. This applies to all commands that emit field paths: `mapping`, `arrows`, `fields`, `find`, `graph`.
+
+---
+
+## 4. Quoted Metadata Values Must Round-Trip Through Output
+
+**Tickets:** cbh-djny
+
+When a metadata value is quoted in source (e.g., `filter "active"`), the quotes must appear in text output. The CLI tracks a `quoted` flag on metadata entries and re-wraps values in double quotes when rendering. Without this, consumers cannot distinguish `filter active` (a bare token) from `filter "active"` (a string value).
+
+---
+
+## 5. Flatten/Each Blocks Are Structural Containers, Not Arrows
+
+**Tickets:** cbh-zdk3, sc-1ar0
+
+`flatten` and `each` blocks are structural containers whose child arrows are the actual mapping arrows. The `arrowCount` on a mapping must count only the leaf arrows inside these blocks, not the container blocks themselves. Double-counting inflates arrow counts and misleads coverage analysis.
+
+However, flatten/each blocks themselves must appear in mapping text and JSON output (with their child arrows nested inside), even though they don't count as arrows.
+
+---
+
+## 6. Path Continuation Dots Must Not Cross Newlines
+
+**Tickets:** sl-9uh0, sl-3alz
+
+In the tree-sitter grammar, the `.` that continues a dotted field path (e.g., `record.field`) must use `token.immediate(".")` so that it immediately follows the preceding segment with no intervening whitespace or newlines. Without this, the parser merges text across line boundaries in nested blocks, causing "target contamination" — a bare arrow's target text gets concatenated with the next arrow's source.
+
+This was the root cause of the entire "nested block extraction gaps" epic — it caused the last arrow in any nested block to absorb the next line.
+
+---
+
+## 7. Schema-Qualified Paths Must Not Be Double-Prefixed
+
+**Tickets:** sc-7zt0
+
+When emitting JSON for arrows that already contain a schema-qualified path (e.g., `target_schema.field`), the CLI must not blindly prepend the schema name again. A `qualifyPath` helper must check whether the path already starts with the schema name before prefixing.
+
+---
+
+## 8. Anonymous Mappings Use `<anon>@file:row` Keys
+
+**Tickets:** sl-0o1x
+
+Mappings without a name are indexed as `<anon>@filepath:row`. All commands that look up mappings — especially NL-based lint rules — must use this key format, not an empty string. Using an empty string causes silent skips where anonymous mappings are never validated.
+
+---
+
+## 9. NL Backtick References Are Not Structural Sources
+
+**Tickets:** sl-n11t, cbh-h0or
+
+When a mapping's NL text references a schema via backtick (e.g., `` "Look up `dim_customer`" ``), that reference must **not** be promoted to a structural source edge in the graph or lineage. Graph `schema_edges` must only reflect declared `source` / `target` blocks. NL references are surfaced separately via `nl-refs` and may inform lint rules, but they are not part of the structural graph.
+
+This distinction is easy to conflate. The `lineage` command was also found creating phantom edges from NL backtick refs. The `arrows` command was incorrectly prefixing NL-derived source fields with the mapping's source schema. These are all symptoms of treating NL mentions as structural declarations.
+
+---
+
+## 10. Lint --fix Must Match Existing Quoting Style
+
+**Tickets:** sl-z157
+
+When `lint --fix` inserts a new source entry (e.g., adding a hidden source detected from NL), it must match the quoting convention of existing entries. If existing source entries use backtick wrapping, the inserted entry must also be backtick-wrapped.
+
+---
+
+## 11. Nested Fields Must Be Recursively Rendered
+
+**Tickets:** sl-1ugo, sl-4mh2, sl-giss, sl-bfue
+
+Commands that render field trees (`fields`, `meta`, `find`) must recurse into record and list children. Flat rendering that only shows top-level fields hides nested structure. Similarly:
+
+- `--unmapped-by` must check individual leaf fields inside partially-mapped records, not treat the whole record as a single unit
+- `meta` must walk into record/list blocks (not just `field_decl` nodes)
+- Nested field paths like `schema.record.field` must be supported for disambiguation when the same field name appears in multiple nested blocks
+
+---
+
+## 12. Metric Blocks Are First-Class Citizens
+
+**Tickets:** sl-h0n8, sl-09bo, sl-se2f, sl-g4u2, cbh-ocid, cbh-kyv3, stm-axj8
+
+Metrics are first-class blocks with fields, source references, slices, namespaces, note blocks, and measure annotations. Many commands initially treated metrics as second-class:
+
+- Lint rules operating on metric note blocks must include the metric's own fields and declared sources as valid resolution context (otherwise: false-positive unresolved-reference warnings)
+- Metric JSON must include: namespace, slices, filter values, measure annotations (`additive`/`non_additive`/`semi_additive`), and all metadata
+- `meta` must include metric body note blocks (not just header metadata)
+- `--compact` on metrics must strip notes but preserve measure metadata
+- When metrics use namespace-qualified source refs (e.g., `source vault::hub_deal`), metadata extraction must not duplicate the key as the value
+
+---
+
+## 13. Container Arrows vs. Leaf Arrows
+
+**Tickets:** sl-zfi0, sl-wjb9
+
+An arrow with a `{ }` body containing child arrows (a "container arrow") is structurally different from an arrow with a transform body. Container arrows:
+- Have `hasTransform: false` (the braces contain children, not a transform)
+- Must include their child arrows in output (not silently drop them)
+- Must not be classified as `"none"` — they are structural groupings
+
+Child arrows inside nested blocks must also include their parent path prefix (e.g., `.field -> .target` inside `Items[] -> items[]` becomes `Items[].field -> items[].target`).
+
+---
+
+## 14. The `nl-derived` Arrow Classification Exists
+
+**Tickets:** sl-2x93
+
+The `arrows` command can return a fifth classification value: `nl-derived`, for implicit arrows inferred from NL backtick references. This is in addition to the four documented values (`structural`, `nl`, `mixed`, `none`). Any consumer switching on classification values must handle this case.
+
+Transform classification is purely mechanical CST analysis — it does not interpret semantics. The categories are:
+- `structural`: deterministic pipe chain, no NL
+- `nl`: NL-only transform body
+- `mixed`: pipe chain + NL annotation
+- `none`: bare arrow with no transform body
+- `nl-derived`: implicit arrow inferred from NL backtick reference (undocumented until sl-2x93)
+
+---
+
+## 15. Standalone Note and Transform Blocks Need NL Extraction
+
+**Tickets:** sl-3dd2, sl-xrc8
+
+`nl-refs` and lint must walk standalone `note { }` and `transform { }` blocks, not just schema/mapping/metric bodies. Standalone notes get a pseudo-mapping key of `"note:"` — resolving backtick refs in them requires special handling since they have no parent schema context.
+
+---
+
+## 16. Comments in Schema Bodies Are Part of the Output
+
+**Tickets:** sl-i956
+
+Schema text output must include `//`, `//!`, and `//?` comments from the schema body. These carry important context (warnings about known issues, TODOs). The `--compact` flag strips them; default output preserves them.
+
+Edge-case: comments before the first field or after the last field in a schema body were initially dropped — only inter-field comments were preserved. All positions must be handled.
+
+---
+
+## 17. Formatter Conventions
+
+**Tickets:** cbh-vgka, cbh-0lhj, cbh-394k, cbh-qwyg
+
+The formatter enforces these spacing conventions that aren't in the spec:
+
+- **One blank line** between top-level blocks (not two)
+- **One blank line** preserved between file header comments and section comments
+- Files with parse errors are **skipped** (not partially formatted)
+- **Trailing comments** after the last arrow in a mapping block must be preserved (not silently dropped)
+- **Multi-line field metadata** must preserve its multi-line layout (not be collapsed to single-line)
+- Fragment spread lines (`...name`) are standalone at block indent, not column-aligned with fields
+- Inline trailing comments must have a minimum 2-space gap from code
+- ~80-character threshold for breaking source/target blocks and metadata blocks across lines
+
+---
+
+## 18. find --in Must Validate Scope Values
+
+**Tickets:** sl-1f9d
+
+When `find --in <scope>` receives an unrecognized scope value, it must emit an error — not silently return zero results. Silent empty results are indistinguishable from "no matches" and mislead users into thinking their query matched nothing.
+
+---
+
+## 19. Validate Must Check All Declared Sources in Multi-Source Mappings
+
+**Tickets:** sl-mb6k, sc-8g9a, stm-fi63
+
+When a mapping declares multiple sources, `validate` must check schema-prefixed arrow paths against **all** declared sources, not just the first. It must also handle flatten arrow targets that are schema-qualified without producing false-positive `field-not-in-schema` warnings.
+
+The validator was found to use `mapping.sources[0]` for resolution instead of matching the schema qualifier in the arrow path to the correct source declaration.
+
+---
+
+## 20. Convention Fields Are Inferred, Not Declared
+
+**Tickets:** stm-1hsk, stm-pxl6
+
+Data Vault and other convention metadata tokens (e.g., `datavault hub`) imply the existence of convention fields (`hub_customer_hk`, `record_source`, `load_date`). The validator must suppress `field-not-in-schema` warnings for these inferred fields. A `getConventionFields()` helper derives expected fields from schema metadata tokens.
+
+Similarly, `hub`/`satellite`/`link` vocabulary tokens imply hash keys, record sources, and load dates that are never declared in the schema body.
+
+---
+
+## 21. Import Statements Are References
+
+**Tickets:** sl-izap, stm-6gh9
+
+`import { name } from "file.stm"` declarations must be detected as references by `where-used`. Import references are a distinct reference type alongside arrow sources, arrow targets, NL backtick references, and metric source declarations.
+
+Note: the parser initially lacked grammar support for import declarations entirely — they are spec-backed and used heavily in examples but were a late addition to the grammar.
+
+---
+
+## 22. graph Double-Dot Path Bug Pattern
+
+**Tickets:** sl-bl5e
+
+When constructing dotted field paths for nested record/list fields in graph output, the intermediate segment name must be included. Skipping it produces malformed paths like `schema..field` (double dot) instead of `schema.record.field`. This is a recurring pattern whenever path construction skips the container field name.
+
+---
+
+## 23. --compact and --no-nl Must Strip All NL Content
+
+**Tickets:** sl-vfbv, sl-d8h5
+
+`schema --compact` must strip triple-quoted notes as well as single-line notes. `graph --no-nl` must strip the `unresolved_nl` section in addition to `nl_text` on edges. Partial stripping defeats the purpose of these flags (reducing token count for LLM consumption).
+
+---
+
+## 24. Column Offsets Must Account for Quote Characters
+
+**Tickets:** sl-5erh
+
+When computing column offsets for backtick references inside NL strings, the offset must account for the opening quote character. Off-by-one column values break IDE go-to-definition and highlight features.
+
+---
+
+## 25. Warnings JSON Must Include Block Context
+
+**Tickets:** sl-c7yn
+
+`warnings --json` must include `block` (name) and `blockType` (schema/mapping/metric) fields so consumers know which block a warning belongs to. Warnings without block context require the consumer to re-parse the file to determine provenance.
+
+---
+
+## 26. Diff Command Must Attribute Changes to Parent Blocks
+
+**Tickets:** sl-kf76
+
+When a note block inside a metric or mapping changes, the diff output must attribute the change to that parent block — not report it as an orphaned top-level note addition/removal. Misattribution makes it impossible to assess the impact of a change.
+
+---
+
+## 27. Version Must Be Synchronized Across All Package Files
+
+**Tickets:** cbh-1uu9
+
+A single `VERSION` file is the source of truth. All `package.json` files, the changelog, and any version-reporting code must derive from it. Use `scripts/bump-version.sh` to update atomically. Version drift between packages causes confusing `--version` output.
+
+---
+
+## 28. Fragment Spreads Must Be Expanded Across All Commands
+
+**Tickets:** cbh-5tvk, sl-42ev, sg-u8sh, stm-qjwm
+
+Fragment spreads (`...fragment_name`) are one of the most pervasive sources of inconsistency across the CLI. When a schema uses a fragment spread, every command that operates on fields must expand it:
+
+- **fields**: must include spread fields in the field tree
+- **arrows**: must resolve arrow references against expanded fields
+- **graph**: must include spread fields in schema nodes
+- **validate**: must not flag spread fields as "not in schema"
+- **find**: must match spread fields (but must report them at the consuming schema's location, not the fragment definition's location)
+- **meta**: must look into spread fields for metadata queries
+- **nl-refs**: must resolve backtick refs against expanded fields
+- **where-used**: must detect spreads as references to the fragment
+
+Additional complexities:
+- **Transitive spreads**: fragments can spread other fragments
+- **Namespace-qualified spreads**: `...ns::fragmentName` must resolve across namespaces
+- **Nested record spreads**: `PID.Address record { ...address_fields }` must expand at the nested record scope, not at schema level
+
+---
+
+## 29. Namespace Resolution: Current-Namespace-First, Then Global
+
+**Tickets:** stm-prfz, stm-ku9i, stm-sbgx
+
+Namespaces use `::` as separator (e.g., `crm::orders.field`), deliberately chosen to not collide with `.field.nested` syntax. The resolution rule is:
+
+1. Unqualified references inside a namespace block resolve to current namespace first, then global
+2. Once a qualified identity is resolved, it must stay qualified throughout that operation
+3. Commands must not search CST by bare label only after resolving a qualified key — this aliases different blocks together
+
+This resolution rule was found to be broken across multiple commands (`schema`, `mapping`, `metric`, `nl`, `find`, `lineage`, `graph`), all of which searched by bare label and corrupted qualified lookups.
+
+The `lineage --from` command was also found to emit unqualified target schema names, breaking multi-hop traversal in namespace-aware graphs. Target schemas must always include the namespace prefix.
+
+---
+
+## 30. Deeply Nested Dotted Paths in NL References
+
+**Tickets:** (recent commits on fix/cli-bug-batch-3)
+
+Backtick references in NL strings can use deeply nested dotted paths like `` `CdtTrfTxInf.PmtId.UETR` `` or `` `PID.DateOfBirth` ``. These must resolve to nested record fields, not just schema.field pairs. The `nl-refs` and `arrows` commands must support arbitrary depth in path resolution.
+
+Additionally, NL content must never be silently truncated — if a triple-quoted string contains 500 characters of text, all 500 characters must appear in output.
+
+---
+
+## 31. Metadata Supports Rich Value Forms
+
+**Tickets:** stm-ixb4, stm-zy83
+
+Metadata in `( )` blocks supports a much richer set of forms than basic key-value pairs:
+
+| Form | Example |
+|------|---------|
+| Bare token | `pk` |
+| Numeric | `precision 0` |
+| Boolean | `nullable false` |
+| Quoted string | `format "E.164"` |
+| Dotted reference | `ref addresses.id` |
+| Decimal | `tolerance 0.02` |
+| Namespace-qualified | `ref ord::orders.id` |
+| Filter expression | `filter QUAL == "ON"` |
+| Compound ref...on | `ref dim_customer on customer_id` |
+| Enum | `enum {A, B, C}` |
+
+Each form needs explicit parsing in the grammar — generic expression parsing is insufficient.
+
+---
+
+## 32. Trailing Comments Must Not Be Dropped
+
+**Tickets:** cbh-394k
+
+The formatter and mapping output must preserve comments after the last arrow in a mapping block. These are typically `//!` warnings or `//?` questions — dropping them is data loss. Comments in any position (before first field, between fields, after last field, after last arrow) must be preserved.
+
+---
+
+## 33. Multi-Line Metadata Blocks Must Preserve Structure
+
+**Tickets:** cbh-qwyg
+
+Multi-line metadata blocks (metadata that spans multiple lines inside parentheses for readability) must not be collapsed to single lines by the formatter or output renderers. The multi-line layout is intentional when the metadata contains many tokens or long note strings.
+
+---
+
+## 34. JSON Output Consistency Contract
+
+**Tickets:** cbh-myj2, sl-io70, sl-rbvk
+
+All JSON output must follow these consistency rules:
+
+- **Filter flags apply to JSON**: `--compact`, `--fields-only`, `--matched-only`, `--unmatched-only` must affect JSON output, not just text
+- **Error responses as JSON**: when `--json` is active and an error occurs, the error must be emitted as a JSON object on stdout (not as plain text on stderr)
+- **Consistent envelope**: `validate --json` and `lint --json` must use the same envelope structure (both were found using different formats — bare array vs. structured object)
+- **Complete field data**: `schema --json` must include all field metadata (pk, required, enum, ref, default, note, xpath, encrypt, format, filter) — not just name and type
+- **Arrow details**: arrow metadata, transform content, and field metadata must all appear in JSON output
+- **Namespace preservation**: JSON schema output must include namespace field for namespace-qualified schemas
+
+---
+
+## 35. Errors and Warnings Must Use stderr, Not stdout
+
+**Tickets:** (discovered during import resolution work)
+
+Import-resolution warnings, parse-error diagnostics, and other non-data messages must go to stderr, not stdout. Writing them to stdout pollutes `--json` output and breaks pipe chains.
+
+---
+
+## 36. Single-File Entry Points Must Resolve Imports Transitively
+
+**Tickets:** stm-8k6p, stm-gde5
+
+When a single `.stm` file is passed to the CLI (not a directory), the CLI must transitively follow `import` declarations to discover all dependencies. Without this, cross-file validation fails — fields declared in a source schema are flagged as missing because the CLI doesn't know about the other file.
+
+`workspace.js` `resolveInput()` handles this, but it's a non-obvious requirement that single-file invocations need transitive resolution.
+
+---
+
+## 37. Backtick Stripping in Workspace Index
+
+**Tickets:** stm-mks5
+
+When building the workspace index, `extractMappings` must strip backtick delimiters from source/target names before indexing. Storing `` `target_name` `` with backticks breaks every downstream command (`lineage`, `where-used`, `validate`) because backtick-quoted names don't match the indexed names of schemas.
+
+This is the inverse of requirement #3 — backticks must be preserved in *output* but stripped in the *index*.
+
+---
+
+## 38. NL String Escape Sequences Must Be Unescaped
+
+**Tickets:** (discovered during NL extraction work)
+
+NL strings containing escape sequences (`\"`, `\\`) must be unescaped during extraction. Raw escapes in extracted NL text confuse downstream consumers and break backtick-reference resolution (a `` `ref` `` preceded by `\"` won't parse correctly if the escape isn't resolved first).
+
+---
+
+## 39. Upstream Lineage Must Follow All Branches
+
+**Tickets:** sg-pufq
+
+`lineage --to` must walk all upstream predecessor branches, not just a single arbitrary chain. A mapping with multiple sources must surface all of them. Missing branches means incomplete lineage, which defeats the purpose of impact analysis.
+
+`--depth` truncation should use `[?]` markers to indicate truncated paths, not silently drop them.
+
+---
+
+## 40. Field Count Meaning Depends on Fragment Spreads
+
+**Tickets:** cbh-5tvk
+
+There is no single "correct" field count for schemas with fragment spreads. Different commands use different counting strategies:
+
+- `summary`: recursive/leaf counting (includes all nested + spread fields)
+- `schema --json`: top-level-only counting
+- `find`: reports spread fields at the fragment definition's file/line, not the consuming schema's location
+
+This ambiguity should be documented explicitly. Consumers comparing field counts across commands will get different numbers.
+
+---
+
+## 41. Note Blocks Must Be Extracted from All Parent Types
+
+**Tickets:** cbh-e01s, cbh-ukcx, cbh-kyv3, cbh-7ji8, cbh-so1o
+
+Note blocks (`note { }`) can appear inside:
+- Schemas (extracted by most commands)
+- Mappings (initially missed by `mapping --json`)
+- Metrics (initially missed by `meta`)
+- Standalone at file level (needs pseudo-key for NL resolution)
+- Inside record/list blocks (should use record/list name as parent, not schema)
+
+All five positions must be handled by every command that surfaces NL or note content.
+
+---
+
+## 42. Diff Must Detect All Change Kinds
+
+**Tickets:** sl-kf76, and the diff epic tickets
+
+The diff command must detect granular changes at every level:
+
+- **Field-level metadata changes**: required, pii, format, etc. changing on a field (not just field add/remove)
+- **Arrow-level changes**: individual arrow additions/removals/transform modifications (not just count deltas)
+- **Transform body changes**: NL text changing inside a transform
+- **Note block changes**: inside mappings, metrics, schemas, and standalone
+- **Metric header changes**: source, grain, slice, filter attribute modifications
+- **Block-level content**: fragments, transforms, and standalone notes must all be comparable
+- **Parent attribution**: all changes must be attributed to their parent block (schema, mapping, metric)
+
+---
+
+## 43. Formatter Field Alignment Rules
+
+**Tickets:** (discovered during formatter implementation)
+
+The formatter uses two-pass column alignment for fields inside blocks:
+
+1. Field names: column-aligned with a 24-character cap
+2. Field types: column-aligned with a 14-character cap
+3. Metadata: follows type with a minimum 2-space gap
+
+Fragment spreads (`...name`) are not aligned — they sit standalone at block indent level.
+
+---
+
+## 44. Source Block Join Descriptions Are NL Content
+
+**Tickets:** cbh-so1o
+
+NL strings inside source blocks that describe join conditions (e.g., `source { \`orders\`, \`customers\` "joined on customer_id" }`) are NL content that must be extracted by `satsuma nl`. These were initially missed because `nl` only walked mapping bodies, not source declarations.
+
+---
+
+## 45. Arrow-Adjacent Comments Are Field-Scoped NL
+
+**Tickets:** cbh-9cqh
+
+When querying NL content scoped to a specific field (`satsuma nl field schema.field`), warning comments (`//!`) and question comments (`//?`) adjacent to arrows involving that field must be included. These comments are semantically about the field even though they're syntactically siblings.
+
+---
+
+## 46. Numeric and Quoted Enum Values Are Valid
+
+**Tickets:** sl-qc7y
+
+Enum declarations can contain:
+- Bare identifiers: `enum {A, B, C}`
+- Numeric values: `enum {1, 2, 5, 6}`
+- Quoted strings: `enum {"Value Prop", "Follow Up"}`
+- Comparison operators: `enum {<, <=, >=, >}`
+
+The grammar must handle all four forms. Numeric enum values initially caused parse failures.
+
+---
+
+## 47. Multi-Target Mapping Extraction
+
+**Tickets:** (discovered during extraction work)
+
+Mappings can declare multiple targets: `target { \`t1\`, \`t2\` }`. Extraction must capture both targets — initially only the first was recognized. Target names with backticks must have the backticks stripped during extraction (same index-vs-output rule as #3/#37).
+
+---
+
+## 48. Multi-Word Schema Labels Must Be Quoted in Output
+
+**Tickets:** (discovered during output rendering)
+
+When rendering schema or mapping labels that contain spaces or special characters in text output, they must be wrapped in single quotes (matching the source syntax). `schema 'order-headers-parquet'` must display as `'order-headers-parquet'`, not as bare text that breaks downstream parsing.
+
+---
+
+## Design Principles Discovered (Not in Spec)
+
+### The CLI Is Structural Primitives, Not High-Level Commands
+
+**Tickets:** stm-u65b, stm-u32p
+
+The CLI provides only deterministic structural extraction — no NL interpretation, no impact analysis, no coverage scoring. These are composed by the agent calling the CLI. The design explicitly separates:
+
+- `validate` (parser/semantic correctness) from `lint` (policy/convention enforcement)
+- Structural extraction (CLI) from NL interpretation (agent)
+- Deterministic output (always correct) from heuristic output (may need judgment)
+
+### Lint vs. Validate Contract
+
+**Tickets:** stm-mt1d
+
+- `validate`: parser/semantic correctness checks. Exit 0 = valid, exit 1 = invalid.
+- `lint`: policy and convention enforcement with optional `--fix`. Exit non-zero when findings exist (even warnings). Autofix must be idempotent and deterministic, never speculative about semantics. Rules must be explicitly named and individually testable.
+
+### NL References Are Structural Extracts, Not Semantic Links
+
+**Tickets:** sl-n11t, cbh-h0or
+
+Backtick references in NL are syntactic/structural extracts, not validated semantic links. The CLI extracts them mechanically. The agent decides what they mean. Promoting them to structural declarations breaks the graph and lineage.

--- a/features/22-language-simplification/PRD.md
+++ b/features/22-language-simplification/PRD.md
@@ -1,0 +1,416 @@
+# Feature 22 — Language Simplification
+
+> **Status: DRAFT**
+
+## Goal
+
+Simplify the Satsuma language surface and CLI output to eliminate entire classes of bugs discovered through 300+ tickets of exploratory testing. The grammar currently has ~45 rules for metadata/transforms/paths with 13 distinct metadata value forms — far more complexity than a language whose parser is an LLM needs. This feature reduces the grammar to its structural essentials, unifies quoting, normalizes output references, adds multi-source arrows, and elevates NL backtick references to structural sources.
+
+---
+
+## Problem
+
+The DISCOVERED-REQUIREMENTS.md audit identified 48 latent requirements, most stemming from unnecessary grammar and output complexity:
+
+1. **Inconsistent field references.** Different commands emit bare names (`customer_id`), schema-qualified (`crm_customers.customer_id`), or namespace-qualified (`crm::crm_customers.customer_id`) for the same field. Downstream consumers comparing output across commands get silent mismatches.
+
+2. **Over-specified grammar.** The metadata grammar parses 13 value forms (boolean, numeric, dotted, comparison, ref-on compound, etc.) but Satsuma doesn't care about types — metadata is string data for the agent to reason about. Every distinct grammar rule is a CST node type that every CLI command must handle, and every missed case is a bug.
+
+3. **Three quote types.** Single quotes for labels, double quotes for NL, backticks for identifiers. Single quotes appear only after keywords and nowhere else — they add a third quoting convention for minimal benefit. Users write `schema "my schema"` (wrong quotes) and get a parse error.
+
+4. **No multi-source arrows.** When a target field derives from multiple source fields, there's no way to express it at arrow level. The current workaround is a prose NL description, which breaks field-level lineage precision.
+
+5. **NL refs are second-class.** Backtick references in NL strings (`` "Look up `dim_customer`" ``) are informational only. The graph and lineage commands ignore them. But they represent real data dependencies that users expect to see in lineage output.
+
+6. **Pipe step ceremony.** Transform pipe chains require quotes around NL text (`"Convert to uppercase" | trim`), but since the CLI doesn't execute any of it — `trim` and `"Convert to uppercase"` are both just text for the agent — the quotes are unnecessary ceremony.
+
+---
+
+## Design Decisions
+
+### D1: Canonical field reference form
+
+All CLI output (JSON and text) emits fully-qualified field references:
+
+| Workspace has namespaces? | Form |
+|---------------------------|------|
+| No | `::schema.field` |
+| Yes | `namespace::schema.field` |
+
+The `::` prefix on unscoped schemas is visually distinct, machine-parseable, and never ambiguous. A shared `canonicalRef()` utility produces this form everywhere.
+
+### D2: Two quote types only
+
+| Type | Syntax | Purpose |
+|------|--------|---------|
+| Backticks | `` `...` `` | Identifiers and names that aren't bare-safe, or cross-references inside NL |
+| Double quotes | `"..."` / `"""..."""` | Natural language content |
+
+Single quotes are removed. `schema 'my schema'` becomes `` schema `my schema` ``. This reduces the mental model to: "backticks for names, quotes for prose."
+
+#### When backticks are required vs optional
+
+**Bare identifiers** matching `[a-zA-Z_][a-zA-Z0-9_-]*` never need backticks:
+
+```stm
+schema customers { ... }              // bare — simple name
+mapping load_customers { ... }        // bare — underscores are fine
+Lead_Source__c STRING                  // bare — double underscores are fine
+transform normalize { ... }           // bare
+...audit_fields                       // bare spread
+source { orders, crm_customers }      // bare source refs
+```
+
+**Backticks** are required when the name contains spaces, dots, or other special characters:
+
+```stm
+schema `order-headers-parquet` { ... }   // hyphen in name
+mapping `customer migration` { ... }     // space in name
+`Account.Name` STRING                    // dot in name (single field, not a path)
+...`US Address`                          // space in spread label
+source { `order-headers` }               // hyphen in source ref
+```
+
+**In dotted paths**, backticks wrap individual segments, not the whole path. The dot lives outside any quoting:
+
+```stm
+schema.field                          // both segments bare
+`order-headers`.field                 // first segment needs backticks
+schema.`Account.Name`                 // second segment has a literal dot in its name
+`order-headers`.`Account.Name`        // both segments need backticks
+```
+
+`` `schema.field` `` (whole path in one backtick pair) means "a single identifier whose name literally contains a dot" — it is NOT a path with two segments. This follows the SQL convention: `"my schema"."my column"`, not `"my schema.my column"`.
+
+**Inside NL strings**, structural cross-references use `{...}` (not backticks). Backticks in NL are inert cosmetic markup (like Markdown code spans) with no structural meaning:
+
+```stm
+field -> target { Look up {customers.email} in the dim table }
+field -> target { Apply {normalize} then check {crm::legacy.status} }
+field -> target { See {`order-headers`.status} for edge cases }
+```
+
+Inside `{...}` refs, the same path and quoting rules apply — dots are path separators, backticks wrap segments with special chars. Refs can point to schemas, fields, mappings, transforms, fragments, or spreads.
+
+Literal `{` and `}` characters in NL strings are escaped: `\{` and `\}`.
+
+**One rule: bare names work when the name matches `[a-zA-Z_][a-zA-Z0-9_-]*`. Everything else gets backticks. Inside NL strings, `{...}` marks structural cross-references.**
+
+The formatter (`satsuma fmt`) auto-adds backticks to names that need them and strips unnecessary ones.
+
+### D3: Simplified metadata grammar
+
+The 13 `_kv_value` forms collapse to greedy text capture. Only three metadata entry types retain structured grammar rules:
+
+| Entry | Why structured |
+|-------|----------------|
+| `enum { ... }` | Brace matching required |
+| `slice { ... }` | Brace matching required |
+| `note "..." / note """..."""` | CLI extracts notes specifically |
+
+Everything else is `tag_name [value_text]`, where `value_text` consumes tokens up to the next `,` or `)`. No depth tracking, no external scanner — just a simple greedy rule. If a metadata value itself contains a comma, wrap it in double quotes.
+
+**Before (13 forms):**
+```
+_kv_value := nl_string | multiline_string | backtick_name | kv_braced_list
+           | kv_comparison | kv_ref_on | kv_compound | qualified_dotted_name
+           | dotted_name | number_literal | boolean_literal | qualified_name
+           | identifier
+```
+
+**After (simple greedy rule + 3 structured):**
+```
+_metadata_entry := enum_body | slice_body | note_tag | tag_with_value | tag_token
+tag_with_value  := identifier value_text
+value_text      := repeat1(choice(identifier, number, nl_string, multiline_string,
+                                   backtick_name, dotted_name, operator_chars))
+```
+
+The `value_text` rule is a `repeat1` of simple token types — no external scanner needed. Commas and closing parens naturally terminate it because they're not in the choice set. Values containing commas must be quoted: `(note "apples, oranges")` not `(note apples, oranges)`.
+
+### D4: Implicit NL in pipe steps
+
+Pipe step content between `|` delimiters is implicitly NL text — no quotes required. Double quotes remain available when the text contains literal `|` or `}` characters.
+
+**Before:**
+```stm
+field -> target { "Convert to uppercase" | trim | "Handle nulls" | coalesce(0) }
+```
+
+**After:**
+```stm
+field -> target { Convert to uppercase | trim | Handle nulls | coalesce(0) }
+```
+
+The pipe step grammar becomes:
+
+```
+pipe_step := fragment_spread       // ...name(args) — structural, for IDE nav
+           | map_literal           // map { ... } — structural, brace matching
+           | pipe_text             // everything else — greedy text
+```
+
+The `arithmetic_step`, `token_call`, and `_tc_arg` rules are removed — they're all just text now.
+
+Structural cross-references inside pipe text use `{...}` syntax (e.g., `Convert {amount} to USD`) and are extracted for NL-ref resolution and IDE features. Backticks in pipe text are inert.
+
+### D5: Multi-source arrow syntax
+
+New syntax for arrows with multiple source fields:
+
+```stm
+a, b, c -> target { a + b + c | Concatenate and uppercase }
+orders.amount, rates.fx_rate -> amount_usd { Multiply amount by fx_rate }
+```
+
+Source fields can be bare (resolved from mapping's declared sources) or schema-qualified (required when ambiguous in multi-source mappings). The grammar extends `map_arrow` to accept `commaSep1($.src_path)` instead of a single `$.src_path`.
+
+In the extracted data model, `ArrowRecord.sources` becomes `string[]` (always an array; single-source arrows have length 1). The graph emits one edge per source field.
+
+### D6: NL refs are structural sources
+
+`{...}` references in NL strings that resolve to schemas or fields are structural data dependencies, not informational asides. The contract:
+
+1. The `hidden-source-in-nl` lint rule becomes an **error** (was: warning).
+2. The auto-fix adds undeclared refs to the left side of a multi-source arrow, or to the mapping's `source { }` block.
+3. The graph and lineage commands treat NL refs as first-class edges (safe because lint guarantees they're declared).
+
+**Before (informational):**
+```stm
+field -> target { "Add to `other_field`" }
+// lint: warning — other_field not in source list
+// graph: no edge from other_field
+```
+
+**After (structural):**
+```stm
+other_field, field -> target { Add to {other_field} }
+// lint: passes — other_field declared on left
+// graph: edge from other_field to target
+```
+
+### D7: Unified escaping
+
+One rule: **backslash escapes the next character.** Applies identically inside backticks and double quotes:
+
+| Escape | Result | Where |
+|--------|--------|-------|
+| `\"` | Literal `"` | Inside `"..."` |
+| `` \` `` | Literal `` ` `` | Inside `` `...` `` |
+| `\{` | Literal `{` | Inside `"..."` and `"""..."""` |
+| `\}` | Literal `}` | Inside `"..."` and `"""..."""` |
+| `\\` | Literal `\` | Everywhere |
+| `\n`, `\t`, etc. | Literal `n`, `t`, etc. (no special sequences) |
+
+`\{` and `\}` are needed because `{...}` is the structural cross-reference syntax inside NL strings (see D2). Literal braces in prose must be escaped.
+
+Triple-quoted strings (`"""..."""`) still need `\{` / `\}` for literal braces (since `{...}` refs work there too), but do not need `\"` escaping.
+
+### D8: Duplicate metadata tags
+
+Allowed. No grammar or lint enforcement. `(note "Potato", note "Apple")` produces two entries. This is intentional — multiple notes, multiple annotations of the same tag, are valid use cases.
+
+### D9: Map entry simplification
+
+Map entries become `LEFT_TEXT : RIGHT_TEXT` with greedy text capture:
+
+```
+map_entry := map_key_text ":" map_value_text
+```
+
+The 7 structured map key types (`identifier`, `nl_string`, `number`, `_`, `null`, `default`, comparison expressions) and 5 map value types are replaced by greedy scanners. The CLI doesn't evaluate map logic — it extracts the text for the agent.
+
+---
+
+## Non-Goals
+
+- **Executing transforms.** Satsuma transforms are text for agents. The CLI never evaluates `trim`, `coalesce(0)`, or arithmetic expressions.
+- **Type checking metadata.** `(format E.164)` and `(format 42)` are both valid — the grammar doesn't distinguish.
+- **Sorting or reordering.** No auto-sorting of sources, fields, or arrows.
+- **Backwards compatibility shims.** Single-quote support is removed, not deprecated. A migration tool handles conversion.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Canonical Field References
+
+**Scope:** CLI only. No grammar changes. Non-breaking.
+
+Introduce a shared `canonicalRef(namespace, schema, field?)` utility that all commands use. Update all 16 command files to emit `[ns]::schema.field` in JSON and text output. Update the workspace index to store qualified keys.
+
+**Key files:**
+- `tooling/satsuma-cli/src/extract.ts` — `pathText()`, `extractArrowRecords()`
+- `tooling/satsuma-cli/src/index-builder.ts` — qualified key storage
+- `tooling/satsuma-cli/src/commands/*.ts` — all output paths
+- `tooling/satsuma-cli/src/nl-ref-extract.ts` — ref classification
+
+**Parallelizable with:** Phase 2.
+
+### Phase 2 — Multi-Source Arrow Syntax
+
+**Scope:** Grammar + CLI. Non-breaking (additive).
+
+Extend `map_arrow` in the grammar to accept comma-separated source paths. Update extraction to produce `sources: string[]`. Update arrows, mapping, graph, lineage, and validate commands.
+
+**Key files:**
+- `tooling/tree-sitter-satsuma/grammar.js` — `map_arrow` rule
+- `tooling/tree-sitter-satsuma/test/corpus/` — new `multi_source_arrows.txt`
+- `tooling/satsuma-cli/src/extract.ts` — multi-source extraction
+- `tooling/satsuma-cli/src/types.ts` — `ArrowRecord.sources`
+- `tooling/satsuma-cli/src/commands/arrows.ts`, `mapping.ts`, `graph.ts`, `lineage.ts`, `validate.ts`
+- `SATSUMA-V2-SPEC.md` — syntax documentation
+- `examples/` — canonical multi-source example
+
+**Parallelizable with:** Phase 1.
+
+### Phase 3 — Grammar Simplification
+
+**Scope:** Grammar + CLI + VS Code. Breaking for CST consumers (not for .stm source files).
+
+#### 3a: Metadata simplification
+Replace 13 `_kv_value` choices with a simple `value_text` rule (repeat of basic token types — identifiers, numbers, strings, backtick names, dotted names, operator chars). Commas and `)` naturally terminate the rule. No external scanner needed. Keep `enum_body`, `slice_body`, `note_tag` as structured rules. Remove `key_value_pair`, `kv_key`, `kv_braced_list`, `kv_comparison`, `kv_ref_on`, `kv_compound`.
+
+#### 3b: Pipe step simplification (implicit NL)
+Replace `pipe_step` choices with `fragment_spread | map_literal | pipe_text`. Remove `arithmetic_step`, `token_call`, `_tc_arg`. The `pipe_text` rule is a `repeat1` of basic tokens (identifiers, numbers, backtick names, operator chars, etc.) — `|` and `}` naturally terminate it because they're not in the token set. Double quotes still work for text containing literal `|` or `}`. Update NL-ref extraction to scan for `{...}` refs (replacing backtick scanning) in both quoted and bare pipe text.
+
+#### 3c: Map entry simplification
+Replace structured `map_key`/`map_value` with simple token-repeat rules. Map keys consume until `:`, map values consume until `,` or `}`. Same pattern as metadata — no external scanner, just natural termination by excluded delimiters.
+
+#### 3d: Unified escaping
+Ensure `backtick_name` and `nl_string` use identical `\\[\\s\\S]` escape pattern. Document: "backslash escapes the next character."
+
+**Key files:**
+- `tooling/tree-sitter-satsuma/grammar.js` — rule rewrites
+- `tooling/tree-sitter-satsuma/test/corpus/simplified_metadata.txt` — new corpus tests for simplified forms
+- `tooling/tree-sitter-satsuma/test/corpus/*.txt` — rewrite CST expectations
+- `tooling/satsuma-cli/src/meta-extract.ts` — simpler extraction from `tag_with_value`
+- `tooling/satsuma-cli/src/extract.ts` — pipe step classification
+- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch from backtick regex to `{...}` ref extraction
+- `tooling/vscode-satsuma/server/src/*.ts` — update CST node type references
+- `tooling/vscode-satsuma/syntaxes/satsuma.tmLanguage.json` — TextMate patterns
+
+**Migration:** No `.stm` file changes needed — the grammar becomes more permissive. Only tooling code that pattern-matches on removed CST node types needs updating.
+
+**Sequential with:** Phase 4 (both rewrite grammar.js).
+
+### Phase 4 — Unify Quotes (Drop Single Quotes)
+
+**Scope:** Grammar + CLI + VS Code + examples. Breaking for `.stm` source files.
+
+Replace `quoted_name` (single-quote) with `backtick_name` in all label positions. Remove the `quoted_name` rule. Update all example files, corpus tests, CLI extraction, formatter, and VS Code extension.
+
+**Key files:**
+- `tooling/tree-sitter-satsuma/grammar.js` — `block_label`, `import_name`, `spread_label`
+- `tooling/tree-sitter-satsuma/test/corpus/*.txt` — replace `'label'` with `` `label` ``
+- `tooling/satsuma-cli/src/extract.ts` — `labelText()` function
+- `tooling/satsuma-cli/src/format.ts` — label rendering
+- `tooling/vscode-satsuma/syntaxes/satsuma.tmLanguage.json` — label patterns
+- `tooling/vscode-satsuma/server/src/*.ts` — `quoted_name` references
+- `examples/*.stm` — migrate all single-quoted labels
+- `SATSUMA-V2-SPEC.md` — sections 2.2, 2.3
+
+**Migration tool:** `satsuma fmt` auto-converts `'label'` to `` `label` `` as part of standard formatting. Run on all example files before landing.
+
+**Sequential after:** Phase 3.
+
+### Phase 5 — Elevate NL Refs to Structural Sources
+
+**Scope:** CLI only. Non-breaking (lint severity change).
+
+Change `hidden-source-in-nl` from warning to error. Add auto-fix that inserts undeclared refs into multi-source arrows or source blocks. Update graph and lineage to emit `{...}` ref edges (now safe because lint guarantees declaration).
+
+**Key files:**
+- `tooling/satsuma-cli/src/lint-engine.ts` — severity change + auto-fix
+- `tooling/satsuma-cli/src/graph-builder.ts` — NL ref edge promotion
+- `tooling/satsuma-cli/src/commands/lineage.ts` — NL ref traversal
+- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch to `{...}` extraction, add `isStructuralSource` flag
+
+**Depends on:** Phase 2 (multi-source arrows must exist for auto-fix target).
+**Parallelizable with:** Phases 3 and 4.
+
+---
+
+## Sequencing
+
+```
+Phase 1 (Canonical Refs) ──────────────────────────────┐
+                                                        ├──▶ Phase 3 (Grammar Simplification)
+Phase 2 (Multi-Source Arrow) ──┬───────────────────────┘            │
+                               │                                    ▼
+                               └──▶ Phase 5 (Elevate NL Refs)    Phase 4 (Unify Quotes)
+```
+
+- **Phases 1 + 2**: parallel (different files)
+- **Phase 3**: after 1+2 merge (builds on normalized refs)
+- **Phase 4**: after 3 (sequential grammar changes)
+- **Phase 5**: after 2 merges (needs multi-source arrows); parallelizable with 3+4
+
+**Total: 5-6 PRs.**
+
+---
+
+## Success Criteria
+
+### Correctness
+1. All 16 CLI commands emit canonical `[ns]::schema.field` references in both JSON and text output.
+2. Multi-source arrows parse correctly: `a, b, c -> target { ... }` with bare and schema-qualified sources.
+3. Metadata with any combination of tags, values, enums, slices, and notes parses correctly under the simplified grammar.
+4. Bare text pipe steps (no quotes) parse correctly: `field -> target { Convert to uppercase | trim }`.
+5. The formatter auto-converts `'label'` to `` `label` `` and produces idempotent output.
+6. `hidden-source-in-nl` is an error. `satsuma lint --fix` auto-adds undeclared NL refs to source declarations.
+7. `satsuma graph --json` includes NL backtick ref edges in `schema_edges`.
+8. All example `.stm` files parse cleanly under the new grammar.
+9. Escaping behaves identically in backticks and double quotes.
+10. Duplicate metadata tags are preserved without error.
+
+### Testing
+11. Tree-sitter corpus tests updated and passing (482+ tests).
+12. CLI tests updated and passing (637+ tests).
+13. New corpus tests for: multi-source arrows, bare pipe text, simplified metadata, backtick labels.
+14. Round-trip test: `parse(format(source)) ≅ parse(source)` for all corpus fixtures.
+15. Integration tests: `satsuma fmt --check examples/` exits 0 after migration.
+
+### Documentation
+16. `SATSUMA-V2-SPEC.md` updated: quoting rules, multi-source arrows, simplified metadata, implicit NL in pipes.
+17. `SATSUMA-CLI.md` updated: canonical ref format, multi-source arrow output, lint error change.
+18. `AI-AGENT-REFERENCE.md` updated: new syntax forms, canonical ref convention.
+19. `DISCOVERED-REQUIREMENTS.md` updated: mark resolved requirements.
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Grammar ambiguity in simplified rules | Medium — tree-sitter may struggle with greedy token repeats | Use `prec()` and `conflicts` to resolve; extensive corpus testing; keep delimiter exclusion clean |
+| Breaking change for `.stm` files (single→backtick quotes) | Medium — all existing files need migration | Ship `satsuma fmt` migration before or with the change; run on all examples |
+| Multi-source arrow ambiguity with comma in metadata | Low — comma in arrow source list vs metadata | Grammar precedence: comma-separated paths only before `->`, metadata only inside `()` |
+| NL ref elevation changes graph semantics | Medium — downstream consumers may not expect new edges | Document the change; add `--no-nl-edges` flag if needed for backward compat |
+| Test update volume (~1100 tests touch output formats) | High — time cost | Phase 1 (canonical refs) is the biggest test update; subsequent phases are incremental |
+
+---
+
+## File Locations
+
+| Artifact | Path |
+|----------|------|
+| Feature PRD | `features/22-language-simplification/PRD.md` |
+| Tree-sitter grammar | `tooling/tree-sitter-satsuma/grammar.js` |
+| Simplified corpus tests | `tooling/tree-sitter-satsuma/test/corpus/simplified_metadata.txt` (new) |
+| Corpus tests | `tooling/tree-sitter-satsuma/test/corpus/` |
+| CLI extraction | `tooling/satsuma-cli/src/extract.ts` |
+| Metadata extraction | `tooling/satsuma-cli/src/meta-extract.ts` |
+| NL ref extraction | `tooling/satsuma-cli/src/nl-ref-extract.ts` |
+| Lint engine | `tooling/satsuma-cli/src/lint-engine.ts` |
+| Graph builder | `tooling/satsuma-cli/src/graph-builder.ts` |
+| Index builder | `tooling/satsuma-cli/src/index-builder.ts` |
+| Formatter | `tooling/satsuma-cli/src/format.ts` |
+| CLI commands | `tooling/satsuma-cli/src/commands/*.ts` |
+| VS Code TextMate grammar | `tooling/vscode-satsuma/syntaxes/satsuma.tmLanguage.json` |
+| VS Code LSP server | `tooling/vscode-satsuma/server/src/` |
+| Language spec | `SATSUMA-V2-SPEC.md` |
+| CLI docs | `SATSUMA-CLI.md` |
+| Agent reference | `AI-AGENT-REFERENCE.md` |
+| Example corpus | `examples/*.stm` |
+| Discovered requirements | `DISCOVERED-REQUIREMENTS.md` |


### PR DESCRIPTION
## Summary

- **DISCOVERED-REQUIREMENTS.md**: Audit of 48 latent requirements found across 300+ bug tickets. Documents non-obvious behaviors that the spec and CLI docs don't explicitly call out — output indexing, exit codes, backtick preservation, fragment spread expansion, namespace resolution, and more.

- **Feature 22 PRD** (`features/22-language-simplification/PRD.md`): Proposes simplifying the Satsuma language surface to eliminate entire classes of bugs:
  - Canonical field refs (`::schema.field` always)
  - Two quote types only (drop single quotes, backticks for names, double quotes for NL)
  - Simplified metadata grammar (13 value forms → greedy text)
  - Implicit NL in pipe steps (no quotes needed)
  - Multi-source arrows (`a, b, c -> target`)
  - `{ref}` syntax for structural cross-references in NL strings
  - NL refs elevated to structural sources (lint error + graph promotion)
  - Unified escaping rules

## Test plan

- [x] Docs-only change — no code modified
- [x] All existing tests pass (pre-commit hooks ran)

🤖 Generated with [Claude Code](https://claude.com/claude-code)