### PR TITLE
chore(tickets): close 7 delivered tickets that were never marked done

### DIFF
--- a/.tickets/sl-661o.md
+++ b/.tickets/sl-661o.md
@@ -1,6 +1,6 @@
 ---
 id: sl-661o
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-26T17:33:44Z
@@ -21,3 +21,12 @@ Replace the CLI's native tree-sitter binding with web-tree-sitter (WASM) to elim
 - One universal satsuma-cli.tgz works on all platforms
 - No node-gyp or native binding deps remain
 
+
+## Notes
+
+**2026-03-27T10:40:15Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: CLI depended on native tree-sitter bindings requiring C compiler, blocking cross-platform distribution.
+Fix: All three child tasks completed — CLI rewritten to WASM (sl-75u3), native binding artifacts removed (sl-yn9m), release workflow simplified to single universal build (sl-l8sz). npm install no longer requires a C compiler; all tests pass on all platforms. (commits 79b0bba, 1bc0aca, 2664897)

--- a/.tickets/sl-75u3.md
+++ b/.tickets/sl-75u3.md
@@ -1,6 +1,6 @@
 ---
 id: sl-75u3
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-03-26T17:33:51Z
@@ -24,3 +24,12 @@ Core migration: rewrite src/parser.ts to use web-tree-sitter with async initPars
 - All 824+ CLI tests pass
 - parseFile() and parseSource() API unchanged
 
+
+## Notes
+
+**2026-03-27T10:39:57Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: CLI used native tree-sitter bindings requiring a C compiler, blocking cross-platform distribution.
+Fix: Rewrote parser.ts to use web-tree-sitter (WASM) with async initParser(); removed tree-sitter and tree-sitter-satsuma native deps from package.json; added WASM file copying in prebuild.js; updated index.ts with top-level await. (commit 79b0bba)

--- a/.tickets/sl-7btg.md
+++ b/.tickets/sl-7btg.md
@@ -1,6 +1,6 @@
 ---
 id: sl-7btg
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-23T09:55:53Z
@@ -15,3 +15,12 @@ tags: [feature-04, excel]
 
 excel_tool.py with survey, headers, formatting, range, lookup subcommands. Returns structured Markdown. Tested against 3+ diverse spreadsheet layouts. requirements.txt + venv bootstrap logic.
 
+
+## Notes
+
+**2026-03-27T10:40:31Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: No Python CLI tool existed for structured Excel interrogation needed by the skill.
+Fix: Created skills/excel-to-satsuma/scripts/excel_tool.py with all 5 subcommands (survey, headers, formatting, range, lookup), requirements.txt, and test_excel_tool.py. Returns structured Markdown. (commit 6960e18)

--- a/.tickets/sl-l8sz.md
+++ b/.tickets/sl-l8sz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-l8sz
-status: open
+status: closed
 deps: [sl-yn9m]
 links: []
 created: 2026-03-26T17:34:03Z
@@ -22,3 +22,12 @@ Consolidate the 4-platform release matrix to a single build that produces one un
 - CLAUDE.md updated to reflect WASM-only toolchain
 - No native compilation in release workflow
 
+
+## Notes
+
+**2026-03-27T10:40:09Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: Release workflow used a 4-platform matrix to build platform-specific native binaries; WASM migration made this unnecessary.
+Fix: Replaced 4-platform matrix with single universal build producing one satsuma-cli.tgz; updated install docs in README.md, site/cli.njk, and site/learn.njk to show one universal install command. (commit 2664897)

--- a/.tickets/sl-yn9m.md
+++ b/.tickets/sl-yn9m.md
@@ -1,6 +1,6 @@
 ---
 id: sl-yn9m
-status: open
+status: closed
 deps: [sl-75u3]
 links: []
 created: 2026-03-26T17:33:56Z
@@ -21,3 +21,12 @@ Remove node-addon-api and node-gyp-build from tree-sitter-satsuma/package.json d
 - CI install job simplified
 - tree-sitter corpus tests still pass
 
+
+## Notes
+
+**2026-03-27T10:40:04Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: tree-sitter-satsuma/package.json still listed node-addon-api and node-gyp-build as deps after CLI migrated to WASM, causing unnecessary native build attempts.
+Fix: Removed node-addon-api and node-gyp-build from tree-sitter-satsuma deps; replaced npm install script with a no-op echo; fixed install:all ordering so WASM build precedes CLI build. (commit 1bc0aca)

--- a/.tickets/sl-zftl.md
+++ b/.tickets/sl-zftl.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zftl
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-03-26T17:49:25Z
@@ -21,3 +21,12 @@ Audit npm dependencies across all package.json files (root, satsuma-cli, tree-si
 - Local tests pass on Node 24 (or failures documented as upstream issues)
 - package-lock.json files regenerated cleanly
 
+
+## Notes
+
+**2026-03-27T10:40:24Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: web-tree-sitter was on 0.25.x and some packages still had stale/native references after WASM migration.
+Fix: Bumped web-tree-sitter to 0.26.7 in CLI and VS Code server; fixed WASM runtime filename (tree-sitter.wasm → web-tree-sitter.wasm renamed in 0.26); removed last native tree-sitter reference in workspace.ts. Root package has 3 moderate vulns in markdownlint-cli2 via smol-toml — no fix without downgrade, acceptable for dev-only linting tool. All critical/high vulns resolved across all packages. (commit ff5c1f9)

--- a/.tickets/sl-zgam.md
+++ b/.tickets/sl-zgam.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zgam
-status: open
+status: closed
 deps: [sl-7btg]
 links: []
 created: 2026-03-23T09:55:53Z
@@ -15,3 +15,12 @@ tags: [feature-04, excel]
 
 Skill prompt at .claude/commands/excel-to-satsuma.md. Survey phase with user confirmation gate. Translate phase with chunked extraction. Critique phase with refinement loop. End-to-end test against 2+ spreadsheets.
 
+
+## Notes
+
+**2026-03-27T10:40:46Z**
+
+**2026-03-27T12:00:00Z**
+
+Cause: No Claude Code skill prompt existed for Excel-to-Satsuma conversion.
+Fix: Created skills/excel-to-satsuma/SKILL.md with full three-phase workflow (survey with confirmation gate, chunked translation, critique+refine loop) and .claude/commands/excel-to-satsuma.md as the invocable command. (commits db22327, 5f84879)


### PR DESCRIPTION
## Summary

Agents completed the WASM migration, Excel tooling, and dependency audit work but didn't commit `.tickets/` updates alongside their code — those status changes were lost. This PR syncs ticket state with what's actually been delivered and merged.

**Closed tickets:**
- `sl-75u3` — CLI parser.ts rewritten to web-tree-sitter (WASM) (commit 79b0bba)
- `sl-yn9m` — native binding artifacts removed from tree-sitter-satsuma (commit 1bc0aca)
- `sl-l8sz` — release workflow simplified to single universal CLI build (commit 2664897)
- `sl-661o` — WASM migration epic; all three children complete
- `sl-zftl` — dep audit done; 0 critical/high vulns across all packages; 3 moderate in markdownlint-cli2 (no fix without breaking downgrade, dev-only tool)
- `sl-7btg` — excel_tool.py with 5 subcommands delivered (commit 6960e18)
- `sl-zgam` — Excel-to-Satsuma Claude Code skill prompt delivered (commits db22327, 5f84879)

**Remaining open (genuinely not done):**
- `ser-29w1` — satsuma-core package extraction (no code change yet)
- `sl-u4lf` — LSP lineage code lens (not implemented)

## Test plan
- [ ] `tk list` shows only `ser-29w1` and `sl-u4lf` as open
- [ ] `tk ready` shows those two as the only actionable items
- [ ] No regression to existing code — this is `.tickets/` files only

🤖 Generated with [Claude Code](https://claude.com/claude-code)