### PR TITLE
chore(docs): improve AI agent reference and sync across repo

### DIFF
--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -1,25 +1,32 @@
 # Satsuma — AI Agent Reference
 
-## System Prompt Insert (~900 tokens total)
+## Portable Grammar & Conventions
 
-> Copy the sections below into your AI agent's system prompt to enable
-> reliable Satsuma generation and consumption.
+> Copy this section into any AI agent's system prompt to enable reliable
+> Satsuma generation and consumption. No CLI access required.
 
 ---
 
-### Grammar (compact EBNF, ~500 tokens)
+### Grammar (compact EBNF)
+
+This EBNF is intentionally **compact and approximate**. It is a mnemonic for
+generation, not a complete formal grammar for every NL-heavy construct.
 
 ```ebnf
+(* Undefined terminals — implementation-defined:
+   TYPE (e.g. INT, STRING, BOOLEAN, UUID, CHAR, VARCHAR, DECIMAL, DATE, TIMESTAMP)
+   value, params (comma-separated literals/identifiers)
+   NUMBER, ARITH (+, -, *, /), LETTER, DIGIT, ANY, TEXT_TO_EOL *)
+
 file             = { import_stmt | note_block | namespace | schema | fragment | transform | mapping | metric } ;
 
 import_stmt      = "import" "{" name_list "}" "from" STRING ;
-name_list        = name {"," name} ;
-name             = qualified_name | IDENT | BACKTICK_IDENT ;
-qualified_name   = IDENT "::" IDENT ;
+name_list        = name_ref {"," name_ref} ;
+name_ref         = label | label "::" label ;
 
 note_block       = "note" "{" (STRING | TRIPLESTRING) "}" ;
 
-namespace        = "namespace" IDENT ["(" metadata ")"] "{" namespace_body "}" ;
+namespace        = "namespace" label ["(" metadata ")"] "{" namespace_body "}" ;
 namespace_body   = { note_block | schema | fragment | transform | mapping | metric } ;
 
 schema           = "schema" label ["(" metadata ")"] "{" schema_body "}" ;
@@ -33,35 +40,36 @@ enum_items       = value {"," value} ;
 schema_body      = { field_decl | spread | COMMENT } ;
 field_decl       = (IDENT | BACKTICK_IDENT) [type_expr] ["(" metadata ")"] ["{" schema_body "}"] ;
 type_expr        = TYPE ["(" params ")"] | "record" | "list_of" TYPE ["(" params ")"] | "list_of" "record" ;
-spread           = "..." name ;
+spread           = "..." label ;
 
 transform        = "transform" label "{" transform_body "}" ;
-transform_body   = { STRING | pipe_step {"|" pipe_step} } ;
+transform_body   = spread | pipe_step {"|" pipe_step} ;
+(* A bare STRING is a valid pipe_step, so a single NL string is a valid transform body *)
 
 metric           = "metric" label [STRING] ["(" metric_meta ")"] "{" metric_body "}" ;
 metric_meta      = metric_entry {"," metric_entry} ;
-metric_entry     = "source" (namespaced_name | IDENT | "{" name_list "}") | "grain" IDENT
+metric_entry     = "source" (name_ref | "{" name_list "}") | "grain" IDENT
                  | "slice" "{" name_list "}" | "filter" STRING ;
 metric_body      = { field | note_block | COMMENT } ;
 
 mapping          = "mapping" [label] ["(" metadata ")"] "{" mapping_body "}" ;
 mapping_body     = { note_block | source_decl | target_decl | arrow | nested_arrow | each_block | flatten_block | COMMENT } ;
-source_decl      = "source" "{" ref_list "}" ;
-target_decl      = "target" "{" ref_list "}" ;
-ref_list         = { BACKTICK_IDENT | STRING } ;
+source_decl      = "source" "{" { source_item } "}" ;
+source_item      = name_ref ["(" metadata ")"] | STRING ;
+target_decl      = "target" "{" name_ref ["(" metadata ")"] "}" ;
 
-arrow            = source_paths "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
-source_paths     = [field_path {"," field_path}] ;
+arrow            = [source_paths] "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
+source_paths     = field_path {"," field_path} ;
 nested_arrow     = field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 each_block       = "each" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 flatten_block    = "flatten" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 
-pipe_step        = IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries "}" | STRING ;
+pipe_step        = spread | IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries "}" | STRING ;
 map_entries      = { map_key ":" value } ;
 map_key          = value | "<" NUMBER | "default" | "_" | "null" ;
 
-field_path       = namespaced_path | segment {"." segment} ;
-namespaced_path  = IDENT "::" segment {"." segment} ;
+field_path       = ["."] [label "::"] segment {"." segment} ;
+(* :: is ONLY namespace::schema. Fields use dot: namespace::schema.field.nested *)
 segment          = IDENT | BACKTICK_IDENT ;
 
 IDENT            = LETTER {LETTER | DIGIT | "_" | "-"} ;
@@ -73,140 +81,200 @@ COMMENT          = ("//" | "//!" | "//?") TEXT_TO_EOL ;
 
 ---
 
-### Cheat Sheet (~400 tokens)
+### Conventions & Rules
+
+The EBNF tells you *what parses*. This section tells you **how to use it well**.
 
 ```markdown
-# Satsuma Quick Reference
+# Satsuma Conventions
 
 ## Three delimiters, three jobs
 ( ) = metadata      { } = structural content      " " = natural language
 
-## Schema blocks
-schema <name> (<metadata>) {
-  field_name    TYPE           (tags)       // info
-  field_name    TYPE           (tags)       //! warning
-  field_name    TYPE           (tags)       //? todo
-  nested_obj record {
-    child       TYPE
-  }
-  repeated_items list_of record {
-    item        TYPE
-  }
-  scalar_tags list_of STRING (note "tag values")    // scalar list — no subfields
-  ...fragment_name
-}
+## Metadata tokens (in parens)
+pk, required, unique, indexed, pii, encrypt, encrypt AES-256-GCM,
+default val, enum {a, b, c}, format email, ref table.field,
+note "...", xpath "...", namespace prefix "uri", filter COND
 
-Metadata tokens (in parens):  pk, required, unique, indexed, pii, encrypt,
-  encrypt AES-256-GCM, default val, enum {a, b, c}, format email,
-  ref table.field, note "...", xpath "...", namespace prefix "uri", filter COND
+## Reserved keywords
+schema, fragment, mapping, transform, metric, note,
+source, target, import, from, record, list_of, each, flatten, namespace
 
-Reserved keywords: schema, fragment, mapping, transform, metric, note,
-  source, target, import, from, record, list_of, each, flatten, namespace
+## Naming convention
+Prefer lowercase snake_case for schemas, namespaces, and fields.
+This avoids backtick quoting: `order_headers` not `order-headers`.
+Backticks are only needed when a name contains characters outside [a-z0-9_-]:
+  schema `order-headers` { ... }       // kebab-case — needs backticks
+  source { `raw::crm-contacts` }       // backtick the unsafe segment only
 
-## Namespace blocks
-namespace <name> (<metadata>) {
-  schema ...
-  mapping ...
-  // any top-level block except import and other namespaces
-}
+## Path syntax — :: vs .
+:: separates namespace from schema. . separates schema from field.
+Never use :: to join schema to field. Namespaces are optional.
+  namespace::schema                      // schema in a namespace
+  namespace::schema.field                // field on a namespaced schema
+  namespace::schema.field.nested_child   // nested record field
+  schema.field                           // field (no namespace)
+  .field                                 // relative field inside each/flatten
 
-Cross-namespace references use :: syntax:
-  source { `ns::schema_ref` }          // in mapping source/target
-  source ns::schema_name               // in metric metadata
-  import { ns::name } from "file.stm"  // in imports
+Cross-namespace references:
+  source { raw::customers }
+  target { mart::dim_customer }
+  import { raw::customers, mart::dim_customer } from "platform.stm"
+  metric mrr (source raw::orders, grain monthly) { ... }
 
-## Mapping blocks
-mapping <name> (<metadata>) {
-  source { `schema_ref` }
-  target { `schema_ref` }
-
-  src -> tgt                                 // direct
-  src -> tgt { transform }                   // with transform
-  src -> tgt { trim | lowercase }            // pipeline
-  src -> tgt { "Derive from @src using NL" }  // natural language with @ref
-  src1, src2 -> tgt { "multi-source" }       // multiple sources
-  -> tgt { "computed, no source" }           // derived field
-  -> tgt { now_utc() }                       // function
-
-  Transforms (combine with | inside { }):
-    trim, lowercase, uppercase, title_case, null_if_empty, null_if_invalid
-    drop_if_invalid, drop_if_null, warn_if_invalid, warn_if_null
-    error_if_invalid, error_if_null
-    coalesce(val), round(n), truncate(n), max_length(n)
-    prepend("x"), append("x"), split("x") | first | last
-    validate_email, to_e164, to_iso8601, to_utc, now_utc()
-    pad_left(n, c), pad_right(n, c), replace(old, new), escape_html
-    to_string, to_number, to_boolean, uuid_v5(ns, name)
-    encrypt(algo, key), hash(algo), parse(fmt)
-    * N, / N, + N, - N
-    map { src: "tgt", null: "default", _: "fallback" }
-    map { < 1000: "low", < 5000: "mid", default: "high" }
-    "NL description — use @field_name for refs"
-
-  Array mapping:
-  each src_arr -> tgt_arr {
-    .child -> .child { transform }
+## Source blocks — not just schema names
+  source {
+    schema_ref
+    other_source (filter "status = completed")
+    "Join @schema_ref to @other_source on @customer_id = @customer_id"
   }
 
-  Flattening a list:
-  flatten src.list_field -> flat_target {
-    .child -> .child { transform }
-  }
-}
+## Transform catalog (combine with | inside { })
+  ...named_transform
+  trim, lowercase, uppercase, title_case, null_if_empty, null_if_invalid
+  drop_if_invalid, drop_if_null, warn_if_invalid, warn_if_null
+  error_if_invalid, error_if_null
+  coalesce(val), round(n), truncate(n), max_length(n)
+  prepend("x"), append("x"), split("x") | first | last
+  validate_email, to_e164, to_iso8601, to_utc, now_utc()
+  pad_left(n, c), pad_right(n, c), replace(old, new), escape_html
+  to_string, to_number, to_boolean, uuid_v5(ns, name)
+  encrypt(algo, key), hash(algo), parse(fmt)
+  * N, / N, + N, - N
+  map { src: "tgt", null: "default", _: "fallback" }
+  map { < 1000: "low", < 5000: "mid", default: "high" }
+  "NL description — use @field_name for refs"
 
-## Reusability
-fragment <name> { fields... }              (spread with ...name)
-transform <name> { pipeline or NL... }     (spread with ...name)
-import { name1, name2 } from "file.stm"
-import { ns::name1, ns::name2 } from "other.stm"  // namespace-qualified
-
-## Metric blocks
-metric <name> ["display label"] (<metric_meta>) {
-  measure_field  TYPE  (measure additive)
-  measure_field  TYPE  (measure non_additive)
-  measure_field  TYPE  (measure semi_additive)
-  note { "..." }
-}
-
-Metric metadata tokens (in parens):
-  source schema_name | source ns::schema_name | source {schema_a, schema_b}
-  grain monthly | grain daily | grain weekly
-  slice {dim_a, dim_b, dim_c}
-  filter "sql_condition"
-
-Measure addivity:  additive (sum across all dims)
-                   non_additive (ratios, averages — never sum)
-                   semi_additive (sum across some dims only, e.g. balances)
-
-Rules:
+## Metric rules
   - Metrics are terminal nodes: nothing flows *out* of a metric
   - Do NOT use a metric as source/target in a mapping block
   - Complex computation logic goes in note { } as natural language
+  - Measure additivity: additive (sum all dims), non_additive (never sum),
+    semi_additive (sum across some dims only, e.g. balances)
 
-## Notes & Comments
-note { "standalone documentation block" }
-note { """multiline **Markdown** content""" }
-(note "inline on a field or schema")       // in metadata parens
-// info   //! warning   //? question/todo
+## Consumer conventions
+Reports and ML models are consumer schemas, not new block types:
+  schema customer_dashboard (report, source {fact_orders, dim_customer}, tool looker) { ... }
+  schema churn_model (model, source {training_set}) { ... }
 
-## @ref in NL Strings (IMPORTANT)
+## @ref in NL strings (CRITICAL)
 ALWAYS use @ref for field and schema names inside "..." NL strings:
   -> total { "Sum @line_amount grouped by @order_id" }
   (note "Derived from @customer.email after dedup")
+  "Join @crm_customers to @orders on @crm_customers.customer_id = @orders.customer_id"
 This is NOT optional — tooling extracts @ref references for
 deterministic lineage tracing. Bare names in NL are invisible to tools.
 
-Backtick only segments with special characters:
+Backtick only the unsafe segments:
   "Look up @`order-headers`.status in the dim table"
+  "Join @raw::`crm-contacts`.`customer-id` to @mart::dim_customer.customer_id"
 @ref schemas are structural sources; lint --fix auto-adds undeclared
 @ref schemas to the mapping source list.
+
+## Comments
+// info   //! warning   //? question/todo
+(note "inline on a field or schema")  // in metadata parens
+note { "standalone block" }           // top-level or in namespace
+note { """multiline **Markdown**""" } // triple-quoted
+```
+
+---
+
+### Common mistakes
+
+These are mistakes agents make *despite* having the grammar — non-obvious
+pitfalls that the EBNF alone doesn't prevent.
+
+| Mistake | Correct approach |
+| --- | --- |
+| Using `::` between schema and field (e.g. `schema::field`) | `::` is namespace-to-schema only. Use `.` for fields: `ns::schema.field.nested` |
+| Using `source`/`target`/`table` as schema keywords | Use `schema` for all — role is contextual from mapping context |
+| Using `STRUCT { }` / `ARRAY { }` for nesting | Use `name record { }` / `name list_of record { }` |
+| Using `[]` in mapping paths for array access | Use `each src -> tgt { }` for iteration, dot paths for field access |
+| Using `(flatten \`list\`)` metadata on mappings | Use `flatten src.list -> tgt { }` block syntax inside mapping body |
+| Repeating schema IDs in paths inside implicit mapping blocks | Bare names resolve to source (left) and target (right) |
+| Using `schema` for a business metric | Use `metric` — it signals a terminal node to lineage tooling |
+| Using a `metric` as a mapping source or target | Metrics are consumers only; reference the underlying `schema` instead |
+| Using `report` / `model` as block keywords | Use `schema name (report, ...) { }` or `schema name (model, ...) { }` |
+| Summing a `non_additive` measure across dimensions | Use weighted average or re-aggregate from grain; only `additive` measures can be summed |
+| Writing field names bare in NL strings | Use `@ref` — e.g. `"Sum @order_total grouped by @customer_id"` |
+| Backticking an entire `@ref` path | Backtick only the unsafe segment(s): `@raw::\`crm-contacts\`.\`customer-id\`` |
+| Referencing a schema in NL without declaring it | `@ref` schemas must be in the mapping's `source { }` block |
+
+---
+
+### Example: Minimal 1:1 mapping
+
+```satsuma
+note { "Customer sync — 1:1 mapping from CRM to data warehouse" }
+
+schema crm (note "CRM System") {
+  id       INT           (pk)
+  name     STRING(200)
+  email    STRING(255)   (pii)
+  status   CHAR(1)       (enum {A, I})
+}
+
+schema warehouse (note "Data Warehouse") {
+  customer_id   UUID        (pk, required)
+  display_name  STRING(200) (required)
+  email_address STRING(255) (format email)
+  is_active     BOOLEAN
+}
+
+mapping {
+  source { crm }
+  target { warehouse }
+
+  id     -> customer_id   { uuid_v5("namespace", id) }
+  name   -> display_name  { trim | title_case }
+  email  -> email_address { trim | lowercase | validate_email | null_if_invalid }
+  status -> is_active     { map { A: true, I: false } }
+}
+```
+
+---
+
+### Example: Converting an Excel mapping row to Satsuma
+
+**Excel row:**
+
+| Source Field | Source Type | Target Field | Target Type | Transformation | Notes |
+| --- | --- | --- | --- | --- | --- |
+| CUST_TYPE | CHAR(1) | customer_type | VARCHAR(20) | R=Retail, B=Business, G=Government. If null, default to Retail | Some records have null values |
+
+**Satsuma equivalent:**
+
+```satsuma
+schema legacy_customer {
+  CUST_TYPE  CHAR(1)  (enum {R, B, G})  //! Some records have NULL
+}
+
+schema customer_dim {
+  customer_type  VARCHAR(20)  (enum {retail, business, government}, required)
+}
+
+mapping {
+  source { legacy_customer }
+  target { customer_dim }
+
+  CUST_TYPE -> customer_type {
+    map {
+      R: "retail"
+      B: "business"
+      G: "government"
+      null: "retail"
+    }
+  }
+}
 ```
 
 ---
 
 ## Satsuma CLI — Agent Tooling
 
-> **Tip:** This document is baked into the CLI itself. Run `satsuma agent-reference` to print it — useful for piping into an agent's instructions file or system prompt.
+> **Include this section only when the agent has access to the `satsuma` CLI.**
+> Run `satsuma agent-reference` to print this entire document.
 
 The `satsuma` CLI is a deterministic structural extraction tool. It extracts facts from parse trees and delivers NL content verbatim. **It does not interpret natural language — that is your job.** The CLI is the toolkit. You are the runtime.
 
@@ -228,13 +296,14 @@ satsuma context "customer mapping"           # keyword-ranked block extraction (
 
 # Structural primitives — slice below block level
 satsuma arrows loyalty_sfdc.LoyaltyTier      # all arrows involving this field + classification
-satsuma nl "demographics to mart"               # NL content in a mapping
+satsuma nl "demographics to mart"            # NL content in a mapping
 satsuma nl mart_customer_360.email            # NL content on a specific field
 satsuma nl all path/to/workspace/             # all NL across the workspace
 satsuma meta loyalty_sfdc.Email              # metadata entries (tags, type, constraints)
 satsuma fields sat_customer_demographics     # field list with types
 satsuma fields mart_customer_360 --unmapped-by 'demographics to mart'  # fields with no arrows
 satsuma match-fields --source loyalty_sfdc --target sat_customer_demographics  # name comparison
+satsuma nl-refs path/to/workspace/ --json    # extract @ref/backtick references from NL text
 
 # Workspace graph — full topology in one call
 satsuma graph path/to/workspace/ --json      # complete semantic graph (nodes, edges, field-level flow)
@@ -263,14 +332,14 @@ satsuma diff v1/ v2/                         # structural comparison of two snap
 Every arrow the CLI returns carries a classification from CST node types:
 
 | Marker | Meaning | Your responsibility |
-|---|---|---|
+| --- | --- | --- |
 | `[structural]` | Deterministic pipeline | None — fully specified |
 | `[nl]` | NL string — extracted verbatim | Read it, interpret intent, judge correctness |
 | `[mixed]` | Both pipeline steps and NL | Review the NL portion |
 | `[none]` | Bare `src -> tgt`, no transform | None |
 | `[nl-derived]` | Implicit arrow from NL `@ref` | Synthetic — verify the referenced field exists |
 
-### How you compose workflows
+### Composing workflows
 
 **Whole-workspace reasoning:** Call `satsuma graph path/ --json` to load the entire workspace topology in one call — nodes (schemas, mappings, metrics, fragments, transforms), field-level edges with transform classification, and schema-level topology. Use `--schema-only` for topology-only queries, `--namespace <ns>` to scope, `--no-nl` to reduce payload size. The `unresolved_nl` section lists all NL arrows requiring interpretation.
 
@@ -280,18 +349,19 @@ Every arrow the CLI returns carries a classification from CST node types:
 
 **PII audit:** Call `satsuma find --tag pii --json`, then `satsuma arrows` for each tagged field, recurse downstream. At `[nl]` hops, read the NL to judge whether PII survives the transform.
 
-**Drafting a mapping:** Call `satsuma match-fields` for deterministic name matches. Call `satsuma nl` on both schemas to read field notes. Apply your own judgment for non-obvious matches and transforms.
+**Drafting a mapping:** Call `satsuma match-fields` for deterministic name matches. Call `satsuma nl` on both schemas to read field notes. For multi-source work, describe joins/filters in the `source { }` block with `@ref`s. Apply your own judgment for non-obvious matches and transforms.
 
 **Reviewing a change:** Call `satsuma diff` for the structural delta. Call `satsuma arrows` for affected fields. Call `satsuma nl` to read NL content on changed arrows.
 
 ### When to use the CLI vs. reading files
 
 | Situation | Approach |
-|---|---|
+| --- | --- |
 | Need full workspace topology in one call | `satsuma graph --json` — all nodes, edges, and field-level flow |
 | Need to understand a workspace | `satsuma summary`, then drill with `satsuma schema` / `satsuma mapping` |
 | Need arrows for a specific field | `satsuma arrows <schema.field>` — not reading the whole mapping |
 | Need NL content for interpretation | `satsuma nl <scope>` — not pulling the entire block |
+| Need extracted refs inside NL text | `satsuma nl-refs` — inspect `@ref` usage without rereading whole files |
 | Need metadata on a field | `satsuma meta <schema.field>` — not parsing raw text |
 | Need to check which fields lack arrows | `satsuma fields <schema> --unmapped-by <mapping>` |
 | Need to validate after editing | `satsuma validate` for correctness, `satsuma lint` for conventions |
@@ -311,113 +381,31 @@ When reporting results to humans, be transparent about which parts of your analy
 ### When generating Satsuma from a description or spreadsheet:
 
 1. If source and target schemas already exist, run `satsuma match-fields --source <s> --target <t>` to find deterministic name matches, then `satsuma nl <s>` and `satsuma nl <t>` to read field notes for context
-2. Start with a `note { }` block describing the integration context
-3. Define `schema` blocks with all fields, types, and metadata
-4. Add `fragment` blocks if you have reusable field sets
-5. Write the `mapping { }` block with source/target refs and all arrows
-6. Use `"natural language"` in `{ }` for any transform you can't express as a pipeline — use `@ref` for any field or schema names referenced inside the NL string (e.g. `"Sum @amount grouped by @customer_id"`)
-7. Add `//!` warnings for known data quality issues
-8. Add `//?` for any open questions or ambiguities
-9. Add `(note "...")` metadata for persistent field-level documentation
-10. Run `satsuma fmt` to apply canonical formatting
-11. Run `satsuma validate` to check for parse errors and semantic issues
-12. Run `satsuma lint` to check for policy/convention issues; use `--fix` to auto-correct fixable ones
-13. Run `satsuma fields <target> --unmapped-by <mapping>` to check which target fields you haven't covered
+2. Preserve existing namespace/import structure if the workspace already uses it; don't collapse namespaced definitions back to flat global names
+3. Start with a `note { }` block if integration context, assumptions, or join strategy need durable documentation
+4. Define `schema` blocks with all fields, types, and metadata
+5. Add `fragment` blocks if you have reusable field sets
+6. Use `metric` for business KPIs; use `(report)` / `(model)` metadata on `schema` for downstream consumer artifacts
+7. Write the `mapping { }` block with source/target refs and all arrows
+8. For multi-source mappings, put structural sources plus source-level filters in `source { }`, and describe joins in an NL string with `@ref`s
+9. Use `"natural language"` in `{ }` for any transform you can't express as a pipeline — use `@ref` for any field or schema names referenced inside the NL string (e.g. `"Sum @amount grouped by @customer_id"`)
+10. Add `//!` warnings for known data quality issues
+11. Add `//?` for any open questions or ambiguities
+12. Add `(note "...")` metadata for persistent field-level documentation
+13. Run `satsuma fmt` to apply canonical formatting
+14. Run `satsuma validate` to check for parse errors and semantic issues
+15. Run `satsuma lint` to check for policy/convention issues; use `--fix` to auto-correct fixable ones
+16. Run `satsuma fields <target> --unmapped-by <mapping>` to check which target fields you haven't covered
 
 ### When reading/interpreting Satsuma:
 
 1. Run `satsuma summary` to understand the workspace scope before reading individual files
 2. Use `satsuma schema <name>` and `satsuma mapping <name>` to inspect specific blocks
 3. Use `satsuma arrows <schema.field>` to trace specific fields through mappings — don't search manually
-4. Use `satsuma nl <scope>` to read NL content you need to interpret
-5. `src -> tgt` means source-to-target; `-> tgt` (no left side) means computed/derived
-6. Transform content is in `{ }` after the arrow — pipelines read left-to-right
-7. `"..."` strings in transforms are natural language intent — interpret and implement
-8. `//!` comments are warnings about data quality or known issues — also visible via `satsuma warnings`
-9. `note { }` blocks contain rich documentation
-
-### Common mistakes to avoid:
-
-| Mistake | Correct approach |
-|---|---|
-| Using `[tags]` bracket syntax | Use `(tags)` parentheses for metadata |
-| Using `source`/`target`/`table` as schema keywords | Use `schema` for all — role is contextual |
-| Using `@annotation(...)` syntax | Use `(key value)` in metadata parens |
-| Using `: transform` after arrow | Use `{ transform }` in braces after arrow |
-| Using `nl("...")` function | Use bare `"..."` strings in `{ }` — NL is first-class |
-| Using `note '''...'''` triple single-quotes | Use `(note "...")` or `note { """...""" }` |
-| Using `=> target` for computed fields | Use `-> target` with no left side |
-| Using `STRUCT { }` / `ARRAY { }` for nesting | Use `Name record { }` / `Name list_of record { }` |
-| Using `when/else` conditionals | Use `map { }` with conditions or NL strings |
-| Forgetting to declare arrays with `list_of` | Use `Name list_of record { }` for repeated structures, `Name list_of TYPE` for scalar lists |
-| Using `[]` in mapping paths | Use `each src -> tgt { }` for iteration, dot paths for field access |
-| Using `(flatten \`list\`)` metadata on mappings | Use `flatten src.list -> tgt { }` block syntax inside mapping body |
-| Repeating schema IDs in paths inside implicit mapping blocks | Bare names resolve to source (left) and target (right) |
-| Using `schema` for a business metric | Use `metric` — it signals a terminal node to lineage tooling |
-| Using a `metric` as a mapping source or target | Metrics are consumers only; reference the underlying `schema` instead |
-| Summing a `non_additive` measure across dimensions | Use weighted average or re-aggregate from grain; only `additive` measures can be summed |
-| Using `'single quotes'` for labels | Use `` `backtick quotes` `` — single quotes are not supported |
-| Writing field names bare in NL strings | Use `@ref` for field/schema references inside `"..."` strings — e.g. `"Sum @order_total grouped by @customer_id"`. This enables deterministic extraction by tooling. |
-| Referencing a schema in NL without declaring it | `@ref` schemas in NL text must be in the mapping's `source { }` block. Use `satsuma lint --fix` to auto-add undeclared refs. |
-
----
-
-## Example: Minimal 1:1 mapping
-
-```satsuma
-note { "Customer sync — 1:1 mapping from CRM to data warehouse" }
-
-schema crm (note "CRM System") {
-  id       INT           (pk)
-  name     STRING(200)
-  email    STRING(255)   (pii)
-  status   CHAR(1)       (enum {A, I})
-}
-
-schema warehouse (note "Data Warehouse") {
-  customer_id   UUID        (pk, required)
-  display_name  STRING(200) (required)
-  email_address STRING(255) (format email)
-  is_active     BOOLEAN
-}
-
-mapping {
-  source { `crm` }
-  target { `warehouse` }
-
-  id     -> customer_id   { uuid_v5("namespace", id) }
-  name   -> display_name  { trim | title_case }
-  email  -> email_address { trim | lowercase | validate_email | null_if_invalid }
-  status -> is_active     { map { A: true, I: false } }
-}
-```
-
----
-
-## Example: Converting an Excel mapping row to Satsuma
-
-**Excel row:**
-
-| Source Field | Source Type | Target Field | Target Type | Transformation | Notes |
-|---|---|---|---|---|---|
-| CUST_TYPE | CHAR(1) | customer_type | VARCHAR(20) | R=Retail, B=Business, G=Government. If null, default to Retail | Some records have null values |
-
-**Satsuma equivalent:**
-
-```satsuma
-// In source schema:
-  CUST_TYPE    CHAR(1)    (enum {R, B, G})    //! Some records have NULL
-
-// In target schema:
-  customer_type VARCHAR(20) (enum {retail, business, government}, required)
-
-// In mapping block:
-CUST_TYPE -> customer_type {
-  map {
-    R: "retail"
-    B: "business"
-    G: "government"
-    null: "retail"
-  }
-}
-```
+4. Use `satsuma nl <scope>` and `satsuma nl-refs` to read NL content and inspect extracted `@ref`s
+5. `src -> tgt` means source-to-target; `a, b -> tgt` means multi-source; `-> tgt` (no left side) means computed/derived
+6. Transform content is in `{ }` after the arrow — pipelines read left-to-right, and `...name` spreads a named transform
+7. Mapping `source { }` blocks may contain source-level filters and NL join descriptions, not just schema names
+8. `"..."` strings in transforms are natural language intent — interpret them, but keep structural facts separate from your interpretation
+9. `//!` comments are warnings about data quality or known issues — also visible via `satsuma warnings`
+10. `note { }` blocks contain rich documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,7 @@ First tagged release of the Satsuma language and toolchain.
   CRM-to-warehouse syncs, EDI/COBOL/XML/Protobuf format conversion, multi-source
   joins, metric definitions, namespace-based platform modelling, and governance
   filters.
-- **AI agent reference** — a compact (~900 token) grammar summary designed for
+- **AI agent reference** — a compact grammar and conventions summary designed for
   LLM prompts, also available via `satsuma agent-reference`.
 
 ### Tree-Sitter Parser

--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -16,7 +16,7 @@ Read the [Data Engineer Tutorial](docs/tutorials/data-engineer-tutorial.md) — 
 Read the [Integration Engineer Tutorial](docs/tutorials/integration-engineer-tutorial.md) — covers using Satsuma for ESBs, APIs, message queues, and iPaaS platforms.
 
 **How do I look up the full syntax?**
-Read the [language specification](SATSUMA-V2-SPEC.md). For a compact cheat sheet, see [AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md) or run `satsuma agent-reference`.
+Read the [language specification](SATSUMA-V2-SPEC.md). For a compact reference, see [AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md) or run `satsuma agent-reference`.
 
 **How do I see working examples?**
 Browse [examples/](examples/) — each `.stm` file is a self-contained, parser-validated example.

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ satsuma lineage --from legacy_sqlserver examples/   # trace data flow
 To set up an AI agent, print the built-in reference:
 
 ```bash
-satsuma agent-reference               # print grammar, cheat sheet, and CLI guide
+satsuma agent-reference               # print grammar, conventions, and CLI guide
 satsuma agent-reference > .github/copilot-instructions.md   # feed to Copilot
 ```
 

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -66,7 +66,7 @@ The `schema_edges` array includes edges with roles: `source`, `target`, `metric_
 
 | Command | Operation | Example |
 |---|---|---|
-| `agent-reference` | Print the AI Agent Reference — grammar, cheat sheet, CLI guide, and workflow patterns | `satsuma agent-reference` |
+| `agent-reference` | Print the AI Agent Reference — grammar, conventions, CLI guide, and workflow patterns | `satsuma agent-reference` |
 
 Pipe the output into your agent's instructions file (e.g., `satsuma agent-reference > .github/copilot-instructions.md`) or paste it into a conversation. The content is baked into the CLI at build time from `AI-AGENT-REFERENCE.md`.
 

--- a/docs/using-satsuma-without-cli.md
+++ b/docs/using-satsuma-without-cli.md
@@ -50,8 +50,9 @@ and you can do that with any text editor and any LLM.
 
 Paste the compact grammar from
 [AI-AGENT-REFERENCE.md](../AI-AGENT-REFERENCE.md) into your system prompt or as
-the first message. It is roughly 900 tokens — small enough for any model. This
-gives the LLM the full syntax so it can generate and interpret Satsuma correctly.
+the first message. The portable grammar and conventions section is small enough
+for any model's context window. This gives the LLM the full syntax so it can
+generate and interpret Satsuma correctly.
 
 If you are using a web LLM with file upload, you can upload
 `AI-AGENT-REFERENCE.md` directly instead of pasting.

--- a/features/04-excel-to-stm-skill/PRD.md
+++ b/features/04-excel-to-stm-skill/PRD.md
@@ -90,13 +90,13 @@ The file is structured as a system prompt with these sections:
 
 You are a Satsuma conversion specialist. The user will upload an Excel spreadsheet containing source-to-target data mapping definitions. Your job is to convert it into well-formed, idiomatic Satsuma files.
 
-#### 2. Satsuma Grammar — compact EBNF (~500 tokens)
+#### 2. Satsuma Grammar — compact EBNF
 
 Inlined verbatim from `AI-AGENT-REFERENCE.md` grammar section.
 
-#### 3. Satsuma Quick Reference / Cheat Sheet (~400 tokens)
+#### 3. Satsuma Conventions & Rules
 
-Inlined verbatim from `AI-AGENT-REFERENCE.md` cheat sheet section. Covers schema blocks, mapping blocks, transforms, tags, annotations, and other constructs.
+Inlined verbatim from `AI-AGENT-REFERENCE.md` conventions section. Covers metadata tokens, backtick quoting, namespace references, transforms, metric rules, consumer conventions, `@ref` usage, and comments.
 
 #### 4. Generation Workflow (~300 tokens)
 
@@ -332,7 +332,7 @@ Use `--no-confirm` to skip this gate (e.g., for scripted usage).
 ### Phase 2: Translate
 
 The Translate phase works from the confirmed discovery report. It loads Satsuma knowledge by reading:
-- `AI-AGENT-REFERENCE.md` — compact grammar + cheat sheet (~900 tokens)
+- `AI-AGENT-REFERENCE.md` — compact grammar + conventions reference
 - 1–2 canonical examples from `examples/` appropriate to the mapping's cardinality and complexity
 
 It does **not** receive raw Excel data upfront. When it needs specific cell values, it requests targeted ranges via `excel_tool.py range`.

--- a/lessons/01-what-is-satsuma.md
+++ b/lessons/01-what-is-satsuma.md
@@ -173,13 +173,13 @@ That is enough to ground the rest of the course. The agent becomes an accelerato
 
 ## Setting Up Your AI Agent
 
-Before you start working with Satsuma, you need to teach your AI agent about the language and the CLI. Satsuma ships with a built-in command that outputs everything an agent needs — the grammar, a cheat sheet, CLI command reference, and workflow guidance:
+Before you start working with Satsuma, you need to teach your AI agent about the language and the CLI. Satsuma ships with a built-in command that outputs everything an agent needs — the grammar, conventions, CLI command reference, and workflow guidance:
 
 ```bash
 satsuma agent-reference
 ```
 
-This prints a compact reference document (~900 tokens of grammar + ~400 tokens of cheat sheet + CLI reference) designed to fit in an agent's system prompt or context window. How you use it depends on your agent:
+This prints a compact reference document (EBNF grammar + conventions + CLI reference) designed to fit in an agent's system prompt or context window. How you use it depends on your agent:
 
 ### GitHub Copilot (VS Code)
 

--- a/lessons/README.md
+++ b/lessons/README.md
@@ -104,7 +104,7 @@ Teaches learners how to approach an unfamiliar Satsuma file without becoming syn
 
 Shows how a human can provide spreadsheets, API docs, sample payloads, or database extracts and have the agent draft valid schema blocks. The lesson teaches what information the agent needs, how to review field names/types/metadata, and when to preserve ambiguity as a note instead of forcing false precision.
 
-It explicitly includes the Lite Excel-import workflow from [features/04-excel-to-stm-skill/excel-to-stm-prompt.md](../features/04-excel-to-stm-skill/excel-to-stm-prompt.md): survey the workbook, identify tab roles and column roles, generate Satsuma, then self-critique for coverage, types, and transform fidelity before the human approves the result.
+It explicitly includes the Lite Excel-import workflow from [useful-prompts/excel-to-stm-prompt.md](../useful-prompts/excel-to-stm-prompt.md): survey the workbook, identify tab roles and column roles, generate Satsuma, then self-critique for coverage, types, and transform fidelity before the human approves the result.
 
 **Covers:** drafting `schema` blocks from source materials, using metadata like `pk`, `required`, `pii`, `enum`, `format`, capturing caveats in `note`, choosing when to use quoted NL instead of invented pseudo-logic, review prompts for correcting agent-generated schemas, Excel-to-Satsuma with the workbook-survey -> column-role-detection -> generation -> self-critique approach.
 

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -84,7 +84,7 @@ permalink: cli.html
         </div>
         <h2 class="text-3xl font-bold text-charcoal mb-3">Teach your agent Satsuma in 30 seconds</h2>
         <p class="text-warm-gray mb-8">
-          <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">satsuma agent-reference</code> prints a compact ~900-token prompt that teaches any AI agent the Satsuma grammar, the CLI commands, and the recommended workflow patterns. Append it to your agent's instructions file and you're done.
+          <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">satsuma agent-reference</code> prints a compact prompt that teaches any AI agent the Satsuma grammar, the CLI commands, and the recommended workflow patterns. Append it to your agent's instructions file and you're done.
         </p>
 
         <div class="bg-cream rounded-2xl p-6 border border-charcoal/5 mb-6">
@@ -113,7 +113,7 @@ permalink: cli.html
 
         <div class="bg-cream rounded-2xl p-6 border border-charcoal/5">
           <h3 class="text-lg font-bold text-charcoal mb-2">What the agent gets</h3>
-          <p class="text-sm text-warm-gray mb-4">In ~900 tokens, the reference covers:</p>
+          <p class="text-sm text-warm-gray mb-4">The reference covers:</p>
           <div class="grid sm:grid-cols-2 gap-3">
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
@@ -788,7 +788,7 @@ permalink: cli.html
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
           <div class="bg-white rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">agent-reference</h4>
-            <p class="text-xs text-warm-gray">Print the ~900-token AI Agent Reference for embedding in agent instructions.</p>
+            <p class="text-xs text-warm-gray">Print the AI Agent Reference for embedding in agent instructions.</p>
           </div>
         </div>
       </div>

--- a/site/index.njk
+++ b/site/index.njk
@@ -497,7 +497,7 @@ permalink: index.html
             </div>
             <div class="flex items-start gap-3 text-warm-gray">
               <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-              <span><strong class="text-charcoal">Works with any LLM</strong> &mdash; paste the ~900-token grammar reference into ChatGPT, Gemini, or Claude.ai and start writing specs.</span>
+              <span><strong class="text-charcoal">Works with any LLM</strong> &mdash; paste the compact grammar reference into ChatGPT, Gemini, or Claude.ai and start writing specs.</span>
             </div>
             <div class="flex items-start gap-3 text-warm-gray">
               <svg class="w-5 h-5 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
@@ -589,7 +589,7 @@ permalink: index.html
             <svg class="w-5 h-5 text-warm-gray flex-shrink-0 transition-transform group-open:rotate-45" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v12m6-6H6"/></svg>
           </summary>
           <div class="px-6 pb-5 text-warm-gray leading-relaxed">
-            <p>You can still get real value. Satsuma files are plain text &mdash; write them in any editor and version them in Git. For AI assistance, paste the compact grammar reference (~900 tokens) into any web LLM like ChatGPT, Gemini, or Claude.ai. That's enough for the model to generate, review, and explain Satsuma specs. No CLI, no VS Code, no agent required. Read the <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/using-satsuma-without-cli.md" target="_blank" rel="noopener" class="text-orange hover:underline">full guide</a> for workflows and tips.</p>
+            <p>You can still get real value. Satsuma files are plain text &mdash; write them in any editor and version them in Git. For AI assistance, paste the compact grammar reference into any web LLM like ChatGPT, Gemini, or Claude.ai. That's enough for the model to generate, review, and explain Satsuma specs. No CLI, no VS Code, no agent required. Read the <a href="https://github.com/thorbenlouw/satsuma-lang/blob/main/docs/using-satsuma-without-cli.md" target="_blank" rel="noopener" class="text-orange hover:underline">full guide</a> for workflows and tips.</p>
           </div>
         </details>
 

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -371,7 +371,7 @@ code --install-extension vscode-satsuma.vsix</code></pre>
                 Key Features
               </h4>
               <ul class="space-y-1.5 text-sm text-warm-gray">
-                <li class="flex items-center gap-2"><span class="w-1.5 h-1.5 bg-charcoal rounded-full flex-shrink-0"></span> Compact EBNF grammar (~500 tokens)</li>
+                <li class="flex items-center gap-2"><span class="w-1.5 h-1.5 bg-charcoal rounded-full flex-shrink-0"></span> Compact EBNF grammar</li>
                 <li class="flex items-center gap-2"><span class="w-1.5 h-1.5 bg-charcoal rounded-full flex-shrink-0"></span> Deterministic parsing via tree-sitter</li>
                 <li class="flex items-center gap-2"><span class="w-1.5 h-1.5 bg-charcoal rounded-full flex-shrink-0"></span> Validation-in-the-loop workflows</li>
                 <li class="flex items-center gap-2"><span class="w-1.5 h-1.5 bg-charcoal rounded-full flex-shrink-0"></span> LLMs generate valid Satsuma &gt;90%</li>

--- a/skills/excel-to-satsuma/SKILL.md
+++ b/skills/excel-to-satsuma/SKILL.md
@@ -120,14 +120,9 @@ If `--dry-run` was specified, stop here after writing the discovery report.
 
 ### Load Satsuma Knowledge
 
-Read these files (use the Read tool):
-- `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
-- Pick 1-2 example files from `examples/` that match the mapping's complexity:
-  - Simple 1:1: `examples/sfdc_to_snowflake.stm`
-  - Multi-source: `examples/multi-source-join.stm`
-  - Nested/list: `examples/filter-flatten-governance.stm`
-  - Lookups: `examples/db-to-db.stm`
-  - Fragments: `examples/common.stm`
+Run `satsuma agent-reference` to load the grammar, conventions, and CLI reference.
+Then pick 1-2 example `.stm` files from the workspace that match the mapping's complexity
+(1:1, multi-source, nested/list, lookups, fragments) to use as style references.
 
 ### Step 2.1 — Plan File Structure
 

--- a/skills/satsuma-to-excel/SKILL.md
+++ b/skills/satsuma-to-excel/SKILL.md
@@ -2,7 +2,7 @@
 name: satsuma-to-excel
 description: Convert Satsuma .stm files into professional, stakeholder-ready Excel workbooks. Deterministic, parser-backed export using the satsuma CLI for structural extraction and openpyxl for workbook generation. Produces Overview, Issues, Mapping, Schema, and Lookup tabs with full styling.
 license: MIT
-compatibility: Requires Python 3.10+ and openpyxl. Requires satsuma CLI (npx satsuma).
+compatibility: Requires Python 3.10+ and openpyxl. Requires satsuma CLI.
 metadata:
   author: satsuma
   version: "1.0"
@@ -31,7 +31,7 @@ Supported options:
    ```
    Then prefix all `python3` commands with `skills/satsuma-to-excel/scripts/.venv/bin/python3`.
 
-2. **Check satsuma CLI**: Run `npx satsuma --version`. If it fails, the satsuma CLI is not available — stop and tell the user.
+2. **Check satsuma CLI**: Run `satsuma --version`. If it fails, the satsuma CLI is not available — stop and tell the user.
 
 3. **Validate input**: Check the `.stm` file(s) exist.
 

--- a/testing-prompts/test-arrows.md
+++ b/testing-prompts/test-arrows.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma arrows --help` output.

--- a/testing-prompts/test-context.md
+++ b/testing-prompts/test-context.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma context --help` output.

--- a/testing-prompts/test-cross-command.md
+++ b/testing-prompts/test-cross-command.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to test **multi
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Review existing open bug tickets with `tk list` to avoid duplicating known issues.

--- a/testing-prompts/test-diff.md
+++ b/testing-prompts/test-diff.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma diff --help` output.

--- a/testing-prompts/test-fields.md
+++ b/testing-prompts/test-fields.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma fields --help` output.

--- a/testing-prompts/test-find.md
+++ b/testing-prompts/test-find.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma find --help` output.

--- a/testing-prompts/test-graph.md
+++ b/testing-prompts/test-graph.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma graph --help` output.

--- a/testing-prompts/test-lineage.md
+++ b/testing-prompts/test-lineage.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma lineage --help` output.

--- a/testing-prompts/test-lint.md
+++ b/testing-prompts/test-lint.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma lint --help` output and `satsuma lint --rules` to see available lint rules.

--- a/testing-prompts/test-mapping.md
+++ b/testing-prompts/test-mapping.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma mapping --help` output.

--- a/testing-prompts/test-match-fields.md
+++ b/testing-prompts/test-match-fields.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma match-fields --help` output.

--- a/testing-prompts/test-meta.md
+++ b/testing-prompts/test-meta.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma meta --help` output.

--- a/testing-prompts/test-metric.md
+++ b/testing-prompts/test-metric.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma metric --help` output.

--- a/testing-prompts/test-nl-refs.md
+++ b/testing-prompts/test-nl-refs.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma nl-refs --help` output.

--- a/testing-prompts/test-nl.md
+++ b/testing-prompts/test-nl.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma nl --help` output.

--- a/testing-prompts/test-schema.md
+++ b/testing-prompts/test-schema.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma schema --help` output.

--- a/testing-prompts/test-summary.md
+++ b/testing-prompts/test-summary.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma summary --help` output.

--- a/testing-prompts/test-validate.md
+++ b/testing-prompts/test-validate.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma validate --help` output.

--- a/testing-prompts/test-warnings.md
+++ b/testing-prompts/test-warnings.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma warnings --help` output.

--- a/testing-prompts/test-where-used.md
+++ b/testing-prompts/test-where-used.md
@@ -7,7 +7,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 ## Setup
 
 1. Read these files to understand the language and CLI contract:
-   - `AI-AGENT-REFERENCE.md` — compact grammar and cheat sheet
+   - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
    - `SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma where-used --help` output.

--- a/useful-prompts/README.md
+++ b/useful-prompts/README.md
@@ -10,7 +10,7 @@ Claude.ai) to work with Satsuma without installing any tooling.
 **Excel-to-Satsuma Conversion Specialist** — Upload this prompt alongside a
 mapping spreadsheet and the LLM will convert it into idiomatic Satsuma v2 files.
 
-The prompt includes the full Satsuma grammar, a quick reference cheat sheet,
+The prompt includes the full Satsuma grammar, a conventions reference,
 generation rules, worked examples, and a self-critique checklist. It produces
 Satsuma output with a confidence rating and flags ambiguities for human review.
 

--- a/useful-prompts/excel-to-stm-prompt.md
+++ b/useful-prompts/excel-to-stm-prompt.md
@@ -1,27 +1,31 @@
 # Excel-to-Satsuma Conversion Specialist
 
-You are a Satsuma (Source-to-Target Mapping) conversion specialist. The user will upload an Excel spreadsheet containing source-to-target data mapping definitions. Your job is to convert it into well-formed, idiomatic Satsuma (.stm) files. You have a CLI avaiable (`satsuma agent-reference` for details) that provides token-saving, deterministic ways to query Satsuma files.
+You are a Satsuma (Source-to-Target Mapping) conversion specialist. The user will upload an Excel spreadsheet containing source-to-target data mapping definitions. Your job is to convert it into well-formed, idiomatic Satsuma (.stm) files. If you have the `satsuma` CLI available, run `satsuma agent-reference` for deterministic ways to query Satsuma files.
 
 ---
 
 ## Satsuma Grammar (compact EBNF)
 
 ```ebnf
+(* Undefined terminals — implementation-defined:
+   TYPE (e.g. INT, STRING, BOOLEAN, UUID, CHAR, VARCHAR, DECIMAL, DATE, TIMESTAMP)
+   value, params (comma-separated literals/identifiers)
+   NUMBER, ARITH (+, -, *, /), LETTER, DIGIT, ANY, TEXT_TO_EOL *)
+
 file             = { import_stmt | note_block | namespace | schema | fragment | transform | mapping | metric } ;
 
 import_stmt      = "import" "{" name_list "}" "from" STRING ;
-name_list        = name {"," name} ;
-name             = qualified_name | IDENT | "'" ANY "'" ;
-qualified_name   = IDENT "::" IDENT ;
+name_list        = name_ref {"," name_ref} ;
+name_ref         = label | label "::" label ;
 
 note_block       = "note" "{" (STRING | TRIPLESTRING) "}" ;
 
-namespace        = "namespace" IDENT ["(" metadata ")"] "{" namespace_body "}" ;
+namespace        = "namespace" label ["(" metadata ")"] "{" namespace_body "}" ;
 namespace_body   = { note_block | schema | fragment | transform | mapping | metric } ;
 
 schema           = "schema" label ["(" metadata ")"] "{" schema_body "}" ;
 fragment         = "fragment" label "{" schema_body "}" ;
-label            = IDENT | "'" ANY "'" ;
+label            = IDENT | BACKTICK_IDENT ;
 
 metadata         = meta_entry {"," meta_entry} ;
 meta_entry       = IDENT [value] | IDENT "{" enum_items "}" | "note" (STRING | TRIPLESTRING) ;
@@ -30,34 +34,36 @@ enum_items       = value {"," value} ;
 schema_body      = { field_decl | spread | COMMENT } ;
 field_decl       = (IDENT | BACKTICK_IDENT) [type_expr] ["(" metadata ")"] ["{" schema_body "}"] ;
 type_expr        = TYPE ["(" params ")"] | "record" | "list_of" TYPE ["(" params ")"] | "list_of" "record" ;
-spread           = "..." name ;
+spread           = "..." label ;
 
 transform        = "transform" label "{" transform_body "}" ;
-transform_body   = { STRING | pipe_step {"|" pipe_step} } ;
+transform_body   = spread | pipe_step {"|" pipe_step} ;
+(* A bare STRING is a valid pipe_step, so a single NL string is a valid transform body *)
 
 metric           = "metric" label [STRING] ["(" metric_meta ")"] "{" metric_body "}" ;
 metric_meta      = metric_entry {"," metric_entry} ;
-metric_entry     = "source" (namespaced_name | IDENT | "{" name_list "}") | "grain" IDENT
+metric_entry     = "source" (name_ref | "{" name_list "}") | "grain" IDENT
                  | "slice" "{" name_list "}" | "filter" STRING ;
 metric_body      = { field | note_block | COMMENT } ;
 
 mapping          = "mapping" [label] ["(" metadata ")"] "{" mapping_body "}" ;
 mapping_body     = { note_block | source_decl | target_decl | arrow | nested_arrow | each_block | flatten_block | COMMENT } ;
-source_decl      = "source" "{" ref_list "}" ;
-target_decl      = "target" "{" ref_list "}" ;
-ref_list         = { BACKTICK_IDENT | STRING } ;
+source_decl      = "source" "{" { source_item } "}" ;
+source_item      = name_ref ["(" metadata ")"] | STRING ;
+target_decl      = "target" "{" name_ref ["(" metadata ")"] "}" ;
 
-arrow            = [field_path] "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
+arrow            = [source_paths] "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
+source_paths     = field_path {"," field_path} ;
 nested_arrow     = field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 each_block       = "each" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 flatten_block    = "flatten" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 
-pipe_step        = IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries "}" | STRING ;
+pipe_step        = spread | IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries "}" | STRING ;
 map_entries      = { map_key ":" value } ;
 map_key          = value | "<" NUMBER | "default" | "_" | "null" ;
 
-field_path       = namespaced_path | segment {"." segment} ;
-namespaced_path  = IDENT "::" segment {"." segment} ;
+field_path       = ["."] [label "::"] segment {"." segment} ;
+(* :: is ONLY namespace::schema. Fields use dot: namespace::schema.field.nested *)
 segment          = IDENT | BACKTICK_IDENT ;
 
 IDENT            = LETTER {LETTER | DIGIT | "_" | "-"} ;
@@ -69,121 +75,97 @@ COMMENT          = ("//" | "//!" | "//?") TEXT_TO_EOL ;
 
 ---
 
-## Satsuma Quick Reference
+## Satsuma Conventions & Rules
 
 ```text
 ## Three delimiters, three jobs
 ( ) = metadata      { } = structural content      " " = natural language
 
-## Schema blocks
-schema <name> (<metadata>) {
-  field_name    TYPE           (tags)       // info
-  field_name    TYPE           (tags)       //! warning
-  field_name    TYPE           (tags)       //? todo
-  nested_obj record {
-    child       TYPE
-  }
-  repeated_items list_of record {
-    item        TYPE
-  }
-  scalar_tags list_of STRING (note "tag values")    // scalar list — no subfields
-  ...fragment_name
-}
+## Metadata tokens (in parens)
+pk, required, unique, indexed, pii, encrypt, encrypt AES-256-GCM,
+default val, enum {a, b, c}, format email, ref table.field,
+note "...", xpath "...", namespace prefix "uri", filter COND
 
-Metadata tokens (in parens):  pk, required, unique, indexed, pii, encrypt,
-  encrypt AES-256-GCM, default val, enum {a, b, c}, format email,
-  ref table.field, note "...", xpath "...", namespace prefix "uri", filter COND
+## Reserved keywords
+schema, fragment, mapping, transform, metric, note,
+source, target, import, from, record, list_of, each, flatten, namespace
 
-Reserved keywords: schema, fragment, mapping, transform, metric, note,
-  source, target, import, from, record, list_of, each, flatten, namespace
+## Naming convention
+Prefer lowercase snake_case for schemas, namespaces, and fields.
+This avoids backtick quoting: `order_headers` not `order-headers`.
+Backticks are only needed when a name contains characters outside [a-z0-9_-]:
+  schema `order-headers` { ... }       // kebab-case — needs backticks
+  source { `raw::crm-contacts` }       // backtick the unsafe segment only
 
-## Namespace blocks
-namespace <name> (<metadata>) {
-  schema ...
-  mapping ...
-  // any top-level block except import and other namespaces
-}
+## Path syntax — :: vs .
+:: separates namespace from schema. . separates schema from field.
+Never use :: to join schema to field. Namespaces are optional.
+  namespace::schema                      // schema in a namespace
+  namespace::schema.field                // field on a namespaced schema
+  namespace::schema.field.nested_child   // nested record field
+  schema.field                           // field (no namespace)
+  .field                                 // relative field inside each/flatten
 
-Cross-namespace references use :: syntax:
-  source { `ns::schema_ref` }          // in mapping source/target
-  source ns::schema_name               // in metric metadata
-  import { ns::name } from "file.stm"  // in imports
+Cross-namespace references:
+  source { raw::customers }
+  target { mart::dim_customer }
+  import { raw::customers, mart::dim_customer } from "platform.stm"
+  metric mrr (source raw::orders, grain monthly) { ... }
 
-## Mapping blocks
-mapping <name> (<metadata>) {
-  source { `schema_ref` }
-  target { `schema_ref` }
-
-  src -> tgt                                 // direct
-  src -> tgt { transform }                   // with transform
-  src -> tgt { trim | lowercase }            // pipeline
-  src -> tgt { "NL transform description" }  // natural language
-  -> tgt { "computed, no source" }           // derived field
-  -> tgt { now_utc() }                       // function
-
-  Transforms (combine with | inside { }):
-    trim, lowercase, uppercase, title_case, null_if_empty, null_if_invalid
-    drop_if_invalid, drop_if_null, warn_if_invalid, warn_if_null
-    error_if_invalid, error_if_null
-    coalesce(val), round(n), truncate(n), max_length(n)
-    prepend("x"), append("x"), split("x") | first | last
-    validate_email, to_e164, to_iso8601, to_utc, now_utc()
-    pad_left(n, c), pad_right(n, c), replace(old, new), escape_html
-    to_string, to_number, to_boolean, uuid_v5(ns, name)
-    encrypt(algo, key), hash(algo), parse(fmt)
-    * N, / N, + N, - N
-    map { src: "tgt", null: "default", _: "fallback" }
-    map { < 1000: "low", < 5000: "mid", default: "high" }
-    "natural language transform description"
-
-  Array mapping:
-  each src_arr -> tgt_arr {
-    .child -> .child { transform }
+## Source blocks — not just schema names
+  source {
+    schema_ref
+    other_source (filter "status = completed")
+    "Join @schema_ref to @other_source on @customer_id = @customer_id"
   }
 
-  Flattening a list:
-  flatten src.list_field -> flat_target {
-    .child -> .child { transform }
-  }
-}
+## Transform catalog (combine with | inside { })
+  ...named_transform
+  trim, lowercase, uppercase, title_case, null_if_empty, null_if_invalid
+  drop_if_invalid, drop_if_null, warn_if_invalid, warn_if_null
+  error_if_invalid, error_if_null
+  coalesce(val), round(n), truncate(n), max_length(n)
+  prepend("x"), append("x"), split("x") | first | last
+  validate_email, to_e164, to_iso8601, to_utc, now_utc()
+  pad_left(n, c), pad_right(n, c), replace(old, new), escape_html
+  to_string, to_number, to_boolean, uuid_v5(ns, name)
+  encrypt(algo, key), hash(algo), parse(fmt)
+  * N, / N, + N, - N
+  map { src: "tgt", null: "default", _: "fallback" }
+  map { < 1000: "low", < 5000: "mid", default: "high" }
+  "NL description — use @field_name for refs"
 
-## Reusability
-fragment <name> { fields... }              (spread with ...name)
-transform <name> { pipeline or NL... }     (spread with ...name)
-import { name1, name2 } from "file.stm"
-import { ns::name1, ns::name2 } from "other.stm"  // namespace-qualified
-
-## Metric blocks
-metric <name> ["display label"] (<metric_meta>) {
-  measure_field  TYPE  (measure additive)
-  measure_field  TYPE  (measure non_additive)
-  measure_field  TYPE  (measure semi_additive)
-  note { "..." }
-}
-
-Metric metadata tokens (in parens):
-  source schema_name | source ns::schema_name | source {schema_a, schema_b}
-  grain monthly | grain daily | grain weekly
-  slice {dim_a, dim_b, dim_c}
-  filter "sql_condition"
-
-Rules:
+## Metric rules
   - Metrics are terminal nodes: nothing flows *out* of a metric
   - Do NOT use a metric as source/target in a mapping block
   - Complex computation logic goes in note { } as natural language
+  - Measure additivity: additive (sum all dims), non_additive (never sum),
+    semi_additive (sum across some dims only, e.g. balances)
 
-## Notes & Comments
-note { "standalone documentation block" }
-note { """multiline **Markdown** content""" }
-(note "inline on a field or schema")       // in metadata parens
-// info   //! warning   //? question/todo
+## Consumer conventions
+Reports and ML models are consumer schemas, not new block types:
+  schema customer_dashboard (report, source {fact_orders, dim_customer}, tool looker) { ... }
+  schema churn_model (model, source {training_set}) { ... }
 
-## Backtick References in NL Strings (IMPORTANT)
-ALWAYS backtick field and schema names inside "..." NL strings:
-  -> total { "Sum `line_amount` grouped by `order_id`" }
-  (note "Derived from `customer.email` after dedup")
-This is NOT optional — tooling extracts backticked references for
+## @ref in NL strings (CRITICAL)
+ALWAYS use @ref for field and schema names inside "..." NL strings:
+  -> total { "Sum @line_amount grouped by @order_id" }
+  (note "Derived from @customer.email after dedup")
+  "Join @crm_customers to @orders on @crm_customers.customer_id = @orders.customer_id"
+This is NOT optional — tooling extracts @ref references for
 deterministic lineage tracing. Bare names in NL are invisible to tools.
+
+Backtick only the unsafe segments:
+  "Look up @`order-headers`.status in the dim table"
+  "Join @raw::`crm-contacts`.`customer-id` to @mart::dim_customer.customer_id"
+@ref schemas are structural sources; lint --fix auto-adds undeclared
+@ref schemas to the mapping source list.
+
+## Comments
+// info   //! warning   //? question/todo
+(note "inline on a field or schema")  // in metadata parens
+note { "standalone block" }           // top-level or in namespace
+note { """multiline **Markdown**""" } // triple-quoted
 ```
 
 ---
@@ -204,13 +186,13 @@ Follow these steps in order:
 ## Generation Rules
 
 - Start with a `note { }` block describing the integration name, direction, and cardinality.
-- Use `schema` for **all** schema blocks — source, target, lookup, reference. The role (source vs. target) is declared inside the `mapping` block with `source { `ref` }` and `target { `ref` }`.
+- Use `schema` for **all** schema blocks — source, target, lookup, reference. The role (source vs. target) is declared inside the `mapping` block with `source { ref }` and `target { ref }`.
 - Define all fields with metadata in `(...)` parentheses — **not** `[...]` brackets.
 - Use `Name record { }` for nested objects and `Name list_of record { }` for repeated / array structures. Use `Name list_of TYPE` for scalar lists.
 - Use `fragment` for any field pattern that appears 2+ times across schemas.
 - Write transforms inside `{ }` braces after the arrow — **not** after a `:` colon.
 - Use bare `"..."` strings in `{ }` for any transformation described in prose that you can't express as a pipeline.
-- **Always backtick field and schema names** referenced inside `"..."` NL strings (e.g. `` "Sum `amount` grouped by `customer_id`" ``). This is required — tooling extracts backticked references for deterministic lineage tracing. Bare names in NL strings are invisible to tools.
+- **Always use `@ref`** for field and schema names referenced inside `"..."` NL strings (e.g. `"Sum @amount grouped by @customer_id"`). This is required — tooling extracts `@ref` references for deterministic lineage tracing. Bare names in NL strings are invisible to tools.
 - For conditional value mapping, use `map { key: "value", _: "fallback" }`. For complex conditions involving multiple fields or logic, use a `"..."` NL string.
 - For derived / computed fields with no source, use `-> target { ... }` with no left-hand side.
 - Represent lookup/reference/code tables found in the spreadsheet as `schema` blocks with fields.
@@ -219,28 +201,26 @@ Follow these steps in order:
 - Use `note { """...""" }` for rich multi-line context. Use `(note "...")` in metadata for inline field/schema documentation.
 - Use `metric` blocks for business metrics (KPIs, measures, aggregations). Do not use `schema` for terminal metric definitions and do not use a `metric` as a mapping source or target.
 - For very large spreadsheets with multiple domains or systems, use **namespaces** to organize schemas. Use `import { ns::name } from "file.stm"` with namespace-qualified names and split the output into multiple files per domain (e.g., `crm/pipeline.stm`, `billing/pipeline.stm`). Create a platform entry point file that imports across domains.
-- Only use annotations shown in the cheat sheet. Don't invent annotation names.
+- Only use annotations shown in the conventions reference. Don't invent annotation names.
 - Prefer concise, idiomatic Satsuma — don't over-specify.
 
 ### Common mistakes to avoid
 
 | Mistake | Correct approach |
 | --- | --- |
-| Using `[tags]` bracket syntax | Use `(tags)` parentheses for metadata |
-| Using `source`/`target`/`table` as schema keywords | Use `schema` for all — role is contextual |
-| Using `@annotation(...)` syntax | Use `(key value)` in metadata parens |
-| Using `: transform` after arrow | Use `{ transform }` in braces after arrow |
-| Using `nl("...")` function | Use bare `"..."` strings in `{ }` — NL is first-class |
-| Using `note '''...'''` triple single-quotes | Use `(note "...")` or `note { """...""" }` |
-| Using `=> target` for computed fields | Use `-> target` with no left side |
-| Using `STRUCT { }` / `ARRAY { }` for nesting | Use `Name record { }` / `Name list_of record { }` |
-| Using `when/else` conditionals | Use `map { }` with conditions or NL strings |
-| Forgetting to declare arrays with `list_of` | Use `Name list_of record { }` for repeated structures, `Name list_of TYPE` for scalar lists |
-| Using `[]` in mapping paths | Use `each src -> tgt { }` for iteration, dot paths for field access |
+| Using `::` between schema and field (e.g. `schema::field`) | `::` is namespace-to-schema only. Use `.` for fields: `ns::schema.field.nested` |
+| Using `source`/`target`/`table` as schema keywords | Use `schema` for all — role is contextual from mapping context |
+| Using `STRUCT { }` / `ARRAY { }` for nesting | Use `name record { }` / `name list_of record { }` |
+| Using `[]` in mapping paths for array access | Use `each src -> tgt { }` for iteration, dot paths for field access |
 | Using `(flatten \`list\`)` metadata on mappings | Use `flatten src.list -> tgt { }` block syntax inside mapping body |
+| Repeating schema IDs in paths inside implicit mapping blocks | Bare names resolve to source (left) and target (right) |
 | Using `schema` for a business metric | Use `metric` — it signals a terminal node to lineage tooling |
 | Using a `metric` as a mapping source or target | Metrics are consumers only; reference the underlying `schema` instead |
-| Writing field names bare in NL strings | Backtick field/schema references inside `"..."` strings |
+| Using `report` / `model` as block keywords | Use `schema name (report, ...) { }` or `schema name (model, ...) { }` |
+| Summing a `non_additive` measure across dimensions | Use weighted average or re-aggregate from grain; only `additive` measures can be summed |
+| Writing field names bare in NL strings | Use `@ref` — e.g. `"Sum @order_total grouped by @customer_id"` |
+| Backticking an entire `@ref` path | Backtick only the unsafe segment(s): `@raw::\`crm-contacts\`.\`customer-id\`` |
+| Referencing a schema in NL without declaring it | `@ref` schemas must be in the mapping's `source { }` block |
 
 ---
 
@@ -266,8 +246,8 @@ schema warehouse (note "Data Warehouse") {
 }
 
 mapping {
-  source { `crm` }
-  target { `warehouse` }
+  source { crm }
+  target { warehouse }
 
   id     -> customer_id   { uuid_v5("namespace", id) }
   name   -> display_name  { trim | title_case }
@@ -278,29 +258,34 @@ mapping {
 
 ### Converting an Excel mapping row to Satsuma
 
-
 **Excel row:**
 
-| Source Field | Source Type | Target Field  | Target Type | Transformation                                                 | Notes                         |
-| ---          | ---         | ---           | ---         | ---                                                            | ---                           |
-| CUST_TYPE    | CHAR(1)     | customer_type | VARCHAR(20) | R=Retail, B=Business, G=Government. If null, default to Retail | Some records have null values |
+| Source Field | Source Type | Target Field | Target Type | Transformation | Notes |
+| --- | --- | --- | --- | --- | --- |
+| CUST_TYPE | CHAR(1) | customer_type | VARCHAR(20) | R=Retail, B=Business, G=Government. If null, default to Retail | Some records have null values |
 
 **Satsuma equivalent:**
 
 ```satsuma
-// In source schema:
-  CUST_TYPE    CHAR(1)    (enum {R, B, G})    //! Some records have NULL
+schema legacy_customer {
+  CUST_TYPE  CHAR(1)  (enum {R, B, G})  //! Some records have NULL
+}
 
-// In target schema:
-  customer_type VARCHAR(20) (enum {retail, business, government}, required)
+schema customer_dim {
+  customer_type  VARCHAR(20)  (enum {retail, business, government}, required)
+}
 
-// In mapping block:
-CUST_TYPE -> customer_type {
-  map {
-    R: "retail"
-    B: "business"
-    G: "government"
-    null: "retail"
+mapping {
+  source { legacy_customer }
+  target { customer_dim }
+
+  CUST_TYPE -> customer_type {
+    map {
+      R: "retail"
+      B: "business"
+      G: "government"
+      null: "retail"
+    }
   }
 }
 ```
@@ -322,7 +307,7 @@ After generating Satsuma, review your output against this checklist. Report each
 - **Idiom**: All schema blocks use `schema` keyword (not `source`/`target`/`lookup`)
 - **Idiom**: Metadata in `(...)` parens, transforms in `{ }` braces
 - **Idiom**: No V1 syntax (`nl()`, `[tags]`, `: transform`, `=> field`, `integration { }`)
-- **Idiom**: NL strings backtick field/schema references
+- **Idiom**: NL strings use `@ref` for field/schema references
 - **Documentation**: Data quality warnings preserved as `//!`
 - **Documentation**: Ambiguities flagged as `//?`
 - **Structure**: Balanced braces, valid block nesting
@@ -345,7 +330,7 @@ After generating Satsuma, review your output against this checklist. Report each
 
 - Don't skip tabs without explaining why.
 - Don't silently drop mapping rows that are hard to interpret — use `"NL description"` or `//?`.
-- Don't invent Satsuma syntax or transform functions not in the grammar/cheat sheet above.
+- Don't invent Satsuma syntax or transform functions not in the grammar/conventions above.
 - Don't use V1 syntax (`nl()`, `[tags]`, `: transform`, `=> field`, `integration { }`, `note '''...'''`).
 - Don't produce partial output without flagging it.
 - Don't claim the output is validated — remind the user it needs local verification.

--- a/useful-prompts/stm-to-excel-prompt.md
+++ b/useful-prompts/stm-to-excel-prompt.md
@@ -12,34 +12,40 @@ The generated workbook is a **read-only snapshot** designed for review meetings,
 file             = { import_stmt | note_block | namespace | schema | fragment | transform | mapping | metric } ;
 
 import_stmt      = "import" "{" name_list "}" "from" STRING ;
+name_list        = name_ref {"," name_ref} ;
+name_ref         = label | label "::" label ;
 note_block       = "note" "{" (STRING | TRIPLESTRING) "}" ;
 
-namespace        = "namespace" IDENT "{" namespace_body "}" ;
+namespace        = "namespace" label ["(" metadata ")"] "{" namespace_body "}" ;
 schema           = "schema" label ["(" metadata ")"] "{" schema_body "}" ;
 fragment         = "fragment" label "{" schema_body "}" ;
-label            = IDENT | "'" ANY "'" ;
+label            = IDENT | BACKTICK_IDENT ;
 
 metadata         = meta_entry {"," meta_entry} ;
 meta_entry       = IDENT [value] | IDENT "{" enum_items "}" | "note" (STRING | TRIPLESTRING) ;
 
 schema_body      = { field_decl | spread | COMMENT } ;
 field_decl       = (IDENT | BACKTICK_IDENT) [type_expr] ["(" metadata ")"] ["{" schema_body "}"] ;
-type_expr        = TYPE ["(" params ")"] | "record" | "list_of" TYPE | "list_of" "record" ;
-spread           = "..." name ;
+type_expr        = TYPE ["(" params ")"] | "record" | "list_of" TYPE ["(" params ")"] | "list_of" "record" ;
+spread           = "..." label ;
 
 transform        = "transform" label "{" transform_body "}" ;
-transform_body   = { STRING | pipe_step {"|" pipe_step} } ;
+transform_body   = spread | pipe_step {"|" pipe_step} ;
+
+metric           = "metric" label [STRING] ["(" metric_meta ")"] "{" metric_body "}" ;
 
 mapping          = "mapping" [label] ["(" metadata ")"] "{" mapping_body "}" ;
 mapping_body     = { note_block | source_decl | target_decl | arrow | nested_arrow | each_block | flatten_block | COMMENT } ;
-source_decl      = "source" "{" ref_list "}" ;
-target_decl      = "target" "{" ref_list "}" ;
+source_decl      = "source" "{" { source_item } "}" ;
+source_item      = name_ref ["(" metadata ")"] | STRING ;
+target_decl      = "target" "{" name_ref ["(" metadata ")"] "}" ;
 
-arrow            = [field_path] "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
-each_block       = "each" field_path "->" field_path "{" mapping_body "}" ;
-flatten_block    = "flatten" field_path "->" field_path "{" mapping_body "}" ;
+arrow            = [source_paths] "->" field_path ["(" metadata ")"] ["{" transform_body "}"] ;
+source_paths     = field_path {"," field_path} ;
+each_block       = "each" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
+flatten_block    = "flatten" field_path "->" field_path ["(" metadata ")"] "{" mapping_body "}" ;
 
-pipe_step        = IDENT ["(" params ")"] | "map" "{" map_entries "}" | STRING ;
+pipe_step        = spread | IDENT ["(" params ")"] | ARITH NUMBER | "map" "{" map_entries "}" | STRING ;
 map_entries      = { map_key ":" value } ;
 ```
 


### PR DESCRIPTION
## Summary
- Restructure AI-AGENT-REFERENCE.md: remove bogus token counts, deduplicate EBNF vs conventions, add portable/CLI section boundary, add `::` vs `.` path guidance, add `snake_case` naming convention
- Sync updated EBNF and conventions to `useful-prompts/`, `skills/`, site templates, testing prompts, and user-facing docs (37 files)
- Make excel-to-satsuma skill standalone (uses `satsuma agent-reference` instead of reading project files)
- Replace `npx satsuma` with `satsuma` in satsuma-to-excel skill

## Test plan
- [ ] Verify `satsuma agent-reference` output matches the updated AI-AGENT-REFERENCE.md (prebuild bakes it in)
- [ ] Spot-check site pages (cli, index, learn) render correctly without token count claims
- [ ] Confirm excel-to-satsuma skill works standalone without project file references

🤖 Generated with [Claude Code](https://claude.com/claude-code)