### PR TITLE
fix(lsp): fix server crash from bundled web-tree-sitter import.meta.url

### DIFF
--- a/.tickets/sl-3lfu.md
+++ b/.tickets/sl-3lfu.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3lfu
-status: open
+status: closed
 deps: [sl-u31z, sl-teg4, sl-ax50, sl-yml8, sl-i9pt, sl-ueij, sl-yumm, sl-yjga, sl-hnbv]
 links: []
 created: 2026-03-30T06:39:43Z

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -11,7 +11,7 @@ export type {
   SemanticNLRef,
   SemanticDuplicate,
 } from "./validate.js";
-export { initParser, getParser, getLanguage } from "./parser.js";
+export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";
 export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";

--- a/tooling/satsuma-core/src/parser.ts
+++ b/tooling/satsuma-core/src/parser.ts
@@ -22,12 +22,17 @@
  *   3. There is no teardown — the singleton lives for the process lifetime.
  */
 
-import type { Parser, Language } from "web-tree-sitter";
+import type { Parser, Language, Query } from "web-tree-sitter";
 
 // ── Singleton state ─────────────────────────────────────────────────────────
 
 let _parser: Parser | null = null;
 let _language: Language | null = null;
+
+// Retained so that createQuery() can construct Query instances from the same
+// WASM module that Parser.init() loaded — avoiding the duplicate-module
+// problem that occurs when consumers bundle web-tree-sitter separately.
+let _TreeSitter: typeof import("web-tree-sitter") | null = null;
 
 // Stored so that re-entrant calls to initParser() return the same Promise
 // instead of starting a second initialisation race.
@@ -80,6 +85,7 @@ export function initParser(wasmPath: string, options?: ParserInitOptions): Promi
     // both that case and future ESM builds that may add a default.
     const mod = await import("web-tree-sitter");
     const TreeSitter = (mod.default ?? mod) as unknown as typeof import("web-tree-sitter");
+    _TreeSitter = TreeSitter;
     await TreeSitter.Parser.init(
       options?.locateFile ? { locateFile: options.locateFile } : undefined,
     );
@@ -110,4 +116,17 @@ export function getParser(): Parser {
 export function getLanguage(): Language {
   if (!_language) throw new Error("Language not loaded — call initParser() first");
   return _language;
+}
+
+/**
+ * Create a tree-sitter Query from a highlights source string.
+ *
+ * Uses the same WASM module instance that initParser() loaded, avoiding the
+ * duplicate-module problem that occurs when consumers import web-tree-sitter
+ * separately (esbuild bundles ESM and CJS copies as distinct modules, each
+ * with its own uninitialised WASM state).
+ */
+export function createQuery(language: Language, source: string): Query {
+  if (!_TreeSitter) throw new Error("Parser not initialised — call initParser() first");
+  return new _TreeSitter.Query(language, source);
 }

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -24,6 +24,18 @@ const serverConfig = {
   outfile: "server/dist/server.js",
   format: "cjs",
   sourcemap: true,
+  // web-tree-sitter uses import.meta.url internally (for createRequire and
+  // WASM file location). esbuild replaces import.meta with {} in CJS bundles,
+  // making import.meta.url → undefined and crashing at runtime. The banner
+  // injects a CJS-compatible shim so the bundled code gets a real URL.
+  banner: {
+    js: [
+      `var __import_meta_url = require("url").pathToFileURL(__filename).href;`,
+    ].join("\n"),
+  },
+  define: {
+    "import.meta.url": "__import_meta_url",
+  },
 };
 
 /** @type {import("esbuild").BuildOptions} */

--- a/tooling/vscode-satsuma/server/package.json
+++ b/tooling/vscode-satsuma/server/package.json
@@ -7,7 +7,7 @@
   "main": "dist/server.js",
   "scripts": {
     "prebuild": "npm --prefix ../../satsuma-core run build",
-    "build": "esbuild src/server.ts --bundle --platform=node --target=node20 --outfile=dist/server.js --sourcemap",
+    "build": "esbuild src/server.ts --bundle --platform=node --target=node20 --outfile=dist/server.js --sourcemap --banner:js='var __import_meta_url = require(\"url\").pathToFileURL(__filename).href;' --define:import.meta.url=__import_meta_url",
     "watch": "npm run build -- --watch",
     "test": "node --test test/**/*.test.js",
     "pretest": "npm --prefix ../../satsuma-core run build && tsc"

--- a/tooling/vscode-satsuma/server/src/parser-utils.ts
+++ b/tooling/vscode-satsuma/server/src/parser-utils.ts
@@ -24,7 +24,7 @@ export type SyntaxNode = Node;
 export type { Tree };
 
 // Re-export the singleton lifecycle from core.
-export { initParser, getParser, getLanguage } from "@satsuma/core";
+export { initParser, getParser, getLanguage, createQuery } from "@satsuma/core";
 export type { ParserInitOptions } from "@satsuma/core";
 
 // ---------- CST navigation helpers (delegating to satsuma-core) ----------

--- a/tooling/vscode-satsuma/server/src/semantic-tokens.ts
+++ b/tooling/vscode-satsuma/server/src/semantic-tokens.ts
@@ -5,7 +5,7 @@ import {
   SemanticTokensLegend,
 } from "vscode-languageserver";
 import type { Tree, Query } from "web-tree-sitter";
-import { getLanguage } from "./parser-utils";
+import { getLanguage, createQuery } from "./parser-utils";
 import type { SyntaxNode } from "./parser-utils";
 
 // ---------- Legend ----------
@@ -115,8 +115,7 @@ function getHighlightsQuery(): Query {
   if (_query) return _query;
   if (!_highlightsSource) throw new Error("highlights.scm not loaded — call setHighlightsSource() first");
   const language = getLanguage();
-  const TreeSitter = require("web-tree-sitter") as typeof import("web-tree-sitter");
-  _query = new TreeSitter.Query(language, _highlightsSource);
+  _query = createQuery(language, _highlightsSource);
   return _query;
 }
 

--- a/tooling/vscode-satsuma/server/test/helper.js
+++ b/tooling/vscode-satsuma/server/test/helper.js
@@ -1,36 +1,28 @@
 /**
  * Shared test helper — initialises the WASM parser once and exports a parse()
  * function for use across all LSP server tests.
+ *
+ * Uses satsuma-core's parser singleton so that trees, languages, and queries
+ * all share the same WASM module instance. This avoids cross-module memory
+ * errors when tsc-compiled dist/ code (which delegates to satsuma-core) operates
+ * on trees created by a different web-tree-sitter instance.
  */
 const path = require("path");
-const TreeSitter = require("web-tree-sitter");
+const { initParser, getParser, getLanguage } = require("@satsuma/core");
 
 const WASM_PATH = path.resolve(
   __dirname,
   "../../../tree-sitter-satsuma/tree-sitter-satsuma.wasm",
 );
 
-let _parser = null;
-
 /** Initialise the WASM parser.  Must be awaited once before parse() is called. */
 async function initTestParser() {
-  if (_parser) return;
-  await TreeSitter.Parser.init();
-  const language = await TreeSitter.Language.load(WASM_PATH);
-  _parser = new TreeSitter.Parser();
-  _parser.setLanguage(language);
+  await initParser(WASM_PATH);
 }
 
 /** Parse Satsuma source.  Call initTestParser() first. */
 function parse(source) {
-  if (!_parser) throw new Error("Call initTestParser() before parse()");
-  return _parser.parse(source);
+  return getParser().parse(source);
 }
 
-/** Get the loaded Language instance (for Query construction in semantic token tests). */
-function getLanguage() {
-  if (!_parser) throw new Error("Call initTestParser() before getLanguage()");
-  return _parser.language;
-}
-
-module.exports = { initTestParser, parse, getLanguage, TreeSitter };
+module.exports = { initTestParser, parse, getLanguage };


### PR DESCRIPTION
## Summary

- **esbuild import.meta.url shim**: web-tree-sitter uses `import.meta.url` internally for `createRequire()` and WASM file location. esbuild replaces `import.meta` with `{}` in CJS bundles → `undefined` → crash. Added a banner shim that derives the URL from `__filename`, and a matching `define` to replace all `import.meta.url` references.
- **createQuery() in satsuma-core**: `semantic-tokens.ts` had a direct `require("web-tree-sitter")` that resolved to the server's CJS copy — a separate WASM module from the one satsuma-core initialised via its ESM copy. Cross-instance `Query.captures(tree)` caused WASM memory errors. Added `createQuery()` to satsuma-core so all WASM operations share one initialised instance.
- **Test helper updated**: uses satsuma-core's parser singleton instead of its own `require("web-tree-sitter")` to avoid the same cross-instance issue in tests.

Also closes sl-3lfu (readability audit epic — all 9 child tickets were already done).

## Test plan

- [x] 284/284 LSP server tests pass
- [x] vsix installs and server starts without crash
- [x] Semantic tokens render correctly (no `lengthBytesUTF8` error)
- [x] Banner shim verified inside packaged vsix

🤖 Generated with [Claude Code](https://claude.com/claude-code)