### PR TITLE
feat(viz): Feature 23 — Satsuma Mapping Visualization

### DIFF
--- a/.tickets/f2v-ftbg.md
+++ b/.tickets/f2v-ftbg.md
@@ -1,0 +1,23 @@
+---
+id: f2v-ftbg
+status: open
+deps: [f2v-k3do]
+links: []
+created: 2026-03-27T07:12:58Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.3: Schema-level thick arrow rendering with click-to-open
+
+Update or create a mode on the edge layer that renders thick (3-4px) curved arrows between schema nodes. Each arrow labeled with mapping name at midpoint. Click dispatches SzOpenMappingEvent. Hover shows tooltip with mapping name, source->target, arrow count.
+
+## Acceptance Criteria
+
+- Thick arrows render between schema cards
+- Mapping name label at arrow midpoint
+- Click arrow opens mapping detail view
+- Hover shows tooltip with mapping summary
+- Orange for pipeline-heavy, green for NL-heavy mappings
+

--- a/.tickets/f2v-ftbg.md
+++ b/.tickets/f2v-ftbg.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-ftbg
-status: open
+status: closed
 deps: [f2v-k3do]
 links: []
 created: 2026-03-27T07:12:58Z
@@ -21,3 +21,10 @@ Update or create a mode on the edge layer that renders thick (3-4px) curved arro
 - Hover shows tooltip with mapping summary
 - Orange for pipeline-heavy, green for NL-heavy mappings
 
+
+## Notes
+
+**2026-03-27T07:34:16Z**
+
+Cause: No overview-level edge rendering existed for schema-to-schema thick arrows.
+Fix: Created sz-overview-edge-layer component with thick (3px) curved Bezier arrows, mapping name labels at midpoints, click-to-open via SzOpenMappingEvent, hover tooltips with mapping summary and arrow count. Colors: orange for pipeline-heavy, green for NL-heavy, gray for bare mappings.

--- a/.tickets/f2v-iv1v.md
+++ b/.tickets/f2v-iv1v.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-iv1v
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-27T07:13:21Z
@@ -25,3 +25,10 @@ New sz-mapping-detail component. Three columns: source schema cards (full fields
 - Click schema header navigates to schema source
 - Click mapping header navigates to mapping source
 
+
+## Notes
+
+**2026-03-27T07:27:20Z**
+
+Cause: No component existed for detailed mapping inspection with source/target context.
+Fix: Created sz-mapping-detail web component with three-column grid layout. Left: source schema cards with full fields. Center: mapping header (name, sources, targets, join, filters) and arrow table showing source fields, transforms, target fields. Right: target schema card. Pipeline transforms render monospace steps with | separators, NL transforms in italic green. Each/flatten blocks shown as labeled nested sections.

--- a/.tickets/f2v-iv1v.md
+++ b/.tickets/f2v-iv1v.md
@@ -1,0 +1,27 @@
+---
+id: f2v-iv1v
+status: open
+deps: []
+links: []
+created: 2026-03-27T07:13:21Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.5: Mapping Detail component with three-column layout
+
+New sz-mapping-detail component. Three columns: source schema cards (full fields) on left, mapping detail table in center, target schema card (full fields) on right. Center block has header (mapping name, sources, targets, joins, filters) and arrow table (source fields | transform | target field). Each/flatten blocks as nested sections.
+
+## Acceptance Criteria
+
+- Three-column layout renders correctly
+- Mapping header shows name, sources, targets, join description, filters
+- Arrow table shows all arrows with transform details
+- Pipeline transforms show monospace steps with | separators
+- NL transforms show italic green text
+- Each/flatten blocks shown as labeled nested sections
+- Click arrow row navigates to source location
+- Click schema header navigates to schema source
+- Click mapping header navigates to mapping source
+

--- a/.tickets/f2v-ja41.md
+++ b/.tickets/f2v-ja41.md
@@ -1,0 +1,24 @@
+---
+id: f2v-ja41
+status: open
+deps: [f2v-iv1v]
+links: []
+created: 2026-03-27T07:13:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.6: Hover cross-highlighting in Mapping Detail view
+
+Bidirectional hover highlighting in the mapping detail view. Hover a mapping table row highlights the source field(s) in left schema card(s) and target field in right card. Hover a field in a schema card highlights the matching table row(s) and connected field on the other side. Highlighting: bold name + colored bg. Non-highlighted fields dim to opacity 0.5.
+
+## Acceptance Criteria
+
+- Hover table row highlights source and target fields in schema cards
+- Hover schema field highlights matching table rows and opposite field
+- Highlighting is bidirectional and immediate
+- Peach background for source highlights, light green for target
+- Non-highlighted fields dim to ~50% opacity
+- Highlight clears on mouse leave
+

--- a/.tickets/f2v-ja41.md
+++ b/.tickets/f2v-ja41.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-ja41
-status: open
+status: closed
 deps: [f2v-iv1v]
 links: []
 created: 2026-03-27T07:13:30Z
@@ -22,3 +22,10 @@ Bidirectional hover highlighting in the mapping detail view. Hover a mapping tab
 - Non-highlighted fields dim to ~50% opacity
 - Highlight clears on mouse leave
 
+
+## Notes
+
+**2026-03-27T07:34:16Z**
+
+Cause: No cross-highlighting between the mapping table and schema cards.
+Fix: Added bidirectional hover highlighting to sz-mapping-detail. Table row hover highlights source fields (peach bg) and target field (green bg) in schema cards. Card field hover highlights matching table rows and connected field on the other side. Added highlightFields and highlightColor properties to sz-schema-card with CSS for dimming non-highlighted fields to 50% opacity.

--- a/.tickets/f2v-jd4t.md
+++ b/.tickets/f2v-jd4t.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-jd4t
-status: open
+status: closed
 deps: [f2v-ukjt, f2v-k3do, f2v-ftbg]
 links: []
 created: 2026-03-27T07:13:13Z
@@ -21,3 +21,10 @@ Add _viewMode state (overview | mapping-detail) to root satsuma-viz component. D
 - Pan/zoom/minimap/toolbar all work in overview mode
 - Clicking a mapping arrow sets _selectedMapping and transitions view
 
+
+## Notes
+
+**2026-03-27T07:39:32Z**
+
+Cause: No overview mode existed — the viz always showed the field-level detail layout.
+Fix: Added _viewMode ('overview' | 'detail') state to satsuma-viz root component. Default is overview showing compact schema cards via computeOverviewLayout + thick overview edges via sz-overview-edge-layer. Clicking a mapping arrow sets _selectedMapping and transitions to detail view showing sz-mapping-detail. Toolbar adapts per view with a Back button in detail mode. Pan/zoom/minimap all work in overview.

--- a/.tickets/f2v-jd4t.md
+++ b/.tickets/f2v-jd4t.md
@@ -1,0 +1,23 @@
+---
+id: f2v-jd4t
+status: open
+deps: [f2v-ukjt, f2v-k3do, f2v-ftbg]
+links: []
+created: 2026-03-27T07:13:13Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.4: Graph Overview rendering with view mode state
+
+Add _viewMode state (overview | mapping-detail) to root satsuma-viz component. Default to overview. Add _renderOverview() that uses compact schema cards + schema-level edges. Track _selectedMapping for transitions. Toolbar adapts per view mode.
+
+## Acceptance Criteria
+
+- Default view shows compact schema cards with thick mapping arrows
+- No field-level detail visible in overview
+- Namespace grouping with bordered boxes and labels
+- Pan/zoom/minimap/toolbar all work in overview mode
+- Clicking a mapping arrow sets _selectedMapping and transitions view
+

--- a/.tickets/f2v-k3do.md
+++ b/.tickets/f2v-k3do.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-k3do
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-27T07:12:50Z
@@ -21,3 +21,10 @@ Add computeOverviewLayout(model) to elk-layout.ts. Creates compact nodes without
 - Namespace compound nodes still used for grouping
 - No ELK errors from missing ports
 
+
+## Notes
+
+**2026-03-27T07:27:20Z**
+
+Cause: No schema-level (overview) layout engine existed — only field-level layout.
+Fix: Added computeOverviewLayout(model) to elk-layout.ts. Creates compact nodes (48px height, no ports), one edge per MappingBlock source ref. Returns OverviewLayoutResult with LayoutNode[] and OverviewEdge[] carrying MappingBlock reference.

--- a/.tickets/f2v-k3do.md
+++ b/.tickets/f2v-k3do.md
@@ -1,0 +1,23 @@
+---
+id: f2v-k3do
+status: open
+deps: []
+links: []
+created: 2026-03-27T07:12:50Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.2: Schema-level ELK layout (no field ports)
+
+Add computeOverviewLayout(model) to elk-layout.ts. Creates compact nodes without per-field ports, one edge per MappingBlock (sourceRefs to targetRef). Returns OverviewLayoutResult with LayoutNode[] and OverviewEdge[] carrying the full MappingBlock reference.
+
+## Acceptance Criteria
+
+- computeOverviewLayout produces valid ELK layout for all example files
+- Nodes sized for compact card height (no fields)
+- One edge per mapping, not per arrow
+- Namespace compound nodes still used for grouping
+- No ELK errors from missing ports
+

--- a/.tickets/f2v-l9x2.md
+++ b/.tickets/f2v-l9x2.md
@@ -1,0 +1,23 @@
+---
+id: f2v-l9x2
+status: open
+deps: [f2v-jd4t, f2v-iv1v]
+links: []
+created: 2026-03-27T07:15:04Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.7: View transition wiring (overview <-> detail)
+
+Wire the view transitions between overview and mapping detail. Arrow click in overview sets viewMode to mapping-detail. Back button in detail returns to overview. Toolbar shows back button + mapping name in detail mode. Ensure pan/zoom state resets on transition.
+
+## Acceptance Criteria
+
+- Clicking mapping arrow transitions to detail view
+- Back button returns to overview
+- Toolbar shows mapping name and back button in detail mode
+- Pan/zoom resets on view transition
+- View transition is smooth (no flicker)
+

--- a/.tickets/f2v-l9x2.md
+++ b/.tickets/f2v-l9x2.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-l9x2
-status: open
+status: closed
 deps: [f2v-jd4t, f2v-iv1v]
 links: []
 created: 2026-03-27T07:15:04Z
@@ -21,3 +21,10 @@ Wire the view transitions between overview and mapping detail. Arrow click in ov
 - Pan/zoom resets on view transition
 - View transition is smooth (no flicker)
 
+
+## Notes
+
+**2026-03-27T07:42:21Z**
+
+Cause: View transitions between overview and detail needed pan/zoom reset and smooth animation.
+Fix: Added _resetPanZoom() called on both overview→detail and detail→overview transitions. Added fadeIn CSS animation (0.2s) on view-content wrapper for flicker-free transitions. All five ACs were mostly covered by Phase 5.4 — this ticket finishes the polish.

--- a/.tickets/f2v-ukjt.md
+++ b/.tickets/f2v-ukjt.md
@@ -1,6 +1,6 @@
 ---
 id: f2v-ukjt
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-27T07:12:43Z
@@ -20,3 +20,10 @@ Add a compact boolean property to sz-schema-card. When compact: hide fields, por
 - Metadata pills and notes still visible
 - Card height is significantly smaller than full mode
 
+
+## Notes
+
+**2026-03-27T07:27:20Z**
+
+Cause: No compact mode existed for schema cards needed by the overview graph.
+Fix: Added compact boolean property to sz-schema-card. When true, hides fields, port dots, constraints, spreads, lineage buttons. Shows namespace::name in header for namespaced schemas. Metadata pills and notes remain visible.

--- a/.tickets/f2v-ukjt.md
+++ b/.tickets/f2v-ukjt.md
@@ -1,0 +1,22 @@
+---
+id: f2v-ukjt
+status: open
+deps: []
+links: []
+created: 2026-03-27T07:12:43Z
+type: task
+priority: 2
+assignee: Thorben Louw
+tags: [viz, phase5]
+---
+# Phase 5.1: Schema card compact mode with namespace in title
+
+Add a compact boolean property to sz-schema-card. When compact: hide fields, port dots, constraints, spread indicators, lineage buttons. Show header with namespace::name format when namespaced, metadata pills, and collapsible notes only.
+
+## Acceptance Criteria
+
+- compact property hides field list and field-level UI
+- Header shows namespace::name when schema has a namespace
+- Metadata pills and notes still visible
+- Card height is significantly smaller than full mode
+

--- a/features/23-viz/PRD.md
+++ b/features/23-viz/PRD.md
@@ -1,6 +1,6 @@
 # Feature 23 — Mapping Visualization
 
-> **Status: NOT STARTED**
+> **Status: Phase 1-4 complete, Phase 5 redesign in progress**
 
 ## Goal
 
@@ -491,6 +491,155 @@ Render a single `.stm` file as an interactive card-and-wire diagram.
 - [ ] Fragment spread indicators (dotted outline showing inlined fields)
 - [ ] Minimap for large diagrams
 - [ ] Export to SVG/PNG (headless render of current view)
+
+## Phase 5 — Two-Level View Redesign
+
+> Supersedes the field-level wiring approach from Phases 1-4. The existing VizModel, LSP integration, card components, and ELK layout engine are retained but the rendering is restructured into two distinct views.
+
+### Design Rationale
+
+The field-level Bezier wiring approach (Phase 1.3) produces visually cluttered diagrams for real-world files with 20+ fields per schema and multiple mappings. The redesign separates concerns: the **Graph Overview** shows the big picture (which schemas feed which, through which mappings), and the **Mapping Detail View** shows the transformation specifics for one mapping at a time.
+
+### View 1: Graph Overview (default)
+
+The default view is a schema-level lineage graph with no field-level detail.
+
+**Schema cards (compact mode):**
+- Header shows `namespace::name` when namespaced (e.g. `crm::customers`), bare name otherwise
+- Metadata pills below the header (owner, classification, retention, etc.)
+- Schema-level notes collapsed by default
+- NO field list, NO port dots, NO constraint badges
+- Click card header → navigate to source (`SzNavigateEvent`)
+
+**Mapping arrows (schema-level):**
+- One thick arrow per `MappingBlock`, connecting source schema(s) to target schema
+- Arrow label shows mapping name (truncated if long)
+- Arrow color: orange for pipeline-heavy mappings, green for NL-heavy
+- Click arrow → transition to Mapping Detail View for that mapping
+- Hover arrow → tooltip with mapping name, source→target, arrow count
+
+**Layout:**
+- ELK layered algorithm, direction RIGHT
+- No per-field ports — edges connect node-to-node (node center or dedicated edge ports)
+- Schemas in the same namespace grouped in a dashed bordered box with namespace label
+- Metrics positioned in rightmost layer
+- Fragments positioned near consuming schemas
+
+**Retained features:**
+- Toolbar (Schema Only toggle becomes less relevant but kept for hiding arrows)
+- Show Notes toggle, Fit, Refresh, Export, namespace filter
+- Pan/zoom with minimap
+- File-level notes pane
+- Cross-file lineage expansion (breadcrumbs)
+
+### View 2: Mapping Detail View
+
+Entered by clicking a mapping arrow in the Graph Overview. Shows a focused, detailed view of one mapping.
+
+**Layout (three-column):**
+- Left column: source schema card(s) with full field list
+- Center: mapping detail block (table layout)
+- Right column: target schema card with full field list
+
+**Mapping detail block (center):**
+
+Header section:
+- Mapping name (large, bold)
+- Source schemas listed (clickable → navigate)
+- Target schema listed (clickable → navigate)
+- Join description from `sourceBlock.joinDescription` (if present)
+- Filter expressions from `sourceBlock.filters` (if present)
+- Mapping-level notes and comments
+
+Arrow table:
+- Each row represents one `ArrowEntry`
+- Columns: source field(s) | transform | target field
+- Transform cell shows:
+  - Pipeline: monospace steps separated by `|`
+  - NL: italic green text
+  - Mixed: both
+  - Map: map block preview
+- Arrow-level metadata and comments shown inline
+- Each/flatten blocks shown as labeled nested sections with their own arrow rows
+- Click any row → navigate to arrow source location
+
+**Hover highlighting (no connectors):**
+- Hover a row in the mapping table → highlight the source field(s) in the left schema card(s) AND the target field in the right schema card
+- Hover a field in a source/target schema card → highlight the corresponding mapping table row(s) AND the connected field on the other side
+- Highlighting: bold field name + colored background (peach for source, light green for target)
+- Non-highlighted fields dim slightly (opacity 0.5)
+
+**Navigation:**
+- Back button (top-left) returns to Graph Overview
+- Click schema card header → navigate to schema source
+- Click mapping header → navigate to mapping source
+- Click arrow row → navigate to arrow source
+
+### Implementation Plan
+
+**5.1 Schema card compact mode**
+- Add a `compact` boolean property to `<sz-schema-card>`
+- When compact: hide fields, port dots, constraint badges, spread indicators, lineage buttons
+- Show: header (with `namespace::name` format), metadata pills, collapsible notes
+- Update header to display qualified name when namespace is present
+
+**5.2 Schema-level ELK layout**
+- Add a `computeOverviewLayout(model)` function to `elk-layout.ts`
+- Creates nodes without per-field ports (compact card height)
+- Creates one edge per MappingBlock (sourceRefs[0] → targetRef)
+- Returns `OverviewLayoutResult` with `LayoutNode[]` and `OverviewEdge[]`
+- `OverviewEdge` carries the full `MappingBlock` reference for click handling
+
+**5.3 Schema-level edge rendering**
+- New `<sz-overview-edges>` component (or mode on existing edge layer)
+- Renders thick (3-4px) curved arrows between schema nodes
+- Arrow label (mapping name) at midpoint
+- Click dispatches a new `SzOpenMappingEvent` with the MappingBlock
+- Hover shows tooltip
+
+**5.4 Graph Overview rendering in root component**
+- New view state: `_viewMode: "overview" | "mapping-detail"`
+- Default to "overview"
+- `_renderOverview()` method uses compact schema cards + overview edges
+- `_selectedMapping: MappingBlock | null` — set when an arrow is clicked
+
+**5.5 Mapping Detail component**
+- New `<sz-mapping-detail>` component in `components/`
+- Accepts: `MappingBlock`, source `SchemaCard[]`, target `SchemaCard`
+- Renders three-column layout: source cards | mapping table | target card
+- Mapping header with name, sources, targets, joins, filters
+- Arrow table with transform details
+- Each/flatten blocks as nested sections
+
+**5.6 Hover cross-highlighting in Mapping Detail**
+- `<sz-mapping-detail>` manages `_highlightedField: {schema: string, field: string} | null`
+- Passes to child schema cards as a property
+- Schema cards highlight matching fields (bold + colored bg) and dim others
+- Mapping table rows highlight when their source/target matches
+- Bidirectional: hover table row ↔ hover schema field
+
+**5.7 View transition wiring**
+- Arrow click in overview → sets `_viewMode = "mapping-detail"`, `_selectedMapping = mapping`
+- Back button in detail view → sets `_viewMode = "overview"`, `_selectedMapping = null`
+- Toolbar adapts: overview shows graph controls, detail shows back button + mapping name
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `satsuma-viz.ts` | Add view mode state, overview rendering, view transitions |
+| `sz-schema-card.ts` | Add `compact` property, qualified name display |
+| `elk-layout.ts` | Add `computeOverviewLayout()` for schema-level edges |
+| `sz-edge-layer.ts` | Add overview mode (thick arrows, labels, click-to-open) |
+| `model.ts` | No changes needed — existing types suffice |
+| `panel.ts` | No changes needed — existing message protocol suffices |
+| `viz.ts` | No changes needed |
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `components/sz-mapping-detail.ts` | Mapping detail view component |
 
 ## Success Criteria
 

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, nothing, type TemplateResult } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import type {
   MappingBlock,
   SchemaCard,
@@ -7,7 +7,7 @@ import type {
   EachBlock,
   FlattenBlock,
 } from "../model.js";
-import { SzNavigateEvent } from "../satsuma-viz.js";
+import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
 
 /**
  * Three-column mapping detail view.
@@ -15,6 +15,9 @@ import { SzNavigateEvent } from "../satsuma-viz.js";
  * Left:   source schema cards (full fields)
  * Center: mapping header + arrow table
  * Right:  target schema card (full fields)
+ *
+ * Supports bidirectional hover cross-highlighting between the arrow table
+ * and the schema cards.
  */
 @customElement("sz-mapping-detail")
 export class SzMappingDetail extends LitElement {
@@ -119,10 +122,25 @@ export class SzMappingDetail extends LitElement {
 
     .arrow-table tr {
       cursor: pointer;
+      transition: opacity 0.15s ease, background 0.15s ease;
     }
 
     .arrow-table tr:hover {
       background: rgba(45, 42, 38, 0.03);
+    }
+
+    /* Cross-highlighting on arrow rows */
+    :host([has-highlight]) .arrow-table tr.arrow-row {
+      opacity: 0.5;
+    }
+
+    :host([has-highlight]) .arrow-table tr.arrow-row.hl {
+      opacity: 1;
+      background: rgba(242, 145, 61, 0.08);
+    }
+
+    :host([has-highlight]) .arrow-table tr.arrow-row.hl .field-ref {
+      font-weight: 700;
     }
 
     .field-ref {
@@ -211,9 +229,157 @@ export class SzMappingDetail extends LitElement {
   @property({ type: Object })
   targetMappedFields: Set<string> = new Set();
 
+  /** Currently hovered arrow (from table row hover). */
+  @state()
+  private _hoveredArrow: ArrowEntry | null = null;
+
+  /** Field name hovered from a schema card (via field-hover event). */
+  @state()
+  private _hoveredCardField: string | null = null;
+
+  /** Schema ID of the card whose field is hovered. */
+  @state()
+  private _hoveredCardSchema: string | null = null;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener("field-hover", this._onFieldHover as EventListener);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener("field-hover", this._onFieldHover as EventListener);
+  }
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has("_hoveredArrow") || changed.has("_hoveredCardField")) {
+      if (this._hoveredArrow || this._hoveredCardField) {
+        this.setAttribute("has-highlight", "");
+      } else {
+        this.removeAttribute("has-highlight");
+      }
+    }
+  }
+
+  private _onFieldHover = ((e: SzFieldHoverEvent) => {
+    this._hoveredCardSchema = e.schemaId;
+    this._hoveredCardField = e.fieldName;
+    // Clear table row hover when card field is hovered
+    if (e.fieldName) this._hoveredArrow = null;
+  }) as EventListener;
+
+  /** Compute which source fields should be highlighted. */
+  private get _sourceHighlightFields(): Map<string, Set<string>> {
+    const result = new Map<string, Set<string>>();
+    const m = this.mapping;
+    if (!m) return result;
+
+    if (this._hoveredArrow) {
+      // Highlight source fields of the hovered arrow in all source schemas
+      for (const sr of m.sourceRefs) {
+        const fields = new Set(this._hoveredArrow.sourceFields);
+        result.set(sr, fields);
+      }
+    } else if (this._hoveredCardField && this._hoveredCardSchema) {
+      // If a target field is hovered, find which source fields map to it
+      if (this._hoveredCardSchema === m.targetRef) {
+        const matchingSourceFields = this._findSourceFieldsForTarget(
+          this._hoveredCardField, m
+        );
+        for (const sr of m.sourceRefs) {
+          result.set(sr, matchingSourceFields);
+        }
+      }
+      // If a source field is hovered, highlight it in its own card
+      else if (m.sourceRefs.includes(this._hoveredCardSchema)) {
+        result.set(
+          this._hoveredCardSchema,
+          new Set([this._hoveredCardField])
+        );
+      }
+    }
+
+    return result;
+  }
+
+  /** Compute which target fields should be highlighted. */
+  private get _targetHighlightFields(): Set<string> {
+    const m = this.mapping;
+    if (!m) return new Set();
+
+    if (this._hoveredArrow) {
+      return new Set([this._hoveredArrow.targetField]);
+    }
+
+    if (this._hoveredCardField && this._hoveredCardSchema) {
+      // If a source field is hovered, find which target fields it maps to
+      if (m.sourceRefs.includes(this._hoveredCardSchema)) {
+        return this._findTargetFieldsForSource(this._hoveredCardField, m);
+      }
+      // If target card field is hovered, highlight it
+      if (this._hoveredCardSchema === m.targetRef) {
+        return new Set([this._hoveredCardField]);
+      }
+    }
+
+    return new Set();
+  }
+
+  /** Find source fields that map to a given target field. */
+  private _findSourceFieldsForTarget(targetField: string, m: MappingBlock): Set<string> {
+    const result = new Set<string>();
+    const search = (arrows: ArrowEntry[]) => {
+      for (const a of arrows) {
+        if (a.targetField === targetField) {
+          for (const sf of a.sourceFields) result.add(sf);
+        }
+      }
+    };
+    search(m.arrows);
+    for (const eb of m.eachBlocks) search(eb.arrows);
+    for (const fb of m.flattenBlocks) search(fb.arrows);
+    return result;
+  }
+
+  /** Find target fields that a given source field maps to. */
+  private _findTargetFieldsForSource(sourceField: string, m: MappingBlock): Set<string> {
+    const result = new Set<string>();
+    const search = (arrows: ArrowEntry[]) => {
+      for (const a of arrows) {
+        if (a.sourceFields.includes(sourceField)) {
+          result.add(a.targetField);
+        }
+      }
+    };
+    search(m.arrows);
+    for (const eb of m.eachBlocks) search(eb.arrows);
+    for (const fb of m.flattenBlocks) search(fb.arrows);
+    return result;
+  }
+
+  /** Check if an arrow row should be highlighted. */
+  private _isArrowHighlighted(a: ArrowEntry): boolean {
+    if (this._hoveredArrow === a) return true;
+    if (!this._hoveredCardField || !this._hoveredCardSchema) return false;
+
+    const m = this.mapping!;
+    // Source card field hovered → highlight rows where it's a source
+    if (m.sourceRefs.includes(this._hoveredCardSchema)) {
+      return a.sourceFields.includes(this._hoveredCardField);
+    }
+    // Target card field hovered → highlight rows where it's the target
+    if (this._hoveredCardSchema === m.targetRef) {
+      return a.targetField === this._hoveredCardField;
+    }
+    return false;
+  }
+
   override render() {
     const m = this.mapping;
     if (!m) return html`<div>No mapping selected</div>`;
+
+    const sourceHL = this._sourceHighlightFields;
+    const targetHL = this._targetHighlightFields;
 
     return html`
       <div class="layout">
@@ -223,6 +389,8 @@ export class SzMappingDetail extends LitElement {
             <sz-schema-card
               .schema=${s}
               .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
+              .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
+              highlightColor="source"
             ></sz-schema-card>
           `)}
         </div>
@@ -239,6 +407,8 @@ export class SzMappingDetail extends LitElement {
             ? html`<sz-schema-card
                 .schema=${this.targetSchema}
                 .mappedFields=${this.targetMappedFields}
+                .highlightFields=${targetHL}
+                highlightColor="target"
               ></sz-schema-card>`
             : nothing}
         </div>
@@ -292,8 +462,15 @@ export class SzMappingDetail extends LitElement {
   }
 
   private _renderArrowRow(a: ArrowEntry): TemplateResult {
+    const hl = this._isArrowHighlighted(a) ? "hl" : "";
+
     return html`
-      <tr @click=${() => this._navigate(a.location)}>
+      <tr
+        class="arrow-row ${hl}"
+        @click=${() => this._navigate(a.location)}
+        @mouseenter=${() => { this._hoveredArrow = a; this._hoveredCardField = null; }}
+        @mouseleave=${() => { this._hoveredArrow = null; }}
+      >
         <td><span class="field-ref">${a.sourceFields.join(", ")}</span></td>
         <td><span class="arrow-icon">&#x2192;</span></td>
         <td>${this._renderTransform(a)}</td>

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -1,0 +1,360 @@
+import { LitElement, html, css, nothing, type TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import type {
+  MappingBlock,
+  SchemaCard,
+  ArrowEntry,
+  EachBlock,
+  FlattenBlock,
+} from "../model.js";
+import { SzNavigateEvent } from "../satsuma-viz.js";
+
+/**
+ * Three-column mapping detail view.
+ *
+ * Left:   source schema cards (full fields)
+ * Center: mapping header + arrow table
+ * Right:  target schema card (full fields)
+ */
+@customElement("sz-mapping-detail")
+export class SzMappingDetail extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      font-family: var(--sz-font-sans, system-ui);
+    }
+
+    .layout {
+      display: grid;
+      grid-template-columns: minmax(200px, 1fr) minmax(300px, 2fr) minmax(200px, 1fr);
+      gap: 16px;
+      align-items: start;
+    }
+
+    .column {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .column-header {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--sz-text-muted, #6B6560);
+      padding: 0 4px 4px;
+      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    /* Mapping header */
+    .mapping-header {
+      background: var(--sz-card-bg, #fff);
+      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-radius: var(--sz-card-radius, 8px);
+      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      overflow: hidden;
+    }
+
+    .mapping-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      background: var(--sz-orange, #F2913D);
+      color: #fff;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .mapping-title:hover {
+      filter: brightness(0.95);
+    }
+
+    .mapping-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    .meta-tag {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      background: var(--sz-badge-bg, #FFF3E8);
+      color: var(--sz-text-muted, #6B6560);
+    }
+
+    .meta-tag .label {
+      color: var(--sz-orange-dark, #D97726);
+      font-weight: 500;
+    }
+
+    /* Arrow table */
+    .arrow-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .arrow-table th {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--sz-text-muted, #6B6560);
+      text-align: left;
+      padding: 6px 12px;
+      border-bottom: 2px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    .arrow-table td {
+      padding: 5px 12px;
+      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      font-size: 12px;
+      vertical-align: top;
+    }
+
+    .arrow-table tr {
+      cursor: pointer;
+    }
+
+    .arrow-table tr:hover {
+      background: rgba(45, 42, 38, 0.03);
+    }
+
+    .field-ref {
+      font-family: var(--sz-font-mono, monospace);
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--sz-text, #2D2A26);
+    }
+
+    .transform-pipeline {
+      font-family: var(--sz-font-mono, monospace);
+      font-size: 11px;
+      color: var(--sz-orange-dark, #D97726);
+    }
+
+    .transform-pipeline .pipe {
+      color: var(--sz-text-muted, #6B6560);
+      padding: 0 3px;
+    }
+
+    .transform-nl {
+      font-style: italic;
+      font-size: 11px;
+      color: var(--sz-green, #5A9E6F);
+    }
+
+    .transform-bare {
+      font-size: 11px;
+      color: var(--sz-text-muted, #6B6560);
+    }
+
+    .arrow-icon {
+      color: var(--sz-text-muted, #6B6560);
+      font-size: 11px;
+    }
+
+    /* Scope sections (each/flatten) */
+    .scope-section {
+      margin: 4px 0;
+    }
+
+    .scope-label {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--sz-text-muted, #6B6560);
+      background: var(--sz-namespace-bg, #FFF3E8);
+      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    .scope-label .scope-tag {
+      font-family: var(--sz-font-mono, monospace);
+      font-size: 10px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      background: var(--sz-orange-dark, #D97726);
+      color: #fff;
+    }
+
+    .scope-fields {
+      font-family: var(--sz-font-mono, monospace);
+      font-size: 11px;
+      color: var(--sz-text, #2D2A26);
+    }
+  `;
+
+  @property({ type: Object })
+  mapping: MappingBlock | null = null;
+
+  /** Source schema cards to show on the left. */
+  @property({ type: Array })
+  sourceSchemas: SchemaCard[] = [];
+
+  /** Target schema card to show on the right. */
+  @property({ type: Object })
+  targetSchema: SchemaCard | null = null;
+
+  /** Set of mapped field names for source schemas. */
+  @property({ type: Object })
+  sourceMappedFields: Map<string, Set<string>> = new Map();
+
+  /** Set of mapped field names for the target schema. */
+  @property({ type: Object })
+  targetMappedFields: Set<string> = new Set();
+
+  override render() {
+    const m = this.mapping;
+    if (!m) return html`<div>No mapping selected</div>`;
+
+    return html`
+      <div class="layout">
+        <div class="column">
+          <div class="column-header">Sources</div>
+          ${this.sourceSchemas.map((s) => html`
+            <sz-schema-card
+              .schema=${s}
+              .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
+            ></sz-schema-card>
+          `)}
+        </div>
+
+        <div class="column">
+          <div class="column-header">Mapping</div>
+          ${this._renderMappingHeader(m)}
+          ${this._renderArrowTable(m)}
+        </div>
+
+        <div class="column">
+          <div class="column-header">Target</div>
+          ${this.targetSchema
+            ? html`<sz-schema-card
+                .schema=${this.targetSchema}
+                .mappedFields=${this.targetMappedFields}
+              ></sz-schema-card>`
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderMappingHeader(m: MappingBlock) {
+    const sb = m.sourceBlock;
+
+    return html`
+      <div class="mapping-header">
+        <div class="mapping-title" @click=${() => this._navigate(m.location)}>
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M2 4h5l2 2h5v8H2V4z" opacity="0.9"/>
+          </svg>
+          ${m.id}
+        </div>
+        <div class="mapping-meta">
+          ${m.sourceRefs.map((s) => html`<span class="meta-tag"><span class="label">source</span> ${s}</span>`)}
+          <span class="meta-tag"><span class="label">target</span> ${m.targetRef}</span>
+          ${sb?.joinDescription
+            ? html`<span class="meta-tag"><span class="label">join</span> ${sb.joinDescription}</span>`
+            : nothing}
+          ${(sb?.filters ?? []).map((f) => html`<span class="meta-tag"><span class="label">filter</span> ${f}</span>`)}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderArrowTable(m: MappingBlock) {
+    return html`
+      <div class="mapping-header" style="padding: 0;">
+        <table class="arrow-table">
+          <thead>
+            <tr>
+              <th>Source</th>
+              <th></th>
+              <th>Transform</th>
+              <th>Target</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${m.arrows.map((a) => this._renderArrowRow(a))}
+            ${m.eachBlocks.map((eb) => this._renderEachSection(eb))}
+            ${m.flattenBlocks.map((fb) => this._renderFlattenSection(fb))}
+          </tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private _renderArrowRow(a: ArrowEntry): TemplateResult {
+    return html`
+      <tr @click=${() => this._navigate(a.location)}>
+        <td><span class="field-ref">${a.sourceFields.join(", ")}</span></td>
+        <td><span class="arrow-icon">&#x2192;</span></td>
+        <td>${this._renderTransform(a)}</td>
+        <td><span class="field-ref">${a.targetField}</span></td>
+      </tr>
+    `;
+  }
+
+  private _renderTransform(a: ArrowEntry): TemplateResult {
+    if (!a.transform) {
+      return html`<span class="transform-bare">direct</span>`;
+    }
+
+    const t = a.transform;
+    if (t.kind === "pipeline" || t.kind === "mixed") {
+      return html`
+        <span class="transform-pipeline">
+          ${t.steps.map((step, i) => html`${i > 0 ? html`<span class="pipe">|</span>` : nothing}${step}`)}
+        </span>
+        ${t.nlText ? html`<br/><span class="transform-nl">${t.nlText}</span>` : nothing}
+      `;
+    }
+
+    if (t.kind === "nl") {
+      return html`<span class="transform-nl">${t.nlText ?? t.text}</span>`;
+    }
+
+    // map kind
+    return html`<span class="transform-pipeline">${t.text}</span>`;
+  }
+
+  private _renderEachSection(eb: EachBlock): TemplateResult {
+    return html`
+      <tr class="scope-section">
+        <td colspan="4">
+          <div class="scope-label">
+            <span class="scope-tag">each</span>
+            <span class="scope-fields">${eb.sourceField} &#x2192; ${eb.targetField}</span>
+          </div>
+        </td>
+      </tr>
+      ${eb.arrows.map((a) => this._renderArrowRow(a))}
+      ${eb.nestedEach.map((ne) => this._renderEachSection(ne))}
+    `;
+  }
+
+  private _renderFlattenSection(fb: FlattenBlock): TemplateResult {
+    return html`
+      <tr class="scope-section">
+        <td colspan="4">
+          <div class="scope-label">
+            <span class="scope-tag">flatten</span>
+            <span class="scope-fields">${fb.sourceField}</span>
+          </div>
+        </td>
+      </tr>
+      ${fb.arrows.map((a) => this._renderArrowRow(a))}
+    `;
+  }
+
+  private _navigate(loc: import("../model.js").SourceLocation) {
+    this.dispatchEvent(new SzNavigateEvent(loc));
+  }
+}

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -29,9 +29,16 @@ export class SzMappingDetail extends LitElement {
 
     .layout {
       display: grid;
-      grid-template-columns: minmax(200px, 1fr) minmax(300px, 2fr) minmax(200px, 1fr);
+      grid-template-columns: minmax(280px, 1fr) minmax(360px, 2fr) minmax(280px, 1fr);
       gap: 16px;
       align-items: start;
+    }
+
+    /* Let schema cards fill the available column width without capping at 380px */
+    .column sz-schema-card {
+      --sz-card-max-width: none;
+      width: 100%;
+      box-sizing: border-box;
     }
 
     .column {

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -172,7 +172,8 @@ export class SzSchemaCard extends LitElement {
       display: none;
     }
 
-    .collapsed .label {
+    .collapsed .label,
+    .collapsed .metadata-pills {
       display: none;
     }
 
@@ -206,6 +207,30 @@ export class SzSchemaCard extends LitElement {
       background: var(--sz-badge-bg, #FFF3E8);
       color: var(--sz-orange-dark, #D97726);
       border-color: var(--sz-orange-dark, #D97726);
+    }
+
+    .metadata-pills {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding: 4px 12px 6px;
+      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    .meta-pill {
+      font-family: var(--sz-font-sans, system-ui);
+      font-size: 10px;
+      font-weight: 500;
+      padding: 1px 6px;
+      border-radius: var(--sz-badge-radius, 4px);
+      background: var(--sz-namespace-bg, #FFF3E8);
+      color: var(--sz-text-muted, #6B6560);
+      line-height: 1.4;
+      white-space: nowrap;
+    }
+
+    .meta-pill .meta-key {
+      color: var(--sz-orange-dark, #D97726);
     }
 
     .spread-indicator {
@@ -282,6 +307,7 @@ export class SzSchemaCard extends LitElement {
     const totalFields = this._countFields(s.fields);
     const mappedCount = this._countMapped(s.fields);
     const hasNotes = s.notes.length > 0;
+    const metaPills = s.metadata.filter((m) => m.key !== "note");
 
     return html`
       <div class=${this._collapsed ? "collapsed" : ""}>
@@ -295,6 +321,13 @@ export class SzSchemaCard extends LitElement {
           <span class="header-toggle" ?data-collapsed=${this._collapsed}>&#9660;</span>
         </div>
         ${s.label ? html`<div class="label">${s.label}</div>` : ""}
+        ${metaPills.length > 0
+          ? html`<div class="metadata-pills">
+              ${metaPills.map(
+                (m) => html`<span class="meta-pill"><span class="meta-key">${m.key}</span> ${m.value}</span>`
+              )}
+            </div>`
+          : ""}
         <div class="fields">
           ${s.fields.map((f) => this._renderField(f, 0))}
         </div>

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -285,6 +285,28 @@ export class SzSchemaCard extends LitElement {
       white-space: pre-wrap;
       word-break: break-word;
     }
+
+    /* Cross-highlighting */
+    :host([has-highlight]) .field-row {
+      opacity: 0.5;
+      transition: opacity 0.15s ease;
+    }
+
+    :host([has-highlight]) .field-row.hl {
+      opacity: 1;
+    }
+
+    :host([has-highlight]) .field-row.hl.hl-source {
+      background: rgba(242, 145, 61, 0.12);
+    }
+
+    :host([has-highlight]) .field-row.hl.hl-target {
+      background: rgba(90, 158, 111, 0.12);
+    }
+
+    :host([has-highlight]) .field-row.hl .field-name {
+      font-weight: 700;
+    }
   `;
 
   @property({ type: Object })
@@ -299,11 +321,30 @@ export class SzSchemaCard extends LitElement {
   @property({ type: Boolean })
   compact = false;
 
+  /** Set of field names to highlight (peach for source, green for target).
+   *  When non-empty, non-highlighted fields dim to ~50% opacity. */
+  @property({ type: Object })
+  highlightFields: Set<string> = new Set();
+
+  /** Highlight color: "source" for peach, "target" for green. */
+  @property({ type: String })
+  highlightColor: "source" | "target" | "" = "";
+
   @state()
   private _collapsed = false;
 
   @state()
   private _notesExpanded = false;
+
+  override updated(changed: Map<string, unknown>) {
+    if (changed.has("highlightFields")) {
+      if (this.highlightFields.size > 0) {
+        this.setAttribute("has-highlight", "");
+      } else {
+        this.removeAttribute("has-highlight");
+      }
+    }
+  }
 
   override render() {
     const s = this.schema;
@@ -393,10 +434,14 @@ export class SzSchemaCard extends LitElement {
     const hasWarning = f.comments.some((c) => c.kind === "warning");
     const hasQuestion = f.comments.some((c) => c.kind === "question");
     const hasPii = f.constraints.includes("pii");
+    const isHighlighted = this.highlightFields.has(f.name);
+    const hlClass = isHighlighted
+      ? `hl ${this.highlightColor === "target" ? "hl-target" : "hl-source"}`
+      : "";
 
     return html`
       <div
-        class="field-row ${depth > 0 ? "nested" : ""}"
+        class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
         @mouseenter=${() => this._onFieldHover(f.name)}

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -294,6 +294,11 @@ export class SzSchemaCard extends LitElement {
   @property({ type: Object })
   mappedFields: Set<string> = new Set();
 
+  /** Compact mode: hides fields, port dots, constraints, spread indicators, lineage buttons.
+   *  Shows namespace::name in header when schema has a namespace (qualifiedId contains ::). */
+  @property({ type: Boolean })
+  compact = false;
+
   @state()
   private _collapsed = false;
 
@@ -303,6 +308,8 @@ export class SzSchemaCard extends LitElement {
   override render() {
     const s = this.schema;
     if (!s) return html``;
+
+    if (this.compact) return this._renderCompact(s);
 
     const totalFields = this._countFields(s.fields);
     const mappedCount = this._countMapped(s.fields);
@@ -441,6 +448,34 @@ export class SzSchemaCard extends LitElement {
       count += this._countMapped(f.children);
     }
     return count;
+  }
+
+  private _renderCompact(s: SchemaCard) {
+    const displayName = s.qualifiedId.includes("::") ? s.qualifiedId : s.id;
+    const totalFields = this._countFields(s.fields);
+    const metaPills = s.metadata.filter((m) => m.key !== "note");
+    const hasNotes = s.notes.length > 0;
+
+    return html`
+      <div>
+        <div class="header" @click=${() => this._navigate(s.location)}>
+          <svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
+            <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
+            <line x1="1" y1="6" x2="15" y2="6" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
+          </svg>
+          <span class="header-name">${displayName}</span>
+          <span class="header-count">${totalFields} fields</span>
+        </div>
+        ${metaPills.length > 0
+          ? html`<div class="metadata-pills">
+              ${metaPills.map(
+                (m) => html`<span class="meta-pill"><span class="meta-key">${m.key}</span> ${m.value}</span>`
+              )}
+            </div>`
+          : ""}
+        ${hasNotes ? this._renderNotes(s.notes) : ""}
+      </div>
+    `;
   }
 
   private _onHeaderClick() {

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -1,7 +1,9 @@
 import { LitElement, html, css, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SchemaCard, FieldEntry } from "../model.js";
-import { SzNavigateEvent, SzExpandLineageEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
+import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
+import { renderMarkdown } from "../markdown.js";
 
 @customElement("sz-schema-card")
 export class SzSchemaCard extends LitElement {
@@ -27,6 +29,10 @@ export class SzSchemaCard extends LitElement {
       color: #fff;
       cursor: pointer;
       user-select: none;
+    }
+
+    .header.report {
+      background: var(--sz-report, #4A90B8);
     }
 
     .header-icon {
@@ -181,35 +187,7 @@ export class SzSchemaCard extends LitElement {
       display: none;
     }
 
-    .lineage-buttons {
-      display: flex;
-      justify-content: center;
-      gap: 4px;
-      padding: 4px 12px 6px;
-      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
-    }
-
-    .lineage-btn {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 2px 8px;
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      border-radius: 4px;
-      background: transparent;
-      color: var(--sz-text-muted, #6B6560);
-      cursor: pointer;
-      font-size: 11px;
-      font-family: inherit;
-    }
-
-    .lineage-btn:hover {
-      background: var(--sz-badge-bg, #FFF3E8);
-      color: var(--sz-orange-dark, #D97726);
-      border-color: var(--sz-orange-dark, #D97726);
-    }
-
-    .metadata-pills {
+.metadata-pills {
       display: flex;
       flex-wrap: wrap;
       gap: 4px;
@@ -282,8 +260,49 @@ export class SzSchemaCard extends LitElement {
       color: var(--sz-text, #2D2A26);
       line-height: 1.5;
       padding: 4px 0 2px 22px;
-      white-space: pre-wrap;
       word-break: break-word;
+    }
+
+    .note-content p {
+      margin: 0 0 6px;
+    }
+
+    .note-content p:last-child {
+      margin-bottom: 0;
+    }
+
+    .note-content h1,
+    .note-content h2,
+    .note-content h3 {
+      font-size: 12px;
+      font-weight: 700;
+      margin: 6px 0 2px;
+    }
+
+    .note-content ul,
+    .note-content ol {
+      margin: 0 0 6px;
+      padding-left: 16px;
+    }
+
+    .note-content li {
+      margin: 1px 0;
+    }
+
+    .note-content code {
+      font-family: var(--sz-font-mono, monospace);
+      font-size: 11px;
+      background: rgba(45, 42, 38, 0.06);
+      padding: 1px 4px;
+      border-radius: 3px;
+    }
+
+    .note-content strong {
+      font-weight: 700;
+    }
+
+    .note-content em {
+      font-style: italic;
     }
 
     /* Cross-highlighting */
@@ -334,7 +353,7 @@ export class SzSchemaCard extends LitElement {
   private _collapsed = false;
 
   @state()
-  private _notesExpanded = false;
+  private _notesExpanded = true;
 
   override updated(changed: Map<string, unknown>) {
     if (changed.has("highlightFields")) {
@@ -344,6 +363,27 @@ export class SzSchemaCard extends LitElement {
         this.removeAttribute("has-highlight");
       }
     }
+  }
+
+  private _isReport(s: SchemaCard): boolean {
+    return s.metadata.some((m) => m.key === "report" || m.key === "model");
+  }
+
+  private _headerIcon(isReport: boolean) {
+    if (isReport) {
+      // Chart/report icon
+      return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
+        <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
+        <rect x="4" y="8" width="2" height="4" rx="0.5" fill="rgba(255,255,255,0.6)"/>
+        <rect x="7" y="5" width="2" height="7" rx="0.5" fill="rgba(255,255,255,0.6)"/>
+        <rect x="10" y="7" width="2" height="5" rx="0.5" fill="rgba(255,255,255,0.6)"/>
+      </svg>`;
+    }
+    // Table/schema icon
+    return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
+      <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
+      <line x1="1" y1="6" x2="15" y2="6" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
+    </svg>`;
   }
 
   override render() {
@@ -356,14 +396,12 @@ export class SzSchemaCard extends LitElement {
     const mappedCount = this._countMapped(s.fields);
     const hasNotes = s.notes.length > 0;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
+    const isReport = this._isReport(s);
 
     return html`
       <div class=${this._collapsed ? "collapsed" : ""}>
-        <div class="header" @click=${this._onHeaderClick}>
-          <svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
-            <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-            <line x1="1" y1="6" x2="15" y2="6" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
-          </svg>
+        <div class="header ${isReport ? "report" : ""}" @click=${this._onHeaderClick}>
+          ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
           <span class="header-count">${mappedCount}/${totalFields}</span>
           <span class="header-toggle" ?data-collapsed=${this._collapsed}>&#9660;</span>
@@ -385,18 +423,6 @@ export class SzSchemaCard extends LitElement {
             )
           : ""}
         ${hasNotes ? this._renderNotes(s.notes) : ""}
-        ${s.hasExternalLineage ? this._renderLineageButtons(s.qualifiedId) : ""}
-      </div>
-    `;
-  }
-
-  private _renderLineageButtons(qualifiedId: string) {
-    return html`
-      <div class="lineage-buttons">
-        <button class="lineage-btn" @click=${(e: Event) => { e.stopPropagation(); this._expandLineage(qualifiedId); }}
-          title="Expand cross-file lineage">
-          &#9664; upstream &middot; downstream &#9654;
-        </button>
       </div>
     `;
   }
@@ -404,10 +430,6 @@ export class SzSchemaCard extends LitElement {
   private _onFieldHover(fieldName: string | null) {
     const schemaId = this.schema?.qualifiedId ?? "";
     this.dispatchEvent(new SzFieldHoverEvent(schemaId, fieldName));
-  }
-
-  private _expandLineage(schemaId: string) {
-    this.dispatchEvent(new SzExpandLineageEvent(schemaId));
   }
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
@@ -418,7 +440,7 @@ export class SzSchemaCard extends LitElement {
           <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
         </div>
         ${this._notesExpanded
-          ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
+          ? notes.map((n) => html`<div class="note-content">${unsafeHTML(renderMarkdown(n.text))}</div>`)
           : ""}
       </div>
     `;
@@ -500,14 +522,12 @@ export class SzSchemaCard extends LitElement {
     const totalFields = this._countFields(s.fields);
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const hasNotes = s.notes.length > 0;
+    const isReport = this._isReport(s);
 
     return html`
       <div>
-        <div class="header" @click=${() => this._navigate(s.location)}>
-          <svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
-            <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-            <line x1="1" y1="6" x2="15" y2="6" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
-          </svg>
+        <div class="header ${isReport ? "report" : ""}" @click=${() => this._navigate(s.location)}>
+          ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>
           <span class="header-count">${totalFields} fields</span>
         </div>

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -1,0 +1,289 @@
+/**
+ * SVG edge layer for the schema-level overview.
+ *
+ * Renders thick (3-4px) curved arrows between schema nodes. Each arrow is
+ * labeled with the mapping name at the midpoint. Click dispatches
+ * SzOpenMappingEvent. Hover shows a tooltip with mapping summary.
+ */
+
+import { LitElement, html, svg, css, unsafeCSS, type SVGTemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type { OverviewEdge } from "../layout/elk-layout.js";
+import type { MappingBlock } from "../model.js";
+import tokens from "../tokens.css";
+
+/** Event dispatched when a user clicks an overview edge to open a mapping detail. */
+export class SzOpenMappingEvent extends Event {
+  readonly mapping: MappingBlock;
+  constructor(mapping: MappingBlock) {
+    super("open-mapping", { bubbles: true, composed: true });
+    this.mapping = mapping;
+  }
+}
+
+@customElement("sz-overview-edge-layer")
+export class SzOverviewEdgeLayer extends LitElement {
+  static override styles = css`
+    ${unsafeCSS(tokens)}
+
+    :host {
+      display: block;
+      position: absolute;
+      top: 0;
+      left: 0;
+      pointer-events: none;
+      overflow: visible;
+    }
+
+    svg {
+      overflow: visible;
+    }
+
+    .overview-path {
+      fill: none;
+      stroke-width: 3;
+      pointer-events: stroke;
+      cursor: pointer;
+      transition: stroke-width 0.15s ease, opacity 0.15s ease;
+    }
+
+    .overview-path:hover {
+      stroke-width: 5;
+    }
+
+    .overview-path.pipeline {
+      stroke: var(--sz-edge-pipeline, #D97726);
+    }
+
+    .overview-path.nl {
+      stroke: var(--sz-edge-nl, #5A9E6F);
+    }
+
+    .overview-path.mixed {
+      stroke: var(--sz-edge-pipeline, #D97726);
+    }
+
+    .overview-path.bare {
+      stroke: var(--sz-text-muted, #6B6560);
+    }
+
+    .mapping-label-group {
+      pointer-events: all;
+      cursor: pointer;
+    }
+
+    .mapping-label-bg {
+      fill: var(--sz-card-bg, #fff);
+      stroke: var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      stroke-width: 1;
+      rx: 4;
+    }
+
+    .mapping-label-text {
+      font-family: var(--sz-font-sans, system-ui);
+      font-size: 10px;
+      font-weight: 600;
+      fill: var(--sz-text-muted, #6B6560);
+      text-anchor: middle;
+      dominant-baseline: central;
+    }
+
+    .mapping-label-group:hover .mapping-label-bg {
+      fill: var(--sz-badge-bg, #FFF3E8);
+      stroke: var(--sz-orange-dark, #D97726);
+    }
+
+    .mapping-label-group:hover .mapping-label-text {
+      fill: var(--sz-orange-dark, #D97726);
+    }
+
+    /* Tooltip */
+    .tooltip {
+      position: absolute;
+      pointer-events: none;
+      background: var(--sz-card-bg, #fff);
+      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-size: 11px;
+      white-space: nowrap;
+      z-index: 20;
+    }
+
+    .tooltip-name {
+      font-weight: 600;
+      color: var(--sz-text, #2D2A26);
+      margin-bottom: 2px;
+    }
+
+    .tooltip-detail {
+      color: var(--sz-text-muted, #6B6560);
+    }
+
+    .tooltip-count {
+      font-family: var(--sz-font-mono, monospace);
+      color: var(--sz-orange-dark, #D97726);
+    }
+  `;
+
+  @property({ type: Array })
+  edges: OverviewEdge[] = [];
+
+  @property({ type: Number })
+  width = 800;
+
+  @property({ type: Number })
+  height = 600;
+
+  @state()
+  private _hoveredEdge: string | null = null;
+
+  @state()
+  private _hoverPos: { x: number; y: number } = { x: 0, y: 0 };
+
+  override render() {
+    const hoveredEdge = this._hoveredEdge
+      ? this.edges.find((e) => e.id === this._hoveredEdge)
+      : null;
+
+    return html`
+      <svg
+        width=${this.width}
+        height=${this.height}
+        viewBox="0 0 ${this.width} ${this.height}"
+      >
+        ${this.edges.map((e) => this._renderOverviewEdge(e))}
+      </svg>
+      ${hoveredEdge ? this._renderTooltip(hoveredEdge) : ""}
+    `;
+  }
+
+  private _renderOverviewEdge(edge: OverviewEdge): SVGTemplateResult {
+    if (edge.points.length < 2) return svg``;
+
+    const d = this._buildCurvePath(edge.points);
+    const cls = this._edgeColorClass(edge.mapping);
+    const mid = this._midpoint(edge.points);
+    const labelText = edge.mapping.id;
+    const labelWidth = Math.min(labelText.length * 6.5 + 16, 160);
+
+    return svg`
+      <path
+        class="overview-path ${cls}"
+        d=${d}
+        @click=${() => this._onEdgeClick(edge)}
+        @mouseenter=${(ev: MouseEvent) => this._onEdgeHover(edge.id, ev)}
+        @mouseleave=${() => this._onEdgeLeave()}
+      />
+      <g
+        class="mapping-label-group"
+        transform="translate(${mid.x}, ${mid.y})"
+        @click=${() => this._onEdgeClick(edge)}
+        @mouseenter=${(ev: MouseEvent) => this._onEdgeHover(edge.id, ev)}
+        @mouseleave=${() => this._onEdgeLeave()}
+      >
+        <rect
+          class="mapping-label-bg"
+          x=${-labelWidth / 2}
+          y="-10"
+          width=${labelWidth}
+          height="20"
+        />
+        <text class="mapping-label-text">${labelText}</text>
+      </g>
+    `;
+  }
+
+  /** Classify the mapping's dominant transform type for coloring. */
+  private _edgeColorClass(m: MappingBlock): string {
+    let pipeline = 0;
+    let nl = 0;
+    let bare = 0;
+
+    const countArrows = (arrows: typeof m.arrows) => {
+      for (const a of arrows) {
+        if (!a.transform) bare++;
+        else if (a.transform.kind === "nl") nl++;
+        else pipeline++;
+      }
+    };
+
+    countArrows(m.arrows);
+    for (const eb of m.eachBlocks) countArrows(eb.arrows);
+    for (const fb of m.flattenBlocks) countArrows(fb.arrows);
+
+    if (nl > pipeline && nl > bare) return "nl";
+    if (pipeline > 0) return "pipeline";
+    if (nl > 0) return "nl";
+    return "bare";
+  }
+
+  private _buildCurvePath(points: Array<{ x: number; y: number }>): string {
+    if (points.length === 2) {
+      const [p0, p1] = points;
+      const dx = (p1.x - p0.x) * 0.5;
+      return `M ${p0.x} ${p0.y} C ${p0.x + dx} ${p0.y}, ${p1.x - dx} ${p1.y}, ${p1.x} ${p1.y}`;
+    }
+
+    const parts = [`M ${points[0].x} ${points[0].y}`];
+    for (let i = 1; i < points.length; i++) {
+      const prev = points[i - 1];
+      const curr = points[i];
+      const dx = (curr.x - prev.x) * 0.4;
+      parts.push(
+        `C ${prev.x + dx} ${prev.y}, ${curr.x - dx} ${curr.y}, ${curr.x} ${curr.y}`
+      );
+    }
+    return parts.join(" ");
+  }
+
+  private _midpoint(
+    points: Array<{ x: number; y: number }>
+  ): { x: number; y: number } {
+    const mid = Math.floor(points.length / 2);
+    if (points.length % 2 === 0) {
+      return {
+        x: (points[mid - 1].x + points[mid].x) / 2,
+        y: (points[mid - 1].y + points[mid].y) / 2,
+      };
+    }
+    return points[mid];
+  }
+
+  private _onEdgeClick(edge: OverviewEdge) {
+    this.dispatchEvent(new SzOpenMappingEvent(edge.mapping));
+  }
+
+  private _onEdgeHover(edgeId: string, ev: MouseEvent) {
+    this._hoveredEdge = edgeId;
+    const rect = this.getBoundingClientRect();
+    this._hoverPos = { x: ev.clientX - rect.left + 12, y: ev.clientY - rect.top - 10 };
+  }
+
+  private _onEdgeLeave() {
+    this._hoveredEdge = null;
+  }
+
+  private _countAllArrows(m: MappingBlock): number {
+    let count = m.arrows.length;
+    for (const eb of m.eachBlocks) count += eb.arrows.length;
+    for (const fb of m.flattenBlocks) count += fb.arrows.length;
+    return count;
+  }
+
+  private _renderTooltip(edge: OverviewEdge) {
+    const m = edge.mapping;
+    const arrowCount = this._countAllArrows(m);
+
+    return html`
+      <div class="tooltip" style="left: ${this._hoverPos.x}px; top: ${this._hoverPos.y}px;">
+        <div class="tooltip-name">${m.id}</div>
+        <div class="tooltip-detail">
+          ${m.sourceRefs.join(", ")} &#x2192; ${m.targetRef}
+        </div>
+        <div class="tooltip-count">${arrowCount} arrow${arrowCount !== 1 ? "s" : ""}</div>
+      </div>
+    `;
+  }
+}

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -157,8 +157,20 @@ function buildElkGraph(
       addFragmentNodes(ns.fragments, children);
       addMetricNodes(ns.metrics, children);
     }
+  }
 
-    // Edges from mappings
+  // Build a set of all port IDs so we can validate edge endpoints
+  allPortIds = new Set<string>();
+  const collectPorts = (nodes: ElkNode[]) => {
+    for (const n of nodes) {
+      for (const p of n.ports) allPortIds.add(p.id);
+      if (n.children.length > 0) collectPorts(n.children);
+    }
+  };
+  collectPorts(children);
+
+  // Add edges after ports are collected (so missing-port validation works)
+  for (const ns of model.namespaces) {
     addMappingEdges(ns.mappings, edges);
   }
 
@@ -298,6 +310,9 @@ interface EdgeMeta {
 /** Mapping from edge ID to arrow metadata — used by extractLayout to populate LayoutEdge fields. */
 const edgeMetaMap = new Map<string, EdgeMeta>();
 
+/** Set of all port IDs added to the graph, used to validate edge endpoints. */
+let allPortIds = new Set<string>();
+
 function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[]) {
   edgeMetaMap.clear();
 
@@ -311,10 +326,16 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[]) {
         const sourceField = a.sourceFields[0] ?? a.targetField;
         const edgeId = `${prefix}:${i}`;
 
+        const srcPort = `${sourceNode}:${sourceField}:src`;
+        const tgtPort = `${m.targetRef}:${a.targetField}:tgt`;
+
+        // Skip edges with missing ports — ELK throws if a port doesn't exist
+        if (!allPortIds.has(srcPort) || !allPortIds.has(tgtPort)) continue;
+
         edges.push({
           id: edgeId,
-          sources: [`${sourceNode}:${sourceField}:src`],
-          targets: [`${m.targetRef}:${a.targetField}:tgt`],
+          sources: [srcPort],
+          targets: [tgtPort],
         });
 
         edgeMetaMap.set(edgeId, {

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -62,6 +62,24 @@ export interface LayoutResult {
   height: number;
 }
 
+/** Edge in the overview layout: one per MappingBlock, linking sourceRefs to targetRef. */
+export interface OverviewEdge {
+  id: string;
+  sourceNode: string;
+  targetNode: string;
+  /** Array of {x,y} points forming the routed edge path */
+  points: Array<{ x: number; y: number }>;
+  /** The full MappingBlock this edge represents. */
+  mapping: MappingBlock;
+}
+
+export interface OverviewLayoutResult {
+  nodes: LayoutNode[];
+  edges: OverviewEdge[];
+  width: number;
+  height: number;
+}
+
 // Card dimension constants (px)
 const HEADER_HEIGHT = 40;
 const LABEL_HEIGHT = 24;
@@ -69,6 +87,7 @@ const FIELD_HEIGHT = 28;
 const CARD_PADDING_Y = 8; // top + bottom padding in fields area
 const CARD_MIN_WIDTH = 240;
 const PORT_Y_OFFSET = FIELD_HEIGHT / 2; // center of field row
+const COMPACT_CARD_HEIGHT = HEADER_HEIGHT + CARD_PADDING_Y; // header only, no fields
 
 const elk = new ELK();
 
@@ -466,6 +485,156 @@ function extractLayout(
     nodes,
     edges,
     sourceBlocks,
+    width: result.width ?? 800,
+    height: result.height ?? 600,
+  };
+}
+
+/**
+ * Compute a schema-level overview layout (no field ports).
+ * Creates compact nodes and one edge per MappingBlock.
+ */
+export async function computeOverviewLayout(model: VizModel): Promise<OverviewLayoutResult> {
+  const children: ElkNode[] = [];
+  const edges: ElkEdge[] = [];
+  const overviewEdgeMeta = new Map<string, { sourceNode: string; targetNode: string; mapping: MappingBlock }>();
+
+  for (const ns of model.namespaces) {
+    const nsNodes: ElkNode[] = [];
+
+    for (const s of ns.schemas) {
+      nsNodes.push({
+        id: s.qualifiedId,
+        width: CARD_MIN_WIDTH,
+        height: COMPACT_CARD_HEIGHT,
+        ports: [],
+        children: [],
+        edges: [],
+      });
+    }
+
+    for (const f of ns.fragments) {
+      nsNodes.push({
+        id: f.id,
+        width: CARD_MIN_WIDTH,
+        height: COMPACT_CARD_HEIGHT,
+        ports: [],
+        children: [],
+        edges: [],
+      });
+    }
+
+    for (const m of ns.metrics) {
+      nsNodes.push({
+        id: m.qualifiedId,
+        width: CARD_MIN_WIDTH,
+        height: COMPACT_CARD_HEIGHT,
+        ports: [],
+        children: [],
+        edges: [],
+      });
+    }
+
+    if (ns.name) {
+      children.push({
+        id: `ns:${ns.name}`,
+        layoutOptions: {
+          "elk.padding": "[top=28,left=16,bottom=16,right=16]",
+        },
+        children: nsNodes,
+        ports: [],
+        edges: [],
+      });
+    } else {
+      children.push(...nsNodes);
+    }
+
+    // One edge per mapping block
+    for (const m of ns.mappings) {
+      for (const sourceRef of m.sourceRefs) {
+        const edgeId = `overview:${m.id}:${sourceRef}`;
+        edges.push({
+          id: edgeId,
+          sources: [sourceRef],
+          targets: [m.targetRef],
+        });
+        overviewEdgeMeta.set(edgeId, {
+          sourceNode: sourceRef,
+          targetNode: m.targetRef,
+          mapping: m,
+        });
+      }
+    }
+  }
+
+  const elkGraph: ElkGraph = {
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "RIGHT",
+      "elk.spacing.nodeNode": "40",
+      "elk.layered.spacing.nodeNodeBetweenLayers": "80",
+      "elk.spacing.edgeEdge": "20",
+      "elk.spacing.edgeNode": "20",
+      "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
+      "elk.hierarchyHandling": "INCLUDE_CHILDREN",
+    },
+    children,
+    edges,
+  };
+
+  const result = await elk.layout(elkGraph) as unknown as ElkLayoutResult;
+
+  // Extract positioned nodes
+  const nodes: LayoutNode[] = [];
+  const walkOverviewNodes = (elkNodes: ElkLayoutNode[], offsetX = 0, offsetY = 0) => {
+    for (const n of elkNodes) {
+      const x = (n.x ?? 0) + offsetX;
+      const y = (n.y ?? 0) + offsetY;
+
+      if (!n.id.startsWith("ns:")) {
+        nodes.push({
+          id: n.id,
+          x,
+          y,
+          width: n.width ?? CARD_MIN_WIDTH,
+          height: n.height ?? COMPACT_CARD_HEIGHT,
+          ports: new Map(),
+        });
+      }
+
+      if (n.children && n.children.length > 0) {
+        walkOverviewNodes(n.children, x, y);
+      }
+    }
+  };
+  walkOverviewNodes(result.children ?? []);
+
+  // Extract edge routes
+  const overviewEdges: OverviewEdge[] = [];
+  for (const e of (result as ElkLayoutResult).edges ?? []) {
+    const points: Array<{ x: number; y: number }> = [];
+    for (const section of e.sections ?? []) {
+      if (section.startPoint) points.push(section.startPoint);
+      if (section.bendPoints) points.push(...section.bendPoints);
+      if (section.endPoint) points.push(section.endPoint);
+    }
+
+    const meta = overviewEdgeMeta.get(e.id);
+    if (meta) {
+      overviewEdges.push({
+        id: e.id,
+        sourceNode: meta.sourceNode,
+        targetNode: meta.targetNode,
+        points,
+        mapping: meta.mapping,
+      });
+    }
+  }
+
+  return {
+    nodes,
+    edges: overviewEdges,
     width: result.width ?? 800,
     height: result.height ?? 600,
   };

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -80,14 +80,29 @@ export interface OverviewLayoutResult {
   height: number;
 }
 
-// Card dimension constants (px)
+// Card dimension constants (px) — must match CSS in sz-schema-card.ts
 const HEADER_HEIGHT = 40;
-const LABEL_HEIGHT = 24;
+const LABEL_HEIGHT = 24;  // .label padding (4+6) + font ~14px
+const METADATA_PILLS_HEIGHT = 28; // .metadata-pills padding (4+6) + pill line ~17px + border 1px
 const FIELD_HEIGHT = 28;
-const CARD_PADDING_Y = 8; // top + bottom padding in fields area
+const FIELDS_PADDING_TOP = 4; // .fields { padding: 4px 0; }
+const FIELDS_PADDING_BOTTOM = 4;
 const CARD_MIN_WIDTH = 240;
 const PORT_Y_OFFSET = FIELD_HEIGHT / 2; // center of field row
-const COMPACT_CARD_HEIGHT = HEADER_HEIGHT + CARD_PADDING_Y; // header only, no fields
+
+/** Height of the area above the fields list (header + optional label + optional metadata pills). */
+function preambleHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
+  let h = HEADER_HEIGHT;
+  if (schema.label) h += LABEL_HEIGHT;
+  const pills = schema.metadata.filter((m) => m.key !== "note");
+  if (pills.length > 0) h += METADATA_PILLS_HEIGHT;
+  return h;
+}
+
+/** Compact card height: header + optional label + optional pills + small padding. */
+function compactHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
+  return preambleHeight(schema) + FIELDS_PADDING_BOTTOM;
+}
 
 const elk = new ELK();
 
@@ -217,13 +232,14 @@ function addSchemaNodes(
   target: ElkNode[],
 ) {
   for (const s of schemas) {
-    const ports = buildFieldPorts(s.fields, s.qualifiedId, mappedFields);
+    const topOffset = preambleHeight(s) + FIELDS_PADDING_TOP;
+    const ports = buildFieldPorts(s.fields, s.qualifiedId, mappedFields, topOffset);
     const fieldCount = countFields(s.fields);
     const height =
-      HEADER_HEIGHT +
-      (s.label ? LABEL_HEIGHT : 0) +
+      preambleHeight(s) +
+      FIELDS_PADDING_TOP +
       fieldCount * FIELD_HEIGHT +
-      CARD_PADDING_Y;
+      FIELDS_PADDING_BOTTOM;
 
     target.push({
       id: s.qualifiedId,
@@ -239,7 +255,7 @@ function addSchemaNodes(
 function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[]) {
   for (const f of fragments) {
     const ports = buildFieldPorts(f.fields, f.id, new Map());
-    const height = HEADER_HEIGHT + f.fields.length * FIELD_HEIGHT + CARD_PADDING_Y;
+    const height = HEADER_HEIGHT + FIELDS_PADDING_TOP + f.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM;
 
     target.push({
       id: f.id,
@@ -257,7 +273,7 @@ function addMetricNodes(metrics: MetricCard[], target: ElkNode[]) {
     const hasMeta = m.label || m.grain || m.slices.length > 0;
     const metaHeight = hasMeta ? LABEL_HEIGHT : 0;
     const height =
-      HEADER_HEIGHT + metaHeight + m.fields.length * FIELD_HEIGHT + CARD_PADDING_Y;
+      HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + m.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM;
 
     target.push({
       id: m.qualifiedId,
@@ -275,13 +291,14 @@ function buildFieldPorts(
   fields: FieldEntry[],
   nodeId: string,
   _mappedFields: Map<string, Set<string>>,
+  topOffset = HEADER_HEIGHT + FIELDS_PADDING_TOP,
 ): ElkPort[] {
   const ports: ElkPort[] = [];
   let index = 0;
 
   const walk = (fieldList: FieldEntry[], depth: number) => {
     for (const f of fieldList) {
-      const y = HEADER_HEIGHT + index * FIELD_HEIGHT + PORT_Y_OFFSET;
+      const y = topOffset + index * FIELD_HEIGHT + PORT_Y_OFFSET;
       // Left port (source side)
       ports.push({
         id: `${nodeId}:${f.name}:src`,
@@ -506,7 +523,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       nsNodes.push({
         id: s.qualifiedId,
         width: CARD_MIN_WIDTH,
-        height: COMPACT_CARD_HEIGHT,
+        height: compactHeight(s),
         ports: [],
         children: [],
         edges: [],
@@ -517,7 +534,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       nsNodes.push({
         id: f.id,
         width: CARD_MIN_WIDTH,
-        height: COMPACT_CARD_HEIGHT,
+        height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
         ports: [],
         children: [],
         edges: [],
@@ -528,7 +545,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       nsNodes.push({
         id: m.qualifiedId,
         width: CARD_MIN_WIDTH,
-        height: COMPACT_CARD_HEIGHT,
+        height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
         ports: [],
         children: [],
         edges: [],
@@ -598,7 +615,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
           x,
           y,
           width: n.width ?? CARD_MIN_WIDTH,
-          height: n.height ?? COMPACT_CARD_HEIGHT,
+          height: n.height ?? (HEADER_HEIGHT + FIELDS_PADDING_BOTTOM),
           ports: new Map(),
         });
       }

--- a/tooling/satsuma-viz/src/markdown.ts
+++ b/tooling/satsuma-viz/src/markdown.ts
@@ -1,0 +1,80 @@
+/**
+ * Minimal Markdown → HTML converter for Satsuma notes.
+ * Handles headings, lists, bold, italic, inline code, and paragraphs.
+ * HTML in the input is escaped to prevent XSS.
+ */
+export function renderMarkdown(text: string): string {
+  // Escape HTML special chars
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  // Apply inline formatting to an already-escaped string
+  const inline = (s: string) =>
+    s
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/`([^`]+)`/g, "<code>$1</code>");
+
+  const lines = text.split("\n");
+  const output: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Heading
+    const hm = line.match(/^(#{1,3})\s+(.+)$/);
+    if (hm) {
+      const level = hm[1].length;
+      output.push(`<h${level}>${inline(esc(hm[2]))}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    // Unordered list
+    if (/^[-*]\s/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[-*]\s/.test(lines[i])) {
+        items.push(`<li>${inline(esc(lines[i].replace(/^[-*]\s+/, "")))}</li>`);
+        i++;
+      }
+      output.push(`<ul>${items.join("")}</ul>`);
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\.\s/.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^\d+\.\s/.test(lines[i])) {
+        items.push(`<li>${inline(esc(lines[i].replace(/^\d+\.\s+/, "")))}</li>`);
+        i++;
+      }
+      output.push(`<ol>${items.join("")}</ol>`);
+      continue;
+    }
+
+    // Blank line → paragraph break (skip)
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    // Paragraph: collect consecutive non-blank, non-special lines
+    const para: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !/^#{1,3}\s/.test(lines[i]) &&
+      !/^[-*]\s/.test(lines[i]) &&
+      !/^\d+\.\s/.test(lines[i])
+    ) {
+      para.push(inline(esc(lines[i])));
+      i++;
+    }
+    if (para.length > 0) {
+      output.push(`<p>${para.join("<br>")}</p>`);
+    }
+  }
+
+  return output.join("");
+}

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -12,6 +12,7 @@ export { SzSchemaCard } from "./components/sz-schema-card.js";
 export { SzMetricCard } from "./components/sz-metric-card.js";
 export { SzFragmentCard } from "./components/sz-fragment-card.js";
 export { SzEdgeLayer } from "./edges/sz-edge-layer.js";
+export { SzOverviewEdgeLayer, SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 export { SzMappingDetail } from "./components/sz-mapping-detail.js";
 export { computeLayout, computeOverviewLayout } from "./layout/elk-layout.js";
 export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout, OverviewLayoutResult, OverviewEdge } from "./layout/elk-layout.js";

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -95,6 +95,16 @@ export class SatsumaViz extends LitElement {
       letter-spacing: 0.05em;
     }
 
+    /* View transition fade */
+    .view-content {
+      animation: fadeIn 0.2s ease-out;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+    }
+
     /* Flexbox fallback when no layout computed yet */
     .flex-canvas {
       display: flex;
@@ -612,6 +622,7 @@ export class SatsumaViz extends LitElement {
     this.addEventListener("open-mapping", ((e: SzOpenMappingEvent) => {
       this._selectedMapping = e.mapping;
       this._viewMode = "detail";
+      this._resetPanZoom();
     }) as EventListener);
   }
 
@@ -753,7 +764,7 @@ export class SatsumaViz extends LitElement {
     if (this._viewMode === "detail" && this._selectedMapping && this._layout) {
       return html`
         ${this._renderToolbar(namespaces)}
-        <div class=${toggleClasses}>
+        <div class="${toggleClasses} view-content">
           ${this._renderFileNotes()}
           <div style="padding: 16px;">
             ${this._renderMappingDetailView(this._selectedMapping)}
@@ -767,7 +778,7 @@ export class SatsumaViz extends LitElement {
       return html`
         ${this._renderToolbar(namespaces)}
         ${this._renderBreadcrumbs()}
-        <div class=${toggleClasses}>
+        <div class="${toggleClasses} view-content">
           ${this._renderFileNotes()}
           <div class="notes-pane-wrapper">
             <div class="viewport"
@@ -890,6 +901,13 @@ export class SatsumaViz extends LitElement {
   private _backToOverview() {
     this._viewMode = "overview";
     this._selectedMapping = null;
+    this._resetPanZoom();
+  }
+
+  private _resetPanZoom() {
+    this._zoom = 1;
+    this._panX = 0;
+    this._panY = 0;
   }
 
   private _fit() {

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -12,8 +12,9 @@ export { SzSchemaCard } from "./components/sz-schema-card.js";
 export { SzMetricCard } from "./components/sz-metric-card.js";
 export { SzFragmentCard } from "./components/sz-fragment-card.js";
 export { SzEdgeLayer } from "./edges/sz-edge-layer.js";
-export { computeLayout } from "./layout/elk-layout.js";
-export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout } from "./layout/elk-layout.js";
+export { SzMappingDetail } from "./components/sz-mapping-detail.js";
+export { computeLayout, computeOverviewLayout } from "./layout/elk-layout.js";
+export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout, OverviewLayoutResult, OverviewEdge } from "./layout/elk-layout.js";
 
 /** Navigate event — dispatched when the user clicks a source-linked element. */
 export class SzNavigateEvent extends Event {

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -1,7 +1,8 @@
 import { LitElement, html, svg, css, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import type { VizModel, SourceLocation, NamespaceGroup } from "./model.js";
-import { computeLayout, type LayoutResult, type SourceBlockLayout } from "./layout/elk-layout.js";
+import type { VizModel, SourceLocation, NamespaceGroup, MappingBlock, SchemaCard } from "./model.js";
+import { computeLayout, computeOverviewLayout, type LayoutResult, type OverviewLayoutResult, type SourceBlockLayout } from "./layout/elk-layout.js";
+import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 
 export { VizModel } from "./model.js";
@@ -539,7 +540,16 @@ export class SatsumaViz extends LitElement {
   model: VizModel | null = null;
 
   @state()
+  private _viewMode: "overview" | "detail" = "overview";
+
+  @state()
   private _layout: LayoutResult | null = null;
+
+  @state()
+  private _overviewLayout: OverviewLayoutResult | null = null;
+
+  @state()
+  private _selectedMapping: MappingBlock | null = null;
 
   @state()
   private _layoutError = false;
@@ -599,11 +609,17 @@ export class SatsumaViz extends LitElement {
       this._hoveredSchema = e.schemaId;
       this._hoveredField = e.fieldName;
     }) as EventListener);
+    this.addEventListener("open-mapping", ((e: SzOpenMappingEvent) => {
+      this._selectedMapping = e.mapping;
+      this._viewMode = "detail";
+    }) as EventListener);
   }
 
   override updated(changed: Map<string, unknown>) {
     if (changed.has("model") && this.model) {
       this._expandedModels = new Map();
+      this._viewMode = "overview";
+      this._selectedMapping = null;
       this._runLayout();
     }
   }
@@ -635,6 +651,7 @@ export class SatsumaViz extends LitElement {
     if (!this.model) return;
 
     this._layout = null;
+    this._overviewLayout = null;
     this._layoutError = false;
 
     // Build a merged model that includes expanded cross-file schemas
@@ -644,7 +661,12 @@ export class SatsumaViz extends LitElement {
     this._mappedFieldsBySchema = this._buildMappedFieldsIndex();
 
     try {
-      this._layout = await computeLayout(mergedModel);
+      const [detail, overview] = await Promise.all([
+        computeLayout(mergedModel),
+        computeOverviewLayout(mergedModel),
+      ]);
+      this._layout = detail;
+      this._overviewLayout = overview;
     } catch {
       this._layoutError = true;
     }
@@ -708,8 +730,8 @@ export class SatsumaViz extends LitElement {
     const filtered = this._filterNamespaces(namespaces);
     const toggleClasses = `${this._schemaOnly ? "schema-only" : ""} ${!this._showNotes ? "hide-notes" : ""}`;
 
-    // If layout hasn't computed yet, show flex fallback
-    if (!this._layout && !this._layoutError) {
+    // If layout hasn't computed yet, show loading
+    if (!this._layout && !this._overviewLayout && !this._layoutError) {
       return html`
         ${this._renderToolbar(namespaces)}
         <div class="loading">Computing layout...</div>
@@ -717,7 +739,7 @@ export class SatsumaViz extends LitElement {
     }
 
     // If layout failed, fall back to simple flex layout
-    if (this._layoutError || !this._layout) {
+    if (this._layoutError || (!this._layout && !this._overviewLayout)) {
       return html`
         ${this._renderToolbar(namespaces)}
         <div class=${toggleClasses}>
@@ -727,6 +749,50 @@ export class SatsumaViz extends LitElement {
       `;
     }
 
+    // Detail view: show mapping detail with source/target schema cards
+    if (this._viewMode === "detail" && this._selectedMapping && this._layout) {
+      return html`
+        ${this._renderToolbar(namespaces)}
+        <div class=${toggleClasses}>
+          ${this._renderFileNotes()}
+          <div style="padding: 16px;">
+            ${this._renderMappingDetailView(this._selectedMapping)}
+          </div>
+        </div>
+      `;
+    }
+
+    // Overview mode: compact schema cards with thick mapping arrows
+    if (this._overviewLayout) {
+      return html`
+        ${this._renderToolbar(namespaces)}
+        ${this._renderBreadcrumbs()}
+        <div class=${toggleClasses}>
+          ${this._renderFileNotes()}
+          <div class="notes-pane-wrapper">
+            <div class="viewport"
+              @wheel=${this._onWheel}
+              @mousedown=${this._onMouseDown}
+              @mousemove=${this._onMouseMove}
+              @mouseup=${this._onMouseUp}
+              @mouseleave=${this._onMouseUp}
+            >
+              <div class="viewport-inner"
+                style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
+              >
+                ${this._renderOverview(this._overviewLayout, filtered)}
+              </div>
+              <div class="zoom-indicator ${this._zoomIndicatorVisible ? "visible" : ""}">
+                ${Math.round(this._zoom * 100)}%
+              </div>
+              ${this._renderMinimap(this._overviewLayoutAsDetail())}
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    // Fallback to detail layout if overview isn't available
     const allComments = this._collectAllComments();
     const hasComments = allComments.warnings.length > 0 || allComments.questions.length > 0;
     const hasFileNotes = this.model.fileNotes.length > 0;
@@ -748,12 +814,12 @@ export class SatsumaViz extends LitElement {
             <div class="viewport-inner"
               style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
             >
-              ${this._renderPositioned(this._layout, filtered)}
+              ${this._renderPositioned(this._layout!, filtered)}
             </div>
             <div class="zoom-indicator ${this._zoomIndicatorVisible ? "visible" : ""}">
               ${Math.round(this._zoom * 100)}%
             </div>
-            ${this._renderMinimap(this._layout)}
+            ${this._renderMinimap(this._layout!)}
           </div>
           ${showPane ? this._renderNotesPane(allComments) : ""}
         </div>
@@ -764,17 +830,29 @@ export class SatsumaViz extends LitElement {
   private _renderToolbar(allNamespaces: NamespaceGroup[]) {
     const namedNs = allNamespaces.filter((ns) => ns.name);
     const hasNamespaces = namedNs.length > 0;
+    const inDetail = this._viewMode === "detail";
 
     return html`
       <div class="toolbar">
-        <span class="toolbar-title">&#9673; Mapping Viz</span>
+        ${inDetail
+          ? html`
+              <button class="toolbar-btn" @click=${this._backToOverview}
+                title="Back to overview">&#9664; Overview</button>
+              <div class="toolbar-sep"></div>
+              <span class="toolbar-title">${this._selectedMapping?.id ?? "Mapping Detail"}</span>
+            `
+          : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`}
         <div class="toolbar-sep"></div>
-        <button
-          class="toolbar-btn"
-          ?data-active=${this._schemaOnly}
-          @click=${() => { this._schemaOnly = !this._schemaOnly; }}
-          title="Show only schema cards, hide arrows and transforms"
-        >Schema Only</button>
+        ${!inDetail
+          ? html`
+              <button
+                class="toolbar-btn"
+                ?data-active=${this._schemaOnly}
+                @click=${() => { this._schemaOnly = !this._schemaOnly; }}
+                title="Show only schema cards, hide arrows and transforms"
+              >Schema Only</button>
+            `
+          : ""}
         <button
           class="toolbar-btn"
           ?data-active=${this._showNotes}
@@ -782,10 +860,14 @@ export class SatsumaViz extends LitElement {
           title="Show or hide notes"
         >Show Notes</button>
         <div class="toolbar-sep"></div>
-        <button class="toolbar-btn" @click=${this._fit} title="Fit all content in viewport">Fit</button>
+        ${!inDetail
+          ? html`<button class="toolbar-btn" @click=${this._fit} title="Fit all content in viewport">Fit</button>`
+          : ""}
         <button class="toolbar-btn" @click=${this._refresh} title="Re-fetch visualization data">&#8635; Refresh</button>
-        <button class="toolbar-btn" @click=${this._exportSvg} title="Export as SVG">&#x21E9; Export</button>
-        ${hasNamespaces
+        ${!inDetail
+          ? html`<button class="toolbar-btn" @click=${this._exportSvg} title="Export as SVG">&#x21E9; Export</button>`
+          : ""}
+        ${hasNamespaces && !inDetail
           ? html`
               <div class="toolbar-sep"></div>
               <select
@@ -803,6 +885,11 @@ export class SatsumaViz extends LitElement {
         <div class="toolbar-spacer"></div>
       </div>
     `;
+  }
+
+  private _backToOverview() {
+    this._viewMode = "overview";
+    this._selectedMapping = null;
   }
 
   private _fit() {
@@ -953,6 +1040,161 @@ export class SatsumaViz extends LitElement {
           &#10005; Collapse all
         </button>
       </div>
+    `;
+  }
+
+  /** Render the overview: compact schema cards + thick overview edges. */
+  private _renderOverview(overview: OverviewLayoutResult, namespaces: NamespaceGroup[]) {
+    const nsBoxes = this._computeOverviewNamespaceBoxes(overview, namespaces);
+
+    return html`
+      <div class="canvas" style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;">
+        <!-- Overview SVG edge layer -->
+        <sz-overview-edge-layer
+          .edges=${overview.edges}
+          .width=${overview.width + 48}
+          .height=${overview.height + 48}
+        ></sz-overview-edge-layer>
+
+        <!-- Namespace bounding boxes -->
+        ${nsBoxes.map(
+          (box) => html`
+            <div
+              class="namespace-box"
+              style="left: ${box.x}px; top: ${box.y}px; width: ${box.w}px; height: ${box.h}px;"
+            >
+              <span class="namespace-label">${box.name}</span>
+            </div>
+          `
+        )}
+
+        <!-- Compact positioned cards -->
+        <div class="card-layer">
+          ${namespaces.flatMap((ns) => [
+            ...ns.schemas.map((s) => {
+              const node = overview.nodes.find((n) => n.id === s.qualifiedId);
+              if (!node) return html``;
+              return html`
+                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                  <sz-schema-card .schema=${s} compact></sz-schema-card>
+                </div>
+              `;
+            }),
+            ...ns.fragments.map((f) => {
+              const node = overview.nodes.find((n) => n.id === f.id);
+              if (!node) return html``;
+              return html`
+                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                  <sz-fragment-card .fragment=${f}></sz-fragment-card>
+                </div>
+              `;
+            }),
+            ...ns.metrics.map((m) => {
+              const node = overview.nodes.find((n) => n.id === m.qualifiedId);
+              if (!node) return html``;
+              return html`
+                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                  <sz-metric-card .metric=${m}></sz-metric-card>
+                </div>
+              `;
+            }),
+          ])}
+        </div>
+      </div>
+    `;
+  }
+
+  /** Compute namespace bounding boxes from the overview layout. */
+  private _computeOverviewNamespaceBoxes(
+    overview: OverviewLayoutResult,
+    namespaces: NamespaceGroup[]
+  ): Array<{ name: string; x: number; y: number; w: number; h: number }> {
+    const boxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
+
+    for (const ns of namespaces) {
+      if (!ns.name) continue;
+
+      const ids = [
+        ...ns.schemas.map((s) => s.qualifiedId),
+        ...ns.fragments.map((f) => f.id),
+        ...ns.metrics.map((m) => m.qualifiedId),
+      ];
+
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      let found = false;
+
+      for (const id of ids) {
+        const node = overview.nodes.find((n) => n.id === id);
+        if (!node) continue;
+        found = true;
+        minX = Math.min(minX, node.x);
+        minY = Math.min(minY, node.y);
+        maxX = Math.max(maxX, node.x + node.width);
+        maxY = Math.max(maxY, node.y + node.height);
+      }
+
+      if (found) {
+        const pad = 16;
+        boxes.push({
+          name: ns.name,
+          x: minX - pad,
+          y: minY - pad - 12,
+          w: maxX - minX + pad * 2,
+          h: maxY - minY + pad * 2 + 12,
+        });
+      }
+    }
+
+    return boxes;
+  }
+
+  /** Adapt overview layout to LayoutResult shape for minimap reuse. */
+  private _overviewLayoutAsDetail(): LayoutResult {
+    const ov = this._overviewLayout!;
+    const nodes = new Map<string, import("./layout/elk-layout.js").LayoutNode>();
+    for (const n of ov.nodes) {
+      nodes.set(n.id, n);
+    }
+    return { nodes, edges: [], sourceBlocks: [], width: ov.width, height: ov.height };
+  }
+
+  /** Render the mapping detail view with schema cards and arrow table. */
+  private _renderMappingDetailView(mapping: MappingBlock) {
+    if (!this.model) return html``;
+
+    // Find source and target schemas from the model
+    const allSchemas = this.model.namespaces.flatMap((ns) => ns.schemas);
+    const sourceSchemas = mapping.sourceRefs
+      .map((ref) => allSchemas.find((s) => s.qualifiedId === ref))
+      .filter((s): s is SchemaCard => s !== undefined);
+    const targetSchema = allSchemas.find((s) => s.qualifiedId === mapping.targetRef) ?? null;
+
+    // Build mapped fields for the detail view
+    const sourceMapped = new Map<string, Set<string>>();
+    const targetMapped = new Set<string>();
+    const collectArrows = (arrows: import("./model.js").ArrowEntry[]) => {
+      for (const a of arrows) {
+        targetMapped.add(a.targetField);
+        for (const sf of a.sourceFields) {
+          for (const sr of mapping.sourceRefs) {
+            if (!sourceMapped.has(sr)) sourceMapped.set(sr, new Set());
+            sourceMapped.get(sr)!.add(sf);
+          }
+        }
+      }
+    };
+    collectArrows(mapping.arrows);
+    for (const eb of mapping.eachBlocks) collectArrows(eb.arrows);
+    for (const fb of mapping.flattenBlocks) collectArrows(fb.arrows);
+
+    return html`
+      <sz-mapping-detail
+        .mapping=${mapping}
+        .sourceSchemas=${sourceSchemas}
+        .targetSchema=${targetSchema}
+        .sourceMappedFields=${sourceMapped}
+        .targetMappedFields=${targetMapped}
+      ></sz-mapping-detail>
     `;
   }
 

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -1,9 +1,11 @@
 import { LitElement, html, svg, css, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { VizModel, SourceLocation, NamespaceGroup, MappingBlock, SchemaCard } from "./model.js";
 import { computeLayout, computeOverviewLayout, type LayoutResult, type OverviewLayoutResult, type SourceBlockLayout } from "./layout/elk-layout.js";
 import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
+import { renderMarkdown } from "./markdown.js";
 
 export { VizModel } from "./model.js";
 export type { NamespaceGroup } from "./model.js";
@@ -854,22 +856,12 @@ export class SatsumaViz extends LitElement {
             `
           : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`}
         <div class="toolbar-sep"></div>
-        ${!inDetail
-          ? html`
-              <button
-                class="toolbar-btn"
-                ?data-active=${this._schemaOnly}
-                @click=${() => { this._schemaOnly = !this._schemaOnly; }}
-                title="Show only schema cards, hide arrows and transforms"
-              >Schema Only</button>
-            `
-          : ""}
         <button
           class="toolbar-btn"
           ?data-active=${this._showNotes}
           @click=${() => { this._showNotes = !this._showNotes; }}
-          title="Show or hide notes"
-        >Show Notes</button>
+          title="Show or hide file notes"
+        >Show File Notes</button>
         <div class="toolbar-sep"></div>
         ${!inDetail
           ? html`<button class="toolbar-btn" @click=${this._fit} title="Fit all content in viewport">Fit</button>`
@@ -1257,7 +1249,7 @@ export class SatsumaViz extends LitElement {
         ${fileNotes.length > 0
           ? html`
               <div class="notes-pane-section">File Notes</div>
-              ${fileNotes.map((n) => html`<div class="note-card">${n.text}</div>`)}
+              ${fileNotes.map((n) => html`<div class="note-card">${unsafeHTML(renderMarkdown(n.text))}</div>`)}
             `
           : ""}
         ${allComments.warnings.length > 0
@@ -1406,7 +1398,7 @@ export class SatsumaViz extends LitElement {
           <span>&#128221; File Notes (${notes.length})</span>
         </div>
         ${this._fileNotesExpanded
-          ? notes.map((n) => html`<div class="file-note-item">${n.text}</div>`)
+          ? notes.map((n) => html`<div class="file-note-item">${unsafeHTML(renderMarkdown(n.text))}</div>`)
           : ""}
       </div>
     `;

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -26,6 +26,35 @@ const arrow = (source, target, transform = null) => ({
   location: loc,
 });
 
+/** Helper: minimal schema */
+const schema = (id, fields = [field("id")], qualifiedId = id) => ({
+  id,
+  qualifiedId,
+  kind: "schema",
+  label: null,
+  fields,
+  notes: [],
+  comments: [],
+  metadata: [],
+  location: loc,
+  hasExternalLineage: false,
+  spreads: [],
+});
+
+/** Helper: minimal mapping */
+const mapping = (id, sourceRefs, targetRef, arrows = []) => ({
+  id,
+  sourceRefs,
+  targetRef,
+  arrows,
+  eachBlocks: [],
+  flattenBlocks: [],
+  sourceBlock: null,
+  notes: [],
+  comments: [],
+  location: loc,
+});
+
 describe("computeLayout", () => {
   /** @type {typeof import("../dist/satsuma-viz.js").computeLayout} */
   let computeLayout;
@@ -274,6 +303,134 @@ describe("computeLayout", () => {
     };
 
     const result = await computeLayout(model);
+    assert.ok(result.width > 0, "Layout width should be positive");
+    assert.ok(result.height > 0, "Layout height should be positive");
+  });
+});
+
+describe("computeOverviewLayout", () => {
+  /** @type {typeof import("../dist/satsuma-viz.js").computeOverviewLayout} */
+  let computeOverviewLayout;
+
+  it("loads the overview layout function", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    computeOverviewLayout = mod.computeOverviewLayout;
+    assert.equal(typeof computeOverviewLayout, "function");
+  });
+
+  it("produces compact nodes without ports", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [schema("src"), schema("tgt")],
+        mappings: [mapping("m1", ["src"], "tgt", [arrow("id", "id")])],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+
+    assert.ok(result.nodes.length >= 2, "Should have at least 2 nodes");
+    const srcNode = result.nodes.find(n => n.id === "src");
+    const tgtNode = result.nodes.find(n => n.id === "tgt");
+    assert.ok(srcNode, "Should have src node");
+    assert.ok(tgtNode, "Should have tgt node");
+    // Compact nodes have no ports
+    assert.equal(srcNode.ports.size, 0, "Overview nodes should have no ports");
+    assert.equal(tgtNode.ports.size, 0, "Overview nodes should have no ports");
+    // Compact card height: header (40) + padding (8) = 48
+    assert.equal(srcNode.height, 48, "Compact node should have header-only height");
+  });
+
+  it("creates one edge per mapping, not per arrow", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [
+          schema("src", [field("a"), field("b"), field("c")]),
+          schema("tgt", [field("x"), field("y"), field("z")]),
+        ],
+        mappings: [mapping("m1", ["src"], "tgt", [
+          arrow("a", "x"),
+          arrow("b", "y"),
+          arrow("c", "z"),
+        ])],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+
+    // One mapping with one source → one edge (not three)
+    assert.equal(result.edges.length, 1, "Should produce one edge per mapping source ref");
+    assert.equal(result.edges[0].sourceNode, "src");
+    assert.equal(result.edges[0].targetNode, "tgt");
+    assert.ok(result.edges[0].mapping, "Edge should carry the MappingBlock reference");
+    assert.equal(result.edges[0].mapping.id, "m1");
+  });
+
+  it("creates edges for multiple source refs", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [schema("s1"), schema("s2"), schema("tgt")],
+        mappings: [mapping("m1", ["s1", "s2"], "tgt", [arrow("id", "id")])],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+
+    // Two source refs → two edges
+    assert.equal(result.edges.length, 2, "Should produce one edge per source ref");
+    const sources = result.edges.map(e => e.sourceNode).sort();
+    assert.deepEqual(sources, ["s1", "s2"]);
+  });
+
+  it("uses namespace compound nodes for grouping", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: "crm",
+        schemas: [schema("customers", [field("id")], "crm::customers")],
+        mappings: [],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+
+    const node = result.nodes.find(n => n.id === "crm::customers");
+    assert.ok(node, "Should have namespaced schema node");
+    // Namespace compound node should not appear in the output
+    assert.ok(!result.nodes.find(n => n.id === "ns:crm"), "No namespace node in output");
+  });
+
+  it("produces positive overall dimensions", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [schema("a")],
+        mappings: [],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
     assert.ok(result.width > 0, "Layout width should be positive");
     assert.ok(result.height > 0, "Layout height should be positive");
   });

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -341,8 +341,8 @@ describe("computeOverviewLayout", () => {
     // Compact nodes have no ports
     assert.equal(srcNode.ports.size, 0, "Overview nodes should have no ports");
     assert.equal(tgtNode.ports.size, 0, "Overview nodes should have no ports");
-    // Compact card height: header (40) + padding (8) = 48
-    assert.equal(srcNode.height, 48, "Compact node should have header-only height");
+    // Compact card height: header (40) + bottom-padding (4) = 44
+    assert.equal(srcNode.height, 44, "Compact node should have header-only height");
   });
 
   it("creates one edge per mapping, not per arrow", async () => {

--- a/tooling/satsuma-viz/test/model.test.js
+++ b/tooling/satsuma-viz/test/model.test.js
@@ -52,9 +52,27 @@ describe("@satsuma/viz bundle", () => {
     assert.equal(typeof mod.SzMappingDetail, "function");
   });
 
+  it("exports SzOverviewEdgeLayer class", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    assert.equal(typeof mod.SzOverviewEdgeLayer, "function");
+  });
+
+  it("exports SzOpenMappingEvent class", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    assert.equal(typeof mod.SzOpenMappingEvent, "function");
+  });
+
   it("exports computeOverviewLayout function", async () => {
     mod ??= await import("../dist/satsuma-viz.js");
     assert.equal(typeof mod.computeOverviewLayout, "function");
+  });
+
+  it("SzSchemaCard has highlightFields and highlightColor properties", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    assert.ok(card.highlightFields instanceof Set, "highlightFields should be a Set");
+    assert.equal(card.highlightFields.size, 0, "highlightFields should default empty");
+    assert.equal(card.highlightColor, "", "highlightColor should default to empty string");
   });
 });
 

--- a/tooling/satsuma-viz/test/model.test.js
+++ b/tooling/satsuma-viz/test/model.test.js
@@ -21,6 +21,12 @@ describe("@satsuma/viz bundle", () => {
     assert.equal(typeof mod.SzSchemaCard, "function");
   });
 
+  it("SzSchemaCard has compact property defaulting to false", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    assert.equal(card.compact, false, "compact should default to false");
+  });
+
   it("exports SzMetricCard class", async () => {
     mod ??= await import("../dist/satsuma-viz.js");
     assert.equal(typeof mod.SzMetricCard, "function");
@@ -39,6 +45,16 @@ describe("@satsuma/viz bundle", () => {
   it("exports SzEdgeLayer class", async () => {
     mod ??= await import("../dist/satsuma-viz.js");
     assert.equal(typeof mod.SzEdgeLayer, "function");
+  });
+
+  it("exports SzMappingDetail class", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    assert.equal(typeof mod.SzMappingDetail, "function");
+  });
+
+  it("exports computeOverviewLayout function", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    assert.equal(typeof mod.computeOverviewLayout, "function");
   });
 });
 

--- a/tooling/vscode-satsuma/LICENSE
+++ b/tooling/vscode-satsuma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Equal Experts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tooling/vscode-satsuma/server/src/parser-utils.ts
+++ b/tooling/vscode-satsuma/server/src/parser-utils.ts
@@ -21,8 +21,15 @@ let _initPromise: Promise<void> | null = null;
 export function initParser(wasmPath: string): Promise<void> {
   if (_initPromise) return _initPromise;
   _initPromise = (async () => {
+    const path = require("path");
     const TreeSitter = require("web-tree-sitter") as typeof import("web-tree-sitter");
-    await TreeSitter.Parser.init();
+    // The runtime WASM (tree-sitter.wasm) is copied next to server.js during build.
+    // We must tell web-tree-sitter where to find it since esbuild bundling changes
+    // the default module-relative lookup path.
+    const runtimeWasm = path.join(path.dirname(wasmPath), "tree-sitter.wasm");
+    await TreeSitter.Parser.init({
+      locateFile: () => runtimeWasm,
+    });
     _language = await TreeSitter.Language.load(wasmPath);
     _parser = new TreeSitter.Parser();
     _parser.setLanguage(_language);

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -8,6 +8,8 @@ export class VizPanel {
   private readonly extensionUri: vscode.Uri;
   private readonly client: LanguageClient;
   private disposables: vscode.Disposable[] = [];
+  /** URI of the last successfully loaded .stm file — used by Refresh to reload without requiring focus. */
+  private _lastUri: string | undefined;
 
   static createOrShow(
     extensionUri: vscode.Uri,
@@ -79,17 +81,22 @@ export class VizPanel {
   }
 
   async refresh(): Promise<void> {
-    // Get the active .stm document URI
+    // Prefer last loaded URI so Refresh works even when the webview has focus
+    // and the .stm editor is no longer the active editor.
     const editor = vscode.window.activeTextEditor;
-    if (!editor || editor.document.languageId !== "satsuma") {
+    const activeUri =
+      editor?.document.languageId === "satsuma"
+        ? editor.document.uri.toString()
+        : undefined;
+    const uri = activeUri ?? this._lastUri;
+
+    if (!uri) {
       this.panel.webview.postMessage({
         type: "error",
         message: "Open a .stm file to see its mapping visualization",
       });
       return;
     }
-
-    const uri = editor.document.uri.toString();
 
     try {
       const model = await this.client.sendRequest("satsuma/vizModel", { uri });
@@ -100,6 +107,9 @@ export class VizPanel {
         });
         return;
       }
+
+      // Remember this URI so Refresh can reload it even without editor focus
+      this._lastUri = uri;
 
       // Detect theme kind and send alongside model
       const themeKind = vscode.window.activeColorTheme.kind;


### PR DESCRIPTION
## Summary

- Adds `@satsuma/viz` package: Lit web components (`SatsumaViz`, `SzSchemaCard`, `SzMetricCard`, `SzFragmentCard`, `SzMappingDetail`, `SzEdgeLayer`, `SzOverviewEdgeLayer`) for interactive mapping visualization
- ELK.js-backed graph layout with field-level port alignment, overview compact layout, and two-level view (overview ↔ mapping detail)
- VS Code `VizPanel` webview serving the viz bundle; refreshes on save and active editor change
- Cross-highlighting on field hover between schema cards and the arrow table
- Markdown rendering for schema and file notes (`**bold**`, *italic*, `code`, headings, lists)
- Report and ML model schemas visually distinct (blue header + chart icon)
- Phase-by-phase: zoom/pan, minimap, SVG export, cross-file lineage expansion, breadcrumb trail, each/flatten scope labels, source block joins/filters, fragment spread indicators, block-level comment badges, right-side notes pane

## Polish fixes (final commit)

- Arrow/port alignment: `preambleHeight()` accounts for label and metadata-pill sections so ELK port positions match rendered card output exactly
- Column truncation in mapping detail: wider grid minimums (280/360px) and `--sz-card-max-width: none` on cards in detail context
- Refresh button: caches last loaded URI so it works even when the webview has focus and no `.stm` editor is active
- Removed upstream/downstream lineage expansion buttons (no longer useful)
- Toolbar: removed Schema Only button; renamed Show Notes → Show File Notes
- LICENSE included in VSIX package

## Test plan

- [ ] All 28 `@satsuma/viz` tests pass (`npm test` in `tooling/satsuma-viz/`)
- [ ] VS Code extension builds cleanly (`npm run build` in `tooling/vscode-satsuma/`)
- [ ] Open a `.stm` file → click eye icon → viz panel opens and renders cards with arrows
- [ ] Click a mapping edge in overview → mapping detail opens with source/target cards
- [ ] Click Refresh in the viz panel (without focusing the .stm editor) → reloads correctly
- [ ] Notes with `"""` blocks render Markdown formatting
- [ ] Report/model schemas show blue header; regular schemas show orange

🤖 Generated with [Claude Code](https://claude.com/claude-code)