### PR TITLE
Fix CLI release packaging for missing parser WASM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
         working-directory: .
         run: npm run ci:all
 
+      - name: Build WASM parser
+        working-directory: tooling/tree-sitter-satsuma
+        run: ../../scripts/tree-sitter-local.sh build --wasm . -o tree-sitter-satsuma.wasm
+
       - name: Bundle for distribution
         shell: bash
         run: |
@@ -50,6 +54,7 @@ jobs:
 
           npm pack
           mv satsuma-cli-*.tgz satsuma-cli.tgz
+          node scripts/verify-pack.js
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.tickets/fcrw-m94f.md
+++ b/.tickets/fcrw-m94f.md
@@ -1,0 +1,22 @@
+---
+id: fcrw-m94f
+status: in_progress
+deps: []
+links: []
+created: 2026-03-27T10:30:47Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [cli, release, wasm, ci]
+---
+# Fail CLI release packaging when parser WASM is missing
+
+The v0.4.0 CLI release tarball omitted dist/tree-sitter-satsuma.wasm, causing installed CLIs to fail immediately at startup with ENOENT. Tighten packaging so CI builds the parser WASM before packing and fails if required assets are missing.
+
+## Acceptance Criteria
+
+Release build generates tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm before packing the CLI
+CLI prebuild fails fast when required WASM assets are missing
+Packed satsuma-cli.tgz is verified to include dist/tree-sitter-satsuma.wasm and dist/web-tree-sitter.wasm
+Relevant CLI tests pass locally
+

--- a/.tickets/fcrw-m94f.md
+++ b/.tickets/fcrw-m94f.md
@@ -1,6 +1,6 @@
 ---
 id: fcrw-m94f
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-03-27T10:30:47Z
@@ -20,3 +20,10 @@ CLI prebuild fails fast when required WASM assets are missing
 Packed satsuma-cli.tgz is verified to include dist/tree-sitter-satsuma.wasm and dist/web-tree-sitter.wasm
 Relevant CLI tests pass locally
 
+
+## Notes
+
+**2026-03-27T10:33:09Z**
+
+Cause: The release workflow packed the CLI without first generating tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm, and the CLI prebuild step only warned when the asset was missing.
+Fix: Build the parser WASM in the release job, fail prebuild if required WASM assets are absent, and verify the packed tarball contains both WASM files before upload. (commit ba53173)

--- a/tooling/satsuma-cli/scripts/prebuild.js
+++ b/tooling/satsuma-cli/scripts/prebuild.js
@@ -60,6 +60,9 @@ for (const { src, dest, label } of wasmFiles) {
     copyFileSync(src, dest);
     console.log(`prebuild: copied ${label} → dist/`);
   } else {
-    console.warn(`prebuild: WARNING — ${label} not found at ${src}`);
+    throw new Error(
+      `prebuild: required ${label} not found at ${src}. ` +
+      "Build tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm before packaging the CLI.",
+    );
   }
 }

--- a/tooling/satsuma-cli/scripts/verify-pack.js
+++ b/tooling/satsuma-cli/scripts/verify-pack.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(__dirname, "..");
+const tarballPath = join(cliRoot, "satsuma-cli.tgz");
+
+if (!existsSync(tarballPath)) {
+  throw new Error(`verify-pack: tarball not found at ${tarballPath}`);
+}
+
+const contents = execFileSync("tar", ["-tzf", tarballPath], {
+  cwd: cliRoot,
+  encoding: "utf8",
+});
+
+const requiredEntries = [
+  "package/dist/index.js",
+  "package/dist/tree-sitter-satsuma.wasm",
+  "package/dist/web-tree-sitter.wasm",
+];
+
+for (const entry of requiredEntries) {
+  if (!contents.includes(`${entry}\n`) && !contents.endsWith(entry)) {
+    throw new Error(`verify-pack: required tarball entry missing: ${entry}`);
+  }
+}
+
+console.log("verify-pack: tarball contains CLI entrypoint and both WASM assets");


### PR DESCRIPTION
## Summary
- build the tree-sitter parser WASM in the CLI release job before packing
- fail CLI prebuild immediately when a required WASM asset is missing
- verify the packed tarball contains both WASM assets before upload

## Validation
- npm test (tooling/satsuma-cli)
- npm pack >/dev/null && mv -f satsuma-cli-*.tgz satsuma-cli.tgz && node scripts/verify-pack.js
- repo commit hooks (lint, CLI tests, VS Code extension tests, tree-sitter corpus, Python tests)

Closes fcrw-m94f.

Post-merge follow-up: retag and republish `v0.4.0` so the GitHub release asset is rebuilt with `dist/tree-sitter-satsuma.wasm` included.