### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,90 @@
 # Changelog
 
+## v0.7.0 — 2026-04-02
 
+### Language Simplification (Feature 28)
 
+- **All pipe steps are now NL.** The grammar no longer distinguishes structural
+  vs NL pipe steps — every step in a pipe chain is natural language. The
+  `structural` and `mixed` transform classifications are removed from the grammar,
+  core, CLI, LSP, viz-model, and viz component.
+- **`metric` keyword replaced with `schema(metric)` metadata.** Metrics are now
+  regular schemas with a `metric` metadata tag, making them valid both as sources
+  and targets. The dedicated `metric` keyword and its grammar rules are removed.
+- Pipeline tokens (`to_decimal`, `count`, `equals`, etc.) are reframed as
+  vocabulary conventions, not grammar-level constructs.
+- All canonical examples updated to the simplified syntax.
+
+### Standalone Viz Harness (Feature 29)
+
+- **New `@satsuma/viz-backend` package** extracts VizModel production logic from
+  the LSP into a shared package consumable by both the LSP and the harness.
+- **New `satsuma-viz-harness`** provides a fixture-driven browser app that renders
+  source code alongside the `<satsuma-viz>` web component. Includes syntax
+  highlighting, fixture picker, and lineage/single mode toggle.
+- **8 Playwright browser tests** covering overview rendering, detail view, hover
+  events, cross-file lineage, navigation intents, and layout stability.
+- LSP refactored to delegate viz model assembly to the shared backend.
+
+### VS Code Visualization
+
+- **@ref highlighting** in mapping detail and edge layer — `@ref` tokens in NL
+  transform text now render bold in a darker green for visual emphasis.
+- Full transitive lineage display with file-scope filter dropdown.
+- Field notes, arrow notes, and left-aligned transforms in the mapping detail.
+- Schema card labels capped at 400px width; minimap anchored to visible viewport.
+- Removed `ClassificationFilter` and structural CSS from field-lineage panel.
+- Removed pipeline/mixed rendering branches and orange edge colour.
+
+### LSP
+
+- **Symbol-level import reachability** — diagnostics now enforce that referenced
+  symbols are actually imported, not just file-level reachability.
+- **Core semantic diagnostics** via a new `SemanticIndex` adapter.
+- Migrated field extraction, spread resolution, classification, metadata
+  extraction, and CST text helpers from LSP into `@satsuma/core`.
+
+### CLI
+
+- **File-based entry points (ADR-022)** — the CLI now requires `.stm` file
+  arguments and rejects directory arguments. Import reachability determines the
+  workspace scope.
+- Fixed 3 lineage/graph JSON output bugs, 4 nl/arrows bugs, 6 validate/lint
+  bugs, and 4 diff/dispatch bugs.
+- Refactored `graph.ts` into `graph-builder.ts` and `graph-format.ts`.
+- Migrated all test files from JavaScript to TypeScript.
+- Added test coverage measurement with c8 and coverage summary in CI.
+- Standardized JSON output format across 7 CLI commands.
+
+### Core
+
+- Added source positions to `FieldDecl` and `startColumn` to `Extracted*` types.
+- Added escape handling to `stringText()`.
+- Consolidated extraction tests and fixed `sourceRefNameNs` regression.
+
+### Grammar
+
+- Simplified `pipe_text` — all steps are NL.
+- Restored parenthesized NL tokens in `pipe_text`.
+- Rejected empty backtick identifiers as parse errors.
+- Replaced `metric` keyword with `schema(metric)` metadata decoration.
+
+### Infrastructure
+
+- Extracted `satsuma-lsp` package from `vscode-satsuma/server` (ADR-021).
+- Core extraction consolidation (ADR-020) completed.
+- Added `satsuma-viz-harness` to root `install:all`, `ci:all`, and `clean:all`.
+- Added `build-artifacts.sh` for unified release artifact builds.
+- CI dependency bumps: actions/checkout v6, actions/setup-node v6,
+  actions/upload-artifact v7, dorny/test-reporter v3.
+- Retrospective ADRs 010–023 documenting implicit architectural decisions.
+
+### Documentation
+
+- Added Satsuma Diaries section to the website.
+- Archived 7 completed features (22–25, 29).
+- Reorganised `docs/` into `developer/` and `product-owner/` subfolders.
+- Added `adr-draft` skill for assessing and drafting ADRs.
 
 ## v0.6.0 — 2026-03-30
 

--- a/tooling/satsuma-cli/package.json
+++ b/tooling/satsuma-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satsuma-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Satsuma CLI — LLM context slicer for Satsuma workspaces",
   "license": "MIT",

--- a/tooling/satsuma-lsp/package.json
+++ b/tooling/satsuma-lsp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satsuma/lsp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Satsuma Language Server — standalone LSP for the Satsuma data mapping language",
   "type": "commonjs",

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -3,7 +3,7 @@
   "displayName": "Satsuma Language Support",
   "description": "VS Code language support for the Satsuma data mapping language",
   "license": "MIT",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "satsuma",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump CLI, LSP, and VS Code extension versions to 0.7.0
- Add comprehensive changelog covering all work since v0.6.0

## Highlights
- **Feature 28**: Language simplification — all pipe steps are NL, metric keyword removed
- **Feature 29**: Standalone viz harness with Playwright browser tests
- **@ref highlighting** in mapping detail and edge layer
- **Symbol-level import reachability** in LSP diagnostics
- **File-based CLI entry points** (ADR-022)
- Core extraction consolidation (ADR-020), LSP extraction (ADR-021)
- 48 bugs filed and fixed, retrospective ADRs 010–023

## After merge
Tag `v0.7.0` and trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)