### PR TITLE
Fix mapping viz bounds, resize handling, and metric/report layout sizing

### DIFF
--- a/.tickets/sl-xodu.md
+++ b/.tickets/sl-xodu.md
@@ -17,9 +17,13 @@ Fix overview layout regressions in the VS Code Mapping Viz: account for mapping 
 
 - Overview edges reserve space for long mapping labels and labels align with rendered arrows\n- Multi-source mappings with join-description text still render overview arrows\n- Namespaced mappings resolve local source/target refs to qualified schema ids so namespace arrows render\n- Namespace bounding boxes enclose actual rendered cards and sit behind edges/cards\n- Relevant viz and server tests pass locally
 
-
 ## Notes
 
 **2026-03-27T09:06:35Z**
 
 Cause: Overview-mode layout used mismatched geometry sources: overview labels did not reserve or align to padded edge space, namespaced mapping refs could remain unresolved, and namespace bounds were derived from abstract node sizes rather than rendered cards. Fix: Updated the viz layout/model pipeline to size cards and label gaps more accurately, resolve mapping refs in namespace context, ignore invalid overview edges, and measure namespace boxes from rendered card bounds. (commit 08c84fa)
+
+**2026-03-27T14:45:00Z**
+
+Cause: Overview mode rendered schema, metric, and fragment cards at sizes that diverged from the compact layout assumptions, and the shell viewport did not recompute fit/minimap geometry after panel resizes.
+Fix: Added true compact rendering for overview cards, measured namespace/content bounds from rendered geometry for fit and box placement, and updated the webview shell to stretch and rerender on resize so minimap anchoring stays correct.

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -8,6 +8,8 @@ export class SzFragmentCard extends LitElement {
   static override styles = css`
     :host {
       display: block;
+      width: 100%;
+      box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
       border-radius: var(--sz-card-radius, 8px);
@@ -165,11 +167,22 @@ export class SzFragmentCard extends LitElement {
   @property({ type: Boolean })
   compact = false;
 
+  @property({ type: String, attribute: "namespace-label" })
+  namespaceLabel: string | null = null;
+
   @state()
   private _collapsed = false;
 
   @state()
   private _notesExpanded = false;
+
+  private _renderNamespacePill() {
+    return this.namespaceLabel
+      ? html`<div style="padding: 8px 12px 0; background: var(--sz-green, #5A9E6F);">
+          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+        </div>`
+      : html``;
+  }
 
   override render() {
     const fr = this.fragment;
@@ -178,6 +191,7 @@ export class SzFragmentCard extends LitElement {
     if (this.compact) {
       return html`
         <div>
+          ${this._renderNamespacePill()}
           <div class="header" @click=${() => this._navigate(fr.location)}>
             <span class="header-icon">&#9674;</span>
             <span class="header-name">${fr.id}</span>
@@ -191,6 +205,7 @@ export class SzFragmentCard extends LitElement {
 
     return html`
       <div class=${this._collapsed ? "collapsed" : ""}>
+        ${this._renderNamespacePill()}
         <div class="header" @click=${this._onHeaderClick}>
           <span class="header-icon">&#9674;</span>
           <span class="header-name">${fr.id}</span>

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -162,6 +162,9 @@ export class SzFragmentCard extends LitElement {
   @property({ type: Object })
   fragment: FragmentCard | null = null;
 
+  @property({ type: Boolean })
+  compact = false;
+
   @state()
   private _collapsed = false;
 
@@ -171,6 +174,18 @@ export class SzFragmentCard extends LitElement {
   override render() {
     const fr = this.fragment;
     if (!fr) return html``;
+
+    if (this.compact) {
+      return html`
+        <div>
+          <div class="header" @click=${() => this._navigate(fr.location)}>
+            <span class="header-icon">&#9674;</span>
+            <span class="header-name">${fr.id}</span>
+            <span class="header-count">${fr.fields.length} fields</span>
+          </div>
+        </div>
+      `;
+    }
 
     const hasNotes = fr.notes.length > 0;
 

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -9,6 +9,20 @@ import type {
 } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
 
+/** Strip namespace::schema prefix from a qualified field ref, returning just the field name. */
+function stripFieldQualifier(fieldRef: string): string {
+  const dotIdx = fieldRef.lastIndexOf(".");
+  return dotIdx >= 0 ? fieldRef.slice(dotIdx + 1) : fieldRef;
+}
+
+/** Check if a qualified field ref belongs to a given schema (by qualifiedId). */
+function fieldBelongsToSchema(fieldRef: string, schemaQualifiedId: string): boolean {
+  const dotIdx = fieldRef.lastIndexOf(".");
+  if (dotIdx < 0) return true; // unqualified field — could be any schema
+  const prefix = fieldRef.slice(0, dotIdx);
+  return prefix === schemaQualifiedId;
+}
+
 /**
  * Three-column mapping detail view.
  *
@@ -29,15 +43,17 @@ export class SzMappingDetail extends LitElement {
 
     .layout {
       display: grid;
-      grid-template-columns: minmax(280px, 1fr) minmax(360px, 2fr) minmax(280px, 1fr);
+      grid-template-columns: max-content max-content max-content;
       gap: 16px;
       align-items: start;
+      width: max-content;
+      min-width: 100%;
     }
 
-    /* Let schema cards fill the available column width without capping at 380px */
+    /* Let schema cards grow to their content width instead of truncating to the viewport. */
     .column sz-schema-card {
       --sz-card-max-width: none;
-      width: 100%;
+      width: max-content;
       box-sizing: border-box;
     }
 
@@ -45,6 +61,8 @@ export class SzMappingDetail extends LitElement {
       display: flex;
       flex-direction: column;
       gap: 12px;
+      width: max-content;
+      min-width: 280px;
     }
 
     .column-header {
@@ -64,6 +82,8 @@ export class SzMappingDetail extends LitElement {
       border-radius: var(--sz-card-radius, 8px);
       box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
       overflow: hidden;
+      width: max-content;
+      min-width: 100%;
     }
 
     .mapping-title {
@@ -84,10 +104,17 @@ export class SzMappingDetail extends LitElement {
 
     .mapping-meta {
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
       gap: 6px;
       padding: 8px 12px;
       border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+    }
+
+    .mapping-meta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: flex-start;
     }
 
     .meta-tag {
@@ -96,6 +123,7 @@ export class SzMappingDetail extends LitElement {
       border-radius: 4px;
       background: var(--sz-badge-bg, #FFF3E8);
       color: var(--sz-text-muted, #6B6560);
+      max-width: 100%;
     }
 
     .meta-tag .label {
@@ -103,9 +131,17 @@ export class SzMappingDetail extends LitElement {
       font-weight: 500;
     }
 
+    .meta-tag.wrap {
+      max-width: 600px;
+      white-space: normal;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }
+
     /* Arrow table */
     .arrow-table {
-      width: 100%;
+      width: max-content;
+      min-width: 100%;
       border-collapse: collapse;
     }
 
@@ -155,12 +191,37 @@ export class SzMappingDetail extends LitElement {
       font-size: 12px;
       font-weight: 500;
       color: var(--sz-text, #2D2A26);
+      white-space: normal;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+    }
+
+    .source-ref-list {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 2px;
+      max-width: 280px;
+    }
+
+    .source-ref-item {
+      display: block;
+    }
+
+    .transform-cell {
+      width: 400px;
+      max-width: 400px;
+      min-width: 320px;
     }
 
     .transform-pipeline {
+      display: inline;
       font-family: var(--sz-font-mono, monospace);
       font-size: 11px;
       color: var(--sz-orange-dark, #D97726);
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow-wrap: anywhere;
     }
 
     .transform-pipeline .pipe {
@@ -169,9 +230,14 @@ export class SzMappingDetail extends LitElement {
     }
 
     .transform-nl {
+      display: inline-block;
       font-style: italic;
       font-size: 11px;
       color: var(--sz-green, #5A9E6F);
+      max-width: 400px;
+      white-space: normal;
+      word-break: break-word;
+      overflow-wrap: anywhere;
     }
 
     .transform-bare {
@@ -236,6 +302,9 @@ export class SzMappingDetail extends LitElement {
   @property({ type: Object })
   targetMappedFields: Set<string> = new Set();
 
+  @property({ type: String, attribute: "namespace-label" })
+  namespaceLabel: string | null = null;
+
   /** Currently hovered arrow (from table row hover). */
   @state()
   private _hoveredArrow: ArrowEntry | null = null;
@@ -282,10 +351,20 @@ export class SzMappingDetail extends LitElement {
     if (!m) return result;
 
     if (this._hoveredArrow) {
-      // Highlight source fields of the hovered arrow in all source schemas
+      // Highlight source fields of the hovered arrow in all source schemas.
+      // Source fields may be qualified (e.g. "ns::schema.field"); extract the
+      // bare field name so it matches the schema card's field names, and also
+      // route each field to the correct source schema.
       for (const sr of m.sourceRefs) {
-        const fields = new Set(this._hoveredArrow.sourceFields);
-        result.set(sr, fields);
+        const fields = new Set<string>();
+        for (const sf of this._hoveredArrow.sourceFields) {
+          const bare = stripFieldQualifier(sf);
+          // Only highlight in the schema the field belongs to
+          if (fieldBelongsToSchema(sf, sr) || m.sourceRefs.length === 1) {
+            fields.add(bare);
+          }
+        }
+        if (fields.size > 0) result.set(sr, fields);
       }
     } else if (this._hoveredCardField && this._hoveredCardSchema) {
       // If a target field is hovered, find which source fields map to it
@@ -315,7 +394,7 @@ export class SzMappingDetail extends LitElement {
     if (!m) return new Set();
 
     if (this._hoveredArrow) {
-      return new Set([this._hoveredArrow.targetField]);
+      return new Set([stripFieldQualifier(this._hoveredArrow.targetField)]);
     }
 
     if (this._hoveredCardField && this._hoveredCardSchema) {
@@ -332,13 +411,13 @@ export class SzMappingDetail extends LitElement {
     return new Set();
   }
 
-  /** Find source fields that map to a given target field. */
+  /** Find source fields that map to a given target field (returns bare names). */
   private _findSourceFieldsForTarget(targetField: string, m: MappingBlock): Set<string> {
     const result = new Set<string>();
     const search = (arrows: ArrowEntry[]) => {
       for (const a of arrows) {
-        if (a.targetField === targetField) {
-          for (const sf of a.sourceFields) result.add(sf);
+        if (stripFieldQualifier(a.targetField) === targetField) {
+          for (const sf of a.sourceFields) result.add(stripFieldQualifier(sf));
         }
       }
     };
@@ -348,13 +427,13 @@ export class SzMappingDetail extends LitElement {
     return result;
   }
 
-  /** Find target fields that a given source field maps to. */
+  /** Find target fields that a given source field maps to (handles qualified refs). */
   private _findTargetFieldsForSource(sourceField: string, m: MappingBlock): Set<string> {
     const result = new Set<string>();
     const search = (arrows: ArrowEntry[]) => {
       for (const a of arrows) {
-        if (a.sourceFields.includes(sourceField)) {
-          result.add(a.targetField);
+        if (a.sourceFields.some((sf) => stripFieldQualifier(sf) === sourceField)) {
+          result.add(stripFieldQualifier(a.targetField));
         }
       }
     };
@@ -372,11 +451,11 @@ export class SzMappingDetail extends LitElement {
     const m = this.mapping!;
     // Source card field hovered → highlight rows where it's a source
     if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-      return a.sourceFields.includes(this._hoveredCardField);
+      return a.sourceFields.some((sf) => stripFieldQualifier(sf) === this._hoveredCardField);
     }
     // Target card field hovered → highlight rows where it's the target
     if (this._hoveredCardSchema === m.targetRef) {
-      return a.targetField === this._hoveredCardField;
+      return stripFieldQualifier(a.targetField) === this._hoveredCardField;
     }
     return false;
   }
@@ -398,6 +477,7 @@ export class SzMappingDetail extends LitElement {
               .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
               .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
               highlightColor="source"
+              content-width
             ></sz-schema-card>
           `)}
         </div>
@@ -416,6 +496,7 @@ export class SzMappingDetail extends LitElement {
                 .mappedFields=${this.targetMappedFields}
                 .highlightFields=${targetHL}
                 highlightColor="target"
+                content-width
               ></sz-schema-card>`
             : nothing}
         </div>
@@ -428,6 +509,11 @@ export class SzMappingDetail extends LitElement {
 
     return html`
       <div class="mapping-header">
+        ${this.namespaceLabel
+          ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange, #F2913D);">
+              <span class="meta-tag" style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+            </div>`
+          : nothing}
         <div class="mapping-title" @click=${() => this._navigate(m.location)}>
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
             <path d="M2 4h5l2 2h5v8H2V4z" opacity="0.9"/>
@@ -435,12 +521,26 @@ export class SzMappingDetail extends LitElement {
           ${m.id}
         </div>
         <div class="mapping-meta">
-          ${m.sourceRefs.map((s) => html`<span class="meta-tag"><span class="label">source</span> ${s}</span>`)}
-          <span class="meta-tag"><span class="label">target</span> ${m.targetRef}</span>
+          ${m.sourceRefs.map((s) => html`
+            <div class="mapping-meta-row">
+              <span class="meta-tag"><span class="label">source</span> ${s}</span>
+            </div>
+          `)}
+          <div class="mapping-meta-row">
+            <span class="meta-tag"><span class="label">target</span> ${m.targetRef}</span>
+          </div>
           ${sb?.joinDescription
-            ? html`<span class="meta-tag"><span class="label">join</span> ${sb.joinDescription}</span>`
+            ? html`
+                <div class="mapping-meta-row">
+                  <span class="meta-tag wrap"><span class="label">join</span> ${sb.joinDescription}</span>
+                </div>
+              `
             : nothing}
-          ${(sb?.filters ?? []).map((f) => html`<span class="meta-tag"><span class="label">filter</span> ${f}</span>`)}
+          ${(sb?.filters ?? []).map((f) => html`
+            <div class="mapping-meta-row">
+              <span class="meta-tag wrap"><span class="label">filter</span> ${f}</span>
+            </div>
+          `)}
         </div>
       </div>
     `;
@@ -478,9 +578,15 @@ export class SzMappingDetail extends LitElement {
         @mouseenter=${() => { this._hoveredArrow = a; this._hoveredCardField = null; }}
         @mouseleave=${() => { this._hoveredArrow = null; }}
       >
-        <td><span class="field-ref">${a.sourceFields.join(", ")}</span></td>
+        <td>
+          <div class="source-ref-list">
+            ${a.sourceFields.map((sourceField) => html`
+              <span class="field-ref source-ref-item">${sourceField}</span>
+            `)}
+          </div>
+        </td>
         <td><span class="arrow-icon">&#x2192;</span></td>
-        <td>${this._renderTransform(a)}</td>
+        <td class="transform-cell">${this._renderTransform(a)}</td>
         <td><span class="field-ref">${a.targetField}</span></td>
       </tr>
     `;

--- a/tooling/satsuma-viz/src/components/sz-metric-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-metric-card.ts
@@ -166,6 +166,9 @@ export class SzMetricCard extends LitElement {
   @property({ type: Object })
   metric: MetricCard | null = null;
 
+  @property({ type: Boolean })
+  compact = false;
+
   @state()
   private _collapsed = false;
 
@@ -175,6 +178,18 @@ export class SzMetricCard extends LitElement {
   override render() {
     const m = this.metric;
     if (!m) return html``;
+
+    if (this.compact) {
+      return html`
+        <div>
+          <div class="header" @click=${() => this._navigate(m.location)}>
+            <span class="header-icon">&#9670;</span>
+            <span class="header-name">${m.qualifiedId}</span>
+            <span class="header-toggle">&#9660;</span>
+          </div>
+        </div>
+      `;
+    }
 
     const hasMeta = m.label || m.grain || m.slices.length > 0;
     const hasNotes = m.notes.length > 0;

--- a/tooling/satsuma-viz/src/components/sz-metric-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-metric-card.ts
@@ -14,6 +14,8 @@ export class SzMetricCard extends LitElement {
   static override styles = css`
     :host {
       display: block;
+      width: 100%;
+      box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
       border-radius: var(--sz-card-radius, 8px);
@@ -169,11 +171,22 @@ export class SzMetricCard extends LitElement {
   @property({ type: Boolean })
   compact = false;
 
+  @property({ type: String, attribute: "namespace-label" })
+  namespaceLabel: string | null = null;
+
   @state()
   private _collapsed = false;
 
   @state()
   private _notesExpanded = false;
+
+  private _renderNamespacePill() {
+    return this.namespaceLabel
+      ? html`<div style="padding: 8px 12px 0; background: var(--sz-violet, #8E5BB0);">
+          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+        </div>`
+      : html``;
+  }
 
   override render() {
     const m = this.metric;
@@ -182,9 +195,10 @@ export class SzMetricCard extends LitElement {
     if (this.compact) {
       return html`
         <div>
+          ${this._renderNamespacePill()}
           <div class="header" @click=${() => this._navigate(m.location)}>
             <span class="header-icon">&#9670;</span>
-            <span class="header-name">${m.qualifiedId}</span>
+            <span class="header-name">${m.id}</span>
             <span class="header-toggle">&#9660;</span>
           </div>
         </div>
@@ -196,6 +210,7 @@ export class SzMetricCard extends LitElement {
 
     return html`
       <div class=${this._collapsed ? "collapsed" : ""}>
+        ${this._renderNamespacePill()}
         <div class="header" @click=${this._onHeaderClick}>
           <span class="header-icon">&#9670;</span>
           <span class="header-name">${m.id}</span>

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -10,6 +10,8 @@ export class SzSchemaCard extends LitElement {
   static override styles = css`
     :host {
       display: block;
+      width: 100%;
+      box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
       border-radius: var(--sz-card-radius, 8px);
@@ -18,6 +20,11 @@ export class SzSchemaCard extends LitElement {
       box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
       overflow: hidden;
       font-family: var(--sz-font-sans, system-ui);
+    }
+
+    :host([content-width]) {
+      width: max-content;
+      max-width: none;
     }
 
     .header {
@@ -45,8 +52,8 @@ export class SzSchemaCard extends LitElement {
       font-size: 14px;
       font-weight: 600;
       flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      overflow: var(--sz-header-name-overflow, hidden);
+      text-overflow: var(--sz-header-name-overflow-mode, ellipsis);
       white-space: nowrap;
     }
 
@@ -112,9 +119,9 @@ export class SzSchemaCard extends LitElement {
       font-size: 12px;
       font-weight: 500;
       color: var(--sz-text, #2D2A26);
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      flex: var(--sz-field-name-flex, 1);
+      overflow: var(--sz-field-name-overflow, hidden);
+      text-overflow: var(--sz-field-name-overflow-mode, ellipsis);
       white-space: nowrap;
     }
 
@@ -326,6 +333,24 @@ export class SzSchemaCard extends LitElement {
     :host([has-highlight]) .field-row.hl .field-name {
       font-weight: 700;
     }
+
+    :host([content-width]) .field-row {
+      width: max-content;
+      min-width: 100%;
+    }
+
+    :host([content-width]) .header-name {
+      --sz-header-name-overflow: visible;
+      --sz-header-name-overflow-mode: clip;
+      min-width: max-content;
+    }
+
+    :host([content-width]) .field-name {
+      --sz-field-name-flex: 0 0 auto;
+      --sz-field-name-overflow: visible;
+      --sz-field-name-overflow-mode: clip;
+      min-width: max-content;
+    }
   `;
 
   @property({ type: Object })
@@ -339,6 +364,12 @@ export class SzSchemaCard extends LitElement {
    *  Shows namespace::name in header when schema has a namespace (qualifiedId contains ::). */
   @property({ type: Boolean })
   compact = false;
+
+  @property({ type: String, attribute: "namespace-label" })
+  namespaceLabel: string | null = null;
+
+  @property({ type: Boolean, attribute: "content-width", reflect: true })
+  contentWidth = false;
 
   /** Set of field names to highlight (peach for source, green for target).
    *  When non-empty, non-highlighted fields dim to ~50% opacity. */
@@ -367,6 +398,14 @@ export class SzSchemaCard extends LitElement {
 
   private _isReport(s: SchemaCard): boolean {
     return s.metadata.some((m) => m.key === "report" || m.key === "model");
+  }
+
+  private _renderNamespacePill() {
+    return this.namespaceLabel
+      ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange, #F2913D);">
+          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+        </div>`
+      : html``;
   }
 
   private _headerIcon(isReport: boolean) {
@@ -400,6 +439,7 @@ export class SzSchemaCard extends LitElement {
 
     return html`
       <div class=${this._collapsed ? "collapsed" : ""}>
+        ${this._renderNamespacePill()}
         <div class="header ${isReport ? "report" : ""}" @click=${this._onHeaderClick}>
           ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
@@ -518,13 +558,14 @@ export class SzSchemaCard extends LitElement {
   }
 
   private _renderCompact(s: SchemaCard) {
-    const displayName = s.qualifiedId.includes("::") ? s.qualifiedId : s.id;
+    const displayName = s.id;
     const totalFields = this._countFields(s.fields);
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
 
     return html`
       <div>
+        ${this._renderNamespacePill()}
         <div class="header ${isReport ? "report" : ""}" @click=${() => this._navigate(s.location)}>
           ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -521,7 +521,6 @@ export class SzSchemaCard extends LitElement {
     const displayName = s.qualifiedId.includes("::") ? s.qualifiedId : s.id;
     const totalFields = this._countFields(s.fields);
     const metaPills = s.metadata.filter((m) => m.key !== "note");
-    const hasNotes = s.notes.length > 0;
     const isReport = this._isReport(s);
 
     return html`
@@ -538,7 +537,6 @@ export class SzSchemaCard extends LitElement {
               )}
             </div>`
           : ""}
-        ${hasNotes ? this._renderNotes(s.notes) : ""}
       </div>
     `;
   }

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -43,7 +43,6 @@ export class SzOverviewEdgeLayer extends LitElement {
       fill: none;
       stroke-width: 3;
       pointer-events: stroke;
-      cursor: pointer;
       transition: stroke-width 0.15s ease, opacity 0.15s ease;
     }
 
@@ -67,34 +66,24 @@ export class SzOverviewEdgeLayer extends LitElement {
       stroke: var(--sz-text-muted, #6B6560);
     }
 
-    .mapping-label-group {
-      pointer-events: all;
-      cursor: pointer;
+    .anchor-dot {
+      pointer-events: none;
     }
 
-    .mapping-label-bg {
-      fill: var(--sz-card-bg, #fff);
-      stroke: var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      stroke-width: 1;
-      rx: 4;
+    .anchor-dot.pipeline {
+      fill: var(--sz-edge-pipeline, #D97726);
     }
 
-    .mapping-label-text {
-      font-family: var(--sz-font-sans, system-ui);
-      font-size: 10px;
-      font-weight: 600;
+    .anchor-dot.nl {
+      fill: var(--sz-edge-nl, #5A9E6F);
+    }
+
+    .anchor-dot.mixed {
+      fill: var(--sz-edge-pipeline, #D97726);
+    }
+
+    .anchor-dot.bare {
       fill: var(--sz-text-muted, #6B6560);
-      text-anchor: middle;
-      dominant-baseline: central;
-    }
-
-    .mapping-label-group:hover .mapping-label-bg {
-      fill: var(--sz-badge-bg, #FFF3E8);
-      stroke: var(--sz-orange-dark, #D97726);
-    }
-
-    .mapping-label-group:hover .mapping-label-text {
-      fill: var(--sz-orange-dark, #D97726);
     }
 
     /* Tooltip */
@@ -162,36 +151,20 @@ export class SzOverviewEdgeLayer extends LitElement {
   private _renderOverviewEdge(edge: OverviewEdge): SVGTemplateResult {
     if (edge.points.length < 2) return svg``;
 
-    const d = this._buildCurvePath(edge.points);
+    const d = this._buildRoutedPath(edge.points);
     const cls = this._edgeColorClass(edge.mapping);
-    const labelPos = this._labelAnchor(edge.points);
-    const labelText = edge.mapping.id;
-    const labelWidth = edge.labelWidth;
+    const first = edge.points[0];
+    const last = edge.points[edge.points.length - 1];
 
     return svg`
       <path
         class="overview-path ${cls}"
         d=${d}
-        @click=${() => this._onEdgeClick(edge)}
         @mouseenter=${(ev: MouseEvent) => this._onEdgeHover(edge.id, ev)}
         @mouseleave=${() => this._onEdgeLeave()}
       />
-      <g
-        class="mapping-label-group"
-        transform="translate(${labelPos.x}, ${labelPos.y})"
-        @click=${() => this._onEdgeClick(edge)}
-        @mouseenter=${(ev: MouseEvent) => this._onEdgeHover(edge.id, ev)}
-        @mouseleave=${() => this._onEdgeLeave()}
-      >
-        <rect
-          class="mapping-label-bg"
-          x=${-labelWidth / 2}
-          y="-10"
-          width=${labelWidth}
-          height="20"
-        />
-        <text class="mapping-label-text">${labelText}</text>
-      </g>
+      <circle class="anchor-dot ${cls}" cx=${first.x} cy=${first.y} r="3.5" />
+      <circle class="anchor-dot ${cls}" cx=${last.x} cy=${last.y} r="3.5" />
     `;
   }
 
@@ -219,75 +192,27 @@ export class SzOverviewEdgeLayer extends LitElement {
     return "bare";
   }
 
-  private _buildCurvePath(points: Array<{ x: number; y: number }>): string {
-    if (points.length === 2) {
-      const [p0, p1] = points;
-      const dx = (p1.x - p0.x) * 0.5;
-      return `M ${p0.x} ${p0.y} C ${p0.x + dx} ${p0.y}, ${p1.x - dx} ${p1.y}, ${p1.x} ${p1.y}`;
+  private _buildRoutedPath(points: Array<{ x: number; y: number }>): string {
+    if (points.length < 2) return "";
+    const [first, ...rest] = points;
+    if (rest.length === 1) {
+      return `M ${first.x} ${first.y} L ${rest[0].x} ${rest[0].y}`;
     }
-
-    const parts = [`M ${points[0].x} ${points[0].y}`];
-    for (let i = 1; i < points.length; i++) {
-      const prev = points[i - 1];
-      const curr = points[i];
-      const dx = (curr.x - prev.x) * 0.4;
-      parts.push(
-        `C ${prev.x + dx} ${prev.y}, ${curr.x - dx} ${curr.y}, ${curr.x} ${curr.y}`
-      );
+    // Use cubic bezier for smooth horizontal-exit, vertical-mid, horizontal-enter routing
+    if (rest.length === 3) {
+      const [mid1, mid2, last] = rest;
+      const r = Math.min(20, Math.abs(mid1.y - mid2.y) / 2, Math.abs(mid1.x - first.x) / 2);
+      return [
+        `M ${first.x} ${first.y}`,
+        `L ${mid1.x - r} ${mid1.y}`,
+        `Q ${mid1.x} ${mid1.y} ${mid1.x} ${mid1.y + Math.sign(mid2.y - mid1.y) * r}`,
+        `L ${mid2.x} ${mid2.y - Math.sign(mid2.y - mid1.y) * r}`,
+        `Q ${mid2.x} ${mid2.y} ${mid2.x + r} ${mid2.y}`,
+        `L ${last.x} ${last.y}`,
+      ].join(" ");
     }
-    return parts.join(" ");
-  }
-
-  private _midpoint(
-    points: Array<{ x: number; y: number }>
-  ): { x: number; y: number } {
-    const mid = Math.floor(points.length / 2);
-    if (points.length % 2 === 0) {
-      return {
-        x: (points[mid - 1].x + points[mid].x) / 2,
-        y: (points[mid - 1].y + points[mid].y) / 2,
-      };
-    }
-    return points[mid];
-  }
-
-  private _labelAnchor(
-    points: Array<{ x: number; y: number }>
-  ): { x: number; y: number } {
-    if (points.length < 2) return { x: 0, y: 0 };
-
-    let best:
-      | {
-          score: number;
-          length: number;
-          start: { x: number; y: number };
-          end: { x: number; y: number };
-        }
-      | null = null;
-
-    for (let i = 1; i < points.length; i++) {
-      const start = points[i - 1];
-      const end = points[i];
-      const dx = Math.abs(end.x - start.x);
-      const dy = Math.abs(end.y - start.y);
-      const length = Math.hypot(end.x - start.x, end.y - start.y);
-      const score = dx - dy * 0.5;
-
-      if (!best || score > best.score || (score === best.score && length > best.length)) {
-        best = { score, length, start, end };
-      }
-    }
-
-    if (!best) return this._midpoint(points);
-
-    return {
-      x: (best.start.x + best.end.x) / 2,
-      y: (best.start.y + best.end.y) / 2,
-    };
-  }
-
-  private _onEdgeClick(edge: OverviewEdge) {
-    this.dispatchEvent(new SzOpenMappingEvent(edge.mapping));
+    // Fallback: straight segments
+    return [`M ${first.x} ${first.y}`, ...rest.map((p) => `L ${p.x} ${p.y}`)].join(" ");
   }
 
   private _onEdgeHover(edgeId: string, ev: MouseEvent) {

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -99,6 +99,19 @@ const OVERVIEW_PILL_CHAR_WIDTH = 6.1;
 const OVERVIEW_LABEL_CHAR_WIDTH = 6.8;
 const OVERVIEW_LABEL_PADDING = 18;
 const OVERVIEW_LABEL_MAX_WIDTH = 220;
+const FULL_TITLE_CHAR_WIDTH = 8.1;
+const FULL_META_CHAR_WIDTH = 6.3;
+const FULL_FIELD_CHAR_WIDTH = 7.2;
+const FULL_TYPE_CHAR_WIDTH = 6.6;
+const FULL_NOTE_CHAR_WIDTH = 6.5;
+const FULL_HEADER_BASE_WIDTH = 86;
+const FULL_FIELD_BASE_WIDTH = 92;
+const FULL_NOTES_TOGGLE_HEIGHT = 28;
+const FULL_NOTES_SECTION_CHROME = 14;
+const FULL_NOTE_LINE_HEIGHT = 18;
+const FULL_SPREAD_HEIGHT = 24;
+const FULL_META_ROW_HEIGHT = 20;
+const FULL_META_BASE_HEIGHT = 12;
 
 /** Height of the area above the fields list (header + optional label + optional metadata pills). */
 function preambleHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
@@ -151,6 +164,154 @@ function estimateCompactTextCardWidth(id: string): number {
   return clamp(Math.ceil(headerWidth), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
 }
 
+function estimateLines(text: string, charsPerLine: number): number {
+  const segments = text
+    .split("\n")
+    .map((line) => Math.max(1, Math.ceil(line.trim().length / charsPerLine)));
+  return Math.max(1, segments.reduce((sum, lines) => sum + lines, 0));
+}
+
+function estimateNoteBlockHeight(text: string, expanded: boolean): number {
+  const base = FULL_NOTES_TOGGLE_HEIGHT + FULL_NOTES_SECTION_CHROME;
+  if (!expanded) return base;
+  return base + estimateLines(text, 34) * FULL_NOTE_LINE_HEIGHT;
+}
+
+function estimateSchemaWidth(schema: SchemaCard): number {
+  const spreads = schema.spreads ?? [];
+  const notes = schema.notes ?? [];
+  const titleWidth =
+    FULL_HEADER_BASE_WIDTH +
+    estimateTextWidth(schema.id, FULL_TITLE_CHAR_WIDTH) +
+    estimateTextWidth(`${countFields(schema.fields)}/${countFields(schema.fields)}`, OVERVIEW_COUNT_CHAR_WIDTH);
+
+  const labelWidth = schema.label
+    ? estimateTextWidth(schema.label, FULL_META_CHAR_WIDTH) + 48
+    : 0;
+
+  const pillWidth = schema.metadata
+    .filter((m) => m.key !== "note")
+    .reduce((max, m) => Math.max(max, estimateTextWidth(`${m.key} ${m.value}`, FULL_META_CHAR_WIDTH) + 48), 0);
+
+  const fieldWidth = measureFieldWidth(schema.fields);
+  const spreadWidth = spreads.reduce(
+    (max, spread) => Math.max(max, estimateTextWidth(`spreads ${spread}`, FULL_META_CHAR_WIDTH) + 48),
+    0,
+  );
+  const noteWidth = notes.reduce(
+    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    0,
+  );
+
+  return clamp(
+    Math.ceil(Math.max(titleWidth, labelWidth, pillWidth, fieldWidth, spreadWidth, noteWidth)),
+    CARD_MIN_WIDTH,
+    CARD_MAX_WIDTH,
+  );
+}
+
+function estimateMetricWidth(metric: MetricCard): number {
+  const notes = metric.notes ?? [];
+  const titleWidth = FULL_HEADER_BASE_WIDTH + estimateTextWidth(metric.id, FULL_TITLE_CHAR_WIDTH);
+  const metaTexts = [
+    metric.label ? `"${metric.label}"${metric.grain ? ` · grain: ${metric.grain}` : ""}` : "",
+    !metric.label && metric.grain ? `grain: ${metric.grain}` : "",
+    metric.slices.length > 0 ? `slice: ${metric.slices.join(", ")}` : "",
+  ].filter(Boolean);
+  const metaWidth = metaTexts.reduce(
+    (max, text) => Math.max(max, estimateTextWidth(text, FULL_META_CHAR_WIDTH) + 48),
+    0,
+  );
+  const fieldWidth = metric.fields.reduce(
+    (max, field) => Math.max(
+      max,
+      FULL_FIELD_BASE_WIDTH +
+        16 +
+        estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
+        estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
+    ),
+    0,
+  );
+  const noteWidth = notes.reduce(
+    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    0,
+  );
+
+  return clamp(Math.ceil(Math.max(titleWidth, metaWidth, fieldWidth, noteWidth)), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
+}
+
+function estimateFragmentWidth(fragment: FragmentCard): number {
+  const notes = fragment.notes ?? [];
+  const titleWidth =
+    FULL_HEADER_BASE_WIDTH +
+    estimateTextWidth(fragment.id, FULL_TITLE_CHAR_WIDTH) +
+    estimateTextWidth(`${fragment.fields.length} fields`, OVERVIEW_COUNT_CHAR_WIDTH);
+  const fieldWidth = fragment.fields.reduce(
+    (max, field) => Math.max(
+      max,
+      FULL_FIELD_BASE_WIDTH +
+        estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
+        estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
+    ),
+    0,
+  );
+  const noteWidth = notes.reduce(
+    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    0,
+  );
+
+  return clamp(Math.ceil(Math.max(titleWidth, fieldWidth, noteWidth)), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
+}
+
+function estimateMetricHeight(metric: MetricCard): number {
+  const notes = metric.notes ?? [];
+  const metaRows =
+    (metric.label ? 1 : 0) +
+    (!metric.label && metric.grain ? 1 : 0) +
+    (metric.slices.length > 0 ? 1 : 0);
+  const metaHeight = metaRows > 0 ? FULL_META_BASE_HEIGHT + metaRows * FULL_META_ROW_HEIGHT : 0;
+  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
+
+  return HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + metric.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+}
+
+function estimateFragmentHeight(fragment: FragmentCard): number {
+  const notes = fragment.notes ?? [];
+  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
+  return HEADER_HEIGHT + FIELDS_PADDING_TOP + fragment.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+}
+
+function estimateSchemaHeight(schema: SchemaCard): number {
+  const notes = schema.notes ?? [];
+  const spreads = schema.spreads ?? [];
+  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, true), 0);
+  const spreadsHeight = spreads.length * FULL_SPREAD_HEIGHT;
+  return (
+    preambleHeight(schema) +
+    FIELDS_PADDING_TOP +
+    countFields(schema.fields) * FIELD_HEIGHT +
+    FIELDS_PADDING_BOTTOM +
+    spreadsHeight +
+    notesHeight
+  );
+}
+
+function measureFieldWidth(fields: FieldEntry[], depth = 0): number {
+  return fields.reduce((max, field) => {
+    const constraintText = field.constraints.filter((c) => c !== "pii").join(" ");
+    const commentWidth = field.comments.length > 0 ? 32 : 0;
+    const width =
+      FULL_FIELD_BASE_WIDTH +
+      depth * 20 +
+      estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
+      estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH) +
+      (constraintText ? estimateTextWidth(constraintText, FULL_META_CHAR_WIDTH) + 24 : 0) +
+      (field.constraints.includes("pii") ? 44 : 0) +
+      commentWidth;
+    const childWidth = field.children.length > 0 ? measureFieldWidth(field.children, depth + 1) : 0;
+    return Math.max(max, width, childWidth);
+  }, 0);
+}
 const elk = new ELK();
 
 /**
@@ -279,19 +440,14 @@ function addSchemaNodes(
   target: ElkNode[],
 ) {
   for (const s of schemas) {
+    const width = estimateSchemaWidth(s);
     const topOffset = preambleHeight(s) + FIELDS_PADDING_TOP;
-    const ports = buildFieldPorts(s.fields, s.qualifiedId, mappedFields, topOffset);
-    const fieldCount = countFields(s.fields);
-    const height =
-      preambleHeight(s) +
-      FIELDS_PADDING_TOP +
-      fieldCount * FIELD_HEIGHT +
-      FIELDS_PADDING_BOTTOM;
+    const ports = buildFieldPorts(s.fields, s.qualifiedId, mappedFields, topOffset, width);
 
     target.push({
       id: s.qualifiedId,
-      width: CARD_MIN_WIDTH,
-      height,
+      width,
+      height: estimateSchemaHeight(s),
       ports,
       children: [],
       edges: [],
@@ -301,13 +457,13 @@ function addSchemaNodes(
 
 function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[]) {
   for (const f of fragments) {
-    const ports = buildFieldPorts(f.fields, f.id, new Map());
-    const height = HEADER_HEIGHT + FIELDS_PADDING_TOP + f.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM;
+    const width = estimateFragmentWidth(f);
+    const ports = buildFieldPorts(f.fields, f.id, new Map(), HEADER_HEIGHT + FIELDS_PADDING_TOP, width);
 
     target.push({
       id: f.id,
-      width: CARD_MIN_WIDTH,
-      height,
+      width,
+      height: estimateFragmentHeight(f),
       ports,
       children: [],
       edges: [],
@@ -317,15 +473,10 @@ function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[]) {
 
 function addMetricNodes(metrics: MetricCard[], target: ElkNode[]) {
   for (const m of metrics) {
-    const hasMeta = m.label || m.grain || m.slices.length > 0;
-    const metaHeight = hasMeta ? LABEL_HEIGHT : 0;
-    const height =
-      HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + m.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM;
-
     target.push({
       id: m.qualifiedId,
-      width: CARD_MIN_WIDTH,
-      height,
+      width: estimateMetricWidth(m),
+      height: estimateMetricHeight(m),
       // Metrics have no outgoing ports
       ports: [],
       children: [],
@@ -339,6 +490,7 @@ function buildFieldPorts(
   nodeId: string,
   _mappedFields: Map<string, Set<string>>,
   topOffset = HEADER_HEIGHT + FIELDS_PADDING_TOP,
+  nodeWidth = CARD_MIN_WIDTH,
 ): ElkPort[] {
   const ports: ElkPort[] = [];
   let index = 0;
@@ -357,7 +509,7 @@ function buildFieldPorts(
       // Right port (target side)
       ports.push({
         id: `${nodeId}:${f.name}:tgt`,
-        x: CARD_MIN_WIDTH,
+        x: nodeWidth,
         y,
         width: 1,
         height: 1,

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -25,6 +25,8 @@ export interface LayoutNode {
   y: number;
   width: number;
   height: number;
+  kind?: "schema" | "metric" | "fragment" | "mapping";
+  hasNamespace?: boolean;
   /** Port positions keyed by field name */
   ports: Map<string, { x: number; y: number }>;
 }
@@ -69,8 +71,6 @@ export interface OverviewEdge {
   targetNode: string;
   /** Array of {x,y} points forming the routed edge path */
   points: Array<{ x: number; y: number }>;
-  /** Estimated label width used for spacing and rendering. */
-  labelWidth: number;
   /** The full MappingBlock this edge represents. */
   mapping: MappingBlock;
 }
@@ -97,8 +97,9 @@ const OVERVIEW_TITLE_CHAR_WIDTH = 8.2;
 const OVERVIEW_COUNT_CHAR_WIDTH = 6.3;
 const OVERVIEW_PILL_CHAR_WIDTH = 6.1;
 const OVERVIEW_LABEL_CHAR_WIDTH = 6.8;
-const OVERVIEW_LABEL_PADDING = 18;
-const OVERVIEW_LABEL_MAX_WIDTH = 220;
+const OVERVIEW_LABEL_PADDING = 76; // left 12 + right 40 + icon 16 + gap 8
+const OVERVIEW_LABEL_MAX_WIDTH = 420;
+const OVERVIEW_NAMESPACE_PILL_PADDING = 30; // left 12 + right padding + pill internal padding
 const FULL_TITLE_CHAR_WIDTH = 8.1;
 const FULL_META_CHAR_WIDTH = 6.3;
 const FULL_FIELD_CHAR_WIDTH = 7.2;
@@ -112,10 +113,14 @@ const FULL_NOTE_LINE_HEIGHT = 18;
 const FULL_SPREAD_HEIGHT = 24;
 const FULL_META_ROW_HEIGHT = 20;
 const FULL_META_BASE_HEIGHT = 12;
+const NAMESPACE_PILL_HEIGHT = 24;
 
 /** Height of the area above the fields list (header + optional label + optional metadata pills). */
-function preambleHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
-  let h = HEADER_HEIGHT;
+function preambleHeight(
+  schema: { label: string | null; metadata: Array<{ key: string; value: string }> },
+  hasNamespace = false,
+): number {
+  let h = HEADER_HEIGHT + (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0);
   if (schema.label) h += LABEL_HEIGHT;
   const pills = schema.metadata.filter((m) => m.key !== "note");
   if (pills.length > 0) h += METADATA_PILLS_HEIGHT;
@@ -123,8 +128,11 @@ function preambleHeight(schema: { label: string | null; metadata: Array<{ key: s
 }
 
 /** Compact card height: header + optional label + optional pills + small padding. */
-function compactHeight(schema: { label: string | null; metadata: Array<{ key: string; value: string }> }): number {
-  return preambleHeight(schema) + FIELDS_PADDING_BOTTOM;
+function compactHeight(
+  schema: { label: string | null; metadata: Array<{ key: string; value: string }> },
+  hasNamespace = false,
+): number {
+  return preambleHeight(schema, hasNamespace) + FIELDS_PADDING_BOTTOM;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -135,16 +143,25 @@ function estimateTextWidth(text: string, charWidth: number): number {
   return text.length * charWidth;
 }
 
-function estimateOverviewLabelWidth(mappingId: string): number {
+function estimateOverviewLabelWidth(mappingId: string, namespaceName?: string | null): number {
+  const labelWidth = Math.ceil(estimateTextWidth(mappingId, OVERVIEW_LABEL_CHAR_WIDTH) + OVERVIEW_LABEL_PADDING);
+  // Namespace pill sits in its own row; take the wider of the two
+  const pillWidth = namespaceName
+    ? Math.ceil(estimateTextWidth(namespaceName, OVERVIEW_PILL_CHAR_WIDTH) + OVERVIEW_NAMESPACE_PILL_PADDING)
+    : 0;
   return clamp(
-    Math.ceil(estimateTextWidth(mappingId, OVERVIEW_LABEL_CHAR_WIDTH) + OVERVIEW_LABEL_PADDING),
-    48,
+    Math.max(labelWidth, pillWidth),
+    CARD_MIN_WIDTH,
     OVERVIEW_LABEL_MAX_WIDTH,
   );
 }
 
+function overviewMappingNodeId(namespaceName: string | null, mappingId: string): string {
+  return `mapping:${namespaceName ?? "_"}:${mappingId}`;
+}
+
 function estimateCompactSchemaWidth(schema: SchemaCard): number {
-  const displayName = schema.qualifiedId.includes("::") ? schema.qualifiedId : schema.id;
+  const displayName = schema.id;
   const countText = `${countFields(schema.fields)} fields`;
   const headerWidth =
     OVERVIEW_HEADER_BASE_WIDTH +
@@ -263,7 +280,7 @@ function estimateFragmentWidth(fragment: FragmentCard): number {
   return clamp(Math.ceil(Math.max(titleWidth, fieldWidth, noteWidth)), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
 }
 
-function estimateMetricHeight(metric: MetricCard): number {
+function estimateMetricHeight(metric: MetricCard, hasNamespace = false): number {
   const notes = metric.notes ?? [];
   const metaRows =
     (metric.label ? 1 : 0) +
@@ -272,22 +289,22 @@ function estimateMetricHeight(metric: MetricCard): number {
   const metaHeight = metaRows > 0 ? FULL_META_BASE_HEIGHT + metaRows * FULL_META_ROW_HEIGHT : 0;
   const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
 
-  return HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + metric.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+  return (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + metric.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
 }
 
-function estimateFragmentHeight(fragment: FragmentCard): number {
+function estimateFragmentHeight(fragment: FragmentCard, hasNamespace = false): number {
   const notes = fragment.notes ?? [];
   const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
-  return HEADER_HEIGHT + FIELDS_PADDING_TOP + fragment.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+  return (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_TOP + fragment.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
 }
 
-function estimateSchemaHeight(schema: SchemaCard): number {
+function estimateSchemaHeight(schema: SchemaCard, hasNamespace = false): number {
   const notes = schema.notes ?? [];
   const spreads = schema.spreads ?? [];
   const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, true), 0);
   const spreadsHeight = spreads.length * FULL_SPREAD_HEIGHT;
   return (
-    preambleHeight(schema) +
+    preambleHeight(schema, hasNamespace) +
     FIELDS_PADDING_TOP +
     countFields(schema.fields) * FIELD_HEIGHT +
     FIELDS_PADDING_BOTTOM +
@@ -378,27 +395,9 @@ function buildElkGraph(
   const edges: ElkEdge[] = [];
 
   for (const ns of model.namespaces) {
-    if (ns.name) {
-      // Namespace → compound node
-      const nsChildren: ElkNode[] = [];
-      addSchemaNodes(ns.schemas, mappedFields, nsChildren);
-      addFragmentNodes(ns.fragments, nsChildren);
-      addMetricNodes(ns.metrics, nsChildren);
-
-      children.push({
-        id: `ns:${ns.name}`,
-        layoutOptions: {
-          "elk.padding": "[top=28,left=16,bottom=16,right=16]",
-        },
-        children: nsChildren,
-        ports: [],
-        edges: [],
-      });
-    } else {
-      addSchemaNodes(ns.schemas, mappedFields, children);
-      addFragmentNodes(ns.fragments, children);
-      addMetricNodes(ns.metrics, children);
-    }
+    addSchemaNodes(ns.schemas, mappedFields, children, !!ns.name);
+    addFragmentNodes(ns.fragments, children, !!ns.name);
+    addMetricNodes(ns.metrics, children, !!ns.name);
   }
 
   // Build a set of all port IDs so we can validate edge endpoints
@@ -427,7 +426,6 @@ function buildElkGraph(
       "elk.spacing.edgeNode": "20",
       "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
       "elk.portConstraints": "FIXED_POS",
-      "elk.hierarchyHandling": "INCLUDE_CHILDREN",
     },
     children,
     edges,
@@ -438,16 +436,17 @@ function addSchemaNodes(
   schemas: SchemaCard[],
   mappedFields: Map<string, Set<string>>,
   target: ElkNode[],
+  hasNamespace = false,
 ) {
   for (const s of schemas) {
     const width = estimateSchemaWidth(s);
-    const topOffset = preambleHeight(s) + FIELDS_PADDING_TOP;
+    const topOffset = preambleHeight(s, hasNamespace) + FIELDS_PADDING_TOP;
     const ports = buildFieldPorts(s.fields, s.qualifiedId, mappedFields, topOffset, width);
 
     target.push({
       id: s.qualifiedId,
       width,
-      height: estimateSchemaHeight(s),
+      height: estimateSchemaHeight(s, hasNamespace),
       ports,
       children: [],
       edges: [],
@@ -455,15 +454,21 @@ function addSchemaNodes(
   }
 }
 
-function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[]) {
+function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[], hasNamespace = false) {
   for (const f of fragments) {
     const width = estimateFragmentWidth(f);
-    const ports = buildFieldPorts(f.fields, f.id, new Map(), HEADER_HEIGHT + FIELDS_PADDING_TOP, width);
+    const ports = buildFieldPorts(
+      f.fields,
+      f.id,
+      new Map(),
+      (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_TOP,
+      width,
+    );
 
     target.push({
       id: f.id,
       width,
-      height: estimateFragmentHeight(f),
+      height: estimateFragmentHeight(f, hasNamespace),
       ports,
       children: [],
       edges: [],
@@ -471,12 +476,12 @@ function addFragmentNodes(fragments: FragmentCard[], target: ElkNode[]) {
   }
 }
 
-function addMetricNodes(metrics: MetricCard[], target: ElkNode[]) {
+function addMetricNodes(metrics: MetricCard[], target: ElkNode[], hasNamespace = false) {
   for (const m of metrics) {
     target.push({
       id: m.qualifiedId,
       width: estimateMetricWidth(m),
-      height: estimateMetricHeight(m),
+      height: estimateMetricHeight(m, hasNamespace),
       // Metrics have no outgoing ports
       ports: [],
       children: [],
@@ -624,17 +629,14 @@ function extractLayout(
         });
       }
 
-      // Only add non-namespace nodes
-      if (!n.id.startsWith("ns:")) {
-        nodes.set(n.id, {
-          id: n.id,
-          x,
-          y,
-          width: n.width ?? CARD_MIN_WIDTH,
-          height: n.height ?? 100,
-          ports,
-        });
-      }
+      nodes.set(n.id, {
+        id: n.id,
+        x,
+        y,
+        width: n.width ?? CARD_MIN_WIDTH,
+        height: n.height ?? 100,
+        ports,
+      });
 
       if (n.children && n.children.length > 0) {
         walkNodes(n.children, x, y);
@@ -713,13 +715,13 @@ function extractLayout(
 export async function computeOverviewLayout(model: VizModel): Promise<OverviewLayoutResult> {
   const children: ElkNode[] = [];
   const edges: ElkEdge[] = [];
+  const overviewNodeKinds = new Map<string, LayoutNode["kind"]>();
+  const overviewNodeHasNamespace = new Set<string>();
   const overviewEdgeMeta = new Map<string, {
     sourceNode: string;
     targetNode: string;
     mapping: MappingBlock;
-    labelWidth: number;
   }>();
-  let maxLabelWidth = 0;
   const nodeIds = new Set<string>();
 
   for (const ns of model.namespaces) {
@@ -727,10 +729,15 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
 
     for (const s of ns.schemas) {
       nodeIds.add(s.qualifiedId);
+      overviewNodeKinds.set(s.qualifiedId, "schema");
+      if (ns.name) overviewNodeHasNamespace.add(s.qualifiedId);
       nsNodes.push({
         id: s.qualifiedId,
         width: estimateCompactSchemaWidth(s),
-        height: compactHeight(s),
+        height: compactHeight(s, !!ns.name),
+        layoutOptions: {
+          "elk.layered.layerConstraint": "NONE",
+        },
         ports: [],
         children: [],
         edges: [],
@@ -739,10 +746,15 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
 
     for (const f of ns.fragments) {
       nodeIds.add(f.id);
+      overviewNodeKinds.set(f.id, "fragment");
+      if (ns.name) overviewNodeHasNamespace.add(f.id);
       nsNodes.push({
         id: f.id,
         width: estimateCompactTextCardWidth(f.id),
-        height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
+        height: (ns.name ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
+        layoutOptions: {
+          "elk.layered.layerConstraint": "NONE",
+        },
         ports: [],
         children: [],
         edges: [],
@@ -751,53 +763,72 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
 
     for (const m of ns.metrics) {
       nodeIds.add(m.qualifiedId);
+      overviewNodeKinds.set(m.qualifiedId, "metric");
+      if (ns.name) overviewNodeHasNamespace.add(m.qualifiedId);
       nsNodes.push({
         id: m.qualifiedId,
-        width: estimateCompactTextCardWidth(m.qualifiedId),
-        height: HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
+        width: estimateCompactTextCardWidth(m.id),
+        height: (ns.name ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
+        layoutOptions: {
+          "elk.layered.layerConstraint": "NONE",
+        },
         ports: [],
         children: [],
         edges: [],
       });
     }
 
-    if (ns.name) {
-      children.push({
-        id: `ns:${ns.name}`,
+    for (const m of ns.mappings) {
+      const mappingNodeId = overviewMappingNodeId(ns.name, m.id);
+      overviewNodeKinds.set(mappingNodeId, "mapping");
+      if (ns.name) overviewNodeHasNamespace.add(mappingNodeId);
+      nsNodes.push({
+        id: mappingNodeId,
+        width: estimateOverviewLabelWidth(m.id, ns.name),
+        height: (ns.name ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
         layoutOptions: {
-          "elk.padding": "[top=28,left=16,bottom=16,right=16]",
+          "elk.layered.layerConstraint": "NONE",
         },
-        children: nsNodes,
         ports: [],
+        children: [],
         edges: [],
       });
-    } else {
-      children.push(...nsNodes);
     }
 
-    // One edge per mapping block
+    children.push(...nsNodes);
+
+    // Model mappings as intermediate nodes: sources -> mapping block -> target.
     for (const m of ns.mappings) {
-      const labelWidth = estimateOverviewLabelWidth(m.id);
-      maxLabelWidth = Math.max(maxLabelWidth, labelWidth);
+      const mappingNodeId = overviewMappingNodeId(ns.name, m.id);
       for (const sourceRef of m.sourceRefs) {
-        if (!nodeIds.has(sourceRef) || !nodeIds.has(m.targetRef)) continue;
-        const edgeId = `overview:${m.id}:${sourceRef}`;
+        if (!nodeIds.has(sourceRef)) continue;
+        const edgeId = `overview:${mappingNodeId}:in:${sourceRef}`;
         edges.push({
           id: edgeId,
           sources: [sourceRef],
-          targets: [m.targetRef],
+          targets: [mappingNodeId],
         });
         overviewEdgeMeta.set(edgeId, {
           sourceNode: sourceRef,
-          targetNode: m.targetRef,
+          targetNode: mappingNodeId,
           mapping: m,
-          labelWidth,
         });
       }
+
+      if (!nodeIds.has(m.targetRef)) continue;
+      const targetEdgeId = `overview:${mappingNodeId}:out:${m.targetRef}`;
+      edges.push({
+        id: targetEdgeId,
+        sources: [mappingNodeId],
+        targets: [m.targetRef],
+      });
+      overviewEdgeMeta.set(targetEdgeId, {
+        sourceNode: mappingNodeId,
+        targetNode: m.targetRef,
+        mapping: m,
+      });
     }
   }
-
-  const layerSpacing = Math.max(80, maxLabelWidth + 72);
 
   const elkGraph: ElkGraph = {
     id: "root",
@@ -805,11 +836,10 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       "elk.algorithm": "layered",
       "elk.direction": "RIGHT",
       "elk.spacing.nodeNode": "40",
-      "elk.layered.spacing.nodeNodeBetweenLayers": String(layerSpacing),
+      "elk.layered.spacing.nodeNodeBetweenLayers": "96",
       "elk.spacing.edgeEdge": "20",
       "elk.spacing.edgeNode": "20",
       "elk.layered.considerModelOrder.strategy": "NODES_AND_EDGES",
-      "elk.hierarchyHandling": "INCLUDE_CHILDREN",
     },
     children,
     edges,
@@ -824,16 +854,21 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
       const x = (n.x ?? 0) + offsetX;
       const y = (n.y ?? 0) + offsetY;
 
-      if (!n.id.startsWith("ns:")) {
-        nodes.push({
-          id: n.id,
-          x,
-          y,
-          width: n.width ?? CARD_MIN_WIDTH,
-          height: n.height ?? (HEADER_HEIGHT + FIELDS_PADDING_BOTTOM),
-          ports: new Map(),
-        });
-      }
+      nodes.push({
+        id: n.id,
+        x,
+        y,
+        width: n.width ?? CARD_MIN_WIDTH,
+        height: n.height ?? (HEADER_HEIGHT + FIELDS_PADDING_BOTTOM),
+        kind: overviewNodeKinds.get(n.id)
+          ?? (n.id.startsWith("mapping:")
+            ? "mapping"
+            : nodeIds.has(n.id)
+              ? "schema"
+              : undefined),
+        hasNamespace: overviewNodeHasNamespace.has(n.id),
+        ports: new Map(),
+      });
 
       if (n.children && n.children.length > 0) {
         walkOverviewNodes(n.children, x, y);
@@ -854,14 +889,36 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
 
     const meta = overviewEdgeMeta.get(e.id);
     if (meta) {
-      overviewEdges.push({
-        id: e.id,
-        sourceNode: meta.sourceNode,
-        targetNode: meta.targetNode,
-        points,
-        labelWidth: meta.labelWidth,
-        mapping: meta.mapping,
-      });
+      const sourceNode = nodes.find((node) => node.id === meta.sourceNode);
+      const targetNode = nodes.find((node) => node.id === meta.targetNode);
+      if (sourceNode && targetNode) {
+        // Replace ELK's routing with clean horizontal-exit / horizontal-enter paths
+        const src = overviewVisualAnchor(sourceNode, "source");
+        const tgt = overviewVisualAnchor(targetNode, "target");
+        const midX = (src.x + tgt.x) / 2;
+        const cleanPoints = [
+          src,
+          { x: midX, y: src.y },
+          { x: midX, y: tgt.y },
+          tgt,
+        ];
+        overviewEdges.push({
+          id: e.id,
+          sourceNode: meta.sourceNode,
+          targetNode: meta.targetNode,
+          points: cleanPoints,
+          mapping: meta.mapping,
+        });
+      } else {
+        // Fallback: use ELK points as-is
+        overviewEdges.push({
+          id: e.id,
+          sourceNode: meta.sourceNode,
+          targetNode: meta.targetNode,
+          points,
+          mapping: meta.mapping,
+        });
+      }
     }
   }
 
@@ -871,6 +928,18 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
     width: result.width ?? 800,
     height: result.height ?? 600,
   };
+}
+
+function overviewVisualAnchor(node: LayoutNode, side: "source" | "target"): { x: number; y: number } {
+  const x = side === "source" ? node.x + node.width : node.x;
+  const namespaceOffset = node.hasNamespace ? NAMESPACE_PILL_HEIGHT : 0;
+
+  if (node.kind === "mapping") {
+    // Center on the visual card area below the namespace pill
+    return { x, y: node.y + namespaceOffset + (node.height - namespaceOffset) / 2 };
+  }
+
+  return { x, y: node.y + namespaceOffset + HEADER_HEIGHT / 2 };
 }
 
 // ---- ELK type stubs (minimal) ----

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -59,6 +59,7 @@ export class SatsumaViz extends LitElement {
       background: var(--sz-bg);
       color: var(--sz-text);
       font-family: var(--sz-font-sans);
+      height: 100%;
       min-height: 100%;
       overflow: auto;
     }
@@ -102,6 +103,10 @@ export class SatsumaViz extends LitElement {
 
     /* View transition fade */
     .view-content {
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      min-height: 0;
       animation: fadeIn 0.2s ease-out;
     }
 
@@ -386,6 +391,7 @@ export class SatsumaViz extends LitElement {
       display: flex;
       flex: 1;
       overflow: hidden;
+      min-height: 0;
     }
 
     .notes-pane-wrapper > .viewport {
@@ -620,9 +626,13 @@ export class SatsumaViz extends LitElement {
   private _panStartY = 0;
   private _panStartPanX = 0;
   private _panStartPanY = 0;
+  private readonly _handleWindowResize = () => {
+    this.requestUpdate();
+  };
 
   override connectedCallback() {
     super.connectedCallback();
+    window.addEventListener("resize", this._handleWindowResize);
     this.addEventListener("field-hover", ((e: SzFieldHoverEvent) => {
       this._hoveredSchema = e.schemaId;
       this._hoveredField = e.fieldName;
@@ -632,6 +642,11 @@ export class SatsumaViz extends LitElement {
       this._viewMode = "detail";
       this._resetPanZoom();
     }) as EventListener);
+  }
+
+  override disconnectedCallback() {
+    window.removeEventListener("resize", this._handleWindowResize);
+    super.disconnectedCallback();
   }
 
   override updated(changed: Map<string, unknown>) {
@@ -683,6 +698,7 @@ export class SatsumaViz extends LitElement {
     this._layout = null;
     this._overviewLayout = null;
     this._layoutError = false;
+    this._renderedNamespaceBoxes = [];
 
     // Build a merged model that includes expanded cross-file schemas
     const mergedModel = this._buildMergedModel();
@@ -920,10 +936,38 @@ export class SatsumaViz extends LitElement {
   }
 
   private _fit() {
-    this._zoom = 1;
-    this._panX = 0;
-    this._panY = 0;
-    this.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+    const viewport = this.renderRoot?.querySelector?.(".viewport") as HTMLElement | null;
+    const canvas = this.renderRoot?.querySelector?.(".canvas") as HTMLElement | null;
+    if (!viewport || !canvas) {
+      this._resetPanZoom();
+      return;
+    }
+
+    const bounds = this._measureContentBounds(canvas);
+    if (!bounds) {
+      this._resetPanZoom();
+      return;
+    }
+
+    const viewportWidth = viewport.clientWidth;
+    const viewportHeight = viewport.clientHeight;
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+      this._resetPanZoom();
+      return;
+    }
+
+    const zoom = Math.min(
+      SatsumaViz.MAX_ZOOM,
+      Math.max(
+        SatsumaViz.MIN_ZOOM,
+        Math.min(viewportWidth / bounds.width, viewportHeight / bounds.height),
+      ),
+    );
+
+    this._zoom = zoom;
+    this._panX = (viewportWidth - bounds.width * zoom) / 2 - bounds.minX * zoom;
+    this._panY = (viewportHeight - bounds.height * zoom) / 2 - bounds.minY * zoom;
+    this._showZoomIndicator();
   }
 
   private _refresh() {
@@ -1113,7 +1157,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               return html`
                 <div class="positioned-card" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-fragment-card .fragment=${f}></sz-fragment-card>
+                  <sz-fragment-card .fragment=${f} compact></sz-fragment-card>
                 </div>
               `;
             }),
@@ -1122,7 +1166,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               return html`
                 <div class="positioned-card" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-metric-card .metric=${m}></sz-metric-card>
+                  <sz-metric-card .metric=${m} compact></sz-metric-card>
                 </div>
               `;
             }),
@@ -1658,6 +1702,50 @@ export class SatsumaViz extends LitElement {
     }
   }
 
+  private _measureContentBounds(canvas: HTMLElement): {
+    minX: number;
+    minY: number;
+    width: number;
+    height: number;
+  } | null {
+    const selectors = [
+      ".positioned-card",
+      ".namespace-box",
+      ".block-comment-badge",
+      ".source-block-label",
+      ".source-block-filter",
+    ];
+    const elements = selectors.flatMap((selector) =>
+      Array.from(canvas.querySelectorAll(selector)) as HTMLElement[]
+    );
+
+    if (elements.length === 0) {
+      const width = Math.max(canvas.scrollWidth, canvas.offsetWidth);
+      const height = Math.max(canvas.scrollHeight, canvas.offsetHeight);
+      if (width <= 0 || height <= 0) return null;
+      return { minX: 0, minY: 0, width, height };
+    }
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const el of elements) {
+      minX = Math.min(minX, el.offsetLeft);
+      minY = Math.min(minY, el.offsetTop);
+      maxX = Math.max(maxX, el.offsetLeft + el.offsetWidth);
+      maxY = Math.max(maxY, el.offsetTop + el.offsetHeight);
+    }
+
+    const padding = 24;
+    return {
+      minX: minX - padding,
+      minY: minY - padding,
+      width: maxX - minX + padding * 2,
+      height: maxY - minY + padding * 2,
+    };
+  }
   private _buildMappedFieldsIndex(): Map<string, Set<string>> {
     const index = new Map<string, Set<string>>();
     if (!this.model) return index;

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -55,13 +55,14 @@ export class SatsumaViz extends LitElement {
     ${unsafeCSS(tokens)}
 
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
       background: var(--sz-bg);
       color: var(--sz-text);
       font-family: var(--sz-font-sans);
       height: 100%;
       min-height: 100%;
-      overflow: auto;
+      overflow: hidden;
     }
 
     .canvas {
@@ -72,33 +73,52 @@ export class SatsumaViz extends LitElement {
 
     .card-layer {
       position: relative;
-      z-index: 20;
+      z-index: 10;
     }
 
     .positioned-card {
       position: absolute;
     }
 
-    .namespace-box {
-      position: absolute;
-      border: 2px dashed var(--sz-namespace-border);
-      background: var(--sz-namespace-bg);
-      border-radius: var(--sz-card-radius);
-      z-index: 0;
-      pointer-events: none;
+    .positioned-card.mapping-node {
+      cursor: pointer;
+      z-index: 25;
     }
 
-    .namespace-label {
-      position: absolute;
-      top: -10px;
-      left: 12px;
-      background: var(--sz-namespace-bg);
-      padding: 0 6px;
-      font-size: 11px;
+    .overview-mapping-card {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      box-sizing: border-box;
+      min-height: 44px;
+      padding: 0 40px 0 12px;
+      border-radius: var(--sz-card-radius, 8px);
+      background:
+        linear-gradient(135deg, rgba(16, 80, 104, 0.98), rgba(10, 53, 76, 0.98)),
+        linear-gradient(45deg, rgba(255,255,255,0.06), rgba(255,255,255,0));
+      border: 1px solid rgba(8, 36, 52, 0.35);
+      color: #fff;
+      box-shadow: 0 8px 20px rgba(10, 53, 76, 0.18);
+      font-size: 13px;
       font-weight: 600;
-      text-transform: uppercase;
-      color: var(--sz-text-muted);
-      letter-spacing: 0.05em;
+      white-space: nowrap;
+    }
+
+    .overview-mapping-card:hover {
+      filter: brightness(1.03);
+    }
+
+    .overview-mapping-icon {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      opacity: 0.92;
+    }
+
+    .overview-mapping-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     /* View transition fade */
@@ -286,7 +306,24 @@ export class SatsumaViz extends LitElement {
     .viewport {
       overflow: hidden;
       flex: 1;
+      min-height: 0;
+      height: 100%;
       position: relative;
+      isolation: isolate;
+    }
+
+    .detail-scroll {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      padding: 16px;
+      /* Ensure scroll works within flex layout */
+      height: 0;
+    }
+
+    .detail-inner {
+      width: max-content;
+      min-width: 100%;
     }
 
     .viewport-inner {
@@ -392,6 +429,7 @@ export class SatsumaViz extends LitElement {
       flex: 1;
       overflow: hidden;
       min-height: 0;
+      position: relative;
     }
 
     .notes-pane-wrapper > .viewport {
@@ -801,8 +839,26 @@ export class SatsumaViz extends LitElement {
         ${this._renderToolbar(namespaces)}
         <div class="${toggleClasses} view-content">
           ${this._renderFileNotes()}
-          <div style="padding: 16px;">
-            ${this._renderMappingDetailView(this._selectedMapping)}
+          <div class="notes-pane-wrapper">
+            <div class="viewport"
+              @wheel=${this._onWheel}
+              @mousedown=${this._onMouseDown}
+              @mousemove=${this._onMouseMove}
+              @mouseup=${this._onMouseUp}
+              @mouseleave=${this._onMouseUp}
+            >
+              <div class="viewport-inner"
+                style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
+              >
+                <div class="detail-inner" style="padding: 16px;">
+                  ${this._renderMappingDetailView(this._selectedMapping)}
+                </div>
+              </div>
+              <div class="zoom-indicator ${this._zoomIndicatorVisible ? "visible" : ""}">
+                ${Math.round(this._zoom * 100)}%
+              </div>
+              ${this._renderMinimap(this._layout)}
+            </div>
           </div>
         </div>
       `;
@@ -1116,26 +1172,12 @@ export class SatsumaViz extends LitElement {
 
   /** Render the overview: compact schema cards + thick overview edges. */
   private _renderOverview(overview: OverviewLayoutResult, namespaces: NamespaceGroup[]) {
-    const nsBoxes = this._computeOverviewNamespaceBoxes(overview, namespaces);
-
     return html`
       <div class="canvas" style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;">
-        <!-- Namespace bounding boxes -->
-        ${nsBoxes.map(
-          (box) => html`
-            <div
-              class="namespace-box"
-              style="left: ${box.x}px; top: ${box.y}px; width: ${box.w}px; height: ${box.h}px;"
-            >
-              <span class="namespace-label">${box.name}</span>
-            </div>
-          `
-        )}
-
-        <!-- Overview SVG edge layer -->
+        <!-- Overview SVG edge layer (filtered to visible nodes) -->
         <sz-overview-edge-layer
-          style="left: 24px; top: 24px; z-index: 10;"
-          .edges=${overview.edges}
+          style="left: 24px; top: 0; z-index: 30;"
+          .edges=${this._filterOverviewEdges(overview.edges, namespaces)}
           .width=${overview.width}
           .height=${overview.height}
         ></sz-overview-edge-layer>
@@ -1148,7 +1190,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               return html`
                 <div class="positioned-card" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-schema-card .schema=${s} compact></sz-schema-card>
+                  <sz-schema-card .schema=${s} .namespaceLabel=${ns.name} compact></sz-schema-card>
                 </div>
               `;
             }),
@@ -1157,7 +1199,7 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               return html`
                 <div class="positioned-card" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-fragment-card .fragment=${f} compact></sz-fragment-card>
+                  <sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name} compact></sz-fragment-card>
                 </div>
               `;
             }),
@@ -1166,7 +1208,37 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               return html`
                 <div class="positioned-card" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-metric-card .metric=${m} compact></sz-metric-card>
+                  <sz-metric-card .metric=${m} .namespaceLabel=${ns.name} compact></sz-metric-card>
+                </div>
+              `;
+            }),
+            ...ns.mappings.map((m) => {
+              const mappingNodeId = this._overviewMappingNodeId(ns.name, m.id);
+              const node = overview.nodes.find((n) => n.id === mappingNodeId);
+              if (!node) return html``;
+              return html`
+                <div
+                  class="positioned-card mapping-node"
+                  data-node-id=${mappingNodeId}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                  @click=${() => this._openOverviewMapping(m)}
+                >
+                  <div class="overview-mapping-card" title=${m.id}>
+                    <div style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0;">
+                      ${ns.name
+                        ? html`<span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:999px;background:#DCECF6;color:#0A354C;">${ns.name}</span>`
+                        : ""}
+                      <div style="display:flex;align-items:center;gap:8px;min-width:0;">
+                        <svg class="overview-mapping-icon" viewBox="0 0 16 16" fill="currentColor">
+                          <path d="M2 3h3v2H2v2l-2-3 2-3v2z" opacity="0.95"></path>
+                          <path d="M14 11h-3V9h3V7l2 3-2 3v-2z" opacity="0.95"></path>
+                          <path d="M4.5 5.5h7v1.5h-7z" opacity="0.78"></path>
+                          <path d="M4.5 9h7v1.5h-7z" opacity="0.78"></path>
+                        </svg>
+                        <span class="overview-mapping-name">${m.id}</span>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               `;
             }),
@@ -1193,6 +1265,7 @@ export class SatsumaViz extends LitElement {
         ...ns.schemas.map((s) => s.qualifiedId),
         ...ns.fragments.map((f) => f.id),
         ...ns.metrics.map((m) => m.qualifiedId),
+        ...ns.mappings.map((m) => this._overviewMappingNodeId(ns.name, m.id)),
       ];
 
       let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
@@ -1209,13 +1282,16 @@ export class SatsumaViz extends LitElement {
       }
 
       if (found) {
-        const pad = 16;
+        const padX = 0;
+        const padTop = 0;
+        const padBottom = 0;
+        const labelPad = 10;
         boxes.push({
           name: ns.name,
-          x: minX - pad,
-          y: minY - pad - 12,
-          w: maxX - minX + pad * 2,
-          h: maxY - minY + pad * 2 + 12,
+          x: minX - padX,
+          y: minY - padTop - labelPad,
+          w: maxX - minX + padX * 2,
+          h: maxY - minY + padTop + padBottom + labelPad,
         });
       }
     }
@@ -1233,16 +1309,41 @@ export class SatsumaViz extends LitElement {
     return { nodes, edges: [], sourceBlocks: [], width: ov.width, height: ov.height };
   }
 
+  private _overviewMappingNodeId(namespaceName: string | null, mappingId: string): string {
+    return `mapping:${namespaceName ?? "_"}:${mappingId}`;
+  }
+
+  private _openOverviewMapping(mapping: MappingBlock) {
+    this._selectedMapping = mapping;
+    this._viewMode = "detail";
+    this._resetPanZoom();
+  }
+
   /** Render the mapping detail view with schema cards and arrow table. */
+  /** Expand ...spread references by merging fragment fields into a schema copy. */
+  private _expandSpreads(schema: SchemaCard): SchemaCard {
+    if (!this.model || schema.spreads.length === 0) return schema;
+    const allFragments = this.model.namespaces.flatMap((ns) => ns.fragments);
+    const extraFields: import("./model.js").FieldEntry[] = [];
+    for (const spreadName of schema.spreads) {
+      const frag = allFragments.find((f) => f.id === spreadName);
+      if (frag) extraFields.push(...frag.fields);
+    }
+    if (extraFields.length === 0) return schema;
+    return { ...schema, fields: [...schema.fields, ...extraFields] };
+  }
+
   private _renderMappingDetailView(mapping: MappingBlock) {
     if (!this.model) return html``;
 
-    // Find source and target schemas from the model
+    // Find source and target schemas from the model, expanding spreads
     const allSchemas = this.model.namespaces.flatMap((ns) => ns.schemas);
     const sourceSchemas = mapping.sourceRefs
       .map((ref) => allSchemas.find((s) => s.qualifiedId === ref))
-      .filter((s): s is SchemaCard => s !== undefined);
+      .filter((s): s is SchemaCard => s !== undefined)
+      .map((s) => this._expandSpreads(s));
     const targetSchema = allSchemas.find((s) => s.qualifiedId === mapping.targetRef) ?? null;
+    const expandedTarget = targetSchema ? this._expandSpreads(targetSchema) : null;
 
     // Build mapped fields for the detail view
     const sourceMapped = new Map<string, Set<string>>();
@@ -1262,15 +1363,26 @@ export class SatsumaViz extends LitElement {
     for (const eb of mapping.eachBlocks) collectArrows(eb.arrows);
     for (const fb of mapping.flattenBlocks) collectArrows(fb.arrows);
 
+    const namespaceLabel = this._namespaceForMapping(mapping);
+
     return html`
       <sz-mapping-detail
         .mapping=${mapping}
         .sourceSchemas=${sourceSchemas}
-        .targetSchema=${targetSchema}
+        .targetSchema=${expandedTarget}
         .sourceMappedFields=${sourceMapped}
         .targetMappedFields=${targetMapped}
+        .namespaceLabel=${namespaceLabel}
       ></sz-mapping-detail>
     `;
+  }
+
+  private _namespaceForMapping(mapping: MappingBlock): string | null {
+    if (!this.model) return null;
+    for (const ns of this.model.namespaces) {
+      if (ns.mappings.includes(mapping)) return ns.name;
+    }
+    return null;
   }
 
   private _collectAllComments(): {
@@ -1452,6 +1564,22 @@ export class SatsumaViz extends LitElement {
     );
   }
 
+  /** Filter overview edges to only those whose source and target nodes are visible. */
+  private _filterOverviewEdges(
+    edges: import("./layout/elk-layout.js").OverviewEdge[],
+    visibleNamespaces: NamespaceGroup[],
+  ): import("./layout/elk-layout.js").OverviewEdge[] {
+    if (!this._nsFilter) return edges;
+    const visibleIds = new Set<string>();
+    for (const ns of visibleNamespaces) {
+      for (const s of ns.schemas) visibleIds.add(s.qualifiedId);
+      for (const f of ns.fragments) visibleIds.add(f.id);
+      for (const m of ns.metrics) visibleIds.add(m.qualifiedId);
+      for (const m of ns.mappings) visibleIds.add(this._overviewMappingNodeId(ns.name, m.id));
+    }
+    return edges.filter((e) => visibleIds.has(e.sourceNode) && visibleIds.has(e.targetNode));
+  }
+
   private _renderFileNotes() {
     if (!this.model || this.model.fileNotes.length === 0) return html``;
 
@@ -1474,9 +1602,6 @@ export class SatsumaViz extends LitElement {
   }
 
   private _renderPositioned(layout: LayoutResult, namespaces: NamespaceGroup[]) {
-    // Build namespace bounding boxes from child node positions
-    const nsBoxes = this._computeNamespaceBoxes(layout, namespaces);
-
     // Track which schema IDs came from expansions for animation
     const expandedIds = new Set<string>();
     for (const models of this._expandedModels.values()) {
@@ -1491,21 +1616,9 @@ export class SatsumaViz extends LitElement {
 
     return html`
       <div class="canvas" style="width: ${layout.width + 48}px; height: ${layout.height + 48}px; padding: 24px;">
-        <!-- Namespace bounding boxes -->
-        ${nsBoxes.map(
-          (box) => html`
-            <div
-              class="namespace-box"
-              style="left: ${box.x}px; top: ${box.y}px; width: ${box.w}px; height: ${box.h}px;"
-            >
-              <span class="namespace-label">${box.name}</span>
-            </div>
-          `
-        )}
-
         <!-- SVG edge layer (behind cards) -->
         <sz-edge-layer
-          style="left: 24px; top: 24px; z-index: 10;"
+          style="left: 24px; top: 0; z-index: 30;"
           .edges=${layout.edges}
           .width=${layout.width}
           .height=${layout.height}
@@ -1526,7 +1639,7 @@ export class SatsumaViz extends LitElement {
               const isExpanded = expandedIds.has(s.qualifiedId);
               const results = [html`
                 <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-schema-card .schema=${s} .mappedFields=${mapped}></sz-schema-card>
+                  <sz-schema-card .schema=${s} .mappedFields=${mapped} .namespaceLabel=${ns.name}></sz-schema-card>
                 </div>
               `];
               // Block-level comment badges
@@ -1549,7 +1662,7 @@ export class SatsumaViz extends LitElement {
               const isExpanded = expandedIds.has(f.id);
               return html`
                 <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-fragment-card .fragment=${f}></sz-fragment-card>
+                  <sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name}></sz-fragment-card>
                 </div>
               `;
             }),
@@ -1559,7 +1672,7 @@ export class SatsumaViz extends LitElement {
               const isExpanded = expandedIds.has(m.qualifiedId);
               return html`
                 <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-metric-card .metric=${m}></sz-metric-card>
+                  <sz-metric-card .metric=${m} .namespaceLabel=${ns.name}></sz-metric-card>
                 </div>
               `;
             }),
@@ -1590,13 +1703,13 @@ export class SatsumaViz extends LitElement {
     return html`
       ${ns.schemas.map((s) => {
         const mapped = this._mappedFieldsBySchema.get(s.qualifiedId) ?? new Set();
-        return html`<sz-schema-card .schema=${s} .mappedFields=${mapped}></sz-schema-card>`;
+        return html`<sz-schema-card .schema=${s} .mappedFields=${mapped} .namespaceLabel=${ns.name}></sz-schema-card>`;
       })}
       ${ns.fragments.map(
-        (f) => html`<sz-fragment-card .fragment=${f}></sz-fragment-card>`
+        (f) => html`<sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name}></sz-fragment-card>`
       )}
       ${ns.metrics.map(
-        (m) => html`<sz-metric-card .metric=${m}></sz-metric-card>`
+        (m) => html`<sz-metric-card .metric=${m} .namespaceLabel=${ns.name}></sz-metric-card>`
       )}
     `;
   }
@@ -1617,6 +1730,7 @@ export class SatsumaViz extends LitElement {
         ...ns.schemas.map((s) => s.qualifiedId),
         ...ns.fragments.map((f) => f.id),
         ...ns.metrics.map((m) => m.qualifiedId),
+        ...ns.mappings.map((m) => this._overviewMappingNodeId(ns.name, m.id)),
       ];
 
       let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
@@ -1656,8 +1770,10 @@ export class SatsumaViz extends LitElement {
 
     const namespaces = this._filterNamespaces(this.model.namespaces);
     const boxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
-    const pad = 16;
-    const labelPad = 12;
+    const padX = 0;
+    const padTop = 0;
+    const padBottom = 0;
+    const labelPad = 10;
 
     for (const ns of namespaces) {
       if (!ns.name) continue;
@@ -1666,6 +1782,7 @@ export class SatsumaViz extends LitElement {
         ...ns.schemas.map((s) => s.qualifiedId),
         ...ns.fragments.map((f) => f.id),
         ...ns.metrics.map((m) => m.qualifiedId),
+        ...ns.mappings.map((m) => this._overviewMappingNodeId(ns.name, m.id)),
       ];
 
       let minX = Infinity;
@@ -1687,10 +1804,10 @@ export class SatsumaViz extends LitElement {
       if (found) {
         boxes.push({
           name: ns.name,
-          x: minX - pad,
-          y: minY - pad - labelPad,
-          w: maxX - minX + pad * 2,
-          h: maxY - minY + pad * 2 + labelPad,
+          x: minX - padX,
+          y: minY - padTop - labelPad,
+          w: maxX - minX + padX * 2,
+          h: maxY - minY + padTop + padBottom + labelPad,
         });
       }
     }

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -184,7 +184,7 @@ describe("computeLayout", () => {
     assert.ok(result.edges.length >= 0, "Should have edges array");
   });
 
-  it("includes namespace compound nodes without adding them to result nodes", async () => {
+  it("keeps namespaced schemas as flat result nodes", async () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
@@ -220,7 +220,7 @@ describe("computeLayout", () => {
     );
     assert.ok(
       !result.nodes.has("ns:crm"),
-      "Namespace compound node should NOT appear in result nodes"
+      "Namespace layout container should not exist in result nodes"
     );
   });
 
@@ -404,11 +404,13 @@ describe("computeOverviewLayout", () => {
 
     const result = await computeOverviewLayout(model);
 
-    assert.ok(result.nodes.length >= 2, "Should have at least 2 nodes");
+    assert.ok(result.nodes.length >= 3, "Should include schema nodes plus a mapping node");
     const srcNode = result.nodes.find(n => n.id === "src");
     const tgtNode = result.nodes.find(n => n.id === "tgt");
+    const mappingNode = result.nodes.find(n => n.id === "mapping:_:m1");
     assert.ok(srcNode, "Should have src node");
     assert.ok(tgtNode, "Should have tgt node");
+    assert.ok(mappingNode, "Should have a mapping node");
     // Compact nodes have no ports
     assert.equal(srcNode.ports.size, 0, "Overview nodes should have no ports");
     assert.equal(tgtNode.ports.size, 0, "Overview nodes should have no ports");
@@ -416,7 +418,7 @@ describe("computeOverviewLayout", () => {
     assert.equal(srcNode.height, 44, "Compact node should have header-only height");
   });
 
-  it("creates one edge per mapping, not per arrow", async () => {
+  it("creates source-to-mapping and mapping-to-target edges", async () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
@@ -438,12 +440,10 @@ describe("computeOverviewLayout", () => {
 
     const result = await computeOverviewLayout(model);
 
-    // One mapping with one source → one edge (not three)
-    assert.equal(result.edges.length, 1, "Should produce one edge per mapping source ref");
-    assert.equal(result.edges[0].sourceNode, "src");
-    assert.equal(result.edges[0].targetNode, "tgt");
-    assert.ok(result.edges[0].mapping, "Edge should carry the MappingBlock reference");
-    assert.equal(result.edges[0].mapping.id, "m1");
+    assert.equal(result.edges.length, 2, "Should route through a mapping node");
+    assert.ok(result.edges.some((e) => e.sourceNode === "src" && e.targetNode === "mapping:_:m1"));
+    assert.ok(result.edges.some((e) => e.sourceNode === "mapping:_:m1" && e.targetNode === "tgt"));
+    assert.ok(result.edges.every((e) => e.mapping.id === "m1"));
   });
 
   it("creates edges for multiple source refs", async () => {
@@ -461,13 +461,16 @@ describe("computeOverviewLayout", () => {
 
     const result = await computeOverviewLayout(model);
 
-    // Two source refs → two edges
-    assert.equal(result.edges.length, 2, "Should produce one edge per source ref");
-    const sources = result.edges.map(e => e.sourceNode).sort();
-    assert.deepEqual(sources, ["s1", "s2"]);
+    assert.equal(result.edges.length, 3, "Two source inputs plus one target edge");
+    const inboundSources = result.edges
+      .filter((e) => e.targetNode === "mapping:_:m1")
+      .map(e => e.sourceNode)
+      .sort();
+    assert.deepEqual(inboundSources, ["s1", "s2"]);
+    assert.ok(result.edges.some((e) => e.sourceNode === "mapping:_:m1" && e.targetNode === "tgt"));
   });
 
-  it("uses namespace compound nodes for grouping", async () => {
+  it("keeps overview namespaced nodes in the flat output", async () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
@@ -484,7 +487,6 @@ describe("computeOverviewLayout", () => {
 
     const node = result.nodes.find(n => n.id === "crm::customers");
     assert.ok(node, "Should have namespaced schema node");
-    // Namespace compound node should not appear in the output
     assert.ok(!result.nodes.find(n => n.id === "ns:crm"), "No namespace node in output");
   });
 
@@ -540,7 +542,7 @@ describe("computeOverviewLayout", () => {
     );
   });
 
-  it("reserves horizontal space for long mapping labels", async () => {
+  it("positions mapping nodes between source and target schemas", async () => {
     const longMappingId = "normalize_and_curate_order_headers_for_reporting";
     const model = {
       uri: "file:///test.stm",
@@ -556,20 +558,19 @@ describe("computeOverviewLayout", () => {
 
     const result = await computeOverviewLayout(model);
     const srcNode = result.nodes.find((n) => n.id === "src");
+    const mappingNode = result.nodes.find((n) => n.id === `mapping:_:${longMappingId}`);
     const tgtNode = result.nodes.find((n) => n.id === "tgt");
 
     assert.ok(srcNode, "Should have src node");
+    assert.ok(mappingNode, "Should have mapping node");
     assert.ok(tgtNode, "Should have tgt node");
-    assert.equal(result.edges.length, 1, "Should have one overview edge");
     assert.ok(
-      result.edges[0].labelWidth >= 180,
-      `Long mapping label width (${result.edges[0].labelWidth}) should be preserved on the edge`,
+      mappingNode.width >= 180,
+      `Long mapping node width (${mappingNode.width}) should expand for the mapping name`,
     );
-
-    const gap = tgtNode.x - (srcNode.x + srcNode.width);
     assert.ok(
-      gap >= result.edges[0].labelWidth,
-      `Gap between nodes (${gap}) should fit label width (${result.edges[0].labelWidth})`,
+      srcNode.x < mappingNode.x && mappingNode.x < tgtNode.x,
+      `Mapping node should be placed between source (${srcNode.x}) and target (${tgtNode.x})`,
     );
   });
 
@@ -587,8 +588,8 @@ describe("computeOverviewLayout", () => {
     };
 
     const result = await computeOverviewLayout(model);
-    assert.equal(result.edges.length, 1, "Should only keep the valid source-ref edge");
-    assert.equal(result.edges[0].sourceNode, "src");
-    assert.equal(result.edges[0].targetNode, "tgt");
+    assert.equal(result.edges.length, 2, "Should keep the valid inbound edge plus the mapping-to-target edge");
+    assert.ok(result.edges.some((e) => e.sourceNode === "src" && e.targetNode === "mapping:_:m1"));
+    assert.ok(result.edges.some((e) => e.sourceNode === "mapping:_:m1" && e.targetNode === "tgt"));
   });
 });

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -274,6 +274,77 @@ describe("computeLayout", () => {
     assert.ok(result.nodes.has("audit_fields"), "Should have fragment node");
   });
 
+  it("expands schema node height for report metadata, spreads, and notes", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [{
+          ...schema(
+            "branch_product_daily_as_is",
+            [field("branch_id"), field("branch_name"), field("effective_from", "DATE")],
+          ),
+          metadata: [{ key: "report", value: "" }, { key: "tool", value: "powerbi" }],
+          notes: [{ text: "Long report note that should reserve extra card height in the detailed lineage view.", isMultiline: false, location: loc }],
+          spreads: ["audit_fields"],
+        }],
+        mappings: [],
+        metrics: [],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeLayout(model);
+    const node = result.nodes.get("branch_product_daily_as_is");
+
+    assert.ok(node, "Should have report schema node");
+    assert.ok(
+      node.height > 160,
+      `Report schema node height (${node.height}) should include notes and spread rows`,
+    );
+    assert.ok(
+      node.width >= 260,
+      `Report schema node width (${node.width}) should expand for report metadata/content`,
+    );
+  });
+
+  it("expands metric node dimensions for metadata and notes", async () => {
+    const model = {
+      uri: "file:///test.stm",
+      fileNotes: [],
+      namespaces: [{
+        name: null,
+        schemas: [],
+        mappings: [],
+        metrics: [{
+          id: "branch_product_revenue_variance",
+          qualifiedId: "branch_product_revenue_variance",
+          label: "Revenue Variance",
+          source: ["orders"],
+          grain: "daily",
+          slices: ["region", "branch", "product"],
+          filter: null,
+          fields: [
+            { name: "variance_amount", type: "DECIMAL(14,2)", measure: "additive", notes: [], location: loc },
+            { name: "variance_pct", type: "DECIMAL(9,4)", measure: "non_additive", notes: [], location: loc },
+          ],
+          notes: [{ text: "Used by operational reporting and downstream dashboards.", isMultiline: false, location: loc }],
+          comments: [],
+          location: loc,
+        }],
+        fragments: [],
+      }],
+    };
+
+    const result = await computeLayout(model);
+    const node = result.nodes.get("branch_product_revenue_variance");
+
+    assert.ok(node, "Should have metric node");
+    assert.ok(node.height > 120, `Metric node height (${node.height}) should include meta and notes`);
+    assert.ok(node.width > 240, `Metric node width (${node.width}) should expand for long names/content`);
+  });
+
   it("produces positive dimensions for the overall layout", async () => {
     const model = {
       uri: "file:///test.stm",

--- a/tooling/satsuma-viz/test/model.test.js
+++ b/tooling/satsuma-viz/test/model.test.js
@@ -32,9 +32,21 @@ describe("@satsuma/viz bundle", () => {
     assert.equal(typeof mod.SzMetricCard, "function");
   });
 
+  it("SzMetricCard has compact property defaulting to false", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    const card = new mod.SzMetricCard();
+    assert.equal(card.compact, false, "compact should default to false");
+  });
+
   it("exports SzFragmentCard class", async () => {
     mod ??= await import("../dist/satsuma-viz.js");
     assert.equal(typeof mod.SzFragmentCard, "function");
+  });
+
+  it("SzFragmentCard has compact property defaulting to false", async () => {
+    mod ??= await import("../dist/satsuma-viz.js");
+    const card = new mod.SzFragmentCard();
+    assert.equal(card.compact, false, "compact should default to false");
   });
 
   it("exports SzNavigateEvent class", async () => {

--- a/useful-prompts/README.md
+++ b/useful-prompts/README.md
@@ -66,3 +66,17 @@ a balanced enterprise-ready security assessment.
 2. Paste or reference `useful-prompts/security-report-prompt.md` as your prompt.
 3. The agent will read source files, verify claims, and generate an updated report.
 4. Review the output and commit.
+
+### [satsuma-visual-style-prompt.md](satsuma-visual-style-prompt.md)
+
+**Satsuma Visual Style Prompt** — A reusable art direction prompt extracted from
+the `site/` codebase. It captures the website's colour palette, typography, UI
+surfaces, motion style, and overall brand feeling so you can generate matching
+mockups, social cards, diagrams, illustrations, or other visual assets.
+
+**How to use:**
+
+1. Open any capable image or design-oriented model.
+2. Paste or upload `satsuma-visual-style-prompt.md` as your prompt or style guide.
+3. Add your specific asset request after it, for example: "Generate a launch social card" or "Create a landing page hero illustration."
+4. Review the output against the existing `site/` look and adjust for the specific asset format.

--- a/useful-prompts/satsuma-visual-style-prompt.md
+++ b/useful-prompts/satsuma-visual-style-prompt.md
@@ -1,0 +1,194 @@
+# Satsuma Visual Style Prompt
+
+You are designing assets for the Satsuma project. Match the existing Satsuma website aesthetic closely so the output feels like part of the same product family.
+
+## Brand Direction
+
+Satsuma should feel warm, calm, precise, and quietly technical. The style is not cold enterprise blue, glossy startup neon, or dark cyberpunk. It combines:
+
+- warm editorial product design
+- clean technical documentation UI
+- gentle code-tooling aesthetics
+- approachable enterprise polish
+
+The result should feel human-readable and machine-parseable: soft and welcoming, but also structured, exact, and trustworthy.
+
+Also incorporate the visual language used in the Satsuma VS Code visualization: compact schema cards, precise graph topology, restrained badges, and semantic colour coding for mapping relationships.
+
+## Colour Palette
+
+Use this palette as the main source of truth:
+
+- Primary orange: `#F2913D`
+- Dark orange: `#D97726`
+- Light orange: `#F9B97A`
+- Primary green: `#5A9E6F`
+- Dark green: `#3D7A52`
+- Light green: `#7DBF92`
+- Cream background: `#FFFAF5`
+- Peach background: `#FFF3E8`
+- Charcoal text: `#2D2A26`
+- Warm gray secondary text: `#6B6560`
+- Code background: `#FEF7EE`
+- Code border: `#F5E6D3`
+
+Optional accent colours already implied by the site:
+
+- Soft violet accent for AI/reasoning concepts: `#8E5BB0` to `#7C6BAE`
+- Terminal dark: `#1E1E1E`
+
+Visualization-specific support colours:
+
+- Warning amber: `#C45D22`
+- Warning background: `#FEF3CD`
+- Question background: `#E8F0FE`
+- Question violet: `#7C6BAE`
+- White card surface: `#FFFFFF`
+- Soft card border: `rgba(45, 42, 38, 0.08)`
+- Soft card shadow: `0 2px 8px rgba(45, 42, 38, 0.06)`
+
+## Colour Usage Rules
+
+- Default page background should be cream, not pure white.
+- Use peach and very light orange tints for warmth and section separation.
+- Orange is the main call-to-action and highlight colour.
+- Green is the secondary accent for parsing, correctness, validation, and success states.
+- Charcoal is the primary text colour.
+- Warm gray is for secondary copy, helper labels, and subdued UI.
+- Use gradients sparingly but intentionally, especially orange and green linear gradients.
+- In diagrams and structural visualizations, orange should represent direct pipeline mappings and green should represent natural-language or inferred transform flows.
+- Violet can be used sparingly for AI/reasoning or question-state accents.
+- Avoid bright blues, saturated purples, pure black, or stark high-contrast monochrome treatments.
+
+## Typography
+
+- Primary UI/document font: Inter
+- Monospace/code font: JetBrains Mono
+
+Typography should feel crisp and modern, with a strong hierarchy:
+
+- large, confident, bold headlines
+- restrained body text
+- generous line height
+- mono used for code, filenames, commands, inline technical tokens, and structured examples
+
+Do not use decorative serif typography, futuristic display fonts, or playful rounded tech fonts.
+
+## Layout And Composition
+
+Use a spacious, modern documentation-product layout:
+
+- large hero areas
+- generous padding and whitespace
+- rounded cards and panels
+- subtle borders instead of heavy dividers
+- clear grid-based composition
+- code examples presented as polished product artifacts
+- graph views presented as clean node-link systems with generous spacing and legible hierarchy
+
+Common surfaces:
+
+- rounded cards with soft shadows
+- lightly tinted panels
+- code windows with warm off-white backgrounds
+- dark terminal panels for CLI moments
+- fixed or anchored navigation with translucent cream backgrounds and subtle blur
+- schema cards with coloured header bars, mono field rows, tiny metadata badges, and understated borders
+- dashed peach namespace containers for grouped domains in lineage or mapping diagrams
+
+## Visualization Style
+
+When the asset includes architecture, lineage, or mapping diagrams, follow the VS Code viz idiom:
+
+- use clean node cards instead of generic flowchart boxes
+- default to white cards on cream backgrounds in light mode
+- use peach-tinted grouping containers for namespaces or domains
+- use orange edges for pipeline/direct mappings
+- use green edges, sometimes dashed, for NL or descriptive transform logic
+- use small orange or peach badges for tags and metadata
+- use amber warning markers and soft violet question markers
+- keep connectors neat, orthogonal where possible, and intentionally spaced
+- prefer compact, legible topology over decorative complexity
+
+Cards should feel like UI components from a real developer tool, not infographic clip art.
+
+## Dark Theme Variant
+
+If the asset needs a dark mode or editor-embedded variant, use the VS Code-inspired dark theme:
+
+- background: `#1E1E1E`
+- card surface: `#252526`
+- primary text: `#D4D4D4`
+- muted text: `#9D9D9D` or `#858585`
+- namespace grouping: deep brown-peach tint, not neon outlines
+- orange shifts warmer and lighter: around `#F2A860` / `#E89040`
+- green shifts lighter: around `#6DBF82`
+- violet shifts softer: around `#A878C8`
+
+Dark mode should still feel warm and restrained, not cyberpunk.
+
+## Visual Language
+
+The visual style should communicate:
+
+- readable for humans
+- structured for machines
+- designed for data and developer tooling
+- friendly enough for analysts and product stakeholders
+
+Prefer:
+
+- warm gradients
+- soft shadows
+- rounded corners
+- understated borders
+- elegant syntax-highlighted code blocks
+- minimal but polished iconography
+- card-based data structures
+- small, semantic badges and pills
+- tidy editor-style diagram composition
+
+Avoid:
+
+- glassmorphism-heavy UI
+- harsh shadows
+- edgy hacker aesthetics
+- flashy 3D illustration
+- noisy dashboards
+- generic SaaS blue gradients
+
+## Motion And Interaction
+
+If motion is needed, keep it subtle and purposeful:
+
+- gentle reveal-on-scroll
+- small upward hover lift on cards
+- soft shadow changes on hover
+- simple tab or expand/collapse transitions
+
+Motion should support clarity, not steal attention.
+
+## Asset Guidance
+
+When generating illustrations, page mockups, banners, diagrams, social cards, or other branded assets:
+
+- keep backgrounds warm and lightly textured or softly graded
+- use orange for emphasis and green for supporting contrast
+- include charcoal text and warm gray supporting copy
+- present code or schema snippets in JetBrains Mono
+- make cards, frames, and UI chrome rounded and refined
+- preserve a balance of documentation seriousness and product warmth
+- for diagrams, render mappings as a premium code-tool graph rather than a corporate slide flowchart
+- show structure clearly: schemas, mappings, tags, warnings, and questions should each have a distinct but restrained visual treatment
+
+## Tone Keywords
+
+Use these words to steer the output:
+
+warm, precise, literate, modern, structured, calm, trustworthy, technical, elegant, approachable, parser-backed, documentation-first, enterprise-ready
+
+## Short Art Direction Prompt
+
+Design in the Satsuma style: a warm documentation-first technical brand with cream and peach backgrounds, citrus orange primary accents, muted leaf green secondary accents, charcoal typography, Inter for interface text, and JetBrains Mono for code. The look should feel calm, precise, elegant, and parser-backed, with rounded cards, soft shadows, subtle gradients, polished code examples, and approachable enterprise-grade clarity. Avoid generic SaaS blue, dark cyberpunk, glossy startup visuals, or noisy dashboard aesthetics.
+
+If the asset includes lineage or mapping visualization, use compact white schema cards, peach namespace groupings, orange direct-mapping edges, green NL-transform edges, subtle badges, and a clean VS Code-quality graph layout.


### PR DESCRIPTION
## Summary
- fix mapping viz overview bounds and fit calculations so namespace boxes and content extents match rendered cards
- fix minimap anchoring and viewport recomputation on window resize
- adjust ELK node sizing for larger metric and report cards in lineage flow to reduce overlap

## Testing
- cd tooling/satsuma-viz && npm run build && npm test
- cd tooling/vscode-satsuma && npm run build
- repo commit hooks passed during commit