### PR TITLE
LSP: add context-aware lineage actions

### DIFF
--- a/.tickets/sl-u4lf.md
+++ b/.tickets/sl-u4lf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-u4lf
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-03-26T13:55:13Z
@@ -18,3 +18,10 @@ Currently lineage is only available via command palette with manual schema selec
 2. Clicking a lineage code lens opens the lineage view without requiring manual input
 3. Context menu on fields in arrows offers Trace field lineage
 
+
+## Notes
+
+**2026-03-27T12:35:30Z**
+
+Cause: Lineage actions in the VS Code extension only existed as manual commands, so schema and field context at the cursor was not wired into code lenses or the field lineage webview.
+Fix: Added schema Lineage from/to code lenses plus a server-backed action-context request so commands can resolve schema and field paths directly from the cursor without manual input (commit 3fec60c).

--- a/.tickets/sl-u4lf.md
+++ b/.tickets/sl-u4lf.md
@@ -1,6 +1,6 @@
 ---
 id: sl-u4lf
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-03-26T13:55:13Z

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -77,6 +77,7 @@ Semantic tokens from the LSP server override TextMate scopes for context-sensiti
 
 Inline annotations above blocks:
 
+- **Schema actions** — `Lineage from` and `Lineage to`
 - **Schema** — `N fields | used in M mappings`
 - **Mapping** — `source → target | N arrows`
 - **Fragment** — `spread in N places`
@@ -113,6 +114,7 @@ Nine commands available via `Ctrl+Shift+P`:
 
 `Satsuma: Trace Field Lineage` traces a field through the entire data pipeline:
 
+- Cursor-aware field inference for arrow paths and schema fields
 - Multi-hop chain tracing via `satsuma arrows`
 - Horizontal flow: `source.field → [transform] → target.field`
 - NL transforms displayed with distinct styling

--- a/tooling/vscode-satsuma/server/src/action-context.ts
+++ b/tooling/vscode-satsuma/server/src/action-context.ts
@@ -1,0 +1,130 @@
+import type { Tree } from "./parser-utils";
+import { findNodeContext, type NodeContext } from "./definition";
+import type { WorkspaceIndex } from "./workspace-index";
+
+export interface ActionContext {
+  schemaName: string | null;
+  fieldPath: string | null;
+}
+
+export function computeActionContext(
+  tree: Tree,
+  line: number,
+  character: number,
+  _uri: string,
+  _index: WorkspaceIndex,
+): ActionContext {
+  const node = tree.rootNode.descendantForPosition({
+    row: line,
+    column: character,
+  });
+  if (!node) {
+    return { schemaName: null, fieldPath: null };
+  }
+
+  const ctx = findNodeContext(node);
+  if (!ctx) {
+    return { schemaName: null, fieldPath: null };
+  }
+
+  return {
+    schemaName: inferSchemaName(ctx),
+    fieldPath: inferFieldPath(ctx),
+  };
+}
+
+function inferSchemaName(ctx: NodeContext): string | null {
+  switch (ctx.kind) {
+    case "source_ref":
+    case "target_ref":
+      return ctx.name;
+
+    case "block_label":
+      return ctx.node.parent?.type === "schema_block" ? ctx.name : null;
+
+    case "field_name":
+      return ctx.parentName ?? null;
+
+    case "arrow_source":
+      return inferSchemaFromPath(ctx.mappingSources ?? [], ctx.rawPath ?? null);
+
+    case "arrow_target":
+      return inferSchemaFromPath(ctx.mappingTargets ?? [], ctx.rawPath ?? null);
+
+    case "nl_ref":
+      return inferSchemaFromNlRef(ctx.name);
+
+    default:
+      return null;
+  }
+}
+
+function inferFieldPath(ctx: NodeContext): string | null {
+  switch (ctx.kind) {
+    case "field_name":
+      return ctx.parentName ? `${ctx.parentName}.${ctx.name}` : null;
+
+    case "arrow_source":
+      return inferArrowFieldPath(ctx.mappingSources ?? [], ctx.rawPath ?? null);
+
+    case "arrow_target":
+      return inferArrowFieldPath(ctx.mappingTargets ?? [], ctx.rawPath ?? null);
+
+    case "nl_ref":
+      return ctx.name.includes(".") ? stripPathDecorators(ctx.name) : null;
+
+    default:
+      return null;
+  }
+}
+
+function inferSchemaFromNlRef(name: string): string | null {
+  if (!name.includes(".")) return null;
+  const normalized = stripPathDecorators(name);
+  const parts = normalized.split(".");
+  return parts.length >= 2 ? parts.slice(0, -1).join(".") : null;
+}
+
+function inferArrowFieldPath(
+  schemas: string[],
+  rawPath: string | null,
+): string | null {
+  const normalizedPath = normalizeArrowPath(rawPath);
+  if (!normalizedPath) return null;
+
+  for (const schema of schemas) {
+    if (
+      normalizedPath === schema ||
+      normalizedPath.startsWith(`${schema}.`)
+    ) {
+      return normalizedPath;
+    }
+  }
+
+  return schemas.length === 1 && schemas[0]
+    ? `${schemas[0]}.${normalizedPath}`
+    : null;
+}
+
+function inferSchemaFromPath(
+  schemas: string[],
+  rawPath: string | null,
+): string | null {
+  const fullPath = inferArrowFieldPath(schemas, rawPath);
+  if (!fullPath) {
+    return schemas.length === 1 ? (schemas[0] ?? null) : null;
+  }
+
+  const parts = fullPath.split(".");
+  return parts.length >= 2 ? (parts[0] ?? null) : null;
+}
+
+function normalizeArrowPath(rawPath: string | null): string | null {
+  if (!rawPath) return null;
+  const normalized = stripPathDecorators(rawPath).replace(/^\.+/, "");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function stripPathDecorators(path: string): string {
+  return path.replace(/`/g, "");
+}

--- a/tooling/vscode-satsuma/server/src/codelens.ts
+++ b/tooling/vscode-satsuma/server/src/codelens.ts
@@ -51,7 +51,7 @@ function collectLenses(
 
   switch (node.type) {
     case "schema_block":
-      lenses.push(schemaLens(node, qualName, range, index));
+      lenses.push(...schemaLenses(node, qualName, range, index));
       break;
     case "fragment_block":
       lenses.push(fragmentLens(qualName, range, index));
@@ -70,12 +70,12 @@ function collectLenses(
 
 // ---------- Per-block-type lenses ----------
 
-function schemaLens(
+function schemaLenses(
   node: SyntaxNode,
   qualName: string,
   range: Range,
   index: WorkspaceIndex,
-): CodeLens {
+): CodeLens[] {
   const body = child(node, "schema_body");
   const fieldCount = body ? children(body, "field_decl").length : 0;
   const mappingCount = findMappingsUsing(index, qualName).length;
@@ -85,7 +85,25 @@ function schemaLens(
     title += ` | used in ${mappingCount} mapping(s)`;
   }
 
-  return { range, command: makeCommand(title) };
+  return [
+    {
+      range,
+      command: makeCommand(
+        "Lineage from",
+        "satsuma.showLineage",
+        { schemaName: qualName, direction: "from" },
+      ),
+    },
+    {
+      range,
+      command: makeCommand(
+        "Lineage to",
+        "satsuma.showLineage",
+        { schemaName: qualName, direction: "to" },
+      ),
+    },
+    { range, command: makeCommand(title) },
+  ];
 }
 
 function fragmentLens(
@@ -153,8 +171,14 @@ function transformLens(
 
 // ---------- Helpers ----------
 
-function makeCommand(title: string): Command {
-  return { title, command: "" };
+function makeCommand(
+  title: string,
+  command = "",
+  ...arguments_: unknown[]
+): Command {
+  return arguments_.length > 0
+    ? { title, command, arguments: arguments_ }
+    : { title, command };
 }
 
 function extractRefNames(body: SyntaxNode, blockType: string): string[] {

--- a/tooling/vscode-satsuma/server/src/definition.ts
+++ b/tooling/vscode-satsuma/server/src/definition.ts
@@ -56,6 +56,8 @@ export interface NodeContext {
   /** For arrow field context: the source/target schemas of the enclosing mapping. */
   mappingSources?: string[];
   mappingTargets?: string[];
+  /** Raw path text for arrow and NL field contexts. */
+  rawPath?: string;
   /** The node we identified context from (for range info). */
   node: SyntaxNode;
 }
@@ -135,13 +137,15 @@ function tryContext(node: SyntaxNode): NodeContext | null {
 
     case "src_path": {
       const pathText = extractPathFieldName(node);
-      if (!pathText) return null;
+      const rawPath = extractPathText(node);
+      if (!pathText || !rawPath) return null;
       const mapping = findEnclosingMapping(node);
       return {
         kind: "arrow_source",
         name: pathText,
         namespace: ns,
         node,
+        rawPath,
         mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
         mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
       };
@@ -149,13 +153,15 @@ function tryContext(node: SyntaxNode): NodeContext | null {
 
     case "tgt_path": {
       const pathText = extractPathFieldName(node);
-      if (!pathText) return null;
+      const rawPath = extractPathText(node);
+      if (!pathText || !rawPath) return null;
       const mapping = findEnclosingMapping(node);
       return {
         kind: "arrow_target",
         name: pathText,
         namespace: ns,
         node,
+        rawPath,
         mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
         mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
       };
@@ -450,6 +456,11 @@ function extractPathFieldName(pathNode: SyntaxNode): string | null {
     return firstSegment.split("::").pop() ?? null;
   }
   return firstSegment;
+}
+
+function extractPathText(pathNode: SyntaxNode): string | null {
+  const text = pathNode.text.trim();
+  return text.length > 0 ? text : null;
 }
 
 /** Get schema names referenced in a mapping's source or target block. */

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -32,6 +32,7 @@ import { computeDefinition } from "./definition";
 import { computeReferences } from "./references";
 import { computeCompletions } from "./completion";
 import { computeCodeLenses } from "./codelens";
+import { computeActionContext } from "./action-context";
 import { prepareRename, computeRename } from "./rename";
 import { computeFormatting, initFormatting } from "./formatting";
 import { buildVizModel } from "./viz-model";
@@ -353,6 +354,27 @@ connection.onRequest(
       uri: def.uri,
       line: f.range.start.line,
     }));
+  },
+);
+
+connection.onRequest(
+  "satsuma/actionContext",
+  (params: {
+    uri: string;
+    position: {
+      line: number;
+      character: number;
+    };
+  }) => {
+    const tree = trees.get(params.uri);
+    if (!tree) return { schemaName: null, fieldPath: null };
+    return computeActionContext(
+      tree,
+      params.position.line,
+      params.position.character,
+      params.uri,
+      wsIndex,
+    );
   },
 );
 

--- a/tooling/vscode-satsuma/server/test/action-context.test.js
+++ b/tooling/vscode-satsuma/server/test/action-context.test.js
@@ -1,0 +1,59 @@
+const { describe, it, before } = require("node:test");
+const assert = require("node:assert/strict");
+const { initTestParser, parse } = require("./helper");
+const { computeActionContext } = require("../dist/action-context");
+const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
+
+before(async () => { await initTestParser(); });
+
+function contextAt(source, line, col) {
+  const uri = "file:///workspace/test.stm";
+  const tree = parse(source);
+  const index = createWorkspaceIndex();
+  indexFile(index, uri, tree);
+  return computeActionContext(tree, line, col, uri, index);
+}
+
+describe("computeActionContext", () => {
+  it("returns schema lineage context on schema labels", () => {
+    const ctx = contextAt("schema customers {\n  id UUID\n}", 0, 8);
+    assert.equal(ctx.schemaName, "customers");
+    assert.equal(ctx.fieldPath, null);
+  });
+
+  it("returns source field lineage context from arrow paths", () => {
+    const ctx = contextAt(
+      "schema customers {\n  email VARCHAR\n}\nschema dim_customers {\n  email VARCHAR\n}\nmapping `m` {\n  source { customers }\n  target { dim_customers }\n  email -> email\n}",
+      9,
+      3,
+    );
+    assert.equal(ctx.schemaName, "customers");
+    assert.equal(ctx.fieldPath, "customers.email");
+  });
+
+  it("returns full nested target field lineage context", () => {
+    const ctx = contextAt(
+      "schema src {\n  order_id UUID\n}\nschema tgt {\n  address record {\n    city VARCHAR\n  }\n}\nmapping `m` {\n  source { src }\n  target { tgt }\n  order_id -> address.city\n}",
+      11,
+      16,
+    );
+    assert.equal(ctx.schemaName, "tgt");
+    assert.equal(ctx.fieldPath, "tgt.address.city");
+  });
+
+  it("keeps explicit schema qualification in multi-source arrows", () => {
+    const ctx = contextAt(
+      "schema customers {\n  email VARCHAR\n}\nschema orders {\n  email VARCHAR\n}\nschema tgt {\n  email VARCHAR\n}\nmapping `m` {\n  source { customers, orders }\n  target { tgt }\n  customers.email -> email\n}",
+      12,
+      6,
+    );
+    assert.equal(ctx.schemaName, "customers");
+    assert.equal(ctx.fieldPath, "customers.email");
+  });
+
+  it("returns enclosing field path for schema fields", () => {
+    const ctx = contextAt("schema customers {\n  email VARCHAR\n}", 1, 3);
+    assert.equal(ctx.schemaName, "customers");
+    assert.equal(ctx.fieldPath, "customers.email");
+  });
+});

--- a/tooling/vscode-satsuma/server/test/codelens.test.js
+++ b/tooling/vscode-satsuma/server/test/codelens.test.js
@@ -34,8 +34,8 @@ describe("computeCodeLenses", () => {
       { "file:///a.stm": "schema customers {\n  id UUID (pk)\n  name VARCHAR\n  email VARCHAR\n}" },
       "file:///a.stm",
     );
-    assert.equal(result.length, 1);
-    assert.ok(result[0].command.title.includes("3 field(s)"));
+    assert.equal(result.length, 3);
+    assert.ok(result.some((lens) => lens.command.title.includes("3 field(s)")));
   });
 
   it("shows mapping count for schema used in mappings", () => {
@@ -47,8 +47,25 @@ describe("computeCodeLenses", () => {
       },
       "file:///a.stm",
     );
-    assert.equal(result.length, 1);
-    assert.ok(result[0].command.title.includes("used in 2 mapping(s)"));
+    assert.equal(result.length, 3);
+    assert.ok(result.some((lens) => lens.command.title.includes("used in 2 mapping(s)")));
+  });
+
+  it("adds clickable lineage actions for schemas", () => {
+    const result = lenses(
+      { "file:///a.stm": "schema customers {\n  id UUID\n}" },
+      "file:///a.stm",
+    );
+    const lineageFrom = result.find((lens) => lens.command.title === "Lineage from");
+    const lineageTo = result.find((lens) => lens.command.title === "Lineage to");
+
+    assert.ok(lineageFrom);
+    assert.equal(lineageFrom.command.command, "satsuma.showLineage");
+    assert.deepEqual(lineageFrom.command.arguments, [{ schemaName: "customers", direction: "from" }]);
+
+    assert.ok(lineageTo);
+    assert.equal(lineageTo.command.command, "satsuma.showLineage");
+    assert.deepEqual(lineageTo.command.arguments, [{ schemaName: "customers", direction: "to" }]);
   });
 
   it("shows spread count for fragments", () => {
@@ -143,8 +160,7 @@ mapping \`test\` {
       { "file:///a.stm": "schema customers {\n  id UUID\n}" },
       "file:///a.stm",
     );
-    assert.equal(result.length, 1);
-    // block_label "customers" is on line 0
+    assert.equal(result.length, 3);
     assert.equal(result[0].range.start.line, 0);
   });
 });

--- a/tooling/vscode-satsuma/src/commands/action-context.ts
+++ b/tooling/vscode-satsuma/src/commands/action-context.ts
@@ -1,0 +1,28 @@
+import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+
+export interface EditorActionContext {
+  schemaName: string | null;
+  fieldPath: string | null;
+}
+
+export async function getEditorActionContext(
+  client: LanguageClient,
+): Promise<EditorActionContext> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== "satsuma") {
+    return { schemaName: null, fieldPath: null };
+  }
+
+  try {
+    return await client.sendRequest("satsuma/actionContext", {
+      uri: editor.document.uri.toString(),
+      position: {
+        line: editor.selection.active.line,
+        character: editor.selection.active.character,
+      },
+    });
+  } catch {
+    return { schemaName: null, fieldPath: null };
+  }
+}

--- a/tooling/vscode-satsuma/src/commands/lineage.ts
+++ b/tooling/vscode-satsuma/src/commands/lineage.ts
@@ -1,6 +1,12 @@
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { runCli } from "./cli-runner";
+import { getEditorActionContext } from "./action-context";
+
+interface ShowLineageArgs {
+  schemaName?: string;
+  direction?: "from" | "to";
+}
 
 export function registerLineageCommand(
   context: vscode.ExtensionContext,
@@ -9,7 +15,15 @@ export function registerLineageCommand(
   outputChannel: vscode.OutputChannel,
 ): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand("satsuma.showLineage", async () => {
+    vscode.commands.registerCommand("satsuma.showLineage", async (args?: ShowLineageArgs) => {
+      const direction = args?.direction === "to" ? "to" : "from";
+      let selected = args?.schemaName;
+
+      if (!selected) {
+        const actionContext = await getEditorActionContext(client);
+        selected = actionContext.schemaName ?? undefined;
+      }
+
       // Get block names from the LSP server
       let names: Array<{ name: string; kind: string }>;
       try {
@@ -27,14 +41,16 @@ export function registerLineageCommand(
         return;
       }
 
-      const selected = await vscode.window.showQuickPick(schemaNames, {
-        placeHolder: "Select a schema to trace lineage from",
-      });
+      if (!selected) {
+        selected = await vscode.window.showQuickPick(schemaNames, {
+          placeHolder: `Select a schema to trace lineage ${direction}`,
+        });
+      }
       if (!selected) return;
 
       const result = await runCli(cliPath, [
         "lineage",
-        "--from",
+        `--${direction}`,
         selected,
         "--json",
       ]);
@@ -49,7 +65,7 @@ export function registerLineageCommand(
       try {
         const dag = JSON.parse(result.stdout);
         outputChannel.clear();
-        outputChannel.appendLine(`Lineage from ${selected}:`);
+        outputChannel.appendLine(`Lineage ${direction} ${selected}:`);
         outputChannel.appendLine("");
         if (dag.nodes) {
           for (const node of dag.nodes) {

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -14,6 +14,7 @@ import { registerWarningsCommand } from "./commands/warnings";
 import { registerSummaryCommand } from "./commands/summary";
 import { registerArrowsCommand } from "./commands/arrows";
 import { registerCoverageCommand } from "./commands/coverage";
+import { getEditorActionContext } from "./commands/action-context";
 import { LineagePanel } from "./webview/lineage/panel";
 import { VizPanel } from "./webview/viz/panel";
 
@@ -84,17 +85,20 @@ export function activate(context: ExtensionContext): void {
 
   // Lineage webview
   context.subscriptions.push(
-    vscode.commands.registerCommand("satsuma.traceFieldLineage", async () => {
+    vscode.commands.registerCommand("satsuma.traceFieldLineage", async (args?: { fieldPath?: string }) => {
       const editor = vscode.window.activeTextEditor;
       if (!editor || editor.document.languageId !== "satsuma") return;
 
+      const actionContext = client
+        ? await getEditorActionContext(client)
+        : { schemaName: null, fieldPath: null };
       const word = editor.document.getText(
         editor.document.getWordRangeAtPosition(editor.selection.active),
       );
 
       const fieldPath = await vscode.window.showInputBox({
         prompt: "Enter field reference (schema.field)",
-        value: word?.includes(".") ? word : `${word ?? ""}.`,
+        value: args?.fieldPath ?? actionContext.fieldPath ?? (word?.includes(".") ? word : `${word ?? ""}.`),
         placeHolder: "customers.email",
       });
       if (!fieldPath) return;


### PR DESCRIPTION
## Summary
- add clickable `Lineage from` / `Lineage to` schema code lenses in the VS Code LSP
- resolve schema and field context from the cursor via a new server-backed action-context request
- make field lineage tracing prefill from schema fields and arrow paths instead of requiring manual entry

## Testing
- npm --prefix tooling/vscode-satsuma/server test
- npm --prefix tooling/vscode-satsuma run build
- npm --prefix tooling/vscode-satsuma run check

## Ticket
- closes sl-u4lf