### PR TITLE
docs: update language simplification PRD with @ref syntax

### DIFF
--- a/.tickets/lsp-4hai.md
+++ b/.tickets/lsp-4hai.md
@@ -1,0 +1,21 @@
+---
+id: lsp-4hai
+status: open
+deps: [lsp-d4yk]
+links: []
+created: 2026-03-25T17:36:36Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-5, cli]
+---
+# P5.4: Update lineage traversal for @ref edges
+
+Update lineage.ts to traverse @ref edges when tracing data flow.
+
+## Acceptance Criteria
+
+- satsuma lineage follows @ref edges
+- Lineage output includes @ref-derived paths
+- Lineage tests updated
+

--- a/.tickets/lsp-6agr.md
+++ b/.tickets/lsp-6agr.md
@@ -1,0 +1,22 @@
+---
+id: lsp-6agr
+status: open
+deps: [lsp-vm73]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, cli]
+---
+# P3.8: Switch nl-ref-extract.ts to @ref extraction
+
+Replace backtick regex scanning with @ref extraction. Scan for @identifier, @backtick_name, and @dotted.path patterns in NL text.
+
+## Acceptance Criteria
+
+- @ref mentions extracted from NL strings and pipe text
+- Bare backticks in NL are ignored (cosmetic only)
+- @ref with backtick segments works: @`order-headers`.status
+- Extraction tests updated and passing
+

--- a/.tickets/lsp-9p9g.md
+++ b/.tickets/lsp-9p9g.md
@@ -1,0 +1,23 @@
+---
+id: lsp-9p9g
+status: open
+deps: [lsp-ah6m]
+links: []
+created: 2026-03-25T17:36:36Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-5, cli]
+---
+# P5.2: Add lint --fix auto-fix for undeclared @refs
+
+Add auto-fix that inserts undeclared @ref mentions into multi-source arrows or source blocks when running satsuma lint --fix.
+
+## Acceptance Criteria
+
+- Undeclared @ref in arrow NL added to arrow source list
+- Undeclared @ref in non-arrow NL added to mapping source block
+- Auto-fix produces valid parseable output
+- Round-trip: lint --fix then lint produces no errors
+- Tests cover both arrow and source-block insertion
+

--- a/.tickets/lsp-9vgj.md
+++ b/.tickets/lsp-9vgj.md
@@ -1,0 +1,21 @@
+---
+id: lsp-9vgj
+status: open
+deps: [lsp-oj5r]
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, cli]
+---
+# P2.3: Update ArrowRecord type for multi-source
+
+Change ArrowRecord.source to ArrowRecord.sources: string[] in types.ts. Single-source arrows have length-1 array.
+
+## Acceptance Criteria
+
+- ArrowRecord.sources is string[]
+- TypeScript compiles with no errors
+- All references updated
+

--- a/.tickets/lsp-ah6m.md
+++ b/.tickets/lsp-ah6m.md
@@ -1,0 +1,21 @@
+---
+id: lsp-ah6m
+status: open
+deps: [lsp-yli5, lsp-6agr]
+links: []
+created: 2026-03-25T17:36:36Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-5, cli]
+---
+# P5.1: Change hidden-source-in-nl to error
+
+Change hidden-source-in-nl lint rule from warning to error in lint-engine.ts.
+
+## Acceptance Criteria
+
+- hidden-source-in-nl produces error severity
+- satsuma lint exits non-zero when undeclared @ref found
+- Lint tests updated
+

--- a/.tickets/lsp-ar7x.md
+++ b/.tickets/lsp-ar7x.md
@@ -1,0 +1,22 @@
+---
+id: lsp-ar7x
+status: open
+deps: [lsp-6agr]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, vscode]
+---
+# P3.9: Update VS Code LSP for simplified CST
+
+Update all LSP server files that reference removed CST node types (kv_comparison, arithmetic_step, token_call, quoted_name variants).
+
+## Acceptance Criteria
+
+- No references to removed node types in LSP server code
+- LSP server compiles
+- Semantic tokens, hover, definition, completions work with new node types
+- LSP tests pass
+

--- a/.tickets/lsp-asfn.md
+++ b/.tickets/lsp-asfn.md
@@ -1,0 +1,22 @@
+---
+id: lsp-asfn
+status: open
+deps: [lsp-k2jg]
+links: []
+created: 2026-03-25T17:36:08Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, grammar]
+---
+# P4.1: Remove quoted_name from grammar
+
+Replace quoted_name (single-quote) with backtick_name in block_label, import_name, spread_label positions. Remove the quoted_name terminal rule.
+
+## Acceptance Criteria
+
+- No quoted_name rule in grammar.js
+- block_label, import_name, spread_label use backtick_name for non-bare names
+- tree-sitter generate succeeds
+- Single-quoted labels produce parse errors
+

--- a/.tickets/lsp-d4yk.md
+++ b/.tickets/lsp-d4yk.md
@@ -1,0 +1,21 @@
+---
+id: lsp-d4yk
+status: open
+deps: [lsp-9p9g]
+links: []
+created: 2026-03-25T17:36:36Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-5, cli]
+---
+# P5.3: Emit @ref edges in graph-builder
+
+Update graph-builder.ts to emit @ref edges as first-class schema_edges in satsuma graph --json output.
+
+## Acceptance Criteria
+
+- @ref mentions in NL produce edges in schema_edges
+- Edges marked with nl-ref source type
+- graph --json tests updated
+

--- a/.tickets/lsp-dwk7.md
+++ b/.tickets/lsp-dwk7.md
@@ -1,0 +1,24 @@
+---
+id: lsp-dwk7
+status: open
+deps: [lsp-l9aq, lsp-4hai]
+links: []
+created: 2026-03-25T17:37:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [docs]
+---
+# DOC.1: Update AI-AGENT-REFERENCE.md
+
+Update AI-AGENT-REFERENCE.md with @ref convention, simplified grammar EBNF, updated cheat sheet, and updated common mistakes table.
+
+## Acceptance Criteria
+
+- Grammar EBNF reflects simplified rules
+- @ref convention documented with examples
+- Backtick-only labels (no single quotes)
+- Multi-source arrows in grammar and cheat sheet
+- Common mistakes table updated
+- Bare pipe text examples shown
+

--- a/.tickets/lsp-eeaq.md
+++ b/.tickets/lsp-eeaq.md
@@ -1,0 +1,23 @@
+---
+id: lsp-eeaq
+status: open
+deps: [lsp-oj5r]
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, grammar]
+---
+# P2.2: Add multi-source arrow corpus tests
+
+Create test/corpus/multi_source_arrows.txt with comprehensive corpus tests for multi-source arrow syntax.
+
+## Acceptance Criteria
+
+- Tests for 2, 3+ source fields
+- Tests for bare and schema-qualified sources
+- Tests for mixed bare/qualified sources
+- Tests for multi-source with transforms
+- All corpus tests pass
+

--- a/.tickets/lsp-ijzz.md
+++ b/.tickets/lsp-ijzz.md
@@ -1,0 +1,23 @@
+---
+id: lsp-ijzz
+status: open
+deps: [lsp-qd13]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, grammar]
+---
+# P3.4: Unified escaping + @ref in grammar
+
+Align backtick_name and nl_string escape patterns. Add @ as optional prefix in identifier positions (allowed everywhere, required only in NL for tooling). Add \@ escape in NL strings.
+
+## Acceptance Criteria
+
+- backtick_name and nl_string use identical \\[\\s\\S] escape pattern
+- @ prefix accepted in identifier positions without error
+- @ref in NL strings creates an at_ref CST node (or similar)
+- \@ in NL strings produces literal @
+- tree-sitter generate succeeds
+

--- a/.tickets/lsp-jpli.md
+++ b/.tickets/lsp-jpli.md
@@ -1,0 +1,22 @@
+---
+id: lsp-jpli
+status: open
+deps: [lsp-tze4]
+links: []
+created: 2026-03-25T17:36:08Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, vscode]
+---
+# P4.4: Update VS Code for backtick-only labels
+
+Remove quoted_name references from TextMate grammar and LSP server. Update single-quote patterns to backtick.
+
+## Acceptance Criteria
+
+- No quoted_name references in VS Code extension code
+- TextMate grammar highlights backtick labels correctly
+- LSP server handles backtick labels in all features
+- Extension compiles
+

--- a/.tickets/lsp-k2jg.md
+++ b/.tickets/lsp-k2jg.md
@@ -1,0 +1,22 @@
+---
+id: lsp-k2jg
+status: open
+deps: [lsp-ar7x]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, vscode]
+---
+# P3.10: Update TextMate grammar for simplified rules
+
+Update satsuma.tmLanguage.json patterns for simplified metadata, pipe steps, and @ref highlighting.
+
+## Acceptance Criteria
+
+- @ref highlighted distinctly in NL strings
+- Pipe text highlighted as NL content
+- Simplified metadata values highlighted correctly
+- TextMate grammar validates
+

--- a/.tickets/lsp-kvby.md
+++ b/.tickets/lsp-kvby.md
@@ -1,0 +1,21 @@
+---
+id: lsp-kvby
+status: open
+deps: [lsp-vm73]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, cli]
+---
+# P3.7: Update extract.ts pipe step classification
+
+Update pipe step extraction and classification for simplified pipe_text nodes.
+
+## Acceptance Criteria
+
+- fragment_spread and map_literal classified as structural
+- pipe_text classified as NL
+- Classification tests pass
+

--- a/.tickets/lsp-l9aq.md
+++ b/.tickets/lsp-l9aq.md
@@ -1,0 +1,21 @@
+---
+id: lsp-l9aq
+status: open
+deps: [lsp-ve2s]
+links: []
+created: 2026-03-25T17:36:08Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, docs]
+---
+# P4.6: Update spec for backtick-only labels
+
+Update SATSUMA-V2-SPEC.md sections 2.2 and 2.3 to document backtick-only quoting for labels.
+
+## Acceptance Criteria
+
+- No references to single-quote labels in spec
+- Backtick vs bare identifier rules documented
+- Examples updated throughout
+

--- a/.tickets/lsp-lk1w.md
+++ b/.tickets/lsp-lk1w.md
@@ -1,0 +1,22 @@
+---
+id: lsp-lk1w
+status: open
+deps: [lsp-z0sq]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, grammar]
+---
+# P3.2: Pipe step simplification in grammar
+
+Replace pipe_step choices with fragment_spread | map_literal | pipe_text. Remove arithmetic_step, token_call, _tc_arg.
+
+## Acceptance Criteria
+
+- pipe_text is repeat1 of basic tokens
+- | and } terminate pipe_text naturally
+- Double quotes still work for text containing | or }
+- tree-sitter generate succeeds
+

--- a/.tickets/lsp-lnmw.md
+++ b/.tickets/lsp-lnmw.md
@@ -1,0 +1,22 @@
+---
+id: lsp-lnmw
+status: open
+deps: [lsp-vupl]
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, examples]
+---
+# P2.6: Add canonical multi-source example .stm
+
+Add a canonical example .stm file demonstrating multi-source arrows in realistic use cases.
+
+## Acceptance Criteria
+
+- Example parses cleanly
+- Demonstrates 2-source and 3+ source arrows
+- Demonstrates bare and schema-qualified sources
+- satsuma validate passes on example
+

--- a/.tickets/lsp-oj5r.md
+++ b/.tickets/lsp-oj5r.md
@@ -1,0 +1,22 @@
+---
+id: lsp-oj5r
+status: open
+deps: []
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, grammar]
+---
+# P2.1: Extend map_arrow grammar for multi-source
+
+Extend map_arrow rule in grammar.js to accept commaSep1(src_path) instead of single src_path. Regenerate parser.
+
+## Acceptance Criteria
+
+- map_arrow accepts comma-separated source paths
+- Single-source arrows still parse correctly (no regression)
+- tree-sitter generate succeeds
+- Existing corpus tests pass
+

--- a/.tickets/lsp-pmzn.md
+++ b/.tickets/lsp-pmzn.md
@@ -1,0 +1,21 @@
+---
+id: lsp-pmzn
+status: open
+deps: [lsp-vm73]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, cli]
+---
+# P3.6: Update meta-extract.ts for simplified grammar
+
+Update metadata extraction to handle tag_with_value instead of key_value_pair with 13 child types.
+
+## Acceptance Criteria
+
+- Extracts tag name and value text from tag_with_value nodes
+- enum_body, slice_body, note_tag still extracted as structured
+- All meta-extract tests pass
+

--- a/.tickets/lsp-pqbu.md
+++ b/.tickets/lsp-pqbu.md
@@ -1,0 +1,21 @@
+---
+id: lsp-pqbu
+status: open
+deps: [lsp-asfn]
+links: []
+created: 2026-03-25T17:36:08Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, grammar]
+---
+# P4.2: Update corpus tests for backtick labels
+
+Replace all 'label' with `label` in corpus test files.
+
+## Acceptance Criteria
+
+- No single-quote labels in corpus tests
+- All corpus tests pass
+- tree-sitter test exits 0
+

--- a/.tickets/lsp-qd13.md
+++ b/.tickets/lsp-qd13.md
@@ -1,0 +1,22 @@
+---
+id: lsp-qd13
+status: open
+deps: [lsp-lk1w]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, grammar]
+---
+# P3.3: Map entry simplification in grammar
+
+Replace structured map_key/map_value with map_key_text : map_value_text greedy capture.
+
+## Acceptance Criteria
+
+- Map keys consume until :
+- Map values consume until , or }
+- No external scanner needed
+- tree-sitter generate succeeds
+

--- a/.tickets/lsp-qmm1.md
+++ b/.tickets/lsp-qmm1.md
@@ -1,0 +1,21 @@
+---
+id: lsp-qmm1
+status: open
+deps: [lsp-xdjz]
+links: []
+created: 2026-03-25T17:28:23Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.4: Update all 16 CLI commands for canonical refs
+
+Update all command files in tooling/satsuma-cli/src/commands/ to emit canonical [ns]::schema.field references in JSON and text output.
+
+## Acceptance Criteria
+
+- All 16 commands produce canonical refs in both JSON and text modes
+- No bare field names or inconsistent schema.field forms in output
+- Tests updated for all commands
+

--- a/.tickets/lsp-rxne.md
+++ b/.tickets/lsp-rxne.md
@@ -1,0 +1,21 @@
+---
+id: lsp-rxne
+status: open
+deps: [lsp-9vgj]
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, cli]
+---
+# P2.4: Update extract.ts for multi-source extraction
+
+Update extractArrowRecords() to extract all source fields from multi-source arrows into sources array.
+
+## Acceptance Criteria
+
+- Multi-source arrows produce correct sources array
+- Single-source arrows produce length-1 array
+- Extraction tests pass
+

--- a/.tickets/lsp-tl3x.md
+++ b/.tickets/lsp-tl3x.md
@@ -1,0 +1,22 @@
+---
+id: lsp-tl3x
+status: open
+deps: [lsp-l9aq, lsp-4hai]
+links: []
+created: 2026-03-25T17:37:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [docs]
+---
+# DOC.2: Update SATSUMA-CLI.md
+
+Update SATSUMA-CLI.md with canonical ref format, @ref output in graph/lineage, multi-source arrow output, and lint error change.
+
+## Acceptance Criteria
+
+- Canonical ref format documented
+- @ref edges described in graph output
+- Multi-source arrow output shown
+- hidden-source-in-nl error severity noted
+

--- a/.tickets/lsp-tze4.md
+++ b/.tickets/lsp-tze4.md
@@ -1,0 +1,22 @@
+---
+id: lsp-tze4
+status: open
+deps: [lsp-pqbu]
+links: []
+created: 2026-03-25T17:36:08Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, cli]
+---
+# P4.3: Update CLI extraction and formatter for backtick labels
+
+Update labelText() in extract.ts and format.ts to handle backtick_name only (no quoted_name).
+
+## Acceptance Criteria
+
+- labelText() handles identifier and backtick_name only
+- Formatter renders labels with backticks (not single quotes)
+- satsuma fmt auto-converts 'label' to `label` for migration
+- CLI tests pass
+

--- a/.tickets/lsp-ulfa.md
+++ b/.tickets/lsp-ulfa.md
@@ -1,0 +1,21 @@
+---
+id: lsp-ulfa
+status: open
+deps: [lsp-upfx]
+links: []
+created: 2026-03-25T17:28:23Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.2: Update extract.ts to use canonicalRef()
+
+Update pathText() and extractArrowRecords() in extract.ts to produce canonical field references via canonicalRef().
+
+## Acceptance Criteria
+
+- pathText() returns canonical form
+- extractArrowRecords() emits canonical source/target refs
+- Existing tests updated to expect canonical format
+

--- a/.tickets/lsp-um8v.md
+++ b/.tickets/lsp-um8v.md
@@ -1,0 +1,21 @@
+---
+id: lsp-um8v
+status: open
+deps: [lsp-vfn0]
+links: []
+created: 2026-03-25T17:28:23Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.6: Update CLI test snapshots for canonical refs
+
+Bulk update ~200+ CLI test snapshots to expect canonical [ns]::schema.field format.
+
+## Acceptance Criteria
+
+- All CLI tests pass
+- npm test in satsuma-cli exits 0
+- No snapshot mismatches remain
+

--- a/.tickets/lsp-upfx.md
+++ b/.tickets/lsp-upfx.md
@@ -1,0 +1,22 @@
+---
+id: lsp-upfx
+status: open
+deps: []
+links: []
+created: 2026-03-25T17:28:11Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.1: Create canonicalRef() utility
+
+Create shared canonicalRef(namespace, schema, field?) utility in tooling/satsuma-cli/src/canonical-ref.ts. Produces [ns]::schema.field form for all CLI output.
+
+## Acceptance Criteria
+
+- canonicalRef() returns ::schema.field when no namespace
+- canonicalRef() returns namespace::schema.field when namespace present
+- Unit tests cover both cases plus edge cases (empty field, special chars)
+- Exported from a new canonical-ref.ts module
+

--- a/.tickets/lsp-ve2s.md
+++ b/.tickets/lsp-ve2s.md
@@ -1,0 +1,22 @@
+---
+id: lsp-ve2s
+status: open
+deps: [lsp-jpli]
+links: []
+created: 2026-03-25T17:36:08Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+tags: [phase-4, examples]
+---
+# P4.5: Migrate example .stm files to backtick labels
+
+Run satsuma fmt on all examples/*.stm files to convert 95+ single-quoted labels to backtick labels.
+
+## Acceptance Criteria
+
+- No single-quoted labels in any example file
+- All examples parse cleanly
+- satsuma validate passes on all examples
+- satsuma fmt --check examples/ exits 0
+

--- a/.tickets/lsp-vfd1.md
+++ b/.tickets/lsp-vfd1.md
@@ -1,0 +1,20 @@
+---
+id: lsp-vfd1
+status: open
+deps: [lsp-l9aq, lsp-4hai]
+links: []
+created: 2026-03-25T17:37:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [docs]
+---
+# DOC.3: Update DISCOVERED-REQUIREMENTS.md
+
+Mark requirements resolved by Feature 22 in DISCOVERED-REQUIREMENTS.md.
+
+## Acceptance Criteria
+
+- Each resolved requirement marked with resolution status
+- References to implementing tickets/PRs included
+

--- a/.tickets/lsp-vfn0.md
+++ b/.tickets/lsp-vfn0.md
@@ -1,0 +1,21 @@
+---
+id: lsp-vfn0
+status: open
+deps: [lsp-qmm1]
+links: []
+created: 2026-03-25T17:28:23Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.5: Update nl-ref-extract.ts ref classification
+
+Update NL reference extraction and classification to use canonical ref form.
+
+## Acceptance Criteria
+
+- Extracted NL refs are classified using canonical form
+- Ref resolution matches canonical keys in workspace index
+- Tests updated
+

--- a/.tickets/lsp-vm73.md
+++ b/.tickets/lsp-vm73.md
@@ -1,0 +1,21 @@
+---
+id: lsp-vm73
+status: open
+deps: [lsp-ijzz]
+links: []
+created: 2026-03-25T17:29:21Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, grammar]
+---
+# P3.5: Update all corpus test CST expectations
+
+Rewrite corpus test CST expectations for simplified metadata, pipe step, and map entry node types.
+
+## Acceptance Criteria
+
+- All corpus tests pass with new CST node types
+- tree-sitter test exits 0
+- No S-expression references to removed node types (kv_comparison, arithmetic_step, token_call, etc.)
+

--- a/.tickets/lsp-vupl.md
+++ b/.tickets/lsp-vupl.md
@@ -1,0 +1,24 @@
+---
+id: lsp-vupl
+status: open
+deps: [lsp-rxne]
+links: []
+created: 2026-03-25T17:28:46Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, cli]
+---
+# P2.5: Update CLI commands for multi-source arrows
+
+Update arrows, mapping, graph, lineage, and validate commands to handle ArrowRecord.sources as array.
+
+## Acceptance Criteria
+
+- arrows command shows all sources
+- mapping command displays multi-source arrows correctly
+- graph emits one edge per source field
+- lineage traverses all source edges
+- validate checks all source refs
+- All command tests pass
+

--- a/.tickets/lsp-xdjz.md
+++ b/.tickets/lsp-xdjz.md
@@ -1,0 +1,21 @@
+---
+id: lsp-xdjz
+status: open
+deps: [lsp-ulfa]
+links: []
+created: 2026-03-25T17:28:23Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-1, cli]
+---
+# P1.3: Update index-builder.ts for qualified keys
+
+Update workspace index to store and look up schemas/fields by canonical qualified keys.
+
+## Acceptance Criteria
+
+- Index keys use canonical ::schema or ns::schema format
+- Lookups by canonical key work
+- Tests updated
+

--- a/.tickets/lsp-yli5.md
+++ b/.tickets/lsp-yli5.md
@@ -1,0 +1,21 @@
+---
+id: lsp-yli5
+status: open
+deps: [lsp-lnmw]
+links: []
+created: 2026-03-25T17:28:46Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [phase-2, docs]
+---
+# P2.7: Update spec for multi-source arrows
+
+Update SATSUMA-V2-SPEC.md with multi-source arrow syntax documentation.
+
+## Acceptance Criteria
+
+- Syntax documented with examples
+- Semantics of multi-source described
+- Comma disambiguation with metadata noted
+

--- a/.tickets/lsp-z0sq.md
+++ b/.tickets/lsp-z0sq.md
@@ -1,0 +1,23 @@
+---
+id: lsp-z0sq
+status: open
+deps: [lsp-um8v, lsp-yli5]
+links: []
+created: 2026-03-25T17:29:21Z
+type: feature
+priority: 2
+assignee: Thorben Louw
+tags: [phase-3, grammar]
+---
+# P3.1: Metadata simplification in grammar
+
+Replace 13 _kv_value choices with value_text greedy rule. Keep enum_body, slice_body, note_tag as structured. Remove kv_braced_list, kv_comparison, kv_ref_on, kv_compound etc.
+
+## Acceptance Criteria
+
+- Grammar has _metadata_entry with 5 choices: enum_body, slice_body, note_tag, tag_with_value, tag_token
+- value_text is repeat1 of basic token types
+- Commas and ) naturally terminate value_text
+- tree-sitter generate succeeds
+- No conflicts or ambiguities
+

--- a/features/22-language-simplification/PRD.md
+++ b/features/22-language-simplification/PRD.md
@@ -4,7 +4,7 @@
 
 ## Goal
 
-Simplify the Satsuma language surface and CLI output to eliminate entire classes of bugs discovered through 300+ tickets of exploratory testing. The grammar currently has ~45 rules for metadata/transforms/paths with 13 distinct metadata value forms — far more complexity than a language whose parser is an LLM needs. This feature reduces the grammar to its structural essentials, unifies quoting, normalizes output references, adds multi-source arrows, and elevates NL backtick references to structural sources.
+Simplify the Satsuma language surface and CLI output to eliminate entire classes of bugs discovered through 300+ tickets of exploratory testing. The grammar currently has ~45 rules for metadata/transforms/paths with 13 distinct metadata value forms — far more complexity than a language whose parser is an LLM needs. This feature reduces the grammar to its structural essentials, unifies quoting, normalizes output references, adds multi-source arrows, and elevates NL `@ref` references to structural sources.
 
 ---
 
@@ -20,7 +20,7 @@ The DISCOVERED-REQUIREMENTS.md audit identified 48 latent requirements, most ste
 
 4. **No multi-source arrows.** When a target field derives from multiple source fields, there's no way to express it at arrow level. The current workaround is a prose NL description, which breaks field-level lineage precision.
 
-5. **NL refs are second-class.** Backtick references in NL strings (`` "Look up `dim_customer`" ``) are informational only. The graph and lineage commands ignore them. But they represent real data dependencies that users expect to see in lineage output.
+5. **NL refs are second-class.** Backtick references in NL strings (`` "Look up `dim_customer`" ``) are informational only. The graph and lineage commands ignore them. But they represent real data dependencies that users expect to see in lineage output. Additionally, backticks inside NL are ambiguous — is `` `order-headers` `` a structural cross-reference or cosmetic Markdown code-span formatting?
 
 6. **Pipe step ceremony.** Transform pipe chains require quotes around NL text (`"Convert to uppercase" | trim`), but since the CLI doesn't execute any of it — `trim` and `"Convert to uppercase"` are both just text for the agent — the quotes are unnecessary ceremony.
 
@@ -43,7 +43,7 @@ The `::` prefix on unscoped schemas is visually distinct, machine-parseable, and
 
 | Type | Syntax | Purpose |
 |------|--------|---------|
-| Backticks | `` `...` `` | Identifiers and names that aren't bare-safe, or cross-references inside NL |
+| Backticks | `` `...` `` | Identifiers and names that aren't bare-safe |
 | Double quotes | `"..."` / `"""..."""` | Natural language content |
 
 Single quotes are removed. `schema 'my schema'` becomes `` schema `my schema` ``. This reduces the mental model to: "backticks for names, quotes for prose."
@@ -82,19 +82,21 @@ schema.`Account.Name`                 // second segment has a literal dot in its
 
 `` `schema.field` `` (whole path in one backtick pair) means "a single identifier whose name literally contains a dot" — it is NOT a path with two segments. This follows the SQL convention: `"my schema"."my column"`, not `"my schema.my column"`.
 
-**Inside NL strings**, structural cross-references use `{...}` (not backticks). Backticks in NL are inert cosmetic markup (like Markdown code spans) with no structural meaning:
+**Inside NL strings**, structural cross-references use the `@` prefix — like a GitHub/Slack mention. Backticks in NL are inert cosmetic markup (like Markdown code spans) with no structural meaning:
 
 ```stm
-field -> target { Look up {customers.email} in the dim table }
-field -> target { Apply {normalize} then check {crm::legacy.status} }
-field -> target { See {`order-headers`.status} for edge cases }
+field -> target { Look up @customers.email in the dim table }
+field -> target { Apply @normalize then check @crm::legacy.status }
+field -> target { See @`order-headers`.status for edge cases }
 ```
 
-Inside `{...}` refs, the same path and quoting rules apply — dots are path separators, backticks wrap segments with special chars. Refs can point to schemas, fields, mappings, transforms, fragments, or spreads.
+After `@`, the same path and quoting rules apply — dots are path separators, backticks wrap segments with special chars. An `@` ref ends at the first character that isn't part of a valid path (whitespace, punctuation other than `.`, `::`, or backtick pairs). Refs can point to schemas, fields, mappings, transforms, fragments, or spreads.
 
-Literal `{` and `}` characters in NL strings are escaped: `\{` and `\}`.
+`@` is **required** in NL strings (pipe text, `"..."`, `"""..."""`) for tooling to detect structural refs. It is **optional but allowed** everywhere else (source blocks, arrow sources, metadata values, etc.) — `@customers` resolves identically to `customers`. This means users who over-apply `@` get correct code; users who forget it in NL get a lint warning. Literal `@` in NL where it should NOT be a ref (rare) is escaped: `\@`.
 
-**One rule: bare names work when the name matches `[a-zA-Z_][a-zA-Z0-9_-]*`. Everything else gets backticks. Inside NL strings, `{...}` marks structural cross-references.**
+**One rule for agents: prefix field, schema, or transform names with `@` when you reference them in NL text — like a GitHub mention.**
+
+**One rule for names: bare names work when the name matches `[a-zA-Z_][a-zA-Z0-9_-]*`. Everything else gets backticks.**
 
 The formatter (`satsuma fmt`) auto-adds backticks to names that need them and strips unnecessary ones.
 
@@ -152,7 +154,7 @@ pipe_step := fragment_spread       // ...name(args) — structural, for IDE nav
 
 The `arithmetic_step`, `token_call`, and `_tc_arg` rules are removed — they're all just text now.
 
-Structural cross-references inside pipe text use `{...}` syntax (e.g., `Convert {amount} to USD`) and are extracted for NL-ref resolution and IDE features. Backticks in pipe text are inert.
+Structural cross-references inside pipe text use `@ref` syntax (e.g., `Convert @amount to USD`) and are extracted for NL-ref resolution and IDE features. Backticks in pipe text are inert.
 
 ### D5: Multi-source arrow syntax
 
@@ -169,11 +171,11 @@ In the extracted data model, `ArrowRecord.sources` becomes `string[]` (always an
 
 ### D6: NL refs are structural sources
 
-`{...}` references in NL strings that resolve to schemas or fields are structural data dependencies, not informational asides. The contract:
+`@ref` references in NL strings that resolve to schemas or fields are structural data dependencies, not informational asides. The contract:
 
 1. The `hidden-source-in-nl` lint rule becomes an **error** (was: warning).
 2. The auto-fix adds undeclared refs to the left side of a multi-source arrow, or to the mapping's `source { }` block.
-3. The graph and lineage commands treat NL refs as first-class edges (safe because lint guarantees they're declared).
+3. The graph and lineage commands treat `@ref` mentions as first-class edges (safe because lint guarantees they're declared).
 
 **Before (informational):**
 ```stm
@@ -184,7 +186,7 @@ field -> target { "Add to `other_field`" }
 
 **After (structural):**
 ```stm
-other_field, field -> target { Add to {other_field} }
+other_field, field -> target { Add to @other_field }
 // lint: passes — other_field declared on left
 // graph: edge from other_field to target
 ```
@@ -197,14 +199,13 @@ One rule: **backslash escapes the next character.** Applies identically inside b
 |--------|--------|-------|
 | `\"` | Literal `"` | Inside `"..."` |
 | `` \` `` | Literal `` ` `` | Inside `` `...` `` |
-| `\{` | Literal `{` | Inside `"..."` and `"""..."""` |
-| `\}` | Literal `}` | Inside `"..."` and `"""..."""` |
+| `\@` | Literal `@` | Inside NL strings (prevents `@` from starting a ref) |
 | `\\` | Literal `\` | Everywhere |
 | `\n`, `\t`, etc. | Literal `n`, `t`, etc. (no special sequences) |
 
-`\{` and `\}` are needed because `{...}` is the structural cross-reference syntax inside NL strings (see D2). Literal braces in prose must be escaped.
+`\@` is needed for the rare case where `@` appears in NL prose but should not be treated as a structural reference (e.g., email addresses). In practice this is uncommon — `@` followed by something that doesn't match an identifier is already inert.
 
-Triple-quoted strings (`"""..."""`) still need `\{` / `\}` for literal braces (since `{...}` refs work there too), but do not need `\"` escaping.
+Triple-quoted strings (`"""..."""`) do not need `\"` escaping. `\@` works the same in both quote forms.
 
 ### D8: Duplicate metadata tags
 
@@ -272,7 +273,7 @@ Extend `map_arrow` in the grammar to accept comma-separated source paths. Update
 Replace 13 `_kv_value` choices with a simple `value_text` rule (repeat of basic token types — identifiers, numbers, strings, backtick names, dotted names, operator chars). Commas and `)` naturally terminate the rule. No external scanner needed. Keep `enum_body`, `slice_body`, `note_tag` as structured rules. Remove `key_value_pair`, `kv_key`, `kv_braced_list`, `kv_comparison`, `kv_ref_on`, `kv_compound`.
 
 #### 3b: Pipe step simplification (implicit NL)
-Replace `pipe_step` choices with `fragment_spread | map_literal | pipe_text`. Remove `arithmetic_step`, `token_call`, `_tc_arg`. The `pipe_text` rule is a `repeat1` of basic tokens (identifiers, numbers, backtick names, operator chars, etc.) — `|` and `}` naturally terminate it because they're not in the token set. Double quotes still work for text containing literal `|` or `}`. Update NL-ref extraction to scan for `{...}` refs (replacing backtick scanning) in both quoted and bare pipe text.
+Replace `pipe_step` choices with `fragment_spread | map_literal | pipe_text`. Remove `arithmetic_step`, `token_call`, `_tc_arg`. The `pipe_text` rule is a `repeat1` of basic tokens (identifiers, numbers, backtick names, operator chars, etc.) — `|` and `}` naturally terminate it because they're not in the token set. Double quotes still work for text containing literal `|` or `}`. Update NL-ref extraction to scan for `@ref` mentions (replacing backtick scanning) in both quoted and bare pipe text.
 
 #### 3c: Map entry simplification
 Replace structured `map_key`/`map_value` with simple token-repeat rules. Map keys consume until `:`, map values consume until `,` or `}`. Same pattern as metadata — no external scanner, just natural termination by excluded delimiters.
@@ -286,7 +287,7 @@ Ensure `backtick_name` and `nl_string` use identical `\\[\\s\\S]` escape pattern
 - `tooling/tree-sitter-satsuma/test/corpus/*.txt` — rewrite CST expectations
 - `tooling/satsuma-cli/src/meta-extract.ts` — simpler extraction from `tag_with_value`
 - `tooling/satsuma-cli/src/extract.ts` — pipe step classification
-- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch from backtick regex to `{...}` ref extraction
+- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch from backtick regex to `@ref` extraction
 - `tooling/vscode-satsuma/server/src/*.ts` — update CST node type references
 - `tooling/vscode-satsuma/syntaxes/satsuma.tmLanguage.json` — TextMate patterns
 
@@ -318,13 +319,13 @@ Replace `quoted_name` (single-quote) with `backtick_name` in all label positions
 
 **Scope:** CLI only. Non-breaking (lint severity change).
 
-Change `hidden-source-in-nl` from warning to error. Add auto-fix that inserts undeclared refs into multi-source arrows or source blocks. Update graph and lineage to emit `{...}` ref edges (now safe because lint guarantees declaration).
+Change `hidden-source-in-nl` from warning to error. Add auto-fix that inserts undeclared refs into multi-source arrows or source blocks. Update graph and lineage to emit `@ref` edges (now safe because lint guarantees declaration).
 
 **Key files:**
 - `tooling/satsuma-cli/src/lint-engine.ts` — severity change + auto-fix
 - `tooling/satsuma-cli/src/graph-builder.ts` — NL ref edge promotion
 - `tooling/satsuma-cli/src/commands/lineage.ts` — NL ref traversal
-- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch to `{...}` extraction, add `isStructuralSource` flag
+- `tooling/satsuma-cli/src/nl-ref-extract.ts` — switch to `@ref` extraction, add `isStructuralSource` flag
 
 **Depends on:** Phase 2 (multi-source arrows must exist for auto-fix target).
 **Parallelizable with:** Phases 3 and 4.
@@ -358,8 +359,8 @@ Phase 2 (Multi-Source Arrow) ──┬──────────────
 3. Metadata with any combination of tags, values, enums, slices, and notes parses correctly under the simplified grammar.
 4. Bare text pipe steps (no quotes) parse correctly: `field -> target { Convert to uppercase | trim }`.
 5. The formatter auto-converts `'label'` to `` `label` `` and produces idempotent output.
-6. `hidden-source-in-nl` is an error. `satsuma lint --fix` auto-adds undeclared NL refs to source declarations.
-7. `satsuma graph --json` includes NL backtick ref edges in `schema_edges`.
+6. `hidden-source-in-nl` is an error. `satsuma lint --fix` auto-adds undeclared `@ref` mentions to source declarations.
+7. `satsuma graph --json` includes `@ref` edges in `schema_edges`.
 8. All example `.stm` files parse cleanly under the new grammar.
 9. Escaping behaves identically in backticks and double quotes.
 10. Duplicate metadata tags are preserved without error.
@@ -372,9 +373,9 @@ Phase 2 (Multi-Source Arrow) ──┬──────────────
 15. Integration tests: `satsuma fmt --check examples/` exits 0 after migration.
 
 ### Documentation
-16. `SATSUMA-V2-SPEC.md` updated: quoting rules, multi-source arrows, simplified metadata, implicit NL in pipes.
-17. `SATSUMA-CLI.md` updated: canonical ref format, multi-source arrow output, lint error change.
-18. `AI-AGENT-REFERENCE.md` updated: new syntax forms, canonical ref convention.
+16. `SATSUMA-V2-SPEC.md` updated: quoting rules, `@ref` syntax, multi-source arrows, simplified metadata, implicit NL in pipes.
+17. `SATSUMA-CLI.md` updated: canonical ref format, `@ref` output, multi-source arrow output, lint error change.
+18. `AI-AGENT-REFERENCE.md` updated: `@ref` convention, new syntax forms, canonical ref convention.
 19. `DISCOVERED-REQUIREMENTS.md` updated: mark resolved requirements.
 
 ---
@@ -386,7 +387,7 @@ Phase 2 (Multi-Source Arrow) ──┬──────────────
 | Grammar ambiguity in simplified rules | Medium — tree-sitter may struggle with greedy token repeats | Use `prec()` and `conflicts` to resolve; extensive corpus testing; keep delimiter exclusion clean |
 | Breaking change for `.stm` files (single→backtick quotes) | Medium — all existing files need migration | Ship `satsuma fmt` migration before or with the change; run on all examples |
 | Multi-source arrow ambiguity with comma in metadata | Low — comma in arrow source list vs metadata | Grammar precedence: comma-separated paths only before `->`, metadata only inside `()` |
-| NL ref elevation changes graph semantics | Medium — downstream consumers may not expect new edges | Document the change; add `--no-nl-edges` flag if needed for backward compat |
+| NL `@ref` elevation changes graph semantics | Medium — downstream consumers may not expect new edges | Document the change; add `--no-nl-edges` flag if needed for backward compat |
 | Test update volume (~1100 tests touch output formats) | High — time cost | Phase 1 (canonical refs) is the biggest test update; subsequent phases are incremental |
 
 ---

--- a/features/22-language-simplification/TODO.md
+++ b/features/22-language-simplification/TODO.md
@@ -1,0 +1,85 @@
+# Feature 22 — Language Simplification: Implementation Plan
+
+> Tracks all implementation work for the [PRD](PRD.md).
+> Each item maps to a `tk` ticket. Dependencies are encoded in the ticket graph.
+
+---
+
+## Phase 1 — Canonical Field References (CLI only, non-breaking)
+
+- [ ] **P1.1** Create `canonicalRef()` utility in `tooling/satsuma-cli/src/canonical-ref.ts`
+- [ ] **P1.2** Update `extract.ts` (`pathText()`, `extractArrowRecords()`) to use `canonicalRef()`
+- [ ] **P1.3** Update `index-builder.ts` to store qualified keys
+- [ ] **P1.4** Update all 16 command files to emit canonical refs in JSON and text output
+- [ ] **P1.5** Update `nl-ref-extract.ts` ref classification to use canonical form
+- [ ] **P1.6** Update CLI test snapshots for canonical ref format (~200+ tests)
+
+## Phase 2 — Multi-Source Arrow Syntax (grammar + CLI, non-breaking)
+
+- [ ] **P2.1** Extend `map_arrow` in `grammar.js` to accept `commaSep1(src_path)`
+- [ ] **P2.2** Add corpus test file `multi_source_arrows.txt`
+- [ ] **P2.3** Update `ArrowRecord` type: `source` -> `sources: string[]`
+- [ ] **P2.4** Update extraction in `extract.ts` for multi-source arrows
+- [ ] **P2.5** Update commands: `arrows`, `mapping`, `graph`, `lineage`, `validate`
+- [ ] **P2.6** Add canonical example `.stm` file with multi-source arrows
+- [ ] **P2.7** Update `SATSUMA-V2-SPEC.md` with multi-source arrow syntax
+
+## Phase 3 — Grammar Simplification (grammar + CLI + VS Code, breaking for CST consumers)
+
+- [ ] **P3.1** Metadata simplification: replace 13 `_kv_value` forms with `value_text` greedy rule
+- [ ] **P3.2** Pipe step simplification: replace with `fragment_spread | map_literal | pipe_text`
+- [ ] **P3.3** Map entry simplification: `map_key_text : map_value_text` greedy capture
+- [ ] **P3.4** Unified escaping: align `backtick_name` and `nl_string` escape patterns, add `\@`
+- [ ] **P3.5** Update all corpus test CST expectations for simplified node types
+- [ ] **P3.6** Update `meta-extract.ts` for simplified `tag_with_value` extraction
+- [ ] **P3.7** Update `extract.ts` pipe step classification
+- [ ] **P3.8** Switch `nl-ref-extract.ts` from backtick regex to `@ref` extraction
+- [ ] **P3.9** Update VS Code LSP server CST node type references
+- [ ] **P3.10** Update TextMate grammar patterns
+
+## Phase 4 — Unify Quotes / Drop Single Quotes (grammar + CLI + VS Code + examples, breaking)
+
+- [ ] **P4.1** Replace `quoted_name` with `backtick_name` in grammar label positions
+- [ ] **P4.2** Update all corpus tests: `'label'` -> `` `label` ``
+- [ ] **P4.3** Update `labelText()` in `extract.ts` and `format.ts`
+- [ ] **P4.4** Update VS Code TextMate and LSP `quoted_name` references
+- [ ] **P4.5** Migrate all `examples/*.stm` files (95+ single-quote instances)
+- [ ] **P4.6** Update `SATSUMA-V2-SPEC.md` sections 2.2, 2.3
+
+## Phase 5 — Elevate NL Refs to Structural Sources (CLI only, non-breaking)
+
+- [ ] **P5.1** Change `hidden-source-in-nl` from warning to error in `lint-engine.ts`
+- [ ] **P5.2** Add `lint --fix` auto-fix: insert undeclared `@ref` mentions into source declarations
+- [ ] **P5.3** Update `graph-builder.ts` to emit `@ref` edges as first-class `schema_edges`
+- [ ] **P5.4** Update `lineage.ts` to traverse `@ref` edges
+
+## Cross-Cutting — Documentation
+
+- [ ] **DOC.1** Update `AI-AGENT-REFERENCE.md`: `@ref` convention, simplified grammar EBNF, updated cheat sheet
+- [ ] **DOC.2** Update `SATSUMA-CLI.md`: canonical ref format, `@ref` output, multi-source arrow output
+- [ ] **DOC.3** Update `DISCOVERED-REQUIREMENTS.md`: mark resolved requirements
+
+---
+
+## Dependency Graph
+
+```
+P1.1 ──> P1.2 ──> P1.3 ──> P1.4 ──> P1.5 ──> P1.6
+                                                  │
+P2.1 ──> P2.2 ──> P2.3 ──> P2.4 ──> P2.5 ──> P2.6 ──> P2.7
+  │                                               │       │
+  │                                               ├───────┤
+  │                                               v       │
+  │                                             P5.1 ──> P5.2 ──> P5.3 ──> P5.4
+  │                                               │
+  v                                               v
+P3.1 ──> P3.2 ──> P3.3 ──> P3.4 ──> P3.5 ──────────────────────────────────┐
+  │                                   │                                      │
+  v                                   v                                      v
+P3.6 ──> P3.7 ──> P3.8 ──> P3.9 ──> P3.10 ──> P4.1 ──> P4.2 ──> P4.3 ──> P4.4 ──> P4.5 ──> P4.6
+                                                                                       │
+                                                                                       v
+                                                                              DOC.1, DOC.2, DOC.3
+```
+
+**Parallel tracks:** P1.x and P2.x can run simultaneously. P5.x can run alongside P3.x/P4.x (after P2 merges).


### PR DESCRIPTION
## Summary

- **Replace `{...}` NL cross-reference syntax with `@ref`** throughout the Feature 22 PRD. The `@` sigil (GitHub-mention style) leverages LLM training priors, avoids brace escaping, and composes naturally with existing backtick quoting rules.
- **`@` is required in NL strings** for tooling to detect structural refs, but **optional and allowed everywhere else** — users who over-apply `@` get correct code, users who forget it in NL get a lint warning.
- **Create 36 dependency-linked tickets** across 5 implementation phases plus documentation, with a `TODO.md` tracking the full plan.

### Key design change from v1 PRD

| | `{...}` refs (v1) | `@ref` (v2) |
|---|---|---|
| LLM prior | Template literals — LLMs hallucinate `${name}` | Mentions — every LLM generates `@name` correctly |
| Escaping | `\{` and `\}` for literal braces | `\@` only (rare — `@` before non-identifiers is inert) |
| Teachability | "Use braces for refs, escape literal braces" | "@ means reference, like a GitHub mention" |
| Quoting | New convention inside braces | Same backtick rules as rest of language |

### Ticket breakdown (36 tickets, 5 phases)

- **Phase 1** (6 tickets): Canonical field references — CLI only, non-breaking
- **Phase 2** (7 tickets): Multi-source arrow syntax — grammar + CLI, non-breaking
- **Phase 3** (10 tickets): Grammar simplification — grammar + CLI + VS Code, breaking for CST consumers
- **Phase 4** (6 tickets): Unify quotes / drop single quotes — breaking for .stm files
- **Phase 5** (4 tickets): Elevate NL refs to structural sources — CLI only
- **Docs** (3 tickets): AI-AGENT-REFERENCE.md, SATSUMA-CLI.md, DISCOVERED-REQUIREMENTS.md

Phases 1+2 are parallel. Phase 3 depends on both. Phase 4 is sequential after 3. Phase 5 runs alongside 3+4 (after Phase 2).

## Test plan

- [ ] PRD reads coherently with all `{...}` replaced by `@ref`
- [ ] No stale `{...}` references remain in PRD
- [ ] `tk ready` shows P1.1 and P2.1 as the two entry points
- [ ] `tk dep tree lsp-dwk7` (DOC.1) shows full dependency chain through all phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)