### PR TITLE
docs: document viz harness Playwright workflow for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,56 @@ Tests should be high-value and low-inertia. A test suite is an asset only when t
 - **No smoke tests.** Do not write tests that only verify a function returns without throwing, or that a known-valid input produces a non-null result. Every assertion should validate a specific, meaningful property of the output.
 - **Name cases by behaviour, not by implementation.** Prefer `"reports a diagnostic when the same schema name appears in two files"` over `"duplicate schema test"`. The description should be a falsifiable statement about the system.
 
+### Viz harness Playwright tests (human-in-the-loop workflow)
+
+The `tooling/satsuma-viz-harness/` Playwright tests cannot run directly in the
+agent sandbox — Chromium and WebKit headless both crash on ARM macOS (SwiftShader
+SIGSEGV), and even Firefox must be launched from the user's terminal.
+
+**How this works:**
+
+The harness uses a sentinel-file protocol so the agent can trigger runs and read
+results without shell access to the browser process:
+
+1. The human runs the watcher once in a background terminal (from the harness directory):
+   ```
+   ./tooling/satsuma-viz-harness/watch-and-test.sh &
+   ```
+   The watcher polls for `.run-tests`, runs `npx playwright test` when it appears,
+   writes output to `.playwright-results.txt`, then removes the sentinel.
+
+2. The agent triggers a run by creating the sentinel:
+   ```bash
+   touch tooling/satsuma-viz-harness/.run-tests
+   ```
+
+3. The agent polls until the sentinel is gone (the watcher removes it immediately
+   on pickup), then reads `.playwright-results.txt` for results.
+
+**What to tell the human:**
+
+When you need Playwright test results, tell the user:
+
+> "Please run `./tooling/satsuma-viz-harness/watch-and-test.sh` in a terminal
+> from the repo root if it's not already running. I'll touch `.run-tests` to
+> trigger a run and read the results from `.playwright-results.txt`."
+
+Then touch the sentinel, wait for it to disappear (the watcher picks it up within
+1 second), and poll `.playwright-results.txt` until it contains `passed` or
+`failed`. A full run takes roughly 30–90 seconds.
+
+**Constraints to remember:**
+
+- **Never** try to run `npx playwright test` directly — it will be blocked or
+  will produce no usable output in the sandbox.
+- **Never** try to start a browser process directly.
+- The watcher kills any stale server on port 3333 before each run, so there is
+  no need to manage the server separately.
+- If `.playwright-results.txt` is stale (timestamp older than your sentinel
+  touch), wait longer — the watcher may still be running the suite.
+- Results from a prior run remain in `.playwright-results.txt` until the next
+  run overwrites them. Always check the file timestamp after triggering.
+
 ## Security
 
 CI runs `npm audit` and `gitleaks` secret scanning on every PR. Before pushing,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,11 +124,21 @@ results without shell access to the browser process:
 
 **What to tell the human:**
 
-When you need Playwright test results, tell the user:
+When you need Playwright test results, tell the user the **full absolute path**
+to the script — do not use a relative path.  You may be running inside a worktree
+at a non-obvious location (e.g. `.worktrees/feat/some-feature/`) and the human
+will not know which directory you mean without the full path.
 
-> "Please run `./tooling/satsuma-viz-harness/watch-and-test.sh` in a terminal
-> from the repo root if it's not already running. I'll touch `.run-tests` to
-> trigger a run and read the results from `.playwright-results.txt`."
+Example message:
+
+> "Please run this in a terminal if it's not already running:
+> `/Users/thorben/dev/personal/satsuma-lang/.worktrees/feat/viz-harness/tooling/satsuma-viz-harness/watch-and-test.sh`
+> I'll trigger runs by touching `.run-tests` in that same directory and read
+> results from `.playwright-results.txt` there."
+
+Substitute the actual absolute path for your current working directory.  Use
+`pwd` or inspect the path you are already using for file operations — you know
+it.  Never make the human guess where the worktree is.
 
 Then touch the sentinel, wait for it to disappear (the watcher picks it up within
 1 second), and poll `.playwright-results.txt` until it contains `passed` or


### PR DESCRIPTION
## Summary

- Adds a subsection under **Testing Expectations** in `AGENTS.md` / `CLAUDE.md` explaining the sentinel-file protocol for triggering Playwright runs from inside the agent sandbox
- Documents the exact wording agents should use when asking the human to start `watch-and-test.sh`
- Clarifies constraints: never run Playwright directly, never manage the server separately, check file timestamps to detect stale results

## Why this is needed

The viz harness Playwright tests require a human-launched browser process. Future agents working on viz components would otherwise try to run `npx playwright test` directly (which is blocked or crashes), or not know the sentinel-file protocol exists at all. This makes the workflow self-documenting in the place every agent reads first.

## Test plan

- [ ] `AGENTS.md` renders correctly — check the new section reads clearly
- [ ] CI passes (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)