### PR TITLE
chore: audit Feature 22 test suite for simplification redundancies

### DIFF
--- a/.tickets/sc-1tcm.md
+++ b/.tickets/sc-1tcm.md
@@ -1,6 +1,6 @@
 ---
 id: sc-1tcm
-status: open
+status: done
 deps: []
 links: []
 created: 2026-03-26T07:01:13Z
@@ -21,4 +21,12 @@ Feature 22 simplified the grammar (collapsed metadata value forms, unified quoti
 - No tests remain that validate removed v1/pre-Feature-22 syntax
 - All remaining tests pass
 - Test count may decrease — that is expected and acceptable
+
+## Notes
+
+**2026-03-26T12:00:00Z**
+
+Cause: Feature 22 grammar simplification removed node types (token_call, arithmetic_step, kv_value forms, quoted_name) but left 5 corpus test titles and 3 CLI test titles referencing the old concepts. No test code or assertions referenced removed node types — the test suite had been properly updated during the simplification, only the descriptive titles lagged.
+
+Fix: Renamed 5 corpus test titles (transforms.txt ×4, pipeline_extensions.txt ×1) and 3 CLI test titles (arrow-extract.test.js, integration.test.js, format.test.js) from pre-simplification terminology (token_call, arithmetic steps) to current grammar concepts (identifier pipeline, pipe step, arithmetic operators). All 824 CLI tests and 266 corpus tests pass. No tests needed removal — all validate distinct, valuable input patterns.
 

--- a/.tickets/sc-i8k8.md
+++ b/.tickets/sc-i8k8.md
@@ -1,6 +1,6 @@
 ---
 id: sc-i8k8
-status: open
+status: done
 deps: []
 links: []
 created: 2026-03-26T06:50:38Z
@@ -19,4 +19,12 @@ Tests should never depend on canonical example .stm files having validation erro
 - Any test asserting on warnings/errors from canonical examples migrated to dedicated fixtures
 - Canonical examples remain clean demonstration files with no test-required defects
 - All tests pass after migration
+
+## Notes
+
+**2026-03-26T12:00:00Z**
+
+Cause: Concern that tests might depend on canonical examples having validation errors or warnings, making examples serve double duty as error fixtures.
+
+Fix: Audited all 60+ references to EXAMPLES paths across integration.test.js, arrow-extract.test.js, format.test.js, bug-purge.test.js, and graph.test.js. Every test using canonical examples either (a) asserts clean validation (`no issues`, exit 0), (b) tests structural output (schema fields, arrow extraction, formatting), or (c) tests comment display features (//! //? appearing in output). All warning/error assertion tests already use dedicated fixtures in test/fixtures/ (parse-error.stm, metric-bad-source.stm, undefined-spread.stm, missing-import.stm, etc.). No remediation needed — the prior fix (sl-5dyc) was the last remaining case.
 

--- a/tooling/satsuma-cli/test/arrow-extract.test.js
+++ b/tooling/satsuma-cli/test/arrow-extract.test.js
@@ -108,7 +108,7 @@ describe("extractArrowRecords", () => {
     assert.equal(records[0].line, 10);
   });
 
-  it("extracts a structural arrow with token_call pipeline", () => {
+  it("extracts a structural arrow with identifier pipeline", () => {
     const steps = [
       pipeStep("pipe_text", "trim"),
       pipeStep("pipe_text", "lowercase"),

--- a/tooling/satsuma-cli/test/format.test.js
+++ b/tooling/satsuma-cli/test/format.test.js
@@ -310,7 +310,7 @@ describe("edge cases", () => {
     assert.ok(out.includes("      x  INT"));
   });
 
-  it("handles arithmetic steps in pipe chains", () => {
+  it("handles arithmetic operators in pipe chains", () => {
     const src = `mapping test {
   source { s }
   target { t }

--- a/tooling/satsuma-cli/test/integration.test.js
+++ b/tooling/satsuma-cli/test/integration.test.js
@@ -1065,7 +1065,7 @@ describe("satsuma arrows", () => {
     assert.match(stdout, /\[none\]/);
   });
 
-  it("shows structural classification on token_call pipeline", async () => {
+  it("shows structural classification on identifier pipeline", async () => {
     const { stdout, code } = await run("arrows", "legacy_sqlserver.FIRST_NM", DB);
     assert.equal(code, 0);
     assert.match(stdout, /\[structural\]/);

--- a/tooling/tree-sitter-satsuma/test/corpus/pipeline_extensions.txt
+++ b/tooling/tree-sitter-satsuma/test/corpus/pipeline_extensions.txt
@@ -39,7 +39,7 @@ mapping {
               (identifier))))))))
 
 ================================================================================
-Token call with dotted path argument
+Pipe step with dotted path argument
 ================================================================================
 
 mapping {

--- a/tooling/tree-sitter-satsuma/test/corpus/transforms.txt
+++ b/tooling/tree-sitter-satsuma/test/corpus/transforms.txt
@@ -31,7 +31,7 @@ transform `clean email` {
           (nl_string))))))
 
 ================================================================================
-Single token_call step
+Single bare identifier pipe step
 ================================================================================
 
 transform `normalize` {
@@ -50,7 +50,7 @@ transform `normalize` {
           (identifier))))))
 
 ================================================================================
-Token call with arguments
+Function-like pipe step with arguments
 ================================================================================
 
 transform `coerce` {
@@ -71,7 +71,7 @@ transform `coerce` {
           (identifier))))))
 
 ================================================================================
-Multi-step pipe chain with token calls
+Multi-step pipe chain with identifiers
 ================================================================================
 
 transform `clean email` {
@@ -96,7 +96,7 @@ transform `clean email` {
           (identifier))))))
 
 ================================================================================
-Pipe chain with NL string then token calls
+Pipe chain with NL string then identifiers
 ================================================================================
 
 transform `normalize phone` {


### PR DESCRIPTION
## Summary
- Audited all 824 CLI tests (26 files) and 266 tree-sitter corpus tests (27 files) for Feature 22 grammar simplification redundancies (sc-1tcm)
- Audited all 60+ EXAMPLES path references for tests depending on canonical examples having errors/warnings (sc-i8k8)
- Renamed 8 stale test titles referencing removed grammar concepts (`token_call`, `arithmetic steps`) to current terminology (`identifier pipeline`, `pipe step`, `arithmetic operators`)
- Confirmed no tests validate removed syntax, reference removed CST node types, or depend on canonical examples having defects

## Test plan
- [x] All 824 CLI tests pass
- [x] All 266 tree-sitter corpus tests pass
- [x] No test logic changed — title-only renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)