### PR TITLE
Fix nested field coverage in mapping detail

### DIFF
--- a/.tickets/sl-8z5m.md
+++ b/.tickets/sl-8z5m.md
@@ -1,0 +1,47 @@
+---
+id: sl-8z5m
+status: closed
+deps: []
+links: []
+created: 2026-04-01T10:05:06Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [vscode, lsp, viz, coverage, exploratory-testing]
+---
+# viz: mapping detail source usage marker stays unfilled for nested source fields
+
+In the mapping detail view for `completed orders` in `examples/filter-flatten-governance/filter-flatten-governance.stm`, nested source fields are resolved correctly for hover/highlight but are not marked as used in the source schema card.
+
+**What I did:**
+Opened the `completed orders` mapping detail view in the VS Code extension and hovered the `customer.email -> customer_email` mapping row.
+
+**Expected:**
+The nested source field `customer.email` is marked as used in the source schema card with the same filled indicator used for covered source fields, because the mapping row and hover state already resolve that nested path successfully.
+
+**Actual:**
+The mapping detail view highlights `customer.email` correctly during hover, but the source schema card still shows the nested child field as unused (empty circle). Top-level usage appears to work; nested child-field usage does not.
+
+This makes the mapping detail view internally inconsistent: nested field resolution works for interaction, but the usage/coverage marker does not reflect that same resolved path.
+
+**Reproducer:**
+1. Open `examples/filter-flatten-governance/filter-flatten-governance.stm` in the VS Code extension.
+2. Open the mapping detail view for `completed orders`.
+3. Hover the `customer.email -> customer_email` row.
+4. Observe that `customer.email` is highlighted/resolved, but the source-side usage marker for the nested child field remains unfilled.
+
+## Acceptance Criteria
+
+- In the mapping detail view, nested source fields used by an arrow are marked as used in the source schema card, not just top-level fields
+- The `completed orders` reproducer marks `customer.email` as used when viewing the mapping detail for `customer.email -> customer_email`
+- Source usage state is derived from the same resolved nested field path logic used by hover/highlight, or an equivalent shared coverage path, so the two views cannot drift
+- Add regression coverage for nested source-field usage in the relevant LSP/extension/viz tests
+- Existing top-level source usage markers continue to behave unchanged
+
+
+## Notes
+
+**2026-04-01T10:18:08Z**
+
+Cause: The mapping detail view and overview cards tracked mapped fields by leaf name only, so nested paths like `customer.email` never marked `customer`/`customer.email` as covered. The viz layer had drifted from the shared coverage semantics already used elsewhere.
+Fix: Added shared core coverage-path helpers and rewired satsuma-viz to build path-based covered-field sets per schema, resolve schema-local field paths for multi-source mappings, and render schema-card usage/highlight state by full dotted path. Also added regression tests in core and satsuma-viz, and rebuilt the LSP/extension bundles.

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -61,6 +61,10 @@
     "./coverage": {
       "types": "./dist/coverage.d.ts",
       "default": "./dist/coverage.js"
+    },
+    "./coverage-paths": {
+      "types": "./dist/coverage-paths.d.ts",
+      "default": "./dist/coverage-paths.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -1,0 +1,31 @@
+/**
+ * coverage-paths.ts — Shared field-path coverage helpers.
+ *
+ * Consumers in the LSP and viz layer both need the same path semantics:
+ * if an arrow references `customer.email`, both `customer` and
+ * `customer.email` count as covered. This module centralizes that expansion so
+ * UI layers do not reimplement their own nested-field matching rules.
+ */
+
+import { addPathAndPrefixes } from "./coverage.js";
+
+/**
+ * Expand a collection of field paths into a coverage set containing the full
+ * path, its ancestor prefixes, and the leaf segment for each entry.
+ */
+export function buildCoveredFieldSet(paths: Iterable<string>): Set<string> {
+  const covered = new Set<string>();
+  for (const path of paths) addPathAndPrefixes(covered, path);
+  return covered;
+}
+
+/**
+ * Return true when a schema-local field path is covered by the expanded set.
+ *
+ * The caller must pass the schema-local path (`customer.email`, not
+ * `orders.customer.email`). Matching is intentionally exact because
+ * buildCoveredFieldSet() already registers prefixes and leaves.
+ */
+export function isCoveredFieldPath(path: string, coveredPaths: Set<string>): boolean {
+  return coveredPaths.has(path);
+}

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -17,6 +17,7 @@ export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
 export { addPathAndPrefixes } from "./coverage.js";
 export type { FieldCoverageEntry, SchemaCoverageResult, MappingCoverageResult } from "./coverage.js";
+export { buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
 export { format } from "./format.js";
 export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
 export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -1,0 +1,26 @@
+/**
+ * coverage-paths.test.js — Shared path-set helpers for nested field coverage.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildCoveredFieldSet, isCoveredFieldPath } from "@satsuma/core";
+
+describe("buildCoveredFieldSet()", () => {
+  it("marks nested field paths and their parents as covered", () => {
+    const covered = buildCoveredFieldSet(["customer.email"]);
+    assert.equal(isCoveredFieldPath("customer", covered), true);
+    assert.equal(isCoveredFieldPath("customer.email", covered), true);
+  });
+
+  it("normalizes array traversal paths via addPathAndPrefixes", () => {
+    const covered = buildCoveredFieldSet(["line_items[].sku"]);
+    assert.equal(isCoveredFieldPath("line_items", covered), true);
+    assert.equal(isCoveredFieldPath("line_items.sku", covered), true);
+  });
+
+  it("returns false for unrelated paths", () => {
+    const covered = buildCoveredFieldSet(["customer.email"]);
+    assert.equal(isCoveredFieldPath("customer.tier", covered), false);
+  });
+});

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -24,7 +24,7 @@ import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText } from "./parser-utils";
 import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
-import { addPathAndPrefixes } from "@satsuma/core";
+import { addPathAndPrefixes, isCoveredFieldPath } from "@satsuma/core";
 
 // Re-export shared types from core so existing LSP code that imports from
 // this module continues to work without import path changes.
@@ -209,7 +209,7 @@ function buildFieldCoverage(
   const result: FieldCoverageEntry[] = [];
   for (const f of fields) {
     const path = prefix ? `${prefix}.${f.name}` : f.name;
-    const mapped = coveredPaths.has(f.name) || coveredPaths.has(path);
+    const mapped = isCoveredFieldPath(path, coveredPaths);
     result.push({ path, uri, line: f.range.start.line, mapped });
     if (f.children.length > 0) {
       result.push(...buildFieldCoverage(f.children, uri, path, coveredPaths));

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@satsuma/viz",
       "version": "0.1.0",
       "dependencies": {
+        "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
         "elkjs": "^0.11.1",
         "lit": "^3.3.0"
@@ -17,6 +18,18 @@
         "@types/node": "^22.0.0",
         "esbuild": "^0.27.4",
         "typescript": "^5.9.3"
+      }
+    },
+    "../satsuma-core": {
+      "name": "@satsuma/core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "web-tree-sitter": "^0.26.7"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "typescript": "^6.0.2"
       }
     },
     "../satsuma-viz-model": {
@@ -484,6 +497,10 @@
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
+    },
+    "node_modules/@satsuma/core": {
+      "resolved": "../satsuma-core",
+      "link": true
     },
     "node_modules/@satsuma/viz-model": {
       "resolved": "../satsuma-viz-model",

--- a/tooling/satsuma-viz/package.json
+++ b/tooling/satsuma-viz/package.json
@@ -13,6 +13,7 @@
     "pretest": "tsc --noEmit"
   },
   "dependencies": {
+    "@satsuma/core": "file:../satsuma-core",
     "@satsuma/viz-model": "file:../satsuma-viz-model",
     "elkjs": "^0.11.1",
     "lit": "^3.3.0"

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -8,20 +8,7 @@ import type {
   FlattenBlock,
 } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
-
-/** Strip namespace::schema prefix from a qualified field ref, returning just the field name. */
-function stripFieldQualifier(fieldRef: string): string {
-  const dotIdx = fieldRef.lastIndexOf(".");
-  return dotIdx >= 0 ? fieldRef.slice(dotIdx + 1) : fieldRef;
-}
-
-/** Check if a qualified field ref belongs to a given schema (by qualifiedId). */
-function fieldBelongsToSchema(fieldRef: string, schemaQualifiedId: string): boolean {
-  const dotIdx = fieldRef.lastIndexOf(".");
-  if (dotIdx < 0) return true; // unqualified field — could be any schema
-  const prefix = fieldRef.slice(0, dotIdx);
-  return prefix === schemaQualifiedId;
-}
+import { resolveSchemaLocalFieldPath } from "../field-coverage.js";
 
 /**
  * Three-column mapping detail view.
@@ -370,35 +357,25 @@ export class SzMappingDetail extends LitElement {
     const result = new Map<string, Set<string>>();
     const m = this.mapping;
     if (!m) return result;
+    const sourceSchemaById = new Map(
+      this.sourceSchemas.map((schema) => [schema.qualifiedId, schema] as const),
+    );
 
     if (this._hoveredArrow) {
-      // Highlight source fields of the hovered arrow in all source schemas.
-      // Source fields may be qualified (e.g. "ns::schema.field"); extract the
-      // bare field name so it matches the schema card's field names, and also
-      // route each field to the correct source schema.
       for (const sr of m.sourceRefs) {
         const fields = new Set<string>();
+        const schema = sourceSchemaById.get(sr);
+        if (!schema) continue;
         for (const sf of this._hoveredArrow.sourceFields) {
-          const bare = stripFieldQualifier(sf);
-          // Only highlight in the schema the field belongs to
-          if (fieldBelongsToSchema(sf, sr) || m.sourceRefs.length === 1) {
-            fields.add(bare);
-          }
+          const localPath = resolveSchemaLocalFieldPath(sf, schema, m.sourceRefs);
+          if (localPath) fields.add(localPath);
         }
         if (fields.size > 0) result.set(sr, fields);
       }
     } else if (this._hoveredCardField && this._hoveredCardSchema) {
-      // If a target field is hovered, find which source fields map to it
       if (this._hoveredCardSchema === m.targetRef) {
-        const matchingSourceFields = this._findSourceFieldsForTarget(
-          this._hoveredCardField, m
-        );
-        for (const sr of m.sourceRefs) {
-          result.set(sr, matchingSourceFields);
-        }
-      }
-      // If a source field is hovered, highlight it in its own card
-      else if (m.sourceRefs.includes(this._hoveredCardSchema)) {
+        return this._findSourceFieldsForTarget(this._hoveredCardField, m);
+      } else if (m.sourceRefs.includes(this._hoveredCardSchema)) {
         result.set(
           this._hoveredCardSchema,
           new Set([this._hoveredCardField])
@@ -413,18 +390,26 @@ export class SzMappingDetail extends LitElement {
   private get _targetHighlightFields(): Set<string> {
     const m = this.mapping;
     if (!m) return new Set();
+    const targetSchema = this.targetSchema;
 
     if (this._hoveredArrow) {
-      return new Set([stripFieldQualifier(this._hoveredArrow.targetField)]);
+      if (!targetSchema) return new Set();
+      const localPath = resolveSchemaLocalFieldPath(
+        this._hoveredArrow.targetField,
+        targetSchema,
+        [m.targetRef],
+      );
+      return localPath ? new Set([localPath]) : new Set();
     }
 
     if (this._hoveredCardField && this._hoveredCardSchema) {
-      // If a source field is hovered, find which target fields it maps to
       if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-        return this._findTargetFieldsForSource(this._hoveredCardField, m);
-      }
-      // If target card field is hovered, highlight it
-      if (this._hoveredCardSchema === m.targetRef) {
+        return this._findTargetFieldsForSource(
+          this._hoveredCardField,
+          this._hoveredCardSchema,
+          m,
+        );
+      } else if (this._hoveredCardSchema === m.targetRef) {
         return new Set([this._hoveredCardField]);
       }
     }
@@ -432,13 +417,27 @@ export class SzMappingDetail extends LitElement {
     return new Set();
   }
 
-  /** Find source fields that map to a given target field (returns bare names). */
-  private _findSourceFieldsForTarget(targetField: string, m: MappingBlock): Set<string> {
-    const result = new Set<string>();
+  /** Find source fields that map to a given target field, grouped by schema id. */
+  private _findSourceFieldsForTarget(targetField: string, m: MappingBlock): Map<string, Set<string>> {
+    const result = new Map<string, Set<string>>();
+    const sourceSchemaById = new Map(
+      this.sourceSchemas.map((schema) => [schema.qualifiedId, schema] as const),
+    );
     const search = (arrows: ArrowEntry[]) => {
       for (const a of arrows) {
-        if (stripFieldQualifier(a.targetField) === targetField) {
-          for (const sf of a.sourceFields) result.add(stripFieldQualifier(sf));
+        const targetSchema = this.targetSchema;
+        const localTargetPath = targetSchema
+          ? resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef])
+          : null;
+        if (localTargetPath === targetField) {
+          for (const sourceSchema of this.sourceSchemas) {
+            for (const sf of a.sourceFields) {
+              const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
+              if (!localSourcePath) continue;
+              if (!result.has(sourceSchema.qualifiedId)) result.set(sourceSchema.qualifiedId, new Set());
+              result.get(sourceSchema.qualifiedId)!.add(localSourcePath);
+            }
+          }
         }
       }
     };
@@ -448,13 +447,21 @@ export class SzMappingDetail extends LitElement {
     return result;
   }
 
-  /** Find target fields that a given source field maps to (handles qualified refs). */
-  private _findTargetFieldsForSource(sourceField: string, m: MappingBlock): Set<string> {
+  /** Find target fields that a given source field maps to. */
+  private _findTargetFieldsForSource(sourceField: string, sourceSchemaId: string, m: MappingBlock): Set<string> {
     const result = new Set<string>();
+    const sourceSchema = this.sourceSchemas.find((schema) => schema.qualifiedId === sourceSchemaId);
+    const targetSchema = this.targetSchema;
+    if (!sourceSchema || !targetSchema) return result;
     const search = (arrows: ArrowEntry[]) => {
       for (const a of arrows) {
-        if (a.sourceFields.some((sf) => stripFieldQualifier(sf) === sourceField)) {
-          result.add(stripFieldQualifier(a.targetField));
+        const sourceMatches = a.sourceFields.some((sf) => {
+          const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
+          return localSourcePath === sourceField;
+        });
+        if (sourceMatches) {
+          const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef]);
+          if (localTargetPath) result.add(localTargetPath);
         }
       }
     };
@@ -470,13 +477,17 @@ export class SzMappingDetail extends LitElement {
     if (!this._hoveredCardField || !this._hoveredCardSchema) return false;
 
     const m = this.mapping!;
-    // Source card field hovered → highlight rows where it's a source
     if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-      return a.sourceFields.some((sf) => stripFieldQualifier(sf) === this._hoveredCardField);
-    }
-    // Target card field hovered → highlight rows where it's the target
-    if (this._hoveredCardSchema === m.targetRef) {
-      return stripFieldQualifier(a.targetField) === this._hoveredCardField;
+      const sourceSchema = this.sourceSchemas.find((schema) => schema.qualifiedId === this._hoveredCardSchema);
+      return !!sourceSchema && a.sourceFields.some((sf) => {
+        const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
+        return localSourcePath === this._hoveredCardField;
+      });
+    } else if (this._hoveredCardSchema === m.targetRef) {
+      const targetSchema = this.targetSchema;
+      if (!targetSchema) return false;
+      const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef]);
+      return localTargetPath === this._hoveredCardField;
     }
     return false;
   }

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -4,6 +4,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
+import { isCoveredFieldPath } from "@satsuma/core/coverage-paths";
 
 @customElement("sz-schema-card")
 export class SzSchemaCard extends LitElement {
@@ -516,9 +517,9 @@ export class SzSchemaCard extends LitElement {
     `;
   }
 
-  private _onFieldHover(fieldName: string | null) {
+  private _onFieldHover(fieldPath: string | null) {
     const schemaId = this.schema?.qualifiedId ?? "";
-    this.dispatchEvent(new SzFieldHoverEvent(schemaId, fieldName));
+    this.dispatchEvent(new SzFieldHoverEvent(schemaId, fieldPath));
   }
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
@@ -540,12 +541,13 @@ export class SzSchemaCard extends LitElement {
     this._notesExpanded = !this._notesExpanded;
   }
 
-  private _renderField(f: FieldEntry, depth: number): TemplateResult {
-    const isMapped = this.mappedFields.has(f.name);
+  private _renderField(f: FieldEntry, depth: number, prefix = ""): TemplateResult {
+    const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
+    const isMapped = isCoveredFieldPath(fieldPath, this.mappedFields);
     const hasWarning = f.comments.some((c) => c.kind === "warning");
     const hasQuestion = f.comments.some((c) => c.kind === "question");
     const hasPii = f.constraints.includes("pii");
-    const isHighlighted = this.highlightFields.has(f.name);
+    const isHighlighted = this.highlightFields.has(fieldPath);
     const hlClass = isHighlighted
       ? `hl ${this.highlightColor === "target" ? "hl-target" : "hl-source"}`
       : "";
@@ -555,7 +557,7 @@ export class SzSchemaCard extends LitElement {
         class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
-        @mouseenter=${() => this._onFieldHover(f.name)}
+        @mouseenter=${() => this._onFieldHover(fieldPath)}
         @mouseleave=${() => this._onFieldHover(null)}
         title=${f.name + ": " + f.type}
       >
@@ -579,7 +581,7 @@ export class SzSchemaCard extends LitElement {
         <button
           class="lineage-btn"
           title="Show field lineage"
-          @click=${(e: Event) => { e.stopPropagation(); this._onFieldLineage(f.name); }}
+          @click=${(e: Event) => { e.stopPropagation(); this._onFieldLineage(fieldPath); }}
         ><svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
           <circle cx="2" cy="6" r="1.5" fill="currentColor"/>
           <circle cx="10" cy="3" r="1.5" fill="currentColor"/>
@@ -591,7 +593,7 @@ export class SzSchemaCard extends LitElement {
       ${f.notes.length > 0
         ? f.notes.map((n) => html`<div class="field-note" style=${depth > 0 ? `padding-left: ${38 + depth * 20}px` : ""}>${n.text}</div>`)
         : ""}
-      ${f.children.map((child) => this._renderField(child, depth + 1))}
+      ${f.children.map((child) => this._renderField(child, depth + 1, fieldPath))}
     `;
   }
 
@@ -611,11 +613,12 @@ export class SzSchemaCard extends LitElement {
     return count;
   }
 
-  private _countMapped(fields: FieldEntry[]): number {
+  private _countMapped(fields: FieldEntry[], prefix = ""): number {
     let count = 0;
     for (const f of fields) {
-      if (this.mappedFields.has(f.name)) count++;
-      count += this._countMapped(f.children);
+      const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
+      if (isCoveredFieldPath(fieldPath, this.mappedFields)) count++;
+      count += this._countMapped(f.children, fieldPath);
     }
     return count;
   }

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -1,0 +1,140 @@
+/**
+ * field-coverage.ts — Shared mapping-detail coverage helpers for satsuma-viz.
+ *
+ * The web component should consume the same nested-field coverage semantics as
+ * the LSP coverage path utilities instead of comparing leaf names ad hoc.
+ */
+
+import { buildCoveredFieldSet } from "@satsuma/core/coverage-paths";
+import type { ArrowEntry, MappingBlock, SchemaCard, VizModel } from "./model.js";
+
+/**
+ * Return true when the schema declares the exact local dotted field path.
+ */
+export function schemaHasFieldPath(schema: SchemaCard, fieldPath: string): boolean {
+  const parts = fieldPath.split(".");
+  let fields = schema.fields;
+  for (const part of parts) {
+    const field = fields.find((candidate) => candidate.name === part);
+    if (!field) return false;
+    fields = field.children;
+  }
+  return true;
+}
+
+/**
+ * Resolve an arrow field reference to the schema-local dotted field path for a
+ * specific schema card.
+ *
+ * Examples:
+ * - `customer_profiles.region` + schema `customer_profiles` -> `region`
+ * - `customer.email` + schema `order_events` -> `customer.email`
+ * - `other_schema.id` + schema `order_events` -> null
+ */
+export function resolveSchemaLocalFieldPath(
+  fieldRef: string,
+  schema: SchemaCard,
+  sourceRefs: string[],
+): string | null {
+  if (fieldRef.startsWith(`${schema.qualifiedId}.`)) {
+    return fieldRef.slice(schema.qualifiedId.length + 1);
+  }
+
+  const explicitOtherSchema = sourceRefs.some(
+    (sourceRef) => sourceRef !== schema.qualifiedId && fieldRef.startsWith(`${sourceRef}.`),
+  );
+  if (explicitOtherSchema) return null;
+
+  return schemaHasFieldPath(schema, fieldRef) ? fieldRef : null;
+}
+
+/**
+ * Walk all arrows in a mapping, including nested each_blocks and flatten_blocks.
+ */
+export function forEachMappingArrow(
+  mapping: MappingBlock,
+  visit: (arrow: ArrowEntry) => void,
+): void {
+  const visitEach = (eachBlocks: MappingBlock["eachBlocks"]): void => {
+    for (const each of eachBlocks) {
+      for (const arrow of each.arrows) visit(arrow);
+      visitEach(each.nestedEach);
+    }
+  };
+
+  for (const arrow of mapping.arrows) visit(arrow);
+  visitEach(mapping.eachBlocks);
+  for (const flatten of mapping.flattenBlocks) {
+    for (const arrow of flatten.arrows) visit(arrow);
+  }
+}
+
+/**
+ * Build schema-local covered-field sets for one mapping detail view.
+ */
+export function buildMappingCoveredFields(
+  mapping: MappingBlock,
+  sourceSchemas: SchemaCard[],
+  targetSchema: SchemaCard | null,
+): { sourceMapped: Map<string, Set<string>>; targetMapped: Set<string> } {
+  const sourceFieldRefs = new Map<string, string[]>();
+  for (const schema of sourceSchemas) sourceFieldRefs.set(schema.qualifiedId, []);
+
+  const targetFieldRefs: string[] = [];
+
+  forEachMappingArrow(mapping, (arrow) => {
+    if (targetSchema) {
+      const targetPath = resolveSchemaLocalFieldPath(arrow.targetField, targetSchema, [mapping.targetRef]);
+      if (targetPath) targetFieldRefs.push(targetPath);
+    }
+
+    for (const sourceField of arrow.sourceFields) {
+      for (const schema of sourceSchemas) {
+        const localPath = resolveSchemaLocalFieldPath(sourceField, schema, mapping.sourceRefs);
+        if (localPath) sourceFieldRefs.get(schema.qualifiedId)!.push(localPath);
+      }
+    }
+  });
+
+  const sourceMapped = new Map<string, Set<string>>();
+  for (const [schemaId, refs] of sourceFieldRefs) {
+    sourceMapped.set(schemaId, buildCoveredFieldSet(refs));
+  }
+
+  return {
+    sourceMapped,
+    targetMapped: buildCoveredFieldSet(targetFieldRefs),
+  };
+}
+
+/**
+ * Build the overview-level mapped-field index across the whole VizModel.
+ */
+export function buildMappedFieldsIndex(model: VizModel): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  const allSchemas = new Map(
+    model.namespaces.flatMap((ns) => ns.schemas.map((schema) => [schema.qualifiedId, schema] as const)),
+  );
+
+  for (const ns of model.namespaces) {
+    for (const mapping of ns.mappings) {
+      const sourceSchemas = mapping.sourceRefs
+        .map((schemaId) => allSchemas.get(schemaId))
+        .filter((schema): schema is SchemaCard => schema != null);
+      const targetSchema = allSchemas.get(mapping.targetRef) ?? null;
+      const { sourceMapped, targetMapped } = buildMappingCoveredFields(mapping, sourceSchemas, targetSchema);
+
+      for (const [schemaId, covered] of sourceMapped) {
+        if (!index.has(schemaId)) index.set(schemaId, new Set());
+        for (const path of covered) index.get(schemaId)!.add(path);
+      }
+
+      if (targetSchema) {
+        if (!index.has(targetSchema.qualifiedId)) index.set(targetSchema.qualifiedId, new Set());
+        for (const path of targetMapped) index.get(targetSchema.qualifiedId)!.add(path);
+      }
+    }
+  }
+
+  return index;
+}

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -18,6 +18,7 @@ import type {
   EachBlock,
   FlattenBlock,
 } from "../model.js";
+import { buildMappedFieldsIndex } from "../field-coverage.js";
 
 export interface LayoutNode {
   id: string;
@@ -344,49 +345,6 @@ export async function computeLayout(model: VizModel): Promise<LayoutResult> {
   return extractLayout(result, model);
 }
 
-/** Build an index: schemaId → Set<fieldName> that are source or target of arrows */
-function buildMappedFieldsIndex(model: VizModel): Map<string, Set<string>> {
-  const index = new Map<string, Set<string>>();
-
-  const ensureSet = (id: string) => {
-    if (!index.has(id)) index.set(id, new Set());
-    return index.get(id)!;
-  };
-
-  for (const ns of model.namespaces) {
-    for (const m of ns.mappings) {
-      const collectArrows = (arrows: ArrowEntry[]) => {
-        for (const a of arrows) {
-          // Target field belongs to target schema
-          ensureSet(m.targetRef).add(a.targetField);
-          // Source fields belong to source schemas
-          for (const sf of a.sourceFields) {
-            for (const sr of m.sourceRefs) {
-              ensureSet(sr).add(sf);
-            }
-          }
-        }
-      };
-
-      collectArrows(m.arrows);
-
-      const collectEach = (blocks: EachBlock[]) => {
-        for (const eb of blocks) {
-          collectArrows(eb.arrows);
-          collectEach(eb.nestedEach);
-        }
-      };
-      collectEach(m.eachBlocks);
-
-      for (const fb of m.flattenBlocks) {
-        collectArrows(fb.arrows);
-      }
-    }
-  }
-
-  return index;
-}
-
 function buildElkGraph(
   model: VizModel,
   mappedFields: Map<string, Set<string>>,
@@ -451,7 +409,7 @@ function addSchemaNodes(
     const width = estimateSchemaWidth(s);
     const topOffset = preambleHeight(s, hasNamespace) + FIELDS_PADDING_TOP;
     // Expand spread fields so ports exist for arrow endpoints that reference them
-    const spreadFields = s.spreads.flatMap((name) => fragmentsById.get(name) ?? []);
+    const spreadFields = (s.spreads ?? []).flatMap((name) => fragmentsById.get(name) ?? []);
     const allFields = [...s.fields, ...spreadFields];
     const ports = buildFieldPorts(allFields, s.qualifiedId, mappedFields, topOffset, width);
 
@@ -744,11 +702,11 @@ export async function computeOverviewLayout(model: VizModel): Promise<OverviewLa
     for (const s of ns.schemas) {
       nodeIds.add(s.qualifiedId);
       overviewNodeKinds.set(s.qualifiedId, "schema");
-      overviewNodeHasNamespace.add(s.qualifiedId);
+      if (ns.name) overviewNodeHasNamespace.add(s.qualifiedId);
       nsNodes.push({
         id: s.qualifiedId,
         width: estimateCompactSchemaWidth(s),
-        height: compactHeight(s, true),
+        height: compactHeight(s, !!ns.name),
         layoutOptions: {
           "elk.layered.layerConstraint": "NONE",
         },

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -6,6 +6,7 @@ import { computeLayout, computeOverviewLayout, type LayoutResult, type OverviewL
 import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 import { renderMarkdown } from "./markdown.js";
+import { buildMappedFieldsIndex, buildMappingCoveredFields } from "./field-coverage.js";
 
 export { VizModel } from "./model.js";
 export type { NamespaceGroup } from "./model.js";
@@ -18,6 +19,7 @@ export { SzEdgeLayer } from "./edges/sz-edge-layer.js";
 export { SzOverviewEdgeLayer, SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 export { SzMappingDetail } from "./components/sz-mapping-detail.js";
 export { computeLayout, computeOverviewLayout } from "./layout/elk-layout.js";
+export { buildMappingCoveredFields, buildMappedFieldsIndex, resolveSchemaLocalFieldPath, schemaHasFieldPath } from "./field-coverage.js";
 export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout, OverviewLayoutResult, OverviewEdge } from "./layout/elk-layout.js";
 
 /** Navigate event — dispatched when the user clicks a source-linked element. */
@@ -1403,23 +1405,11 @@ export class SatsumaViz extends LitElement {
     const targetSchema = allSchemas.find((s) => s.qualifiedId === mapping.targetRef) ?? null;
     const expandedTarget = targetSchema ? this._expandSpreads(targetSchema) : null;
 
-    // Build mapped fields for the detail view
-    const sourceMapped = new Map<string, Set<string>>();
-    const targetMapped = new Set<string>();
-    const collectArrows = (arrows: import("./model.js").ArrowEntry[]) => {
-      for (const a of arrows) {
-        targetMapped.add(a.targetField);
-        for (const sf of a.sourceFields) {
-          for (const sr of mapping.sourceRefs) {
-            if (!sourceMapped.has(sr)) sourceMapped.set(sr, new Set());
-            sourceMapped.get(sr)!.add(sf);
-          }
-        }
-      }
-    };
-    collectArrows(mapping.arrows);
-    for (const eb of mapping.eachBlocks) collectArrows(eb.arrows);
-    for (const fb of mapping.flattenBlocks) collectArrows(fb.arrows);
+    const { sourceMapped, targetMapped } = buildMappingCoveredFields(
+      mapping,
+      sourceSchemas,
+      expandedTarget,
+    );
 
     const namespaceLabel = this._namespaceForMapping(mapping);
 
@@ -1966,38 +1956,7 @@ export class SatsumaViz extends LitElement {
     };
   }
   private _buildMappedFieldsIndex(): Map<string, Set<string>> {
-    const index = new Map<string, Set<string>>();
-    if (!this.model) return index;
-
-    const ensureSet = (id: string) => {
-      if (!index.has(id)) index.set(id, new Set());
-      return index.get(id)!;
-    };
-
-    for (const ns of this.model.namespaces) {
-      for (const m of ns.mappings) {
-        const collect = (arrows: import("./model.js").ArrowEntry[]) => {
-          for (const a of arrows) {
-            ensureSet(m.targetRef).add(a.targetField);
-            for (const sf of a.sourceFields) {
-              for (const sr of m.sourceRefs) {
-                ensureSet(sr).add(sf);
-              }
-            }
-          }
-        };
-
-        collect(m.arrows);
-        for (const eb of m.eachBlocks) {
-          collect(eb.arrows);
-        }
-        for (const fb of m.flattenBlocks) {
-          collect(fb.arrows);
-        }
-      }
-    }
-
-    return index;
+    return this.model ? buildMappedFieldsIndex(this.model) : new Map();
   }
 }
 

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -1,0 +1,102 @@
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+const loc = { uri: "file:///test.stm", line: 1, character: 0 };
+
+const field = (name, children = []) => ({
+  name,
+  type: children.length > 0 ? "record" : "STRING",
+  constraints: [],
+  notes: [],
+  comments: [],
+  children,
+  location: loc,
+});
+
+const schema = (id, fields, qualifiedId = id) => ({
+  id,
+  qualifiedId,
+  kind: "schema",
+  label: null,
+  fields,
+  notes: [],
+  comments: [],
+  metadata: [],
+  location: loc,
+  hasExternalLineage: false,
+  spreads: [],
+});
+
+describe("field-coverage helpers", () => {
+  /** @type {typeof import("../dist/satsuma-viz.js")} */
+  let mod;
+
+  it("loads the bundle exports", async () => {
+    mod = await import("../dist/satsuma-viz.js");
+    assert.equal(typeof mod.buildMappingCoveredFields, "function");
+    assert.equal(typeof mod.resolveSchemaLocalFieldPath, "function");
+    assert.equal(typeof mod.schemaHasFieldPath, "function");
+  });
+
+  it("resolves unqualified nested source paths against the owning schema", () => {
+    const src = schema("order_events", [
+      field("customer", [field("email"), field("tier")]),
+    ]);
+    assert.equal(mod.schemaHasFieldPath(src, "customer.email"), true);
+    assert.equal(
+      mod.resolveSchemaLocalFieldPath("customer.email", src, ["order_events", "customer_profiles"]),
+      "customer.email",
+    );
+  });
+
+  it("strips explicit schema qualifiers when resolving local paths", () => {
+    const profiles = schema("customer_profiles", [field("region")]);
+    assert.equal(
+      mod.resolveSchemaLocalFieldPath("customer_profiles.region", profiles, ["order_events", "customer_profiles"]),
+      "region",
+    );
+  });
+
+  it("builds mapping coverage sets that include nested parents and children", () => {
+    const orderEvents = schema("order_events", [
+      field("customer", [field("email"), field("tier")]),
+    ]);
+    const target = schema("completed_orders", [
+      field("customer_email"),
+    ]);
+    const mapping = {
+      id: "completed orders",
+      sourceRefs: ["order_events", "customer_profiles"],
+      targetRef: "completed_orders",
+      arrows: [
+        {
+          sourceFields: ["customer.email"],
+          targetField: "customer_email",
+          transform: null,
+          metadata: [],
+          comments: [],
+          location: loc,
+        },
+      ],
+      eachBlocks: [],
+      flattenBlocks: [],
+      sourceBlock: null,
+      notes: [],
+      comments: [],
+      location: loc,
+    };
+
+    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
+      mapping,
+      [orderEvents],
+      target,
+    );
+
+    const sourceSet = sourceMapped.get("order_events");
+    assert.ok(sourceSet);
+    assert.equal(sourceSet.has("customer"), true);
+    assert.equal(sourceSet.has("customer.email"), true);
+    assert.equal(targetMapped.has("customer_email"), true);
+  });
+});


### PR DESCRIPTION
## Summary
Fix mapping detail source/target usage markers for nested fields so the visual coverage state matches hover/path resolution.

## What changed
- move nested field coverage path semantics into shared core helpers
- add shared viz field-coverage helpers instead of recomputing leaf-name coverage ad hoc in the component
- render schema-card mapped/highlight state by full dotted field path
- update the LSP coverage path check to use the shared coverage helper
- add regression tests in core and satsuma-viz
- include ticket `sl-8z5m`

## Reproducer
Open `examples/filter-flatten-governance/filter-flatten-governance.stm`, open mapping `completed orders`, and inspect `customer.email -> customer_email` in the mapping detail view.

Before this change, hover/highlight resolved `customer.email` correctly, but the source schema card still showed the nested field as unused.

## Validation
- `npm test -- coverage.test.js coverage-paths.test.js` in `tooling/satsuma-core`
- `npm test -- coverage.test.js` in `tooling/satsuma-lsp`
- `npm run build` in `tooling/satsuma-lsp`
- `npm run build` in `tooling/satsuma-viz`
- `npm test -- field-coverage.test.js layout.test.js` in `tooling/satsuma-viz`
- `npm run build` in `tooling/vscode-satsuma`
