### PR TITLE
refactor(cli): replace getBlockName() with core labelText()

### DIFF
--- a/.tickets/sl-ewyv.md
+++ b/.tickets/sl-ewyv.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ewyv
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-30T18:22:44Z
@@ -33,3 +33,10 @@ getBlockName() appears twice in the CLI: as a private function in nl-extract.ts 
 - All callers use core labelText()
 - No redundant tests for block name extraction in CLI
 
+
+## Notes
+
+**2026-03-30T18:45:55Z**
+
+Cause: getBlockName() was duplicated in cst-query.ts (exported) and nl-extract.ts (private), both identical to core's labelText().
+Fix: Deleted both copies, imported labelText from @satsuma/core in cst-query.ts, nl-extract.ts, and commands/nl.ts. getFieldName() in nl-extract.ts was checked — it navigates to field_name child first, which entryText() does not do (entryText works on the node directly), so it remains as-is. Note: context.ts still has its own getBlockName() that additionally handles qualified_name — this is out of scope as it has different logic than the simple labelText(). All 862 CLI tests pass.

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -15,7 +15,8 @@ import { parseFile } from "../parser.js";
 import { buildIndex, resolveIndexKey } from "../index-builder.js";
 import { extractNLContent } from "../nl-extract.js";
 import type { NLItem } from "../nl-extract.js";
-import { findBlockNode, getBlockName } from "../cst-query.js";
+import { labelText } from "@satsuma/core";
+import { findBlockNode } from "../cst-query.js";
 import type { SyntaxNode, WorkspaceIndex, ParsedFile, FieldDecl } from "../types.js";
 
 interface NLItemWithFile extends NLItem {
@@ -209,7 +210,7 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Wo
     );
     if (!mBody) continue;
 
-    const parentName = getBlockName(mappingNode) ?? "?";
+    const parentName = labelText(mappingNode) ?? "?";
     collectFieldArrowNL(mBody.namedChildren, leafName, parentName, mapping.file, items);
   }
 

--- a/tooling/satsuma-cli/src/cst-query.ts
+++ b/tooling/satsuma-cli/src/cst-query.ts
@@ -2,6 +2,7 @@
  * cst-query.ts — Namespace-aware CST lookup helpers.
  */
 
+import { labelText } from "@satsuma/core";
 import type { SyntaxNode } from "./types.js";
 
 interface QualifiedName {
@@ -16,14 +17,6 @@ function splitQualifiedName(name: string): QualifiedName {
     namespace: name.slice(0, idx),
     localName: name.slice(idx + 2),
   };
-}
-
-export function getBlockName(node: SyntaxNode): string | null {
-  const lbl = node.namedChildren.find((c) => c.type === "block_label");
-  const inner = lbl?.namedChildren[0];
-  if (!inner) return null;
-  if (inner.type === "backtick_name") return inner.text.slice(1, -1);
-  return inner.text;
 }
 
 export function findBlockNode(rootNode: SyntaxNode, nodeType: string, qualifiedName: string): SyntaxNode | null {
@@ -47,7 +40,7 @@ export function findBlockNode(rootNode: SyntaxNode, nodeType: string, qualifiedN
     }
 
     if (namespace) continue;
-    if (c.type === nodeType && getBlockName(c) === localName) return c;
+    if (c.type === nodeType && labelText(c) === localName) return c;
   }
 
   return null;
@@ -67,7 +60,7 @@ function findBlockByRow(rootNode: SyntaxNode, nodeType: string, targetRow: numbe
 
 function findBlockNodeInContainer(containerNode: SyntaxNode, nodeType: string, localName: string): SyntaxNode | null {
   for (const c of containerNode.namedChildren) {
-    if (c.type === nodeType && getBlockName(c) === localName) return c;
+    if (c.type === nodeType && labelText(c) === localName) return c;
   }
   return null;
 }

--- a/tooling/satsuma-cli/src/nl-extract.ts
+++ b/tooling/satsuma-cli/src/nl-extract.ts
@@ -6,7 +6,7 @@
  * Each item includes raw text, position type, and parent block/field context.
  */
 
-import { stringText } from "@satsuma/core";
+import { labelText, stringText } from "@satsuma/core";
 import type { SyntaxNode } from "./types.js";
 
 export interface NLItem {
@@ -102,21 +102,13 @@ function walkNL(node: SyntaxNode, parent: string | null, items: NLItem[]): void 
         c.type === "fragment_block" ||
         c.type === "transform_block"
       ) {
-        newParent = getBlockName(c);
+        newParent = labelText(c);
       } else if (c.type === "field_decl") {
         newParent = getFieldName(c) ?? parent;
       }
       walkNL(c, newParent, items);
     }
   }
-}
-
-function getBlockName(node: SyntaxNode): string | null {
-  const lbl = node.namedChildren.find((c) => c.type === "block_label");
-  const inner = lbl?.namedChildren[0];
-  if (!inner) return null;
-  if (inner.type === "backtick_name") return inner.text.slice(1, -1);
-  return inner.text;
 }
 
 function getFieldName(node: SyntaxNode): string | null {


### PR DESCRIPTION
## Summary
- Delete `getBlockName()` from `cst-query.ts` and `nl-extract.ts`
- Replace all call sites with core's canonical `labelText()`
- Note: `context.ts` has a separate `getBlockName()` with `qualified_name` handling — tracked in sl-03vc

Closes sl-ewyv.

## Test plan
- [x] All 862 CLI tests pass
- [x] No remaining `getBlockName` definitions in CLI (except context.ts, separate ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)