### PR TITLE
fix(release): universal CLI build + fix VSIX CI failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,19 +23,7 @@ jobs:
 
   build:
     needs: [security]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            platform: linux-x64
-          - os: ubuntu-24.04-arm
-            platform: linux-arm64
-          - os: macos-latest
-            platform: darwin-arm64
-          - os: windows-latest
-            platform: win32-x64
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: tooling/satsuma-cli
@@ -53,15 +41,7 @@ jobs:
       - name: Bundle for distribution
         shell: bash
         run: |
-          # Replace file: symlink with actual copy (includes prebuilt native addon)
-          rm -rf node_modules/tree-sitter-satsuma
-          cp -rf ../tree-sitter-satsuma node_modules/tree-sitter-satsuma
-
-          # Remove dev-only / non-runtime files from the bundled copy
-          rm -rf node_modules/tree-sitter-satsuma/{test,scripts,.beads,docs,queries,examples}
-          rm -rf node_modules/tree-sitter-satsuma/node_modules
-
-          # Bundle all dependencies into the tarball so consumers skip native compilation
+          # Bundle all dependencies into the tarball so consumers skip install
           node -e "
             const pkg = JSON.parse(require('fs').readFileSync('package.json', 'utf8'));
             pkg.bundleDependencies = true;
@@ -69,12 +49,12 @@ jobs:
           "
 
           npm pack
-          mv satsuma-cli-*.tgz satsuma-cli-${{ matrix.platform }}.tgz
+          mv satsuma-cli-*.tgz satsuma-cli.tgz
 
       - uses: actions/upload-artifact@v7
         with:
-          name: satsuma-cli-${{ matrix.platform }}
-          path: tooling/satsuma-cli/satsuma-cli-${{ matrix.platform }}.tgz
+          name: satsuma-cli
+          path: tooling/satsuma-cli/satsuma-cli.tgz
 
   vsix:
     needs: [security]
@@ -96,6 +76,10 @@ jobs:
       - name: Build WASM parser
         working-directory: tooling/tree-sitter-satsuma
         run: npx tree-sitter build --wasm
+
+      - name: Build satsuma-viz (needed by webview bundle)
+        working-directory: tooling/satsuma-viz
+        run: npm run build
 
       - name: Build and package .vsix
         run: |
@@ -130,7 +114,7 @@ jobs:
           gh release create "$RELEASE_TAG" \
             --title "$RELEASE_TAG" \
             --generate-notes \
-            satsuma-cli-*.tgz \
+            satsuma-cli.tgz \
             vscode-satsuma.vsix
 
       - name: Update latest release
@@ -147,20 +131,7 @@ jobs:
 
           **Install CLI:**
           ```bash
-          # macOS (Apple Silicon)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-darwin-arm64.tgz
-
-          # macOS (Intel)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-darwin-x64.tgz
-
-          # Linux (x64)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-linux-x64.tgz
-
-          # Linux (ARM64)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-linux-arm64.tgz
-
-          # Windows (x64)
-          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli-win32-x64.tgz
+          npm install -g https://github.com/${{ github.repository }}/releases/download/latest/satsuma-cli.tgz
           ```
 
           **Install VS Code Extension:**
@@ -174,5 +145,5 @@ jobs:
             --title "Latest build" \
             --notes-file notes.md \
             --prerelease \
-            satsuma-cli-*.tgz \
+            satsuma-cli.tgz \
             vscode-satsuma.vsix

--- a/README.md
+++ b/README.md
@@ -150,15 +150,11 @@ For agent workflows specifically, the model is:
 
 ## Install the CLI
 
-Pre-built binaries are published on every merge to `main`. Install with npm
-(no local build required):
+A universal pre-built package is published on every merge to `main`. It uses
+WASM internally, so the same package works on macOS, Linux, and Windows:
 
 ```bash
-# macOS (Apple Silicon)
-npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz
-
-# Linux (x64)
-npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli.tgz
 ```
 
 This gives you the `satsuma` command on your PATH. Run `satsuma --help` to see

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -601,14 +601,8 @@ permalink: cli.html
             <span class="text-xs text-gray-400 ml-2 font-mono">terminal — stable ({{ site.version }})</span>
           </div>
           <pre>
-<span class="output"># macOS (Apple Silicon)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-darwin-arm64.tgz
-
-<span class="output"># macOS (Intel)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-darwin-x64.tgz
-
-<span class="output"># Linux (x64)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-linux-x64.tgz
+<span class="output"># Universal — works on macOS, Linux, and Windows (WASM-based)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli.tgz
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
@@ -624,14 +618,8 @@ permalink: cli.html
               <span class="text-xs text-gray-400 ml-2 font-mono">terminal — unstable (latest)</span>
             </div>
             <pre>
-<span class="output"># macOS (Apple Silicon)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-arm64.tgz
-
-<span class="output"># macOS (Intel)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-darwin-x64.tgz
-
-<span class="output"># Linux (x64)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-linux-x64.tgz</pre>
+<span class="output"># Universal — works on macOS, Linux, and Windows (WASM-based)</span>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli.tgz</pre>
           </div>
         </details>
         <div class="mt-6 flex items-start gap-3 p-4 bg-peach rounded-xl">

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -48,10 +48,10 @@ permalink: learn.html
           <div class="absolute -top-4 left-8 w-8 h-8 gradient-orange rounded-full flex items-center justify-center text-white font-bold text-sm">1</div>
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the CLI</h3>
           <div class="code-block text-sm mb-4">
-            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># macOS (Apple Silicon) — stable ({{ site.version }})</span>
-npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-darwin-arm64.tgz</code></pre>
+            <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># Universal — works on macOS, Linux, and Windows</span>
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli.tgz</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. Prebuilt packages for macOS, Linux, and Windows are on the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">{{ site.version }} release</a>. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. One universal package works on every platform (WASM-based, no native compilation). Available from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">{{ site.version }} release</a>. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>.</p>
         </div>
 
         <!-- Step 2 -->


### PR DESCRIPTION
## Summary

- **Fix VSIX CI failure**: add missing `npm run build` step for `@satsuma/viz` before building the VS Code extension — esbuild couldn't resolve the `@satsuma/viz` alias because `dist/satsuma-viz.js` didn't exist
- **Simplify CLI release**: replace 4-platform matrix build (darwin-arm64, darwin-x64, linux-x64, linux-arm64, win32-x64) with a single universal build producing one `satsuma-cli.tgz` — the CLI now uses WASM (web-tree-sitter) so native binaries are no longer needed
- **Update install docs**: README.md, site/learn.njk, and site/cli.njk now show one universal install command instead of per-platform variants

## Test plan

- [ ] Release workflow succeeds on push to main (vsix job no longer fails)
- [ ] `satsuma-cli.tgz` artifact is produced (single file, no platform suffix)
- [ ] `vscode-satsuma.vsix` artifact is produced
- [ ] Site and README install instructions reference `satsuma-cli.tgz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)