### PR TITLE
feat(viz): full transitive lineage with file-scope filter

### DIFF
--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -212,16 +212,18 @@ export class SzMappingDetail extends LitElement {
       width: 400px;
       max-width: 400px;
       min-width: 320px;
+      text-align: left;
     }
 
     .transform-pipeline {
-      display: inline;
+      display: inline-block;
       font-family: var(--sz-font-mono, monospace);
       font-size: 11px;
       color: var(--sz-orange-dark, #D97726);
       white-space: pre-wrap;
       word-break: break-word;
       overflow-wrap: anywhere;
+      text-align: left;
     }
 
     .transform-pipeline .pipe {
@@ -238,6 +240,7 @@ export class SzMappingDetail extends LitElement {
       white-space: normal;
       word-break: break-word;
       overflow-wrap: anywhere;
+      text-align: left;
     }
 
     .transform-bare {
@@ -248,6 +251,24 @@ export class SzMappingDetail extends LitElement {
     .arrow-icon {
       color: var(--sz-text-muted, #6B6560);
       font-size: 11px;
+    }
+
+    /* Note row displayed beneath an arrow that carries a (note "...") tag. */
+    .arrow-note-row td {
+      padding: 0 12px 6px;
+    }
+
+    .arrow-note {
+      font-family: var(--sz-font-sans, system-ui);
+      font-size: 11px;
+      font-style: italic;
+      color: var(--sz-text-muted, #6B6560);
+      line-height: 1.4;
+      padding: 2px 8px;
+      background: rgba(45, 42, 38, 0.03);
+      border-radius: 3px;
+      max-width: 400px;
+      word-break: break-word;
     }
 
     /* Scope sections (each/flatten) */
@@ -570,6 +591,7 @@ export class SzMappingDetail extends LitElement {
 
   private _renderArrowRow(a: ArrowEntry): TemplateResult {
     const hl = this._isArrowHighlighted(a) ? "hl" : "";
+    const noteEntry = a.metadata.find((m) => m.key === "note");
 
     return html`
       <tr
@@ -589,6 +611,9 @@ export class SzMappingDetail extends LitElement {
         <td class="transform-cell">${this._renderTransform(a)}</td>
         <td><span class="field-ref">${a.targetField}</span></td>
       </tr>
+      ${noteEntry
+        ? html`<tr class="arrow-note-row"><td colspan="4"><span class="arrow-note">${noteEntry.value}</span></td></tr>`
+        : ""}
     `;
   }
 

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -79,6 +79,8 @@ export class SzSchemaCard extends LitElement {
       color: var(--sz-text-muted, #6B6560);
       font-style: italic;
       border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      max-width: 400px;
+      word-break: break-word;
     }
 
     .fields {

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -366,6 +366,19 @@ export class SzSchemaCard extends LitElement {
       min-width: 100%;
     }
 
+    /* Shaded note row displayed beneath a field that has notes. */
+    .field-note {
+      font-family: var(--sz-font-sans, system-ui);
+      font-size: 11px;
+      font-style: italic;
+      color: var(--sz-text-muted, #6B6560);
+      line-height: 1.4;
+      padding: 2px 12px 4px 38px;
+      background: rgba(45, 42, 38, 0.03);
+      max-width: 400px;
+      word-break: break-word;
+    }
+
     :host([content-width]) .header-name {
       --sz-header-name-overflow: visible;
       --sz-header-name-overflow-mode: clip;
@@ -573,6 +586,9 @@ export class SzSchemaCard extends LitElement {
           <line x1="3.5" y1="6.7" x2="8.5" y2="8.3" stroke="currentColor" stroke-width="1.2"/>
         </svg></button>
       </div>
+      ${f.notes.length > 0
+        ? f.notes.map((n) => html`<div class="field-note" style=${depth > 0 ? `padding-left: ${38 + depth * 20}px` : ""}>${n.text}</div>`)
+        : ""}
       ${f.children.map((child) => this._renderField(child, depth + 1))}
     `;
   }

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -268,6 +268,7 @@ export class SzSchemaCard extends LitElement {
       line-height: 1.5;
       padding: 4px 0 2px 22px;
       word-break: break-word;
+      max-width: 400px;
     }
 
     .note-content p {

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -636,6 +636,10 @@ export class SatsumaViz extends LitElement {
   @state()
   private _nsFilter: string | null = null;
 
+  /** File-scope filter: null = show all files (full lineage), URI string = show only that file. */
+  @state()
+  private _fileFilter: string | null = null;
+
   @state()
   private _zoom = 1;
 
@@ -716,6 +720,7 @@ export class SatsumaViz extends LitElement {
       || changed.has("_viewMode")
       || changed.has("model")
       || changed.has("_nsFilter")
+      || changed.has("_fileFilter")
       || changed.has("_showNotes")
     ) {
       requestAnimationFrame(() => this._measureNamespaceBoxes());
@@ -985,6 +990,26 @@ export class SatsumaViz extends LitElement {
                 <option value="" ?selected=${this._nsFilter === null}>All namespaces</option>
                 ${namedNs.map(
                   (ns) => html`<option value=${ns.name!} ?selected=${this._nsFilter === ns.name}>${ns.name}</option>`
+                )}
+              </select>
+            `
+          : ""}
+        ${this._getSourceFiles().length > 1 && !inDetail
+          ? html`
+              <div class="toolbar-sep"></div>
+              <select
+                class="toolbar-select"
+                @change=${this._onFileFilterChange}
+                title="Filter by source file"
+              >
+                <option value="" ?selected=${this._fileFilter === null}>All files</option>
+                ${this._getSourceFiles().map(
+                  (uri) => {
+                    const name = uri.split("/").pop() ?? uri;
+                    const isCurrent = uri === this.model?.uri;
+                    const label = isCurrent ? `${name} (current)` : name;
+                    return html`<option value=${uri} ?selected=${this._fileFilter === uri}>${label}</option>`;
+                  }
                 )}
               </select>
             `
@@ -1590,11 +1615,55 @@ export class SatsumaViz extends LitElement {
     this._nsFilter = val || null;
   }
 
+  private _onFileFilterChange(e: Event) {
+    const val = (e.target as HTMLSelectElement).value;
+    this._fileFilter = val || null;
+  }
+
+  /** Extract unique source file URIs from the current model, primary file first. */
+  private _getSourceFiles(): string[] {
+    if (!this.model) return [];
+    const uris = new Set<string>();
+    for (const ns of this.model.namespaces) {
+      for (const s of ns.schemas) uris.add(s.location.uri);
+      for (const m of ns.mappings) uris.add(m.location.uri);
+      for (const mt of ns.metrics) uris.add(mt.location.uri);
+    }
+    // Put the primary (current) file first in the list.
+    const result: string[] = [];
+    if (this.model.uri && uris.has(this.model.uri)) {
+      result.push(this.model.uri);
+      uris.delete(this.model.uri);
+    }
+    for (const uri of uris) result.push(uri);
+    return result;
+  }
+
   private _filterNamespaces(namespaces: NamespaceGroup[]): NamespaceGroup[] {
-    if (!this._nsFilter) return namespaces;
-    return namespaces.filter(
-      (ns) => ns.name === this._nsFilter || (!ns.name && namespaces.some((n) => n.name === this._nsFilter))
-    );
+    let result = namespaces;
+
+    // Namespace filter
+    if (this._nsFilter) {
+      result = result.filter(
+        (ns) => ns.name === this._nsFilter || (!ns.name && result.some((n) => n.name === this._nsFilter))
+      );
+    }
+
+    // File filter — narrow schemas/mappings/metrics/fragments to those from the selected file.
+    if (this._fileFilter) {
+      result = result.map(ns => ({
+        ...ns,
+        schemas: ns.schemas.filter(s => s.location.uri === this._fileFilter),
+        mappings: ns.mappings.filter(m => m.location.uri === this._fileFilter),
+        metrics: ns.metrics.filter(m => m.location.uri === this._fileFilter),
+        fragments: ns.fragments.filter(f => f.location.uri === this._fileFilter),
+      })).filter(ns =>
+        ns.schemas.length > 0 || ns.mappings.length > 0 ||
+        ns.metrics.length > 0 || ns.fragments.length > 0
+      );
+    }
+
+    return result;
   }
 
   /** Filter overview edges to only those whose source and target nodes are visible. */
@@ -1602,7 +1671,7 @@ export class SatsumaViz extends LitElement {
     edges: import("./layout/elk-layout.js").OverviewEdge[],
     visibleNamespaces: NamespaceGroup[],
   ): import("./layout/elk-layout.js").OverviewEdge[] {
-    if (!this._nsFilter) return edges;
+    if (!this._nsFilter && !this._fileFilter) return edges;
     const visibleIds = new Set<string>();
     for (const ns of visibleNamespaces) {
       for (const s of ns.schemas) visibleIds.add(s.qualifiedId);

--- a/tooling/vscode-satsuma/server/src/server.ts
+++ b/tooling/vscode-satsuma/server/src/server.ts
@@ -38,7 +38,7 @@ import { computeCodeLenses } from "./codelens";
 import { computeActionContext } from "./action-context";
 import { prepareRename, computeRename } from "./rename";
 import { computeFormatting, initFormatting } from "./formatting";
-import { buildVizModel } from "./viz-model";
+import { buildVizModel, mergeVizModels } from "./viz-model";
 import { computeMappingCoverage } from "./coverage";
 
 // ---------- Connection setup ----------
@@ -336,6 +336,30 @@ connection.onRequest(
     const tree = trees.get(params.uri);
     if (!tree) return null;
     return buildVizModel(params.uri, tree, scopeIndex(params.uri));
+  },
+);
+
+/**
+ * Return a merged VizModel spanning the full transitive lineage reachable from
+ * the given file via import declarations. Each import-reachable file contributes
+ * its schemas, mappings, metrics, and fragments — deduplicated so that stub
+ * schemas are superseded by their full upstream definitions.
+ */
+connection.onRequest(
+  "satsuma/vizFullLineage",
+  (params: { uri: string }) => {
+    const primaryTree = trees.get(params.uri);
+    if (!primaryTree) return null;
+
+    const reachableUris = getImportReachableUris(params.uri, wsIndex);
+    const models = [];
+    for (const fileUri of reachableUris) {
+      const fileTree = trees.get(fileUri);
+      if (!fileTree) continue;
+      models.push(buildVizModel(fileUri, fileTree, scopeIndex(fileUri)));
+    }
+
+    return mergeVizModels(params.uri, models);
   },
 );
 

--- a/tooling/vscode-satsuma/server/src/viz-model.ts
+++ b/tooling/vscode-satsuma/server/src/viz-model.ts
@@ -1179,3 +1179,107 @@ function nodeLocation(uri: string, node: SyntaxNode): SourceLocation {
     character: node.startPosition.column,
   };
 }
+
+// ---------- Multi-file merge (full transitive lineage) ----------
+
+/**
+ * Merge multiple per-file VizModels into a single model that represents the
+ * full transitive lineage reachable from `primaryUri`.
+ *
+ * The primary file's entities appear first and win any dedup ties. Schemas are
+ * deduped by `qualifiedId`, mappings by `id` + source URI, metrics by
+ * `qualifiedId`, and fragments by `id`. This means stub schemas injected by
+ * `injectImportedSchemaStubs` are naturally superseded when the upstream file's
+ * full definition is present.
+ *
+ * @param primaryUri - The file URI that anchors the lineage view.
+ * @param models     - One VizModel per import-reachable file (including the primary).
+ */
+export function mergeVizModels(
+  primaryUri: string,
+  models: VizModel[],
+): VizModel {
+  if (models.length === 0) {
+    return { uri: primaryUri, fileNotes: [], namespaces: [] };
+  }
+  if (models.length === 1) return models[0]!;
+
+  // Put primary model first so its entities take precedence in dedup.
+  const sorted = [...models].sort((a, b) =>
+    a.uri === primaryUri ? -1 : b.uri === primaryUri ? 1 : 0,
+  );
+
+  // Global dedup sets — track what has already been included.
+  const seenSchemas = new Set<string>();
+  const seenMappings = new Set<string>();
+  const seenMetrics = new Set<string>();
+  const seenFragments = new Set<string>();
+
+  /** Dedup key for a mapping: id + source URI (same name in different files = different mappings). */
+  const mappingKey = (m: MappingBlock): string =>
+    `${m.id}@${m.location.uri}`;
+
+  // Accumulate merged namespace groups keyed by namespace name (null = global).
+  const nsMap = new Map<string | null, NamespaceGroup>();
+
+  function getOrCreate(nsName: string | null): NamespaceGroup {
+    let ns = nsMap.get(nsName);
+    if (!ns) {
+      ns = { name: nsName, schemas: [], mappings: [], metrics: [], fragments: [] };
+      nsMap.set(nsName, ns);
+    }
+    return ns;
+  }
+
+  for (const model of sorted) {
+    for (const ns of model.namespaces) {
+      const target = getOrCreate(ns.name);
+
+      for (const s of ns.schemas) {
+        if (!seenSchemas.has(s.qualifiedId)) {
+          seenSchemas.add(s.qualifiedId);
+          target.schemas.push(s);
+        }
+      }
+      for (const m of ns.mappings) {
+        const key = mappingKey(m);
+        if (!seenMappings.has(key)) {
+          seenMappings.add(key);
+          target.mappings.push(m);
+        }
+      }
+      for (const mt of ns.metrics) {
+        if (!seenMetrics.has(mt.qualifiedId)) {
+          seenMetrics.add(mt.qualifiedId);
+          target.metrics.push(mt);
+        }
+      }
+      for (const f of ns.fragments) {
+        if (!seenFragments.has(f.id)) {
+          seenFragments.add(f.id);
+          target.fragments.push(f);
+        }
+      }
+    }
+  }
+
+  // Only include the primary file's notes — upstream file notes would be noise.
+  const primary = sorted[0]!;
+  const fileNotes = primary.uri === primaryUri ? primary.fileNotes : [];
+
+  // Build ordered namespace list: global first (if present), then named.
+  const namespaces: NamespaceGroup[] = [];
+  const globalNs = nsMap.get(null);
+  if (globalNs && (globalNs.schemas.length > 0 || globalNs.mappings.length > 0 ||
+      globalNs.metrics.length > 0 || globalNs.fragments.length > 0)) {
+    namespaces.push(globalNs);
+  }
+  for (const [name, ns] of nsMap) {
+    if (name !== null && (ns.schemas.length > 0 || ns.mappings.length > 0 ||
+        ns.metrics.length > 0 || ns.fragments.length > 0)) {
+      namespaces.push(ns);
+    }
+  }
+
+  return { uri: primaryUri, fileNotes, namespaces };
+}

--- a/tooling/vscode-satsuma/server/test/viz-model.test.js
+++ b/tooling/vscode-satsuma/server/test/viz-model.test.js
@@ -7,7 +7,7 @@ const {
   getImportReachableUris,
   indexFile,
 } = require("../dist/workspace-index");
-const { buildVizModel } = require("../dist/viz-model");
+const { buildVizModel, mergeVizModels } = require("../dist/viz-model");
 
 before(async () => { await initTestParser(); });
 
@@ -46,6 +46,29 @@ function vizModelScoped(files, targetUri) {
   const reachable = getImportReachableUris(targetUri, idx);
   const scoped = createScopedIndex(idx, reachable);
   return buildVizModel(targetUri, trees[targetUri], scoped);
+}
+
+/**
+ * Build a full-lineage merged VizModel, mirroring the satsuma/vizFullLineage
+ * endpoint: builds per-file VizModels for all import-reachable files, then
+ * merges them.
+ */
+function vizModelFullLineage(files, targetUri) {
+  const idx = createWorkspaceIndex();
+  const trees = {};
+  for (const [uri, source] of Object.entries(files)) {
+    const tree = parse(source);
+    trees[uri] = tree;
+    indexFile(idx, uri, tree);
+  }
+  const reachable = getImportReachableUris(targetUri, idx);
+  const models = [];
+  for (const fileUri of reachable) {
+    if (!trees[fileUri]) continue;
+    const scoped = createScopedIndex(idx, getImportReachableUris(fileUri, idx));
+    models.push(buildVizModel(fileUri, trees[fileUri], scoped));
+  }
+  return mergeVizModels(targetUri, models);
 }
 
 // ---------- Basic structure ----------
@@ -804,5 +827,166 @@ mapping m {
     const rateRef = arrow.transform.atRefs.find(r => r.ref === "rate");
     assert.ok(rateRef, "expected atRef for rate");
     assert.equal(rateRef.classification, "bare");
+  });
+});
+
+// ---------- mergeVizModels ----------
+
+describe("mergeVizModels", () => {
+  it("returns empty model when given no inputs", () => {
+    const result = mergeVizModels("file:///a.stm", []);
+    assert.equal(result.uri, "file:///a.stm");
+    assert.equal(result.namespaces.length, 0);
+  });
+
+  it("returns the single model unchanged when given one input", () => {
+    const model = vizModel("schema foo { id INT }");
+    const result = mergeVizModels(model.uri, [model]);
+    assert.deepStrictEqual(result, model);
+  });
+
+  it("deduplicates schemas by qualifiedId across models", () => {
+    const m1 = vizModel("schema foo { id INT }", "file:///a.stm");
+    const m2 = vizModel("schema foo { id INT\nname VARCHAR }", "file:///b.stm");
+    // Primary model's schema wins the dedup.
+    const result = mergeVizModels("file:///a.stm", [m1, m2]);
+    const schemas = result.namespaces.flatMap(ns => ns.schemas);
+    assert.equal(schemas.length, 1, "duplicate schema should be deduped");
+    assert.equal(schemas[0].fields.length, 1, "primary model schema should win");
+  });
+
+  it("includes mappings from upstream files", () => {
+    // Model A has a schema and mapping; model B has a different mapping.
+    const modelA = vizModel(`
+schema src { id INT }
+schema tgt { id INT }
+mapping m1 {
+  source { src }
+  target { tgt }
+  src.id -> id
+}`, "file:///a.stm");
+
+    const modelB = vizModel(`
+schema upstream { code VARCHAR }
+schema src { id INT }
+mapping m_upstream {
+  source { upstream }
+  target { src }
+  upstream.code -> id
+}`, "file:///b.stm");
+
+    const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
+    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
+    assert.equal(allMappings.length, 2, "both mappings should be present");
+    const mappingIds = allMappings.map(m => m.id);
+    assert.ok(mappingIds.includes("m1"), "primary mapping present");
+    assert.ok(mappingIds.includes("m_upstream"), "upstream mapping present");
+  });
+
+  it("preserves only primary file's fileNotes", () => {
+    const modelA = vizModel(`
+note { "File A note" }
+schema foo { id INT }
+`, "file:///a.stm");
+
+    const modelB = vizModel(`
+note { "File B note" }
+schema bar { id INT }
+`, "file:///b.stm");
+
+    const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
+    assert.equal(result.fileNotes.length, 1);
+    assert.ok(result.fileNotes[0].text.includes("File A note"));
+  });
+
+  it("merges entities from different namespaces correctly", () => {
+    const modelA = vizModel(`
+namespace crm {
+  schema customers { id INT }
+}`, "file:///a.stm");
+
+    const modelB = vizModel(`
+namespace billing {
+  schema invoices { id INT }
+}`, "file:///b.stm");
+
+    const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
+    assert.equal(result.namespaces.length, 2, "two namespace groups");
+    const nsNames = result.namespaces.map(ns => ns.name).sort();
+    assert.deepStrictEqual(nsNames, ["billing", "crm"]);
+  });
+});
+
+// ---------- Full lineage (vizModelFullLineage) ----------
+
+describe("vizModelFullLineage", () => {
+  it("includes schemas and mappings from transitively imported files", () => {
+    // File C defines an upstream schema.
+    // File B imports C and maps upstream -> intermediate.
+    // File A imports B and maps intermediate -> target.
+    const files = {
+      "file:///c.stm": `
+schema upstream { code VARCHAR }`,
+
+      "file:///b.stm": `
+import { upstream } from "./c.stm"
+schema intermediate { id INT }
+mapping m_b {
+  source { upstream }
+  target { intermediate }
+  upstream.code -> id
+}`,
+
+      "file:///a.stm": `
+import { intermediate } from "./b.stm"
+schema target { key INT }
+mapping m_a {
+  source { intermediate }
+  target { target }
+  intermediate.id -> key
+}`,
+    };
+
+    const result = vizModelFullLineage(files, "file:///a.stm");
+
+    // All three schemas should be present.
+    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
+    const schemaIds = allSchemas.map(s => s.qualifiedId).sort();
+    assert.ok(schemaIds.includes("upstream"), "upstream schema from file C");
+    assert.ok(schemaIds.includes("intermediate"), "intermediate schema from file B");
+    assert.ok(schemaIds.includes("target"), "target schema from file A");
+
+    // Both mappings should be present (one from A, one from B).
+    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
+    const mappingIds = allMappings.map(m => m.id).sort();
+    assert.ok(mappingIds.includes("m_a"), "mapping from file A");
+    assert.ok(mappingIds.includes("m_b"), "mapping from file B");
+  });
+
+  it("location.uri tracks which file each entity came from", () => {
+    const files = {
+      "file:///src.stm": `
+schema source_data { id INT }`,
+
+      "file:///main.stm": `
+import { source_data } from "./src.stm"
+schema result { id INT }
+mapping m {
+  source { source_data }
+  target { result }
+  source_data.id -> id
+}`,
+    };
+
+    const result = vizModelFullLineage(files, "file:///main.stm");
+    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
+
+    const resultSchema = allSchemas.find(s => s.qualifiedId === "result");
+    assert.equal(resultSchema.location.uri, "file:///main.stm",
+      "result schema should come from main.stm");
+
+    const sourceSchema = allSchemas.find(s => s.qualifiedId === "source_data");
+    assert.equal(sourceSchema.location.uri, "file:///src.stm",
+      "source_data schema should come from src.stm");
   });
 });

--- a/tooling/vscode-satsuma/server/test/viz-model.test.js
+++ b/tooling/vscode-satsuma/server/test/viz-model.test.js
@@ -963,6 +963,46 @@ mapping m_a {
     assert.ok(mappingIds.includes("m_b"), "mapping from file B");
   });
 
+  it("renders full lineage from an import-only entry point file", () => {
+    // Entry point has no local schemas or mappings — just imports that stitch
+    // the workspace together. The full lineage should still include everything.
+    const files = {
+      "file:///sources.stm": `
+schema raw_orders { order_id INT\ncustomer_id INT }`,
+
+      "file:///pipeline.stm": `
+import { raw_orders } from "./sources.stm"
+schema cleaned_orders { order_id INT\ncustomer_id INT }
+mapping clean {
+  source { raw_orders }
+  target { cleaned_orders }
+  raw_orders.order_id -> order_id
+  raw_orders.customer_id -> customer_id
+}`,
+
+      "file:///platform.stm": `
+import { raw_orders } from "./sources.stm"
+import { cleaned_orders } from "./pipeline.stm"`,
+    };
+
+    const result = vizModelFullLineage(files, "file:///platform.stm");
+
+    // Both schemas and the mapping from imported files should be present.
+    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
+    const schemaIds = allSchemas.map(s => s.qualifiedId).sort();
+    assert.ok(schemaIds.includes("raw_orders"), "upstream schema present");
+    assert.ok(schemaIds.includes("cleaned_orders"), "downstream schema present");
+
+    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
+    assert.equal(allMappings.length, 1, "mapping from pipeline file present");
+    assert.equal(allMappings[0].id, "clean");
+
+    // Namespaces should not be empty — the import-only file contributes nothing
+    // locally, but the merged model has content from imported files.
+    assert.ok(result.namespaces.length > 0,
+      "merged model has non-empty namespaces despite import-only entry point");
+  });
+
   it("location.uri tracks which file each entity came from", () => {
     const files = {
       "file:///src.stm": `

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -104,7 +104,7 @@ export class VizPanel {
     }
 
     try {
-      const model = await this.client.sendRequest("satsuma/vizModel", { uri });
+      const model = await this.client.sendRequest("satsuma/vizFullLineage", { uri });
       if (!model) {
         this.panel.webview.postMessage({
           type: "error",


### PR DESCRIPTION
## Summary

- The mapping viz now shows the **complete upstream lineage** by default — all schemas and mappings from transitively imported files appear in the graph, not just stubs
- Adds a **file-scope filter** dropdown in the toolbar so users can narrow the view to a single source file when needed
- New `satsuma/vizFullLineage` LSP endpoint builds and merges per-file VizModels across the import graph
- 8 new tests covering merge dedup logic and transitive 3-file lineage chains

## Test plan

- [x] All 292 LSP server tests pass (including 8 new)
- [x] Extension builds and packages successfully
- [x] satsuma-viz component builds successfully
- [ ] Manual: open a file with imports, verify viz shows upstream schemas with their mappings
- [ ] Manual: use file filter dropdown to narrow to current file only
- [ ] Manual: verify namespace filter still works alongside file filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)