### PR TITLE
Fix metadata value normalization and where-used docs

### DIFF
--- a/.tickets/sl-2old.md
+++ b/.tickets/sl-2old.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2old
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:32:55Z
@@ -28,3 +28,10 @@ Affects: meta --json, fields --json (metadata entries). Unquoted identifier valu
 
 This also affects the metadata array in find --json output, where string values like classification appear as 'classification "INTERNAL"' with embedded quotes.
 
+
+## Notes
+
+**2026-04-01T09:16:37Z**
+
+Cause: Metadata key/value extraction only unwrapped bare nl_string nodes, but parser output wraps quoted values in value_text nodes so JSON consumers received literal quote delimiters.
+Fix: Normalized quoted metadata values in satsuma-core and aligned find metadata rendering so meta, fields, and find JSON surfaces return logical string values without embedded quotes (commit <pending>).

--- a/.tickets/sl-2old.md
+++ b/.tickets/sl-2old.md
@@ -34,4 +34,4 @@ This also affects the metadata array in find --json output, where string values 
 **2026-04-01T09:16:37Z**
 
 Cause: Metadata key/value extraction only unwrapped bare nl_string nodes, but parser output wraps quoted values in value_text nodes so JSON consumers received literal quote delimiters.
-Fix: Normalized quoted metadata values in satsuma-core and aligned find metadata rendering so meta, fields, and find JSON surfaces return logical string values without embedded quotes (commit <pending>).
+Fix: Normalized quoted metadata values in satsuma-core and aligned find metadata rendering so meta, fields, and find JSON surfaces return logical string values without embedded quotes (commit a1e7949).

--- a/.tickets/sl-wawy.md
+++ b/.tickets/sl-wawy.md
@@ -30,4 +30,4 @@ The 'schema' kind documented in the help was never observed in testing. Consumer
 **2026-04-01T09:16:37Z**
 
 Cause: The where-used help text documented an outdated JSON kind set that no longer matched the command's emitted ref kinds.
-Fix: Updated the where-used --help JSON contract and added regression coverage to keep the documented kind surface aligned with actual output (commit <pending>).
+Fix: Updated the where-used --help JSON contract and added regression coverage to keep the documented kind surface aligned with actual output (commit a1e7949).

--- a/.tickets/sl-wawy.md
+++ b/.tickets/sl-wawy.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wawy
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:25:16Z
@@ -24,3 +24,10 @@ Actual kind values observed:
 
 The 'schema' kind documented in the help was never observed in testing. Consumers relying on the documented shape will encounter unexpected kind values.
 
+
+## Notes
+
+**2026-04-01T09:16:37Z**
+
+Cause: The where-used help text documented an outdated JSON kind set that no longer matched the command's emitted ref kinds.
+Fix: Updated the where-used --help JSON contract and added regression coverage to keep the documented kind surface aligned with actual output (commit <pending>).

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -242,7 +242,8 @@ function collectAllTags(metaNode: SyntaxNode): string[] {
     else if (c.type === "tag_with_value") {
       const key = c.namedChildren[0]; // identifier
       const val = c.namedChildren[1]; // value_text
-      tags.push(val ? `${key?.text} ${val.text}` : (key?.text ?? ""));
+      const valueText = renderMetadataValue(val);
+      tags.push(valueText ? `${key?.text} ${valueText}` : (key?.text ?? ""));
     } else if (c.type === "note_tag") {
       const strNode = c.namedChildren.find((x) => x.type === "nl_string" || x.type === "multiline_string");
       tags.push(strNode ? `note ${strNode.text}` : "note");
@@ -251,6 +252,36 @@ function collectAllTags(metaNode: SyntaxNode): string[] {
     else if (c.type === "slice_body") tags.push("slice {...}");
   }
   return tags;
+}
+
+/**
+ * Render metadata values for `find --json` using logical values rather than
+ * source syntax, so quoted strings do not keep their delimiters.
+ */
+function renderMetadataValue(valueNode: SyntaxNode | undefined): string {
+  if (!valueNode) return "";
+
+  if (valueNode.type === "nl_string" || valueNode.type === "backtick_name") {
+    return valueNode.text.slice(1, -1);
+  }
+
+  const nestedValue = valueNode.namedChildren.find(
+    (child) => child.type === "nl_string" || child.type === "backtick_name",
+  );
+  if (nestedValue) {
+    return renderMetadataValue(nestedValue);
+  }
+
+  const text = valueNode.text;
+  if (
+    text.length >= 2 &&
+    ((text.startsWith("\"") && text.endsWith("\"")) ||
+      (text.startsWith("`") && text.endsWith("`")))
+  ) {
+    return text.slice(1, -1);
+  }
+
+  return text;
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -41,7 +41,7 @@ Searches mappings (source/target refs), metrics (source refs), schemas
 JSON shape (--json):
   {
     "name": str,   # canonical name searched
-    "refs": [{"kind": "mapping"|"metric"|"schema"|"nl_ref", "name": str, "file": str, "line": int}, ...]
+    "refs": [{"kind": "mapping"|"metric"|"fragment_spread"|"ref_metadata"|"import"|"transform_call"|"nl_ref", "name": str, "file": str, "line": int}, ...]
   }
 
 Examples:

--- a/tooling/satsuma-cli/test/integration.test.ts
+++ b/tooling/satsuma-cli/test/integration.test.ts
@@ -789,6 +789,19 @@ describe("satsuma find", () => {
     }
   });
 
+  it("--json metadata strings unwrap quoted kv values (sl-2old)", async () => {
+    // find renders metadata strings itself, so string-valued metadata needs its
+    // own regression coverage in addition to the shared core extractor tests.
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
+    const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const schemaLevel = data.find((m: any) => m.block === "completed_orders_parquet" && m.field === "(schema)");
+    assert.ok(schemaLevel, "expected completed_orders_parquet schema-level match");
+    assert.ok(schemaLevel.metadata.includes("classification INTERNAL"));
+    assert.ok(!schemaLevel.metadata.includes('classification "INTERNAL"'));
+  });
+
   it("--tag note finds fields with note metadata (sl-amyh)", async () => {
     const { stdout, code } = await run("find", "--tag", "note", PLATFORM);
     assert.equal(code, 0);
@@ -1025,6 +1038,18 @@ describe("satsuma where-used", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.refs.length, 2, "should have exactly 2 refs (spread + bare), not 3");
+  });
+
+  it("--help documents the current JSON ref kinds (sl-wawy)", async () => {
+    // The help text is the published JSON contract for consumers, so it must
+    // enumerate the kinds the command actually emits.
+    const { stdout, code } = await run("where-used", "--help");
+    assert.equal(code, 0);
+    assert.match(stdout, /fragment_spread/);
+    assert.match(stdout, /ref_metadata/);
+    assert.match(stdout, /import/);
+    assert.match(stdout, /transform_call/);
+    assert.match(stdout, /nl_ref/);
   });
 });
 
@@ -1332,6 +1357,20 @@ describe("satsuma fields", () => {
     assert.ok(data[0].type);
   });
 
+  it("--json unwraps quoted metadata values on fields (sl-2old)", async () => {
+    // fields --json forwards FieldDecl metadata from the shared extractor, so
+    // quoted string values should already be normalized here.
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
+    const { stdout, code } = await run("fields", "completed_orders_parquet", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const customerEmail = data.find((field: any) => field.name === "customer_email");
+    const classification = customerEmail.metadata.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
+    const retention = customerEmail.metadata.find((entry: any) => entry.kind === "kv" && entry.key === "retention");
+    assert.equal(classification?.value, "RESTRICTED");
+    assert.equal(retention?.value, "3y");
+  });
+
   it("--unmapped-by on target schema returns correct set difference", async () => {
     const { stdout, code } = await run(
       "fields", "postgres_db", "--unmapped-by", "customer migration", DB,
@@ -1635,6 +1674,30 @@ describe("satsuma meta", () => {
     assert.equal(data.type, "CHAR(1)");
     assert.ok(Array.isArray(data.entries));
     assert.ok(data.entries.some((e: any) => e.kind === "enum"));
+  });
+
+  it("--json unwraps quoted metadata values at schema scope (sl-2old)", async () => {
+    // Schema-level metadata should expose logical string values, not raw source
+    // text including the quote delimiters.
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
+    const { stdout, code } = await run("meta", "completed_orders_parquet", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const classification = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
+    assert.equal(classification?.value, "INTERNAL");
+  });
+
+  it("--json unwraps quoted metadata values at field scope (sl-2old)", async () => {
+    // Field-level metadata uses the same shared extractor and must normalize
+    // string-valued kv metadata identically.
+    const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
+    const { stdout, code } = await run("meta", "completed_orders_parquet.customer_email", "--json", FFG);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const classification = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
+    const retention = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "retention");
+    assert.equal(classification?.value, "RESTRICTED");
+    assert.equal(retention?.value, "3y");
   });
 
   it("exits 1 for unknown scope", async () => {

--- a/tooling/satsuma-core/src/meta-extract.ts
+++ b/tooling/satsuma-core/src/meta-extract.ts
@@ -10,6 +10,39 @@ import type { SyntaxNode, MetaEntry } from "./types.js";
 export type { MetaEntry };
 
 /**
+ * Normalize a metadata value CST node into the logical string value.
+ *
+ * The grammar wraps key/value payloads in `value_text`, so quoted string values
+ * often arrive as `value_text.text === "\"INTERNAL\""`. Downstream JSON
+ * consumers expect the value without those source delimiters.
+ */
+function normalizeMetadataValue(valueNode: SyntaxNode | null | undefined): string {
+  if (!valueNode) return "";
+
+  if (valueNode.type === "nl_string" || valueNode.type === "backtick_name") {
+    return valueNode.text.slice(1, -1);
+  }
+
+  const nestedValue = valueNode.namedChildren.find(
+    (child) => child.type === "nl_string" || child.type === "backtick_name",
+  );
+  if (nestedValue) {
+    return normalizeMetadataValue(nestedValue);
+  }
+
+  const text = valueNode.text;
+  if (
+    text.length >= 2 &&
+    ((text.startsWith("\"") && text.endsWith("\"")) ||
+      (text.startsWith("`") && text.endsWith("`")))
+  ) {
+    return text.slice(1, -1);
+  }
+
+  return text;
+}
+
+/**
  * Extract structured metadata from a metadata_block CST node.
  */
 export function extractMetadata(metaNode: SyntaxNode | null | undefined): MetaEntry[] {
@@ -22,9 +55,7 @@ export function extractMetadata(metaNode: SyntaxNode | null | undefined): MetaEn
     } else if (c.type === "tag_with_value") {
       const key = c.namedChildren[0]; // identifier
       const val = c.namedChildren[1]; // value_text
-      let value = val?.text ?? "";
-      if (val?.type === "nl_string") value = value.slice(1, -1);
-      if (val?.type === "backtick_name") value = value.slice(1, -1);
+      const value = normalizeMetadataValue(val);
       entries.push({ kind: "kv", key: key?.text ?? "", value });
     } else if (c.type === "enum_body") {
       const values = c.namedChildren

--- a/tooling/satsuma-core/test/meta-extract.test.js
+++ b/tooling/satsuma-core/test/meta-extract.test.js
@@ -44,6 +44,16 @@ describe("extractMetadata()", () => {
     assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "label", value: "some label" }]);
   });
 
+  it("unwraps quoted strings wrapped by value_text", () => {
+    // The parser stores metadata key/value payloads under value_text, so the
+    // extractor must normalize the wrapper node rather than only bare nl_string nodes.
+    const key = n("identifier", [], "classification");
+    const val = n("value_text", [n("nl_string", [], '"INTERNAL"')], '"INTERNAL"');
+    const kv = n("tag_with_value", [key, val]);
+    const meta = metaBlock([kv]);
+    assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "classification", value: "INTERNAL" }]);
+  });
+
   it("extracts enum_body entries", () => {
     const id1 = n("identifier", [], "open");
     const id2 = n("identifier", [], "closed");


### PR DESCRIPTION
## Summary
- normalize quoted metadata values at the shared extraction layer and align find metadata rendering
- document the actual where-used JSON ref kinds and add CLI regression coverage
- close sl-2old and sl-wawy with synced ticket notes

## Testing
- npm test -- meta-extract.test.js
- npm test -- test/integration.test.ts

Closes sl-2old
Closes sl-wawy