### PR TITLE
Add Feature 29 planning PRD and tickets

### DIFF
--- a/.tickets/sl-22fg.md
+++ b/.tickets/sl-22fg.md
@@ -1,0 +1,32 @@
+---
+id: sl-22fg
+status: open
+deps: [sl-lkmt, sl-2jq2]
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, viz, playwright, tests]
+---
+# Feature 29 task: add Playwright coverage for viz harness
+
+Add Playwright-based browser coverage for the standalone viz harness using canonical Satsuma fixtures.
+
+The suite should validate real interaction behaviour rather than smoke-testing page load, and should rely on the shared backend plus renderer-ready hooks introduced by this feature.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- Playwright configuration and browser tests are added for the standalone viz harness
+- Tests verify overview rendering for at least one canonical fixture
+- Tests verify clicking a mapping opens the detail view
+- Tests verify a representative hover/highlight interaction
+- Tests verify cross-file expansion for an import-reachable fixture set
+- Tests verify navigation intent emission is observable in the harness
+- Tests verify at least one larger sample fixture renders without layout failure
+- Playwright is documented and enforced as a local developer-machine workflow for this feature
+- No GitHub Actions workflow is required to run Playwright as part of this ticket

--- a/.tickets/sl-2jq2.md
+++ b/.tickets/sl-2jq2.md
@@ -1,0 +1,29 @@
+---
+id: sl-2jq2
+status: open
+deps: [sl-f1kt]
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, viz, harness, frontend]
+---
+# Feature 29 task: build standalone viz harness app
+
+Build a standalone browser harness under tooling/ that renders fixture-driven Satsuma source and the shared visualization side-by-side.
+
+The harness should load canonical fixtures or curated fixture sets, build VizModels through the shared backend package, and surface interaction events for browser assertions.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- A standalone viz harness package exists under tooling/
+- The harness renders fixture-driven source text and the shared visualization side-by-side in a browser
+- The harness builds VizModels through the shared backend package rather than through duplicated logic
+- The harness can switch between multiple named fixtures or fixture sets without unstable state leakage
+- The harness surfaces interaction intents in a form that browser tests can assert against without VS Code APIs
+

--- a/.tickets/sl-66hf.md
+++ b/.tickets/sl-66hf.md
@@ -1,0 +1,28 @@
+---
+id: sl-66hf
+status: open
+deps: [sl-f1kt, sl-vp7w, sl-2jq2, sl-22fg, sl-be9e]
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, docs, architecture]
+---
+# Feature 29 task: update README and architecture docs
+
+Update top-level and architecture documentation so the implemented package map, data flow, local Playwright workflow, and CI/release workflow changes match Feature 29.
+
+This task must update README.md, tooling/ARCHITECTURE.md, docs/developer/ARCHITECTURE.md, and any affected package-level README files. CI workflow documentation is tracked separately in sl-be9e and should be consistent with this task's architecture and workflow descriptions.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- README.md describes the modular viz architecture at a high level, including the standalone harness and how to run browser-based viz tests
+- tooling/ARCHITECTURE.md reflects the new package boundaries and dependency direction after the shared viz backend extraction and harness addition
+- docs/developer/ARCHITECTURE.md reflects the final detailed package map and data flow
+- README and package-level docs make clear that Playwright is a local developer-machine workflow for this feature, not a CI requirement
+- Any affected package-level README files are updated so contributors can tell where viz rendering, viz-model production, and browser harness responsibilities live

--- a/.tickets/sl-be9e.md
+++ b/.tickets/sl-be9e.md
@@ -1,0 +1,29 @@
+---
+id: sl-be9e
+status: open
+deps: [sl-f1kt, sl-vp7w]
+links: []
+created: 2026-04-01T09:25:59Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, ci, release, vscode]
+---
+# Feature 29 task: update CI and release build wiring
+
+Update CI and release build wiring so the refactored VS Code package path still builds correctly after Feature 29 changes the package graph under tooling/.
+
+This task should update GitHub Actions and any supporting package scripts needed to keep the VS Code extension build and packaging flow valid after extracting the shared viz backend and adding the harness package. Playwright remains a local developer-machine workflow for this feature and must not be introduced as a CI requirement here.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- .github/workflows/ci.yml is updated as needed so the refactored VS Code package path still builds and validates correctly
+- .github/workflows/release.yml is updated as needed so the extension packaging path still succeeds after the package extraction
+- Any package scripts affected by the new package graph are updated so CI and release use the correct build order
+- docs/developer/CI-WORKFLOWS.md reflects any CI or release job changes introduced by the feature
+- Playwright is explicitly kept out of CI for this feature; browser UI coverage remains a required local developer workflow
+

--- a/.tickets/sl-f1kt.md
+++ b/.tickets/sl-f1kt.md
@@ -1,0 +1,29 @@
+---
+id: sl-f1kt
+status: open
+deps: []
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, viz, backend, lsp]
+---
+# Feature 29 task: extract shared viz backend package
+
+Extract the reusable VizModel production path out of tooling/satsuma-lsp into a new shared package under tooling/.
+
+This task should move buildVizModel(), mergeVizModels(), and the viz-facing workspace/index logic needed for import-scoped and full-lineage model assembly into a consumer-neutral package that can be used by the LSP, the standalone harness, and future editor integrations.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- A shared viz backend package exists under tooling/ and owns reusable VizModel production logic previously held in tooling/satsuma-lsp
+- buildVizModel() and mergeVizModels() are provided by the shared package rather than by an LSP-only implementation
+- The viz-facing workspace/index logic needed for model assembly is extracted or adapted into the shared package boundary
+- Import-reachable scoping and full-lineage assembly remain behaviourally equivalent after extraction
+- Shared backend tests cover the extracted package at its new boundary
+

--- a/.tickets/sl-i34p.md
+++ b/.tickets/sl-i34p.md
@@ -1,0 +1,25 @@
+---
+id: sl-i34p
+status: open
+deps: []
+links: []
+created: 2026-04-01T09:24:11Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-29, viz, architecture, testability]
+---
+# Feature 29: viz harness and shared backend
+
+Implements Feature 29 as defined in features/29-viz-harness-and-shared-backend/PRD.md.
+
+This epic covers extraction of a shared viz backend from tooling/satsuma-lsp, addition of a standalone browser harness for the mapping visualization, renderer testability improvements, Playwright-based browser coverage, CI/release build updates for the refactored VS Code package path, and the required README/architecture documentation updates.
+
+See also: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- All child tickets for Feature 29 are complete and trace back to features/29-viz-harness-and-shared-backend/PRD.md
+- The visualization can be exercised end-to-end in a standalone browser harness without depending on VS Code webviews
+- CI and release continue to build the refactored VS Code package path correctly after the package extraction
+- README.md, tooling/ARCHITECTURE.md, and docs/developer/ARCHITECTURE.md are updated to reflect the final package map and test workflow

--- a/.tickets/sl-lkmt.md
+++ b/.tickets/sl-lkmt.md
@@ -1,0 +1,29 @@
+---
+id: sl-lkmt
+status: open
+deps: []
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, viz, frontend, testability]
+---
+# Feature 29 task: add renderer testability hooks to satsuma-viz
+
+Improve tooling/satsuma-viz so browser automation can drive the real UI deterministically.
+
+This task adds stable selectors, a ready/layout-complete signal, and a reduced-motion or test mode so browser tests can assert behaviour without timing hacks or VS Code-specific shims.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- tooling/satsuma-viz exposes stable data-testid hooks for the core user interactions needed in browser tests
+- The renderer exposes a deterministic readiness signal after layout/rendering is complete
+- The renderer can run in a reduced-motion or otherwise stable test mode suitable for automation
+- Interaction intents remain observable in a host-agnostic way
+- Renderer tests cover the new automation-oriented behaviour where appropriate
+

--- a/.tickets/sl-vp7w.md
+++ b/.tickets/sl-vp7w.md
@@ -1,0 +1,29 @@
+---
+id: sl-vp7w
+status: open
+deps: [sl-f1kt]
+links: []
+created: 2026-04-01T09:24:11Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-i34p
+tags: [feature-29, viz, lsp, vscode]
+---
+# Feature 29 task: refactor LSP and VS Code to use shared viz backend
+
+Refactor tooling/satsuma-lsp and the VS Code viz path to consume the shared viz backend package rather than owning a parallel implementation.
+
+This task should keep protocol and editor-host responsibilities local while making the viz request path delegate to the shared backend.
+
+PRD reference: features/29-viz-harness-and-shared-backend/PRD.md
+TODO reference: features/29-viz-harness-and-shared-backend/TODO.md
+
+## Acceptance Criteria
+
+- tooling/satsuma-lsp answers viz-related custom requests by calling the shared viz backend package
+- No separate LSP-only VizModel implementation remains in place for the same behaviour
+- The VS Code visualization path continues to work with the shared backend-backed LSP requests
+- Any build wiring affected by the extraction is updated and validated
+- Relevant LSP and VS Code tests are updated to match the new package boundary
+

--- a/features/29-viz-harness-and-shared-backend/PRD.md
+++ b/features/29-viz-harness-and-shared-backend/PRD.md
@@ -1,0 +1,334 @@
+# Feature 29 — Viz Harness and Shared Backend for Browser-Testable Mapping Visualization
+
+> **Status: PLANNED** (2026-04-01)
+
+## Goal
+
+Make the Satsuma mapping visualization reliably testable outside VS Code by extracting shared viz-model production logic into a reusable backend package and introducing a standalone browser harness that renders canonical `.stm` fixtures side-by-side with the visualization.
+
+The primary success criterion is:
+
+**The mapping visualization can be exercised end-to-end with Playwright against canonical Satsuma fixtures, without depending on VS Code webviews.**
+
+---
+
+## Problem
+
+The repository already contains two important pieces of reusable infrastructure:
+
+1. **The renderer is already modular.** The visualization itself lives in `tooling/satsuma-viz/` as a standalone web component package that consumes a `VizModel`.
+2. **The protocol contract is already shared.** The `VizModel` JSON shape lives in `tooling/satsuma-viz-model/` and is used across packages.
+
+But the architecture still falls short of the portability promised by `tooling/ARCHITECTURE.md`:
+
+- **Viz model production is still owned by the LSP package.** `buildVizModel()`, `mergeVizModels()`, import-scoped model assembly, and the viz-facing workspace indexing logic live in `tooling/satsuma-lsp/`.
+- **The interactive host shell is still VS Code-shaped.** The primary real-world rendering surface is the VS Code webview host in `tooling/vscode-satsuma/src/webview/viz/`.
+- **There is no stable browser harness for end-to-end UI testing.** Current tests cover the renderer bundle and the VizModel builder separately, but not the actual browser interaction surface that users see.
+
+This creates three problems:
+
+1. **UI regressions are harder to catch.** Playwright-style interaction testing is awkward when the production surface is embedded in a VS Code webview and depends on LSP custom requests.
+2. **Future reuse is partially blocked.** An IntelliJ plugin or a standalone web viewer can reuse `@satsuma/viz`, but must either reimplement the VizModel backend path or depend on LSP-internal code that was not designed as a shared consumer API.
+3. **The documented architecture is only partially realised.** The current architecture docs say the visualization should be reusable outside VS Code, but the most important data-production path remains in an editor-facing package.
+
+---
+
+## Design Principle
+
+This feature is about **testability first, productization second**.
+
+The first standalone browser app is not primarily a new end-user product. It is a deterministic, browser-based harness for the existing visualization so that interaction behaviour can be tested against real Satsuma fixtures under automation.
+
+That means:
+
+- the browser harness must use the same renderer as VS Code
+- the browser harness must use the same VizModel production logic as VS Code
+- the viz must expose explicit automation-friendly hooks such as stable selectors and readiness signals
+- implementation is not complete until the architecture and package docs describe the new structure accurately
+
+---
+
+## Decision
+
+### What changes
+
+1. **Extract shared viz backend logic into a new package under `tooling/`.**
+
+   This package owns the reusable, non-editor-specific logic needed to produce browser-ready `VizModel` payloads from Satsuma source files and multi-file workspaces.
+
+2. **Keep `tooling/satsuma-viz-model/` as the cross-package protocol contract.**
+
+   The VizModel type package remains the stable JSON boundary between producers and renderers.
+
+3. **Keep `tooling/satsuma-viz/` as the reusable renderer, but add explicit testability hooks.**
+
+   The renderer must become easier to drive and assert against in browser automation, without introducing VS Code-specific dependencies.
+
+4. **Introduce a standalone viz harness package under `tooling/`.**
+
+   This package renders fixture-driven Satsuma source and the shared visualization side-by-side in a browser, and becomes the target for Playwright tests.
+
+5. **Refactor `tooling/satsuma-lsp/` to consume the new shared backend package instead of owning the viz model path directly.**
+
+   The LSP remains responsible for protocol wiring, not for exclusive ownership of viz-model production logic.
+
+6. **Update CI and release build wiring so the refactored VS Code package path continues to build correctly.**
+
+   This feature changes package boundaries under `tooling/`. CI and release workflows must continue to build and validate the VS Code extension and its dependent packages correctly after the extraction.
+
+7. **Update top-level and architecture documentation during implementation.**
+
+   The feature is not done if `README.md`, `tooling/ARCHITECTURE.md`, and `docs/developer/ARCHITECTURE.md` still describe the old structure.
+
+### What does not change
+
+- `tooling/satsuma-viz/` remains the canonical renderer package.
+- `tooling/satsuma-viz-model/` remains the single source of truth for the serialized contract.
+- The VS Code extension remains a supported consumer of the visualization.
+- This feature does not attempt to add visual editing or full browser authoring.
+
+---
+
+## Proposed Package Layout
+
+### New package: `tooling/satsuma-viz-backend/`
+
+This package should own reusable visualization-model production logic that is currently trapped inside `tooling/satsuma-lsp/`.
+
+Expected responsibilities:
+
+- build a `VizModel` from a parsed file plus a workspace-aware index
+- merge per-file VizModels into a full-lineage view
+- own or adapt the workspace indexing needed for viz resolution
+- own import-reachable scoping for viz assembly
+- provide a browser/host-neutral API that can be used by LSP, harness, and future editor integrations
+
+This package is a better fit for the architecture than leaving this logic inside `tooling/satsuma-lsp/`, because the logic is no longer LSP-specific once multiple consumers need it.
+
+### New package: `tooling/satsuma-viz-harness/`
+
+This package should be a minimal standalone browser app focused on testability.
+
+Expected responsibilities:
+
+- load named fixture `.stm` files or fixture sets
+- display source text and visualization side-by-side
+- build viz data through the shared backend package, not via ad hoc duplication
+- expose a stable page structure suitable for Playwright assertions
+- surface interaction events such as navigate, open mapping, expand lineage, and field-lineage requests in a browser-observable way
+
+### Existing package: `tooling/satsuma-lsp/`
+
+Expected post-refactor responsibilities:
+
+- continue to answer custom LSP requests such as `satsuma/vizModel` and `satsuma/vizFullLineage`
+- delegate VizModel production to the shared backend package
+- keep editor/LSP protocol responsibilities local
+
+### Existing package: `tooling/vscode-satsuma/`
+
+Expected post-refactor responsibilities:
+
+- remain a thin host shell for VS Code
+- continue to host the shared visualization in a webview
+- avoid owning unique viz behaviour that the browser harness cannot reproduce
+
+---
+
+## Scope of Changes
+
+### 1. Shared Viz Backend Extraction
+
+**Files/packages affected:**
+
+- `tooling/satsuma-lsp/src/viz-model.ts`
+- `tooling/satsuma-lsp/src/workspace-index.ts`
+- `tooling/satsuma-lsp/src/server.ts`
+- new package under `tooling/`
+
+**Required changes:**
+
+1. Extract `buildVizModel()` and `mergeVizModels()` into a shared backend package.
+2. Extract or adapt the workspace-index logic required for viz assembly so that the browser harness and future editor integrations do not depend on LSP-internal modules.
+3. Ensure import-reachable scoping and full-lineage assembly remain behaviourally identical after the extraction.
+4. Leave LSP protocol handlers as thin adapters that call the shared backend package.
+
+**Why this matters:**
+
+If the browser harness and the VS Code extension do not share the same VizModel production path, Playwright tests will validate a parallel system instead of the production one.
+
+### 2. Renderer Testability Improvements
+
+**Files/packages affected:**
+
+- `tooling/satsuma-viz/src/satsuma-viz.ts`
+- `tooling/satsuma-viz/src/components/*`
+- `tooling/satsuma-viz/test/*`
+
+**Required changes:**
+
+1. Add stable `data-testid` hooks for core interaction targets such as:
+   - root viz surface
+   - overview mapping nodes
+   - schema cards
+   - toolbar actions
+   - detail-view tables
+2. Add an explicit ready/layout-complete signal so browser tests do not rely on fragile timeouts.
+3. Add a test mode or reduced-motion mode to suppress animation-driven flake.
+4. Ensure emitted interaction intents are observable in a generic browser host, not just through VS Code message passing.
+
+**Why this matters:**
+
+A layout-heavy interactive UI is difficult to test reliably if selectors are unstable and readiness is inferred from timing.
+
+### 3. Standalone Viz Harness
+
+**Files/packages affected:**
+
+- new package under `tooling/`
+- potentially fixture references under `examples/`
+
+**Required changes:**
+
+1. Build a small standalone browser app that:
+   - loads canonical Satsuma fixture files
+   - shows source and viz side-by-side
+   - can switch between multiple named fixtures
+   - records or surfaces interaction events for test assertions
+2. Make the harness the target for Playwright UI tests.
+3. Prefer canonical examples or a curated subset of them over synthetic-only fixtures.
+
+**MVP note:**
+
+The harness does not need full end-user file upload or editing. It needs deterministic, fixture-driven behaviour for testing.
+
+### 4. VS Code Integration Refactor
+
+**Files/packages affected:**
+
+- `tooling/vscode-satsuma/src/webview/viz/panel.ts`
+- `tooling/vscode-satsuma/src/webview/viz/viz.ts`
+- `tooling/vscode-satsuma/esbuild.js`
+
+**Required changes:**
+
+1. Update the VS Code viz path to consume the shared backend indirectly via the LSP.
+2. Keep host-specific behaviour in the extension shell.
+3. Avoid introducing any new VS Code-only renderer features that are unavailable in the harness.
+4. Update build wiring if the extraction changes package boundaries or aliases.
+
+### 5. Browser Test Infrastructure
+
+**Files/packages affected:**
+
+- new Playwright config and tests in the harness package or repo-level test area
+
+**Required changes:**
+
+1. Add Playwright-based browser tests for the harness.
+2. Cover canonical interaction flows, not just page-load smoke tests.
+3. Keep tests deterministic and purpose-driven, following the repo’s existing testing expectations.
+4. Treat Playwright as a required local developer-machine workflow for this feature. CI integration is explicitly deferred.
+
+### 6. CI and Release Build Updates
+
+**Files/packages affected:**
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/release.yml`
+- `docs/developer/CI-WORKFLOWS.md`
+- any package scripts affected by the new package graph
+
+**Required changes:**
+
+1. Update CI so the refactored VS Code extension build still validates correctly after the new shared viz backend and harness packages are introduced.
+2. Update release build wiring if package installation or bundling order changes due to the extraction.
+3. Keep Playwright out of CI for now; browser UI coverage is a required local workflow, not a required GitHub Actions workflow in this feature.
+4. Update CI workflow documentation to describe the final build/test behaviour accurately.
+
+---
+
+## Acceptance Criteria
+
+### Shared backend
+
+1. A shared viz backend package exists under `tooling/` and owns reusable VizModel production logic previously held in `tooling/satsuma-lsp/`.
+2. `tooling/satsuma-lsp/` answers viz-related custom requests by calling the shared backend package rather than owning a separate implementation.
+3. Full-lineage VizModel assembly remains import-scoped and behaviourally equivalent to the current LSP implementation.
+4. Shared backend tests cover the extracted behaviour at the new package boundary.
+
+### Browser harness
+
+1. A standalone viz harness package exists under `tooling/`.
+2. The harness renders fixture-driven source text and the shared visualization side-by-side in a browser.
+3. The harness can switch between multiple named fixture files or fixture sets without unstable state leakage.
+4. The harness surfaces interaction intents in a way that Playwright can assert against without VS Code APIs.
+
+### Renderer testability
+
+1. `tooling/satsuma-viz/` exposes stable selectors for the core user interactions needed in browser tests.
+2. The renderer exposes a deterministic readiness signal after layout/rendering is complete.
+3. Tests can run the viz in a reduced-motion or otherwise stable mode suitable for automation.
+
+### Playwright coverage
+
+1. Playwright tests verify that the overview view renders expected schemas and mappings for at least one canonical fixture.
+2. Playwright tests verify that clicking a mapping opens the detail view.
+3. Playwright tests verify that a representative hover/highlight interaction produces the expected visible effect or observable state.
+4. Playwright tests verify that cross-file expansion works for an import-reachable fixture set.
+5. Playwright tests verify that navigation intent emission is observable in the harness.
+6. Playwright tests verify that at least one larger sample fixture renders without layout failure.
+7. The feature documents Playwright as a required local developer workflow; CI execution of Playwright is not required.
+
+### CI and release build wiring
+
+1. `.github/workflows/ci.yml` is updated as needed so the refactored VS Code package path still builds and validates correctly.
+2. `.github/workflows/release.yml` is updated as needed so the extension packaging path still succeeds after the package extraction.
+3. `docs/developer/CI-WORKFLOWS.md` reflects any CI or release job changes introduced by the feature.
+
+### Documentation
+
+1. `README.md` is updated to describe the modular viz architecture at a high level, including the existence and purpose of the standalone harness and how to run the browser-based viz tests.
+2. `tooling/ARCHITECTURE.md` is updated to show the new package boundaries and dependency direction after extracting the shared viz backend and adding the harness package.
+3. `docs/developer/ARCHITECTURE.md` is updated so the detailed package map and data-flow diagrams match the new implementation.
+4. `docs/developer/CI-WORKFLOWS.md` is updated if CI or release workflow behaviour changes as part of the feature.
+5. Any package-level README files affected by the extraction are updated so contributors can tell where viz rendering, viz-model production, browser harness responsibilities, and local Playwright workflow expectations now live.
+
+---
+
+## Non-Goals
+
+- full browser-based editing of `.stm` files
+- feature parity with every VS Code panel unrelated to mapping visualization
+- deployment of a hosted public viewer
+- semantic-token-perfect browser highlighting on day one
+- Playwright execution in GitHub Actions for this feature
+- replacing existing unit tests for `tooling/satsuma-viz/` or contract tests for `tooling/satsuma-viz-model/`
+
+---
+
+## Risks
+
+1. **LSP assumptions may be embedded in the viz model path.** Extracting the backend may reveal hidden coupling to LSP-specific types or indexing choices.
+2. **Layout-heavy UI can be flaky under automation.** Without explicit ready hooks and stable selectors, Playwright tests may become expensive and brittle.
+3. **Syntax highlighting can distract from the core goal.** The testing goal is visualisation behaviour, not perfect editor-equivalent highlighting. The harness should avoid blocking on this unless it materially improves test quality.
+4. **Parallel implementations would reduce test value.** If the harness reimplements VizModel production logic instead of sharing it, the tests become less trustworthy as production regression coverage.
+
+---
+
+## Documentation and Implementation Notes
+
+1. Read `tooling/ARCHITECTURE.md` before implementation and use it to validate the final dependency direction.
+2. Treat this feature as an architectural change, not just a UI addition; the package map and data flow must be updated as part of the work.
+3. Prefer parser-backed fixture handling and shared indexing over text-only shortcuts.
+4. Use canonical examples wherever practical so browser tests validate real Satsuma usage patterns.
+
+---
+
+## Suggested Follow-on ADR Question
+
+This feature may warrant an ADR if the extraction introduces a new long-lived shared package and materially changes the dependency graph under `tooling/`.
+
+The ADR question would be:
+
+**Should VizModel production and viz-oriented workspace indexing live in a dedicated shared backend package rather than in `satsuma-lsp`?**

--- a/features/29-viz-harness-and-shared-backend/TODO.md
+++ b/features/29-viz-harness-and-shared-backend/TODO.md
@@ -1,0 +1,162 @@
+# Feature 29 TODO
+
+PRD: [PRD.md](./PRD.md)
+
+This TODO breaks Feature 29 into implementation tasks that should be mirrored in
+`tk` tickets. Each task refers back to the PRD and should only be closed once
+its code, tests, and documentation obligations are complete.
+
+## Task Breakdown
+
+Epic: `sl-i34p` — Feature 29: viz harness and shared backend
+
+### 1. Shared viz backend extraction
+
+Ticket: `sl-f1kt`
+
+Create a new shared package under `tooling/` that owns reusable VizModel
+production logic currently held in `tooling/satsuma-lsp/`.
+
+Scope:
+
+- extract `buildVizModel()` and `mergeVizModels()`
+- extract or adapt the viz-facing workspace-index logic needed for model assembly
+- preserve import-reachable scoping and full-lineage behaviour
+- add package-local tests for the extracted backend
+
+PRD reference:
+
+- Proposed Package Layout
+- Scope of Changes / Shared Viz Backend Extraction
+- Acceptance Criteria / Shared backend
+
+### 2. LSP and VS Code integration refactor
+
+Ticket: `sl-vp7w`
+
+Refactor `tooling/satsuma-lsp/` and the VS Code viz path so they consume the new
+shared backend package rather than owning a parallel implementation.
+
+Scope:
+
+- update viz-related LSP request handlers to delegate to the shared backend
+- keep editor- and protocol-specific concerns inside the LSP and VS Code shell
+- update any build wiring affected by the package extraction
+
+PRD reference:
+
+- Proposed Package Layout
+- Scope of Changes / VS Code Integration Refactor
+- Acceptance Criteria / Shared backend
+
+### 3. Renderer testability hooks
+
+Ticket: `sl-lkmt`
+
+Improve `tooling/satsuma-viz/` so browser automation can drive the real UI
+deterministically.
+
+Scope:
+
+- add stable `data-testid` hooks for key UI surfaces
+- add an explicit ready/layout-complete signal
+- add a stable reduced-motion or test mode
+- ensure interaction intents are observable in a host-agnostic way
+
+PRD reference:
+
+- Scope of Changes / Renderer Testability Improvements
+- Acceptance Criteria / Renderer testability
+
+### 4. Standalone viz harness app
+
+Ticket: `sl-2jq2`
+
+Build a standalone browser harness under `tooling/` that renders fixture-driven
+Satsuma source and the shared visualization side-by-side.
+
+Scope:
+
+- load named `.stm` fixtures or curated fixture sets
+- build VizModels through the shared backend package
+- render source and viz side-by-side
+- surface emitted interaction events for browser assertions
+
+PRD reference:
+
+- Proposed Package Layout / tooling/satsuma-viz-harness
+- Scope of Changes / Standalone Viz Harness
+- Acceptance Criteria / Browser harness
+
+### 5. Playwright browser tests
+
+Ticket: `sl-22fg`
+
+Add browser-based UI coverage for the harness using canonical Satsuma fixtures.
+
+Scope:
+
+- configure Playwright
+- add purposeful end-to-end tests for overview, detail, hover/highlight,
+  cross-file expansion, navigation intent, and a larger fixture
+- keep the suite deterministic and aligned with renderer ready hooks
+- keep this as a local developer-machine workflow for now; do not require CI
+  execution in this feature
+
+PRD reference:
+
+- Scope of Changes / Browser Test Infrastructure
+- Acceptance Criteria / Playwright coverage
+
+### 6. CI and release workflow updates
+
+Ticket: `sl-be9e`
+
+Update CI and release build wiring so the refactored VS Code package path still
+builds correctly after the new package boundaries land.
+
+Scope:
+
+- update `.github/workflows/ci.yml` as needed for the refactored package graph
+- update `.github/workflows/release.yml` as needed for extension packaging
+- update `docs/developer/CI-WORKFLOWS.md` to match the final workflow behaviour
+- keep Playwright out of CI for this feature
+
+PRD reference:
+
+- Decision / What changes
+- Scope of Changes / CI and Release Build Updates
+- Acceptance Criteria / CI and release build wiring
+
+### 7. Documentation updates
+
+Ticket: `sl-66hf`
+
+Update top-level and architecture documentation so the implemented package map,
+data flow, and testing workflow match the new structure.
+
+Scope:
+
+- update `README.md`
+- update `tooling/ARCHITECTURE.md`
+- update `docs/developer/ARCHITECTURE.md`
+- update any affected package-level README files
+
+PRD reference:
+
+- Decision / What changes
+- Acceptance Criteria / Documentation
+
+## Suggested Dependency Order
+
+1. Shared viz backend extraction
+2. Renderer testability hooks
+3. LSP and VS Code integration refactor
+4. Standalone viz harness app
+5. Playwright browser tests
+6. CI and release workflow updates
+7. Documentation updates
+
+The documentation task should happen during implementation, but it should depend
+on the architectural work so the final docs describe the code that actually
+landed.


### PR DESCRIPTION
## Summary
- add Feature 29 PRD for a shared viz backend and standalone browser harness
- add a feature-local TODO breakdown with task ordering
- create linked tk tickets for backend extraction, renderer testability, harness work, local Playwright coverage, CI/release updates, and docs

## Notes
- Playwright is intentionally scoped as a local developer-machine workflow for this feature, not a CI requirement yet
- CI/release updates for the VS Code package path are included in the planning scope

## Testing
- not run (planning/docs/tickets only)