### PR TITLE
chore: document and extract convention rules (sl-ax50, sl-teg4, sl-yjga)

### DIFF
--- a/.tickets/sl-ax50.md
+++ b/.tickets/sl-ax50.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ax50
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-30T06:38:25Z
@@ -25,3 +25,9 @@ These are domain rules, not implementation details. They are currently buried as
 - The function has a doc-comment explaining its role: given a schema type and convention, return the expected field names — and noting that the lists are opinionated approximations, not a full spec implementation
 - All existing validate tests pass
 
+
+## Notes
+
+**2026-03-30T09:39:45Z**
+
+Cause: getConventionFields() mixed rule definition and rule application in one body, with field names scattered as anonymous string literals — no structure, no citations, no approximation disclaimer. Fix: extracted five named constants (DV_HUB_FIELDS, DV_LINK_FIELDS, DV_SAT_FIELDS, KIMBALL_SCD_FIELDS, KIMBALL_FACT_FIELDS) above the function; rewrote the body to iterate those constants; added a section header with source citations and the approximation caveat; updated the function doc-comment. All 862 tests pass.

--- a/.tickets/sl-teg4.md
+++ b/.tickets/sl-teg4.md
@@ -1,6 +1,6 @@
 ---
 id: sl-teg4
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-30T06:38:13Z
@@ -23,3 +23,9 @@ tooling/satsuma-cli/src/lint-engine.ts has two high-severity readability defects
 - All regex literals that encode structural patterns have a named constant or inline comment explaining what they match and why
 - All existing lint-engine tests pass
 
+
+## Notes
+
+**2026-03-30T09:44:49Z**
+
+Cause: KNOWN_PIPELINE_FUNCTIONS had only a spec citation with no explanation of why the list exists or how to maintain it. makeAddSourceFix and makeAddArrowSourceFix were long, structurally-similar closures with undocumented regexes and no algorithm commentary. Fix: expanded the KNOWN_PIPELINE_FUNCTIONS comment to explain its purpose (suppress false-positive NL ref warnings) and noted the list may be incomplete; added doc-comments to both fix-builders explaining the four-step algorithm; added inline step comments; named the two regex patterns with comments explaining what they match. All 862 tests pass.

--- a/.tickets/sl-yjga.md
+++ b/.tickets/sl-yjga.md
@@ -1,6 +1,6 @@
 ---
 id: sl-yjga
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-30T06:39:22Z
@@ -22,3 +22,9 @@ tooling/satsuma-core/src/types.ts has two documentation gaps on exported types:
 - MetaEntrySlice has a doc-comment explaining what it represents, how it differs from a full MetaEntry, and the typical consumer
 - All existing types tests pass (types.ts is a pure declaration file; any related test that imports these types should still compile)
 
+
+## Notes
+
+**2026-03-30T09:44:41Z**
+
+Cause: Classification type had no doc-comment — the distinction between 'nl', 'mixed', and 'nl-derived' was not obvious from the name alone. MetaEntrySlice had no doc-comment explaining what a slice is or who creates/consumes it. Fix: added a doc-comment to Classification explaining all five members and how each is assigned; added a doc-comment to MetaEntrySlice explaining that it represents the dimension schema names from a metric's slice { } metadata entry. All 862 tests pass.

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -121,6 +121,17 @@ function checkHiddenSourceInNl(index: WorkspaceIndex): LintDiagnostic[] {
   return diagnostics;
 }
 
+/**
+ * Build a fix closure that inserts `schemaRef` into the `source { }` block of the
+ * named mapping. The fix is text-based: it walks source lines to locate the mapping,
+ * then finds the `source { ... }` line and appends the new ref.
+ *
+ * Algorithm:
+ *   1. Locate the mapping header by name (handles backtick, quoted, and bare labels).
+ *   2. Track brace depth to stay inside the mapping body and stop at its closing `}`.
+ *   3. Find the single-line `source { ... }` form and append `insertRef` to its list.
+ *   4. If the ref is already present (qualified or unqualified), return source unchanged.
+ */
 function makeAddSourceFix(mappingKey: string, schemaRef: string): (source: string) => string {
   const nsIdx = mappingKey.indexOf("::");
   const displayName = nsIdx !== -1
@@ -142,6 +153,7 @@ function makeAddSourceFix(mappingKey: string, schemaRef: string): (source: strin
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i]!.trim();
 
+      // Step 1: find the mapping header — matches backtick, double-quoted, or bare label
       if (!inMapping) {
         const mappingRe = /^mapping\s+(?:`([^`]+)`|"([^"]+)"|(.+?))\s*(?:\(|$|\{)/;
         const m = trimmed.match(mappingRe);
@@ -155,17 +167,20 @@ function makeAddSourceFix(mappingKey: string, schemaRef: string): (source: strin
         continue;
       }
 
+      // Step 2: track brace depth; stop when we exit the mapping body
       for (const ch of trimmed) {
         if (ch === "{") braceDepth++;
         else if (ch === "}") braceDepth--;
       }
       if (braceDepth <= 0) break;
 
+      // Step 3: find and rewrite the single-line `source { ref, ref }` form
+      // Matches: `source { ... }` where `...` is the comma-separated ref list
       const sourceLineRe = /^source\s*\{([^}]*)\}\s*$/;
       const sm = trimmed.match(sourceLineRe);
       if (sm) {
         const existing = sm[1]!.trim();
-        // Check both qualified and unqualified forms (with or without backticks)
+        // Step 4: skip if the ref is already present (qualified or unqualified)
         const existingRefs = existing.split(/\s*,\s*/).map((r) => r.replace(/^`|`$/g, ""));
         if (existingRefs.includes(schemaRef) || existingRefs.includes(insertRef)) return source;
         // Use backtick wrapping if existing entries use backticks, or always for spec compliance
@@ -186,6 +201,17 @@ function composeFixes(...fns: ((s: string) => string)[]): (s: string) => string 
   return (source: string): string => fns.reduce((s, fn) => fn(s), source);
 }
 
+/**
+ * Build a fix closure that prepends `schemaRef` to the source list of the arrow
+ * targeting `targetField` inside the named mapping. The fix is text-based.
+ *
+ * Algorithm (mirrors makeAddSourceFix for the mapping-location phase):
+ *   1. Locate the mapping header by name.
+ *   2. Track brace depth to stay inside the mapping body.
+ *   3. Find the arrow whose target matches `targetField` (bare or schema-qualified).
+ *   4. Prepend `insertRef` to the arrow's source list before the `->`.
+ *   5. If the ref is already present, return source unchanged.
+ */
 function makeAddArrowSourceFix(
   mappingKey: string,
   schemaRef: string,
@@ -205,7 +231,7 @@ function makeAddArrowSourceFix(
   if (mappingNs && matchTarget.startsWith(`${mappingNs}::`)) {
     matchTarget = matchTarget.slice(mappingNs.length + 2);
   }
-  // Also strip schema prefix — arrow target in source uses bare field name
+  // Also strip schema prefix — arrow targets in source use bare field names, not schema.field
   const dotIdx = matchTarget.indexOf(".");
   const bareTarget = dotIdx >= 0 ? matchTarget.slice(dotIdx + 1) : matchTarget;
 
@@ -217,6 +243,7 @@ function makeAddArrowSourceFix(
     for (let i = 0; i < lines.length; i++) {
       const trimmed = lines[i]!.trim();
 
+      // Step 1: find the mapping header — handles backtick, double-quoted, and bare labels
       if (!inMapping) {
         const mappingRe = /^mapping\s+(?:`([^`]+)`|"([^"]+)"|(.+?))\s*(?:\(|$|\{)/;
         const m = trimmed.match(mappingRe);
@@ -230,30 +257,32 @@ function makeAddArrowSourceFix(
         continue;
       }
 
+      // Step 2: track brace depth; stop when we exit the mapping body
       for (const ch of trimmed) {
         if (ch === "{") braceDepth++;
         else if (ch === "}") braceDepth--;
       }
       if (braceDepth <= 0) break;
 
-      // Match arrow line: "src -> target" or "src1, src2 -> target"
+      // Step 3: match an arrow line — `src -> target` or `src1, src2 -> target { ... }`
+      // Captures: [1] source list, [2] target field, [3] optional trailing transform block
       const arrowMatch = trimmed.match(/^(.+?)\s*->\s*(.+?)(\s*\{.*)?$/);
       if (!arrowMatch) continue;
 
       const arrowTargetPart = arrowMatch[2]!.trim();
-      // Check if arrow target matches (with or without schema prefix)
+      // Match target by bare field name, ignoring any schema prefix or backticks
       const targetBare = arrowTargetPart.replace(/^`|`$/g, "");
       const targetDotIdx = targetBare.indexOf(".");
       const targetFieldOnly = targetDotIdx >= 0 ? targetBare.slice(targetDotIdx + 1) : targetBare;
 
       if (targetFieldOnly !== bareTarget && targetBare !== matchTarget) continue;
 
-      // Check if insertRef is already in the source list
+      // Step 5: skip if the ref is already in the source list
       const srcPart = arrowMatch[1]!.trim();
       const existingSrcs = srcPart.split(/\s*,\s*/).map((s) => s.replace(/^`|`$/g, ""));
       if (existingSrcs.some((s) => s === insertRef || s === schemaRef)) return source;
 
-      // Insert the schema before the ->
+      // Step 4: prepend the new schema ref before the `->`
       const indent = lines[i]!.match(/^(\s*)/)![1];
       const rest = arrowMatch[2]! + (arrowMatch[3] ?? "");
       lines[i] = `${indent}${srcPart}, ${insertRef} -> ${rest}`;
@@ -264,7 +293,13 @@ function makeAddArrowSourceFix(
   };
 }
 
-// Known pipeline function names from SATSUMA-V2-SPEC.md section 7.2
+// Pipeline function names from SATSUMA-V2-SPEC.md §7.2 (pipeline step catalog).
+// Used to suppress false-positive `unresolved-nl-ref` warnings: @ref tokens in NL
+// strings that match a known pipeline function name are skips — they are transform
+// instructions, not field or schema references.
+//
+// This list covers the commonly-used built-ins as of v2. It may not be exhaustive;
+// if a valid function triggers a warning, add it here and cite the spec section.
 const KNOWN_PIPELINE_FUNCTIONS = new Set([
   "trim", "lowercase", "uppercase", "coalesce", "round", "split", "first",
   "last", "to_utc", "to_iso8601", "parse", "null_if_empty", "null_if_invalid",

--- a/tooling/satsuma-core/src/types.ts
+++ b/tooling/satsuma-core/src/types.ts
@@ -30,6 +30,20 @@ export interface Tree {
 
 // ── Classification ──────────────────────────────────────────────────────────
 
+/**
+ * Arrow transform classification, derived from CST node types by the arrow extractor.
+ *
+ * - "structural"  — the transform is a deterministic pipeline (function calls, map blocks,
+ *                   arithmetic). Fully machine-readable; no interpretation needed.
+ * - "nl"          — the transform is a natural language string. Requires human or LLM
+ *                   interpretation to understand intent.
+ * - "mixed"       — the transform contains both pipeline steps and an NL string.
+ *                   The pipeline portion is deterministic; the NL portion requires interpretation.
+ * - "none"        — bare arrow with no transform (`src -> tgt`). Signals a direct copy.
+ * - "nl-derived"  — a synthetic arrow inferred from an `@ref` mention inside an NL transform
+ *                   string. Not declared explicitly in the source; created by the graph builder
+ *                   to represent implicit field lineage from NL references.
+ */
 export type Classification = "structural" | "nl" | "mixed" | "none" | "nl-derived";
 
 export interface PipeStep {
@@ -60,8 +74,20 @@ export interface MetaEntryNote {
   text: string;
 }
 
+/**
+ * A `slice { dim1, dim2 }` metadata entry on a metric block.
+ *
+ * Specifies the dimension schema names by which the metric can be sliced or
+ * grouped in reporting tools. Unlike MetaEntryEnum (which lists allowed field
+ * values), the `values` here are schema references — names of dimension schemas
+ * that define the slicing axes.
+ *
+ * Created by the metric extractor when it encounters `slice { ... }` in metric
+ * metadata. Consumed by the metric command and diff engine.
+ */
 export interface MetaEntrySlice {
   kind: "slice";
+  /** Dimension schema names that define the valid slicing axes for this metric. */
   values: string[];
 }
 

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -570,20 +570,43 @@ function suggestAlternatives(ref: string, entityMap: Map<string, unknown>): stri
   return hints;
 }
 
+// ---------- Convention field tables ----------
+//
+// These constants enumerate the field names that Data Vault and Kimball standards
+// place on each entity type by convention. They are used in getConventionFields()
+// to suppress "field not in schema" false positives for columns that are populated
+// by the ETL layer and therefore not declared in the schema body.
+//
+// Sources: Data Vault 2.0 standard (Linstedt & Olschimke, 2nd ed.);
+//          The Data Warehouse Toolkit (Kimball & Ross, 3rd ed.).
+// These lists are opinionated approximations — full implementations vary, and we
+// cover the most common field names seen in practice rather than every possible variant.
+
+/** Standard audit columns on a Data Vault hub. The composite hash key ({name}_hk) is derived separately. */
+const DV_HUB_FIELDS = ["load_date", "record_source"] as const;
+
+/** Standard audit columns on a Data Vault link. Hash key and hub foreign keys are derived separately. */
+const DV_LINK_FIELDS = ["load_date", "record_source"] as const;
+
+/** Full set of standard DV satellite audit columns. The parent hash key ({parent}_hk) is derived separately. */
+const DV_SAT_FIELDS = ["load_date", "load_end_date", "hash_diff", "record_source"] as const;
+
+/** Slowly-changing dimension tracking columns added to Kimball dimensions under scd: 2 or scd: 6. */
+const KIMBALL_SCD_FIELDS = ["surrogate_key", "valid_from", "valid_to", "is_current", "row_hash"] as const;
+
+/** ETL audit columns present on all Kimball fact tables. */
+const KIMBALL_FACT_FIELDS = ["etl_batch_id", "loaded_at"] as const;
+
 /**
- * Compute convention-inferred field names for a schema based on its metadata tokens.
+ * Return the set of convention-inferred field names for a schema based on its metadata tags.
  *
- * Data Vault conventions (source: Data Vault 2.0 standard):
- *   hub        → {name}_hk, load_date, record_source
- *   link       → {name}_hk, load_date, record_source, {hub}_hk (per link_hubs kv)
- *   satellite  → load_date, load_end_date, hash_diff, record_source, {parent}_hk
+ * Fields listed here are implicitly present by Data Vault or Kimball convention —
+ * populated by the ETL layer, not declared in the schema body. Adding them to the
+ * valid-path set prevents false "field not in schema" warnings on arrows that
+ * target these columns. See the DV_* and KIMBALL_* constants for the specific sets.
  *
- * Kimball conventions (source: The Data Warehouse Toolkit):
- *   dimension + scd 2 or 6 → surrogate_key, valid_from, valid_to, is_current, row_hash
- *   fact       → etl_batch_id, loaded_at
- *
- * These fields are pre-populated in the valid-path set so arrows targeting them
- * do not trigger false "field not in schema" warnings.
+ * The lists are opinionated approximations and do not constitute a full implementation
+ * of either standard.
  */
 function getConventionFields(schema: SemanticSchema): Set<string> {
   const fields = new Set<string>();
@@ -591,15 +614,18 @@ function getConventionFields(schema: SemanticSchema): Set<string> {
   const tags = new Set(meta.filter((m): m is MetaEntry & { kind: "tag" } => m.kind === "tag").map((m) => m.tag));
   const kvs = meta.filter((m): m is MetaEntry & { kind: "kv" } => m.kind === "kv");
 
+  // --- Data Vault 2.0 conventions ---
+
   if (tags.has("hub")) {
+    // Hub: composite business-key hash + standard DV audit columns
     fields.add(`${schema.name}_hk`);
-    fields.add("load_date");
-    fields.add("record_source");
+    for (const f of DV_HUB_FIELDS) fields.add(f);
   }
+
   if (tags.has("link")) {
+    // Link: composite hash key + DV audit columns + a hash key per linked hub (from link_hubs metadata)
     fields.add(`${schema.name}_hk`);
-    fields.add("load_date");
-    fields.add("record_source");
+    for (const f of DV_LINK_FIELDS) fields.add(f);
     for (const kv of kvs) {
       if (kv.key === "link_hubs") {
         for (const hub of kv.value.split(",").map((h) => h.trim())) {
@@ -608,29 +634,30 @@ function getConventionFields(schema: SemanticSchema): Set<string> {
       }
     }
   }
+
   if (tags.has("satellite")) {
-    fields.add("load_date");
-    fields.add("load_end_date");
-    fields.add("hash_diff");
-    fields.add("record_source");
+    // Satellite: full DV audit columns + parent entity hash key (from parent metadata)
+    for (const f of DV_SAT_FIELDS) fields.add(f);
     for (const kv of kvs) {
       if (kv.key === "parent") fields.add(`${kv.value}_hk`);
     }
   }
+
+  // --- Kimball dimensional modelling conventions ---
+
   if (tags.has("dimension")) {
+    // SCD types 2 and 6 add slowly-changing dimension history tracking columns
     const hasScd2or6 = kvs.some((kv) => kv.key === "scd" && (kv.value === "2" || kv.value === "6"));
     if (hasScd2or6) {
-      fields.add("surrogate_key");
-      fields.add("valid_from");
-      fields.add("valid_to");
-      fields.add("is_current");
-      fields.add("row_hash");
+      for (const f of KIMBALL_SCD_FIELDS) fields.add(f);
     }
   }
+
   if (tags.has("fact")) {
-    fields.add("etl_batch_id");
-    fields.add("loaded_at");
+    // All fact tables carry ETL batch audit columns
+    for (const f of KIMBALL_FACT_FIELDS) fields.add(f);
   }
+
   return fields;
 }
 


### PR DESCRIPTION
## Summary

- **sl-ax50** (`satsuma-core/src/validate.ts`): extracted 5 named constants (`DV_HUB_FIELDS`, `DV_LINK_FIELDS`, `DV_SAT_FIELDS`, `KIMBALL_SCD_FIELDS`, `KIMBALL_FACT_FIELDS`) with source citations (Data Vault 2.0 standard; Kimball & Ross); rewrote `getConventionFields()` to iterate them; added approximation caveat to doc-comment
- **sl-teg4** (`satsuma-cli/src/lint-engine.ts`): expanded `KNOWN_PIPELINE_FUNCTIONS` comment to explain why it exists and note incompleteness; added doc-comments + numbered algorithm steps to `makeAddSourceFix` and `makeAddArrowSourceFix`; documented regex patterns inline
- **sl-yjga** (`satsuma-core/src/types.ts`): added doc-comment to `Classification` explaining all five members and how each is assigned; added doc-comment to `MetaEntrySlice` explaining it represents metric `slice { }` dimension names

## Test plan

- [x] All 862 CLI tests pass locally (`npm test` in `tooling/satsuma-cli`)
- [x] No logic changes — pure documentation and constant extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)