### PR TITLE
fix(vscode): resolve LSP startup crash (createRequire(undefined) from ESM web-tree-sitter in CJS bundle)

### DIFF
--- a/.tickets/sl-3lfu.md
+++ b/.tickets/sl-3lfu.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3lfu
-status: open
+status: closed
 deps: [sl-u31z, sl-teg4, sl-ax50, sl-yml8, sl-i9pt, sl-ueij, sl-yumm, sl-yjga, sl-hnbv]
 links: []
 created: 2026-03-30T06:39:43Z

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -24,6 +24,27 @@ const serverConfig = {
   outfile: "server/dist/server.js",
   format: "cjs",
   sourcemap: true,
+  // Consolidate all web-tree-sitter imports onto the CJS build.
+  //
+  // Without this alias, esbuild bundles two separate instances:
+  //   1. The ESM build (from satsuma-core/node_modules) — picked up via
+  //      satsuma-core's dynamic `await import("web-tree-sitter")`.  esbuild
+  //      stubs `import.meta` as `{}` when converting ESM→CJS, so the ESM
+  //      module calls `createRequire(undefined)` at init and crashes with
+  //      "The argument 'filename' must be … Received undefined".
+  //   2. The CJS build (from server/node_modules) — used by the semantic-
+  //      token helpers via require("web-tree-sitter").
+  //
+  // Aliasing the package name to the concrete .cjs file forces both usages
+  // to the same CJS instance, avoiding the crash and ensuring the Language
+  // object produced by initParser is compatible with Query objects created
+  // by the semantic-token helpers.
+  alias: {
+    "web-tree-sitter": path.resolve(
+      __dirname,
+      "server/node_modules/web-tree-sitter/web-tree-sitter.cjs",
+    ),
+  },
 };
 
 /** @type {import("esbuild").BuildOptions} */


### PR DESCRIPTION
## Summary

- **Root cause**: esbuild bundles the LSP server as CJS but satsuma-core's `await import("web-tree-sitter")` resolves to the ESM build of web-tree-sitter. esbuild stubs `import.meta` as `{}`, so the ESM module calls `createRequire(undefined)` at startup → crash with _"The argument 'filename' must be … Received undefined" Code: -32603_.
- **Fix**: add `alias: { "web-tree-sitter": "…/web-tree-sitter.cjs" }` to the server esbuild config. This forces all imports of `web-tree-sitter` across the bundle (both `initParser` and the semantic-token helpers) to use the single CJS build, which uses `__dirname` rather than `import.meta.url`.
- **Bonus**: previously the bundle contained two separate web-tree-sitter instances (ESM and CJS). The alias consolidates them to one, so the `Language` object from `initParser` and the `Query` objects in the semantic-token helpers are now guaranteed to share the same instance.

## Test plan

- [ ] 284 LSP server unit tests pass (`npm run test:lsp` in `tooling/vscode-satsuma`)
- [ ] Bundle no longer contains `createRequire(import_meta.url)` — verified with grep
- [ ] Install the rebuilt VSIX and confirm the language server starts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)