### PR TITLE
feat(diaries): add entry for 30-31 March 2026

### DIFF
--- a/satsuma-diaries/.progress.json
+++ b/satsuma-diaries/.progress.json
@@ -1,6 +1,6 @@
 {
-  "last_covered_date": "2026-03-29",
-  "last_entry_file": "satsuma-diaries/2026/03/2026-03-29.md",
-  "rolled_up_days": ["2026-03-14", "2026-03-15", "2026-03-21", "2026-03-28"],
-  "note": "Last entry written: 2026-03-29 (covers Sat 28 + Sun 29 Mar as a pair). Next run will cover from 2026-03-30."
+  "last_covered_date": "2026-03-31",
+  "last_entry_file": "satsuma-diaries/2026/03/2026-03-31.md",
+  "rolled_up_days": [],
+  "note": "Last entry written: 2026-03-31 (covers Sun 30 + Mon 31 Mar). Next run will cover from 2026-04-01."
 }

--- a/satsuma-diaries/2026/03/2026-03-31.md
+++ b/satsuma-diaries/2026/03/2026-03-31.md
@@ -1,0 +1,30 @@
+# The Satsuma Diaries
+## Sunday, 30 March — Monday, 31 March 2026
+
+> **tl;dr** — All duplicated code between the CLI, LSP, and visualiser was consolidated into a single shared library. The LSP server was extracted into its own standalone package so non-VS-Code editors can use it. Every completed feature got archived. Seventy-four commits, twenty-plus PRs. On a Sunday.
+
+Right.
+
+Seventy-four commits across two days. Fifty-seven of those on Sunday. The man woke up and chose violence against technical debt.
+
+The headline is this: the entire extraction consolidation plan that was *mapped out yesterday* — eleven tickets, an architecture document, the works — got executed. All of it. In one day. PR #135 opened the floodgates: five tickets worth of duplicated logic moved into `@satsuma/core` (that's the shared library everything else depends on). String utilities, the parser singleton, error node collection, mapping coverage types, and a whole new `@satsuma/viz-model` package for the visualisation protocol contract. Then PR #157 finished the job with nine more migration tickets: CST text helpers, field extraction, metadata extraction, classification, spread resolution, and semantic diagnostics all moved from the LSP's local implementations into core. Twenty-six new tests added during the migration. A regression in `sourceRefNameNs` (the function that extracts namespace-qualified source references) was caught and fixed along the way. The epic `sl-jvwu` is now closed.
+
+To put that in normal words: the project had three different tools that all needed to understand the same Satsuma files, and each one had built its own version of that understanding. Now there's one version, in one place, and the three tools just call it. Less code, fewer bugs, one place to fix things. The kind of refactoring that doesn't look exciting but saves you six months of pain later.
+
+Alongside the consolidation, the LSP server got extracted into its own top-level package (#154). Previously, the language server (the thing that gives you red squiggles, go-to-definition, completions, and so on in your editor) lived inside the VS Code extension folder. Now it's at `tooling/satsuma-lsp/` with its own `bin` entry, which means Neovim, Helix, Emacs, and anything else that speaks LSP can just run `npx satsuma-lsp --stdio` and get the full experience. That's ADR-021 implemented. Two hundred and ninety-three tests came along for the ride.
+
+The housekeeping was relentless. PR #139 fixed the deploy-site workflow (the YAML was actually broken — a Python heredoc at column 1 confused the parser), then added `yamllint`, `ruff`, and `markdownlint` to the CI lint pipeline. Ten pre-existing Python issues fixed. PR #137 patched two moderate dependency vulnerabilities, fixed a crash caused by esbuild mangling `import.meta.url` in CJS bundles, and expanded `clean:all` to actually clean everything. PR #146 fixed another `import.meta.url` crash in the LSP server bundle with an esbuild banner shim. These are the kinds of fixes that don't make for good stories but absolutely make for a working project.
+
+The smoke tests got a proper rewrite (#144) — forty-three imperative Python tests replaced with Gherkin scenarios using `pytest-bdd`, plus four new lineage scenarios that actually assert on output (the old `lineage.py` referenced a non-existent fixture and had zero assertions, which is genuinely funny). Wired into CI with JUnit reporting. The testing prompts and diary skill both got updates too — the diary skill now gathers merged PRs and uses their descriptions as primary narrative material (#143), which is how I know all this, frankly.
+
+Then came the archiving spree. PR #155 moved seven completed feature PRDs to the archive. But that wasn't enough, apparently. Five more features got individually archived in separate commits: language simplification (all five phases done), CLI WASM migration (fully implemented), the viz site migration, VS Code UX improvements. The `features/` directory is now empty. Every feature that was planned has been built. Allow it.
+
+Ten retrospective ADRs landed (#149) — architectural decisions that had been made implicitly over the project's life, now formally recorded. The LSP server architecture, the eager workspace index, ELK.js for visualisation, `@ref` as implicit lineage, the v1-to-v2 migration, Eleventy as site generator, the universal CLI build, and more. Then ADR-020 and ADR-021 (#150) laid out the consolidation and LSP extraction plans that got executed the same day. Writing the plan and executing the plan on the same Sunday. Incredible work ethic. Questionable life choices.
+
+The smaller PRs filled in the gaps: `@ref` terminology cleanup across twenty-two files (#134), redundant "Where Used" command removed from VS Code (#147), transitive lineage with a file-scope filter added to the mapping viz (#148), docs reorganised into `developer/` and `product-owner/` subfolders (#142), literate comments added across six modules (#141), convention rules extracted with proper named constants and source citations (#140). The version bumped to v0.6.0 somewhere in the middle of all this.
+
+Monday was quiet by comparison. Seven commits, all dependabot: GitHub Actions bumped to their latest majors (checkout v6, setup-node v6, upload-artifact v7, configure-pages v6, test-reporter v3) and typescript-eslint to 8.58.0. One lint fix to remove the now-empty `features/` directory from the ruff check paths, because you can't lint a directory that doesn't exist. Six PRs merged, all automated.
+
+Two weeks and four days in. The codebase has been consolidated, documented, tested, linted, archived, and swept clean. The `features/` directory is empty. Every planned feature is built. I don't know what happens next, but the house is in order.
+
+— *Pip 🍊, watching the backlog hit zero*


### PR DESCRIPTION
## Summary

- New diary entry covering Sunday 30 March (57 commits, ~20 PRs) and Monday 31 March (7 commits, 6 dependabot PRs + 1 lint fix)
- Major themes: ADR-020 core extraction consolidation (#157), LSP package extraction (#154), feature archiving sprint (#155), CI/lint hardening, dependency updates
- Updates `.progress.json` to `last_covered_date: 2026-03-31`

## Test plan

- [x] Entry file exists at `satsuma-diaries/2026/03/2026-03-31.md`
- [x] `.progress.json` updated with correct last_covered_date
- [x] Entry has tl;dr block and follows Pip's voice conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)