### PR TITLE
fix: build satsuma-viz in release script; extend TS linting to tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,7 +84,45 @@ export default [
       "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     },
   },
-  // TypeScript files — type-aware linting
+  // TypeScript test files and the viz harness package (satsuma-cli tests, viz-harness
+  // source + tests) — baseline TypeScript rules without type-info (no tsconfig needed).
+  // Other TS packages (core, lsp, viz, vscode-satsuma) are linted incrementally as
+  // they are migrated to include test files in their tsconfigs.
+  ...tseslint.configs.recommended.map((config) => ({
+    ...config,
+    files: [
+      "tooling/satsuma-cli/test/**/*.ts",
+      "tooling/satsuma-viz-harness/**/*.ts",
+    ],
+  })),
+  {
+    files: [
+      "tooling/satsuma-cli/test/**/*.ts",
+      "tooling/satsuma-viz-harness/**/*.ts",
+    ],
+    rules: {
+      // Align with the JS convention used throughout the repo
+      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      // Non-null assertions require targeted inline suppression with a safety justification
+      "@typescript-eslint/no-non-null-assertion": "error",
+    },
+  },
+  // Test files — relax rules that are impractical to enforce in test code:
+  //   - no-explicit-any: test assertions commonly cast parsed output shapes to any
+  //     rather than defining full types for every intermediate result
+  //   - no-non-null-assertion: array accesses after expect(arr.length).toBe(N) are safe
+  //     but non-null assertions are the idiomatic way to narrow type in test code
+  {
+    files: ["tooling/satsuma-cli/test/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+  // satsuma-cli source files additionally get type-aware linting because the package
+  // has a tsconfig with strict settings that supports projectService inference.
+  // Test files are intentionally excluded here — they use import.meta.dirname (Node 22+)
+  // which requires module: "node22" or higher, while the current tsconfig targets node16.
   ...tseslint.configs.recommendedTypeChecked.map((config) => ({
     ...config,
     files: ["tooling/satsuma-cli/src/**/*.ts"],
@@ -98,9 +136,7 @@ export default [
       },
     },
     rules: {
-      // Align with existing JS convention
       "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-      // Non-null assertions require targeted inline suppression with a safety justification
       "@typescript-eslint/no-non-null-assertion": "error",
     },
   },

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -29,6 +29,9 @@ npm --prefix "$REPO_ROOT/tooling/satsuma-core" run build
 echo "==> Building satsuma-viz-backend..."
 npm --prefix "$REPO_ROOT/tooling/satsuma-viz-backend" run build
 
+echo "==> Building satsuma-viz..."
+npm --prefix "$REPO_ROOT/tooling/satsuma-viz" run build
+
 # --------------------------------------------------------------------------- #
 # 1. VS Code extension (.vsix)
 # --------------------------------------------------------------------------- #

--- a/tooling/satsuma-cli/test/errors.test.ts
+++ b/tooling/satsuma-cli/test/errors.test.ts
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it, beforeEach, afterEach } from "node:test";
-import { findSuggestion, loadFiles, notFound, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "#src/errors.js";
+import { findSuggestion, loadFiles, notFound, EXIT_NOT_FOUND } from "#src/errors.js";
 
 describe("findSuggestion", () => {
   it("returns exact case-insensitive match", () => {

--- a/tooling/satsuma-cli/test/fmt.test.ts
+++ b/tooling/satsuma-cli/test/fmt.test.ts
@@ -102,7 +102,7 @@ describe("satsuma fmt idempotency", () => {
 describe("satsuma fmt error handling", () => {
   it("skips files with parse errors and reports on stderr", async () => {
     const fixture = resolve(__dirname, "fixtures/parse-error.stm");
-    const { stderr, code } = await satsuma("fmt", "--check", fixture);
+    const { stderr } = await satsuma("fmt", "--check", fixture);
     // Should mention parse error but not crash
     assert.match(stderr, /parse error/i);
   });

--- a/tooling/satsuma-cli/test/namespace-bugs.test.ts
+++ b/tooling/satsuma-cli/test/namespace-bugs.test.ts
@@ -7,7 +7,6 @@ import { run as _run } from "./helpers.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const FIXTURE = resolve(__dirname, "fixtures/namespace-collision.stm");
-const NS_FIXTURE = resolve(__dirname, "fixtures/namespaces.stm");
 // Fixture with namespace blocks used to verify output canonicalization bugs.
 const OUTPUT_BUGS_FIXTURE = resolve(__dirname, "fixtures/namespace-output-bugs.stm");
 

--- a/tooling/satsuma-viz-harness/src/client/app.ts
+++ b/tooling/satsuma-viz-harness/src/client/app.ts
@@ -68,12 +68,23 @@ window.__satsumaHarness = harness;
 
 // ---------- DOM references ----------
 
-const fixtureListEl = document.getElementById("fixture-list")!;
-const fixtureLabelEl = document.getElementById("fixture-label")!;
-const sourceCodeEl = document.getElementById("source-code")!;
-const vizContainer = document.getElementById("viz-container")!;
-const readyBadge = document.getElementById("harness-ready-badge")!;
-const viewModeToggle = document.getElementById("view-mode-toggle")!;
+/**
+ * Retrieve a required DOM element by id.
+ * Throws a clear error if the element is absent — this indicates a mismatch
+ * between index.html and app.ts rather than a recoverable runtime condition.
+ */
+function getRequired(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`[harness] required element #${id} not found`);
+  return el;
+}
+
+const fixtureListEl = getRequired("fixture-list");
+const fixtureLabelEl = getRequired("fixture-label");
+const sourceCodeEl = getRequired("source-code");
+const vizContainer = getRequired("viz-container");
+const readyBadge = getRequired("harness-ready-badge");
+const viewModeToggle = getRequired("view-mode-toggle");
 
 // ---------- Viz element management ----------
 
@@ -269,9 +280,9 @@ async function init(): Promise<void> {
 
   // Pre-select the first fixture so the page is immediately useful.
   if (fixtures.length > 0) {
-    const firstUri = fixtures[0]!.uri;
+    const first = fixtures[0];
     const firstBtn = fixtureListEl.querySelector<HTMLButtonElement>(".fixture-item");
-    if (firstBtn) selectFixture(firstUri, firstBtn);
+    if (first && firstBtn) selectFixture(first.uri, firstBtn);
   }
 }
 


### PR DESCRIPTION
## Summary

- **Fixes failing release build**: `scripts/build-artifacts.sh` was missing the `satsuma-viz` build step. `npm run ci:all` installs but doesn't build satsuma-viz; the VS Code extension's esbuild then couldn't resolve `satsuma-viz/dist/satsuma-viz.js`. Added the build step between `satsuma-viz-backend` and the VS Code packaging.

- **Extends TypeScript linting to tests**: `eslint.config.mjs` now applies `tseslint.configs.recommended` (no type-info required) to `satsuma-cli` test files and the new `satsuma-viz-harness` package. Test files relax `no-explicit-any` and `no-non-null-assertion` (both are acceptable in assertion code). Three dead-variable violations fixed in test files; `app.ts` non-null DOM assertions replaced with a `getRequired()` helper.

## Test plan

- [ ] CI passes — release artifact build no longer fails on missing `satsuma-viz/dist/satsuma-viz.js`
- [ ] `npm run lint:js` passes with no errors (verified locally)
- [ ] `satsuma-cli` test suite passes — 855 tests (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)