### PR TITLE
feat: canonical refs in NL resolution + P1.3 improvements

### DIFF
--- a/.tickets/lsp-um8v.md
+++ b/.tickets/lsp-um8v.md
@@ -1,6 +1,6 @@
 ---
 id: lsp-um8v
-status: open
+status: closed
 deps: [lsp-vfn0]
 links: []
 created: 2026-03-25T17:28:23Z
@@ -19,3 +19,10 @@ Bulk update ~200+ CLI test snapshots to expect canonical [ns]::schema.field form
 - npm test in satsuma-cli exits 0
 - No snapshot mismatches remain
 
+
+## Notes
+
+**2026-03-26T00:15:00Z**
+
+Cause: P1.5 NL ref canonicalization only required 1 test assertion update
+Fix: Updated nl-ref-extract.test.js bare workspace fallback assertion to expect ::schema.field form. Bulk P1.4 snapshot updates were already merged on main.

--- a/.tickets/lsp-vfn0.md
+++ b/.tickets/lsp-vfn0.md
@@ -1,6 +1,6 @@
 ---
 id: lsp-vfn0
-status: in_progress
+status: closed
 deps: [lsp-qmm1]
 links: []
 created: 2026-03-25T17:28:23Z
@@ -19,3 +19,10 @@ Update NL reference extraction and classification to use canonical ref form.
 - Ref resolution matches canonical keys in workspace index
 - Tests updated
 
+
+## Notes
+
+**2026-03-26T00:15:00Z**
+
+Cause: resolveRef() returned bare index keys (e.g. "schema.field") instead of canonical form (e.g. "::schema.field")
+Fix: Wrapped all resolvedTo.name returns in canonicalKey(). Updated isSchemaInMappingSources() to compare canonical forms. Updated where-used gatherRefs() NL matching for canonical keys. Updated lint-engine makeAddSourceFix() to use resolveCanonicalKey() for source insertion.

--- a/tooling/satsuma-cli/src/canonical-ref.ts
+++ b/tooling/satsuma-cli/src/canonical-ref.ts
@@ -25,3 +25,15 @@ export function canonicalRef(
   if (field) return `${base}.${field}`;
   return base;
 }
+
+/**
+ * Canonical display name for an entity record with namespace and name fields.
+ * Consolidates the repeated `canonicalKey(entity.namespace ? ...)` pattern.
+ *
+ *   canonicalEntityName({ namespace: "crm", name: "customers" })  → "crm::customers"
+ *   canonicalEntityName({ name: "customers" })                     → "::customers"
+ *   canonicalEntityName({ name: null })                            → "::"
+ */
+export function canonicalEntityName(entity: { namespace?: string | null; name: string | null }): string {
+  return canonicalRef(entity.namespace, entity.name ?? "");
+}

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -16,6 +16,7 @@ import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
 import { extractMetadata } from "../meta-extract.js";
+import { canonicalEntityName } from "../canonical-ref.js";
 import { classifyTransform } from "../classify.js";
 import type { SyntaxNode, MappingRecord } from "../types.js";
 
@@ -165,7 +166,7 @@ function printJson(entry: MappingRecord, mappingNode: SyntaxNode | null): void {
   console.log(
     JSON.stringify(
       {
-        name: canonicalKey(entry.namespace ? `${entry.namespace}::${entry.name}` : (entry.name ?? "")),
+        name: canonicalEntityName(entry),
         ...(entry.namespace ? { namespace: entry.namespace } : {}),
         sources: entry.sources.map((s) => canonicalKey(s)),
         targets: entry.targets.map((t) => canonicalKey(t)),
@@ -213,11 +214,7 @@ function printArrowNode(c: SyntaxNode, compact: boolean | undefined, indent: str
   const childArrows = c.namedChildren.filter((x) => x.type === "map_arrow" || x.type === "computed_arrow" || x.type === "nested_arrow");
 
   if (childArrows.length > 0) {
-    if (compact || !pipeChain) {
-      console.log(`${indent}${srcPart}${tgtStr}${metaSuffix} {`);
-    } else {
-      console.log(`${indent}${srcPart}${tgtStr}${metaSuffix} {`);
-    }
+    console.log(`${indent}${srcPart}${tgtStr}${metaSuffix} {`);
     for (const child of childArrows) {
       printArrowNode(child, compact, indent + "  ");
     }

--- a/tooling/satsuma-cli/src/commands/metric.ts
+++ b/tooling/satsuma-cli/src/commands/metric.ts
@@ -13,8 +13,9 @@
 import type { Command } from "commander";
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
-import { buildIndex, resolveIndexKey, canonicalKey } from "../index-builder.js";
+import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
+import { canonicalEntityName } from "../canonical-ref.js";
 import type { SyntaxNode, MetricRecord } from "../types.js";
 
 export function register(program: Command): void {
@@ -151,7 +152,7 @@ function printJson(entry: MetricRecord, metricNode: SyntaxNode | null): void {
   console.log(
     JSON.stringify(
       {
-        name: canonicalKey(entry.namespace ? `${entry.namespace}::${entry.name}` : entry.name),
+        name: canonicalEntityName(entry),
         ...(entry.namespace ? { namespace: entry.namespace } : {}),
         displayName: entry.displayName,
         sources: entry.sources,

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -13,9 +13,10 @@
 import type { Command } from "commander";
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
-import { buildIndex, resolveIndexKey, canonicalKey } from "../index-builder.js";
+import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
 import { expandEntityFields } from "../spread-expand.js";
+import { canonicalEntityName } from "../canonical-ref.js";
 import { extractMetadata } from "../meta-extract.js";
 import type { SyntaxNode, WorkspaceIndex, SchemaRecord } from "../types.js";
 
@@ -198,7 +199,7 @@ function printJson(entry: SchemaRecord, schemaNode: SyntaxNode | null, index: Wo
   const metadata = extractMetadata(metaNode);
 
   const out: Record<string, unknown> = {
-    name: canonicalKey(entry.namespace ? `${entry.namespace}::${entry.name}` : entry.name),
+    name: canonicalEntityName(entry),
     ...(entry.namespace ? { namespace: entry.namespace } : {}),
     file: entry.file,
     row: entry.row + 1,

--- a/tooling/satsuma-cli/src/commands/summary.ts
+++ b/tooling/satsuma-cli/src/commands/summary.ts
@@ -18,6 +18,7 @@ import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, canonicalKey } from "../index-builder.js";
 import { expandEntityFields } from "../spread-expand.js";
+import { canonicalEntityName } from "../canonical-ref.js";
 import type { FieldDecl, WorkspaceIndex } from "../types.js";
 
 function totalFieldCount(schema: { fields: FieldDecl[]; namespace?: string | null }, index: WorkspaceIndex): number {
@@ -70,11 +71,7 @@ export function register(program: Command): void {
 // ── Formatters ────────────────────────────────────────────────────────────────
 
 function printJson(index: WorkspaceIndex, fileCount: number, compact?: boolean): void {
-  /** Format a display name with namespace prefix when applicable. */
-  const displayName = (entity: { namespace?: string; name: string | null }): string => {
-    if (entity.namespace) return `${entity.namespace}::${entity.name}`;
-    return canonicalKey(entity.name ?? "");
-  };
+  const displayName = canonicalEntityName;
 
   const out: Record<string, unknown> = {
     schemas: [...index.schemas.values()].map((s) => {
@@ -117,11 +114,11 @@ function printCompact(index: WorkspaceIndex): void {
     for (const name of items) console.log(`  ${name}`);
   };
 
-  section("schemas", [...index.schemas.keys()]);
-  section("metrics", [...index.metrics.keys()]);
-  section("mappings", [...index.mappings.keys()]);
-  section("fragments", [...index.fragments.keys()]);
-  section("transforms", [...index.transforms.keys()]);
+  section("schemas", [...index.schemas.keys()].map(canonicalKey));
+  section("metrics", [...index.metrics.keys()].map(canonicalKey));
+  section("mappings", [...index.mappings.keys()].map(canonicalKey));
+  section("fragments", [...index.fragments.keys()].map(canonicalKey));
+  section("transforms", [...index.transforms.keys()].map(canonicalKey));
 }
 
 function plural(n: number, word: string): string {
@@ -141,11 +138,7 @@ function printDefault(index: WorkspaceIndex, fileCount: number): void {
   }
   console.log();
 
-  /** Format a display name with namespace prefix when applicable. */
-  const displayName = (entity: { namespace?: string; name: string | null }): string => {
-    if (entity.namespace) return `${entity.namespace}::${entity.name}`;
-    return canonicalKey(entity.name ?? "");
-  };
+  const displayName = canonicalEntityName;
 
   if (schemas.length > 0) {
     console.log(`Schemas (${schemas.length}):`);

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -168,11 +168,11 @@ function gatherRefs(name: string, index: WorkspaceIndex, parsedFiles: ParsedFile
   // NL backtick references — find references inside NL transform bodies
   const nlRefs = resolveAllNLRefs(index);
   const seenNLRefs = new Set<string>();
+  const cName = canonicalKey(name);
   for (const nlRef of nlRefs) {
     if (!nlRef.resolved || !nlRef.resolvedTo) continue;
     const resolvedRefName = nlRef.resolvedTo.name;
-    // Match the queried name against the resolved reference
-    if (resolvedRefName === name || resolvedRefName.startsWith(name + ".")) {
+    if (matchesEntityOrField(resolvedRefName, name, cName)) {
       const dedup = `${nlRef.mapping}:${nlRef.file}:${nlRef.line}`;
       if (seenNLRefs.has(dedup)) continue;
       seenNLRefs.add(dedup);
@@ -186,6 +186,15 @@ function gatherRefs(name: string, index: WorkspaceIndex, parsedFiles: ParsedFile
   }
 
   return refs;
+}
+
+/**
+ * Check whether a resolved ref name matches an entity query.
+ * Handles exact match and field-prefixed match in both internal and canonical forms.
+ */
+function matchesEntityOrField(resolvedName: string, internalName: string, canonicalName: string): boolean {
+  return resolvedName === internalName || resolvedName === canonicalName ||
+    resolvedName.startsWith(internalName + ".") || resolvedName.startsWith(canonicalName + ".");
 }
 
 /**

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -374,7 +374,10 @@ function buildFieldArrows(arrowRecords: ArrowRecord[], mappings: Map<string, Map
       for (const schema of sourceSchemas) {
         // Don't double-prefix if source already starts with schema name
         if (!bareSource.startsWith(schema + ".") && bareSource !== schema) {
-          addToIndex(`${schema}.${bareSource}`, record);
+          const internalKey = `${schema}.${bareSource}`;
+          addToIndex(internalKey, record);
+          // Also index under canonical form for Phase 5 @ref edge lookups
+          addToIndex(canonicalKey(internalKey), record);
         }
       }
       addToIndex(source, record);
@@ -390,7 +393,10 @@ function buildFieldArrows(arrowRecords: ArrowRecord[], mappings: Map<string, Map
       for (const schema of targetSchemas) {
         // Don't double-prefix if target already starts with schema name
         if (!bareTarget.startsWith(schema + ".") && bareTarget !== schema) {
-          addToIndex(`${schema}.${bareTarget}`, record);
+          const internalKey = `${schema}.${bareTarget}`;
+          addToIndex(internalKey, record);
+          // Also index under canonical form for Phase 5 @ref edge lookups
+          addToIndex(canonicalKey(internalKey), record);
         }
       }
       addToIndex(record.target, record);

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -13,6 +13,7 @@ import {
   resolveRef,
   isSchemaInMappingSources,
 } from "./nl-ref-extract.js";
+import { resolveCanonicalKey } from "./index-builder.js";
 import type { LintDiagnostic, LintFix, LintRule, WorkspaceIndex } from "./types.js";
 
 // ── Rule registry ──────────────────────────────────────────────────────────
@@ -109,8 +110,8 @@ function makeAddSourceFix(mappingKey: string, schemaRef: string): (source: strin
     : mappingKey;
   const mappingNs = nsIdx !== -1 ? mappingKey.slice(0, nsIdx) : null;
 
-  // If the schema ref is in the same namespace as the mapping, use the local name
-  let insertRef = schemaRef;
+  // Convert canonical ref (::name) back to source-level form for insertion
+  let insertRef = resolveCanonicalKey(schemaRef);
   if (mappingNs && schemaRef.startsWith(`${mappingNs}::`)) {
     insertRef = schemaRef.slice(mappingNs.length + 2);
   }

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -11,6 +11,7 @@
 
 import type { FieldDecl, MappingRecord, NLRefData, SyntaxNode, WorkspaceIndex } from "./types.js";
 import { expandEntityFields } from "./spread-expand.js";
+import { canonicalKey } from "./index-builder.js";
 
 // ── Extraction ──────────────────────────────────────────────────────────────
 
@@ -73,9 +74,11 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
   const classification = classifyRef(ref);
 
   if (classification === "namespace-qualified-schema") {
-    if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: ref } };
-    if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: ref } };
-    if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: ref } };
+    // canonicalKey is a no-op here (ref already contains ::) but keeps the
+    // contract explicit: resolvedTo.name is always in canonical form.
+    if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(ref) } };
+    if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(ref) } };
+    if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(ref) } };
     return { resolved: false, resolvedTo: null };
   }
 
@@ -85,7 +88,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
     const fieldName = ref.slice(dotIdx + 1);
     const schema = index.schemas.get(schemaRef);
     if (schema && hasFieldWithSpreads(schema, fieldName, index)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: ref } };
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldName}` } };
     }
     return { resolved: false, resolvedTo: null };
   }
@@ -101,13 +104,13 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
     for (const s of allSchemas) {
       const schema = index.schemas.get(s);
       if (schema && hasNestedFieldPath(schema.fields, ref)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${ref}` } };
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
       }
       // Also check expanded spread fields
       if (schema?.hasSpreads) {
         const expanded = expandEntityFields(schema, schema.namespace ?? null, index);
         if (hasNestedFieldPath([...schema.fields, ...expanded], ref)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${ref}` } };
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
         }
       }
     }
@@ -119,7 +122,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
       if (baseName === schemaName || s === schemaName) {
         const schema = index.schemas.get(s);
         if (schema && hasFieldWithSpreads(schema, fieldName, index)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${fieldName}` } };
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${fieldName}` } };
         }
       }
     }
@@ -129,7 +132,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
       const baseName = nsIdx !== -1 ? key.slice(nsIdx + 2) : key;
       if (baseName === schemaName || key === schemaName) {
         if (hasFieldWithSpreads(schema, fieldName, index)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${key}.${fieldName}` } };
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
         }
       }
     }
@@ -141,7 +144,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
   for (const s of allSchemaNames) {
     const schema = index.schemas.get(s);
     if (schema && hasFieldWithSpreads(schema, ref, index)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${s}.${ref}` } };
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
     }
   }
 
@@ -150,7 +153,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
   if (allSchemaNames.length === 0) {
     for (const [key, schema] of index.schemas) {
       if (hasFieldWithSpreads(schema, ref, index)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${key}.${ref}` } };
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
       }
     }
   }
@@ -158,15 +161,15 @@ export function resolveRef(ref: string, mappingContext: MappingContext, index: W
   // Try namespace-qualified lookup from mapping's namespace BEFORE global
   if (mappingContext.namespace) {
     const nsRef = `${mappingContext.namespace}::${ref}`;
-    if (index.schemas.has(nsRef)) return { resolved: true, resolvedTo: { kind: "schema", name: nsRef } };
-    if (index.fragments?.has(nsRef)) return { resolved: true, resolvedTo: { kind: "fragment", name: nsRef } };
-    if (index.transforms?.has(nsRef)) return { resolved: true, resolvedTo: { kind: "transform", name: nsRef } };
+    if (index.schemas.has(nsRef)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(nsRef) } };
+    if (index.fragments?.has(nsRef)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(nsRef) } };
+    if (index.transforms?.has(nsRef)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(nsRef) } };
   }
 
   // Check if it's a global schema, fragment, or transform name
-  if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: ref } };
-  if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: ref } };
-  if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: ref } };
+  if (index.schemas.has(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(ref) } };
+  if (index.fragments?.has(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(ref) } };
+  if (index.transforms?.has(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(ref) } };
 
   return { resolved: false, resolvedTo: null };
 }
@@ -517,5 +520,7 @@ export function resolveAllNLRefs(index: WorkspaceIndex): ResolvedNLRef[] {
 export function isSchemaInMappingSources(schemaRef: string, mapping: MappingRecord | undefined): boolean {
   if (!mapping) return false;
   const allRefs = [...(mapping.sources ?? []), ...(mapping.targets ?? [])];
-  return allRefs.includes(schemaRef);
+  // Compare using canonical forms since schemaRef may be canonical (::name)
+  // while mapping sources/targets are internal keys (bare name)
+  return allRefs.some((r) => r === schemaRef || canonicalKey(r) === schemaRef);
 }

--- a/tooling/satsuma-cli/test/canonical-ref.test.js
+++ b/tooling/satsuma-cli/test/canonical-ref.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { canonicalRef } from "#src/canonical-ref.js";
+import { canonicalRef, canonicalEntityName } from "#src/canonical-ref.js";
 import { canonicalKey, resolveCanonicalKey } from "#src/index-builder.js";
 
 describe("canonicalRef", () => {
@@ -55,6 +55,28 @@ describe("canonicalKey", () => {
 
   it("preserves already-canonical unscoped keys", () => {
     assert.equal(canonicalKey("::customers"), "::customers");
+  });
+});
+
+describe("canonicalEntityName", () => {
+  it("formats global entity", () => {
+    assert.equal(canonicalEntityName({ name: "customers" }), "::customers");
+  });
+
+  it("formats namespaced entity", () => {
+    assert.equal(canonicalEntityName({ namespace: "crm", name: "customers" }), "crm::customers");
+  });
+
+  it("handles null name", () => {
+    assert.equal(canonicalEntityName({ name: null }), "::");
+  });
+
+  it("treats undefined namespace as global", () => {
+    assert.equal(canonicalEntityName({ namespace: undefined, name: "foo" }), "::foo");
+  });
+
+  it("treats null namespace as global", () => {
+    assert.equal(canonicalEntityName({ namespace: null, name: "foo" }), "::foo");
   });
 });
 

--- a/tooling/satsuma-cli/test/nl-ref-extract.test.js
+++ b/tooling/satsuma-cli/test/nl-ref-extract.test.js
@@ -153,7 +153,7 @@ describe("resolveRef", () => {
     const result = resolveRef("user_id", context, index);
     assert.equal(result.resolved, true);
     assert.equal(result.resolvedTo.kind, "field");
-    assert.equal(result.resolvedTo.name, "my_schema.user_id");
+    assert.equal(result.resolvedTo.name, "::my_schema.user_id");
   });
 
   it("does not fall back to all schemas when sources/targets are provided", () => {


### PR DESCRIPTION
## Summary

- **P1.5 (lsp-vfn0):** Update `resolveRef()` in `nl-ref-extract.ts` to return canonical form (`::schema.field`) for all `resolvedTo.name` values. Fix downstream consumers (`isSchemaInMappingSources`, `where-used`, `lint --fix`) to handle canonical forms.
- **P1.6 (lsp-um8v):** Test snapshot updates for canonical NL refs (only 1 assertion change needed).
- **P1.3 reconsideration:** Add `canonicalEntityName()` shared utility to eliminate repeated inline formatting patterns. Index field arrows under canonical keys for Phase 5 `@ref` edge lookups. Canonicalize `summary --compact` output.

## Test plan

- [ ] All 817 CLI tests pass (`npm test` in satsuma-cli)
- [ ] NL ref resolution returns `::schema.field` for global schemas
- [ ] `hidden-source-in-nl` lint rule correctly handles canonical refs
- [ ] `where-used` NL ref matching works with canonical form
- [ ] `lint --fix` inserts bare schema names (not `::` prefixed) into source blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)