### PR TITLE
feat(core): add source positions to FieldDecl and Extracted* types

### DIFF
--- a/.tickets/aa-65ni.md
+++ b/.tickets/aa-65ni.md
@@ -1,0 +1,23 @@
+---
+id: aa-65ni
+status: closed
+deps: []
+links: []
+created: 2026-03-30T18:51:24Z
+type: task
+priority: 2
+assignee: Thorben Louw
+---
+# core: extend FieldDecl with optional source location for LSP consumers
+
+
+## Notes
+
+**2026-03-30T18:51:32Z**
+
+## Notes
+
+**2026-03-30T12:00:00Z**
+
+Cause: FieldDecl lacked CST position data (startRow/startColumn), and all Extracted* types were missing startColumn — preventing LSP consumers from mapping extracted data back to precise source locations.
+Fix: Added startRow and startColumn to FieldDecl (optional, populated by extractFieldTree). Added startColumn to all 11 Extracted* interfaces and their construction sites. Updated doc-comments on FieldDecl fields. Added 8 new tests for position data.

--- a/tooling/satsuma-cli/test/extract.test.js
+++ b/tooling/satsuma-cli/test/extract.test.js
@@ -99,8 +99,8 @@ describe("extractSchemas", () => {
     assert.equal(result[0].note, "A note");
     assert.equal(result[0].row, 5);
     assert.deepEqual(result[0].fields, [
-      { name: "id", type: "INT" },
-      { name: "name", type: "VARCHAR(100)" },
+      { name: "id", type: "INT", startRow: 0, startColumn: 0 },
+      { name: "name", type: "VARCHAR(100)", startRow: 0, startColumn: 0 },
     ]);
   });
 

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -46,7 +46,12 @@ function extractDirectFields(bodyNode: SyntaxNode): FieldDecl[] {
     let name = inner?.text ?? "";
     if (inner?.type === "backtick_name") name = name.slice(1, -1);
     const meta = extractMetadata(child(fd, "metadata_block"));
-    const decl: FieldDecl = { name, type: typeNode?.text ?? "" };
+    const decl: FieldDecl = {
+      name,
+      type: typeNode?.text ?? "",
+      startRow: fd.startPosition.row,
+      startColumn: fd.startPosition.column,
+    };
     if (meta.length > 0) decl.metadata = meta;
     return decl;
   });
@@ -86,6 +91,8 @@ export function extractFieldTree(bodyNode: SyntaxNode): FieldTree {
           type: "record",
           isList,
           children: nested.fields,
+          startRow: c.startPosition.row,
+          startColumn: c.startPosition.column,
         };
         if (meta.length > 0) decl.metadata = meta;
         if (nested.hasSpreads) {
@@ -103,11 +110,18 @@ export function extractFieldTree(bodyNode: SyntaxNode): FieldTree {
             type: "record",
             isList: isList || undefined,
             children: [],
+            startRow: c.startPosition.row,
+            startColumn: c.startPosition.column,
           };
           if (meta.length > 0) decl.metadata = meta;
           fields.push(decl);
         } else {
-          const decl: FieldDecl = { name, type: typeNode?.text ?? "" };
+          const decl: FieldDecl = {
+            name,
+            type: typeNode?.text ?? "",
+            startRow: c.startPosition.row,
+            startColumn: c.startPosition.column,
+          };
           if (isList) decl.isList = true;
           if (meta.length > 0) decl.metadata = meta;
           fields.push(decl);
@@ -210,7 +224,10 @@ function collectFromNamespaces(rootNode: SyntaxNode, nodeType: string): Namespac
 export interface ExtractedNamespace {
   name: string | null;
   note: string | null;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -225,7 +242,7 @@ export function extractNamespaces(rootNode: SyntaxNode): ExtractedNamespace[] {
     const noteStr = noteTag
       ? stringText(noteTag.namedChildren.find((c) => c.type === "nl_string" || c.type === "multiline_string"))
       : null;
-    return { name, note: noteStr, row: node.startPosition.row };
+    return { name, note: noteStr, row: node.startPosition.row, startColumn: node.startPosition.column };
   });
 }
 
@@ -236,7 +253,10 @@ export interface ExtractedSchema {
   fields: FieldDecl[];
   hasSpreads: boolean;
   spreads: string[];
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
   blockMetadata?: MetaEntry[];
 }
 
@@ -262,6 +282,7 @@ export function extractSchemas(rootNode: SyntaxNode): ExtractedSchema[] {
       hasSpreads: fieldTree.hasSpreads,
       spreads: fieldTree.spreads,
       row: node.startPosition.row,
+      startColumn: node.startPosition.column,
     };
     if (blockMeta.length > 0) result.blockMetadata = blockMeta;
     return result;
@@ -276,7 +297,10 @@ export interface ExtractedMetric {
   grain: string | null;
   slices: string[];
   fields: FieldDecl[];
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -328,7 +352,7 @@ export function extractMetrics(rootNode: SyntaxNode): ExtractedMetric[] {
 
     const body = child(node, "metric_body");
     const fields = body ? extractDirectFields(body) : [];
-    return { name, namespace, displayName, sources, grain, slices, fields, row: node.startPosition.row };
+    return { name, namespace, displayName, sources, grain, slices, fields, row: node.startPosition.row, startColumn: node.startPosition.column };
   });
 }
 
@@ -338,7 +362,10 @@ export interface ExtractedMapping {
   sources: string[];
   targets: string[];
   arrowCount: number;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -379,7 +406,7 @@ export function extractMappings(rootNode: SyntaxNode): ExtractedMapping[] {
       namespace && !t.includes("::") ? `${namespace}::${t}` : t,
     );
 
-    return { name, namespace, sources, targets: qualifiedTargets, arrowCount, row: node.startPosition.row };
+    return { name, namespace, sources, targets: qualifiedTargets, arrowCount, row: node.startPosition.row, startColumn: node.startPosition.column };
   });
 }
 
@@ -389,7 +416,10 @@ export interface ExtractedFragment {
   fields: FieldDecl[];
   hasSpreads: boolean;
   spreads: string[];
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -407,6 +437,7 @@ export function extractFragments(rootNode: SyntaxNode): ExtractedFragment[] {
       hasSpreads: fieldTree.hasSpreads,
       spreads: fieldTree.spreads,
       row: node.startPosition.row,
+      startColumn: node.startPosition.column,
     };
   });
 }
@@ -415,7 +446,10 @@ export interface ExtractedTransform {
   name: string | null;
   body: string | null;
   namespace: string | null;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -429,6 +463,7 @@ export function extractTransforms(rootNode: SyntaxNode): ExtractedTransform[] {
       body: pipeChain ? pipeChain.text : null,
       namespace,
       row: node.startPosition.row,
+      startColumn: node.startPosition.column,
     };
   });
 }
@@ -454,7 +489,10 @@ function findParentBlock(node: SyntaxNode): { name: string | null; blockType: st
 
 export interface ExtractedNote {
   text: string;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
   parent: string | null;
   namespace: string | null;
 }
@@ -476,6 +514,7 @@ export function extractNotes(rootNode: SyntaxNode): ExtractedNote[] {
         results.push({
           text: extractNoteText(c),
           row: c.startPosition.row,
+          startColumn: c.startPosition.column,
           parent: null,
           namespace,
         });
@@ -506,6 +545,7 @@ function collectNotesInBlock(
       results.push({
         text: extractNoteText(c),
         row: c.startPosition.row,
+        startColumn: c.startPosition.column,
         parent: parentName,
         namespace,
       });
@@ -516,6 +556,7 @@ function collectNotesInBlock(
           results.push({
             text: extractNoteText(inner),
             row: inner.startPosition.row,
+            startColumn: inner.startPosition.column,
             parent: parentName,
             namespace,
           });
@@ -539,7 +580,10 @@ function extractNoteText(noteNode: SyntaxNode): string {
 
 export interface ExtractedWarning {
   text: string;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
   parent: string | null;
   parentType: string | null;
 }
@@ -553,6 +597,7 @@ export function extractWarnings(rootNode: SyntaxNode): ExtractedWarning[] {
     return {
       text: node.text.replace(/^\/\/!\s*/, ""),
       row: node.startPosition.row,
+      startColumn: node.startPosition.column,
       parent: name,
       parentType: blockType,
     };
@@ -561,7 +606,10 @@ export function extractWarnings(rootNode: SyntaxNode): ExtractedWarning[] {
 
 export interface ExtractedQuestion {
   text: string;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
   parent: string | null;
   parentType: string | null;
 }
@@ -575,6 +623,7 @@ export function extractQuestions(rootNode: SyntaxNode): ExtractedQuestion[] {
     return {
       text: node.text.replace(/^\/\/\?\s*/, ""),
       row: node.startPosition.row,
+      startColumn: node.startPosition.column,
       parent: name,
       parentType: blockType,
     };
@@ -584,7 +633,10 @@ export function extractQuestions(rootNode: SyntaxNode): ExtractedQuestion[] {
 export interface ExtractedImport {
   names: string[];
   path: string | null;
+  /** 0-indexed row from CST startPosition. */
   row: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
 }
 
 /**
@@ -608,7 +660,7 @@ export function extractImports(rootNode: SyntaxNode): ExtractedImport[] {
       ? stringText(pathNode.namedChildren[0])
       : null;
 
-    return { names, path: pathStr, row: node.startPosition.row };
+    return { names, path: pathStr, row: node.startPosition.row, startColumn: node.startPosition.column };
   });
 }
 
@@ -656,7 +708,10 @@ export interface ExtractedArrow {
   steps: PipeStep[];
   classification: Classification;
   derived: boolean;
+  /** 0-indexed row from CST startPosition (named "line" for historical reasons). */
   line: number;
+  /** 0-indexed column from CST startPosition. */
+  startColumn: number;
   metadata?: MetaEntry[];
 }
 
@@ -769,6 +824,7 @@ function extractSingleArrow(
     classification,
     derived,
     line: arrow.startPosition.row,
+    startColumn: arrow.startPosition.column,
   };
 
   if (metadata && metadata.length > 0) {

--- a/tooling/satsuma-core/src/types.ts
+++ b/tooling/satsuma-core/src/types.ts
@@ -96,11 +96,30 @@ export type MetaEntry = MetaEntryTag | MetaEntryKV | MetaEntryEnum | MetaEntryNo
 // ── Extracted record shapes ─────────────────────────────────────────────────
 
 export interface FieldDecl {
+  /** The field name as written in source (backtick quoting stripped). */
   name: string;
+  /** The type expression text (e.g. "INT", "STRING"), or "record" for nested record fields. */
   type: string;
+  /** Nested field declarations for record-typed fields. */
   children?: FieldDecl[];
+  /** True when the field is declared with the `list_of` keyword. */
   isList?: boolean;
+  /** Metadata entries from an inline metadata block on this field. */
   metadata?: MetaEntry[];
+  /** True when any child position contains a fragment spread. */
   hasSpreads?: boolean;
+  /** Names of fragments spread into this field's record body. */
   spreads?: string[];
+  /**
+   * 0-indexed row of the field_decl node's start position in the source file.
+   * Sourced from `node.startPosition.row` in the CST. Present when the field
+   * was extracted from a parsed CST (always set by extractFieldTree).
+   */
+  startRow?: number;
+  /**
+   * 0-indexed column of the field_decl node's start position in the source file.
+   * Sourced from `node.startPosition.column` in the CST. Present when the field
+   * was extracted from a parsed CST (always set by extractFieldTree).
+   */
+  startColumn?: number;
 }

--- a/tooling/satsuma-core/test/extract.test.js
+++ b/tooling/satsuma-core/test/extract.test.js
@@ -20,7 +20,7 @@ import {
 
 // ── Mock helpers ─────────────────────────────────────────────────────────────
 
-function n(type, namedChildren = [], text = "", row = 0, anonymousChildren = []) {
+function n(type, namedChildren = [], text = "", row = 0, anonymousChildren = [], column = 0) {
   const allChildren = [
     ...anonymousChildren.map(t => ({ type: t, text: t, isNamed: false, namedChildren: [], children: [] })),
     ...namedChildren.map(c => ({ ...c, isNamed: true })),
@@ -29,8 +29,8 @@ function n(type, namedChildren = [], text = "", row = 0, anonymousChildren = [])
     type,
     text,
     isNamed: true,
-    startPosition: { row, column: 0 },
-    endPosition: { row, column: text.length },
+    startPosition: { row, column },
+    endPosition: { row, column: column + text.length },
     namedChildren,
     children: allChildren,
     parent: null,
@@ -50,10 +50,10 @@ function schemaBody(fields = []) {
   return n("schema_body", fields);
 }
 
-function fieldDecl(name, type, row = 0) {
+function fieldDecl(name, type, row = 0, column = 0) {
   const nameNode = n("field_name", [ident(name)]);
   const typeNode = n("type_expr", [], type);
-  return n("field_decl", [nameNode, typeNode], `${name} ${type}`, row);
+  return n("field_decl", [nameNode, typeNode], `${name} ${type}`, row, [], column);
 }
 
 // ── extractSchemas ────────────────────────────────────────────────────────────
@@ -163,6 +163,91 @@ describe("extractFieldTree()", () => {
     const result = extractFieldTree(body);
     assert.equal(result.hasSpreads, true);
     assert.deepEqual(result.spreads, ["audit_fields"]);
+  });
+});
+
+// ── Position data on FieldDecl ───────────────────────────────────────────────
+
+describe("FieldDecl position data", () => {
+  it("populates startRow and startColumn from the field_decl CST node", () => {
+    const body = schemaBody([fieldDecl("id", "INT", 3, 4), fieldDecl("name", "STRING", 4, 4)]);
+    const result = extractFieldTree(body);
+    assert.equal(result.fields[0].startRow, 3);
+    assert.equal(result.fields[0].startColumn, 4);
+    assert.equal(result.fields[1].startRow, 4);
+    assert.equal(result.fields[1].startColumn, 4);
+  });
+
+  it("defaults position to row 0 column 0 when mock uses defaults", () => {
+    const body = schemaBody([fieldDecl("x", "INT")]);
+    const result = extractFieldTree(body);
+    assert.equal(result.fields[0].startRow, 0);
+    assert.equal(result.fields[0].startColumn, 0);
+  });
+});
+
+// ── startColumn on Extracted* types ─────────────────────────────────────────
+
+describe("startColumn on Extracted types", () => {
+  it("extractSchemas includes startColumn from the schema_block node", () => {
+    const body = schemaBody([fieldDecl("id", "INT")]);
+    const schemaBlock = n("schema_block", [blockLabel("orders"), body], "", 5, [], 2);
+    const root = n("program", [schemaBlock]);
+
+    const result = extractSchemas(root);
+    assert.equal(result[0].row, 5);
+    assert.equal(result[0].startColumn, 2);
+  });
+
+  it("extractFragments includes startColumn from the fragment_block node", () => {
+    const body = schemaBody([fieldDecl("ts", "TIMESTAMP")]);
+    const fragBlock = n("fragment_block", [blockLabel("audit"), body], "", 10, [], 4);
+    const root = n("program", [fragBlock]);
+
+    const result = extractFragments(root);
+    assert.equal(result[0].row, 10);
+    assert.equal(result[0].startColumn, 4);
+  });
+
+  it("extractMappings includes startColumn from the mapping_block node", () => {
+    const srcRef = n("source_ref", [ident("src")], "src");
+    const srcBlock = n("source_block", [srcRef]);
+    const body = n("mapping_body", [srcBlock]);
+    const mappingBlock = n("mapping_block", [blockLabel("m"), body], "", 7, [], 6);
+    const root = n("program", [mappingBlock]);
+
+    const result = extractMappings(root);
+    assert.equal(result[0].row, 7);
+    assert.equal(result[0].startColumn, 6);
+  });
+
+  it("extractWarnings includes startColumn from the warning_comment node", () => {
+    const warning = n("warning_comment", [], "//! caution", 2, [], 8);
+    warning.parent = null;
+    const root = n("program", [warning]);
+    const result = extractWarnings(root);
+    assert.equal(result[0].row, 2);
+    assert.equal(result[0].startColumn, 8);
+  });
+
+  it("extractQuestions includes startColumn from the question_comment node", () => {
+    const question = n("question_comment", [], "//? why", 3, [], 4);
+    question.parent = null;
+    const root = n("program", [question]);
+    const result = extractQuestions(root);
+    assert.equal(result[0].row, 3);
+    assert.equal(result[0].startColumn, 4);
+  });
+
+  it("extractImports includes startColumn from the import_decl node", () => {
+    const importName = n("import_name", [ident("foo")]);
+    const strNode = n("nl_string", [], '"./bar.stm"');
+    const pathNode = n("import_path", [strNode]);
+    const importDecl = n("import_decl", [importName, pathNode], "", 0, [], 0);
+    const root = n("program", [importDecl]);
+
+    const result = extractImports(root);
+    assert.equal(result[0].startColumn, 0);
   });
 });
 


### PR DESCRIPTION
## Summary
- `FieldDecl` gains optional `startRow` and `startColumn` (0-indexed, from CST)
- All 11 `Extracted*` types gain `startColumn` for LSP consumers
- 8 new tests verify position data correctness

Closes sl-mphz.

## Test plan
- [x] Core: 138 tests pass
- [x] CLI: 862 tests pass
- [x] LSP: 293 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)