### PR TITLE
Fix LSP join descriptions in source blocks

### DIFF
--- a/.tickets/sjsr-01ad.md
+++ b/.tickets/sjsr-01ad.md
@@ -1,0 +1,35 @@
+---
+id: sjsr-01ad
+status: closed
+deps: []
+links: []
+created: 2026-04-01T10:35:47Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [lsp, vscode, validate, exploratory-testing]
+---
+# lsp: quoted join descriptions in source blocks produce false undefined-source warnings
+
+Opening `examples/filter-flatten-governance/filter-flatten-governance.stm` in the VS Code extension produced a warning on mapping `completed orders` that treated the quoted join description inside `source {}` as an undefined source.
+
+**Expected:** The quoted join/filter prose is documentation, not a structural schema reference. It should not be indexed as a source ref and should not trigger undefined-source or missing-import diagnostics.
+
+**Actual:** The LSP path indexed the quoted join description as a source reference, producing a false warning even though the CLI validated the file cleanly.
+
+**Reproducer:** Open `examples/filter-flatten-governance/filter-flatten-governance.stm` in the VS Code extension and inspect mapping `completed orders`.
+
+## Acceptance Criteria
+
+- Quoted join descriptions inside `source {}` are ignored as structural source refs
+- `examples/filter-flatten-governance/filter-flatten-governance.stm` produces no undefined-source warning for mapping `completed orders`
+- Workspace indexing, missing-import diagnostics, and core semantic diagnostics agree on this rule
+- Add regression coverage in core and LSP tests for quoted join descriptions in source blocks
+
+
+## Notes
+
+**2026-04-01T10:36:51Z**
+
+Cause: The LSP workspace index treated quoted join descriptions inside `source {}` as structural `source_ref` names, so VS Code emitted false undefined-source and missing-import diagnostics even though the CLI extractor ignored those NL strings.
+Fix: Added a structural-only source-ref extractor in core, switched LSP source/target indexing to use it, and added regression tests for workspace indexing and diagnostics. Also scoped merged core semantic diagnostics to the active import graph.

--- a/tooling/satsuma-core/src/cst-utils.ts
+++ b/tooling/satsuma-core/src/cst-utils.ts
@@ -111,6 +111,24 @@ export function sourceRefText(node: SyntaxNode | null | undefined): string | nul
 }
 
 /**
+ * Extract the structural schema/fragment name from a source_ref CST node.
+ *
+ * Unlike sourceRefText(), this deliberately ignores nl_string children because
+ * quoted text inside `source {}` is natural-language join/filter documentation,
+ * not a structural schema reference.
+ */
+export function sourceRefStructuralText(node: SyntaxNode | null | undefined): string | null {
+  if (!node) return null;
+  const qn = child(node, "qualified_name");
+  if (qn) return qualifiedNameText(qn);
+  const bn = child(node, "backtick_name");
+  if (bn) return bn.text.slice(1, -1);
+  const id = child(node, "identifier");
+  if (id) return id.text;
+  return null;
+}
+
+/**
  * Extract the display name from a field_name CST node.
  * Strips backtick delimiters when the inner node is a backtick_name.
  */

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -9,7 +9,7 @@
 import { canonicalRef } from "./canonical-ref.js";
 import { classifyTransform, classifyArrow } from "./classify.js";
 import { extractMetadata } from "./meta-extract.js";
-import { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText as cstSourceRefText } from "./cst-utils.js";
+import { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText as cstSourceRefText, sourceRefStructuralText } from "./cst-utils.js";
 import type { Classification, FieldDecl, MetaEntry, PipeStep, SyntaxNode } from "./types.js";
 
 // ── Internal field tree ────────────────────────────────────────────────────
@@ -155,16 +155,8 @@ function spreadLabelText(labelNode: SyntaxNode): string {
 }
 
 /**
- * Extract a source_ref name for extraction purposes, excluding nl_string
- * children (which represent join descriptions in source blocks, not names).
- *
- * This differs from core's generic sourceRefText() which treats nl_string
- * as a valid source ref value. In the extraction context, only qualified_name,
- * backtick_name, and identifier children represent schema names.
- *
- * Also adds ERROR-node recovery: when tree-sitter wraps a partially-parsed
- * source_ref in an ERROR node during mid-edit, we walk the ERROR node's
- * named children to recover any already-typed identifier or qualified_name.
+ * Extract a structural source_ref name for mapping extraction and recover
+ * through ERROR nodes during mid-edit tree-sitter states.
  */
 function sourceRefNameNs(node: SyntaxNode | null | undefined): string | null {
   if (!node) return null;
@@ -176,13 +168,7 @@ function sourceRefNameNs(node: SyntaxNode | null | undefined): string | null {
     return null;
   }
   if (node.type !== "source_ref") return entryText(node);
-  // Only extract structural name children — nl_string is a join description
-  for (const c of node.namedChildren) {
-    if (c.type === "qualified_name") return qualifiedNameText(c);
-    if (c.type === "backtick_name") return c.text.slice(1, -1);
-    if (c.type === "identifier") return c.text;
-  }
-  return null;
+  return sourceRefStructuralText(node);
 }
 
 interface NamespaceCollected {

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -19,7 +19,7 @@ export { addPathAndPrefixes } from "./coverage.js";
 export type { FieldCoverageEntry, SchemaCoverageResult, MappingCoverageResult } from "./coverage.js";
 export { format } from "./format.js";
 export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
-export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, fieldNameText, walkDescendants } from "./cst-utils.js";
+export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";
 export { classifyTransform, classifyArrow } from "./classify.js";
 export { canonicalRef, canonicalEntityName, resolveScopedEntityRef } from "./canonical-ref.js";
 export { extractMetadata } from "./meta-extract.js";

--- a/tooling/satsuma-core/test/cst-utils.test.js
+++ b/tooling/satsuma-core/test/cst-utils.test.js
@@ -16,6 +16,7 @@ import {
   entryText,
   qualifiedNameText,
   sourceRefText,
+  sourceRefStructuralText,
   fieldNameText,
   walkDescendants,
 } from "../dist/cst-utils.js";
@@ -282,6 +283,26 @@ describe("sourceRefText()", () => {
 
   it("returns null for null input", () => {
     assert.equal(sourceRefText(null), null);
+  });
+});
+
+// ── sourceRefStructuralText() ──────────────────────────────────────────────
+
+describe("sourceRefStructuralText()", () => {
+  it("extracts identifier text from a structural source_ref", () => {
+    const ref = n("source_ref", [ident("orders")], "orders");
+    assert.equal(sourceRefStructuralText(ref), "orders");
+  });
+
+  it("extracts qualified names from structural source refs", () => {
+    const qn = n("qualified_name", [ident("crm"), ident("orders")], "crm::orders");
+    const ref = n("source_ref", [qn], "crm::orders");
+    assert.equal(sourceRefStructuralText(ref), "crm::orders");
+  });
+
+  it("ignores nl_string join descriptions inside a source_ref", () => {
+    const ref = n("source_ref", [nlStr("Join on a.id = b.id")], '"Join on a.id = b.id"');
+    assert.equal(sourceRefStructuralText(ref), null);
   });
 });
 

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -457,7 +457,7 @@ function scopeIndex(uri: string): WorkspaceIndex {
 function sendMergedDiagnostics(uri: string, tree: Tree): void {
   const parseDiags = computeDiagnostics(tree);
   const validateDiags = validateDiagCache.get(uri) ?? [];
-  const coreSemanticDiags = computeCoreSemanticDiagnostics(uri, wsIndex);
+  const coreSemanticDiags = computeCoreSemanticDiagnostics(uri, scopeIndex(uri));
   const missingImportDiags = computeMissingImportDiagnostics(tree, uri, wsIndex);
 
   // Deduplicate: core semantic diagnostics may overlap with CLI validate

--- a/tooling/satsuma-lsp/src/workspace-index.ts
+++ b/tooling/satsuma-lsp/src/workspace-index.ts
@@ -18,6 +18,7 @@ import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, walkDescendants } from "./parser-utils";
 import {
   sourceRefText as coreSourceRefText,
+  sourceRefStructuralText as coreSourceRefStructuralText,
   qualifiedNameText as coreQualifiedNameText,
   fieldNameText as coreFieldNameText,
   entryText,
@@ -476,7 +477,7 @@ function indexMappingRefs(
   for (const ch of body.namedChildren) {
     if (ch.type === "source_block") {
       for (const ref of children(ch, "source_ref")) {
-        const name = sourceRefText(ref);
+        const name = sourceRefStructuralText(ref);
         if (name) {
           addReference(index, name, {
             uri,
@@ -488,7 +489,7 @@ function indexMappingRefs(
       }
     } else if (ch.type === "target_block") {
       for (const ref of children(ch, "source_ref")) {
-        const name = sourceRefText(ref);
+        const name = sourceRefStructuralText(ref);
         if (name) {
           addReference(index, name, {
             uri,
@@ -591,7 +592,7 @@ function getMappingBodySchemas(body: SyntaxNode, blockType: string): string[] {
   for (const ch of body.namedChildren) {
     if (ch.type === blockType) {
       for (const ref of children(ch, "source_ref")) {
-        const name = sourceRefText(ref);
+        const name = sourceRefStructuralText(ref);
         if (name) names.push(name);
       }
     }
@@ -834,6 +835,14 @@ function sourceRefText(ref: SyntaxNode): string | null {
 }
 
 /**
+ * Extract the structural schema/fragment name from a source_ref node.
+ * NL join descriptions inside `source {}` are intentionally ignored.
+ */
+function sourceRefStructuralText(ref: SyntaxNode): string | null {
+  return coreSourceRefStructuralText(ref);
+}
+
+/**
  * Extract import name text from an import_name node.
  * Handles qualified_name (ns::name), backtick_name, and identifier children.
  * LSP-specific: import_name nodes are only relevant for workspace indexing.
@@ -889,4 +898,3 @@ function addReference(
   existing.push(entry);
   index.references.set(name, existing);
 }
-

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -1,7 +1,12 @@
 const { describe, it, before } = require("node:test");
 const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
-const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
+const {
+  createWorkspaceIndex,
+  indexFile,
+  createScopedIndex,
+  getImportReachableUris,
+} = require("../dist/workspace-index");
 const { computeMissingImportDiagnostics, computeCoreSemanticDiagnostics } = require("../dist/semantic-diagnostics");
 
 before(async () => { await initTestParser(); });
@@ -62,6 +67,24 @@ mapping m {
     assert.equal(diag.source, "satsuma");
     assert.ok(diag.message.includes("orders"), "message should mention the symbol name");
     assert.ok(diag.message.includes("import"), "message should suggest an import");
+  });
+
+  it("ignores quoted join descriptions when checking missing imports", () => {
+    const aSrc = `schema a { id INT }
+schema b { id INT }
+schema t { id INT }
+mapping m {
+  source {
+    a
+    b
+    "Join on a.id = b.id WHERE @a.status = complete"
+  }
+  target { t }
+  a.id -> id
+}`;
+    const idx = buildIndex({ "file:///a.stm": aSrc });
+    const diags = computeMissingImportDiagnostics(parse(aSrc), "file:///a.stm", idx);
+    assert.equal(diags.length, 0);
   });
 
   it("includes the suggested import statement in the diagnostic message", () => {
@@ -138,18 +161,46 @@ mapping m {
 });
 
 describe("computeCoreSemanticDiagnostics", () => {
-  it("detects duplicate definitions for the same schema name across files", () => {
+  it("does not report quoted join descriptions as undefined mapping sources", () => {
+    const src = `schema a { id INT }
+schema b { id INT }
+schema t { id INT }
+mapping m {
+  source {
+    a
+    b
+    "Join on a.id = b.id WHERE @a.status = complete"
+  }
+  target { t }
+  a.id -> id
+}`;
+    const idx = buildIndex({ "file:///a.stm": src });
+    const diags = computeCoreSemanticDiagnostics("file:///a.stm", idx);
+    assert.equal(diags.length, 0);
+  });
+
+  it("does not report duplicate definitions from files outside the active import graph", () => {
     const aSrc = `schema orders { id UUID }`;
     const bSrc = `schema orders { name STRING }`;
     const idx = buildIndex({
       "file:///a.stm": aSrc,
       "file:///b.stm": bSrc,
     });
-    // Both files define 'orders' — should produce a duplicate diagnostic
-    const diagsA = computeCoreSemanticDiagnostics("file:///a.stm", idx);
-    const diagsB = computeCoreSemanticDiagnostics("file:///b.stm", idx);
-    const allDiags = [...diagsA, ...diagsB];
-    const dupDiag = allDiags.find((d) => d.code === "duplicate-definition");
+    const scoped = createScopedIndex(idx, getImportReachableUris("file:///a.stm", idx));
+    const diags = computeCoreSemanticDiagnostics("file:///a.stm", scoped);
+    assert.equal(diags.length, 0);
+  });
+
+  it("reports duplicate definitions when both files are in the active import graph", () => {
+    const aSrc = `import { orders } from "b.stm"\nschema orders { id UUID }`;
+    const bSrc = `schema orders { name STRING }`;
+    const idx = buildIndex({
+      "file:///a.stm": aSrc,
+      "file:///b.stm": bSrc,
+    });
+    const scoped = createScopedIndex(idx, getImportReachableUris("file:///a.stm", idx));
+    const diags = computeCoreSemanticDiagnostics("file:///b.stm", scoped);
+    const dupDiag = diags.find((d) => d.code === "duplicate-definition");
     assert.ok(dupDiag, "expected a duplicate-definition diagnostic");
   });
 
@@ -166,13 +217,14 @@ mapping m {
   });
 
   it("returns diagnostics with 0-indexed positions (LSP convention)", () => {
-    const aSrc = `schema orders { id UUID }`;
+    const aSrc = `import { orders } from "b.stm"\nschema orders { id UUID }`;
     const bSrc = `schema orders { name STRING }`;
     const idx = buildIndex({
       "file:///a.stm": aSrc,
       "file:///b.stm": bSrc,
     });
-    const diags = computeCoreSemanticDiagnostics("file:///b.stm", idx);
+    const scoped = createScopedIndex(idx, getImportReachableUris("file:///a.stm", idx));
+    const diags = computeCoreSemanticDiagnostics("file:///b.stm", scoped);
     if (diags.length > 0) {
       // LSP lines are 0-indexed
       assert.ok(diags[0].range.start.line >= 0, "line should be 0-indexed");

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -195,6 +195,26 @@ describe("indexFile", () => {
     assert.equal(refs[0].context, "source");
   });
 
+  it("does not index quoted join descriptions as source references", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `schema a { id INT }
+schema b { id INT }
+schema t { id INT }
+mapping \`test\` {
+  source {
+    a
+    b
+    "Join on a.id = b.id"
+  }
+  target { t }
+  a.id -> id
+}`,
+    });
+    assert.equal(idx.references.get("Join on a.id = b.id"), undefined);
+    const srcRefs = idx.references.get("a") ?? [];
+    assert.equal(srcRefs.filter((ref) => ref.context === "source").length, 1);
+  });
+
   it("indexes fragment spread references from schemas", () => {
     const idx = buildIndex({
       "file:///a.stm": `schema customers {


### PR DESCRIPTION
## Summary
Fix the VS Code/LSP false positive where quoted join descriptions inside `source {}` were indexed as structural source refs and triggered undefined-source warnings.

## What changed
- add a structural-only source-ref extractor in core
- use that extractor for LSP source/target block indexing
- scope merged core semantic diagnostics to the active import graph
- add regression tests for workspace indexing and diagnostics
- include ticket `sjsr-01ad`

## Reproducer
Open `examples/filter-flatten-governance/filter-flatten-governance.stm` in the VS Code extension and inspect mapping `completed orders`.

Before this change, the quoted join text in the source block could be reported as an undefined source even though the CLI validated the file cleanly.

## Validation
- `npm test -- cst-utils.test.js` in `tooling/satsuma-core`
- `npm test -- workspace-index.test.js semantic-diagnostics.test.js` in `tooling/satsuma-lsp`
