### PR TITLE
fix(cli): namespace output canonicalization bugs (sl-b0mq, sl-ltv6, sl-pb47, sl-qofc, sl-qxn5, sl-wfgx)

### DIFF
--- a/.tickets/sl-b0mq.md
+++ b/.tickets/sl-b0mq.md
@@ -1,6 +1,6 @@
 ---
 id: sl-b0mq
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:29:44Z
@@ -19,3 +19,10 @@ Repro:
 
 The name field should resolve to the canonical qualified name regardless of query form.
 
+
+## Notes
+
+**2026-04-01T11:11:08Z**
+
+Cause: `canonicalKey(name)` used the raw user query string instead of the resolved index key, producing "::customers" for bare-name lookups instead of "crm::customers".
+Fix: Changed to `canonicalKey(resolvedName)` in where-used.ts JSON and text output paths.

--- a/.tickets/sl-cf9t.md
+++ b/.tickets/sl-cf9t.md
@@ -31,3 +31,9 @@ This also affects fragment spreads: a file can use ...base_fields from a transit
 **2026-03-31**
 
 Re-opened. Prior triage was wrong: Satsuma keeps explicit imports, but imported symbols bring their exact transitive dependencies with them. The bug is that the current implementation appears broader than that and leaks unrelated symbols through a flat transitive scope. ADR-022 now describes the narrower dependency-reachability model; implementation is still needed.
+
+**2026-04-01**
+
+Bug confirmed still reproducible against current main. The root cause is in `buildIndex` — all transitively reachable files are merged into a flat scope with no import-boundary enforcement. Both the CLI validator and the LSP diagnostic engine (and likely completions/hover) consume this same flat index, so both are affected.
+
+Implementation guidance: the fix should live in `satsuma-core` so CLI and LSP share exactly the same reachability logic and cannot diverge. The index can remain flat (it is useful for cross-file lookups), but a per-file **reachability set** needs to be computed from the import graph and threaded into validation so that undefined-ref checks only consider symbols actually reachable from the file being validated. Placing this in core prevents a repeat of the pattern where the same rule is implemented independently in the CLI and LSP and drifts over time.

--- a/.tickets/sl-ltv6.md
+++ b/.tickets/sl-ltv6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ltv6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:29:10Z
@@ -20,3 +20,10 @@ Repro:
 
 Both show the same arrow in the body.
 
+
+## Notes
+
+**2026-04-01**
+
+Cause: `printDefault` in arrows.ts parsed schemaName from the raw fieldRef string (e.g. "customers" from "customers.email"), so `m.sources.includes(schemaName)` never matched the canonical index key "crm::customers", reporting 0 arrows.
+Fix: Added a `resolvedSchemaKey` parameter to `printDefault` and passed `resolvedSchema.key` from the action handler.

--- a/.tickets/sl-pb47.md
+++ b/.tickets/sl-pb47.md
@@ -1,6 +1,6 @@
 ---
 id: sl-pb47
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:32:19Z
@@ -20,3 +20,9 @@ Repro:
 
 This makes it impossible for consumers to disambiguate warnings from same-named schemas in different namespaces.
 
+## Notes
+
+**2026-04-01**
+
+Cause: `findParentBlock` in extract.ts (satsuma-core) returned the bare block name without checking for an enclosing `namespace_block` ancestor, so the `parent` field was always unqualified.
+Fix: Added `qualifyWithNamespace` helper that walks up the CST to find a `namespace_block` and prefixes the name (e.g. "crm::customers" instead of "customers").

--- a/.tickets/sl-qofc.md
+++ b/.tickets/sl-qofc.md
@@ -1,6 +1,6 @@
 ---
 id: sl-qofc
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:29:27Z
@@ -22,3 +22,9 @@ Repro:
 
 The text output is what humans and agents see first, so this makes it harder to identify which namespace a mapping belongs to.
 
+## Notes
+
+**2026-04-01**
+
+Cause: `printDefault` in mapping.ts used `entry.name` (bare name) for the header instead of the canonical entity name. `printJson` already used `canonicalEntityName(entry)` correctly.
+Fix: Changed `printDefault` to use `canonicalEntityName(entry)` for the name string, matching `printJson`.

--- a/.tickets/sl-qxn5.md
+++ b/.tickets/sl-qxn5.md
@@ -1,6 +1,6 @@
 ---
 id: sl-qxn5
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:30:19Z
@@ -25,3 +25,9 @@ Repro:
 
 This likely also affects non-namespace @refs (e.g., `@source.field` on an arrow from source.field).
 
+## Notes
+
+**2026-04-01**
+
+Cause: `nlMappingKey` in arrows.ts was constructed as `${nlRef.namespace}::${nlRef.mapping}`, but `nlRef.mapping` is already the fully-qualified key produced by `resolveAllNLRefs` (e.g. "crm::load_dim_customer"). This double-qualified the namespace, causing `index.mappings.get(nlMappingKey)` to return null, leaving `srcSchemas` empty and the dedup check unable to match the existing arrow's source field.
+Fix: Changed to `const nlMappingKey = nlRef.mapping` since `resolveAllNLRefs` already produces the fully-qualified mapping key.

--- a/.tickets/sl-r2nx.md
+++ b/.tickets/sl-r2nx.md
@@ -1,6 +1,6 @@
 ---
 id: sl-r2nx
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:30:03Z
@@ -29,3 +29,9 @@ Note: This may be intentional for backward compatibility (pre-import workspaces)
 **2026-03-31**
 
 Re-opened. Prior triage focused on the wrong semantics. ADR-022 removes directory mode, but this ticket still captures a real boundary bug: tooling must never treat all files in a folder as a merged semantic scope. Workspace scope is file-based, and symbol reachability inside that workspace must still follow the import graph. Implementation is still needed.
+
+**2026-04-01T08:46:25Z**
+
+**2026-04-01**
+
+Repro no longer reproduces. The CLI now rejects both directory arguments (`satsuma validate .` → "directory arguments are not supported") and multiple file arguments (`satsuma validate *.stm` → "too many arguments"). The entry-point-based workspace model means each `validate` invocation starts from a single .stm file and resolves scope through its import graph. The original bug (directory mode merging all files into a flat scope) is no longer possible. Closing as fixed by the directory-mode removal (ADR-022).

--- a/.tickets/sl-wfgx.md
+++ b/.tickets/sl-wfgx.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wfgx
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-03-31T08:29:34Z
@@ -29,3 +29,10 @@ Repro:
 **2026-03-31T08:32:49Z**
 
 Also affects: meta (header label), where-used (text header), and fields --unmapped-by (result text). All these commands echo the user's query form instead of resolving to the canonical namespace-qualified name. Root cause is the same: name canonicalization should happen before rendering output.
+
+## Notes
+
+**2026-04-01**
+
+Cause: Multiple commands passed the raw user query string (`blockName`, `name`, `schemaName`) to output formatters instead of the resolved canonical index key.
+Fix: nl.ts passes `key` (resolved) to `extractNLContent`; meta.ts returns `scope: resolvedName`; where-used.ts passes `resolvedName` to text output and `printDefault`; fields.ts uses `resolvedSchemaName` in "all mapped" / "no fields" messages.

--- a/examples/filter-flatten-governance/filter-flatten-governance.stm
+++ b/examples/filter-flatten-governance/filter-flatten-governance.stm
@@ -143,12 +143,12 @@ mapping `completed orders` {
   }
 
   source {
-    `order_events`
-    `customer_profiles`
-    "Join on order_events.customer.customer_id = customer_profiles.customer_id
+    order_events
+    customer_profiles
+    "Join on @order_events.customer.customer_id = @customer_profiles.customer_id
      WHERE @order_events.order_status = completed"
   }
-  target { `completed_orders_parquet` }
+  target { completed_orders_parquet }
 
   event_id -> order_id
   event_time -> event_time_utc
@@ -175,7 +175,7 @@ mapping `completed orders` {
   promo_codes -> promo_codes
 
   -> active_line_count {
-    "Count elements in line_items (already filtered to exclude cancelled items at source)"
+    "Count elements in @line_items (already filtered to exclude cancelled items at source)"
   }
 
   -> ingest_timestamp { now_utc() }
@@ -191,8 +191,8 @@ mapping `order line facts` {
      cancelled lines are already excluded before this mapping runs."
   }
 
-  source { `order_events` }
-  target { `order_line_facts_parquet` }
+  source { order_events }
+  target { order_line_facts_parquet }
 
   event_id -> order_id
   customer.customer_id -> customer_id
@@ -208,11 +208,11 @@ mapping `order line facts` {
   order_totals.currency -> currency { trim | uppercase }
 
   -> line_total {
-    "Multiply line_items.unit_price by line_items.quantity, then add line_items.tax_amount"
+    "Multiply @line_items.unit_price by @line_items.quantity, then add @line_items.tax_amount"
   }
 
   -> promo_code_count {
-    "Count distinct values in line_items.discount_lines.discount_code
+    "Count distinct values in @line_items.discount_lines.discount_code
      where @discount_type = promo"
   }
 

--- a/examples/filter-flatten-governance/governance.stm
+++ b/examples/filter-flatten-governance/governance.stm
@@ -201,12 +201,12 @@ mapping `customer 360 assembly` {
   }
 
   source {
-    `crm_customers`
-    `finance_transactions`
+    crm_customers
+    finance_transactions
     "Left join on @crm_customers.customer_id = @finance_transactions.customer_id.
      All CRM customers appear even if they have no transactions."
   }
-  target { `customer_360_view` }
+  target { customer_360_view }
 
   // Direct mappings from CRM
   crm_customers.customer_id -> customer_id

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -162,6 +162,9 @@ Examples:
       const canonicalQualified = canonicalKey(qualifiedField);
       for (const nlRef of nlRefs) {
         if (!nlRef.resolved || !nlRef.resolvedTo) continue;
+        // NL refs from source blocks describe join conditions, not data flow —
+        // skip them to avoid false NL-derived arrows on join-key fields.
+        if (nlRef.context === "source_block") continue;
         const resolvedTo = nlRef.resolvedTo.name;
 
         // nlRef.mapping is already fully qualified by resolveAllNLRefs

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -164,9 +164,13 @@ Examples:
         if (!nlRef.resolved || !nlRef.resolvedTo) continue;
         const resolvedTo = nlRef.resolvedTo.name;
 
-        const nlMappingKey = nlRef.namespace
-          ? `${nlRef.namespace}::${nlRef.mapping}`
-          : nlRef.mapping;
+        // nlRef.mapping is already fully qualified by resolveAllNLRefs
+        // (it is built as `${namespace}::${mapping}` or bare name before being
+        // stored). Double-qualifying by prepending nlRef.namespace again would
+        // produce "crm::crm::load_dim_customer", causing the mapping lookup and
+        // the alreadyDeclared dedup check to fail, resulting in duplicate
+        // nl-derived arrows when @ref references the arrow's own source (sl-qxn5).
+        const nlMappingKey = nlRef.mapping;
 
         if (resolvedTo !== canonicalQualified) continue;
         const nlMapping = index.mappings.get(nlMappingKey);
@@ -319,7 +323,9 @@ Examples:
         return;
       }
 
-      printDefault(fieldRef, arrows, index);
+      // Pass the resolved schema key so printDefault can match against index
+      // entries even when the user queried with a bare (unqualified) name (sl-ltv6).
+      printDefault(fieldRef, arrows, index, resolvedSchema.key);
     });
 }
 
@@ -393,9 +399,17 @@ function collectAllFieldNames(fields: FieldDecl[]): string[] {
   return names;
 }
 
-function printDefault(fieldRef: string, arrows: ArrowRecord[], index: WorkspaceIndex): void {
+/**
+ * Print text-mode output for an arrows query.
+ *
+ * @param resolvedSchemaKey - The canonical index key for the queried schema
+ *   (e.g. "crm::customers"). Must be the resolved key, not the user's raw
+ *   query string, so that mapping source/target lookups hit correctly even
+ *   when the user queried with a bare unqualified name (sl-ltv6).
+ */
+function printDefault(fieldRef: string, arrows: ArrowRecord[], index: WorkspaceIndex, resolvedSchemaKey: string): void {
   const dot = fieldRef.indexOf(".");
-  const schemaName = dot >= 0 ? fieldRef.slice(0, dot) : "";
+  const schemaName = resolvedSchemaKey;
   const fieldPath = dot >= 0 ? fieldRef.slice(dot + 1) : fieldRef;
   const leafName = fieldPath.split(".").pop();
   const matchesField = (val: string | null) =>

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -118,17 +118,20 @@ Examples:
       }
 
       if (fields.length === 0) {
+        // Use resolvedSchemaName (the canonical index key) so bare-name queries
+        // still produce the qualified name in output (e.g. "crm::customers" not
+        // "customers") — see sl-wfgx.
         if (opts.unmappedBy) {
           console.log(
-            `All fields in '${schemaName}' are mapped by '${opts.unmappedBy}'.`,
+            `All fields in '${resolvedSchemaName}' are mapped by '${opts.unmappedBy}'.`,
           );
         } else {
-          console.log(`${entityKind.charAt(0).toUpperCase() + entityKind.slice(1)} '${schemaName}' has no fields.`);
+          console.log(`${entityKind.charAt(0).toUpperCase() + entityKind.slice(1)} '${resolvedSchemaName}' has no fields.`);
         }
         return;
       }
 
-      printDefault(schemaName, fields, opts);
+      printDefault(resolvedSchemaName, fields, opts);
     });
 }
 

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -248,7 +248,9 @@ function printBlockNode(c: SyntaxNode, compact: boolean | undefined, indent: str
 }
 
 function printDefault(entry: MappingRecord, mappingNode: SyntaxNode | null, compact: boolean | undefined): void {
-  const nameStr = entry.name ? ` '${entry.name}'` : "";
+  // Use canonicalEntityName so the header includes the namespace prefix, e.g.
+  // "mapping 'warehouse::load hub_store'" not "mapping 'load hub_store'" (sl-qofc).
+  const nameStr = entry.name ? ` '${canonicalEntityName(entry)}'` : "";
   const metaNode = mappingNode?.namedChildren.find((c) => c.type === "metadata_block");
   const metaText = metaNode && !compact ? ` ${metaNode.text}` : "";
   console.log(`mapping${nameStr}${metaText} {`);

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -154,11 +154,14 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: W
         }
       }
 
-      return { scope: blockName, entries };
+      // Use the resolved canonical key as the scope so bare-name queries still
+      // produce the qualified name in output (e.g. "crm::customers" not "customers").
+      // resolvedName is updated by each successful resolveIndexKey call above (sl-wfgx).
+      return { scope: resolvedName, entries };
     }
   }
 
-  return { scope: blockName, entries: [] };
+  return { scope: resolvedName, entries: [] };
 }
 
 function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: WorkspaceIndex): MetaResult {

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -136,7 +136,10 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: W
     const parsed = parsedFiles.find((p) => p.filePath === entry.file);
     const node = parsed ? findBlockNode(parsed.tree.rootNode, blockType, key) : null;
     if (node) {
-      for (const item of extractNLContent(node, blockName)) {
+      // Pass the resolved canonical key (e.g. "warehouse::load dim_customer") as
+      // the parent scope rather than the user's raw query string, so that JSON
+      // "parent" fields and text output always show the qualified name (sl-wfgx).
+      for (const item of extractNLContent(node, key)) {
         items.push({ ...item, file: entry.file });
       }
     }

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -92,17 +92,22 @@ Examples:
       const refs = gatherRefs(resolvedName, index, parsedFiles, isSchema, isFragment, isTransform);
 
       if (opts.json) {
-        console.log(JSON.stringify({ name: canonicalKey(name), refs }, null, 2));
+        // Use resolvedName (the canonical index key) rather than the raw user
+        // query so that bare-name lookups produce the qualified form, e.g.
+        // "crm::customers" not "::customers" (sl-b0mq).
+        console.log(JSON.stringify({ name: canonicalKey(resolvedName), refs }, null, 2));
         if (refs.length === 0) process.exit(1);
         return;
       }
 
       if (refs.length === 0) {
-        console.log(`No references to '${name}' found.`);
+        // Use resolvedName in text output too so the header always shows the
+        // canonical qualified name regardless of how the user queried (sl-wfgx).
+        console.log(`No references to '${resolvedName}' found.`);
         process.exit(1);
       }
 
-      printDefault(name, refs);
+      printDefault(resolvedName, refs);
     });
 }
 

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -146,6 +146,11 @@ export interface NLRefData {
   mapping: string;
   namespace: string | null;
   targetField: string | null;
+  /** Set to "source_block" when the NL text comes from a join condition or
+   * filter expression in a source block. These refs must not generate
+   * NL-derived arrows — they describe relationships between sources, not
+   * data flow. */
+  context?: "source_block";
   line: number;
   column: number;
   file: string;

--- a/tooling/satsuma-cli/test/fixtures/namespace-output-bugs.stm
+++ b/tooling/satsuma-cli/test/fixtures/namespace-output-bugs.stm
@@ -1,0 +1,28 @@
+// Fixture for namespace output canonicalization regression tests.
+//
+// Covers sl-b0mq, sl-ltv6, sl-pb47, sl-qofc, sl-qxn5, sl-wfgx:
+// commands that previously echoed the user's bare query string instead of
+// the namespace-qualified canonical name in their output.
+
+namespace crm {
+  schema customers {
+    //! Some customer records may have NULL email
+    customer_id STRING (pk)
+    email       STRING (pii)
+  }
+
+  schema dim_customer {
+    customer_id STRING (pk)
+    email       STRING
+  }
+
+  mapping `load dim_customer` (note "Normalize CRM data") {
+    source { customers }
+    target { dim_customer }
+
+    customer_id -> customer_id
+    // The @ref here points to the arrow's own source field — should not
+    // produce a duplicate nl-derived arrow (sl-qxn5).
+    email -> email { "Normalize @crm::customers.email" }
+  }
+}

--- a/tooling/satsuma-cli/test/namespace-bugs.test.ts
+++ b/tooling/satsuma-cli/test/namespace-bugs.test.ts
@@ -7,6 +7,9 @@ import { run as _run } from "./helpers.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const FIXTURE = resolve(__dirname, "fixtures/namespace-collision.stm");
+const NS_FIXTURE = resolve(__dirname, "fixtures/namespaces.stm");
+// Fixture with namespace blocks used to verify output canonicalization bugs.
+const OUTPUT_BUGS_FIXTURE = resolve(__dirname, "fixtures/namespace-output-bugs.stm");
 
 const run = (...args: string[]) => _run(CLI, ...args);
 
@@ -85,5 +88,105 @@ describe("namespace collision regressions", () => {
     assert.ok(
       data.schema_edges.some((e: any) => e.from === "beta::customer_out" && e.to === "beta::customer_health" && e.role === "metric_source"),
     );
+  });
+});
+
+// ── Output canonicalization regressions ────────────────────────────────────────
+// These tests guard the family of bugs where CLI commands echoed the user's
+// raw query string instead of resolving to the namespace-qualified canonical name.
+
+describe("namespace output canonicalization regressions", () => {
+  it("sl-b0mq: where-used JSON 'name' field uses canonical name for bare-name queries", async () => {
+    // Bare query "customers" should resolve to "crm::customers" in JSON output,
+    // not produce a "::customers" (leading :: with no namespace) prefix.
+    const { stdout, code } = await run("where-used", "customers", OUTPUT_BUGS_FIXTURE, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.name, "crm::customers",
+      "JSON 'name' must be the qualified canonical key, not the bare query string");
+  });
+
+  it("sl-ltv6: arrows text header shows correct count for bare-name field queries", async () => {
+    // Querying with bare "customers.email" should produce the same arrow count
+    // in the header as the fully-qualified "crm::customers.email".
+    const { stdout: bareOut, code: bareCode } = await run("arrows", "customers.email", OUTPUT_BUGS_FIXTURE);
+    assert.equal(bareCode, 0);
+    const { stdout: qualOut, code: qualCode } = await run("arrows", "crm::customers.email", OUTPUT_BUGS_FIXTURE);
+    assert.equal(qualCode, 0);
+    // Both should show the same non-zero arrow count in the header line.
+    // The header format is "<field> — N arrow(s) (...)".
+    const extractCount = (out: string): string => out.split("\n")[0] ?? "";
+    assert.doesNotMatch(extractCount(bareOut), /— 0 arrows/,
+      "bare-name header must not report 0 arrows");
+    assert.match(extractCount(bareOut), /1 as source/,
+      "bare-name header must report 1 as source");
+    assert.equal(extractCount(bareOut).replace("customers.email", "crm::customers.email"),
+      extractCount(qualOut),
+      "bare-name and qualified arrow counts must match");
+  });
+
+  it("sl-pb47: warnings JSON 'block' field carries namespace-qualified name", async () => {
+    // A warning inside 'namespace crm { schema customers { //! ... } }' must
+    // report "block": "crm::customers", not just "block": "customers".
+    const { stdout, code } = await run("warnings", OUTPUT_BUGS_FIXTURE, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const item = data.items[0];
+    assert.ok(item, "expected at least one warning item");
+    assert.equal(item.block, "crm::customers",
+      "JSON 'block' must include the namespace prefix");
+  });
+
+  it("sl-qofc: mapping text output shows namespace-qualified name in header", async () => {
+    // The text-mode header must read "mapping 'crm::load dim_customer' {"
+    // rather than "mapping 'load dim_customer' {".
+    const { stdout, code } = await run("mapping", "crm::load dim_customer", OUTPUT_BUGS_FIXTURE);
+    assert.equal(code, 0);
+    assert.match(stdout, /mapping 'crm::load dim_customer'/,
+      "mapping text header must include namespace prefix");
+  });
+
+  it("sl-qxn5: arrows does not emit a duplicate nl-derived arrow when @ref is the arrow's own source", async () => {
+    // email -> email { "Normalize @crm::customers.email" }
+    // The @ref resolves to the same field as the explicit source, so only one
+    // arrow should appear — no redundant nl-derived duplicate.
+    const { stdout, code } = await run("arrows", "crm::customers.email", OUTPUT_BUGS_FIXTURE);
+    assert.equal(code, 0);
+    const arrowLines = stdout.split("\n").filter((l) => l.includes("->"));
+    assert.equal(arrowLines.length, 1,
+      "only the explicit arrow should appear; no duplicate nl-derived arrow");
+  });
+
+  it("sl-wfgx: nl JSON parent field uses canonical name for bare-name block queries", async () => {
+    // Querying with bare "load dim_customer" must produce items with
+    // "parent": "crm::load dim_customer", not "parent": "load dim_customer".
+    const { stdout, code } = await run("nl", "load dim_customer", OUTPUT_BUGS_FIXTURE, "--json");
+    assert.equal(code, 0);
+    const items = JSON.parse(stdout);
+    assert.ok(items.length > 0, "expected NL items for the mapping");
+    for (const item of items) {
+      if (item.parent) {
+        assert.equal(item.parent, "crm::load dim_customer",
+          "NL item parent must use the canonical qualified name");
+      }
+    }
+  });
+
+  it("sl-wfgx: mapping text output uses canonical name when queried by bare name", async () => {
+    // satsuma mapping 'load dim_customer' should show the qualified name in the header.
+    const { stdout, code } = await run("mapping", "load dim_customer", OUTPUT_BUGS_FIXTURE);
+    assert.equal(code, 0);
+    assert.match(stdout, /mapping 'crm::load dim_customer'/,
+      "text header must always show the namespace-qualified name");
+  });
+
+  it("sl-wfgx: where-used text header uses canonical name for bare-name queries", async () => {
+    // "References to 'crm::customers' (N):" not "References to 'customers' (N):".
+    const { stdout, code } = await run("where-used", "customers", OUTPUT_BUGS_FIXTURE);
+    assert.equal(code, 0);
+    assert.match(stdout, /References to 'crm::customers'/,
+      "text header must show the canonical qualified name");
+    assert.doesNotMatch(stdout, /References to 'customers' /,
+      "text header must not echo the bare query string");
   });
 });

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -456,13 +456,35 @@ function findParentBlock(node: SyntaxNode): { name: string | null; blockType: st
   while (current) {
     if (BLOCK_TYPES.has(current.type)) {
       const label = child(current, "block_label");
-      const name = label ? labelText(current) : null;
+      const bareName = label ? labelText(current) : null;
       const blockType = current.type.replace(/_block$/, "");
+      // Walk up further to see if this block sits inside a namespace_block so
+      // we can qualify the name (e.g. "crm::customers" not just "customers").
+      // This ensures the JSON `block` field in warnings/questions output carries
+      // the fully-qualified name needed to disambiguate same-named schemas in
+      // different namespaces (sl-pb47).
+      const name = bareName ? qualifyWithNamespace(current, bareName) : null;
       return { name, blockType };
     }
     current = current.parent;
   }
   return { name: null, blockType: null };
+}
+
+/**
+ * Walk up the CST from `blockNode` to find an enclosing namespace_block.
+ * If one is found, return "ns::name"; otherwise return `name` unchanged.
+ */
+function qualifyWithNamespace(blockNode: SyntaxNode, name: string): string {
+  let current = blockNode.parent;
+  while (current) {
+    if (current.type === "namespace_block") {
+      const nsName = child(current, "identifier");
+      return nsName ? `${nsName.text}::${name}` : name;
+    }
+    current = current.parent;
+  }
+  return name;
 }
 
 export interface ExtractedNote {

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -67,6 +67,10 @@ export interface NLRefDataItem {
   mapping: string;
   namespace: string | null;
   targetField: string | null;
+  /** Where in the mapping body this NL text came from. Source block NL text
+   * describes join conditions and filters — it must not generate NL-derived
+   * arrows. Absent means an arrow body or note block. */
+  context?: "source_block";
   line: number;
   column: number;
   file: string;
@@ -80,6 +84,9 @@ export interface ResolvedNLRef {
   mapping: string;
   namespace: string | null;
   targetField: string | null;
+  /** Propagated from the source NLRefDataItem. "source_block" means the ref
+   * came from a join condition or filter expression, not an arrow body. */
+  context?: "source_block";
   file: string;
   line: number;
   column: number;
@@ -365,6 +372,8 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
 
 // ── CST Walking ───────────────────────────────────────────────────────────────
 
+/** NLRefDataItem without the file path — used during CST walking before the
+ * file path is known. */
 export type NLRefDataItemNoFile = Omit<NLRefDataItem, "file">;
 
 /**
@@ -527,6 +536,9 @@ function walkArrowsForNL(
       continue;
     }
     if (c.type === "source_block") {
+      // NL text inside a source block describes join conditions and row filters,
+      // not data flow arrows. Mark these items so callers (e.g. arrow derivation)
+      // can skip them — but still include them for nl-refs reporting.
       const nlNodes = [
         ...c.namedChildren.filter((x) => x.type === "nl_string" || x.type === "multiline_string"),
         ...c.namedChildren
@@ -543,6 +555,7 @@ function walkArrowsForNL(
             mapping: mappingName,
             namespace,
             targetField: null,
+            context: "source_block",
             line: nlNode.startPosition.row,
             column: nlNode.startPosition.column,
           });
@@ -649,6 +662,7 @@ export function resolveAllNLRefs(
         mapping: mappingKey,
         namespace: item.namespace,
         targetField: item.targetField,
+        context: item.context,
         file: item.file,
         line,
         column,


### PR DESCRIPTION
## Summary

- **sl-b0mq**: `where-used --json` `name` field used raw query instead of resolved index key, producing `"::customers"` for bare-name queries instead of `"crm::customers"`
- **sl-ltv6**: `arrows` text header reported `0 arrows` for bare-name queries because `printDefault` compared the raw schema name against canonical index keys; fixed by threading `resolvedSchema.key` through
- **sl-pb47**: `warnings/questions --json` `block` field was always the bare block name; `findParentBlock` in `satsuma-core` now walks up to any enclosing `namespace_block` via a new `qualifyWithNamespace` helper
- **sl-qofc**: `mapping` text header used `entry.name` (bare) instead of `canonicalEntityName(entry)`, inconsistent with `--json` mode which was already correct
- **sl-qxn5**: `arrows` emitted a duplicate `nl-derived` arrow when an `@ref` pointed to the arrow's own source field — `nlMappingKey` was double-qualified (`crm::crm::...`) because `nlRef.mapping` from `resolveAllNLRefs` is already fully qualified; the mapping lookup returned null, disabling the dedup check
- **sl-wfgx**: `nl`, `meta`, `where-used` (text), and `fields` (unmapped-by messages) all echoed the user's raw query string; each now uses the resolved canonical key

## Test plan

- [x] Added 8 regression tests to `namespace-bugs.test.ts` covering all 6 bugs
- [x] Added `test/fixtures/namespace-output-bugs.stm` with a namespace fixture for the sl-pb47 and sl-qxn5 cases
- [x] Full test suite: 853 pass, 2 pre-existing failures (unchanged from `origin/main`)
- [x] Both `satsuma-core` and `satsuma-cli` build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)