### PR TITLE
fix: LSP Find All References, coverage command, and where-used

### DIFF
--- a/.tickets/sl-3jgb.md
+++ b/.tickets/sl-3jgb.md
@@ -1,0 +1,20 @@
+---
+id: sl-3jgb
+status: closed
+deps: []
+links: [sl-7bhh]
+created: 2026-03-26T13:55:09Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# Where-used command: fails for dotted paths and namespace-qualified names
+
+The Where Used command uses getWordRangeAtPosition() to extract the symbol at cursor, which only captures a single word boundary. For dotted paths like schema.field or namespace-qualified names like ns::schema, it sends only one segment to satsuma where-used, which returns not found. Should extract the full qualified name at cursor via the CST node.
+
+## Acceptance Criteria
+
+1. Where-used works on dotted field paths (e.g. schema.field)
+2. Where-used works on namespace-qualified names (e.g. ns::schema)
+3. Where-used works on @ref syntax
+

--- a/.tickets/sl-7bhh.md
+++ b/.tickets/sl-7bhh.md
@@ -1,0 +1,20 @@
+---
+id: sl-7bhh
+status: closed
+deps: []
+links: [sl-3jgb]
+created: 2026-03-26T13:55:04Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+---
+# Show Mapping Coverage: fails to detect cursor inside mapping block
+
+The Show Mapping Coverage command says 'move cursor to mapping block' even when the cursor is inside one. extractMappingInfo() in coverage.ts uses regex on raw text lines instead of the parse tree. The regex matches single-quoted names (removed in v2) but not backtick names. Should use the tree-sitter CST via LSP to find the enclosing mapping_block node.
+
+## Acceptance Criteria
+
+1. Command works when cursor is anywhere inside a mapping block
+2. Works with backtick-quoted mapping names
+3. Works with plain identifier mapping names
+

--- a/.tickets/sl-i4go.md
+++ b/.tickets/sl-i4go.md
@@ -1,0 +1,26 @@
+---
+id: sl-i4go
+status: done
+deps: []
+links: [sl-zufn, sl-txbo]
+created: 2026-03-26T13:55:00Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# LSP find-references: transform usage in arrows not tracked
+
+Find All References works for ...spread references but not for transform usage. Transform definitions are indexed but their spread references in arrows are not tracked in the workspace reference index.
+
+## Acceptance Criteria
+
+1. Find All References on a transform block name shows all spread usages in arrows
+2. Results include cross-file references
+
+## Notes
+
+**2026-03-26T14:30:00Z**
+
+Cause: This was already working. Transform spreads in arrows use the `fragment_spread` CST node type, and `indexArrowSpreadRefs()` already walked all descendants looking for `fragment_spread` nodes. The bug report was based on incorrect analysis.
+Fix: No code change needed. Added a test confirming transform spread references in arrows are correctly indexed.
+

--- a/.tickets/sl-i4go.md
+++ b/.tickets/sl-i4go.md
@@ -1,6 +1,6 @@
 ---
 id: sl-i4go
-status: done
+status: closed
 deps: []
 links: [sl-zufn, sl-txbo]
 created: 2026-03-26T13:55:00Z

--- a/.tickets/sl-txbo.md
+++ b/.tickets/sl-txbo.md
@@ -1,0 +1,27 @@
+---
+id: sl-txbo
+status: done
+deps: []
+links: [sl-zufn, sl-i4go]
+created: 2026-03-26T13:54:57Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# LSP find-references: @refs and backtick refs in NL strings not indexed
+
+Find All References does not find @ref or backtick references inside NL strings. Go-to-definition works for these (via tryNlRefContext() in definition.ts), but workspace-index.ts never walks NL string content to create reference entries.
+
+## Acceptance Criteria
+
+1. Find All References on a schema name includes @ref mentions in NL strings
+2. Find All References on a schema name includes backtick mentions in NL strings
+3. Find All References on a field includes @ref and backtick mentions
+
+## Notes
+
+**2026-03-26T14:30:00Z**
+
+Cause: `workspace-index.ts` never walked NL string content to create reference entries, even though `definition.ts` had `tryNlRefContext()` for go-to-definition.
+Fix: Added `indexNlRefs()` that walks all `nl_string` and `multiline_string` descendants in mapping bodies, extracts `@ref` and backtick references via regex, and registers them with context `"arrow"`. Added 5 workspace-index tests and 1 references integration test.
+

--- a/.tickets/sl-txbo.md
+++ b/.tickets/sl-txbo.md
@@ -1,6 +1,6 @@
 ---
 id: sl-txbo
-status: done
+status: closed
 deps: []
 links: [sl-zufn, sl-i4go]
 created: 2026-03-26T13:54:57Z

--- a/.tickets/sl-u4lf.md
+++ b/.tickets/sl-u4lf.md
@@ -1,0 +1,20 @@
+---
+id: sl-u4lf
+status: open
+deps: []
+links: []
+created: 2026-03-26T13:55:13Z
+type: feature
+priority: 3
+assignee: Thorben Louw
+---
+# LSP: add context-aware lineage actions (Lineage To / Lineage From)
+
+Currently lineage is only available via command palette with manual schema selection or field path input. Users expect inline actions (code lens, context menu, or hover) that pick up the schema or field at cursor position. Proposed: code lens on schema blocks for Lineage from/to, and context menu on field paths for Trace field lineage.
+
+## Acceptance Criteria
+
+1. Schema blocks show Lineage from / Lineage to code lens actions
+2. Clicking a lineage code lens opens the lineage view without requiring manual input
+3. Context menu on fields in arrows offers Trace field lineage
+

--- a/.tickets/sl-zufn.md
+++ b/.tickets/sl-zufn.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zufn
-status: done
+status: closed
 deps: []
 links: [sl-txbo, sl-i4go]
 created: 2026-03-26T13:54:53Z

--- a/.tickets/sl-zufn.md
+++ b/.tickets/sl-zufn.md
@@ -1,0 +1,27 @@
+---
+id: sl-zufn
+status: done
+deps: []
+links: [sl-txbo, sl-i4go]
+created: 2026-03-26T13:54:53Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+---
+# LSP find-references: fields not indexed — no results for arrow src/tgt paths
+
+Find All References on a field name (e.g. cursor on email in email -> contact_email) returns no results. workspace-index.ts indexMappingRefs() only indexes schema-level source/target block refs, not field-level arrow paths (src_path/tgt_path). The CLI satsuma where-used correctly finds these — the data just isn't wired into the LSP reference provider.
+
+## Acceptance Criteria
+
+1. Find All References on a field in an arrow shows all arrows sourcing or targeting that field
+2. Find All References on a field in a schema declaration shows all arrow usages
+3. Results span multiple files in workspace
+
+## Notes
+
+**2026-03-26T14:30:00Z**
+
+Cause: `indexMappingRefs()` only indexed schema-level source/target block refs but never walked arrow nodes for field-level `src_path`/`tgt_path` references.
+Fix: Added `indexArrowFieldRefs()` that walks all descendants of the mapping body for `src_path`/`tgt_path` nodes and registers each field name as a reference with context `"arrow"`. Added 6 workspace-index tests and 1 references integration test.
+

--- a/tooling/vscode-satsuma/server/src/workspace-index.ts
+++ b/tooling/vscode-satsuma/server/src/workspace-index.ts
@@ -407,6 +407,12 @@ function indexMappingRefs(
     if (ch.type === "source_block" || ch.type === "target_block") continue;
     indexArrowSpreadRefs(index, uri, ch);
   }
+
+  // Index field-level references from arrow src_path / tgt_path nodes
+  indexArrowFieldRefs(index, uri, body);
+
+  // Index @refs and backtick refs inside NL strings in arrows
+  indexNlRefs(index, uri, body);
 }
 
 function indexArrowSpreadRefs(
@@ -429,6 +435,152 @@ function indexArrowSpreadRefs(
       }
     }
   });
+}
+
+function indexArrowFieldRefs(
+  index: WorkspaceIndex,
+  uri: string,
+  body: SyntaxNode,
+): void {
+  walkDescendants(body, (n) => {
+    if (n.type === "src_path" || n.type === "tgt_path") {
+      const fieldName = extractArrowFieldName(n);
+      if (fieldName) {
+        addReference(index, fieldName, {
+          uri,
+          range: nodeRange(n),
+          name: fieldName,
+          context: "arrow",
+        });
+      }
+    }
+  });
+}
+
+/** Extract the leaf field name from a src_path or tgt_path node. */
+function extractArrowFieldName(pathNode: SyntaxNode): string | null {
+  const text = pathNode.text;
+  if (!text) return null;
+
+  // Handle backtick paths: `field name` or `field name`.sub
+  if (text.startsWith("`")) {
+    const endTick = text.indexOf("`", 1);
+    if (endTick > 0) return text.slice(1, endTick);
+    return null;
+  }
+
+  // Handle relative paths: .field or .parent.field — strip leading dot
+  const stripped = text.startsWith(".") ? text.slice(1) : text;
+
+  // Take the first segment (before any dots)
+  const firstSegment = stripped.split(".")[0]!;
+
+  // Handle namespaced: ns::field → take field part
+  if (firstSegment.includes("::")) {
+    return firstSegment.split("::").pop() ?? null;
+  }
+
+  return firstSegment || null;
+}
+
+const NL_BACKTICK_REF_RE = /`([^`\\]*(?:\\.[^`\\]*)*)`/g;
+const NL_AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+
+function indexNlRefs(
+  index: WorkspaceIndex,
+  uri: string,
+  body: SyntaxNode,
+): void {
+  walkDescendants(body, (n) => {
+    if (n.type !== "nl_string" && n.type !== "multiline_string") return;
+
+    const text = n.text;
+    const startRow = n.startPosition.row;
+    const startCol = n.startPosition.column;
+
+    // Index @refs
+    NL_AT_REF_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = NL_AT_REF_RE.exec(text)) !== null) {
+      // Strip leading @ and backtick delimiters
+      const rawRef = match[0].slice(1);
+      const refName = rawRef.replace(/`([^`]+)`/g, "$1");
+
+      const range = offsetToRange(text, match.index, match[0].length, startRow, startCol);
+      addReference(index, refName, {
+        uri,
+        range,
+        name: refName,
+        context: "arrow",
+      });
+    }
+
+    // Index backtick refs (only those NOT already covered by @ref)
+    NL_BACKTICK_REF_RE.lastIndex = 0;
+    while ((match = NL_BACKTICK_REF_RE.exec(text)) !== null) {
+      const refName = match[1]!;
+      // Skip if this backtick ref overlaps with an @ref already indexed
+      const matchStart = match.index;
+      if (isInsideAtRef(text, matchStart)) continue;
+
+      const range = offsetToRange(text, match.index, match[0].length, startRow, startCol);
+      addReference(index, refName, {
+        uri,
+        range,
+        name: refName,
+        context: "arrow",
+      });
+    }
+  });
+}
+
+/** Check if a position in the text falls inside an @ref match. */
+function isInsideAtRef(text: string, offset: number): boolean {
+  NL_AT_REF_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = NL_AT_REF_RE.exec(text)) !== null) {
+    if (offset >= m.index && offset < m.index + m[0].length) return true;
+  }
+  return false;
+}
+
+/** Convert an offset within a node's text to an LSP Range. */
+function offsetToRange(
+  text: string,
+  offset: number,
+  length: number,
+  nodeStartRow: number,
+  nodeStartCol: number,
+): Range {
+  // Find the row/col of the offset
+  let row = 0;
+  let col = 0;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      row++;
+      col = 0;
+    } else {
+      col++;
+    }
+  }
+  const startLine = nodeStartRow + row;
+  const startChar = row === 0 ? nodeStartCol + col : col;
+
+  // Find the row/col of offset + length
+  let endRow = row;
+  let endCol = col;
+  for (let i = offset; i < offset + length; i++) {
+    if (text[i] === "\n") {
+      endRow++;
+      endCol = 0;
+    } else {
+      endCol++;
+    }
+  }
+  const endLine = nodeStartRow + endRow;
+  const endChar = endRow === 0 ? nodeStartCol + endCol : (endRow === row ? (row === 0 ? nodeStartCol + endCol : endCol) : endCol);
+
+  return Range.create(startLine, startChar, endLine, endChar);
 }
 
 function indexSpreadRefs(

--- a/tooling/vscode-satsuma/server/test/references.test.js
+++ b/tooling/vscode-satsuma/server/test/references.test.js
@@ -150,6 +150,40 @@ mapping \`b\` {
     assert.equal(result.length, 0);
   });
 
+  it("finds arrow field references for a schema field", () => {
+    const src = `schema customers {
+  id UUID
+  email VARCHAR
+}
+mapping \`a\` {
+  source { customers }
+  target { dim }
+  email -> contact_email
+}`;
+    // Cursor on "email" in schema definition (line 2, col 2)
+    const result = refs({ "file:///a.stm": src }, "file:///a.stm", 2, 3, false);
+    // Should include the arrow src_path reference
+    assert.ok(result.length >= 1, "expected at least one reference from arrow field path");
+    // Check that at least one result points to the arrow line
+    const arrowRef = result.find((r) => r.range.start.line === 7);
+    assert.ok(arrowRef, "expected a reference on the arrow line (line 7)");
+  });
+
+  it("finds @ref references in NL strings for a schema", () => {
+    const src = `schema customers {
+  id UUID
+}
+mapping \`a\` {
+  source { customers }
+  target { dim }
+  -> name { "Use data from @customers table" }
+}`;
+    // Cursor on "customers" in schema definition (line 0, col 8)
+    const result = refs({ "file:///a.stm": src }, "file:///a.stm", 0, 8, false);
+    // Should include: source block ref + @ref in NL string
+    assert.ok(result.length >= 2, `expected at least 2 references, got ${result.length}`);
+  });
+
   it("finds import references", () => {
     const result = refs(
       {

--- a/tooling/vscode-satsuma/server/test/workspace-index.test.js
+++ b/tooling/vscode-satsuma/server/test/workspace-index.test.js
@@ -400,6 +400,176 @@ describe("getFields", () => {
   });
 });
 
+describe("arrow field path indexing", () => {
+  it("indexes src_path field names from map_arrow", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim_customers }
+  email -> contact_email
+}`,
+    });
+    const srcRefs = idx.references.get("email");
+    assert.ok(srcRefs);
+    const arrowRefs = srcRefs.filter((r) => r.context === "arrow");
+    assert.ok(arrowRefs.length >= 1, "expected at least one arrow ref for email");
+  });
+
+  it("indexes tgt_path field names from map_arrow", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim_customers }
+  email -> contact_email
+}`,
+    });
+    const tgtRefs = idx.references.get("contact_email");
+    assert.ok(tgtRefs);
+    const arrowRefs = tgtRefs.filter((r) => r.context === "arrow");
+    assert.ok(arrowRefs.length >= 1, "expected at least one arrow ref for contact_email");
+  });
+
+  it("indexes field names from computed_arrow (no source)", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim_customers }
+  -> display_name { "Concat first + last" }
+}`,
+    });
+    const refs = idx.references.get("display_name");
+    assert.ok(refs);
+    const arrowRefs = refs.filter((r) => r.context === "arrow");
+    assert.ok(arrowRefs.length >= 1, "expected arrow ref for display_name");
+  });
+
+  it("indexes field names from nested_arrow children", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { orders }
+  target { dim_orders }
+  items -> line_items {
+    sku -> product_sku
+    qty -> quantity
+  }
+}`,
+    });
+    const skuRefs = (idx.references.get("sku") || []).filter((r) => r.context === "arrow");
+    assert.ok(skuRefs.length >= 1, "expected arrow ref for sku");
+    const qtyRefs = (idx.references.get("qty") || []).filter((r) => r.context === "arrow");
+    assert.ok(qtyRefs.length >= 1, "expected arrow ref for qty");
+    // Also the outer arrow fields
+    const itemsRefs = (idx.references.get("items") || []).filter((r) => r.context === "arrow");
+    assert.ok(itemsRefs.length >= 1, "expected arrow ref for items");
+  });
+
+  it("indexes field names from each_block", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { orders }
+  target { dim_orders }
+  each items -> line_items {
+    sku -> product_sku
+  }
+}`,
+    });
+    const itemsRefs = (idx.references.get("items") || []).filter((r) => r.context === "arrow");
+    assert.ok(itemsRefs.length >= 1, "expected arrow ref for items in each_block");
+    const skuRefs = (idx.references.get("sku") || []).filter((r) => r.context === "arrow");
+    assert.ok(skuRefs.length >= 1, "expected arrow ref for sku in each_block");
+  });
+
+  it("indexes field names from flatten_block", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { orders }
+  target { flat_items }
+  flatten items -> line_items {
+    sku -> product_sku
+  }
+}`,
+    });
+    const itemsRefs = (idx.references.get("items") || []).filter((r) => r.context === "arrow");
+    assert.ok(itemsRefs.length >= 1, "expected arrow ref for items in flatten_block");
+  });
+});
+
+describe("NL string reference indexing", () => {
+  it("indexes @refs in NL strings", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim }
+  -> display_name { "Use @FIRST_NM and @LAST_NM" }
+}`,
+    });
+    const firstRefs = (idx.references.get("FIRST_NM") || []).filter((r) => r.context === "arrow");
+    assert.ok(firstRefs.length >= 1, "expected arrow ref for @FIRST_NM");
+    const lastRefs = (idx.references.get("LAST_NM") || []).filter((r) => r.context === "arrow");
+    assert.ok(lastRefs.length >= 1, "expected arrow ref for @LAST_NM");
+  });
+
+  it("indexes @refs with backtick-delimited names", () => {
+    const idx = buildIndex({
+      "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  -> name { \"Use @`first name` here\" }\n}",
+    });
+    const refs = (idx.references.get("first name") || []).filter((r) => r.context === "arrow");
+    assert.ok(refs.length >= 1, "expected arrow ref for @`first name`");
+  });
+
+  it("indexes backtick refs in NL strings", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim }
+  -> notes { "Filter using \`profanity_list\` v3.2" }
+}`,
+    });
+    const refs = (idx.references.get("profanity_list") || []).filter((r) => r.context === "arrow");
+    assert.ok(refs.length >= 1, "expected arrow ref for backtick ref profanity_list");
+  });
+
+  it("indexes @refs in multiline NL strings", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim }
+  -> address_id {
+    """
+    Create a record using @ADDR_LINE_1 and @CITY.
+    Normalize @STATE_PROV to 2-char code.
+    """
+  }
+}`,
+    });
+    const addrRefs = (idx.references.get("ADDR_LINE_1") || []).filter((r) => r.context === "arrow");
+    assert.ok(addrRefs.length >= 1, "expected arrow ref for @ADDR_LINE_1");
+    const stateRefs = (idx.references.get("STATE_PROV") || []).filter((r) => r.context === "arrow");
+    assert.ok(stateRefs.length >= 1, "expected arrow ref for @STATE_PROV");
+  });
+
+  it("does not double-index backtick inside @ref", () => {
+    const idx = buildIndex({
+      "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  -> name { \"Use @`first name` here\" }\n}",
+    });
+    // "first name" should appear exactly once (from the @ref), not twice
+    const refs = (idx.references.get("first name") || []).filter((r) => r.context === "arrow");
+    assert.equal(refs.length, 1, "backtick inside @ref should not be double-counted");
+  });
+});
+
+describe("transform spread indexing in arrows", () => {
+  it("indexes transform spread references in arrows", () => {
+    const idx = buildIndex({
+      "file:///a.stm": "transform `clean email` {\n  trim | lowercase\n}\nmapping test {\n  source { customers }\n  target { dim }\n  email -> email { ...`clean email` }\n}",
+    });
+    const refs = idx.references.get("clean email");
+    assert.ok(refs);
+    const spreadRefs = refs.filter((r) => r.context === "spread");
+    assert.ok(spreadRefs.length >= 1, "expected spread ref for transform in arrow");
+  });
+});
+
 describe("re-indexing", () => {
   it("replaces old entries when re-indexing a file", () => {
     const idx = createWorkspaceIndex();

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -155,7 +155,7 @@ function extractMappingInfo(
   // Walk backwards from cursor to find "mapping" keyword
   let mappingName: string | null = null;
   for (let i = cursorLine; i >= 0; i--) {
-    const match = lines[i]?.match(/^mapping\s+(?:'([^']+)'|(\S+))/);
+    const match = lines[i]?.match(/^\s*mapping\s+(?:`([^`]+)`|(\S+))/);
     if (match) {
       mappingName = match[1] ?? match[2] ?? null;
       break;
@@ -169,7 +169,7 @@ function extractMappingInfo(
   let braceDepth = 0;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? "";
-    if (line.match(/^mapping\s/)) {
+    if (line.match(/^\s*mapping\s/)) {
       inMapping = line.includes(mappingName);
       braceDepth = 0;
     }

--- a/tooling/vscode-satsuma/src/commands/where-used.ts
+++ b/tooling/vscode-satsuma/src/commands/where-used.ts
@@ -12,9 +12,10 @@ export function registerWhereUsedCommand(
 
       const wordRange = editor.document.getWordRangeAtPosition(
         editor.selection.active,
+        /[@]?[a-zA-Z_][a-zA-Z0-9_-]*(?:::[a-zA-Z_][a-zA-Z0-9_-]*)?(?:\.[a-zA-Z_][a-zA-Z0-9_-]*)*/,
       );
       if (!wordRange) return;
-      const word = editor.document.getText(wordRange);
+      const word = editor.document.getText(wordRange).replace(/^@/, "");
 
       const result = await runCli(cliPath, [
         "where-used",


### PR DESCRIPTION
## Summary

- **sl-zufn (P1)**: Find All References now indexes arrow field paths (`src_path`/`tgt_path`) — cursor on a field in an arrow shows all arrow usages across the workspace
- **sl-txbo (P2)**: Find All References now indexes `@ref` and backtick references inside NL strings
- **sl-i4go (P2)**: Confirmed transform spread references already work (added test)
- **sl-7bhh (P1)**: Show Mapping Coverage regex now matches backtick labels and namespace-indented mappings
- **sl-3jgb (P2)**: Where-used extracts full dotted paths, namespace-qualified names, and `@ref` syntax at cursor

## Test plan
- [x] 172 LSP server tests pass (14 new)
- [x] 845 CLI tests pass
- [x] VS Code extension builds cleanly
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)