### PR TITLE
fix: correct mapping viz overview layout regressions

### DIFF
--- a/.tickets/sl-xodu.md
+++ b/.tickets/sl-xodu.md
@@ -1,0 +1,25 @@
+---
+id: sl-xodu
+status: closed
+deps: []
+links: []
+created: 2026-03-27T09:03:22Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, ux]
+---
+# Fix Mapping Viz layout regressions in overview mode
+
+Fix overview layout regressions in the VS Code Mapping Viz: account for mapping label width, align overview labels with padded edge coordinates, resolve namespaced mapping refs correctly, ignore invalid source refs in overview edges, and compute namespace bounding boxes from rendered card geometry so boxes stay behind cards and fully enclose notes/metrics/fragments.
+
+## Acceptance Criteria
+
+- Overview edges reserve space for long mapping labels and labels align with rendered arrows\n- Multi-source mappings with join-description text still render overview arrows\n- Namespaced mappings resolve local source/target refs to qualified schema ids so namespace arrows render\n- Namespace bounding boxes enclose actual rendered cards and sit behind edges/cards\n- Relevant viz and server tests pass locally
+
+
+## Notes
+
+**2026-03-27T09:06:35Z**
+
+Cause: Overview-mode layout used mismatched geometry sources: overview labels did not reserve or align to padded edge space, namespaced mapping refs could remain unresolved, and namespace bounds were derived from abstract node sizes rather than rendered cards. Fix: Updated the viz layout/model pipeline to size cards and label gaps more accurately, resolve mapping refs in namespace context, ignore invalid overview edges, and measure namespace boxes from rendered card bounds. (commit 08c84fa)

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -164,9 +164,9 @@ export class SzOverviewEdgeLayer extends LitElement {
 
     const d = this._buildCurvePath(edge.points);
     const cls = this._edgeColorClass(edge.mapping);
-    const mid = this._midpoint(edge.points);
+    const labelPos = this._labelAnchor(edge.points);
     const labelText = edge.mapping.id;
-    const labelWidth = Math.min(labelText.length * 6.5 + 16, 160);
+    const labelWidth = edge.labelWidth;
 
     return svg`
       <path
@@ -178,7 +178,7 @@ export class SzOverviewEdgeLayer extends LitElement {
       />
       <g
         class="mapping-label-group"
-        transform="translate(${mid.x}, ${mid.y})"
+        transform="translate(${labelPos.x}, ${labelPos.y})"
         @click=${() => this._onEdgeClick(edge)}
         @mouseenter=${(ev: MouseEvent) => this._onEdgeHover(edge.id, ev)}
         @mouseleave=${() => this._onEdgeLeave()}
@@ -249,6 +249,41 @@ export class SzOverviewEdgeLayer extends LitElement {
       };
     }
     return points[mid];
+  }
+
+  private _labelAnchor(
+    points: Array<{ x: number; y: number }>
+  ): { x: number; y: number } {
+    if (points.length < 2) return { x: 0, y: 0 };
+
+    let best:
+      | {
+          score: number;
+          length: number;
+          start: { x: number; y: number };
+          end: { x: number; y: number };
+        }
+      | null = null;
+
+    for (let i = 1; i < points.length; i++) {
+      const start = points[i - 1];
+      const end = points[i];
+      const dx = Math.abs(end.x - start.x);
+      const dy = Math.abs(end.y - start.y);
+      const length = Math.hypot(end.x - start.x, end.y - start.y);
+      const score = dx - dy * 0.5;
+
+      if (!best || score > best.score || (score === best.score && length > best.length)) {
+        best = { score, length, start, end };
+      }
+    }
+
+    if (!best) return this._midpoint(points);
+
+    return {
+      x: (best.start.x + best.end.x) / 2,
+      y: (best.start.y + best.end.y) / 2,
+    };
   }
 
   private _onEdgeClick(edge: OverviewEdge) {

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -69,6 +69,8 @@ export interface OverviewEdge {
   targetNode: string;
   /** Array of {x,y} points forming the routed edge path */
   points: Array<{ x: number; y: number }>;
+  /** Estimated label width used for spacing and rendering. */
+  labelWidth: number;
   /** The full MappingBlock this edge represents. */
   mapping: MappingBlock;
 }
@@ -88,7 +90,15 @@ const FIELD_HEIGHT = 28;
 const FIELDS_PADDING_TOP = 4; // .fields { padding: 4px 0; }
 const FIELDS_PADDING_BOTTOM = 4;
 const CARD_MIN_WIDTH = 240;
+const CARD_MAX_WIDTH = 380;
 const PORT_Y_OFFSET = FIELD_HEIGHT / 2; // center of field row
+const OVERVIEW_HEADER_BASE_WIDTH = 72; // icon + gaps + padding
+const OVERVIEW_TITLE_CHAR_WIDTH = 8.2;
+const OVERVIEW_COUNT_CHAR_WIDTH = 6.3;
+const OVERVIEW_PILL_CHAR_WIDTH = 6.1;
+const OVERVIEW_LABEL_CHAR_WIDTH = 6.8;
+const OVERVIEW_LABEL_PADDING = 18;
+const OVERVIEW_LABEL_MAX_WIDTH = 220;
 
 /** Height of the area above the fields list (header + optional label + optional metadata pills). */
 function preambleHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
@@ -102,6 +112,43 @@ function preambleHeight(schema: { label: string | null; metadata: Array<{ key: s
 /** Compact card height: header + optional label + optional pills + small padding. */
 function compactHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
   return preambleHeight(schema) + FIELDS_PADDING_BOTTOM;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function estimateTextWidth(text: string, charWidth: number): number {
+  return text.length * charWidth;
+}
+
+function estimateOverviewLabelWidth(mappingId: string): number {
+  return clamp(
+    Math.ceil(estimateTextWidth(mappingId, OVERVIEW_LABEL_CHAR_WIDTH) + OVERVIEW_LABEL_PADDING),
+    48,
+    OVERVIEW_LABEL_MAX_WIDTH,
+  );
+}
+
+function estimateCompactSchemaWidth(schema: SchemaCard): number {
+  const displayName = schema.qualifiedId.includes("::") ? schema.qualifiedId : schema.id;
+  const countText = `${countFields(schema.fields)} fields`;
+  const headerWidth =
+    OVERVIEW_HEADER_BASE_WIDTH +
+    estimateTextWidth(displayName, OVERVIEW_TITLE_CHAR_WIDTH) +
+    estimateTextWidth(countText, OVERVIEW_COUNT_CHAR_WIDTH);
+
+  const pillWidths = schema.metadata
+    .filter((m) => m.key !== "note")
+    .map((m) => estimateTextWidth(`${m.key} ${m.value}`, OVERVIEW_PILL_CHAR_WIDTH) + 44);
+  const contentWidth = pillWidths.length > 0 ? Math.max(headerWidth, ...pillWidths) : headerWidth;
+
+  return clamp(Math.ceil(contentWidth), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
+}
+
+function estimateCompactTextCardWidth(id: string): number {
+  const headerWidth = OVERVIEW_HEADER_BASE_WIDTH + estimateTextWidth(id, OVERVIEW_TITLE_CHAR_WIDTH);
+  return clamp(Math.ceil(headerWidth), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
 }
 
 const elk = new ELK();
@@ -514,15 +561,23 @@ function extractLayout(
 export async function computeOverviewLayout(model: VizModel): Promise<OverviewLayoutResult> {
   const children: ElkNode[] = [];
   const edges: ElkEdge[] = [];
-  const overviewEdgeMeta = new Map<string, { sourceNode: string; targetNode: string; mapping: MappingBlock }>();
+  const overviewEdgeMeta = new Map<string, {
+    sourceNode: string;
+    targetNode: string;
+    mapping: MappingBlock;
+    labelWidth: number;
+  }>();
+  let maxLabelWidth = 0;
+  const nodeIds = new Set<string>();
 
   for (const ns of model.namespaces) {
     const nsNodes: ElkNode[] = [];
 
     for (const s of ns.schemas) {
+      nodeIds.add(s.qualifiedId);
       nsNodes.push({
         id: s.qualifiedId,
-        width: CARD_MIN_WIDTH,
+        width: estimateCompactSchemaWidth(s),
         height: compactHeight(s),
         ports: [],
         children: [],
@@ -531,9 +586,10 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
     }
 
     for (const f of ns.fragments) {
+      nodeIds.add(f.id);
       nsNodes.push({
         id: f.id,
-        width: CARD_MIN_WIDTH,
+        width: estimateCompactTextCardWidth(f.id),
         height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
         ports: [],
         children: [],
@@ -542,9 +598,10 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
     }
 
     for (const m of ns.metrics) {
+      nodeIds.add(m.qualifiedId);
       nsNodes.push({
         id: m.qualifiedId,
-        width: CARD_MIN_WIDTH,
+        width: estimateCompactTextCardWidth(m.qualifiedId),
         height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
         ports: [],
         children: [],
@@ -568,7 +625,10 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
 
     // One edge per mapping block
     for (const m of ns.mappings) {
+      const labelWidth = estimateOverviewLabelWidth(m.id);
+      maxLabelWidth = Math.max(maxLabelWidth, labelWidth);
       for (const sourceRef of m.sourceRefs) {
+        if (!nodeIds.has(sourceRef) || !nodeIds.has(m.targetRef)) continue;
         const edgeId = `overview:${m.id}:${sourceRef}`;
         edges.push({
           id: edgeId,
@@ -579,10 +639,13 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
           sourceNode: sourceRef,
           targetNode: m.targetRef,
           mapping: m,
+          labelWidth,
         });
       }
     }
   }
+
+  const layerSpacing = Math.max(80, maxLabelWidth + 72);
 
   const elkGraph: ElkGraph = {
     id: "root",
@@ -590,7 +653,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.spacing.nodeNode": "40",
-      "elk.layered.spacing.nodeNodeBetweenLayers": "80",
+      "elk.layered.spacing.nodeNodeBetweenLayers": String(layerSpacing),
       "elk.spacing.edgeEdge": "20",
       "elk.spacing.edgeNode": "20",
       "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
@@ -644,6 +707,7 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
         sourceNode: meta.sourceNode,
         targetNode: meta.targetNode,
         points,
+        labelWidth: meta.labelWidth,
         mapping: meta.mapping,
       });
     }

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -71,6 +71,7 @@ export class SatsumaViz extends LitElement {
 
     .card-layer {
       position: relative;
+      z-index: 20;
     }
 
     .positioned-card {
@@ -82,6 +83,8 @@ export class SatsumaViz extends LitElement {
       border: 2px dashed var(--sz-namespace-border);
       background: var(--sz-namespace-bg);
       border-radius: var(--sz-card-radius);
+      z-index: 0;
+      pointer-events: none;
     }
 
     .namespace-label {
@@ -606,6 +609,9 @@ export class SatsumaViz extends LitElement {
   @state()
   private _mappedFieldsBySchema = new Map<string, Set<string>>();
 
+  @state()
+  private _renderedNamespaceBoxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
+
   private static readonly MIN_ZOOM = 0.2;
   private static readonly MAX_ZOOM = 3;
 
@@ -634,6 +640,17 @@ export class SatsumaViz extends LitElement {
       this._viewMode = "overview";
       this._selectedMapping = null;
       this._runLayout();
+    }
+
+    if (
+      changed.has("_layout")
+      || changed.has("_overviewLayout")
+      || changed.has("_viewMode")
+      || changed.has("model")
+      || changed.has("_nsFilter")
+      || changed.has("_showNotes")
+    ) {
+      requestAnimationFrame(() => this._measureNamespaceBoxes());
     }
   }
 
@@ -1059,13 +1076,6 @@ export class SatsumaViz extends LitElement {
 
     return html`
       <div class="canvas" style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;">
-        <!-- Overview SVG edge layer -->
-        <sz-overview-edge-layer
-          .edges=${overview.edges}
-          .width=${overview.width + 48}
-          .height=${overview.height + 48}
-        ></sz-overview-edge-layer>
-
         <!-- Namespace bounding boxes -->
         ${nsBoxes.map(
           (box) => html`
@@ -1078,6 +1088,14 @@ export class SatsumaViz extends LitElement {
           `
         )}
 
+        <!-- Overview SVG edge layer -->
+        <sz-overview-edge-layer
+          style="left: 24px; top: 24px; z-index: 10;"
+          .edges=${overview.edges}
+          .width=${overview.width}
+          .height=${overview.height}
+        ></sz-overview-edge-layer>
+
         <!-- Compact positioned cards -->
         <div class="card-layer">
           ${namespaces.flatMap((ns) => [
@@ -1085,7 +1103,7 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === s.qualifiedId);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-schema-card .schema=${s} compact></sz-schema-card>
                 </div>
               `;
@@ -1094,7 +1112,7 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === f.id);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-fragment-card .fragment=${f}></sz-fragment-card>
                 </div>
               `;
@@ -1103,7 +1121,7 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === m.qualifiedId);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-metric-card .metric=${m}></sz-metric-card>
                 </div>
               `;
@@ -1119,6 +1137,9 @@ export class SatsumaViz extends LitElement {
     overview: OverviewLayoutResult,
     namespaces: NamespaceGroup[]
   ): Array<{ name: string; x: number; y: number; w: number; h: number }> {
+    if (this._renderedNamespaceBoxes.length > 0) {
+      return this._renderedNamespaceBoxes;
+    }
     const boxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
 
     for (const ns of namespaces) {
@@ -1426,15 +1447,6 @@ export class SatsumaViz extends LitElement {
 
     return html`
       <div class="canvas" style="width: ${layout.width + 48}px; height: ${layout.height + 48}px; padding: 24px;">
-        <!-- SVG edge layer (behind cards) -->
-        <sz-edge-layer
-          .edges=${layout.edges}
-          .width=${layout.width + 48}
-          .height=${layout.height + 48}
-          .highlightSchema=${this._hoveredSchema}
-          .highlightField=${this._hoveredField}
-        ></sz-edge-layer>
-
         <!-- Namespace bounding boxes -->
         ${nsBoxes.map(
           (box) => html`
@@ -1446,6 +1458,16 @@ export class SatsumaViz extends LitElement {
             </div>
           `
         )}
+
+        <!-- SVG edge layer (behind cards) -->
+        <sz-edge-layer
+          style="left: 24px; top: 24px; z-index: 10;"
+          .edges=${layout.edges}
+          .width=${layout.width}
+          .height=${layout.height}
+          .highlightSchema=${this._hoveredSchema}
+          .highlightField=${this._hoveredField}
+        ></sz-edge-layer>
 
         <!-- Source block join/filter labels -->
         ${layout.sourceBlocks.map((sb) => this._renderSourceBlock(sb, layout))}
@@ -1459,7 +1481,7 @@ export class SatsumaViz extends LitElement {
               const mapped = this._mappedFieldsBySchema.get(s.qualifiedId) ?? new Set();
               const isExpanded = expandedIds.has(s.qualifiedId);
               const results = [html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-schema-card .schema=${s} .mappedFields=${mapped}></sz-schema-card>
                 </div>
               `];
@@ -1482,7 +1504,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               const isExpanded = expandedIds.has(f.id);
               return html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-fragment-card .fragment=${f}></sz-fragment-card>
                 </div>
               `;
@@ -1492,7 +1514,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               const isExpanded = expandedIds.has(m.qualifiedId);
               return html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
                   <sz-metric-card .metric=${m}></sz-metric-card>
                 </div>
               `;
@@ -1539,6 +1561,9 @@ export class SatsumaViz extends LitElement {
     layout: LayoutResult,
     namespaces: NamespaceGroup[]
   ): Array<{ name: string; x: number; y: number; w: number; h: number }> {
+    if (this._renderedNamespaceBoxes.length > 0) {
+      return this._renderedNamespaceBoxes;
+    }
     const boxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
 
     for (const ns of namespaces) {
@@ -1576,6 +1601,61 @@ export class SatsumaViz extends LitElement {
     }
 
     return boxes;
+  }
+
+  private _measureNamespaceBoxes() {
+    const canvas = this.renderRoot?.querySelector?.(".canvas") as HTMLElement | null;
+    if (!canvas || !this.model) {
+      if (this._renderedNamespaceBoxes.length > 0) this._renderedNamespaceBoxes = [];
+      return;
+    }
+
+    const namespaces = this._filterNamespaces(this.model.namespaces);
+    const boxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
+    const pad = 16;
+    const labelPad = 12;
+
+    for (const ns of namespaces) {
+      if (!ns.name) continue;
+
+      const ids = [
+        ...ns.schemas.map((s) => s.qualifiedId),
+        ...ns.fragments.map((f) => f.id),
+        ...ns.metrics.map((m) => m.qualifiedId),
+      ];
+
+      let minX = Infinity;
+      let minY = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      let found = false;
+
+      for (const id of ids) {
+        const el = canvas.querySelector(`.positioned-card[data-node-id="${CSS.escape(id)}"]`) as HTMLElement | null;
+        if (!el) continue;
+        found = true;
+        minX = Math.min(minX, el.offsetLeft);
+        minY = Math.min(minY, el.offsetTop);
+        maxX = Math.max(maxX, el.offsetLeft + el.offsetWidth);
+        maxY = Math.max(maxY, el.offsetTop + el.offsetHeight);
+      }
+
+      if (found) {
+        boxes.push({
+          name: ns.name,
+          x: minX - pad,
+          y: minY - pad - labelPad,
+          w: maxX - minX + pad * 2,
+          h: maxY - minY + pad * 2 + labelPad,
+        });
+      }
+    }
+
+    const prev = JSON.stringify(this._renderedNamespaceBoxes);
+    const next = JSON.stringify(boxes);
+    if (prev !== next) {
+      this._renderedNamespaceBoxes = boxes;
+    }
   }
 
   private _buildMappedFieldsIndex(): Map<string, Set<string>> {

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -434,4 +434,90 @@ describe("computeOverviewLayout", () => {
     assert.ok(result.width > 0, "Layout width should be positive");
     assert.ok(result.height > 0, "Layout height should be positive");
   });
+
+  it("widens overview nodes for longer schema names and metadata", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [
+          schema("src"),
+          {
+            ...schema(
+              "order_headers_parquet_with_a_long_name",
+              [field("id"), field("customer_id"), field("created_at")],
+            ),
+            metadata: [{ key: "format", value: "parquet" }],
+          },
+        ],
+        mappings: [],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+    const srcNode = result.nodes.find((n) => n.id === "src");
+    const longNode = result.nodes.find((n) => n.id === "order_headers_parquet_with_a_long_name");
+
+    assert.ok(srcNode, "Should have src node");
+    assert.ok(longNode, "Should have long-name node");
+    assert.ok(
+      longNode.width > srcNode.width,
+      `Long-name node width (${longNode.width}) should exceed short node width (${srcNode.width})`,
+    );
+  });
+
+  it("reserves horizontal space for long mapping labels", async () => {
+    const longMappingId = "normalize_and_curate_order_headers_for_reporting";
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [schema("src"), schema("tgt")],
+        mappings: [mapping(longMappingId, ["src"], "tgt", [arrow("id", "id")])],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+    const srcNode = result.nodes.find((n) => n.id === "src");
+    const tgtNode = result.nodes.find((n) => n.id === "tgt");
+
+    assert.ok(srcNode, "Should have src node");
+    assert.ok(tgtNode, "Should have tgt node");
+    assert.equal(result.edges.length, 1, "Should have one overview edge");
+    assert.ok(
+      result.edges[0].labelWidth >= 180,
+      `Long mapping label width (${result.edges[0].labelWidth}) should be preserved on the edge`,
+    );
+
+    const gap = tgtNode.x - (srcNode.x + srcNode.width);
+    assert.ok(
+      gap >= result.edges[0].labelWidth,
+      `Gap between nodes (${gap}) should fit label width (${result.edges[0].labelWidth})`,
+    );
+  });
+
+  it("ignores overview edges whose source ref does not resolve to a node", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [schema("src"), schema("tgt")],
+        mappings: [mapping("m1", ["src", "Join text that is not a schema"], "tgt", [arrow("id", "id")])],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeOverviewLayout(model);
+    assert.equal(result.edges.length, 1, "Should only keep the valid source-ref edge");
+    assert.equal(result.edges[0].sourceNode, "src");
+    assert.equal(result.edges[0].targetNode, "tgt");
+  });
 });

--- a/tooling/vscode-satsuma/server/src/viz-model.ts
+++ b/tooling/vscode-satsuma/server/src/viz-model.ts
@@ -1,7 +1,7 @@
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
 import type { WorkspaceIndex } from "./workspace-index";
-import { findReferences } from "./workspace-index";
+import { findReferences, resolveDefinition } from "./workspace-index";
 
 // ---------- VizModel interfaces ----------
 
@@ -242,7 +242,7 @@ function processTopLevelBlock(
       group.fragments.push(extractFragment(uri, node));
       break;
     case "mapping_block":
-      group.mappings.push(extractMapping(uri, node));
+      group.mappings.push(extractMapping(uri, node, namespace, wsIndex));
       break;
     case "metric_block":
       group.metrics.push(extractMetric(uri, node, namespace));
@@ -471,7 +471,29 @@ function extractConstraints(meta: SyntaxNode): string[] {
 
 // ---------- Mapping extraction ----------
 
-function extractMapping(uri: string, node: SyntaxNode): MappingBlock {
+function resolveMappingRef(
+  refName: string,
+  namespace: string | null,
+  wsIndex: WorkspaceIndex,
+): string {
+  const defs = resolveDefinition(wsIndex, refName, namespace);
+  const schemaDef = defs.find((d) => d.kind === "schema");
+  return schemaDef ? (namespace && !refName.includes("::") && schemaDef.namespace
+    ? `${schemaDef.namespace}::${refName}`
+    : refName.includes("::")
+      ? refName
+      : schemaDef.namespace
+        ? `${schemaDef.namespace}::${refName}`
+        : refName)
+    : refName;
+}
+
+function extractMapping(
+  uri: string,
+  node: SyntaxNode,
+  namespace: string | null,
+  wsIndex: WorkspaceIndex,
+): MappingBlock {
   const name = labelText(node) ?? "unknown";
   const body = child(node, "mapping_body");
 
@@ -488,15 +510,18 @@ function extractMapping(uri: string, node: SyntaxNode): MappingBlock {
       switch (ch.type) {
         case "source_block":
           sourceBlock = extractSourceBlock(ch);
-          for (const ref of children(ch, "source_ref")) {
-            const refName = sourceRefText(ref);
-            if (refName) sourceRefs.push(refName);
+          if (sourceBlock.schemas.length > 0) {
+            const resolvedSchemas = sourceBlock.schemas.map((ref) =>
+              resolveMappingRef(ref, namespace, wsIndex)
+            );
+            sourceBlock = { ...sourceBlock, schemas: resolvedSchemas };
+            sourceRefs.push(...resolvedSchemas);
           }
           break;
         case "target_block":
           for (const ref of children(ch, "source_ref")) {
             const refName = sourceRefText(ref);
-            if (refName) targetRef = refName;
+            if (refName) targetRef = resolveMappingRef(refName, namespace, wsIndex);
           }
           break;
         case "map_arrow":

--- a/tooling/vscode-satsuma/server/test/viz-model.test.js
+++ b/tooling/vscode-satsuma/server/test/viz-model.test.js
@@ -245,6 +245,50 @@ describe("mappings", () => {
     assert.equal(sb.joinDescription, "Join on a.id = b.id");
   });
 
+  it("resolves local namespaced mapping refs to qualified schema ids", () => {
+    const model = vizModel(
+      "namespace warehouse {\n" +
+      "  schema src { id INT }\n" +
+      "  schema tgt { id INT }\n" +
+      "  mapping m {\n" +
+      "    source { src }\n" +
+      "    target { tgt }\n" +
+      "    id -> id\n" +
+      "  }\n" +
+      "}",
+    );
+    const mapping = model.namespaces.find((ns) => ns.name === "warehouse").mappings[0];
+    assert.deepEqual(mapping.sourceRefs, ["warehouse::src"]);
+    assert.equal(mapping.targetRef, "warehouse::tgt");
+    assert.deepEqual(mapping.sourceBlock.schemas, ["warehouse::src"]);
+  });
+
+  it("falls back to global schema refs from inside namespaces", () => {
+    const model = vizModel(
+      "schema global_src { id INT }\n" +
+      "namespace warehouse {\n" +
+      "  schema tgt { id INT }\n" +
+      "  mapping m {\n" +
+      "    source { global_src }\n" +
+      "    target { tgt }\n" +
+      "    id -> id\n" +
+      "  }\n" +
+      "}",
+    );
+    const mapping = model.namespaces.find((ns) => ns.name === "warehouse").mappings[0];
+    assert.deepEqual(mapping.sourceRefs, ["global_src"]);
+    assert.equal(mapping.targetRef, "warehouse::tgt");
+  });
+
+  it("does not treat source join descriptions as source refs", () => {
+    const model = vizModel(
+      "schema a { id INT }\nschema b { id INT }\nschema t { id INT }\n" +
+      'mapping m {\n  source {\n    a\n    b\n    "Join on a.id = b.id"\n  }\n  target { t }\n  a.id -> id\n}',
+    );
+    const mapping = model.namespaces[0].mappings[0];
+    assert.deepEqual(mapping.sourceRefs, ["a", "b"]);
+  });
+
   it("extracts flatten blocks", () => {
     const model = vizModel(
       "schema s { items list_of record { sku STRING } }\n" +


### PR DESCRIPTION
## Summary
- fix overview edge spacing and label anchoring for long mapping names
- resolve mapping refs in namespace context and ignore invalid overview edges
- measure namespace boxes from rendered cards and keep them behind edges/cards

## Testing
- npm test (tooling/satsuma-viz)
- npm test (tooling/vscode-satsuma/server)
- npm run build (tooling/vscode-satsuma)
- repo pre-commit hooks passed during commit/amend

Closes sl-xodu