### PR TITLE
fix(release): run postbuild in prepare so npm pack sets executable bit

### DIFF
--- a/tooling/satsuma-cli/package.json
+++ b/tooling/satsuma-cli/package.json
@@ -18,7 +18,7 @@
     "build": "npm run prebuild && tsc",
     "dev": "tsc --watch",
     "pretest": "npm run prebuild && tsc",
-    "prepare": "npm run prebuild && tsc",
+    "prepare": "npm run build",
     "test": "node --import ./test/setup.js --test test/**/*.test.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Append `node scripts/postbuild.js` to the `prepare` script in `tooling/satsuma-cli/package.json` so the executable bit is set on `dist/index.js` when `npm pack` triggers the `prepare` lifecycle

## Context
PR #121 added a `postbuild` lifecycle hook to chmod `dist/index.js`, but `postbuild` only fires after `npm run build`. The `prepare` script (which `npm pack` triggers in CI) ran `prebuild && tsc` directly, bypassing the hook — so the release workflow's `verify-pack` check failed with `dist/index.js is not executable`.

## Validation
- `npm run prepare` in `tooling/satsuma-cli` → `ls -l dist/index.js` shows `+x`
- `npm pack` + `node scripts/verify-pack.js` → both checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)