### PR TITLE
chore: 12 CLI bugs from exploratory testing + updated test prompts

### DIFF
--- a/.tickets/cbh-so1o.md
+++ b/.tickets/cbh-so1o.md
@@ -1,8 +1,8 @@
 ---
 id: cbh-so1o
-status: closed
+status: open
 deps: []
-links: [cbh-ukcx, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s, sl-kutf]
+links: [cbh-ukcx, cbh-kyv3, cbh-2y8p, cbh-7ji8, cbh-9cqh, cbh-b0w8, cbh-e01s, sl-kutf, sl-sq4u, sl-h8sb, sl-kqfj]
 created: 2026-03-25T11:17:46Z
 type: bug
 priority: 2
@@ -19,3 +19,9 @@ When a mapping has NL strings in the source block (join descriptions), 'satsuma 
 The join NL is defined on line 138-139 of mappings.stm inside the source block of the 'order enrichment' mapping. This is meaningful NL content that describes how sources are joined.
 - Test file: /tmp/satsuma-bug-hunt/mappings.stm (lines 138-139)
 
+
+## Notes
+
+**2026-03-26T08:30:15Z**
+
+2026-03-26: Reopened — bug still reproduces. Both nl and nl-refs fail to extract source block join descriptions. The nl command does not include join NL text, and nl-refs does not scan source_block children for @refs. Confirmed with minimal fixture: source { orders, customers, "Left join @orders.id = @customers.id" } — both commands return empty output for this NL content.

--- a/.tickets/sl-04eg.md
+++ b/.tickets/sl-04eg.md
@@ -1,0 +1,19 @@
+---
+id: sl-04eg
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:30:39Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# validate: false field-not-in-schema warning when duplicate mapping names exist across files
+
+When two files define mappings with the same name (e.g. 'order headers' in json-api-to-parquet.stm and xml-to-parquet.stm), workspace-level validate can resolve a mapping's arrows against the wrong file's schema. This produces false 'Arrow source X not declared in schema Y' warnings where Y is the other file's source schema. Single-file validation passes cleanly.
+
+## Acceptance Criteria
+
+1. validate does not produce false field-not-in-schema warnings when duplicate mapping names exist
+2. Either: each mapping is validated against its own source/target schemas, OR duplicate-definition is caught first and prevents downstream false warnings
+

--- a/.tickets/sl-057k.md
+++ b/.tickets/sl-057k.md
@@ -1,0 +1,19 @@
+---
+id: sl-057k
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:30:01Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# graph --schema-only: duplicate edges for namespaced mappings
+
+In --schema-only mode, namespaced mappings produce two sets of edges: one from field-edge aggregation using the namespace-qualified name (e.g. 'sales::summarize') and another from the declared-source/target fallback using the bare name ('summarize'). Root cause: line 300 of graph.ts builds mappingsWithEdges from fieldEdges[].mapping (qualified) but line 303 checks mapping.name (bare), so the membership test fails and the fallback fires.
+
+## Acceptance Criteria
+
+1. satsuma graph --schema-only produces exactly one edge per mapping relationship for namespaced mappings
+2. All edges use the namespace-qualified mapping name
+

--- a/.tickets/sl-2ayt.md
+++ b/.tickets/sl-2ayt.md
@@ -1,0 +1,19 @@
+---
+id: sl-2ayt
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:30:34Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+---
+# mapping vs arrows: inconsistent classification for empty transform body { }
+
+An arrow 'a -> x { }' with empty braces is classified as kind:'nested' by the mapping command but classification:'none' by the arrows command. The arrows command is correct — an empty body is not a nested block. The mapping command should classify it consistently.
+
+## Acceptance Criteria
+
+1. mapping --json classifies a -> x { } consistently with arrows command
+2. Empty braces are not treated as nested blocks
+

--- a/.tickets/sl-9zcv.md
+++ b/.tickets/sl-9zcv.md
@@ -1,0 +1,20 @@
+---
+id: sl-9zcv
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:29:53Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# nl-ref-extract: @ref with 3+ dot-segment paths (@schema.record.field) falsely flagged as unresolved
+
+When an @ref uses a 3-segment dot path like @source_data.address.street (schema.record.subfield), the resolver splits at the first dot and calls hasFieldWithSpreads(schema, 'address.street'), which does flat name matching. It should use hasNestedFieldPath() to walk the nested record structure. This produces false [nl-ref-unresolved] warnings for valid nested paths.
+
+## Acceptance Criteria
+
+1. satsuma validate does not warn for @schema.record.subfield paths when the nested path exists
+2. satsuma nl-refs correctly resolves 3+ segment @ref paths
+3. lineage edges are correctly created for nested @ref paths
+

--- a/.tickets/sl-gqoy.md
+++ b/.tickets/sl-gqoy.md
@@ -1,0 +1,20 @@
+---
+id: sl-gqoy
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:30:30Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+---
+# mapping --compact --json: still includes transforms and notes in JSON output
+
+The --compact flag correctly omits transform bodies and notes in text output mode, but JSON output still includes 'transform' and 'metadata' fields on arrows. Expected: JSON --compact should also strip transform text and note metadata for consistency with text mode.
+
+## Acceptance Criteria
+
+1. satsuma mapping name --compact --json omits transform text from arrows
+2. satsuma mapping name --compact --json omits note metadata from arrows
+3. Text and JSON compact modes produce equivalent levels of detail
+

--- a/.tickets/sl-h8sb.md
+++ b/.tickets/sl-h8sb.md
@@ -1,0 +1,21 @@
+---
+id: sl-h8sb
+status: open
+deps: []
+links: [sl-sq4u, cbh-so1o, sl-kqfj]
+created: 2026-03-26T08:29:47Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+---
+# nl-ref-extract: @refs in standalone/schema note blocks silently ignored
+
+extractStandaloneNoteRefs in nl-ref-extract.ts only checks for backtick refs (line 360: text.includes('`')), missing the @ref pattern check that walkArrowsForNL has (line 421). Result: @refs in standalone note blocks, schema notes, metric notes, and fragment notes are never extracted. They don't appear in validate warnings, lint findings, lineage edges, or graph output. Backtick refs in the same positions ARE detected.
+
+## Acceptance Criteria
+
+1. satsuma nl-refs finds @refs in standalone note blocks
+2. satsuma nl-refs finds @refs in schema/metric/fragment note blocks
+3. satsuma validate warns about unresolved @refs in all note block types
+4. satsuma lint hidden-source-in-nl detects @refs in all note block types
+

--- a/.tickets/sl-kqfj.md
+++ b/.tickets/sl-kqfj.md
@@ -1,0 +1,22 @@
+---
+id: sl-kqfj
+status: open
+deps: []
+links: [sl-sq4u, sl-h8sb, cbh-so1o]
+created: 2026-03-26T08:30:20Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+---
+# nl-refs: does not walk into each_block or flatten_block nodes
+
+walkArrowsForNL in nl-ref-extract.ts (line 407) handles map_arrow, computed_arrow, and nested_arrow but not flatten_block or each_block. Arrows inside these block types are never scanned for @refs or backtick refs. This means: nl-refs returns empty for mappings that only have NL inside each/flatten; validate produces no warnings for @refs in these blocks; graph misses nl_ref edges; lint hidden-source-in-nl cannot detect hidden sources.
+
+## Acceptance Criteria
+
+1. satsuma nl-refs finds @refs in each block transforms
+2. satsuma nl-refs finds @refs in flatten block transforms
+3. satsuma validate warns about unresolved @refs in each/flatten
+4. satsuma graph includes nl_ref edges from each/flatten NL
+5. satsuma lint hidden-source-in-nl detects refs in each/flatten blocks
+

--- a/.tickets/sl-rkdz.md
+++ b/.tickets/sl-rkdz.md
@@ -1,0 +1,19 @@
+---
+id: sl-rkdz
+status: open
+deps: []
+links: [sl-vrsu]
+created: 2026-03-26T08:30:46Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# lint hidden-source-in-nl: false positive for dotted sub-field paths of declared source records
+
+When an NL transform references a dotted sub-field path like PERSONAL_NAME.FIRST_NAME where PERSONAL_NAME is a declared record field in the source schema, the hidden-source-in-nl rule flags it as an error. The rule should recognize that dotted paths whose root segment is a declared source/target field are not hidden sources. Reproduces with cobol-to-avro.stm.
+
+## Acceptance Criteria
+
+1. lint does not flag dotted sub-field paths when the root segment is in source/target
+2. lint still correctly flags truly hidden sources (root segment not in source/target)
+

--- a/.tickets/sl-sq4u.md
+++ b/.tickets/sl-sq4u.md
@@ -1,0 +1,20 @@
+---
+id: sl-sq4u
+status: open
+deps: []
+links: [sl-h8sb, cbh-so1o, sl-kqfj]
+created: 2026-03-26T08:30:27Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# nl: field-scoped query does not find NL inside each/flatten blocks
+
+extractFromField in nl.ts (lines 203-231) scans mapping_body children for map_arrow/computed_arrow but does not recurse into flatten_block or each_block children. Result: 'satsuma nl target_schema.field_name' returns empty for fields mapped inside each/flatten blocks, even though mapping-scoped 'satsuma nl mapping_name' correctly finds the same NL.
+
+## Acceptance Criteria
+
+1. satsuma nl target.field finds NL from arrows inside flatten blocks
+2. satsuma nl target.field finds NL from arrows inside each blocks
+3. Both text and JSON output modes work
+

--- a/.tickets/sl-tfqt.md
+++ b/.tickets/sl-tfqt.md
@@ -1,0 +1,20 @@
+---
+id: sl-tfqt
+status: open
+deps: []
+links: []
+created: 2026-03-26T08:30:09Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# classify.ts: mixed classification missed when NL and structural tokens share a pipe_text node
+
+In classify.ts (lines 28-36), the code checks kids.every((k) => NL_TYPES.has(k.type)) to decide if a pipe step is NL. When identifiers and NL strings coexist within a single pipe_text node (e.g. 'lookup some_table "Apply business rule"'), every() fails and the whole step is classified as structural. It never checks whether ANY child is NL. Result: arrows, graph, and downstream commands report [structural] instead of [mixed].
+
+## Acceptance Criteria
+
+1. Pipe steps with both structural and NL tokens are classified as [mixed]
+2. arrows command shows [mixed] classification for such transforms
+3. graph field edges show classification: mixed
+

--- a/.tickets/sl-vrsu.md
+++ b/.tickets/sl-vrsu.md
@@ -1,0 +1,19 @@
+---
+id: sl-vrsu
+status: open
+deps: []
+links: [sl-rkdz]
+created: 2026-03-26T08:30:51Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+---
+# lint unresolved-nl-ref: false positives for backtick emphasis in file-level notes
+
+File-level note blocks use backtick-quoted terms for emphasis/code formatting (e.g. `flatten`, `pii`, `owner`), not as field references. The unresolved-nl-ref rule treats all backtick-quoted text in notes as NL refs and flags them. This produces 36 false positive warnings across the example corpus. The rule should either: skip file-level notes entirely, or use a heuristic to distinguish emphasis from refs (e.g. known keywords, single-word terms).
+
+## Acceptance Criteria
+
+1. lint does not flag backtick-quoted terms used for emphasis in file-level notes
+2. lint still correctly flags genuine unresolved backtick refs in mapping transforms
+

--- a/testing-prompts/test-arrows.md
+++ b/testing-prompts/test-arrows.md
@@ -37,9 +37,16 @@ Test areas:
 - **Field not found**: Non-existent schema or field. Exit code?
 - **Schema exists but field doesn't**: Correct error message?
 - **Namespace-qualified fields**: `crm::customers.name`.
-- **NL backtick references**: Are implicit arrows from backtick references in NL included?
+- **@ref-derived arrows**: Are implicit arrows from `@ref` references in NL included? (Backticks are only for quoting complex names, not for NL references.)
 - **Arithmetic transforms**: `{ * 100 }`, `{ + 1 }`. Classified as `structural`?
 - **Function transforms**: `{ now_utc() }`, `{ uuid_v5("ns", id) }`. Classification?
+- **@ref in NL transforms**: `{ "Sum @line_amount grouped by @order_id" }` — are @refs shown as sources? Classification?
+- **@ref-derived arrows**: Computed arrows like `-> total { "Sum @amount" }` — does `@amount` create an nl-derived arrow?
+- **Arrows inside each blocks**: `each items -> output { .sku -> .code { transform } }` — can arrows be looked up by target field?
+- **Arrows inside flatten blocks**: `flatten lines -> flat { .field -> .field }` — are these arrows findable?
+- **Mixed classification with @ref**: `{ lookup table "Apply rule using @field" }` — structural + NL in same pipe step. Classified as `[mixed]`?
+- **Multi-source arrows**: `a, b -> c { "combine" }` — does arrows show both sources?
+- **Empty transform body**: `a -> x { }` — classified as `[none]`?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-cross-command.md
+++ b/testing-prompts/test-cross-command.md
@@ -1,0 +1,183 @@
+# Exploratory Testing: Cross-Command Workflows
+
+## Context
+
+You are an exploratory QA agent for the Satsuma CLI. Your job is to test **multi-command workflows** — sequences of CLI commands that compose to answer real questions. Bugs here are often about inconsistency between commands, not individual command failures. **Do not fix any bugs — only report them.**
+
+## Setup
+
+1. Read these files to understand the language and CLI contract:
+   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `SATSUMA-CLI.md` — full CLI command reference
+   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+2. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
+3. Explore the `examples/` folder for realistic workspaces.
+
+## What to test
+
+Each workflow below chains multiple commands. The key question is: **do the commands agree with each other?**
+
+### Workflow 1: Impact Analysis
+Trace a field from source to downstream consumers.
+```bash
+# 1. Find all arrows from a source field
+satsuma arrows source_schema.field --as-source --json
+
+# 2. For each target found, trace further
+satsuma arrows target_schema.field --as-source --json
+
+# 3. At NL hops, read the NL content
+satsuma nl mapping_name.field
+
+# 4. Check lineage for the full picture
+satsuma lineage --from source_schema --json
+```
+- Does the arrow chain match what lineage reports?
+- Do @ref-derived arrows from `nl-refs` appear in the `arrows` output?
+- Does `nl` find the same NL content that `arrows` reports as `transform_raw`?
+
+### Workflow 2: Coverage Assessment
+Find unmapped target fields across all mappings.
+```bash
+# 1. Get target fields
+satsuma fields target_schema --json
+
+# 2. Check unmapped fields for each mapping
+satsuma fields target_schema --unmapped-by "mapping_name" --json
+
+# 3. Cross-reference with mapping arrow count
+satsuma mapping "mapping_name" --json
+```
+- Does the unmapped count plus mapped arrows equal total fields?
+- Are fragment-spread fields counted correctly by both commands?
+
+### Workflow 3: Graph vs Lineage Consistency
+```bash
+# 1. Get the full graph
+satsuma graph path/ --json
+
+# 2. Get lineage for a specific schema
+satsuma lineage --from schema_name path/ --json
+
+# 3. Compare
+```
+- Does every edge in lineage output appear in the graph?
+- Does `graph --schema-only` produce the same topology as lineage?
+- Do `nl_ref` edges in graph match what `nl-refs` reports?
+
+### Workflow 4: Lint vs Validate Consistency
+```bash
+satsuma validate path/ --json
+satsuma lint path/ --json
+```
+- Do both commands find the same duplicate-definition errors?
+- Does validate's `[nl-ref-unresolved]` warning match lint's `unresolved-nl-ref` rule?
+- If lint `--fix` is applied, does validate pass afterward?
+
+### Workflow 5: PII Audit Trail
+```bash
+# 1. Find PII fields
+satsuma find --tag pii --json
+
+# 2. Trace each downstream
+satsuma arrows schema.pii_field --as-source --json
+
+# 3. Check if downstream has pii tag
+satsuma meta target_schema.target_field --json
+
+# 4. Read any NL transforms for PII survival
+satsuma nl mapping.target_field
+```
+- At NL hops, is the @ref chain intact so agents can reason about PII survival?
+- Does `find --tag pii` match what `meta` reports for each field?
+
+### Workflow 6: @ref Consistency Across Commands
+Create a fixture with @refs in various positions and verify all commands agree:
+```bash
+# Does nl-refs find the ref?
+satsuma nl-refs path/ --json
+
+# Does lineage trace through it?
+satsuma lineage --from ref_target path/ --json
+
+# Does graph include it as an nl_ref edge?
+satsuma graph path/ --json
+
+# Does where-used find the reference?
+satsuma where-used ref_target path/ --json
+
+# Does lint flag it if undeclared?
+satsuma lint path/ --json
+
+# Does validate warn if unresolved?
+satsuma validate path/ --json
+```
+- Do all 6 commands agree on which @refs exist and whether they resolve?
+- Test with @refs in: arrow transforms, note blocks, source join descriptions, each/flatten blocks, named transforms.
+
+### Workflow 7: Classification Consistency
+```bash
+satsuma arrows schema.field --json    # classification field
+satsuma mapping mapping_name --json   # kind field on arrows
+satsuma graph path/ --json            # classification on field edges
+```
+- Do all three commands agree on the classification of every arrow?
+- Pay special attention to: empty `{ }` bodies, mixed NL+structural in same pipe step, map transforms.
+
+### Workflow 8: Namespace Consistency
+```bash
+satsuma summary path/ --json          # namespace counts
+satsuma graph path/ --namespace ns    # filtered graph
+satsuma lineage --from ns::schema     # namespace-qualified lineage
+satsuma where-used ns::schema path/   # namespace-qualified search
+```
+- Are namespace-qualified names consistent across commands?
+- Does `graph --namespace` match what summary reports for that namespace?
+- Does `graph --schema-only` use qualified or bare mapping names?
+
+### Workflow 9: Format Round-Trip
+```bash
+satsuma fmt --diff path/file.stm      # see what would change
+satsuma fmt path/file.stm             # apply formatting
+satsuma validate path/file.stm        # still valid?
+satsuma graph path/ --json            # same topology?
+```
+- Does formatting preserve all semantics?
+- Does the graph before and after formatting have identical nodes/edges?
+
+### Workflow 10: Diff Accuracy
+```bash
+# Create two versions of a workspace
+satsuma diff v1/ v2/                  # structural diff
+satsuma summary v1/ --json            # baseline counts
+satsuma summary v2/ --json            # updated counts
+```
+- Does the diff correctly capture all additions/removals between the two summaries?
+- Are renamed schemas detected as renames or as add+remove?
+
+## Creating test fixtures
+
+Create all temporary test files under `/tmp/satsuma-test-cross-cmd/`. Build workspaces that exercise multi-command composition, especially around @refs, each/flatten blocks, and namespaces.
+
+## Logging bugs
+
+When you find an inconsistency:
+1. Check `tk list` for existing tickets.
+2. If no duplicate:
+   ```bash
+   tk create "cross-cmd: <concise title>" \
+     -t bug \
+     -d "<description including:
+     - Commands run in sequence
+     - Output from each command
+     - Where the inconsistency lies
+     - Path to test fixture>"
+   ```
+3. Tag with `--tags cli,cross-command,exploratory-testing`.
+
+## Rules
+
+- **Do not fix bugs.** Only log them.
+- **Do not modify any existing files** in the repo. Only create files in `/tmp/`.
+- Be systematic — run each workflow end-to-end and compare outputs.
+- Focus on **consistency between commands**, not individual command behavior.

--- a/testing-prompts/test-graph.md
+++ b/testing-prompts/test-graph.md
@@ -28,7 +28,7 @@ Test areas:
 - **Node completeness**: All schemas, mappings, metrics, fragments, transforms present as nodes?
 - **Edge completeness**: Every arrow in every mapping represented as an edge? Field-level data flow correct?
 - **Edge classification**: Transform classifications on edges match what `satsuma arrows` reports?
-- **`unresolved_nl` section**: NL arrows listed for agent interpretation?
+- **`unresolved_nl` section**: NL arrows listed for agent interpretation? Note: this section name may be misleading — it contains ALL NL content, not just unresolved refs.
 - **Schema-level edges**: `schema_edges` section correctly represents which schemas are connected via mappings?
 - **Metric connections**: Metrics connected to their source schemas?
 - **Fragment connections**: Fragment spreads create connections?
@@ -40,6 +40,14 @@ Test areas:
 - **Disconnected nodes**: Schemas with no mappings. Present as isolated nodes?
 - **Self-referencing**: Mapping where source and target are the same schema.
 - **Derived arrows**: `-> tgt` arrows in graph edges.
+- **@ref edges (nl_ref role)**: NL transforms with `@other_schema` refs should create `nl_ref` role entries in `schema_edges`. Do they?
+- **@ref in each/flatten blocks**: Do @refs inside each/flatten NL transforms create graph edges? Or are they invisible?
+- **@ref vs --no-nl**: Does `--no-nl` strip NL text but preserve `nl_ref` edges (since they're structural)?
+- **@ref vs --schema-only**: Are `nl_ref` edges preserved in schema-only mode?
+- **Namespaced mapping edge duplication**: In `--schema-only` mode, do namespaced mappings produce duplicate edges (one with bare name, one with qualified name)?
+- **Edge classification accuracy**: Do `mixed` classifications match what `satsuma arrows` reports? Test with transforms that have both structural and NL tokens in the same pipe step.
+- **Source join description NL**: `source { a, b, "join on @a.id = @b.id" }` — does graph capture this NL content and its @refs?
+- **@ref in note blocks**: @refs in schema/metric/standalone notes — do they produce graph edges?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-lineage.md
+++ b/testing-prompts/test-lineage.md
@@ -35,7 +35,16 @@ Test areas:
 - **Neither `--from` nor `--to`**: What happens? Error message?
 - **Non-existent schema**: Exit code and message?
 - **Single file**: `satsuma lineage --from schema examples/common.stm`.
-- **NL backtick references**: Do NL references like `` "Join with `other_schema`" `` create lineage edges?
+- **@ref lineage edges**: Do `@ref` references in NL strings (e.g., `"Join with @other_schema"`) create lineage edges?
+- **@ref in NL transforms**: `"Sum @line_amount grouped by @order_id"` — do @refs create lineage edges? These are the primary ref syntax in v2.
+- **@ref to undeclared schema**: A mapping's NL transform references `@external_lookup.code` but `external_lookup` is not in source/target. Does lineage show it as an `nl_ref` dependency?
+- **@ref with dot-qualified nested paths**: `@schema.record.subfield` (3+ segments) — does lineage resolve nested record paths correctly?
+- **@ref in note blocks**: Do @refs in `note { "references @schema" }` create lineage edges? Test standalone notes, schema notes, and mapping-body notes.
+- **@ref in source join descriptions**: `source { a, b, "Join on @a.id = @b.id" }` — does lineage track @refs from join NL?
+- **@ref in each/flatten blocks**: `each items -> output { .sku -> .code { "Look up @catalog.sku" } }` — does lineage trace through each/flatten NL?
+- **Multiple @refs in one NL string**: `"Join @orders.id with @customers.customer_id and lookup @products.sku"` — are all three schemas tracked?
+- **Multi-hop @ref lineage**: Schema A maps to B, B maps to C where the NL references @A — does lineage show A as upstream of C?
+- **@ref in named transforms**: `transform enricher { "Look up @lookup.code" }` spread into a mapping. Does lineage follow through the spread?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-lint.md
+++ b/testing-prompts/test-lint.md
@@ -24,8 +24,8 @@ Known lint rules (from SATSUMA-CLI.md):
 - `duplicate-definition` (error, not fixable) — Named definition declared more than once in a namespace
 
 Test areas:
-- **`hidden-source-in-nl`**: Create a mapping where NL text references `` `other_schema` `` but `other_schema` is not in source/target. Does the rule fire?
-- **`unresolved-nl-ref`**: Create NL text with `` `nonexistent_thing` ``. Does the rule fire?
+- **`hidden-source-in-nl`**: Create a mapping where NL text references `@other_schema` but `other_schema` is not in source/target. Does the rule fire?
+- **`unresolved-nl-ref`**: Create NL text with `@nonexistent_thing` — does the rule fire?
 - **`duplicate-definition`**: Create two schemas with the same name. Does the rule fire?
 - **`--fix` flag**: For fixable rules, does `--fix` apply corrections? What does it change? (Test on copies in `/tmp/`.)
 - **`--json` flag**: Valid JSON with rule ID, severity, message, file, line?
@@ -42,6 +42,13 @@ Test areas:
 - **Namespace context**: NL references using namespace-qualified names.
 - **Metric source context**: NL in a metric body referencing its source schema.
 - **Single file**: `satsuma lint examples/common.stm`. Works?
+- **@ref in `hidden-source-in-nl`**: `"Sum @external_schema.amount"` where `external_schema` is not in source/target — does the rule fire?
+- **@ref in each/flatten blocks**: NL with @refs inside `each`/`flatten` blocks — does lint detect hidden sources there?
+- **Dotted sub-field paths as hidden sources**: `PARENT_RECORD.CHILD_FIELD` where `PARENT_RECORD` IS in the source schema — is this a false positive?
+- **Backtick emphasis vs field refs**: File-level `note { }` blocks using backticks for emphasis (e.g., `` `flatten` ``, `` `pii` ``) — should `unresolved-nl-ref` fire? Watch for false positives.
+- **@ref in note blocks**: `note { "Based on @source" }` — does `hidden-source-in-nl` apply to note blocks?
+- **@ref in source join descriptions**: `source { a, b, "Join on @a.id = @b.id" }` — are @refs in join NL checked by lint?
+- **Duplicate definitions with --fix**: What happens when `--fix` is applied to a workspace with duplicate-definition errors?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-mapping.md
+++ b/testing-prompts/test-mapping.md
@@ -39,6 +39,14 @@ Test areas:
 - **Not found**: Non-existent mapping name. Exit code?
 - **Multiple mappings same name**: In different files or namespaces.
 - **Field paths with dots**: `record.child -> target.child` arrow paths.
+- **Each blocks**: `each items -> output.list { .field -> .field }` — are each block arrows shown with correct nesting?
+- **Flatten blocks**: `flatten lines -> flat { .field -> .field }` — are flatten block arrows included?
+- **Nested each blocks**: `each outer -> target { each inner -> .nested { ... } }` — correct nesting representation?
+- **Multi-source arrows**: `a, b -> c { "combine" }` — both sources shown?
+- **@ref in NL transforms**: `{ "Sum @line_amount grouped by @order_id" }` — @refs preserved in transform output?
+- **Source join descriptions**: `source { a, b, "Join condition" }` — is the join NL shown in mapping output?
+- **`--compact --json` consistency**: Does `--compact` omit transforms and notes in JSON mode too (not just text mode)?
+- **Empty transform body**: `a -> x { }` — what kind is it classified as?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-nl-refs.md
+++ b/testing-prompts/test-nl-refs.md
@@ -12,34 +12,43 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma nl-refs --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
-4. Explore the `examples/` folder for files with NL content containing backtick references.
+4. Explore the `examples/` folder for files with NL content containing `@ref` references.
 
 ## What to test
 
-`satsuma nl-refs [path]` extracts backtick references from NL transform bodies.
+`satsuma nl-refs [path]` extracts `@ref` references from NL transform bodies.
+
+Note: Backtick refs in NL strings are no longer valid Satsuma v2 syntax. All NL references use `@ref` syntax (e.g., `@schema.field`). Backticks are only for identifiers/labels (e.g., `` `My Schema` ``).
 
 Test areas:
-- **Basic backtick refs**: NL string containing `` `field_name` ``. Extracted?
-- **Multiple refs in one string**: `` "Sum `amount` grouped by `customer_id`" ``. Both extracted?
-- **Schema-qualified refs**: `` `schema_name.field_name` ``. Extracted with dot path?
-- **Namespace-qualified refs**: `` `crm::customers.name` ``. Extracted?
-- **Refs in note blocks**: `` note { "See `other_schema` for details" } ``. Extracted?
-- **Refs in inline notes**: `` (note "Based on `source_field`") ``. Extracted?
-- **Refs in comments**: `` //! Watch out for `field_name` ``. Are comment backtick refs extracted?
-- **Refs in triple-quoted strings**: `` """See `field` for more""" ``. Extracted?
-- **No backtick refs**: NL content without any backtick references. Exit code? Output?
+
+### @ref extraction
+- **Basic @ref**: `"Sum @line_amount grouped by @order_id"`. Both @refs extracted?
+- **@ref with dot-qualified names**: `@schema.field` — extracted and resolved?
+- **@ref with nested paths (3+ segments)**: `@schema.record.subfield` — resolved against nested record structure?
+- **Multiple @refs in one string**: `"Join @orders.id with @customers.customer_id"` — all extracted?
+- **@ref in each/flatten blocks**: NL inside `each` or `flatten` block transforms — are @refs found?
+- **@ref in standalone note blocks**: `note { "References @some_schema" }` at file level — extracted?
+- **@ref in schema/metric/fragment notes**: `note { "Based on @source.field" }` inside a schema body — extracted?
+- **@ref in source join descriptions**: `source { a, b, "Join on @a.id = @b.id" }` — @refs found?
+- **@ref in named transforms**: `transform t { "Look up @lookup.code" }` — extracted with transform context?
+- **@ref in triple-quoted strings**: `"""Multi-line with @some_ref"""` — tracked?
+- **@ref resolution status**: Does output indicate resolved vs unresolved for @refs?
+- **@ref to non-existent schema**: `@nonexistent.field` — flagged as unresolved?
+
+### General
+- **No refs at all**: NL content without any references. Exit code? Output?
 - **`--json` flag**: Valid JSON? Each ref includes: the reference text, the containing block, file, line?
 - **Resolution status**: Does output indicate whether each ref resolves to a known identifier?
-- **Nested backticks**: Edge case — `` "Check `record.`nested_field`` " ``. How handled?
-- **Empty backticks**: `` "Something `` here" ``. How handled?
 - **Cross-file**: Refs across multiple files all collected?
 - **Single file path**: Works with a single file argument?
 - **Ref in mapping vs schema vs metric**: Refs in different block types. Context preserved?
-- **Duplicate refs**: Same backtick reference appears multiple times. All occurrences listed?
+- **Duplicate refs**: Same @ref reference appears multiple times. All occurrences listed?
+- **Namespace-qualified @refs**: `@ns::schema.field` — extracted and resolved?
 
 ## Creating test fixtures
 
-Create all temporary test files under `/tmp/satsuma-test-nl-refs/`. Construct files with diverse backtick reference patterns in NL content.
+Create all temporary test files under `/tmp/satsuma-test-nl-refs/`. Construct files with diverse `@ref` patterns in NL content across all block types.
 
 ## Logging bugs
 

--- a/testing-prompts/test-nl.md
+++ b/testing-prompts/test-nl.md
@@ -29,7 +29,7 @@ Test areas:
 - **Triple-quoted strings**: `"""multiline content"""`. Preserved with formatting?
 - **Comment extraction**: `//`, `//!`, `//?` comments. Which are included in NL output?
 - **Mixed transforms**: Pipeline steps with NL strings. Only the NL parts extracted?
-- **Backtick references in NL**: `` "Sum `amount` grouped by `customer_id`" ``. Preserved?
+- **@ref in NL output**: `"Sum @amount grouped by @order_id"` — are @refs preserved verbatim?
 - **`--json` flag**: Valid JSON with content, type, and location for each NL item?
 - **Scope not found**: Non-existent scope. Exit code?
 - **Empty NL**: Scope with no NL content. Exit code? Output?
@@ -37,6 +37,13 @@ Test areas:
 - **Metric NL**: Notes and comments inside metrics.
 - **Single file path**: Does path argument work correctly?
 - **Special characters in NL**: Quotes, backslashes, unicode in NL strings.
+- **@ref preservation in NL output**: `"Sum @line_amount grouped by @order_id"` — are @refs preserved verbatim in NL output?
+- **NL inside each blocks**: `each items -> output { .sku -> .code { "NL text" } }` — is NL extracted?
+- **NL inside flatten blocks**: `flatten lines -> flat { .sku -> .code { "NL text" } }` — is NL extracted?
+- **Field-scoped NL in each/flatten**: `satsuma nl target.field_name` where the field is mapped inside an each/flatten block — found?
+- **Source block join descriptions**: `source { a, b, "Join condition NL" }` — is this NL extracted by `satsuma nl mapping_name`?
+- **NL in named transforms**: `transform t { "NL description" }` — extracted by `satsuma nl all`?
+- **@ref in NL**: `@schema.field` references should be preserved in NL output. (Backticks are only for quoting complex names, not for NL references.)
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-validate.md
+++ b/testing-prompts/test-validate.md
@@ -39,6 +39,13 @@ Test areas:
 - **Namespace validation**: Invalid namespace syntax. Caught?
 - **Import cycle detection**: Circular imports. Handled gracefully?
 - **Ref metadata validation**: `(ref nonexistent.field)`. Is the reference checked?
+- **@ref resolution in NL**: `"Sum @line_amount grouped by @order_id"` — are @refs validated against known schemas/fields?
+- **@ref with nested dot paths**: `@schema.record.subfield` (3+ segments) — correctly resolved against nested record structures?
+- **@ref in each/flatten blocks**: NL with @refs inside each/flatten — are they validated?
+- **@ref in standalone notes**: `note { "References @some_schema" }` — are @refs in top-level notes validated?
+- **@ref in source join descriptions**: `source { a, b, "Join on @a.id = @b.id" }` — are these @refs validated?
+- **Duplicate definitions across files**: Two files define the same mapping name. Does validate produce false field-not-in-schema warnings due to schema resolution confusion?
+- **False warning with cross-file duplicates**: When `mapping "order headers"` exists in two files with different source schemas, does validate attribute arrow fields to the wrong source schema?
 
 ## Creating test fixtures
 

--- a/testing-prompts/test-where-used.md
+++ b/testing-prompts/test-where-used.md
@@ -24,7 +24,7 @@ Test areas:
 - **Transform spreads**: Named transform referenced via `...transform_name` in mapping bodies.
 - **Import references**: Schema or fragment referenced in `import { name } from "file.stm"`.
 - **Metric source references**: Schema referenced as `source schema_name` in metric metadata.
-- **NL backtick references**: Schema or field names in backtick references inside NL strings. Are these surfaced?
+- **@ref references in NL**: Schema or field names referenced via `@ref` syntax in NL strings (e.g., `"Sum @schema.field"`). Are these surfaced?
 - **Cross-file references**: Name used in a different file from its definition.
 - **Namespace-qualified references**: `crm::customers` references.
 - **Quoted names**: Fragments or schemas with quoted labels like `'Common Fields'`.
@@ -35,6 +35,11 @@ Test areas:
 - **Self-reference**: Schema that references itself somehow.
 - **Case sensitivity**: Is lookup case-sensitive?
 - **Ref metadata**: `(ref schema.field)` — is this caught as a reference?
+- **@ref references in NL**: `"Sum @schema.field"` — does where-used find this as a reference to the schema?
+- **@ref in each/flatten blocks**: Schema referenced via @ref inside each/flatten NL — found by where-used?
+- **@ref in standalone notes**: Schema referenced via @ref in a file-level `note { }` — found?
+- **@ref in source join descriptions**: Schema referenced via @ref in `source { a, b, "Join @a.id = @b.id" }` — found?
+- **@ref in named transforms**: Schema referenced via @ref in a named transform definition — found when the transform is spread?
 
 ## Creating test fixtures
 


### PR DESCRIPTION
## Summary

Exploratory testing of the Satsuma CLI focused on @ref handling, lineage/graph commands, nl-refs, and each/flatten blocks. 

- **12 confirmed bugs** logged as tickets (11 new + 1 reopened regression)
- **10 test prompts** updated to cover @ref syntax (replacing outdated backtick NL ref references) and each/flatten block patterns
- **1 new test prompt** added for cross-command workflow testing

### Bugs Found

| Ticket | Severity | Bug |
|--------|----------|-----|
| sl-h8sb | P1 | `nl-ref-extract`: @refs in standalone/schema note blocks silently ignored |
| sl-kqfj | P1 | `nl-refs`: does not walk into each_block or flatten_block nodes |
| sl-9zcv | P2 | `nl-ref-extract`: @ref with 3+ dot-segment paths falsely flagged as unresolved |
| sl-057k | P2 | `graph --schema-only`: duplicate edges for namespaced mappings |
| sl-tfqt | P2 | `classify.ts`: mixed classification missed when NL+structural in same pipe_text |
| cbh-so1o | P2 | `nl`/`nl-refs`: source block join descriptions not extracted (reopened regression) |
| sl-04eg | P2 | `validate`: false field-not-in-schema warning with duplicate mapping names across files |
| sl-rkdz | P2 | `lint hidden-source-in-nl`: false positive for dotted sub-field paths |
| sl-sq4u | P2 | `nl`: field-scoped query does not find NL inside each/flatten blocks |
| sl-gqoy | P3 | `mapping --compact --json`: still includes transforms and notes |
| sl-2ayt | P3 | `mapping` vs `arrows`: inconsistent classification for empty `{ }` |
| sl-vrsu | P3 | `lint unresolved-nl-ref`: false positives for backtick emphasis in file-level notes |

### Test Prompt Updates

Updated: test-lineage, test-graph, test-nl-refs, test-nl, test-lint, test-arrows, test-mapping, test-validate, test-where-used
Added: test-cross-command (multi-command workflow testing)

## Test plan
- [x] All 637 CLI tests pass
- [x] All bugs independently reproduced with minimal fixtures
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)