### PR TITLE
fix(cli): four quick bug fixes (sl-t8b4, sl-xfxd, sl-8o37, sl-8s4b)

### DIFF
--- a/.tickets/sl-8o37.md
+++ b/.tickets/sl-8o37.md
@@ -1,6 +1,6 @@
 ---
 id: sl-8o37
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:27:12Z

--- a/.tickets/sl-8s4b.md
+++ b/.tickets/sl-8s4b.md
@@ -1,6 +1,6 @@
 ---
 id: sl-8s4b
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:25:11Z

--- a/.tickets/sl-t8b4.md
+++ b/.tickets/sl-t8b4.md
@@ -1,6 +1,6 @@
 ---
 id: sl-t8b4
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:31:39Z

--- a/.tickets/sl-xfxd.md
+++ b/.tickets/sl-xfxd.md
@@ -1,6 +1,6 @@
 ---
 id: sl-xfxd
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:26:07Z

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -28,7 +28,7 @@ interface Match {
   block: string;
   field: string;
   tag: string;
-  fieldType?: string;
+  fieldType?: string | null;
   metadata?: string[];
   file: string;
   line: number;
@@ -130,6 +130,7 @@ function searchTag(index: WorkspaceIndex, parsedFiles: ParsedFile[], tag: string
           block: blockName,
           field: "(schema)",
           tag: matched,
+          fieldType: null,
           metadata: allTags.length > 0 ? allTags : undefined,
           file: blockEntry.file,
           line: blockNode.startPosition.row + 1,

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -92,7 +92,12 @@ Examples:
       if (opts.from) {
         const resolved = resolveIndexKey(opts.from, graph.nodes);
         if (!resolved) {
-          console.error(`Node '${opts.from}' not found.`);
+          const msg = `Node '${opts.from}' not found.`;
+          if (opts.json) {
+            console.log(JSON.stringify({ error: msg }, null, 2));
+          } else {
+            console.error(msg);
+          }
           process.exit(1);
         }
         const start = resolved.key;
@@ -108,7 +113,12 @@ Examples:
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by opts.to existence check in enclosing branch
         const resolvedTo = resolveIndexKey(opts.to!, graph.nodes);
         if (!resolvedTo) {
-          console.error(`Node '${opts.to}' not found.`);
+          const msg = `Node '${opts.to}' not found.`;
+          if (opts.json) {
+            console.log(JSON.stringify({ error: msg }, null, 2));
+          } else {
+            console.error(msg);
+          }
           process.exit(1);
         }
         const target = resolvedTo.key;

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -5,9 +5,9 @@
  * hygiene and modelling convention issues as structured diagnostics.
  *
  * Exit codes:
- *   0 — no findings (or all findings fixed with --fix)
+ *   0 — no error-severity findings (warnings alone do not cause exit 2)
  *   1 — internal error (filesystem, parser crash, bad arguments)
- *   2 — lint findings present
+ *   2 — error-severity lint findings present
  *
  * Flags:
  *   --json     machine-readable JSON output
@@ -122,11 +122,12 @@ Examples:
       }
 
       const findingCount = diagnostics.length;
+      const errorCount = diagnostics.filter((d) => d.severity === "error").length;
       const fixableCount = diagnostics.filter((d) => d.fixable).length;
 
       // --quiet: exit code only
       if (opts.quiet) {
-        process.exit(findingCount > 0 ? 2 : 0);
+        process.exit(errorCount > 0 ? 2 : 0);
       }
 
       // --json: structured output
@@ -142,7 +143,7 @@ Examples:
           },
         };
         console.log(JSON.stringify(payload, null, 2));
-        process.exit(findingCount > 0 ? 2 : 0);
+        process.exit(errorCount > 0 ? 2 : 0);
       }
 
       // Text output
@@ -187,6 +188,6 @@ Examples:
         );
       }
 
-      process.exit(2);
+      process.exit(errorCount > 0 ? 2 : 0);
     });
 }

--- a/tooling/satsuma-cli/src/parser.ts
+++ b/tooling/satsuma-cli/src/parser.ts
@@ -41,9 +41,14 @@ export function parseSource(src: string): { src: string; tree: Tree; errorCount:
   return { src, tree: tree as unknown as Tree, errorCount };
 }
 
-/** Count ERROR nodes recursively in a tree node. */
+/**
+ * Count parse-error nodes recursively in a tree.
+ * Counts both ERROR nodes (unexpected tokens) and MISSING nodes (expected
+ * tokens the parser could not find), matching the two error signals that
+ * tree-sitter produces.  See @satsuma/core parse-errors.ts for details.
+ */
 function countErrors(node: SyntaxNode): number {
-  let n = node.type === "ERROR" ? 1 : 0;
+  let n = (node.type === "ERROR" || node.isMissing) ? 1 : 0;
   for (const child of node.namedChildren) n += countErrors(child);
   return n;
 }

--- a/tooling/satsuma-cli/test/integration.test.ts
+++ b/tooling/satsuma-cli/test/integration.test.ts
@@ -111,6 +111,16 @@ describe("satsuma summary", () => {
       "arrowCount should include both declared and nl-derived arrows");
   });
 
+  it("--json totalErrors counts MISSING nodes, not just ERROR nodes (sl-8s4b)", async () => {
+    // Files with parse errors (e.g. missing closing brace) produce MISSING
+    // nodes that must be included in totalErrors, not just ERROR nodes.
+    const BAD = resolve(import.meta.dirname, "fixtures", "parse-error.stm");
+    const { stdout, code } = await run("summary", "--json", BAD);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.totalErrors > 0, "totalErrors should count parse errors");
+  });
+
   it("--json --compact strips notes and file/row from output (sl-86n4)", async () => {
     const { stdout, code } = await run("summary", "--json", "--compact", PLATFORM);
     assert.equal(code, 0);
@@ -813,6 +823,21 @@ describe("satsuma find", () => {
     assert.ok(schemaMatch, "expected uses_fragment match from spread");
     assert.equal(schemaMatch.field, "created_at");
   });
+
+  it("--json schema-level entries include fieldType as null (sl-t8b4)", async () => {
+    // Schema-level tag matches must include fieldType: null in JSON output,
+    // not omit the key entirely, matching the documented JSON shape.
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
+    const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const schemaLevel = data.filter((m: any) => m.field === "(schema)");
+    assert.ok(schemaLevel.length > 0, "expected schema-level matches");
+    for (const m of schemaLevel) {
+      assert.ok("fieldType" in m, "schema-level entry must include fieldType key");
+      assert.equal(m.fieldType, null, "schema-level fieldType must be null");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -845,6 +870,24 @@ describe("satsuma lineage", () => {
     const { code, stderr } = await run("lineage", "--from", "no_such_schema_xyz", PLATFORM);
     assert.equal(code, 1);
     assert.match(stderr, /not found/i);
+  });
+
+  it("--json returns JSON error object for unknown --from schema (sl-xfxd)", async () => {
+    // When --json is passed, not-found errors must return a JSON object
+    // instead of plain text, consistent with other commands like schema.
+    const { stdout, code } = await run("lineage", "--from", "no_such_schema_xyz", "--json", PLATFORM);
+    assert.equal(code, 1);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error, "should have error key in JSON");
+    assert.match(data.error, /not found/i);
+  });
+
+  it("--json returns JSON error object for unknown --to schema (sl-xfxd)", async () => {
+    const { stdout, code } = await run("lineage", "--to", "no_such_schema_xyz", "--json", PLATFORM);
+    assert.equal(code, 1);
+    const data = JSON.parse(stdout);
+    assert.ok(data.error, "should have error key in JSON");
+    assert.match(data.error, /not found/i);
   });
 
   it("exits 1 when neither --from nor --to provided", async () => {
@@ -2929,11 +2972,19 @@ describe("satsuma lint", () => {
     assert.match(stdout, /hidden-source-in-nl/);
   });
 
-  it("reports unresolved NL references", async () => {
+  it("reports unresolved NL references with exit 0 (warning-only)", async () => {
+    // unresolved-nl-ref is warning severity — warnings do not cause exit 2
     const { stdout, code } = await run("lint", resolve(LINT_FIXTURES, "lint-unresolved.stm"));
-    assert.equal(code, 2);
+    assert.equal(code, 0);
     assert.match(stdout, /unresolved-nl-ref/);
     assert.match(stdout, /nonexistent_schema/);
+  });
+
+  it("--quiet exits 0 for warning-only findings (sl-8o37)", async () => {
+    // Warning-severity findings must not cause exit 2, only errors should.
+    const { stdout, code } = await run("lint", "--quiet", resolve(LINT_FIXTURES, "lint-unresolved.stm"));
+    assert.equal(code, 0);
+    assert.equal(stdout.trim(), "");
   });
 
   it("--json produces valid structured output", async () => {
@@ -3015,8 +3066,8 @@ describe("satsuma lint --fix", () => {
     const file = copyFixture("lint-mixed.stm");
 
     const { stdout, code } = await run("lint", "--fix", file);
-    // Non-fixable finding remains → exit 2
-    assert.equal(code, 2);
+    // After fix, only warning-severity findings remain → exit 0
+    assert.equal(code, 0);
     assert.match(stdout, /Fixed:/);
     assert.match(stdout, /hidden-source-in-nl/);
     // Residual non-fixable finding still reported
@@ -3031,7 +3082,8 @@ describe("satsuma lint --fix", () => {
     const file = copyFixture("lint-mixed.stm");
 
     const { stdout, code } = await run("lint", "--fix", "--json", file);
-    assert.equal(code, 2);
+    // After fix, only warning-severity findings remain → exit 0
+    assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.fixes.length > 0, "should have applied fixes");
     assert.ok(data.findings.length > 0, "should have residual findings");
@@ -3046,9 +3098,9 @@ describe("satsuma lint --fix", () => {
     const firstData = JSON.parse(first);
     assert.ok(firstData.summary.fixed > 0, "first run should fix something");
 
-    // Second run: no new fixes, only residual non-fixable findings
+    // Second run: no new fixes, only residual warning-severity findings → exit 0
     const { stdout, code } = await run("lint", "--fix", "--json", file);
-    assert.equal(code, 2);
+    assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.summary.fixed, 0, "no new fixes on second run");
     // Persistent non-fixable finding (nonexistent_fx_rates) still present


### PR DESCRIPTION
## Summary

- **sl-t8b4**: `find --json` schema-level tag entries now include `fieldType: null` instead of omitting the key
- **sl-xfxd**: `lineage --json` not-found errors return `{"error": "..."}` instead of plain text
- **sl-8o37**: `lint` exits 0 for warning-only findings (was incorrectly exiting 2), consistent with `validate`
- **sl-8s4b**: `summary` totalErrors now counts MISSING nodes alongside ERROR nodes, matching `validate` behavior

## Test plan

- [x] Added regression test for find fieldType: null on schema-level entries
- [x] Added regression tests for lineage --json not-found (both --from and --to)
- [x] Added regression test for lint --quiet exit 0 on warning-only findings
- [x] Updated 4 existing lint tests for new exit code semantics
- [x] Added regression test for summary totalErrors with parse-error fixture
- [x] All 786 integration tests pass
- [x] All 34 graph tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)