### PR TITLE
feat(skills): add 5 agent skills and document install across runtimes

### DIFF
--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -15,6 +15,9 @@ Read the [Data Engineer Tutorial](docs/tutorials/data-engineer-tutorial.md) — 
 **How do I use Satsuma as an integration engineer?**
 Read the [Integration Engineer Tutorial](docs/tutorials/integration-engineer-tutorial.md) — covers using Satsuma for ESBs, APIs, message queues, and iPaaS platforms.
 
+**How do I reverse-engineer a folder of legacy Excel mapping spreadsheets into Satsuma?**
+Read the [Copilot + Excel reverse-engineering tutorial](docs/tutorials/copilot-excel-reverse-engineering-tutorial.md) — an end-to-end workflow for bootstrapping a fresh project in VS Code with GitHub Copilot agent mode, the Satsuma CLI, and the `excel-to-satsuma` skill.
+
 **How do I look up the full syntax?**
 Read the [language specification](docs/developer/SATSUMA-V2-SPEC.md). For a compact reference, see [AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md) or run `satsuma agent-reference`.
 

--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -133,7 +133,22 @@ Read [ARCHITECTURE.md](docs/developer/ARCHITECTURE.md) — covers the package ma
 Use the [Excel-to-Satsuma skill](skills/excel-to-satsuma/) or the [lite system prompt](useful-prompts/excel-to-stm-prompt.md) for web LLMs.
 
 **How do I generate an Excel workbook from a Satsuma file?**
-Use the [Satsuma-to-Excel lite prompt](useful-prompts/stm-to-excel-prompt.md) with any web LLM.
+Use the [satsuma-to-excel skill](skills/satsuma-to-excel/) or the [lite system prompt](useful-prompts/stm-to-excel-prompt.md) for web LLMs.
+
+**How do I explain a `.stm` file to a non-technical stakeholder?**
+Use the [satsuma-explainer skill](skills/satsuma-explainer/) — it produces plain-English walkthroughs, PII audits, coverage checks, and impact analysis from a Satsuma file or workspace.
+
+**How do I reverse-engineer Satsuma from an existing dbt project?**
+Use the [satsuma-from-dbt skill](skills/satsuma-from-dbt/) — it reads dbt models, sources, and lineage and emits idiomatic `.stm` mapping specs so you can adopt Satsuma without rewriting everything by hand.
+
+**How do I scaffold a dbt project from a Satsuma spec?**
+Use the [satsuma-to-dbt skill](skills/satsuma-to-dbt/) — it generates staging/marts, Kimball stars, Data Vault 2.0, and dbt exposures from `.stm` files, including governance metadata and merge strategies.
+
+**How do I generate synthetic test data from a Satsuma schema?**
+Use the [satsuma-sample-data skill](skills/satsuma-sample-data/) — it produces realistic CSV/JSON fixtures that respect types, enums, PII patterns, required fields, defaults, filters, and referential integrity across schemas.
+
+**How do I export Satsuma lineage to OpenLineage / Marquez / DataHub / Atlan?**
+Use the [satsuma-to-openlineage skill](skills/satsuma-to-openlineage/) — it emits OpenLineage JSON events with column-level lineage that any OpenLineage-compatible catalog can ingest.
 
 **How do I extract all natural-language strings and find schema references missing @ref?**
 Use the CLI to extract NL content and cross-reference it with known schema names. This is an agent workflow — give your AI agent these instructions:

--- a/README.md
+++ b/README.md
@@ -257,7 +257,15 @@ Start with Lesson 01 or jump to a [suggested reading path](lessons/README.md#sug
 - [tooling/tree-sitter-satsuma/](tooling/tree-sitter-satsuma): tree-sitter parser package
 - [tooling/satsuma-cli/](tooling/satsuma-cli): CLI tool for structural extraction and validation
 - [tooling/vscode-satsuma/](tooling/vscode-satsuma): VS Code extension with LSP server and syntax highlighting
-- [skills/excel-to-satsuma/](skills/excel-to-satsuma): Agent Skill for converting Excel mapping spreadsheets to Satsuma ([agentskills.io](https://agentskills.io) standard) — includes Python CLI tool and Claude Code slash command
+- [skills/](skills): Agent Skills following the [agentskills.io](https://agentskills.io) standard:
+  - [excel-to-satsuma](skills/excel-to-satsuma) — convert Excel mapping spreadsheets to Satsuma (Python CLI tool + Claude Code slash command)
+  - [satsuma-to-excel](skills/satsuma-to-excel) — generate stakeholder-ready Excel workbooks from `.stm` files
+  - [satsuma-explainer](skills/satsuma-explainer) — explain `.stm` files in plain English for business stakeholders, including PII audits, coverage checks, and impact analysis
+  - [satsuma-from-dbt](skills/satsuma-from-dbt) — reverse-engineer Satsuma specs from an existing dbt project
+  - [satsuma-to-dbt](skills/satsuma-to-dbt) — scaffold an idiomatic dbt project (Kimball, Data Vault, exposures) from `.stm` specs
+  - [satsuma-sample-data](skills/satsuma-sample-data) — generate realistic synthetic test data that respects schema constraints and referential integrity
+  - [satsuma-to-openlineage](skills/satsuma-to-openlineage) — emit OpenLineage events (Marquez/DataHub/Atlan/OpenMetadata) with column-level lineage
+  - [adr-draft](skills/adr-draft), [satsuma-diaries](skills/satsuma-diaries) — internal authoring helpers
 - [useful-prompts/](useful-prompts): self-contained system prompts for web LLMs ([Excel-to-Satsuma](useful-prompts/excel-to-stm-prompt.md), [Satsuma-to-Excel](useful-prompts/stm-to-excel-prompt.md))
 
 ## Current Status
@@ -275,10 +283,17 @@ What exists today:
 - data modelling conventions for Kimball and Data Vault patterns with canonical examples
 - pre-built CLI release artifacts published on every merge to `main`
 
-### Excel Conversion Tooling
+### Agent Skills
 
-- **Excel → Satsuma**: A full [Agent Skill](skills/excel-to-satsuma/) with a Python CLI tool (`excel_tool.py`) and a Claude Code slash command (`/excel-to-satsuma`). The skill surveys the spreadsheet, generates idiomatic Satsuma with chunked extraction, and self-critiques the output. A [lite prompt for web LLMs](useful-prompts/excel-to-stm-prompt.md) is also available for zero-setup conversion.
-- **Satsuma → Excel**: A [lite prompt for web LLMs](useful-prompts/stm-to-excel-prompt.md) that generates a Python script producing stakeholder-ready Excel workbooks from `.stm` files. A deterministic CLI tool is planned but not yet started.
+Satsuma ships a suite of [Agent Skills](skills/) that turn `.stm` files into a hub for the rest of your stack. Each skill is self-contained, follows the [agentskills.io](https://agentskills.io) standard, and works with any agent runtime that supports skills (Claude Code, Claude Desktop, etc.).
+
+- **Excel → Satsuma** ([excel-to-satsuma](skills/excel-to-satsuma)) — surveys a spreadsheet, generates idiomatic Satsuma with chunked extraction, and self-critiques the output. Includes a Python CLI tool and `/excel-to-satsuma` slash command. A [lite prompt for web LLMs](useful-prompts/excel-to-stm-prompt.md) is also available for zero-setup conversion.
+- **Satsuma → Excel** ([satsuma-to-excel](skills/satsuma-to-excel)) — produces stakeholder-ready Excel workbooks from `.stm` files. A [lite web-LLM prompt](useful-prompts/stm-to-excel-prompt.md) is also available.
+- **Explain a spec** ([satsuma-explainer](skills/satsuma-explainer)) — plain-English walkthroughs, risk assessments, PII audits, coverage checks, and impact analysis for non-technical stakeholders.
+- **dbt → Satsuma** ([satsuma-from-dbt](skills/satsuma-from-dbt)) — reverse-engineers Satsuma mapping specs from an existing dbt project so you can adopt Satsuma without starting over.
+- **Satsuma → dbt** ([satsuma-to-dbt](skills/satsuma-to-dbt)) — scaffolds an idiomatic dbt project (staging/marts, Kimball stars, Data Vault 2.0, exposures) from `.stm` specs.
+- **Synthetic test data** ([satsuma-sample-data](skills/satsuma-sample-data)) — generates realistic CSV/JSON fixtures from a schema, respecting types, enums, PII patterns, and referential integrity across tables.
+- **OpenLineage export** ([satsuma-to-openlineage](skills/satsuma-to-openlineage)) — emits OpenLineage events with column-level lineage for Marquez, DataHub, Atlan, and OpenMetadata.
 
 ## Multi-File Lineage
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Start with Lesson 01 or jump to a [suggested reading path](lessons/README.md#sug
 - [PROJECT-OVERVIEW.md](docs/product-owner/PROJECT-OVERVIEW.md): problem statement, vision, and roadmap
 - [SATSUMA-CLI.md](SATSUMA-CLI.md): CLI command reference (21 commands for structural extraction, analysis, and validation)
 - [AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md): compact grammar and quick reference for agents (also available via `satsuma agent-reference`)
-- [docs/tutorials/](docs/tutorials/): role-based tutorials (BA, data engineer, integration engineer)
+- [docs/tutorials/](docs/tutorials/): role-based tutorials (BA, data engineer, integration engineer) plus a [Copilot + Excel reverse-engineering workflow](docs/tutorials/copilot-excel-reverse-engineering-tutorial.md)
 - [USE_CASES.md](docs/product-owner/USE_CASES.md): practical scenarios and personas
 - [HOW-DO-I.md](HOW-DO-I.md): question-based index to all guides and conventions
 - [ROADMAP.md](docs/product-owner/ROADMAP.md): deferred work items, ideas, and convention docs still to write

--- a/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
+++ b/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
@@ -1,0 +1,413 @@
+# Reverse-Engineering Legacy Excel Mapping Specs with Satsuma, VS Code, and GitHub Copilot
+
+This tutorial walks through a real workflow for taking a stack of legacy Excel
+data-mapping documents (DMDs) and reverse-engineering them into a clean Satsuma
+workspace, using VS Code with GitHub Copilot in agent mode. It's written for the
+common situation where you have:
+
+- a directory full of inconsistent Excel mapping spreadsheets that have
+  accumulated over years (some current, some templates, some speculative,
+  some deprecated),
+- a small team that needs to understand, query, and modernise those mappings,
+- a desire to pilot Satsuma without first cloning the Satsuma repo or learning
+  every CLI command.
+
+The end result is a workspace where the original spreadsheets are version-
+controlled alongside generated `.stm` files, your AI agent knows how to talk to
+the Satsuma CLI idiomatically, and you can run a single chat command to convert
+a batch of spreadsheets at once.
+
+This is a *workflow* tutorial. If you want to learn the Satsuma language first,
+read the [BA tutorial](ba-tutorial.md) before you start.
+
+---
+
+## What you'll need
+
+- **VS Code** with the **GitHub Copilot** extension, signed in.
+- **Copilot agent mode** enabled, with at least one strong reasoning model
+  available (e.g. Claude Opus 4.6 or GPT-5.4). The workflow works with either,
+  but the reasoning step matters for the harder spreadsheets.
+- **The Satsuma VS Code extension** installed from the Marketplace. This gives
+  you syntax highlighting, diagnostics, hover, go-to-definition, and the
+  Satsuma LSP — without it the generated `.stm` files are much harder to
+  review.
+- **The Satsuma CLI** on your `PATH`. You don't need to clone the Satsuma
+  source repository — install the CLI from the published release artifacts
+  and confirm it works with `satsuma --version`.
+- **Python 3.10+** with `openpyxl` (the Excel-to-Satsuma skill manages its
+  own venv, but Python itself must be available).
+
+You do *not* need to clone `satsuma-lang`. You only need three things from
+that repo, and they all live under `skills/` and `AI-AGENT-REFERENCE.md` —
+we'll lift them into the new project in step 1.
+
+---
+
+## Step 1 — Create the project skeleton
+
+Make a fresh folder for the project, drop your spreadsheets into a
+`legacy-mappings/` subdirectory, and remove anything that isn't a current
+spec: templates, archived versions, "future" speculative specs, drafts.
+The point is to start with a corpus you actually trust.
+
+```
+my-mapping-project/
+├── legacy-mappings/        ← only the real, current spreadsheets
+│   ├── dimensions/
+│   ├── facts/
+│   └── reference/
+└── output/                 ← generated .stm files will land here
+```
+
+Open the folder in VS Code.
+
+### Pull in the Satsuma agent assets
+
+From a checkout (or a `git archive`) of `satsuma-lang`, copy two things into
+your project:
+
+1. The skills you want to use, into a `skills/` folder. For this workflow you
+   want at least:
+   - `excel-to-satsuma` — the spreadsheet → `.stm` converter (Python helper
+     plus a Claude Code slash command), and
+   - `satsuma-to-excel` — the round-trip generator, useful when you want to
+     hand a polished workbook back to a stakeholder.
+   You can also drop in `satsuma-explainer` and `satsuma-sample-data` if you
+   want plain-English walkthroughs and synthetic test data later.
+
+2. The agent reference file, written into the project root as `AGENTS.md`:
+
+   ```bash
+   satsuma agent-reference > AGENTS.md
+   ```
+
+   This is the same content as `AI-AGENT-REFERENCE.md` in the Satsuma repo,
+   but the `agent-reference` CLI command guarantees you get the version that
+   matches your installed CLI. Your AI agent will read this file to learn
+   the Satsuma grammar, conventions, common pitfalls, and the full CLI
+   command catalogue.
+
+> **Why `AGENTS.md` and not the original filename?** `AGENTS.md` is the
+> emerging convention for "instructions any coding agent should read first."
+> Both Claude Code and GitHub Copilot pick it up automatically, alongside
+> their own `.github/copilot-instructions.md` and `CLAUDE.md` files.
+
+---
+
+## Step 2 — Bootstrap the workspace with Copilot
+
+Open Copilot Chat in **Agent Mode** with a strong model selected, and run a
+single bootstrap prompt that tells the agent what you have and what you
+want:
+
+> We want to explore the legacy source-to-target mapping spreadsheets in
+> `legacy-mappings/` using the Satsuma tool and skills. The agent skills
+> are in `skills/`. Please set them up so VS Code with GitHub Copilot can
+> use them idiomatically, and create a `copilot-instructions.md` that
+> describes this project and its conventions.
+
+A reasoning-heavy model will:
+
+- inspect `AGENTS.md` to learn the Satsuma command catalogue,
+- read the `SKILL.md` files under `skills/` to understand each skill's
+  contract,
+- create `.github/copilot-instructions.md` with a project overview,
+  directory layout, key tools, conventions, and the standard workflow,
+- verify the `satsuma` CLI works (`satsuma --version`, `satsuma summary`),
+- verify the Excel helper script runs and that `openpyxl` is installed.
+
+After this step you should have:
+
+```
+my-mapping-project/
+├── .github/
+│   └── copilot-instructions.md   ← created by the agent
+├── AGENTS.md
+├── skills/
+│   ├── excel-to-satsuma/
+│   └── satsuma-to-excel/
+├── legacy-mappings/
+└── output/
+```
+
+> **Pitfall to watch for.** Some skills were written assuming the user has
+> the Satsuma source checkout and runs the CLI via `npx satsuma`. If you
+> installed the published CLI binary, the command is just `satsuma`. Skim
+> the generated `copilot-instructions.md` and the `SKILL.md` files for
+> `npx satsuma` and replace it with `satsuma` so the agent doesn't trip
+> over the wrong invocation.
+
+### Customise the workspace
+
+Once the bootstrap is done, ask Copilot to add a few project-specific
+helpers. These are the things that turn out to matter on every real
+project:
+
+- **A reusable "convert one spreadsheet" prompt.** A single chat command
+  that takes a spreadsheet path and runs the full convert → validate → lint
+  pipeline so you don't have to retype it. In VS Code Copilot this lives
+  in `.github/prompts/`.
+- **A "convert a batch" prompt.** Same idea, but takes a glob and converts
+  many spreadsheets in one go, summarising successes and failures per file.
+  Batch mode is the difference between a half-hour exploration and a
+  productive afternoon.
+- **An on-save instruction.** A scoped instruction file (Copilot calls
+  these `.github/instructions/*.instructions.md` with an `applyTo:` glob)
+  that runs `satsuma validate` and `satsuma lint` whenever a `.stm` file
+  is saved, so issues get flagged inline.
+- **A "BA-friendly" agent persona.** A custom agent under `.github/agents/`
+  that explains generated `.stm` files in plain English, focuses on
+  business meaning over syntax, and assumes no CLI knowledge — useful for
+  reviews with stakeholders.
+
+---
+
+## Step 3 — Convert your first spreadsheet (dry run)
+
+Pick the smallest, cleanest spreadsheet in `legacy-mappings/` and run the
+skill in **dry-run mode** first. In Copilot Chat:
+
+> @excel-to-satsuma `legacy-mappings/dimensions/customer.xlsx` `output/` --dry-run
+
+What you should expect:
+
+1. Copilot recognises the skill and loads `SKILL.md`.
+2. It runs the Python helper to **survey** the spreadsheet — every sheet,
+   every header row, sample values, formatting clues, merged cells.
+3. It writes a *discovery report* to `output/.excel-to-satsuma/` describing
+   what it found. This is the most valuable artifact of the dry run: it
+   tells you what shape the spreadsheet really has, and surfaces any data
+   quality flags it noticed (length mismatches between source and target
+   columns, undocumented enum values, SCD-2 patterns, suspicious header
+   labels, etc.).
+4. Because you passed `--dry-run`, no `.stm` file is written.
+
+Read the discovery report. It will tell you, in concrete terms, whether
+the spreadsheet's structure matches what the skill expects, or whether
+it's a one-of-a-kind layout that needs manual intervention.
+
+> **Approval prompts.** The first time you run a skill, Copilot will ask
+> you to approve the Python invocation, the venv creation, and the file
+> reads. Click through them — for the rest of the session you can switch
+> Copilot to "Allow All Commands in this session" so the agent doesn't
+> have to keep stopping for permission.
+
+---
+
+## Step 4 — Convert for real, then review
+
+Once the dry run looks reasonable, run the full conversion either as a
+direct skill invocation or via the reusable prompt you created in step 2:
+
+> /convert-one-spreadsheet `legacy-mappings/dimensions/customer.xlsx`
+
+The agent will:
+
+1. Re-survey the spreadsheet,
+2. Generate a `.stm` file under `output/`,
+3. Run `satsuma fmt` to apply canonical formatting,
+4. Run `satsuma validate` to catch parse errors and unresolved references,
+5. Run `satsuma lint --fix` to apply safe auto-corrections,
+6. Write a per-file review report in `output/` describing what was
+   generated and what assumptions it made.
+
+A *single* spreadsheet can take a few minutes, especially with a heavyweight
+reasoning model. This is normal — the model is reading every row, deciding
+which transforms are deterministic pipelines and which need natural-language
+descriptions, and double-checking against the rules in `AGENTS.md`. **Batch
+mode is much more efficient** because the agent can survey many sheets in
+one planning pass before generating any output.
+
+### Review the result
+
+Open the generated `.stm` file. Because you have the Satsuma VS Code
+extension installed, you get:
+
+- syntax highlighting and folding,
+- inline diagnostics from `satsuma validate` / `satsuma lint`,
+- hover info on schemas, fields, and `@ref` references,
+- the **Satsuma mapping visualisation** panel — this is where the workflow
+  really pays off: a single click renders the source/target schemas, every
+  arrow, and every transform as an interactive diagram, which is by far
+  the easiest way to spot missing fields and questionable transforms.
+
+If something looks wrong, fix it in the `.stm` file directly and re-run
+`satsuma validate`. The `.stm` file is the source of truth from this
+point on; the original spreadsheet is now a historical artifact.
+
+---
+
+## Step 5 — Batch convert and consolidate
+
+Now switch to the batch prompt:
+
+> /convert-batch `legacy-mappings/dimensions/customer*`
+
+The agent will discover all matching spreadsheets, plan the conversion,
+and generate one `.stm` per file. Each file should declare its own
+namespace or prefix to avoid duplicate-definition errors when several
+spreadsheets describe overlapping source systems.
+
+### Things you'll learn the hard way (so we'll save you the trouble)
+
+These are the rules worth adding to your project's `AGENTS.md` *before*
+you run the first batch — they make the difference between a clean run
+and an afternoon of cleanup:
+
+- **Always write to `output/`** and never overwrite existing `.stm` files
+  silently. If a target file exists, the agent should `STOP` and check
+  with you — or at least update the existing file with a comment about
+  the new source instead of clobbering it.
+- **Per-file review reports must have unique filenames.** A naive batch
+  run will write `review.md` for every file and the last one wins. Tell
+  the agent to suffix review reports with the input filename.
+- **Provenance metadata on every block.** Every generated `schema`,
+  `mapping`, and `fragment` should carry a `(note "source: <filename>")`
+  or a top-level comment so you can trace any block back to the
+  spreadsheet it came from.
+- **Check for near-duplicates before writing.** Real-world spreadsheets
+  re-document the same source table with slightly different column lists.
+  The agent should run `satsuma summary` and `satsuma where-used` against
+  the existing `output/` directory and *re-use* an existing schema rather
+  than create a near-duplicate.
+- **Track progress in a top-level `files-we-have-done.md`** with a
+  timestamped list of converted files, so a long-running batch can be
+  resumed and so reviewers can see what's done at a glance.
+- **Self-contained `.stm` files.** Assume the original spreadsheets will
+  be lost, archived, or moved at some point. The Satsuma file must
+  *contain* every transform rule it needs — no "see the SQL in the
+  original DMD" cop-outs. If the agent finds itself wanting to write
+  that, it should write a natural-language transform with `@ref`s
+  instead.
+- **Multi-source NL transforms should declare their inputs.** When a
+  natural-language transform mentions `@a`, `@b`, `@c` from upstream
+  schemas, prefer the explicit form `a, b, c -> d { "..." }` over a
+  bare `-> d { "..." }`. It makes the lineage traceable.
+
+Add these as bullet points under a `## Converting Excel to Satsuma`
+section in your project's `AGENTS.md`. The agent will read them on every
+run.
+
+### Syntax mistakes that catch every model
+
+These are pitfalls Copilot (with either Opus or GPT) will fall into
+repeatedly until you tell it not to. Add them to `AGENTS.md` once and
+you'll save yourself dozens of failed validations:
+
+- **`::` is for namespaces, not field access.** The syntax is
+  `namespace::schema.field.inner_field`. Use `::` only between a
+  namespace and a schema. Field access is always `.`.
+- **Prefer `lower_snake_case`** for schemas, namespaces, mappings, and
+  fragments. It avoids the constant need to backtick-quote
+  `kebab-cased-names`.
+- **`@ref` is mandatory inside NL strings.** Bare field names inside
+  `"..."` are invisible to lineage tooling — every reference to a field
+  or schema inside a natural-language transform must be `@field` or
+  `@schema.field`.
+
+---
+
+## Step 6 — Refactor for human readability
+
+After the first batch you'll typically have a folder of `.stm` files
+with cryptic legacy table names (`TB_`, `DIM_`, `OCR_`, etc). Don't try
+to fix this in the first pass — get the conversion done first, then run
+a *second* pass to refactor for readability.
+
+Ask Copilot:
+
+> For the tables generated in this batch, group them under a sensible
+> namespace and rename the schemas to friendly snake_case names that
+> reflect their business meaning. Use schema metadata of the form
+> `(table_name "ORIGINAL_LEGACY_NAME")` to keep the link back to the
+> original. The original legacy name should be an implementation detail,
+> not the primary identifier.
+
+The result is a workspace where humans see `customer_dimension` and
+tooling can still resolve it back to `TB_DW_CUSTOMER_DIM`.
+
+You can do the same for fields if their legacy names are particularly
+unfriendly, but in practice the schema-level rename gives most of the
+readability win for far less churn.
+
+---
+
+## Step 7 — Commit, version, and iterate
+
+By the end of this workflow you should have a Git repository with:
+
+- `legacy-mappings/` — the original spreadsheets, ideally `.gitignore`d
+  if they contain anything sensitive,
+- `output/` — generated `.stm` files (committed),
+- `output/review_*.md` — per-file review reports (committed),
+- `files-we-have-done.md` — running progress log (committed),
+- `AGENTS.md` and `.github/copilot-instructions.md` — the prompts that
+  taught the agent how to work in this project (committed).
+
+Once everything is in Git, the round-trip is easy: `satsuma diff old/ new/`
+shows structural deltas between snapshots, the VS Code visualisation
+panel renders any `.stm` file you click on, and you can ask Copilot to
+explain any mapping in plain English using the `satsuma-explainer` skill.
+
+---
+
+## A few hard-won lessons
+
+A handful of things that came out of running this workflow on a real
+project, in order of how much pain they saved:
+
+1. **Use the dry-run first, every time.** A 10-second discovery report
+   tells you whether the spreadsheet is going to convert cleanly or
+   whether you need to hand-prep it. Skipping the dry-run wastes far
+   more time than running it.
+
+2. **Batch mode is the productivity unlock.** A single-file conversion
+   takes the same wall-clock time whether the model planned for one file
+   or for twenty, because most of the latency is in the reasoning pass.
+   Always convert in batches when you can.
+
+3. **Try at least two reasoning models.** Different models have
+   different blind spots. A model that consistently wants to use
+   `schema::field` (wrong) might be fine on transform decomposition,
+   while a model that gets the syntax right might cop out and write
+   "apply the SQL from the original spreadsheet" instead of a real
+   natural-language transform. Pick whichever is wrong less often on
+   *your* spreadsheets.
+
+4. **Keep `AGENTS.md` as a living rules file.** Every time the agent
+   makes the same mistake twice, add a bullet point to `AGENTS.md`.
+   After a week of this, the file becomes the single most valuable
+   document in the project — it captures the implicit knowledge that
+   would otherwise live only in your head.
+
+5. **The visualisation panel is the review tool.** Reviewing `.stm`
+   files as text is fine for engineers; reviewing them as diagrams is
+   what makes business stakeholders trust the output. Lead with the
+   visualisation when you walk a BA through a generated mapping.
+
+6. **Don't try to make it perfect on the first pass.** Get the
+   conversion done; refactor for readability afterwards; consolidate
+   duplicates afterwards; rename for friendliness afterwards. Each
+   pass is much faster than trying to do everything at once, and the
+   intermediate state is always valid Satsuma you can validate, lint,
+   and visualise.
+
+---
+
+## Where to go next
+
+- The [Business Analyst tutorial](ba-tutorial.md) — learn the Satsuma
+  language itself if you skipped it.
+- The [data engineer tutorial](data-engineer-tutorial.md) — once you
+  have a clean `.stm` workspace, this shows you how to drive
+  implementation from it.
+- The [`satsuma-explainer`](../../skills/satsuma-explainer/) skill —
+  generates plain-English walkthroughs of any `.stm` file for
+  stakeholder reviews.
+- The [`satsuma-to-dbt`](../../skills/satsuma-to-dbt/) skill — once
+  your mappings are in Satsuma, scaffold a dbt project from them.
+- The [`satsuma-sample-data`](../../skills/satsuma-sample-data/) skill —
+  generate realistic synthetic test data from your new schemas, useful
+  for stress-testing the converted mappings before pointing them at
+  production data.

--- a/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
+++ b/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
@@ -135,24 +135,58 @@ my-mapping-project/
 
 Once the bootstrap is done, ask Copilot to add a few project-specific
 helpers. These are the things that turn out to matter on every real
-project:
+project. You can ask for them all at once with a single prompt:
 
-- **A reusable "convert one spreadsheet" prompt.** A single chat command
-  that takes a spreadsheet path and runs the full convert → validate → lint
-  pipeline so you don't have to retype it. In VS Code Copilot this lives
-  in `.github/prompts/`.
-- **A "convert a batch" prompt.** Same idea, but takes a glob and converts
-  many spreadsheets in one go, summarising successes and failures per file.
-  Batch mode is the difference between a half-hour exploration and a
-  productive afternoon.
-- **An on-save instruction.** A scoped instruction file (Copilot calls
-  these `.github/instructions/*.instructions.md` with an `applyTo:` glob)
-  that runs `satsuma validate` and `satsuma lint` whenever a `.stm` file
-  is saved, so issues get flagged inline.
-- **A "BA-friendly" agent persona.** A custom agent under `.github/agents/`
-  that explains generated `.stm` files in plain English, focuses on
-  business meaning over syntax, and assumes no CLI knowledge — useful for
-  reviews with stakeholders.
+> Please add the following to this workspace so we can work productively
+> with the Satsuma skills:
+>
+> 1. A reusable Copilot prompt under `.github/prompts/convert-one.prompt.md`
+>    that takes a spreadsheet path as input and runs the full
+>    `excel-to-satsuma` skill end-to-end: survey, generate the `.stm`
+>    file under `output/`, run `satsuma fmt`, then `satsuma validate`,
+>    then `satsuma lint --fix`, and finally write a per-file review
+>    report (suffixed with the input filename so it doesn't clobber
+>    other reports).
+>
+> 2. A second prompt at `.github/prompts/convert-batch.prompt.md` that
+>    takes a glob (e.g. `legacy-mappings/dimensions/*.xlsx`), surveys
+>    every matching file in one planning pass, then runs the same
+>    convert → fmt → validate → lint pipeline for each one. At the end
+>    it should print a summary of which files succeeded, which failed,
+>    and append the successful filenames with timestamps to a top-level
+>    `files-we-have-done.md`.
+>
+> 3. An auto-validate instruction at
+>    `.github/instructions/satsuma-on-save.instructions.md` with
+>    `applyTo: "output/**/*.stm"` that runs `satsuma validate` and
+>    `satsuma lint` against any `.stm` file under `output/` and surfaces
+>    the diagnostics inline.
+>
+> 4. A custom Copilot agent under `.github/agents/satsuma-explainer.md`
+>    aimed at Business Analysts: it should assume no CLI knowledge,
+>    explain a `.stm` file in plain English using business terms, focus
+>    on the meaning of each mapping rather than its syntax, and never
+>    suggest CLI commands to the user.
+>
+> Use the `satsuma agent-reference` output in `AGENTS.md` and the
+> `SKILL.md` files under `skills/` as the source of truth for which
+> commands and skill invocations to call.
+
+Why each one matters:
+
+- **`convert-one`** turns the full convert → validate → lint pipeline
+  into one chat command, so you stop retyping the same flag soup.
+- **`convert-batch`** is the productivity unlock — most of the latency
+  in a single-file conversion is the model's planning pass, and that
+  cost is amortised across the whole batch when you convert many files
+  in one go. It also prevents the agent from forgetting halfway through
+  a long run, because the progress log is durable.
+- **The on-save instruction** means a stale `.stm` file with broken
+  references can never sit unnoticed in the workspace — every save
+  re-runs validation in the background.
+- **The BA-friendly agent** is what you switch to when a stakeholder
+  is in the room. The default Copilot persona will happily talk about
+  CST nodes and lint rules; this one stays in business language.
 
 ---
 
@@ -304,7 +338,7 @@ you'll save yourself dozens of failed validations:
 ## Step 6 — Refactor for human readability
 
 After the first batch you'll typically have a folder of `.stm` files
-with cryptic legacy table names (`TB_`, `DIM_`, `OCR_`, etc). Don't try
+with cryptic legacy table names. Don't try
 to fix this in the first pass — get the conversion done first, then run
 a *second* pass to refactor for readability.
 
@@ -318,7 +352,7 @@ Ask Copilot:
 > not the primary identifier.
 
 The result is a workspace where humans see `customer_dimension` and
-tooling can still resolve it back to `TB_DW_CUSTOMER_DIM`.
+tooling can still resolve it back to `TAB_DWH_CUSTOMER_DIM2`.
 
 You can do the same for fields if their legacy names are particularly
 unfriendly, but in practice the schema-level rename gives most of the

--- a/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
+++ b/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
@@ -1,7 +1,7 @@
 # Reverse-Engineering Legacy Excel Mapping Specs with Satsuma, VS Code, and GitHub Copilot
 
 This tutorial walks through a real workflow for taking a stack of legacy Excel
-data-mapping documents (DMDs) and reverse-engineering them into a clean Satsuma
+data-mapping documents and reverse-engineering them into a clean Satsuma
 workspace, using VS Code with GitHub Copilot in agent mode. It's written for the
 common situation where you have:
 
@@ -304,7 +304,7 @@ and an afternoon of cleanup:
 - **Self-contained `.stm` files.** Assume the original spreadsheets will
   be lost, archived, or moved at some point. The Satsuma file must
   *contain* every transform rule it needs — no "see the SQL in the
-  original DMD" cop-outs. If the agent finds itself wanting to write
+  original spreadsheet" cop-outs. If the agent finds itself wanting to write
   that, it should write a natural-language transform with `@ref`s
   instead.
 - **Multi-source NL transforms should declare their inputs.** When a

--- a/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
+++ b/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
@@ -28,7 +28,7 @@ read the [BA tutorial](ba-tutorial.md) before you start.
 - **Copilot agent mode** enabled, with at least one strong reasoning model
   available (e.g. Claude Opus 4.6 or GPT-5.4). The workflow works with either,
   but the reasoning step matters for the harder spreadsheets.
-- **The Satsuma VS Code extension** installed from the Marketplace. This gives
+- **The Satsuma VS Code extension** installed (see repo instructions). This gives
   you syntax highlighting, diagnostics, hover, go-to-definition, and the
   Satsuma LSP — without it the generated `.stm` files are much harder to
   review.
@@ -130,13 +130,6 @@ my-mapping-project/
 ├── legacy-mappings/
 └── output/
 ```
-
-> **Pitfall to watch for.** Some skills were written assuming the user has
-> the Satsuma source checkout and runs the CLI via `npx satsuma`. If you
-> installed the published CLI binary, the command is just `satsuma`. Skim
-> the generated `copilot-instructions.md` and the `SKILL.md` files for
-> `npx satsuma` and replace it with `satsuma` so the agent doesn't trip
-> over the wrong invocation.
 
 ### Customise the workspace
 

--- a/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
+++ b/docs/tutorials/copilot-excel-reverse-engineering-tutorial.md
@@ -316,22 +316,25 @@ Add these as bullet points under a `## Converting Excel to Satsuma`
 section in your project's `AGENTS.md`. The agent will read them on every
 run.
 
-### Syntax mistakes that catch every model
+### A note on common syntax pitfalls
 
-These are pitfalls Copilot (with either Opus or GPT) will fall into
-repeatedly until you tell it not to. Add them to `AGENTS.md` once and
-you'll save yourself dozens of failed validations:
+There are a handful of Satsuma syntax mistakes that every model — Opus,
+GPT, and others — used to fall into repeatedly: confusing `::` (which
+joins a namespace to a schema) with `.` (which joins a schema to a
+field), preferring `kebab-case` names that need backticks, and dropping
+`@ref` markers inside natural-language transform strings (which makes
+them invisible to lineage tooling).
 
-- **`::` is for namespaces, not field access.** The syntax is
-  `namespace::schema.field.inner_field`. Use `::` only between a
-  namespace and a schema. Field access is always `.`.
-- **Prefer `lower_snake_case`** for schemas, namespaces, mappings, and
-  fragments. It avoids the constant need to backtick-quote
-  `kebab-cased-names`.
-- **`@ref` is mandatory inside NL strings.** Bare field names inside
-  `"..."` are invisible to lineage tooling — every reference to a field
-  or schema inside a natural-language transform must be `@field` or
-  `@schema.field`.
+The good news is that the `satsuma agent-reference` output you wrote
+into `AGENTS.md` in step 1 already calls each of these out — there's a
+dedicated *Path syntax — :: vs .* section, a *snake_case is preferred*
+note, an `@ref in NL strings (CRITICAL)` section, and they all reappear
+in the *Common mistakes* table at the bottom. So as long as your
+`AGENTS.md` is current, you don't need to add them again.
+
+If you find yourself fighting one of these recurring mistakes anyway,
+the most likely cause is that `AGENTS.md` is out of date. Re-run
+`satsuma agent-reference > AGENTS.md` and try again.
 
 ---
 

--- a/site/index.njk
+++ b/site/index.njk
@@ -573,8 +573,8 @@ permalink: index.html
                 <span class="text-white text-xs font-bold">4</span>
               </div>
               <div>
-                <p class="text-sm font-semibold text-charcoal">Convert from Excel</p>
-                <p class="text-xs text-warm-gray">Use the self-contained conversion prompt &mdash; no installation needed.</p>
+                <p class="text-sm font-semibold text-charcoal">Use Agent Skills</p>
+                <p class="text-xs text-warm-gray">Drop-in <a href="https://github.com/thorbenlouw/satsuma-lang/tree/main/skills" class="text-orange hover:underline">Agent Skills</a> for Excel &harr; Satsuma, dbt &harr; Satsuma, OpenLineage export, synthetic test data, and plain-English spec explainers.</p>
               </div>
             </div>
           </div>
@@ -609,6 +609,7 @@ permalink: index.html
           </summary>
           <div class="px-6 pb-5 text-warm-gray leading-relaxed">
             <p>Satsuma is designed to be read and written by AI agents. Give your coding agent &mdash; GitHub Copilot, OpenAI Codex, Claude Code, Cursor, Windsurf, or any agentic coding tool &mdash; a <code>.stm</code> file and it can generate high-fidelity scaffolds for frameworks like <strong>dbt on Snowflake</strong>, <strong>Databricks Lakehouse Declarative Pipelines</strong>, <strong>pandas</strong>, <strong>dltHub</strong>, <strong>DuckDB</strong>, <strong>PySpark</strong>, and more. The structured syntax means the agent doesn't have to guess where a field name ends and a business rule begins &mdash; ambiguity is made explicit, so the generated code is better.</p>
+            <p class="mt-3">Satsuma also ships a suite of <a href="https://github.com/thorbenlouw/satsuma-lang/tree/main/skills" class="text-orange hover:underline font-semibold">Agent Skills</a> (following the <a href="https://agentskills.io" class="text-orange hover:underline">agentskills.io</a> standard) that work out of the box with Claude Code and Claude Desktop: convert <strong>Excel &harr; Satsuma</strong>, reverse-engineer specs from <strong>dbt</strong>, scaffold dbt projects, generate <strong>synthetic test data</strong>, export <strong>OpenLineage</strong> events, and produce plain-English <strong>spec explanations</strong> for stakeholders.</p>
           </div>
         </details>
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,142 @@
+# Satsuma Agent Skills
+
+This directory contains [Agent Skills](https://agentskills.io) for working with
+Satsuma (`.stm`) mapping specs. Each subdirectory is a self-contained skill —
+a `SKILL.md` file with YAML frontmatter (name, description, allowed tools) plus
+any reference docs, scripts, or templates the skill needs.
+
+## Available skills
+
+| Skill | What it does |
+| --- | --- |
+| [`excel-to-satsuma`](excel-to-satsuma) | Convert Excel mapping spreadsheets into idiomatic Satsuma. Includes a Python helper CLI and a Claude Code slash command. |
+| [`satsuma-to-excel`](satsuma-to-excel) | Generate stakeholder-ready Excel workbooks from `.stm` files. |
+| [`satsuma-explainer`](satsuma-explainer) | Plain-English walkthroughs, PII audits, coverage checks, and impact analysis of `.stm` files for non-technical stakeholders. |
+| [`satsuma-from-dbt`](satsuma-from-dbt) | Reverse-engineer Satsuma mapping specs from an existing dbt project. |
+| [`satsuma-to-dbt`](satsuma-to-dbt) | Scaffold an idiomatic dbt project (Kimball stars, Data Vault 2.0, exposures) from `.stm` specs. |
+| [`satsuma-sample-data`](satsuma-sample-data) | Generate realistic synthetic test data that respects schema constraints, PII patterns, and referential integrity. |
+| [`satsuma-to-openlineage`](satsuma-to-openlineage) | Emit OpenLineage events with column-level lineage for Marquez, DataHub, Atlan, and OpenMetadata. |
+| [`adr-draft`](adr-draft) | Internal helper: assess whether a change warrants an ADR and draft one. |
+| [`satsuma-diaries`](satsuma-diaries) | Internal helper: write project diary entries in the established style. |
+
+Most skills work best when the [`satsuma` CLI](../tooling/satsuma-cli) is on
+your `PATH`, since they call commands like `satsuma summary`, `satsuma lineage`,
+and `satsuma validate` to extract structured information from `.stm` files
+instead of guessing from raw text.
+
+## Installing a skill
+
+Agent Skills are a portable, file-based standard, but each agent runtime
+discovers them in a slightly different way. Pick the section that matches
+the tool you're using.
+
+### Claude Code (CLI)
+
+Claude Code auto-discovers skills from a few well-known locations. The
+simplest install is to symlink (or copy) the skill folder into your user-level
+skills directory so it's available across every project:
+
+```bash
+mkdir -p ~/.claude/skills
+ln -s "$(pwd)/skills/satsuma-explainer" ~/.claude/skills/satsuma-explainer
+```
+
+Repeat for any other skills you want. Restart Claude Code (or run `/skills`)
+and the skill should appear in the list. To install a skill for a single
+project only, drop it under `.claude/skills/` inside that project instead.
+
+You can also keep this repository checked out anywhere on disk and symlink
+individual skills into multiple projects — the skill folder is the unit of
+distribution, and a symlink is enough.
+
+### Claude Desktop
+
+Claude Desktop loads skills from your user skills directory the same way
+Claude Code does. The exact path depends on your OS:
+
+- **macOS:** `~/Library/Application Support/Claude/skills/`
+- **Windows:** `%APPDATA%\Claude\skills\`
+- **Linux:** `~/.config/Claude/skills/`
+
+Copy or symlink the skill directory in, then restart Claude Desktop. The
+skill becomes available in any conversation; Claude will trigger it
+automatically when the user's request matches the skill's `description`.
+
+### GitHub Copilot (VS Code, CLI, coding agent)
+
+GitHub Copilot has [native support](https://github.blog/changelog/2025-12-18-github-copilot-now-supports-agent-skills/)
+for `agentskills.io`-format skills across Copilot in VS Code, the Copilot
+CLI, and the Copilot coding agent. The format is identical to the files
+in this directory, so installation is just a copy or symlink:
+
+- **Per-project (committed to the repo):** drop the skill into
+  `.github/skills/<skill-name>/` so the whole team picks it up.
+  ```bash
+  mkdir -p .github/skills
+  cp -r path/to/satsuma-lang/skills/satsuma-explainer .github/skills/
+  ```
+- **Personal (across all your projects):** put it under your user-level
+  Copilot skills directory instead. See the [VS Code Agent Skills docs](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+  for the exact path on your platform and for the UI to manage skills
+  inside VS Code.
+
+Because the format is shared, the *same* skill folder can live in
+`.claude/skills/`, `.github/skills/`, and `.codex/skills/` simultaneously —
+symlinking from one canonical checkout of this repo is the cleanest setup.
+See GitHub's [Creating agent skills for Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills)
+guide for the authoring contract Copilot expects (which matches what these
+skills already follow).
+
+### OpenAI Codex CLI
+
+Codex CLI also has [native skill support](https://developers.openai.com/codex/skills).
+A skill is a directory with a `SKILL.md` plus optional scripts and
+references — exactly what's in this folder.
+
+- **Personal install:** copy or symlink the skill into `~/.codex/skills/`.
+  ```bash
+  mkdir -p ~/.codex/skills
+  ln -s "$(pwd)/skills/satsuma-to-dbt" ~/.codex/skills/satsuma-to-dbt
+  ```
+- **Project install (committed to the repo):** put it under
+  `.codex/skills/<skill-name>/` in the project root so everyone using
+  Codex on that repo gets it automatically.
+
+Codex loads each skill's metadata up front and only pulls in the full
+`SKILL.md` body when it decides to invoke the skill, so there's no
+context-window cost to keeping several installed. You can also invoke a
+skill explicitly with `$skill-name` inside a Codex session.
+
+### ChatGPT (web) and other plain LLMs
+
+For tools without a native skills loader, the skill files are designed to
+be readable as standalone prompts: open the skill's `SKILL.md`, copy the
+body (everything after the YAML frontmatter), and paste it as a system or
+developer message at the start of a new conversation. Attach any files
+from `references/` if the task needs them. The `useful-prompts/` directory
+at the repo root contains zero-setup variants of the Excel skills already
+tuned for plain web LLMs.
+
+### Other agent runtimes
+
+Anything that follows the [agentskills.io](https://agentskills.io) standard
+should be able to load these skills directly — the directory layout, the
+`SKILL.md` filename, and the YAML frontmatter (`name`, `description`,
+`allowed-tools`) are all standard. Point your runtime's skills loader at
+this directory (or at an individual skill subdirectory) and it should
+discover them automatically.
+
+## Authoring new skills
+
+If you want to add a new Satsuma skill:
+
+1. Create a new subdirectory under `skills/` named after the skill.
+2. Add a `SKILL.md` with YAML frontmatter (`name`, `description`,
+   `allowed-tools`) and a body that explains, step by step, how the skill
+   should accomplish its task. Be specific about which `satsuma` CLI
+   commands to call and in what order.
+3. Put any long-form reference material under `references/` inside the
+   skill folder so the agent can load it on demand instead of front-loading
+   everything into context.
+4. Update the table at the top of this README and add a pointer in
+   [`HOW-DO-I.md`](../HOW-DO-I.md) so the skill is discoverable.

--- a/skills/excel-to-satsuma/SKILL.md
+++ b/skills/excel-to-satsuma/SKILL.md
@@ -161,12 +161,12 @@ Follow these rules strictly:
 
 ### Step 2.3 — Validation
 
-After writing each `.stm` file, validate with tree-sitter:
+After writing each `.stm` file, validate with the Satsuma CLI:
 ```bash
-tree-sitter parse --wasm -p tooling/tree-sitter-satsuma <file.stm> --quiet
+satsuma validate <file.stm>
 ```
 
-If it reports errors, fix them before proceeding. If tree-sitter is unavailable, perform heuristic checks:
+If it reports errors, fix them before proceeding. If the `satsuma` CLI is unavailable, perform heuristic checks:
 - Balanced braces
 - All mappings reference declared schemas
 - No duplicate schema names

--- a/skills/satsuma-explainer/SKILL.md
+++ b/skills/satsuma-explainer/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: satsuma-explainer
+description: >
+  Explain Satsuma (.stm) data mapping files in plain English for business stakeholders,
+  analysts, and non-technical reviewers. Use this skill whenever the user asks to explain,
+  summarize, review, walk through, or describe a Satsuma file or workspace — including
+  requests like "what does this mapping do", "explain this to my PM", "review this spec",
+  "what are the risks", "is anything missing", "onboarding summary", or "walk me through
+  this". Also trigger when users ask for a data quality assessment, PII audit summary,
+  coverage check, or impact analysis of a .stm file. This skill requires the `satsuma` CLI
+  to be installed and available on PATH.
+---
+
+# Satsuma Explainer
+
+Produce clear, jargon-free explanations of Satsuma mapping specs for non-technical
+audiences, plus actionable risk/coverage/quality assessments for technical reviewers.
+
+## Prerequisites
+
+- The `satsuma` CLI must be installed and on PATH.
+- The user must provide or reference one or more `.stm` files.
+
+## Workflow
+
+### 1. Gather structural context via CLI (do NOT read raw files yet)
+
+Run these commands to build your understanding. Use `--json` for all calls so you
+can process the output programmatically.
+
+```bash
+# a) Workspace overview — schemas, mappings, metrics, counts
+satsuma summary <file>.stm --json
+
+# b) Full workspace graph for topology and field-level flow
+satsuma graph <file>.stm --json --no-nl
+
+# c) All warnings and open questions
+satsuma warnings <file>.stm --json
+
+# d) Detect data modelling conventions
+satsuma find --tag dimension --json 2>/dev/null
+satsuma find --tag fact --json 2>/dev/null
+satsuma find --tag hub --json 2>/dev/null
+satsuma find --tag satellite --json 2>/dev/null
+satsuma find --tag link --json 2>/dev/null
+
+# e) Detect consumer schemas
+satsuma find --tag report --json 2>/dev/null
+satsuma find --tag model --json 2>/dev/null
+
+# f) Check governance coverage
+satsuma find --tag pii --json
+satsuma find --tag classification --json 2>/dev/null
+satsuma find --tag encrypt --json 2>/dev/null
+satsuma find --tag retention --json 2>/dev/null
+```
+
+Use the results from (d) to determine whether the workspace follows Kimball,
+Data Vault, or flat modelling conventions. This changes how you explain the
+architecture — see `references/conventions-guide.md` for the full token
+dictionaries and how to explain each pattern to different audiences.
+
+### 2. Drill into each mapping
+
+For every mapping found in the summary:
+
+```bash
+# Full mapping with arrows and transforms
+satsuma mapping "<mapping-name>" --json
+
+# Target fields not covered by this mapping
+satsuma fields <target-schema> --unmapped-by "<mapping-name>" --json
+
+# NL content in this mapping (transforms, notes, comments)
+satsuma nl "<mapping-name>"
+```
+
+### 3. Check for PII and governance concerns
+
+```bash
+# All PII-tagged fields
+satsuma find --tag pii --json
+
+# For each PII field, trace downstream
+satsuma field-lineage <schema.field> --downstream --json
+```
+
+### 4. Read the raw file only if needed
+
+Only read the `.stm` file directly if you need full context that the CLI
+commands above didn't provide (e.g., note blocks with rich markdown, or
+to quote a specific section back to the user).
+
+### 5. Produce the explanation
+
+Generate output following the format in `references/output-format.md`.
+Adapt the depth and tone to the audience — see the audience guide below.
+
+## Audience adaptation
+
+| Audience | Tone | Focus | Skip |
+|---|---|---|---|
+| Product owner / BA | Conversational, no jargon | What data moves where, business rules, what's ambiguous | Types, pipe syntax, metadata tokens |
+| Data engineer | Technical but concise | Transform logic, edge cases, unmapped fields, PII lineage | Basic "what is a schema" framing |
+| Governance / audit | Formal, thorough | PII flow, encryption, data quality warnings, open questions | Implementation details |
+| General / unknown | Friendly, mid-level | Everything at moderate depth, flag risks clearly | Nothing — cover all sections |
+
+When unsure of the audience, default to "General / unknown".
+
+## Key interpretation rules
+
+1. **Arrow syntax**: `src -> tgt` means source feeds target. `a, b -> tgt` means
+   multi-source. `-> tgt` (no left side) means computed/derived — flag these as
+   needing human-defined logic.
+
+2. **Transform classification**:
+   - `[none]` — direct copy, no transformation. Safe and deterministic.
+   - `[nl]` — natural language transform. Explain what it says; flag if ambiguous.
+   - `[nl-derived]` — implicit dependency found in NL text via `@ref`. Flag as
+     "inferred, not explicitly declared" so reviewers can verify.
+
+3. **Comments matter**:
+   - `//!` = known data quality warning. Always surface these prominently.
+   - `//?` = open question or ambiguity. Always surface these as "needs decision".
+   - `(note "...")` = documentation. Use to enrich your explanation.
+
+4. **Metadata tokens**: Explain `(pii)`, `(required)`, `(encrypt ...)`,
+   `(enum {...})`, `(format ...)`, `(default ...)` in plain English. Don't just
+   list them — say what they *mean* for the data.
+
+5. **Unmapped fields**: If `satsuma fields --unmapped-by` returns results, this is
+   a gap. Explain which target fields have no source and what that implies.
+
+6. **Data modelling conventions** (see `references/conventions-guide.md` for details):
+
+   **Kimball** — When you see `(dimension)`, `(fact)`, `(grain ...)`, `(scd N)`:
+   - Explain the star schema architecture: facts hold measurements, dimensions
+     provide context for filtering and grouping.
+   - For SCD 2 dimensions, explain that changes create new versions (history is
+     preserved) and mention which fields trigger versioning (`track`) vs. which
+     don't (`ignore`). Explain to non-technical audiences as: "When a customer's
+     email changes, a new version of their record is created so we can see what
+     it was before."
+   - For facts, explain the grain in plain English: "One row per transaction line
+     item" not "grain {transaction_id, line_number}."
+   - Mention conformed dimensions: "This customer dimension is shared across
+     multiple reports — a single source of truth."
+   - Explain measure additivity when relevant: additive measures can be summed
+     freely, semi-additive measures (like balances) can't be summed over time,
+     non-additive measures (like percentages) can't be summed at all.
+   - **Mechanical columns are inferred, not written.** Surrogate keys,
+     valid_from/to, is_current, row_hash, etl_batch_id, loaded_at, and dimension
+     foreign keys on facts are implied by the tokens. Mention them in technical
+     explanations but don't flag their absence as a gap.
+
+   **Data Vault** — When you see `(hub)`, `(satellite)`, `(link)`:
+   - Explain the three-entity architecture: hubs store business keys, satellites
+     store descriptive attributes that change over time, links capture
+     relationships between hubs.
+   - For non-technical audiences: "The hub is the master list of customers (just
+     IDs). The satellite holds the details (name, email, etc.) and tracks every
+     change. The link records which customers bought which products."
+   - Mention effectivity satellites and driving keys when present.
+   - **Mechanical columns are inferred.** Hash keys, load_date, load_end_date,
+     record_source, and hash_diff are implied. Don't flag their absence.
+
+7. **Merge strategy** — When mappings carry `(merge ...)` tokens:
+   - `merge upsert` — "New records are inserted; existing records (matched by
+     [match_on field]) are updated."
+   - `merge append` — "Every record is inserted as a new row. No updates, no
+     deletes. Used for event logs and audit trails."
+   - `merge soft_delete` — "Records are never physically deleted. Instead, a
+     [delete_flag] is set to true. This preserves history for audit."
+   - `merge full_refresh` — "The entire target is wiped and reloaded from
+     scratch. If the source is incomplete, data is lost." Flag safety notes.
+   - Explain `on_match` and `on_no_match` overrides if present.
+   - Flag SCD + merge conflicts: `merge full_refresh` + `scd 2` destroys
+     history — always call this out as a risk.
+
+8. **Governance metadata** — Beyond `pii` and `encrypt`, also explain:
+   - `(classification "LEVEL")` — the sensitivity tier. Explain what access
+     restrictions this implies. Flag if `pii` is present without `classification`
+     as a governance gap.
+   - `(retention "Ny")` — how long data is kept. Mention field-level overrides
+     (e.g., email at 3 years inside a 7-year schema).
+   - `(mask <strategy>)` — how the field is displayed to restricted users. Explain
+     the masking approach (e.g., "only the last four digits are shown").
+   - `(owner "...")` / `(steward "...")` — who is responsible.
+   - `(compliance {GDPR, SOX})` — which regulations apply. Mention the
+     obligations each framework implies.
+   - Run a governance completeness check: every PII field should have
+     classification, every classified field should have encryption or a note
+     explaining why not, every schema with PII should have an owner.
+
+9. **Consumer schemas** — When you see `(report)` or `(model)`:
+   - These are the end-points — dashboards, reports, ML models that people
+     actually use. They consume data but don't produce it.
+   - Explain `(source {schemas})` as the upstream dependencies: "This dashboard
+     reads from the orders fact table and the customer dimension."
+   - Mention `(tool looker)`, `(refresh schedule "...")`, `(registry mlflow)`,
+     and similar operational metadata.
+   - For impact analysis: trace from upstream changes through to which consumers
+     are affected.
+   - Fields on a report = visible measures and dimensions. Fields on a model =
+     input features and prediction outputs.
+
+## What NOT to do
+
+- Do not attempt to validate whether NL transforms are *correct* — you can only
+  report what they say and flag ambiguity.
+- Do not invent field mappings that aren't in the spec.
+- Do not assume the audience knows what Satsuma is — briefly introduce it if the
+  explanation will be shared outside the team.
+- Do not reproduce the `.stm` syntax verbatim in explanations for non-technical
+  audiences. Translate everything to prose.

--- a/skills/satsuma-explainer/references/conventions-guide.md
+++ b/skills/satsuma-explainer/references/conventions-guide.md
@@ -1,0 +1,144 @@
+# Conventions Guide
+
+Satsuma uses free-form metadata tokens in `( )` blocks to express data modelling,
+merge strategy, governance, and consumer patterns. These are vocabulary conventions,
+not grammar keywords. This guide tells you how to recognise and explain each one.
+
+## Detecting the modelling approach
+
+Check schema-level metadata to identify the approach:
+
+| Tokens found | Approach | Explain as |
+|---|---|---|
+| `dimension`, `fact`, `grain`, `scd` | Kimball star schema | "Facts surrounded by dimensions" |
+| `hub`, `satellite`, `link` | Data Vault 2.0 | "Hubs, satellites, and links" |
+| Neither | Flat / custom | Describe the flow without naming a methodology |
+| Both | Hybrid | Note both approaches and explain which schemas use which |
+
+## Kimball conventions
+
+### Schema tokens and what they mean
+
+| Token | Plain English |
+|---|---|
+| `(dimension)` | A reference table of descriptive attributes (customers, products, stores) |
+| `(dimension, conformed)` | A shared dimension used across multiple fact tables — a single source of truth |
+| `(fact)` | A table of measurements (sales, clicks, inventory counts) at a specific grain |
+| `(scd 1)` | Changes overwrite the old value — no history is kept |
+| `(scd 2)` | Changes create a new version — full history is preserved |
+| `(scd 6)` | Hybrid: full history plus a current-value overlay on every row |
+| `(natural_key field)` | The business identifier (e.g., customer_id) — what makes a record unique |
+| `(track {f1, f2})` | Only changes to these fields trigger a new version |
+| `(ignore {f1})` | Changes to these fields do NOT create a new version |
+| `(grain {f1, f2})` | What one row of the fact table represents |
+| `(ref dim_x.field)` | The fact references this dimension via a foreign key |
+
+### Field tokens
+
+| Token | Plain English |
+|---|---|
+| `(measure additive)` | Can be summed across any dimension (e.g., revenue) |
+| `(measure semi_additive)` | Can be summed across some dimensions but NOT time (e.g., account balance) |
+| `(measure non_additive)` | Cannot be meaningfully summed (e.g., unit price, percentage) |
+| `(degenerate)` | A dimensional attribute stored on the fact table (e.g., order number) |
+
+### Mechanical columns (inferred, not written)
+
+For `(dimension, scd 2)`: surrogate_key, valid_from, valid_to, is_current, row_hash.
+For `(fact)`: etl_batch_id, loaded_at, plus a surrogate key FK per `ref`.
+For `(dimension, scd 1)`: natural_key is the primary key; no versioning columns.
+
+These are NOT gaps — they are inferred from the tokens. Mention them in technical
+explanations but do not flag their absence.
+
+## Data Vault conventions
+
+### Schema tokens and what they mean
+
+| Token | Plain English |
+|---|---|
+| `(hub)` | A master registry of business keys (e.g., all customer IDs ever seen) |
+| `(satellite, parent hub_x)` | Descriptive attributes for a hub, with full change history |
+| `(link, link_hubs {h1, h2})` | A recorded relationship between two or more business entities |
+| `(satellite, effectivity, parent link_x)` | Tracks when a relationship starts and ends |
+| `(business_key field)` | The durable business identifier in a hub |
+| `(driving_key hub_x)` | Which hub's key change triggers end-dating in an effectivity satellite |
+
+### Mechanical columns (inferred, not written)
+
+For hubs: {hub}_hk (hash key), load_date, record_source.
+For satellites: {parent}_hk, load_date, load_end_date, hash_diff, record_source.
+For links: {link}_hk, one {hub}_hk per participating hub, load_date, record_source.
+
+## Merge strategy conventions
+
+| Token | Plain English |
+|---|---|
+| `(merge upsert, match_on field)` | Insert new rows; update existing ones matched by the key |
+| `(merge append)` | Every row is inserted — nothing is updated or deleted |
+| `(merge soft_delete, match_on field, delete_flag f)` | Mark records as deleted instead of removing them |
+| `(merge full_refresh)` | Wipe the target and reload everything from scratch |
+| `(on_match update)` | When a match is found: update (this is the default) |
+| `(on_match skip)` | When a match is found: leave the existing row untouched |
+| `(on_no_match insert)` | When no match: insert a new row (this is the default) |
+| `(on_no_match skip)` | When no match: ignore the source row |
+
+### Dangerous combinations to flag
+
+- `merge full_refresh` + `scd 2` → destroys version history. Always flag.
+- `merge append` + `scd 2` → unusual; append creates raw rows, SCD2 logic must happen downstream.
+- No `merge` token on a mapping to a persistent target → ambiguous load behavior. Flag.
+- `match_on` present on `merge append` → ignored; warn user.
+
+## Governance conventions
+
+| Token | Plain English |
+|---|---|
+| `(pii)` | Contains personally identifiable information |
+| `(classification "LEVEL")` | Sensitivity tier: PUBLIC, INTERNAL, CONFIDENTIAL, RESTRICTED |
+| `(encrypt ALGO)` | Must be encrypted at rest with the specified algorithm |
+| `(mask strategy)` | How to display the field to users without full access |
+| `(retention "Ny")` | How long data is kept (field-level overrides schema-level) |
+| `(owner "team")` | Team responsible for this data |
+| `(steward "person")` | Individual data steward for governance decisions |
+| `(compliance {GDPR, SOX})` | Regulatory frameworks that apply |
+
+### Governance completeness checks
+
+1. `pii` without `classification` → gap (sensitivity is undefined)
+2. `RESTRICTED`/`CONFIDENTIAL` without `encrypt` and no note explaining why → gap
+3. `pii` fields without `owner` on the schema → gap (no accountability)
+4. `compliance` without `retention` → gap (regulated data needs lifecycle rules)
+5. `pii` field on a `report`/`model` schema → exposure point (flag for review)
+
+### Classification + masking interaction
+
+- Users at or above the classification level see raw values
+- Users below the level see the masked representation
+- Users with no access don't see the field at all
+
+## Consumer conventions (reports & ML models)
+
+| Token | Plain English |
+|---|---|
+| `(report)` | A dashboard, report, or visualization — a leaf node in the lineage |
+| `(model)` | An ML model — also a leaf node |
+| `(source {s1, s2})` | Which upstream schemas this consumer reads from |
+| `(tool platform)` | The BI or ML platform (Looker, Tableau, MLflow, etc.) |
+| `(dashboard_id "id")` | The specific asset on the platform |
+| `(refresh schedule "...")` | When the consumer is updated or retrained |
+| `(registry platform)` | Where the ML model is versioned (MLflow, SageMaker, etc.) |
+| `(experiment "name")` | The experiment or run identifier |
+
+### What fields mean on consumers
+
+On a `report`: fields are the measures and dimensions visible to users.
+On a `model`: fields are input features and prediction outputs.
+
+These are NOT storage columns — they describe the consumer's interface.
+
+### Impact analysis through consumers
+
+When explaining impact, always trace changes all the way to consumer schemas:
+"If customer email changes, it flows through dim_customer to the customer risk
+dashboard in Tableau, where it is visible to the risk-ops team."

--- a/skills/satsuma-explainer/references/output-format.md
+++ b/skills/satsuma-explainer/references/output-format.md
@@ -1,0 +1,204 @@
+# Output Format Reference
+
+Use this structure for all explanations. Omit sections that don't apply (e.g., skip
+"PII & Governance" if no PII fields exist). Adapt depth per the audience table in
+SKILL.md.
+
+---
+
+## For non-technical audiences (PO, BA, general)
+
+Write in prose paragraphs. No code, no syntax, no metadata tokens.
+
+### Structure
+
+**1. Overview (1–2 paragraphs)**
+What this mapping does in plain English. What system is the data coming from? Where
+is it going? Why does this mapping exist? Pull from `note {}` blocks and the mapping
+name for context.
+
+If the workspace uses a data modelling convention, introduce it here in plain terms:
+- **Kimball**: "This pipeline builds a star schema — a central facts table (measurements
+  like sales amounts) surrounded by dimension tables (descriptive context like customers,
+  products, stores) that let analysts slice and filter the data."
+- **Data Vault**: "This pipeline uses a Data Vault architecture — business keys are stored
+  in hubs, descriptive details in satellites (which track every change), and relationships
+  between entities in links. This design prioritizes auditability and handling multiple
+  source systems."
+- **Flat/custom**: Just describe the flow without naming a methodology.
+
+**2. Data architecture (include only if modelling tokens present)**
+Walk through the major entities and how they relate. For a Kimball star schema, explain
+which dimensions exist and which facts reference them. For Data Vault, explain the
+hub/satellite/link structure. Use concrete business language:
+- "The customer dimension tracks customer details and keeps a full history of changes
+  (when an email or loyalty tier changes, a new version is created)."
+- "The sales fact table records one row per item sold, linking to the customer, product,
+  and store dimensions."
+- "The customer hub is the master registry of customer IDs. Two satellites track
+  different aspects: demographics (name, email) and loyalty details (tier, points)."
+
+**3. What data moves (prose with inline field descriptions)**
+Walk through the key fields being mapped. Group logically (identifiers, contact info,
+financial data, etc.). For each group, explain:
+- What the source data looks like
+- What happens to it (transformation in plain English)
+- What the target expects
+
+Do NOT list every field mechanically. Focus on what matters: business-critical fields,
+fields with transformations, and fields with warnings.
+
+**3. Business rules & decisions (bulleted or numbered)**
+Extract rules from NL transforms, `map {}` blocks, and notes. State each rule plainly:
+- "Customer type codes R, B, G are translated to 'retail', 'business', 'government'. If the code is missing, it defaults to 'retail'."
+- "Phone numbers are reformatted to international format. If the number can't be parsed, a warning is logged but the record is still processed."
+
+**4. Known issues & warnings**
+Surface every `//!` warning and `//?` open question. Frame as risks:
+- "⚠️ Some customer type codes are null in the source system — these will default to 'retail', which may not be correct."
+- "❓ Open question: How should 10-digit phone numbers outside the US be handled?"
+
+**5. Gaps & missing coverage**
+List target fields with no source mapping. Explain the implication:
+- "The target requires a `display_name` but there's no direct source field — it's computed from first name, last name, or company name depending on customer type. This logic is described in natural language and will need human review during implementation."
+
+Note: for Kimball and Data Vault schemas, mechanical columns (surrogate keys,
+hash keys, validity timestamps, row hashes, load dates) are intentionally omitted
+from the spec — they are inferred from the schema's metadata tokens. Do NOT report
+these as gaps.
+
+**6. How data is loaded (include only if merge tokens present)**
+For each mapping with a `merge` token, explain in plain terms:
+- "This mapping updates existing customer records when they change, and inserts new
+  ones that haven't been seen before. Records are matched by customer ID."
+- "Order events are appended — every event becomes a new row, nothing is updated or
+  deleted. This creates an audit trail."
+- "Deleted customers are not physically removed. Instead, they are flagged as deleted
+  with a timestamp, so historical reports still work."
+- "The product catalog is completely reloaded from scratch each night. A safety
+  check aborts the load if fewer than 1,000 products are returned."
+
+**7. PII & governance (if applicable)**
+Which fields contain personal data? Is encryption specified? Does PII flow downstream
+to other schemas? State plainly:
+- "Email addresses are tagged as personally identifiable information (PII). The mapping applies validation and lowercasing but no encryption at this stage."
+- "Tax IDs are encrypted with AES-256-GCM before being written to the target."
+
+Also cover (when present):
+- **Classification**: "Customer profile data is classified as RESTRICTED — only
+  authorized teams can access the raw values. Other users see masked data."
+- **Retention**: "Customer profiles are retained for 7 years. Email addresses have
+  a shorter 3-year retention — they are purged earlier even though the rest of the
+  record is kept."
+- **Masking**: "For users without full access, credit card numbers show only the
+  last four digits."
+- **Compliance**: "This data falls under GDPR and SOX regulations, which require
+  audit trails, deletion rights, and retention policies."
+- **Governance gaps**: Flag any PII field missing a classification, any classified
+  field missing encryption rationale, any schema with PII but no owner.
+
+**8. Downstream consumers (include only if report/model schemas present)**
+Explain who and what actually uses this data:
+- "The weekly sales dashboard in Looker reads from the orders fact table and product
+  dimension. It refreshes every Monday at 6 AM UTC."
+- "A churn prediction model in MLflow uses customer tenure, recent order count, and
+  average order value as features. It retrains weekly and is promoted to production
+  only if accuracy exceeds 82%."
+
+For impact analysis, trace changes: "If the customer email field changes upstream,
+it flows through to the customer risk dashboard in Tableau, where it is displayed
+to the risk-ops team."
+
+---
+
+## For technical audiences (data engineer, architect)
+
+Can include Satsuma syntax snippets, metadata tokens, and CLI output references.
+
+### Structure
+
+**1. Workspace summary**
+Schemas, mappings, fragments, metrics, namespace structure. One paragraph or a
+compact table.
+
+If the workspace uses data modelling conventions, identify the approach and list
+the entity types:
+- **Kimball**: which schemas are dimensions (and their SCD types), which are facts
+  (and their grains), any conformed dimensions shared across star schemas.
+- **Data Vault**: which schemas are hubs, satellites, links; parent relationships;
+  effectivity satellites and driving keys.
+- **Consumers**: any report or model schemas, their source dependencies and tools.
+
+Note which mechanical columns are inferred (surrogate keys, hash keys, validity
+timestamps, etc.) so reviewers know they're intentionally absent from the spec.
+
+**2. Data architecture (include only if modelling tokens present)**
+Describe the modelling topology:
+- Entity types and their roles (dimension/fact or hub/satellite/link)
+- SCD strategies per dimension, including tracked vs. ignored fields
+- Fact grains and dimension references (which dimension FKs are inferred)
+- Consumer schemas and their upstream dependencies
+- Cross-namespace imports and how schemas flow between layers
+
+**3. Mapping walkthrough**
+For each mapping:
+- Source(s) and target, including filters and join descriptions
+- **Merge strategy**: which `merge` token is used, the match key, and any
+  `on_match`/`on_no_match` overrides. Flag mismatches (e.g., `full_refresh` +
+  `scd 2` = history destruction).
+- Arrow-by-arrow breakdown grouped by classification:
+  - `[none]` — list as direct copies
+  - `[nl]` — quote the NL intent, flag ambiguity
+  - `[nl-derived]` — flag as implicit, verify references exist
+- `map {}` blocks — show the value mapping table
+- Pipe chains — describe the transformation pipeline
+
+**4. Coverage analysis**
+Table of unmapped target fields from `satsuma fields --unmapped-by`. For mapped
+fields, note the classification.
+
+For Kimball/Data Vault schemas, do NOT list mechanical columns (surrogate keys,
+hash keys, load dates, validity timestamps, row hashes) as unmapped — these are
+inferred from metadata tokens.
+
+**5. Data quality risks**
+All `//!` warnings and `//?` questions with their locations. Cross-reference with
+the affected arrows.
+
+**6. PII lineage & governance audit**
+For each PII-tagged field, show the downstream chain from `field-lineage`. Note
+where encryption or masking is applied (or missing).
+
+Run the governance completeness checklist:
+- Every `pii` field has `classification` → pass/fail
+- Every `RESTRICTED`/`CONFIDENTIAL` field has `encrypt` or documented rationale → pass/fail
+- Every schema with `pii` fields has `owner` and `steward` → pass/fail
+- Every schema with `compliance` has `retention` → pass/fail
+- Every `pii` field on a consumer schema (report/model) is an exposure point — flag it
+
+For consumer schemas, trace PII all the way to the dashboard or model that
+displays it. This is the final exposure surface.
+
+**7. Recommendations**
+Concrete next steps:
+- Fields needing explicit transforms instead of NL descriptions
+- Missing `@ref` annotations in NL strings
+- PII fields without encryption metadata
+- PII fields without classification (governance gap)
+- Schemas with PII but no owner or steward
+- Missing retention policies on regulated data
+- `merge full_refresh` + `scd 2` conflicts (history destruction risk)
+- Merge strategies not declared on persistent targets (ambiguous load behavior)
+- Consumer schemas missing `source {}` declarations (broken lineage)
+- Open questions requiring stakeholder decisions
+
+---
+
+## Tone guidelines
+
+- Lead with what the mapping *does*, not what Satsuma *is*.
+- Use "this mapping" and "this spec", not "this Satsuma file".
+- For warnings, be direct: "This is a risk because..." not "It might be worth considering..."
+- For gaps, be specific: name the field, name the consequence.
+- For NL transforms, distinguish between what the spec *says* and what you *interpret*.
+  Use phrases like "The spec describes this as..." rather than "This field is transformed by..."

--- a/skills/satsuma-from-dbt/SKILL.md
+++ b/skills/satsuma-from-dbt/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: satsuma-from-dbt
+description: >
+  Reverse-engineer Satsuma (.stm) mapping specs from an existing dbt project. Use this
+  skill whenever the user wants to generate Satsuma from dbt, convert a dbt project to
+  Satsuma, extract mapping specs from dbt models, document dbt transformations in Satsuma
+  format, or create a Satsuma workspace from their existing dbt codebase. Also trigger
+  when the user says things like "I have a dbt project and want to try Satsuma", "convert
+  my dbt models to .stm", or "reverse-engineer my dbt lineage into Satsuma". Requires
+  access to the dbt project files on disk. The `satsuma` CLI should be installed for
+  validation and formatting of the output.
+---
+
+# Satsuma from dbt Project
+
+Reverse-engineer a Satsuma mapping specification from an existing dbt project by
+reading its sources, models, schema YAML, and tests.
+
+## Prerequisites
+
+- The user must provide a path to a dbt project (must contain `dbt_project.yml`).
+- The `satsuma` CLI should be available for `fmt` and `validate` on the output.
+
+## Step 0: Understand the project layout
+
+Before asking the user anything, scan the project to understand what you're working with:
+
+```bash
+# Confirm it's a dbt project
+cat <project_path>/dbt_project.yml
+
+# Find all model SQL files
+find <project_path>/models -name '*.sql' | head -40
+
+# Find all schema/source YAML files
+find <project_path> -name '*.yml' -o -name '*.yaml' | grep -v node_modules | head -20
+
+# Find custom tests
+find <project_path>/tests -name '*.sql' 2>/dev/null | head -20
+
+# Find macros
+find <project_path>/macros -name '*.sql' 2>/dev/null | head -20
+```
+
+## Step 1: Ask the user what they need
+
+After scanning, present what you found and ask:
+
+1. **Scope** — "I found N models across these directories: [list]. Should I convert
+   all of them, or focus on a specific folder/tag/subset?" Large projects benefit
+   from doing one domain at a time.
+
+2. **Namespace strategy** — "Your models are organized into [staging/intermediate/marts]
+   folders. Should each folder become a Satsuma namespace, or do you prefer a flat
+   structure?" Default recommendation: one namespace per dbt model directory layer
+   (e.g., `staging`, `marts`).
+
+3. **SQL translation depth** — "For SQL transformations in your models, should I:
+   (a) translate simple SQL to Satsuma pipe syntax where possible, or
+   (b) capture all transform logic as natural-language descriptions?"
+   Default recommendation: (a) for simple cases, (b) for complex SQL. This is what
+   you should do regardless — the question helps set user expectations.
+
+Do NOT ask about tests — infer metadata from them silently (see Step 3).
+
+## Step 2: Extract source schemas
+
+Read every `sources.yml` / `schema.yml` that defines sources.
+
+For each source table, create a `schema` block:
+
+```
+schema <source_name> (
+  note "<description from yml>",
+  <any meta tags>
+) {
+  <columns with types and metadata>
+}
+```
+
+**Inferring metadata from source definitions:**
+
+| dbt YAML | Satsuma metadata |
+|---|---|
+| `description:` on column | `(note "...")` |
+| `meta: {pii: true}` | `(pii)` |
+| `meta: {classification: "..."}` | `(classification "...")` |
+| `meta: {owner: "..."}` | `(owner "...")` |
+| Any other `meta:` key | Carry it as-is — Satsuma metadata is extensible |
+| Column not in YAML but in SQL | Add with type `STRING` and `//? type not documented` |
+
+## Step 3: Infer metadata from dbt tests
+
+This is where dbt tests become a rich source of Satsuma metadata. Read the `tests:`
+section of every schema YAML column and translate:
+
+| dbt test | Satsuma metadata |
+|---|---|
+| `not_null` | `(required)` |
+| `unique` | `(unique)` |
+| `not_null` + `unique` together | `(pk)` — this is a primary key signal |
+| `accepted_values: {values: [a, b, c]}` | `(enum {a, b, c})` |
+| `relationships: {to: ref('x'), field: 'y'}` | `(ref x.y)` |
+
+For **custom singular tests** (SQL files in `tests/`), read each one:
+- If it tests a specific column constraint, add a `(note "tested: <description>")`.
+- If it encodes a business rule (e.g., "order total must equal sum of line items"),
+  add a `//!` warning or `note {}` block on the relevant mapping.
+
+Custom generic tests (macros like `test_positive_value`) should be noted as metadata
+too — e.g., `(note "tested: must be positive")`.
+
+## Step 3b: Detect data modelling patterns and infer structural metadata
+
+Scan model names, folder structure, and SQL patterns to detect modelling conventions.
+Apply the appropriate Satsuma metadata tokens — see `references/modelling-conventions.md`
+for the full token dictionaries.
+
+**Kimball detection signals:**
+- Model names starting with `dim_` → `(dimension)` schema
+- Model names starting with `fact_` → `(fact)` schema
+- `dbt_utils.generate_surrogate_key()` → signals a surrogate key, likely `(scd 2)`
+- `dbt_utils.star()` or many dimension refs in a fact model → `(ref dim_x.field)` tokens
+- Snapshot models (dbt snapshots) → `(scd 2)` with `(natural_key ...)` and `(track {...})`
+- Grain: unique key config or unique tests on composite keys → `(grain {f1, f2})`
+
+**Data Vault detection signals:**
+- Model names starting with `hub_` → `(hub, business_key field)`
+- Model names starting with `sat_` → `(satellite, parent hub_x)`
+- Model names starting with `link_` → `(link, link_hubs {hub_a, hub_b})`
+- `dbt_vault` or `dbtvault` package macros (e.g., `dbt_vault.hub`, `dbt_vault.sat`)
+  → strong signal; extract business keys and parent refs from macro arguments
+
+**Merge strategy detection:**
+- `materialized='incremental'` + `unique_key` → `(merge upsert, match_on <unique_key>)`
+- `materialized='incremental'` + `is_incremental()` with `DELETE` → `(merge soft_delete, ...)`
+- `materialized='incremental'` without `unique_key` → `(merge append)`
+- `materialized='table'` → `(merge full_refresh)`
+- `materialized='view'` → no merge token (views are not persisted)
+- dbt snapshots → `(merge upsert, match_on <unique_key>)` with `(scd 2)`
+
+**Report / model consumer detection:**
+- dbt exposures in YAML → `(report, source {...}, tool <type>)` or `(model, source {...})`
+- Models tagged `exposure`, `dashboard`, `report` in meta → consumer schemas
+- Models with no downstream refs (leaf nodes) in a `marts/` directory → candidate consumers
+
+**Governance detection from dbt meta:**
+- `meta: {pii: true}` → `(pii)`
+- `meta: {classification: "..."}` → `(classification "...")`
+- `meta: {owner: "..."}` → `(owner "...")`
+- `meta: {retention: "..."}` → `(retention "...")`
+- Tags like `pii`, `sensitive`, `restricted` on models → apply as schema-level metadata
+
+## Step 4: Build model schemas and mappings
+
+For each dbt model SQL file:
+
+### a) Parse the SQL for refs and sources
+
+```bash
+# Extract ref() and source() calls
+grep -oP "ref\('([^']+)'\)" <model>.sql
+grep -oP "source\('([^']+)',\s*'([^']+)'\)" <model>.sql
+```
+
+Every `{{ source('x', 'y') }}` → a source schema reference.
+Every `{{ ref('model_name') }}` → a reference to another model's schema.
+
+### b) Create the target schema
+
+The model itself defines a target schema. Columns come from:
+1. The `schema.yml` entry for this model (preferred — has descriptions, tests).
+2. The `SELECT` clause of the SQL (fallback — parse column aliases).
+
+Apply the same test-to-metadata inference from Step 3.
+
+### c) Create the mapping
+
+```
+mapping `<model_name>` {
+  source { <source schemas and ref'd models> }
+  target { <this model's schema> }
+
+  <arrows derived from SQL>
+}
+```
+
+**SQL to arrow translation rules** (see `references/sql-to-satsuma.md` for full
+patterns):
+
+| SQL pattern | Satsuma arrow |
+|---|---|
+| `SELECT a AS b FROM src` | `a -> b` |
+| `SELECT TRIM(LOWER(email)) AS email` | `email -> email { trim \| lowercase }` |
+| `COALESCE(x, 0) AS x` | `x -> x { coalesce(0) }` |
+| `CASE WHEN type = 'R' THEN 'retail' ...` | `type -> type_name { map { R: "retail", ... } }` |
+| `UUID_V5(ns, id)` | `id -> new_id { uuid_v5("ns", id) }` |
+| Complex CTE chains, window functions, multi-join logic | `-> target_field { "NL description of what the SQL does" }` |
+| `CURRENT_TIMESTAMP AS ingest_ts` | `-> ingest_ts { now_utc }` |
+
+When the SQL is too complex for a direct pipe translation, write a clear NL
+description using `@ref` for every referenced field. Be honest — don't try to
+force complex SQL into pipe syntax. The NL description is a valid and idiomatic
+Satsuma approach.
+
+### d) Handle joins
+
+Multi-source models (JOINs) should be expressed in the source block:
+
+```
+source {
+  stg_orders
+  stg_customers
+  "Join @stg_orders to @stg_customers on @stg_orders.customer_id = @stg_customers.customer_id"
+}
+```
+
+Preserve the join type (LEFT, INNER, etc.) in the NL description — it matters for
+understanding data completeness.
+
+### e) Handle incremental models
+
+If a model uses `{{ config(materialized='incremental') }}` with an
+`is_incremental()` block, add a note:
+
+```
+mapping `model_name` (materialized incremental, unique_key "id") {
+  note { "Incremental — only new/updated rows processed on each run" }
+  ...
+}
+```
+
+The `materialized` and `unique_key` are custom metadata tokens — Satsuma's
+extensible metadata handles this naturally.
+
+## Step 5: Add warnings and questions
+
+After generating all schemas and mappings:
+
+- Add `//!` on any column that exists in SQL but has no YAML documentation.
+- Add `//?` on any complex SQL transform you had to describe in NL — flag it as
+  "verify this NL description matches the SQL intent."
+- Add `//!` if a model has no tests at all — "no dbt tests defined for this model."
+
+## Step 6: Assemble, format, and validate
+
+Decide on file organization based on scope:
+
+- **Small project (< 10 models):** Single `.stm` file.
+- **Medium project (10–30 models):** One file per dbt model directory, with imports.
+- **Large project (30+ models):** One file per domain/namespace, with imports. Use
+  the same grouping the dbt project already uses.
+
+```bash
+# Format
+satsuma fmt <output>.stm
+
+# Validate
+satsuma validate <output>.stm
+
+# Check for lint issues
+satsuma lint <output>.stm
+```
+
+Fix any validation errors before presenting the output.
+
+## Step 7: Present and explain
+
+Use the satsuma-explainer skill (if available) to walk the user through the
+generated spec. If not available, provide a brief summary of what was generated:
+schemas, mappings, any warnings or open questions, and PII-tagged fields.
+
+Explicitly tell the user:
+- Which transforms were translated to pipe syntax vs. NL descriptions.
+- Which metadata was inferred from tests vs. YAML vs. SQL.
+- Any fields or models that need manual review.

--- a/skills/satsuma-from-dbt/references/modelling-conventions.md
+++ b/skills/satsuma-from-dbt/references/modelling-conventions.md
@@ -1,0 +1,156 @@
+# Modelling Conventions Reference
+
+When reverse-engineering a dbt project into Satsuma, use these token dictionaries
+to annotate schemas with structural metadata. This enables downstream tools and
+agents to understand the data modelling intent without reading SQL.
+
+## Kimball Tokens
+
+Apply these when the dbt project follows Kimball star schema conventions.
+
+### Schema-level
+
+| Token | When to apply | Example |
+|---|---|---|
+| `dimension` | Model name starts with `dim_` or is a Type 2 snapshot | `(dimension)` |
+| `fact` | Model name starts with `fact_` or `fct_` | `(fact)` |
+| `conformed` | Dimension referenced by multiple fact models | `(conformed)` |
+| `scd 1` | Dimension with `materialized='table'` and no history tracking | `(scd 1)` |
+| `scd 2` | Dimension with snapshots, surrogate keys, or valid_from/to columns | `(scd 2)` |
+| `natural_key <field>` | The business key (from `unique_key` config or unique test) | `(natural_key customer_id)` |
+| `track {fields}` | Fields included in snapshot `check_cols` or hash diff | `(track {email, phone})` |
+| `ignore {fields}` | Fields explicitly excluded from change detection | `(ignore {last_login})` |
+| `grain {fields}` | Fact table grain (from unique test on composite key) | `(grain {transaction_id, line_number})` |
+| `ref dim_x.field` | Fact references a dimension (from JOIN in SQL) | `(ref dim_customer.customer_id)` |
+
+### Field-level
+
+| Token | When to apply | Example |
+|---|---|---|
+| `measure additive` | Numeric field that's summed in downstream queries | `(measure additive)` |
+| `measure semi_additive` | Balance/inventory field (sum across non-time dims only) | `(measure semi_additive)` |
+| `measure non_additive` | Ratio, percentage, unit price | `(measure non_additive)` |
+| `degenerate` | Dimensional attribute stored on the fact table | `(degenerate)` |
+
+### Mechanical columns to OMIT
+
+These columns exist in the physical table but should NOT be written in Satsuma.
+They are inferred from the schema-level tokens:
+
+- Surrogate keys (`surrogate_key`, `dim_*_key`)
+- `valid_from`, `valid_to`, `is_current` (inferred from `scd 2`)
+- `row_hash`, `hash_diff` (inferred from `scd 2`)
+- `etl_batch_id`, `loaded_at` (inferred from `fact`)
+- `dbt_valid_from`, `dbt_valid_to`, `dbt_updated_at` (dbt snapshot columns)
+
+When converting, strip these and let the Satsuma conventions imply them.
+
+## Data Vault Tokens
+
+Apply these when the dbt project uses Data Vault 2.0 patterns (often via `dbtvault`
+or `dbt_vault` packages).
+
+### Schema-level
+
+| Token | When to apply | Example |
+|---|---|---|
+| `hub` | Model name starts with `hub_` | `(hub, business_key customer_id)` |
+| `satellite` | Model name starts with `sat_` | `(satellite, parent hub_customer)` |
+| `link` | Model name starts with `link_` | `(link, link_hubs {hub_customer, hub_product})` |
+| `effectivity` | Satellite tracking temporal validity of a link | `(satellite, effectivity, parent link_sale)` |
+| `business_key <field>` | Hub's business key | `(business_key customer_id)` |
+| `parent <hub_or_link>` | Satellite's parent entity | `(parent hub_customer)` |
+| `link_hubs {hubs}` | Link's participating hubs | `(link_hubs {hub_customer, hub_product})` |
+| `driving_key <hub>` | Effectivity satellite's driving key | `(driving_key hub_product)` |
+
+### Mechanical columns to OMIT
+
+- `*_hk` hash keys (inferred from `hub`, `link`, `satellite`)
+- `load_date`, `load_end_date` (inferred from hub/satellite)
+- `record_source` (inferred; populate via `-> record_source { "SYSTEM_NAME" }`)
+- `hash_diff` (inferred from `satellite`)
+
+## Merge Strategy Tokens
+
+Map dbt materialization configs to Satsuma merge tokens.
+
+| dbt Config | Satsuma Token |
+|---|---|
+| `materialized='incremental'` + `unique_key='x'` | `(merge upsert, match_on x)` |
+| `materialized='incremental'` + `unique_key=['x','y']` | `(merge upsert, match_on {x, y})` |
+| `materialized='incremental'` without `unique_key` | `(merge append)` |
+| `materialized='incremental'` + `incremental_strategy='delete+insert'` | `(merge upsert, match_on <key>)` with note about delete+insert |
+| `materialized='incremental'` + `incremental_strategy='merge'` | `(merge upsert, match_on <key>)` |
+| `materialized='table'` | `(merge full_refresh)` |
+| `materialized='view'` | No merge token |
+| dbt snapshot with `strategy='check'` | `(merge upsert, match_on <unique_key>)` + `(scd 2, track {check_cols})` |
+| dbt snapshot with `strategy='timestamp'` | `(merge upsert, match_on <unique_key>)` + `(scd 2)` |
+
+For soft delete patterns, look for:
+- An `is_deleted` or `deleted_at` column in the model
+- Logic that sets a flag rather than filtering out rows
+- → `(merge soft_delete, match_on <key>, delete_flag is_deleted)`
+
+## Consumer Tokens (Reports & ML Models)
+
+### dbt exposures → Satsuma consumer schemas
+
+When the dbt project has an `exposures:` section in YAML:
+
+```yaml
+exposures:
+  - name: weekly_sales_dashboard
+    type: dashboard
+    owner:
+      name: Analytics Team
+      email: analytics@company.com
+    depends_on:
+      - ref('fact_orders')
+      - ref('dim_product')
+    url: https://looker.company.com/dashboards/42
+```
+
+→
+
+```satsuma
+schema weekly_sales_dashboard (
+  report,
+  source {fact_orders, dim_product},
+  tool looker,
+  dashboard_id "42",
+  owner "Analytics Team"
+) {
+  // Fields from the exposure description or inferred from source schemas
+}
+```
+
+### Exposure type mapping
+
+| dbt exposure type | Satsuma token |
+|---|---|
+| `dashboard` | `(report, tool <platform>)` |
+| `notebook` | `(report, tool jupyter)` or `(model, tool jupyter)` |
+| `analysis` | `(report)` |
+| `ml` | `(model)` |
+| `application` | `(report)` with note describing the application |
+
+## Governance Tokens
+
+### dbt meta → Satsuma governance
+
+| dbt YAML meta key | Satsuma token |
+|---|---|
+| `pii: true` | `(pii)` |
+| `classification: "RESTRICTED"` | `(classification "RESTRICTED")` |
+| `owner: "team-name"` | `(owner "team-name")` |
+| `retention: "3y"` | `(retention "3y")` |
+| `encrypt: "AES-256"` | `(encrypt AES-256)` |
+| `mask: "last_four"` | `(mask last_four)` |
+| `compliance: ["GDPR", "SOX"]` | `(compliance {GDPR, SOX})` |
+| `steward: "Jane Smith"` | `(steward "Jane Smith")` |
+| Any other key-value | Carry as-is: `(key "value")` |
+
+Apply at schema level or field level, matching where the meta appears in the dbt YAML.
+
+If `pii` is present without `classification`, add `//! PII field without classification —
+governance gap` to flag it.

--- a/skills/satsuma-from-dbt/references/sql-to-satsuma.md
+++ b/skills/satsuma-from-dbt/references/sql-to-satsuma.md
@@ -1,0 +1,167 @@
+# SQL to Satsuma Translation Patterns
+
+Use this reference when converting dbt model SQL into Satsuma arrows and transforms.
+The goal is to capture intent, not reproduce SQL. When in doubt, use NL.
+
+## Direct translations (use pipe syntax)
+
+These SQL patterns have clean Satsuma equivalents. Prefer pipe syntax for these.
+
+### String operations
+```sql
+-- SQL
+TRIM(email)                        →  email -> email { trim }
+LOWER(TRIM(email))                 →  email -> email { trim | lowercase }
+UPPER(region)                      →  region -> region { uppercase }
+INITCAP(name)                      →  name -> name { title_case }
+LEFT(phone, 10)                    →  phone -> phone { truncate(10) }
+LPAD(code, 5, '0')                →  code -> code { pad_left(5, "0") }
+REPLACE(val, 'old', 'new')        →  val -> val { replace("old", "new") }
+CONCAT(first, ' ', last)          →  first, last -> full_name { "Concat @first + ' ' + @last" }
+```
+
+### Null handling
+```sql
+COALESCE(amount, 0)                →  amount -> amount { coalesce(0) }
+NULLIF(status, '')                 →  status -> status { null_if_empty }
+-- For COALESCE across multiple columns, use NL:
+COALESCE(mobile, home, work)       →  mobile, home, work -> phone { "Use first non-null of @mobile, @home, @work" }
+```
+
+### Type conversions
+```sql
+CAST(id AS VARCHAR)                →  id -> id { to_string }
+CAST(amount AS DECIMAL)            →  amount -> amount { to_number }
+CAST(flag AS BOOLEAN)              →  flag -> flag { to_boolean }
+ROUND(amount, 2)                   →  amount -> amount { round(2) }
+```
+
+### CASE → map
+```sql
+CASE
+  WHEN type = 'R' THEN 'retail'
+  WHEN type = 'B' THEN 'business'
+  ELSE 'unknown'
+END AS customer_type
+```
+→
+```satsuma
+type -> customer_type {
+  map { R: "retail", B: "business", _: "unknown" }
+}
+```
+
+For range-based CASE:
+```sql
+CASE
+  WHEN amount < 100 THEN 'small'
+  WHEN amount < 1000 THEN 'medium'
+  ELSE 'large'
+END
+```
+→
+```satsuma
+amount -> size_bucket {
+  map { < 100: "small", < 1000: "medium", default: "large" }
+}
+```
+
+### Timestamps
+```sql
+CURRENT_TIMESTAMP                  →  -> ingest_ts { now_utc }
+DATE_TRUNC('month', order_date)    →  order_date -> order_month { "Truncate @order_date to month" }
+```
+
+### Identity / rename
+```sql
+SELECT customer_id AS cust_id      →  customer_id -> cust_id
+SELECT * (passthrough)             →  -- map each field individually
+```
+
+## NL descriptions (use for complex SQL)
+
+These patterns are too complex or varied for pipe syntax. Write clear NL with @refs.
+
+### Window functions
+```sql
+ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY order_date DESC) AS rn
+```
+→
+```satsuma
+-> row_num {
+  "Row number partitioned by @customer_id, ordered by @order_date descending"
+}
+```
+
+### Aggregations
+```sql
+SUM(amount) AS total_amount
+COUNT(DISTINCT customer_id) AS customer_count
+```
+→
+```satsuma
+-> total_amount { "Sum of @amount" }
+-> customer_count { "Count distinct @customer_id" }
+```
+
+### Multi-table joins (expressed in source block, not arrows)
+```sql
+FROM orders o
+LEFT JOIN customers c ON o.customer_id = c.customer_id
+LEFT JOIN products p ON o.product_id = p.product_id
+```
+→
+```satsuma
+source {
+  orders
+  customers
+  products
+  "Left join @orders to @customers on @orders.customer_id = @customers.customer_id.
+   Left join @orders to @products on @orders.product_id = @products.product_id."
+}
+```
+
+### Subqueries and CTEs
+Don't try to represent CTE structure in Satsuma. Describe the end result:
+```sql
+WITH ranked AS (
+  SELECT *, ROW_NUMBER() OVER (...) AS rn
+  FROM orders
+)
+SELECT * FROM ranked WHERE rn = 1
+```
+→
+```satsuma
+-> order_id {
+  "Most recent order per @customer_id, deduplicated by @order_date descending"
+}
+```
+
+### Conditional logic beyond simple CASE
+```sql
+CASE
+  WHEN status = 'active' AND balance > 0 THEN 'paying'
+  WHEN status = 'active' AND balance = 0 THEN 'free'
+  WHEN status = 'churned' AND last_active > DATEADD(day, -30, CURRENT_DATE) THEN 'recently_churned'
+  ELSE 'inactive'
+END
+```
+→
+```satsuma
+status, balance, last_active -> account_state {
+  "Active with positive @balance → 'paying'.
+   Active with zero @balance → 'free'.
+   Churned within last 30 days (based on @last_active) → 'recently_churned'.
+   Otherwise → 'inactive'."
+}
+```
+
+## Patterns to flag with warnings
+
+| SQL pattern | Satsuma treatment |
+|---|---|
+| `SELECT *` | `//! SELECT * — columns may change without notice` |
+| Hardcoded dates | `//! Hardcoded date in transform — may need updating` |
+| `LIMIT` in non-test context | `//! LIMIT clause — data may be incomplete` |
+| UDF calls | `//? Custom UDF — verify @udf_name behavior` |
+| Dynamic SQL / Jinja logic | `//? Jinja conditional — multiple code paths exist` |

--- a/skills/satsuma-sample-data/SKILL.md
+++ b/skills/satsuma-sample-data/SKILL.md
@@ -1,0 +1,334 @@
+---
+name: satsuma-sample-data
+description: >
+  Generate realistic synthetic test data from Satsuma (.stm) schema definitions. Use this
+  skill whenever the user wants to create test data, sample data, fake data, seed data,
+  mock data, or synthetic data from a Satsuma spec. Also trigger for requests like
+  "generate CSV from this schema", "create test fixtures for my mapping", "I need sample
+  data to test my pipeline", "mock up some data for this spec", or "seed data for my
+  warehouse". Generates data that respects all schema constraints (types, enums, required,
+  PII patterns, formats, defaults, filters) and maintains referential integrity across
+  schemas connected by mappings. Supports CSV, JSON/JSONL, SQL INSERT, and Parquet output.
+  For exotic source formats (COBOL copybooks, HL7, EDI, ISO 8583, etc.), this skill
+  generates the logical data and suggests the user create a format-specific skill for
+  physical serialisation. Requires the `satsuma` CLI.
+---
+
+# Satsuma Sample Data Generator
+
+Generate realistic, constraint-respecting synthetic data from Satsuma schemas.
+
+## Prerequisites
+
+- The `satsuma` CLI must be installed and on PATH.
+- Python 3 with `faker` available (`pip install faker`). If generating Parquet,
+  also needs `pyarrow`.
+- The user must provide one or more `.stm` files.
+
+## Step 0: Extract schema structure
+
+```bash
+# Workspace overview
+satsuma summary <file>.stm --json
+
+# Full graph to understand schema relationships
+satsuma graph <file>.stm --json
+
+# For each schema the user wants data for:
+satsuma fields <schema> --json
+satsuma meta <schema> --json
+satsuma nl <schema>
+
+# Warnings for edge case generation
+satsuma warnings <file>.stm --json
+```
+
+## Step 1: Ask the user
+
+1. **Which schemas?** — Show the schemas found and ask which ones need data.
+   Default: all source schemas (schemas that appear on the left side of mappings).
+   Target schemas often don't need seed data — they're populated by the pipeline.
+
+2. **Row count** — "How many rows per schema?" Default: 100. For schemas connected
+   by one-to-many relationships (e.g., orders → line items), ask for the parent
+   count and suggest a multiplier for children (e.g., "100 orders, 3–7 line items
+   each").
+
+3. **Output format** — CSV, JSON, JSONL, SQL INSERT, or Parquet.
+   Default: CSV (most portable). For schemas with nested records or `list_of`
+   fields, recommend JSON/JSONL since CSV can't represent nesting natively.
+
+4. **Edge cases** — "Should I include realistic edge cases from the spec's
+   warnings? For example, null values where the spec says 'some records have
+   NULL', or malformed data where it says 'not validated'."
+   Default: yes, at ~5–10% of rows.
+
+5. **Seed** — "Want a fixed random seed for reproducible data?"
+   Default: 42.
+
+Do NOT ask about locale — infer it from the schema context (country codes,
+currency, phone format hints). Default to `en_US` if unclear.
+
+## Step 2: Build a generation plan
+
+Before writing any code, build a plan for each schema. For every field, determine
+the generator based on type + metadata. See `references/field-generators.md` for
+the complete generator lookup table.
+
+### Generator selection priority
+
+For each field, check metadata in this order — first match wins:
+
+1. **`(enum {a, b, c})`** → random choice from the enum values
+2. **`(format <pattern>)`** → format-specific generator (email, E.164, etc.)
+3. **`(pii)` + field name heuristic** → Faker generator (see PII section below)
+4. **`(default <val>)`** → use the default for ~30% of rows, generate for rest
+5. **Type-based fallback** → generate from the Satsuma type
+
+### PII field heuristics
+
+When a field has `(pii)`, use the field name to select a realistic Faker provider:
+
+| Field name pattern | Faker provider |
+|---|---|
+| `*email*` | `fake.email()` |
+| `*phone*`, `*mobile*`, `*tel*` | `fake.phone_number()` |
+| `*first_name*`, `*first_nm*` | `fake.first_name()` |
+| `*last_name*`, `*last_nm*`, `*surname*` | `fake.last_name()` |
+| `*name*` (generic) | `fake.name()` |
+| `*address*`, `*street*`, `*addr*` | `fake.street_address()` |
+| `*city*` | `fake.city()` |
+| `*state*`, `*province*` | `fake.state_abbr()` |
+| `*zip*`, `*postal*` | `fake.zipcode()` |
+| `*country*` | `fake.country_code()` |
+| `*ssn*`, `*tax_id*`, `*national_id*` | `fake.ssn()` |
+| `*dob*`, `*date_of_birth*`, `*birth*` | `fake.date_of_birth(minimum_age=18, maximum_age=90)` |
+| `*card*`, `*credit*` | `fake.credit_card_number()` |
+| `*iban*` | `fake.iban()` |
+| `*ip*`, `*ip_address*` | `fake.ipv4()` |
+
+If the field name doesn't match any pattern, generate a plausible string and
+add a `# TODO: refine PII generator for <field>` comment.
+
+### Referential integrity
+
+When schemas are connected by mappings (source → target), or by `(ref dim.field)`,
+or by join descriptions in source blocks:
+
+1. **Identify FK relationships** from the graph output.
+2. **Generate parent data first** — create the parent schema's rows and collect
+   the key values (PK fields).
+3. **Generate child data second** — for FK fields, sample from the parent's key
+   values. This ensures every child row references a valid parent.
+4. **For one-to-many** (e.g., orders → line items): generate a random number of
+   children per parent (configurable range, e.g., 1–5).
+
+### Nested records and list_of fields
+
+For schemas with `record {}` and `list_of record {}` fields:
+
+- **JSON/JSONL output**: generate nested structures naturally.
+- **CSV output**: flatten with dot notation (`customer.email`) or generate
+  separate CSV files per nested level (recommend the latter for `list_of`).
+- **SQL output**: generate separate INSERT statements per nesting level.
+
+For `list_of TYPE` (scalar lists like `list_of STRING`):
+- JSON: generate as arrays `["value1", "value2"]`
+- CSV: generate as pipe-delimited string `"value1|value2|value3"`
+
+### Filters
+
+When a schema has `(filter expr)` on a field or nested block, generate data
+that **passes** the filter. For example:
+- `(filter item_status != "cancelled")` → never generate `"cancelled"` for
+  `item_status` in the primary dataset. Optionally generate a small
+  "pre-filter" dataset that includes cancelled items to test filter logic.
+
+## Step 3: Handle edge cases from warnings
+
+Parse `//!` warnings from `satsuma warnings --json` and generate corresponding
+edge cases in a controlled percentage of rows (default 5–10%):
+
+| Warning pattern | Edge case to generate |
+|---|---|
+| "some records have NULL" / "nullable" | Generate nulls for this field in ~5% of rows |
+| "not validated" / "unvalidated" | Generate some malformed values (e.g., invalid emails) |
+| "mixed formats" | Generate values in 2–3 different formats |
+| "may be empty" | Generate empty strings in ~5% of rows |
+| "duplicates possible" | Generate a few duplicate values for this field |
+| "legacy" / "deprecated" | Generate values in old format alongside new format |
+| "truncated" / "overflow" | Generate values near or exceeding the type's length limit |
+
+When generating edge cases, add a `_edge_case` boolean column (or a comment in
+JSON) so the user can easily identify which rows are edge cases vs. clean data.
+
+## Step 4: Generate the data
+
+Write a Python script that uses Faker and random to generate data, then output
+in the requested format. The script should be:
+
+- **Self-contained** — runnable with `python generate_data.py`
+- **Seeded** — reproducible with the same seed
+- **Commented** — each generator has a comment linking to the Satsuma field
+
+### Python generation template
+
+```python
+import csv, json, random, uuid, os
+from datetime import datetime, date, timedelta
+from decimal import Decimal
+from faker import Faker
+
+fake = Faker()
+Faker.seed(42)
+random.seed(42)
+
+# --- Schema: <schema_name> ---
+def generate_<schema_name>(n: int, parent_keys: dict = None) -> list[dict]:
+    rows = []
+    for i in range(n):
+        row = {}
+        # <field_name>: <type> <metadata>
+        row["field_name"] = <generator_expression>
+        ...
+        rows.append(row)
+    return rows
+
+# --- Generate in dependency order ---
+<parent>_data = generate_<parent>(100)
+<parent>_keys = [r["<pk_field>"] for r in <parent>_data]
+<child>_data = generate_<child>(300, parent_keys={"<fk>": <parent>_keys})
+
+# --- Write output ---
+# CSV / JSON / SQL / Parquet writer here
+```
+
+Run the script and present the output files.
+
+### Output format specifics
+
+**CSV:**
+```python
+with open(f"{schema_name}.csv", "w", newline="") as f:
+    writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+    writer.writeheader()
+    writer.writerows(rows)
+```
+
+**JSON (pretty, one file per schema):**
+```python
+with open(f"{schema_name}.json", "w") as f:
+    json.dump(rows, f, indent=2, default=str)
+```
+
+**JSONL (one object per line, good for streaming):**
+```python
+with open(f"{schema_name}.jsonl", "w") as f:
+    for row in rows:
+        f.write(json.dumps(row, default=str) + "\n")
+```
+
+**SQL INSERT:**
+```python
+with open(f"{schema_name}.sql", "w") as f:
+    for row in rows:
+        cols = ", ".join(row.keys())
+        vals = ", ".join(sql_escape(v) for v in row.values())
+        f.write(f"INSERT INTO {schema_name} ({cols}) VALUES ({vals});\n")
+```
+
+**Parquet:**
+```python
+import pyarrow as pa
+import pyarrow.parquet as pq
+table = pa.Table.from_pylist(rows)
+pq.write_table(table, f"{schema_name}.parquet")
+```
+
+## Step 5: Validate and present
+
+1. **Validate constraints:**
+   - All `(required)` fields are non-null (except intentional edge cases, which
+     should be clearly marked)
+   - All `(enum {...})` values are within the allowed set (except edge cases)
+   - All `(pk)` / `(unique)` fields have unique values
+   - All FK references point to valid parent keys
+   - All `(format ...)` fields match the format (except edge cases)
+
+2. **Present the output:**
+   - Data files in the requested format
+   - The Python generation script (so the user can modify and re-run)
+   - A brief summary: row counts per schema, edge cases included, FK
+     relationships maintained
+
+3. **Suggest next steps:**
+   - "Run `satsuma validate` against your spec to confirm the schema is correct"
+   - "Use these files as seed data in your pipeline tests"
+   - "Pair with a test generator (dbt tests, Great Expectations) to validate
+     your pipeline against this data"
+
+## Exotic format guidance
+
+This skill generates logical data as CSV, JSON, SQL, or Parquet. For schemas that
+represent exotic wire formats, the logical data is correct but needs physical
+serialisation:
+
+| Schema convention | What this skill generates | What you need additionally |
+|---|---|---|
+| COBOL copybooks | CSV with correct field values | A COBOL copybook writer skill for fixed-width EBCDIC |
+| HL7 v2 segments | JSON with segment fields | An HL7 message builder skill for pipe-delimited segments |
+| EDI X12/EDIFACT | JSON with element values | An EDI envelope/segment builder skill |
+| ISO 8583 bitmaps | JSON with field values | An ISO 8583 message packer skill |
+| Fixed-width flat files | CSV with values | A fixed-width formatter skill with position maps |
+| XML (FHIR, ISO 20022) | JSON with element values | An XML serialiser skill with namespace handling |
+| Avro / Protobuf | JSON with field values | A schema-registry-aware serialiser skill |
+
+For any of these, create a format-specific skill using the `skill-creator` skill.
+The Satsuma repo's `docs/conventions-for-schema-formats/` directory has LLM
+guidelines for many of these formats that a format skill can reference.
+
+## Data modelling awareness
+
+### Kimball schemas
+
+For `(dimension, scd 2)` schemas, generate data that exercises SCD behaviour:
+- Generate multiple versions of some entities (same natural key, different
+  attribute values) to simulate history. Mark with different `valid_from` dates.
+- Include `(track {...})` field changes between versions.
+- Keep `(ignore {...})` fields constant across versions — this tests that the
+  pipeline correctly ignores them.
+
+For `(fact)` schemas:
+- Respect the `(grain {...})` — ensure unique combinations of grain fields.
+- FK fields must reference valid dimension keys.
+- `(measure additive)` fields get realistic positive decimals.
+- `(measure semi_additive)` fields (balances) should have realistic progressions.
+- `(degenerate)` fields get realistic transaction-style identifiers.
+
+### Data Vault schemas
+
+For `(hub)` schemas:
+- Generate unique business keys. Include some keys from multiple source systems
+  (same entity, different source identifiers) to test deduplication.
+
+For `(satellite)` schemas:
+- Generate multiple versions per parent hash key with different load dates.
+- Vary the descriptive fields between versions.
+
+For `(link)` schemas:
+- Generate combinations of hub business keys. Include some many-to-many
+  relationships to exercise the link structure.
+
+### Merge strategy awareness
+
+When a mapping has `(merge upsert, match_on field)`:
+- Generate some rows where the match key already exists (simulates updates)
+  and some where it's new (simulates inserts).
+- Provide both an "initial load" file and an "incremental" file so the user
+  can test the upsert behaviour.
+
+When a mapping has `(merge soft_delete)`:
+- Generate a separate "deletion feed" file with a subset of match keys.
+
+When a mapping has `(merge full_refresh)`:
+- Generate a complete dataset (no incremental split needed).

--- a/skills/satsuma-sample-data/references/field-generators.md
+++ b/skills/satsuma-sample-data/references/field-generators.md
@@ -1,0 +1,248 @@
+# Field Generator Reference
+
+For each Satsuma field, select a generator based on metadata and type. Check
+metadata first (enum, format, pii), then fall back to type-based generation.
+
+## Metadata-driven generators (highest priority)
+
+### `(enum {val1, val2, val3})`
+
+```python
+random.choice(["val1", "val2", "val3"])
+```
+
+If the field also has a `//!` warning about NULLs, include `None` in the
+choices at the configured edge-case rate.
+
+### `(format email)`
+
+```python
+fake.email()
+# Edge case: "not-an-email", "user@", "@domain.com"
+```
+
+### `(format E.164)`
+
+```python
+fake.phone_number()  # then normalize to E.164
+# Or directly: f"+1{fake.numerify('##########')}"
+# Edge case: "123", "+1-800-FLOWERS", "N/A"
+```
+
+### `(pii)`
+
+See the PII heuristic table in SKILL.md. If the field name doesn't match any
+pattern, fall back to type-based generation and comment it.
+
+### `(default <val>)`
+
+```python
+val if random.random() < 0.3 else <type_generator>
+```
+
+Use the default value ~30% of the time to create realistic distribution.
+
+### `(required)`
+
+Never generate `None` for this field (unless creating an intentional edge case
+row, clearly marked).
+
+### `(pk)` or `(unique)`
+
+```python
+# Use a counter, UUID, or Faker.unique
+fake.unique.random_int(min=1, max=999999)
+# Or for UUIDs:
+str(uuid.uuid4())
+```
+
+Ensure uniqueness across all generated rows.
+
+### `(ref schema.field)`
+
+```python
+random.choice(parent_keys["field"])
+```
+
+Sample from the parent schema's generated key values. Generate parent first.
+
+## Type-based generators (fallback)
+
+### String types
+
+| Satsuma type | Generator | Notes |
+|---|---|---|
+| `STRING` / `STRING(n)` | `fake.pystr(max_chars=n)` | Respect max length |
+| `VARCHAR(n)` | `fake.pystr(max_chars=n)` | Respect max length |
+| `CHAR(n)` | `fake.pystr(min_chars=n, max_chars=n)` | Fixed length |
+| `TEXT` | `fake.paragraph()` | Longer text |
+
+For short strings (n ≤ 5), prefer `fake.lexify("?" * n)` for code-like values.
+For medium strings (5 < n ≤ 50), prefer `fake.word()` or `fake.name()`.
+For long strings (n > 50), prefer `fake.sentence()`.
+
+### Numeric types
+
+| Satsuma type | Generator | Notes |
+|---|---|---|
+| `INT` / `INTEGER` | `fake.random_int(min=0, max=10000)` | Adjust range to context |
+| `BIGINT` | `fake.random_int(min=0, max=10**9)` | |
+| `DECIMAL(p, s)` | `round(random.uniform(0, 10**(p-s)), s)` | Respect precision and scale |
+| `FLOAT` / `DOUBLE` | `round(random.uniform(0, 10000), 4)` | |
+
+**Context-sensitive ranges:**
+- Fields named `*price*`, `*amount*`, `*total*`, `*cost*` → `0.01` to `9999.99`
+- Fields named `*quantity*`, `*count*` → `1` to `100` (integers)
+- Fields named `*percent*`, `*rate*`, `*pct*` → `0.0` to `100.0`
+- Fields named `*age*` → `18` to `90`
+- Fields named `*year*` → `2015` to `2025`
+
+### Boolean
+
+```python
+random.choice([True, False])
+```
+
+For fields with `(default false)`, bias toward `False` (~70%).
+
+### Date and time types
+
+| Satsuma type | Generator | Notes |
+|---|---|---|
+| `DATE` | `fake.date_between(start_date="-2y", end_date="today")` | |
+| `TIMESTAMP` | `fake.date_time_between(start_date="-2y")` | |
+| `TIMESTAMPTZ` | `fake.date_time_between(start_date="-2y", tzinfo=timezone.utc)` | |
+
+**Context-sensitive dates:**
+- `*created*`, `*registered*`, `*since*` → past dates, reasonable range
+- `*updated*`, `*modified*` → after creation date (if both exist in schema)
+- `*birth*`, `*dob*` → `fake.date_of_birth(minimum_age=18, maximum_age=90)`
+- `*expiry*`, `*expires*` → future dates
+
+### UUID
+
+```python
+str(uuid.uuid4())
+```
+
+Always unique. For `(pk)` UUID fields, use `uuid4()` directly.
+
+### ID types (Salesforce, etc.)
+
+```python
+# Salesforce 18-char ID
+fake.lexify("001" + "?" * 15, letters="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+```
+
+### PICKLIST (Salesforce)
+
+Treat as `(enum {...})` — must have an enum metadata token to generate from.
+If no enum is specified, generate from `["Option_A", "Option_B", "Option_C"]`
+and add a `# TODO: replace with real picklist values` comment.
+
+## Nested structures
+
+### `record {}`
+
+Generate as a nested dict:
+
+```python
+row["customer"] = {
+    "customer_id": str(uuid.uuid4()),
+    "email": fake.email(),
+    "tier": random.choice(["standard", "silver", "gold", "platinum"])
+}
+```
+
+### `list_of TYPE`
+
+Generate a list of scalar values:
+
+```python
+# list_of STRING
+row["promo_codes"] = [fake.lexify("PROMO-????") for _ in range(random.randint(0, 3))]
+
+# list_of INT
+row["tag_ids"] = [fake.random_int(1, 1000) for _ in range(random.randint(1, 5))]
+```
+
+### `list_of record {}`
+
+Generate a list of nested dicts:
+
+```python
+row["line_items"] = [
+    {
+        "line_number": i + 1,
+        "sku": fake.lexify("SKU-######"),
+        "quantity": fake.random_int(1, 10),
+        "unit_price": round(random.uniform(1.0, 500.0), 2)
+    }
+    for i in range(random.randint(1, 5))
+]
+```
+
+### Filtered lists
+
+When a `list_of record` has `(filter field != "value")`:
+
+```python
+# (filter item_status != "cancelled")
+# Generate only items that pass the filter
+row["line_items"] = [
+    {
+        "item_status": random.choice(["active", "backordered"]),  # never "cancelled"
+        ...
+    }
+    for i in range(random.randint(1, 5))
+]
+```
+
+Optionally generate a separate "pre-filter" dataset that includes filtered-out
+values for testing filter logic.
+
+## Measure-aware generation
+
+### `(measure additive)` — revenue, quantity, amounts
+
+```python
+# Positive values, realistic distribution
+round(random.lognormvariate(3, 1), 2)  # log-normal → right-skewed like real financial data
+```
+
+### `(measure semi_additive)` — balances, inventory
+
+```python
+# Simulate progression: start with a base, apply deltas
+base = round(random.uniform(100, 10000), 2)
+# Each subsequent row for the same entity: base + random delta
+```
+
+### `(measure non_additive)` — percentages, unit prices
+
+```python
+# Realistic unit prices
+round(random.uniform(0.99, 299.99), 2)
+# Percentages
+round(random.uniform(0, 100), 1)
+```
+
+## Edge case generation patterns
+
+Apply these at the configured rate (default 5–10%) to random rows:
+
+| Edge case type | Generator |
+|---|---|
+| NULL in normally-populated field | `None` |
+| Empty string | `""` |
+| Max-length string | `"x" * max_length` |
+| Boundary numbers | `0`, `-1`, `MAX_INT`, `0.00` |
+| Invalid email | `"not-an-email"`, `"user@"`, `"@domain.com"` |
+| Invalid phone | `"N/A"`, `"000-000-0000"`, `"call me"` |
+| Mixed date formats | `"2024-01-15"`, `"01/15/2024"`, `"Jan 15, 2024"` |
+| Unicode in strings | `"Ñoño"`, `"日本語"`, `"Ünïcödé"` |
+| Leading/trailing whitespace | `"  value  "` |
+| Duplicate PK values | Reuse a previously generated key |
+
+Mark edge case rows clearly — add a `_is_edge_case` field set to `True`, or
+a JSON comment, so the user can filter them in or out during testing.

--- a/skills/satsuma-to-dbt/SKILL.md
+++ b/skills/satsuma-to-dbt/SKILL.md
@@ -1,0 +1,521 @@
+---
+name: satsuma-to-dbt
+description: >
+  Generate idiomatic dbt project scaffolds from Satsuma (.stm) mapping specs. Use this
+  skill whenever the user wants to create a dbt project from Satsuma, generate dbt models
+  from .stm files, scaffold a dbt pipeline from a mapping spec, or convert Satsuma to dbt.
+  Also trigger for requests like "generate dbt from this spec", "create staging and mart
+  models from this mapping", "scaffold a dbt project for this Satsuma file", or "turn my
+  .stm into dbt SQL". Handles Kimball star schemas, Data Vault 2.0, merge strategies,
+  governance metadata, and consumer schemas (reports/models → dbt exposures). Requires
+  the `satsuma` CLI for structural extraction. Generates dbt projects that use {{ ref() }}
+  and {{ source() }} throughout — never hardcoded table names.
+---
+
+# Satsuma to dbt Project
+
+Generate a complete, idiomatic dbt project scaffold from Satsuma mapping specs.
+
+## Prerequisites
+
+- The `satsuma` CLI must be installed and on PATH.
+- The user must provide one or more `.stm` files.
+
+## Step 0: Extract structural context
+
+Before asking the user anything, use the CLI to understand the workspace:
+
+```bash
+# Workspace overview
+satsuma summary <file>.stm --json
+
+# Full graph for topology
+satsuma graph <file>.stm --json
+
+# All warnings
+satsuma warnings <file>.stm --json
+
+# Check for data modelling tokens
+satsuma find --tag dimension --json 2>/dev/null
+satsuma find --tag fact --json 2>/dev/null
+satsuma find --tag hub --json 2>/dev/null
+satsuma find --tag satellite --json 2>/dev/null
+satsuma find --tag report --json 2>/dev/null
+satsuma find --tag model --json 2>/dev/null
+```
+
+From the graph output, identify:
+- Which schemas are **sources** (appear only on the left side of mappings)
+- Which schemas are **targets** (appear on the right side)
+- Which schemas are **intermediate** (both source and target)
+- Which schemas are **consumers** (report/model metadata)
+- The data modelling approach (Kimball, Data Vault, or flat)
+- Any merge strategy tokens on mappings
+
+## Step 1: Ask the user essential questions
+
+Present these questions — they directly affect the generated code:
+
+1. **Target warehouse** — "Which data warehouse will this run on?"
+   Options: Snowflake, BigQuery, Redshift, Databricks, PostgreSQL, DuckDB.
+   This determines SQL dialect, function names, and type mappings. See
+   `references/dialect-map.md`.
+
+2. **Source connection details** — "What are your dbt source database and schema
+   names? For example, in Snowflake this might be `raw_database.crm_schema`."
+   Show the source schemas found in the spec and ask the user to provide
+   `database.schema` for each. These go into `sources.yml`.
+
+3. **dbt project conventions** — "Do you use a layered model structure?"
+   Options: staging → marts (default), staging → intermediate → marts,
+   raw → staging → warehouse, custom. Map layers to directory structure.
+
+4. **Test generation** — "Should I generate dbt tests from the spec's metadata?"
+   Options: Yes (recommended), No, Only schema tests (skip custom).
+   Explain: "The spec has metadata like `(required)`, `(enum {...})`, and `(pii)`
+   that I can convert to `not_null`, `accepted_values`, and meta tags."
+
+5. **NL transform handling** — "For natural-language transforms that I can't
+   convert to SQL automatically, should I: (a) generate TODO stubs with the NL
+   text as comments, or (b) attempt a best-effort SQL translation with a
+   review-needed marker?"
+   Default: (b) — attempt translation but mark clearly.
+
+Do NOT ask about naming conventions — infer them from the Satsuma spec
+(source schemas keep their names; targets use their Satsuma names prefixed
+with the appropriate layer prefix like `stg_`, `int_`, `dim_`, `fact_`).
+
+## Step 2: Generate dbt project structure
+
+Create the project scaffold:
+
+```
+<project_name>/
+├── dbt_project.yml
+├── packages.yml          # if dbt_utils or dbt_vault needed
+├── models/
+│   ├── staging/
+│   │   ├── <source_system>/
+│   │   │   ├── _<source_system>__sources.yml
+│   │   │   ├── _<source_system>__models.yml
+│   │   │   └── stg_<source>__<table>.sql
+│   ├── intermediate/     # only if user chose this layer
+│   │   └── int_<description>.sql
+│   └── marts/
+│       ├── <domain>/
+│       │   ├── _<domain>__models.yml
+│       │   ├── dim_<name>.sql / fact_<name>.sql
+│       │   └── ...
+│       └── ...
+├── snapshots/            # only if SCD 2 dimensions exist
+│   └── snp_<dim_name>.sql
+├── tests/                # only if custom tests needed
+│   └── ...
+└── exposures/            # only if report/model schemas exist
+    └── _exposures.yml
+```
+
+## Step 3: Generate sources.yml
+
+Every Satsuma schema that appears only as a mapping source (never as a target)
+becomes a dbt source.
+
+```yaml
+# models/staging/<source_system>/_<source_system>__sources.yml
+version: 2
+sources:
+  - name: <source_system>          # from user input
+    database: <database>           # from user input
+    schema: <schema>               # from user input
+    tables:
+      - name: <satsuma_schema_name>
+        description: >             # from schema (note "...")
+        columns:                   # from satsuma fields
+          - name: <field_name>
+            description: <note>
+            data_type: <type>      # mapped via dialect-map
+            meta:                  # from satsuma metadata
+              pii: true            # if (pii)
+              classification: X    # if (classification "X")
+            tests:                 # from satsuma metadata
+              - not_null           # if (required)
+              - unique             # if (unique)
+              - accepted_values:   # if (enum {a, b, c})
+                  values: [a, b, c]
+```
+
+## Step 4: Generate staging models
+
+One staging model per source table. Staging models do minimal cleaning — they
+are the first `{{ source() }}` reference point.
+
+```sql
+-- models/staging/<sys>/stg_<sys>__<table>.sql
+with source as (
+    select * from {{ source('<source_name>', '<table_name>') }}
+),
+
+renamed as (
+    select
+        -- map source columns to clean names
+        <source_field> as <target_field_name>,
+        ...
+    from source
+)
+
+select * from renamed
+```
+
+**Rules for staging models:**
+- Always use `{{ source() }}` — never hardcode table names.
+- Apply only renaming and type casting at this layer.
+- Do NOT apply business transforms — those go in marts.
+- Column names should be snake_case even if the source uses UPPER_CASE.
+
+## Step 5: Generate mart models
+
+Each Satsuma mapping becomes one or more mart models. The mapping's target
+schema determines the model name and structure.
+
+### Generating SQL from Satsuma arrows
+
+For each mapping, use CLI to get the full arrow set:
+
+```bash
+satsuma mapping "<mapping-name>" --json
+```
+
+Then translate each arrow to SQL. See `references/satsuma-to-sql.md` for the
+full translation table. Key patterns:
+
+**Direct copy (`[none]` classification):**
+```sql
+stg.field_name as target_field_name
+```
+
+**Pipe chains:**
+```sql
+-- trim | lowercase | validate_email | null_if_invalid
+case
+    when trim(lower(stg.email)) ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+    then trim(lower(stg.email))
+    else null
+end as email
+```
+
+**Map blocks → CASE WHEN:**
+```sql
+case
+    when stg.cust_type = 'R' then 'retail'
+    when stg.cust_type = 'B' then 'business'
+    when stg.cust_type = 'G' then 'government'
+    when stg.cust_type is null then 'retail'
+    else 'unknown'
+end as customer_type
+```
+
+**NL transforms → best-effort SQL + comment:**
+```sql
+-- TODO: NL transform — "Assign 'vip' if loyalty_tier is 'diamond' and
+-- lifetime_spend > 10000. Assign 'high_value' if loyalty_tier is gold,
+-- platinum, or diamond. Assign 'growth' if loyalty_tier is silver.
+-- Otherwise assign 'standard'."
+case
+    when loyalty_tier = 'diamond' and lifetime_spend > 10000 then 'vip'
+    when loyalty_tier in ('gold', 'platinum', 'diamond') then 'high_value'
+    when loyalty_tier = 'silver' then 'growth'
+    else 'standard'
+end as customer_segment
+-- REVIEW: ^^^ auto-generated from NL description — verify business logic
+```
+
+**Computed fields (`-> target` with no source):**
+```sql
+-- -> ingest_timestamp { now_utc }
+current_timestamp as ingest_timestamp
+```
+
+### Multi-source mappings (JOINs)
+
+When a mapping has multiple sources, read the NL join description from the
+source block. Generate JOINs using `{{ ref() }}`:
+
+```sql
+with customers as (
+    select * from {{ ref('stg_crm__customers') }}
+),
+
+orders as (
+    select * from {{ ref('stg_pos__orders') }}
+),
+
+joined as (
+    select
+        customers.customer_id,
+        orders.order_id,
+        ...
+    from orders
+    left join customers
+        on orders.customer_id = customers.customer_id
+)
+
+select * from joined
+```
+
+**Critical rule**: Every table reference MUST use `{{ ref('model_name') }}` for
+other dbt models or `{{ source('source', 'table') }}` for raw sources. Never
+hardcode schema-qualified table names.
+
+### Model materialization from merge tokens
+
+Map Satsuma merge tokens to dbt config. See `references/merge-to-dbt.md`.
+
+```sql
+-- (merge upsert, match_on customer_id)
+{{
+    config(
+        materialized='incremental',
+        unique_key='customer_id',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+-- (merge append)
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
+-- (merge full_refresh)
+{{
+    config(
+        materialized='table'
+    )
+}}
+```
+
+## Step 6: Generate SCD Type 2 handling
+
+For schemas with `(dimension, scd 2)`, you have two approaches. Ask the user
+which they prefer if not obvious from their existing project:
+
+### Option A: dbt snapshots (recommended for most teams)
+
+```sql
+-- snapshots/snp_dim_customer.sql
+{% snapshot snp_dim_customer %}
+{{
+    config(
+        target_schema='snapshots',
+        unique_key='customer_id',
+        strategy='check',
+        check_cols=['email', 'phone', 'loyalty_tier'],  -- from (track {...})
+        invalidate_hard_deletes=True
+    )
+}}
+
+select * from {{ ref('stg_crm__customers') }}
+
+{% endsnapshot %}
+```
+
+Then create a mart model that reads from the snapshot:
+
+```sql
+-- models/marts/dim_customer.sql
+select
+    {{ dbt_utils.generate_surrogate_key(['customer_id', 'dbt_valid_from']) }}
+        as surrogate_key,
+    *,
+    dbt_valid_from as valid_from,
+    dbt_valid_to as valid_to,
+    case when dbt_valid_to is null then true else false end as is_current
+from {{ ref('snp_dim_customer') }}
+```
+
+### Option B: Incremental with merge (for teams that prefer it)
+
+```sql
+-- models/marts/dim_customer.sql
+{{
+    config(
+        materialized='incremental',
+        unique_key='surrogate_key',
+        on_schema_change='append_new_columns'
+    )
+}}
+-- SCD Type 2 logic implemented inline
+-- See dbt docs on incremental SCD2 patterns for your warehouse
+```
+
+### Inferring snapshot config from Satsuma tokens
+
+| Satsuma token | dbt snapshot config |
+|---|---|
+| `natural_key <field>` | `unique_key='<field>'` |
+| `track {f1, f2, f3}` | `check_cols=['f1', 'f2', 'f3']` |
+| `ignore {f1, f2}` | Omit these from `check_cols`; if `track` is absent, use all fields minus `ignore` |
+| `scd 2` | `strategy='check'` (or `'timestamp'` if a clear updated_at field exists) |
+
+### Omitting mechanical columns
+
+Per Satsuma convention, mechanical columns (surrogate keys, valid_from/to,
+is_current, row_hash, hash keys, load dates, record_source) are NOT written
+in the .stm file — they are inferred. When generating dbt, you must ADD these
+columns back:
+
+**Kimball SCD 2:**
+- `surrogate_key` — use `dbt_utils.generate_surrogate_key()`
+- `valid_from`, `valid_to`, `is_current` — from snapshot or incremental logic
+- `row_hash` — optional; use `dbt_utils.generate_surrogate_key()` on tracked fields
+
+**Data Vault:**
+- `*_hk` hash keys — use `dbt_utils.generate_surrogate_key()` on business keys
+- `load_date` — `current_timestamp`
+- `record_source` — from the mapping's `-> record_source { "SYSTEM" }` arrow
+- `hash_diff` — hash of all descriptive fields in a satellite
+
+**Facts:**
+- `etl_batch_id` — from your orchestrator or `{{ invocation_id }}`
+- `loaded_at` — `current_timestamp`
+- `dim_*_key` — surrogate key lookups via joins to dimensions
+
+## Step 7: Generate schema YAML with tests
+
+For every generated model, create a YAML entry with column definitions and tests
+derived from Satsuma metadata:
+
+```yaml
+# models/marts/_<domain>__models.yml
+version: 2
+models:
+  - name: dim_customer
+    description: >                    # from schema (note "...")
+    meta:
+      owner: "data-team"              # from (owner "...")
+      classification: "INTERNAL"      # from (classification "...")
+      scd_type: 2                     # from (scd 2)
+    columns:
+      - name: customer_id
+        description: "Durable business key"
+        tests:
+          - not_null                   # from (required)
+          - unique                    # from (pk) or (unique)
+      - name: email
+        meta:
+          pii: true                   # from (pii)
+          classification: "RESTRICTED"
+        tests:
+          - not_null                   # from (required)
+      - name: loyalty_tier
+        tests:
+          - accepted_values:           # from (enum {bronze, silver, ...})
+              values: ['bronze', 'silver', 'gold', 'platinum', 'diamond']
+```
+
+### Test generation from Satsuma metadata
+
+| Satsuma metadata | dbt test |
+|---|---|
+| `(pk)` | `not_null` + `unique` |
+| `(pk, required)` | `not_null` + `unique` |
+| `(required)` | `not_null` |
+| `(unique)` | `unique` |
+| `(enum {a, b, c})` | `accepted_values: {values: [a, b, c]}` |
+| `(ref dim_x.field)` | `relationships: {to: ref('dim_x'), field: field}` |
+| `(format email)` | Custom test or regex test (suggest to user) |
+| `(format E.164)` | Custom test or regex test (suggest to user) |
+
+### Test generation from Satsuma warnings and comments
+
+| Satsuma comment | dbt test suggestion |
+|---|---|
+| `//! some records have NULL` | `not_null` with `warn` severity, or note in description |
+| `//! not validated` | Suggest adding a validation test |
+| `//?` open questions | Add as `description` note, flag for team review |
+
+### Fact table dimension relationship tests
+
+For schemas with `(fact, ref dim_x.field)`, generate referential integrity tests:
+
+```yaml
+- name: dim_customer_key
+  tests:
+    - not_null
+    - relationships:
+        to: ref('dim_customer')
+        field: surrogate_key
+```
+
+## Step 8: Generate dbt exposures from consumer schemas
+
+Satsuma schemas with `(report)` or `(model)` metadata become dbt exposures:
+
+```yaml
+# exposures/_exposures.yml
+version: 2
+exposures:
+  - name: weekly_sales_dashboard
+    type: dashboard                     # report → dashboard; model → ml
+    owner:
+      name: "Analytics Team"            # from (owner "...")
+    description: >                      # from (note "...")
+    depends_on:
+      - ref('fact_orders')              # from (source {fact_orders, dim_product})
+      - ref('dim_product')
+    url: "https://..."                  # from (dashboard_id "...") if URL-like
+    meta:
+      tool: looker                      # from (tool looker)
+      classification: "INTERNAL"        # from (classification "...")
+      refresh: "Monday 06:00 UTC"       # from (refresh schedule "...")
+```
+
+### Consumer type mapping
+
+| Satsuma token | dbt exposure type |
+|---|---|
+| `(report)` | `dashboard` |
+| `(model)` | `ml` |
+| `(report)` with `(tool jupyter)` | `notebook` |
+
+## Step 9: Generate packages.yml
+
+Based on what the scaffold needs:
+
+```yaml
+packages:
+  - package: dbt-labs/dbt_utils
+    version: [">=1.0.0", "<2.0.0"]
+  # Add if Data Vault patterns detected:
+  - package: Datavault-UK/dbtvault
+    version: [">=0.10.0", "<1.0.0"]
+```
+
+## Step 10: Validate and present
+
+1. Review the generated project for consistency:
+   - Every `{{ ref() }}` points to a model that exists in the scaffold.
+   - Every `{{ source() }}` has a matching entry in sources.yml.
+   - No hardcoded table names anywhere.
+   - Materializations match the merge strategy tokens.
+
+2. List what was generated and what needs manual attention:
+   - Models with TODO markers from NL transforms.
+   - Any `//!` warnings that need operational decisions.
+   - Any `//?` open questions that need stakeholder input.
+   - Custom tests that were suggested but not generated.
+
+3. Present the files to the user.
+
+## Important: What NOT to generate
+
+- **Do not generate `profiles.yml`** — this contains credentials and is
+  environment-specific. Mention that the user needs to configure it.
+- **Do not hardcode warehouse-specific function names without checking the
+  dialect** — always consult `references/dialect-map.md`.
+- **Do not generate models for Satsuma schemas that are only used as sources** —
+  they belong in sources.yml, not as models.
+- **Do not collapse multiple Satsuma mappings targeting the same schema into one
+  model** without asking the user. Multiple mappings to one target may represent
+  sequential load steps or alternative sources.

--- a/skills/satsuma-to-dbt/references/dialect-map.md
+++ b/skills/satsuma-to-dbt/references/dialect-map.md
@@ -1,0 +1,117 @@
+# SQL Dialect Map
+
+Use this reference when generating SQL for dbt models. The target warehouse affects
+function names, type syntax, and merge behavior.
+
+## Type Mappings
+
+| Satsuma Type | Snowflake | BigQuery | Redshift | Databricks | PostgreSQL | DuckDB |
+|---|---|---|---|---|---|---|
+| `INT` / `INTEGER` | `INTEGER` | `INT64` | `INTEGER` | `INT` | `INTEGER` | `INTEGER` |
+| `BIGINT` | `BIGINT` | `INT64` | `BIGINT` | `BIGINT` | `BIGINT` | `BIGINT` |
+| `DECIMAL(p,s)` | `NUMBER(p,s)` | `NUMERIC(p,s)` | `DECIMAL(p,s)` | `DECIMAL(p,s)` | `NUMERIC(p,s)` | `DECIMAL(p,s)` |
+| `STRING` / `STRING(n)` | `VARCHAR(n)` | `STRING` | `VARCHAR(n)` | `STRING` | `VARCHAR(n)` | `VARCHAR(n)` |
+| `VARCHAR(n)` | `VARCHAR(n)` | `STRING` | `VARCHAR(n)` | `STRING` | `VARCHAR(n)` | `VARCHAR(n)` |
+| `CHAR(n)` | `CHAR(n)` | `STRING` | `CHAR(n)` | `STRING` | `CHAR(n)` | `VARCHAR(n)` |
+| `BOOLEAN` | `BOOLEAN` | `BOOL` | `BOOLEAN` | `BOOLEAN` | `BOOLEAN` | `BOOLEAN` |
+| `DATE` | `DATE` | `DATE` | `DATE` | `DATE` | `DATE` | `DATE` |
+| `TIMESTAMP` | `TIMESTAMP_NTZ` | `TIMESTAMP` | `TIMESTAMP` | `TIMESTAMP` | `TIMESTAMP` | `TIMESTAMP` |
+| `TIMESTAMPTZ` | `TIMESTAMP_TZ` | `TIMESTAMP` | `TIMESTAMPTZ` | `TIMESTAMP` | `TIMESTAMPTZ` | `TIMESTAMPTZ` |
+| `UUID` | `VARCHAR(36)` | `STRING` | `VARCHAR(36)` | `STRING` | `UUID` | `UUID` |
+| `TEXT` | `TEXT` | `STRING` | `TEXT` | `STRING` | `TEXT` | `TEXT` |
+| `ID` (Salesforce) | `VARCHAR(18)` | `STRING` | `VARCHAR(18)` | `STRING` | `VARCHAR(18)` | `VARCHAR(18)` |
+| `PICKLIST` | `VARCHAR(255)` | `STRING` | `VARCHAR(255)` | `STRING` | `VARCHAR(255)` | `VARCHAR(255)` |
+
+## Function Mappings
+
+### String functions
+
+| Satsuma pipe | Snowflake | BigQuery | Redshift | PostgreSQL |
+|---|---|---|---|---|
+| `trim` | `TRIM(x)` | `TRIM(x)` | `TRIM(x)` | `TRIM(x)` |
+| `lowercase` | `LOWER(x)` | `LOWER(x)` | `LOWER(x)` | `LOWER(x)` |
+| `uppercase` | `UPPER(x)` | `UPPER(x)` | `UPPER(x)` | `UPPER(x)` |
+| `title_case` | `INITCAP(x)` | `INITCAP(x)` | `INITCAP(x)` | `INITCAP(x)` |
+| `truncate(n)` | `LEFT(x, n)` | `LEFT(x, n)` | `LEFT(x, n)` | `LEFT(x, n)` |
+| `max_length(n)` | `LEFT(x, n)` | `LEFT(x, n)` | `LEFT(x, n)` | `LEFT(x, n)` |
+| `pad_left(n, c)` | `LPAD(x, n, c)` | `LPAD(x, n, c)` | `LPAD(x, n, c)` | `LPAD(x, n, c)` |
+| `pad_right(n, c)` | `RPAD(x, n, c)` | `RPAD(x, n, c)` | `RPAD(x, n, c)` | `RPAD(x, n, c)` |
+| `replace(a, b)` | `REPLACE(x, a, b)` | `REPLACE(x, a, b)` | `REPLACE(x, a, b)` | `REPLACE(x, a, b)` |
+| `split(d)` | `SPLIT(x, d)` | `SPLIT(x, d)` | `SPLIT_PART(...)` | `STRING_TO_ARRAY(x, d)` |
+
+### Null handling
+
+| Satsuma pipe | All dialects |
+|---|---|
+| `coalesce(v)` | `COALESCE(x, v)` |
+| `null_if_empty` | `NULLIF(x, '')` |
+| `null_if_invalid` | Context-dependent — wrap in CASE |
+| `error_if_null` | Wrap in assertion or test |
+
+### Type conversion
+
+| Satsuma pipe | Snowflake | BigQuery | Redshift | PostgreSQL |
+|---|---|---|---|---|
+| `to_string` | `TO_VARCHAR(x)` | `CAST(x AS STRING)` | `CAST(x AS VARCHAR)` | `x::TEXT` |
+| `to_number` | `TO_NUMBER(x)` | `CAST(x AS NUMERIC)` | `CAST(x AS DECIMAL)` | `x::NUMERIC` |
+| `to_boolean` | `TO_BOOLEAN(x)` | `CAST(x AS BOOL)` | `CAST(x AS BOOLEAN)` | `x::BOOLEAN` |
+| `round(n)` | `ROUND(x, n)` | `ROUND(x, n)` | `ROUND(x, n)` | `ROUND(x, n)` |
+
+### Timestamp functions
+
+| Satsuma pipe | Snowflake | BigQuery | Redshift | PostgreSQL |
+|---|---|---|---|---|
+| `now_utc` / `now_utc()` | `CURRENT_TIMESTAMP()` | `CURRENT_TIMESTAMP()` | `GETDATE()` | `NOW()` |
+| `to_utc` | `CONVERT_TIMEZONE('UTC', x)` | `TIMESTAMP(x, 'UTC')` | `CONVERT_TIMEZONE('UTC', x)` | `x AT TIME ZONE 'UTC'` |
+| `to_iso8601` | `TO_VARCHAR(x, 'YYYY-MM-DD"T"HH24:MI:SS"Z"')` | `FORMAT_TIMESTAMP('%Y-%m-%dT%H:%M:%SZ', x)` | `TO_CHAR(x, 'YYYY-MM-DD"T"HH24:MI:SS"Z"')` | `TO_CHAR(x, 'YYYY-MM-DD"T"HH24:MI:SS"Z"')` |
+
+### Hashing (for surrogate keys / Data Vault)
+
+| Purpose | Snowflake | BigQuery | Redshift | PostgreSQL |
+|---|---|---|---|---|
+| Surrogate key | `MD5(x)` | `TO_HEX(MD5(x))` | `MD5(x)` | `MD5(x)` |
+| Hash diff | `MD5(CONCAT_WS('\|', ...))` | `TO_HEX(MD5(CONCAT(...)))` | `MD5(...)` | `MD5(CONCAT_WS('\|', ...))` |
+| UUID v5 | Not native — use UDF or `UUID_STRING()` | `GENERATE_UUID()` | Not native | `uuid_generate_v5()` |
+
+### Email validation regex
+
+| Dialect | Pattern |
+|---|---|
+| Snowflake | `RLIKE(x, '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$')` |
+| BigQuery | `REGEXP_CONTAINS(x, r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$')` |
+| Redshift | `x ~ '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'` |
+| PostgreSQL | `x ~ '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'` |
+
+## Merge / Incremental Patterns
+
+### Snowflake
+
+```sql
+-- merge upsert (dbt incremental with merge strategy)
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge') }}
+
+-- merge append
+{{ config(materialized='incremental', incremental_strategy='append') }}
+
+-- merge full_refresh
+{{ config(materialized='table') }}
+```
+
+### BigQuery
+
+```sql
+-- merge upsert
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge') }}
+
+-- merge append
+{{ config(materialized='incremental', incremental_strategy='insert_overwrite',
+          partition_by={'field': 'event_date', 'data_type': 'date'}) }}
+```
+
+### Databricks
+
+```sql
+-- merge upsert (Delta Lake)
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge',
+          file_format='delta') }}
+```

--- a/skills/satsuma-to-dbt/references/merge-to-dbt.md
+++ b/skills/satsuma-to-dbt/references/merge-to-dbt.md
@@ -1,0 +1,195 @@
+# Merge Strategy to dbt Materialization
+
+Maps Satsuma merge tokens to dbt model configurations.
+
+## Core Mapping
+
+| Satsuma merge token | dbt materialization | Key config |
+|---|---|---|
+| `merge upsert` | `incremental` | `unique_key`, `incremental_strategy='merge'` |
+| `merge append` | `incremental` | No `unique_key`, `incremental_strategy='append'` |
+| `merge soft_delete` | `incremental` | `unique_key` from `match_on`, custom soft-delete logic |
+| `merge full_refresh` | `table` | No incremental logic needed |
+| No merge token | `view` (staging) or `table` (marts) | Decide by layer |
+
+## Detailed Patterns
+
+### merge upsert
+
+```satsuma
+mapping `customer upsert` (merge upsert, match_on customer_id) { ... }
+```
+→
+```sql
+{{
+    config(
+        materialized='incremental',
+        unique_key='customer_id',
+        incremental_strategy='merge',
+        on_schema_change='append_new_columns'
+    )
+}}
+
+with source as (
+    select * from {{ ref('stg_crm__customers') }}
+)
+
+select
+    customer_id,
+    full_name,
+    email,
+    current_timestamp() as updated_at
+from source
+
+{% if is_incremental() %}
+where updated_at > (select max(updated_at) from {{ this }})
+{% endif %}
+```
+
+**on_match / on_no_match mapping:**
+
+| Satsuma | dbt behavior |
+|---|---|
+| `on_match update` (default) | Standard merge — `WHEN MATCHED THEN UPDATE` |
+| `on_match skip` | Add `merge_exclude_columns` or use `insert_overwrite` |
+| `on_no_match insert` (default) | Standard — `WHEN NOT MATCHED THEN INSERT` |
+| `on_no_match skip` | Use `incremental_predicates` to filter unmatched rows |
+
+### merge append
+
+```satsuma
+mapping `events` (merge append) { ... }
+```
+→
+```sql
+{{
+    config(
+        materialized='incremental',
+        incremental_strategy='append'
+    )
+}}
+
+select
+    event_id,
+    user_id,
+    event_timestamp,
+    current_timestamp() as ingested_at
+from {{ ref('stg_events') }}
+
+{% if is_incremental() %}
+where event_timestamp > (select max(event_timestamp) from {{ this }})
+{% endif %}
+```
+
+Note: even append-only models need an `is_incremental()` filter to avoid
+re-inserting historical data. Use the most natural timestamp field.
+
+### merge soft_delete
+
+```satsuma
+mapping `customer delete` (
+  merge soft_delete,
+  match_on customer_id,
+  delete_flag is_deleted,
+  delete_timestamp deleted_at
+) { ... }
+```
+
+dbt doesn't have native soft-delete support. Two approaches:
+
+**Approach A: Separate delete model (simpler)**
+```sql
+-- models/marts/dim_customer_deletes.sql
+-- Run after dim_customer to apply soft deletes
+{{
+    config(
+        materialized='incremental',
+        unique_key='customer_id',
+        incremental_strategy='merge',
+        merge_update_columns=['is_deleted', 'deleted_at']
+    )
+}}
+
+select
+    customer_id,
+    true as is_deleted,
+    current_timestamp() as deleted_at
+from {{ ref('stg_crm__deleted_customers') }}
+```
+
+**Approach B: Combined in main model (more complex)**
+```sql
+-- Combine active and deleted sources in one model
+-- Use COALESCE and LEFT JOIN to handle both feeds
+```
+
+### merge full_refresh
+
+```satsuma
+mapping `product refresh` (merge full_refresh) { ... }
+```
+→
+```sql
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select
+    sku,
+    trim(product_name) as product_name,
+    category,
+    current_timestamp() as refreshed_at
+from {{ ref('stg_sap__products') }}
+```
+
+For full_refresh with a safety note (e.g., "abort if < 1000 rows"), generate
+a custom test:
+
+```sql
+-- tests/assert_product_minimum_row_count.sql
+select count(*)
+from {{ ref('dim_product') }}
+having count(*) < 1000
+```
+
+### Composite match keys
+
+```satsuma
+mapping `price upsert` (merge upsert, match_on {product_id, effective_date}) { ... }
+```
+→
+```sql
+{{
+    config(
+        materialized='incremental',
+        unique_key=['product_id', 'effective_date'],
+        incremental_strategy='merge'
+    )
+}}
+```
+
+## SCD interaction
+
+When merge tokens appear alongside `scd` tokens, the SCD strategy governs
+history management:
+
+| Combination | dbt approach |
+|---|---|
+| `merge upsert` + `scd 1` | Standard incremental merge — overwrite in place |
+| `merge upsert` + `scd 2` | Use dbt snapshot + downstream mart model (see SKILL.md Step 6) |
+| `merge soft_delete` + `scd 2` | Snapshot + soft-delete model that end-dates the current version |
+| `merge full_refresh` + `scd 2` | `//! Warning` — full refresh destroys history. Flag to user. |
+| `merge append` + `scd 2` | Unusual — raw append feed; SCD2 logic in a downstream model |
+
+## Warehouse-specific incremental strategies
+
+| Strategy | Snowflake | BigQuery | Redshift | Databricks |
+|---|---|---|---|---|
+| `merge` (upsert) | `merge` | `merge` | `merge` | `merge` (Delta) |
+| `append` | `append` | `append` | `append` | `append` |
+| `delete+insert` | `delete+insert` | N/A | `delete+insert` | N/A |
+| `insert_overwrite` | N/A | `insert_overwrite` | N/A | `insert_overwrite` |
+
+Default to `merge` for upserts unless the user specifies otherwise.

--- a/skills/satsuma-to-dbt/references/satsuma-to-sql.md
+++ b/skills/satsuma-to-dbt/references/satsuma-to-sql.md
@@ -1,0 +1,288 @@
+# Satsuma to SQL Translation
+
+Translate Satsuma arrows and transform bodies into SQL SELECT expressions for dbt models.
+Always consult `dialect-map.md` for warehouse-specific function names.
+
+## Arrow classification → SQL pattern
+
+### `[none]` — Direct copy
+
+```satsuma
+field_a -> field_b
+```
+→
+```sql
+source.field_a as field_b
+```
+
+If source and target names are identical, just `source.field_a`.
+
+### `[none]` with rename only
+
+```satsuma
+CUST_ID -> customer_id
+```
+→
+```sql
+source.cust_id as customer_id
+```
+
+### Multi-source arrow
+
+```satsuma
+first_name, last_name -> full_name { "Concat @first_name + ' ' + @last_name" }
+```
+→
+```sql
+concat(source.first_name, ' ', source.last_name) as full_name
+```
+
+### Computed field (no source)
+
+```satsuma
+-> ingest_timestamp { now_utc }
+```
+→
+```sql
+current_timestamp() as ingest_timestamp
+```
+
+```satsuma
+-> is_deleted { true }
+```
+→
+```sql
+true as is_deleted
+```
+
+## Pipe chain → nested SQL functions
+
+Pipe chains read left-to-right. In SQL, the innermost function is the leftmost
+pipe step:
+
+```satsuma
+email -> email { trim | lowercase | validate_email | null_if_invalid }
+```
+→
+```sql
+case
+    when regexp_like(lower(trim(source.email)), '^[A-Za-z0-9._%+-]+@...$')
+    then lower(trim(source.email))
+    else null
+end as email
+```
+
+For readability in complex chains, use a CTE:
+
+```sql
+with email_cleaned as (
+    select
+        *,
+        lower(trim(email)) as _email_cleaned
+    from source
+)
+select
+    case
+        when regexp_like(_email_cleaned, '^[A-Za-z0-9._%+-]+@...$')
+        then _email_cleaned
+        else null
+    end as email
+from email_cleaned
+```
+
+### Common pipe → SQL translations
+
+| Pipe step | SQL |
+|---|---|
+| `trim` | `TRIM(x)` |
+| `lowercase` | `LOWER(x)` |
+| `uppercase` | `UPPER(x)` |
+| `title_case` | `INITCAP(x)` |
+| `coalesce(v)` | `COALESCE(x, v)` |
+| `coalesce(false)` | `COALESCE(x, FALSE)` |
+| `null_if_empty` | `NULLIF(x, '')` |
+| `null_if_invalid` | Wrap preceding chain in CASE WHEN + validation |
+| `warn_if_invalid` | Same as null_if_invalid but add `-- WARNING` comment |
+| `error_if_null` | Add `not_null` test in schema YAML |
+| `error_if_invalid` | Add custom test in schema YAML |
+| `round` / `round(n)` | `ROUND(x)` / `ROUND(x, n)` |
+| `* 100` | `x * 100` (arithmetic in pipe) |
+| `to_string` | `CAST(x AS VARCHAR)` |
+| `to_number` | `CAST(x AS NUMERIC)` |
+| `validate_email` | Regex check (see dialect-map.md) |
+| `to_e164` | NL — generate TODO with comment |
+| `now_utc` / `now_utc()` | `CURRENT_TIMESTAMP()` |
+| `replace(a, b)` | `REPLACE(x, 'a', 'b')` |
+| `pad_left(n, c)` | `LPAD(x, n, 'c')` |
+| `split(d) \| first` | `SPLIT_PART(x, 'd', 1)` |
+| `split(d) \| last` | `SPLIT_PART(x, 'd', -1)` — check dialect |
+| `max_length(n)` | `LEFT(x, n)` |
+
+### Pipes that become tests instead of SQL
+
+Some Satsuma pipes are better expressed as dbt tests than inline SQL:
+
+| Pipe step | dbt test |
+|---|---|
+| `error_if_null` | `tests: [not_null]` in schema YAML |
+| `error_if_invalid` | Custom test on the column |
+| `drop_if_null` | `WHERE x IS NOT NULL` filter in model |
+| `drop_if_invalid` | `WHERE <validation>` filter in model |
+| `warn_if_null` | `tests: [{not_null: {severity: warn}}]` |
+| `warn_if_invalid` | `tests: [{<test>: {severity: warn}}]` |
+
+## Map blocks → CASE WHEN
+
+```satsuma
+type -> type_name {
+  map { R: "retail", B: "business", G: "government", null: "retail", _: "unknown" }
+}
+```
+→
+```sql
+case
+    when source.type = 'R' then 'retail'
+    when source.type = 'B' then 'business'
+    when source.type = 'G' then 'government'
+    when source.type is null then 'retail'
+    else 'unknown'
+end as type_name
+```
+
+### Range-based maps
+
+```satsuma
+amount -> bucket { map { < 100: "low", < 1000: "mid", default: "high" } }
+```
+→
+```sql
+case
+    when source.amount < 100 then 'low'
+    when source.amount < 1000 then 'mid'
+    else 'high'
+end as bucket
+```
+
+## Named transforms (spread)
+
+```satsuma
+transform clean_email {
+  trim | lowercase | validate_email | null_if_invalid
+}
+
+email -> email { ...clean_email }
+```
+
+In dbt, implement as a macro:
+
+```sql
+-- macros/clean_email.sql
+{% macro clean_email(column) %}
+case
+    when regexp_like(lower(trim({{ column }})), '^...$')
+    then lower(trim({{ column }}))
+    else null
+end
+{% endmacro %}
+
+-- In the model:
+{{ clean_email('source.email') }} as email
+```
+
+## NL transforms → best-effort SQL
+
+For transforms described in natural language, attempt a SQL translation but ALWAYS:
+1. Include the original NL text as a SQL comment above the expression.
+2. Add a `-- REVIEW:` marker after the expression.
+3. If you're not confident, wrap it in a `-- TODO:` instead.
+
+```satsuma
+-> display_name {
+  "If @CUST_TYPE is R or null, concat @FIRST_NM + ' ' + @LAST_NM.
+   Otherwise use @COMPANY_NM. Trim and title-case."
+}
+```
+→
+```sql
+-- NL: "If CUST_TYPE is R or null, concat FIRST_NM + LAST_NM.
+--      Otherwise use COMPANY_NM. Trim and title-case."
+initcap(trim(
+    case
+        when source.cust_type = 'R' or source.cust_type is null
+        then concat(source.first_nm, ' ', source.last_nm)
+        else source.company_nm
+    end
+)) as display_name
+-- REVIEW: auto-generated from NL — verify logic
+```
+
+## each/flatten blocks → lateral flatten or UNNEST
+
+### flatten
+
+```satsuma
+flatten line_items -> order_line_facts {
+  .line_number -> line_number
+  .sku -> sku { trim | uppercase }
+}
+```
+
+**Snowflake:**
+```sql
+select
+    source.event_id as order_id,
+    item.value:line_number::int as line_number,
+    upper(trim(item.value:sku::string)) as sku
+from source,
+lateral flatten(input => source.line_items) as item
+```
+
+**BigQuery:**
+```sql
+select
+    source.event_id as order_id,
+    item.line_number,
+    upper(trim(item.sku)) as sku
+from source,
+unnest(source.line_items) as item
+```
+
+**For relational sources** (no nested arrays), flatten typically means a JOIN:
+```sql
+select
+    orders.order_id,
+    lines.line_number,
+    upper(trim(lines.sku)) as sku
+from {{ ref('stg_orders') }} as orders
+inner join {{ ref('stg_order_lines') }} as lines
+    on orders.order_id = lines.order_id
+```
+
+## Source block filters → WHERE clauses
+
+```satsuma
+source {
+  order_events
+  "WHERE @order_events.order_status = completed"
+}
+```
+→
+```sql
+with source as (
+    select * from {{ ref('stg_order_events') }}
+    where order_status = 'completed'
+)
+```
+
+## Schema-level filters on fields
+
+```satsuma
+line_items list_of record (filter item_status != "cancelled") { ... }
+```
+
+This is a pre-mapping filter. In dbt, apply it as a WHERE in the CTE that reads
+this field:
+```sql
+-- Pre-filter: exclude cancelled line items per schema definition
+where item_status != 'cancelled'
+```

--- a/skills/satsuma-to-excel/scripts/stm_to_excel.py
+++ b/skills/satsuma-to-excel/scripts/stm_to_excel.py
@@ -353,7 +353,7 @@ def _run_satsuma(args: list[str]) -> str:
     stdout contains usable output.  We only fail if there is *no*
     stdout at all and the exit code is non-zero.
     """
-    cmd = ["npx", "satsuma"] + args
+    cmd = ["satsuma"] + args
     result = subprocess.run(
         cmd,
         capture_output=True,

--- a/skills/satsuma-to-excel/scripts/test_stm_to_excel.py
+++ b/skills/satsuma-to-excel/scripts/test_stm_to_excel.py
@@ -192,13 +192,13 @@ def _skip_if_no_cli():
     """Skip test if satsuma CLI is not available."""
     try:
         result = subprocess.run(
-            ["npx", "satsuma", "--version"],
+            ["satsuma", "--version"],
             capture_output=True, text=True, timeout=10,
         )
         if result.returncode != 0:
             pytest.skip("satsuma CLI not available")
     except FileNotFoundError:
-        pytest.skip("npx not available")
+        pytest.skip("satsuma CLI not available")
 
 
 def _run_stm_to_excel(stm_files: list[str], output: str, extra_args: list[str] | None = None) -> str:

--- a/skills/satsuma-to-openlineage/SKILL.md
+++ b/skills/satsuma-to-openlineage/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: satsuma-to-openlineage
+description: >
+  Generate OpenLineage events from Satsuma (.stm) mapping specs. Use this skill whenever
+  the user wants to export Satsuma lineage to OpenLineage, integrate Satsuma with Marquez
+  or DataHub, generate OpenLineage JSON from .stm files, create lineage events for a data
+  catalog, or bridge Satsuma specs into an OpenLineage-compatible lineage backend. Also
+  trigger for requests like "export lineage to OpenLineage", "generate Marquez events",
+  "create column-level lineage JSON", "integrate Satsuma with DataHub/Atlan/OpenMetadata",
+  or "publish lineage from my mapping spec". Requires the `satsuma` CLI for structural
+  extraction. Generates spec-compliant OpenLineage 2-0-2 RunEvents with standard and
+  custom facets.
+---
+
+# Satsuma to OpenLineage
+
+Generate OpenLineage-compliant RunEvent JSON from Satsuma mapping specs, including
+column-level lineage, schema facets, documentation, governance, and data modelling
+metadata.
+
+## Core concept
+
+Satsuma is a **design-time** specification — it describes what mappings *should* do.
+OpenLineage is a **run-time** event model — it describes what jobs *did* do. This
+skill bridges the gap by generating **synthetic COMPLETE events** that represent the
+full structural lineage from the Satsuma spec. These events can be:
+
+- Pushed to Marquez, DataHub, Atlan, or any OpenLineage-compatible backend
+- Used as templates that a runtime integration (Airflow, Spark, dbt) decorates
+  with actual run metadata (timestamps, durations, row counts)
+- Consumed by data catalogs for design-time lineage before pipelines are built
+
+## Prerequisites
+
+- The `satsuma` CLI must be installed and on PATH.
+- The user must provide one or more `.stm` files.
+
+## Step 0: Extract structural context
+
+```bash
+# Full workspace graph — all nodes, edges, field-level flow
+satsuma graph <file>.stm --json
+
+# All warnings
+satsuma warnings <file>.stm --json
+```
+
+The graph output gives you everything: schemas (→ Datasets), mappings (→ Jobs),
+field-level edges (→ ColumnLineage), and transform classifications.
+
+## Step 1: Ask the user essential questions
+
+1. **Dataset namespace** — "What is the OpenLineage namespace for your datasets?
+   This is typically derived from your data platform."
+   Examples: `snowflake://account.snowflakecomputing.com`,
+   `bigquery`, `postgres://host:5432/db`, `s3://bucket`.
+   If schemas live on different platforms, ask for a namespace per source system.
+
+2. **Job namespace** — "What is the namespace for your pipeline jobs?"
+   Examples: `airflow://my-dag`, `dbt://project-name`, `satsuma://workspace`.
+   Default: `satsuma://workspace` if the user doesn't have a scheduler yet.
+
+3. **Dataset naming convention** — "How should dataset names be qualified?"
+   Examples: `database.schema.table`, `schema.table`, `table`.
+   If Satsuma schemas use namespaces, offer to use them:
+   `namespace::schema` → `database.namespace.schema`.
+
+4. **Output format** — "Should I generate:
+   (a) Static JSON files (one per mapping) ready to POST to a backend,
+   (b) A Python script using the OpenLineage Python client, or
+   (c) A single JSON array of all events?"
+   Default: (a) — one JSON file per mapping.
+
+## Step 2: Map Satsuma entities to OpenLineage
+
+### Satsuma schema → OpenLineage Dataset
+
+Every schema becomes a Dataset with:
+- `namespace`: from user input (step 1)
+- `name`: schema name, qualified per convention (e.g., `raw.crm.customers`)
+- `facets.schema`: SchemaDatasetFacet with fields and types
+- `facets.documentation`: DocumentationDatasetFacet from `(note "...")`
+- `facets.ownership`: OwnershipDatasetFacet from `(owner "...")` / `(steward "...")`
+- `facets.satsuma_governance`: custom facet for PII, classification, retention, etc.
+- `facets.satsuma_modelling`: custom facet for dimension/fact/hub/satellite tokens
+
+### Satsuma mapping → OpenLineage Job + RunEvent
+
+Every mapping becomes a Job, and we emit one synthetic COMPLETE RunEvent per mapping:
+- `job.namespace`: from user input
+- `job.name`: mapping name (e.g., `customer-migration`)
+- `job.facets.documentation`: from mapping `note {}` blocks
+- `job.facets.jobType`: processing type from merge tokens
+- `inputs`: source schemas as InputDatasets
+- `outputs`: target schema as OutputDataset with ColumnLineageDatasetFacet
+- `run.runId`: a deterministic UUID v5 from the job namespace + name (reproducible)
+- `run.facets`: empty (no actual run metadata for design-time events)
+
+### Satsuma arrows → ColumnLineageDatasetFacet
+
+Field-level arrows become column lineage entries on the **output** dataset:
+
+```json
+{
+  "columnLineage": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet",
+    "fields": {
+      "customer_id": {
+        "inputFields": [
+          {
+            "namespace": "snowflake://...",
+            "name": "raw.crm.customers",
+            "field": "CUST_ID"
+          }
+        ],
+        "transformationDescription": "uuid_v5(\"namespace\", CUST_ID)",
+        "transformationType": "INDIRECT"
+      }
+    }
+  }
+}
+```
+
+See `references/facet-mapping.md` for the complete mapping rules.
+
+## Step 3: Generate events
+
+For each Satsuma mapping, use the CLI to extract arrows:
+
+```bash
+satsuma mapping "<mapping-name>" --json
+```
+
+Then build the RunEvent. See `references/event-template.md` for the full
+JSON structure.
+
+### Transform classification → transformationType
+
+| Satsuma classification | OpenLineage transformationType |
+|---|---|
+| `[none]` (direct copy) | `DIRECT` |
+| `[nl]` (has transform body) | `INDIRECT` |
+| `[nl-derived]` (inferred from @ref) | `INDIRECT` |
+
+### Multi-source arrows
+
+When an arrow has multiple source fields (`a, b -> target`), list all source
+fields in the `inputFields` array:
+
+```json
+"full_name": {
+  "inputFields": [
+    { "namespace": "...", "name": "...", "field": "first_name" },
+    { "namespace": "...", "name": "...", "field": "last_name" }
+  ],
+  "transformationDescription": "Concat first_name + ' ' + last_name",
+  "transformationType": "INDIRECT"
+}
+```
+
+### Computed fields (no source)
+
+Fields with `-> target { ... }` (no left side) use an empty `inputFields` array
+with a description:
+
+```json
+"ingest_timestamp": {
+  "inputFields": [],
+  "transformationDescription": "now_utc",
+  "transformationType": "INDIRECT"
+}
+```
+
+## Step 4: Handle governance metadata as custom facets
+
+Satsuma governance tokens don't have standard OpenLineage facets, so emit them
+as custom facets with the `satsuma_` prefix:
+
+```json
+{
+  "satsuma_governance": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://github.com/thorbenlouw/satsuma-lang/blob/main/openlineage/SatsumaGovernanceDatasetFacet.json",
+    "piiFields": ["email", "phone", "tax_id"],
+    "classification": "RESTRICTED",
+    "retention": "7y",
+    "compliance": ["GDPR", "SOX"],
+    "owner": "data-platform-team",
+    "steward": "Jane Smith",
+    "fieldClassifications": {
+      "email": { "classification": "RESTRICTED", "retention": "3y",
+                 "encrypt": "AES-256-GCM", "mask": "partial_email" }
+    }
+  }
+}
+```
+
+## Step 5: Handle data modelling metadata as custom facets
+
+```json
+{
+  "satsuma_modelling": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://github.com/thorbenlouw/satsuma-lang/blob/main/openlineage/SatsumaModellingDatasetFacet.json",
+    "entityType": "dimension",
+    "scdType": 2,
+    "naturalKey": "customer_id",
+    "trackedFields": ["email", "phone", "loyalty_tier"],
+    "ignoredFields": ["last_login_channel"],
+    "conformed": true
+  }
+}
+```
+
+For facts:
+```json
+{
+  "satsuma_modelling": {
+    "entityType": "fact",
+    "grain": ["transaction_id", "line_number"],
+    "dimensionRefs": [
+      { "dimension": "dim_customer", "joinField": "customer_id" },
+      { "dimension": "dim_product", "joinField": "sku" }
+    ],
+    "measures": {
+      "quantity": "additive",
+      "net_amount": "additive",
+      "unit_price": "non_additive"
+    }
+  }
+}
+```
+
+For Data Vault entities, use equivalent structure with `hub`, `satellite`, `link`.
+
+## Step 6: Handle merge strategy as a job facet
+
+```json
+{
+  "satsuma_mergeStrategy": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://github.com/thorbenlouw/satsuma-lang/blob/main/openlineage/SatsumaMergeStrategyJobFacet.json",
+    "strategy": "upsert",
+    "matchOn": ["customer_id"],
+    "onMatch": "update",
+    "onNoMatch": "insert"
+  }
+}
+```
+
+## Step 7: Handle consumer schemas
+
+Satsuma `(report)` and `(model)` schemas are leaf-node consumers. They become
+OutputDatasets on a synthetic "consumption" job, or can be emitted as standalone
+datasets with documentation and ownership facets.
+
+If a consumer has `(source {schema1, schema2})`, generate an additional synthetic
+job that shows the consumption dependency:
+
+```json
+{
+  "job": {
+    "namespace": "satsuma://workspace",
+    "name": "weekly_sales_dashboard",
+    "facets": {
+      "jobType": {
+        "processingType": "BATCH",
+        "integration": "SATSUMA",
+        "jobType": "REPORT"
+      }
+    }
+  },
+  "inputs": [
+    { "namespace": "...", "name": "fact_orders" },
+    { "namespace": "...", "name": "dim_product" }
+  ],
+  "outputs": [
+    {
+      "namespace": "looker://instance",
+      "name": "weekly_sales_dashboard",
+      "facets": {
+        "documentation": {
+          "description": "Executive weekly sales overview"
+        },
+        "satsuma_consumer": {
+          "consumerType": "report",
+          "tool": "looker",
+          "dashboardId": "retail-weekly-001",
+          "refreshSchedule": "Monday 06:00 UTC"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Step 8: Validate and present
+
+1. Validate every generated event against the OpenLineage 2-0-2 schema:
+   - Required fields: `eventTime`, `producer`, `schemaURL`, `run.runId`
+   - All facets have `_producer` and `_schemaURL`
+   - `columnLineage` is on output datasets only
+   - Dataset names use dot-qualified format
+   - No duplicate runIds across events
+
+2. Present the output files to the user with a summary:
+   - Number of events generated
+   - Number of datasets (input/output)
+   - Number of jobs
+   - Column-level lineage coverage (fields with lineage / total target fields)
+   - Any NL transforms that produced `INDIRECT` lineage
+   - Any governance metadata emitted as custom facets
+
+## Important design decisions
+
+**Why synthetic COMPLETE events?** OpenLineage requires at least a START and
+COMPLETE event per run. For design-time lineage, we emit only COMPLETE events
+with all metadata attached. This is the pattern used by dbt's OpenLineage
+integration for static lineage. Backends like Marquez accept this gracefully.
+
+**Why deterministic UUIDs?** Using UUID v5 with the job name as input means
+re-running the generator produces the same runIds. This makes events idempotent —
+re-emitting to a backend updates rather than duplicates.
+
+**Why custom facets for governance?** OpenLineage has standard facets for schema,
+documentation, ownership, and data source, but not for PII, classification,
+retention, or data modelling tokens. Custom facets with the `satsuma_` prefix are
+the spec-compliant way to carry this metadata. Backends that don't understand
+them will ignore them safely; backends that do (or custom integrations) can use
+them for governance dashboards.
+
+**Mechanical columns**: For Kimball and Data Vault schemas, inferred columns
+(surrogate keys, hash keys, validity timestamps) should be included in the
+SchemaDatasetFacet — unlike in Satsuma files where they are omitted, OpenLineage
+consumers expect the full physical schema. Add them based on the modelling tokens
+and note their origin in the `satsuma_modelling` facet.

--- a/skills/satsuma-to-openlineage/references/event-template.md
+++ b/skills/satsuma-to-openlineage/references/event-template.md
@@ -1,0 +1,169 @@
+# OpenLineage Event Template
+
+Use this template when generating RunEvent JSON from Satsuma mappings. Every
+mapping produces one COMPLETE event.
+
+## Full event structure
+
+```json
+{
+  "eventTime": "2025-01-01T00:00:00.000Z",
+  "eventType": "COMPLETE",
+  "producer": "https://github.com/thorbenlouw/satsuma-lang",
+  "schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent",
+  "run": {
+    "runId": "<deterministic-uuid-v5>",
+    "facets": {}
+  },
+  "job": {
+    "namespace": "<job-namespace>",
+    "name": "<mapping-name>",
+    "facets": {
+      "documentation": {
+        "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+        "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DocumentationJobFacet.json#/$defs/DocumentationJobFacet",
+        "description": "<mapping note text>"
+      },
+      "jobType": {
+        "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+        "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+        "processingType": "BATCH",
+        "integration": "SATSUMA",
+        "jobType": "TASK"
+      },
+      "satsuma_mergeStrategy": {}
+    }
+  },
+  "inputs": [
+    {
+      "namespace": "<dataset-namespace>",
+      "name": "<source-schema-name>",
+      "facets": {
+        "schema": {},
+        "documentation": {},
+        "ownership": {},
+        "satsuma_governance": {},
+        "satsuma_modelling": {},
+        "satsuma_warnings": {}
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "namespace": "<dataset-namespace>",
+      "name": "<target-schema-name>",
+      "facets": {
+        "schema": {},
+        "columnLineage": {},
+        "documentation": {},
+        "ownership": {},
+        "satsuma_governance": {},
+        "satsuma_modelling": {},
+        "satsuma_warnings": {}
+      }
+    }
+  ]
+}
+```
+
+## Field-by-field guide
+
+### Required top-level fields
+
+| Field | Value | Notes |
+|---|---|---|
+| `eventTime` | ISO 8601 timestamp | Use current time when generating, or a fixed timestamp for reproducibility |
+| `eventType` | `"COMPLETE"` | Always COMPLETE for design-time lineage |
+| `producer` | `"https://github.com/thorbenlouw/satsuma-lang"` | Fixed |
+| `schemaURL` | `"https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/RunEvent"` | Current spec version |
+
+### Run
+
+| Field | Value | Notes |
+|---|---|---|
+| `run.runId` | UUID v5 | Generate deterministically from `uuid5(NAMESPACE_URL, job_namespace + "/" + job_name)` so re-runs produce the same ID |
+| `run.facets` | `{}` | Empty for design-time events. Runtime integrations add `nominalTime`, `parent`, etc. |
+
+### Job
+
+| Field | Value | Notes |
+|---|---|---|
+| `job.namespace` | User-provided | e.g., `satsuma://workspace`, `airflow://my-dag` |
+| `job.name` | Mapping name | Kebab-case: `customer-migration`, `sfdc-to-dim-customer` |
+
+### Inputs (one per source schema)
+
+Each source schema in the mapping's `source { }` block becomes one input dataset.
+
+**Dataset naming**: Use dot-qualified names. If Satsuma uses namespaces, include them:
+- `raw::crm_customers` → `raw.crm_customers`
+- `customers` (no namespace) → use user's convention, e.g., `public.customers`
+
+Include `schema` and `documentation` facets on every input. Include governance
+and modelling facets only when the schema has relevant metadata.
+
+### Outputs (one per target schema)
+
+The mapping's `target { }` schema becomes the output dataset.
+
+**Critical**: the `columnLineage` facet goes here and ONLY here. Never on inputs.
+
+## Generating deterministic UUIDs
+
+Python example for reproducible run IDs:
+
+```python
+import uuid
+
+SATSUMA_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # URL namespace
+
+def run_id(job_namespace: str, job_name: str) -> str:
+    return str(uuid.uuid5(SATSUMA_NAMESPACE, f"{job_namespace}/{job_name}"))
+```
+
+This means:
+- Same mapping → same runId every time
+- Re-emitting to a backend replaces the event, not duplicates it
+- Different mappings → different runIds
+
+## Generating a Python emitter script
+
+If the user requests option (b) from Step 1, generate a Python script using
+the OpenLineage client:
+
+```python
+from openlineage.client import OpenLineageClient
+from openlineage.client.run import (
+    RunEvent, RunState, Run, Job, Dataset,
+    InputDataset, OutputDataset
+)
+from openlineage.client.facet_v2 import (
+    schema_dataset, column_lineage_dataset,
+    documentation_dataset, documentation_job,
+    ownership_dataset, job_type_job
+)
+import uuid
+from datetime import datetime, timezone
+
+client = OpenLineageClient.from_environment()
+
+# ... generate events and emit with client.emit(event)
+```
+
+Note: the user needs `pip install openlineage-python` and environment variables
+configured for their backend (e.g., `OPENLINEAGE_URL=http://localhost:5000`).
+
+## Omitting empty facets
+
+Do NOT include facets with no data. If a schema has no `(note "...")`, omit the
+`documentation` facet entirely rather than emitting `{"description": ""}`.
+Same for governance, modelling, warnings, etc.
+
+## Multi-file workspaces
+
+When a Satsuma workspace spans multiple `.stm` files with imports:
+- Use the platform entry point (e.g., `platform.stm`) as the input to
+  `satsuma graph --json` to get the complete workspace
+- Schemas imported from other files are still separate Datasets
+- The namespace of imported schemas follows the same rules as local ones
+- Cross-file lineage is captured naturally through the graph output

--- a/skills/satsuma-to-openlineage/references/facet-mapping.md
+++ b/skills/satsuma-to-openlineage/references/facet-mapping.md
@@ -1,0 +1,289 @@
+# Facet Mapping Reference
+
+Complete mapping from Satsuma metadata to OpenLineage facets.
+
+## Standard OpenLineage Facets
+
+These are defined by the OpenLineage spec and understood by all backends.
+
+### SchemaDatasetFacet (on every dataset)
+
+```json
+{
+  "schema": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet",
+    "fields": [
+      {
+        "name": "customer_id",
+        "type": "VARCHAR(50)",
+        "description": "Durable business key"
+      },
+      {
+        "name": "email",
+        "type": "VARCHAR(255)",
+        "description": "Customer email (PII)"
+      }
+    ]
+  }
+}
+```
+
+**Mapping rules:**
+- Every Satsuma field → one entry in `fields`
+- `type`: use the Satsuma type as-is (e.g., `VARCHAR(255)`, `INT`, `DECIMAL(12,2)`)
+- `description`: from `(note "...")` on the field, or synthesised from metadata
+  (e.g., "PII, encrypted with AES-256-GCM, required")
+- For `record` fields (nested), flatten with dot notation: `customer.email`
+- For `list_of` fields, note the type: `"type": "ARRAY<STRING>"`
+
+**Mechanical columns for modelled schemas:**
+Unlike Satsuma files, OpenLineage schemas should include inferred columns.
+Add them based on modelling tokens:
+
+| Modelling token | Columns to add |
+|---|---|
+| `(dimension, scd 2)` | `surrogate_key BIGINT`, `valid_from TIMESTAMPTZ`, `valid_to TIMESTAMPTZ`, `is_current BOOLEAN`, `row_hash CHAR(64)` |
+| `(dimension, scd 1)` | None — natural key is the PK |
+| `(fact)` | `etl_batch_id BIGINT`, `loaded_at TIMESTAMPTZ`, plus `{dim}_key BIGINT` per `ref` |
+| `(hub)` | `{hub}_hk CHAR(64)`, `load_date TIMESTAMPTZ`, `record_source VARCHAR(100)` |
+| `(satellite)` | `{parent}_hk CHAR(64)`, `load_date TIMESTAMPTZ`, `load_end_date TIMESTAMPTZ`, `hash_diff CHAR(64)`, `record_source VARCHAR(100)` |
+| `(link)` | `{link}_hk CHAR(64)`, one `{hub}_hk CHAR(64)` per hub, `load_date TIMESTAMPTZ`, `record_source VARCHAR(100)` |
+
+Mark these with `"description": "(inferred from Satsuma metadata)"`.
+
+### ColumnLineageDatasetFacet (on output datasets only)
+
+```json
+{
+  "columnLineage": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/ColumnLineageDatasetFacet.json#/$defs/ColumnLineageDatasetFacet",
+    "fields": {
+      "<target_field>": {
+        "inputFields": [
+          {
+            "namespace": "<source_dataset_namespace>",
+            "name": "<source_dataset_name>",
+            "field": "<source_field_name>"
+          }
+        ],
+        "transformationDescription": "<transform text or pipe chain>",
+        "transformationType": "DIRECT | INDIRECT"
+      }
+    }
+  }
+}
+```
+
+**Mapping rules per arrow classification:**
+
+| Satsuma arrow | transformationType | transformationDescription |
+|---|---|---|
+| `src -> tgt` (no transform) | `DIRECT` | empty or `"direct copy"` |
+| `src -> tgt { trim \| lowercase }` | `INDIRECT` | `"trim \| lowercase"` |
+| `src -> tgt { map { R: "retail", ... } }` | `INDIRECT` | `"value map: R→retail, B→business, ..."` |
+| `src -> tgt { "NL description" }` | `INDIRECT` | the NL text verbatim |
+| `-> tgt { now_utc }` | `INDIRECT` | `"now_utc"` (no inputFields) |
+| `a, b -> tgt { "..." }` | `INDIRECT` | NL text; list both source fields |
+| NL-derived (from @ref) | `INDIRECT` | `"(inferred from NL @ref)"` |
+
+**Nested paths:**
+Satsuma paths like `customer.email -> customer_email` should be flattened:
+- Source field: `"customer.email"` (dot notation in the field name)
+- Target field: `"customer_email"`
+
+### DocumentationDatasetFacet / DocumentationJobFacet
+
+```json
+{
+  "documentation": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-1-0/DocumentationDatasetFacet.json#/$defs/DocumentationDatasetFacet",
+    "description": "Customer master — CRM system of record",
+    "contentType": "text/markdown"
+  }
+}
+```
+
+**Source:** `(note "...")` on the schema or mapping, or `note {}` blocks.
+For multi-line notes (triple-quoted), concatenate and set `contentType` to
+`text/markdown`.
+
+### OwnershipDatasetFacet
+
+```json
+{
+  "ownership": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/OwnershipDatasetFacet.json#/$defs/OwnershipDatasetFacet",
+    "owners": [
+      { "name": "data-platform-team", "type": "TEAM" },
+      { "name": "Jane Smith", "type": "PERSON" }
+    ]
+  }
+}
+```
+
+**Source:** `(owner "team")` → type `TEAM`. `(steward "person")` → type `PERSON`.
+
+### JobTypeJobFacet
+
+```json
+{
+  "jobType": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://openlineage.io/spec/facets/2-0-3/JobTypeJobFacet.json#/$defs/JobTypeJobFacet",
+    "processingType": "BATCH",
+    "integration": "SATSUMA",
+    "jobType": "TASK"
+  }
+}
+```
+
+**Mapping from Satsuma:**
+- `processingType`: always `BATCH` (Satsuma is batch-oriented)
+- `integration`: always `SATSUMA`
+- `jobType`: `TASK` for regular mappings, `REPORT` for consumer report schemas,
+  `MODEL` for consumer model schemas
+
+## Custom Satsuma Facets
+
+These carry Satsuma-specific metadata that has no standard OpenLineage equivalent.
+They use the `satsuma_` prefix per OpenLineage custom facet naming conventions.
+
+### satsuma_governance (DatasetFacet)
+
+Carries PII, classification, retention, compliance, and masking metadata.
+
+```json
+{
+  "satsuma_governance": {
+    "_producer": "https://github.com/thorbenlouw/satsuma-lang",
+    "_schemaURL": "https://github.com/thorbenlouw/satsuma-lang/blob/main/openlineage/SatsumaGovernanceDatasetFacet.json",
+    "classification": "RESTRICTED",
+    "retention": "7y",
+    "compliance": ["GDPR", "SOX"],
+    "owner": "data-platform-team",
+    "steward": "Jane Smith",
+    "piiFields": ["email", "phone"],
+    "fieldClassifications": {
+      "email": {
+        "pii": true,
+        "classification": "RESTRICTED",
+        "retention": "3y",
+        "encrypt": "AES-256-GCM",
+        "mask": "partial_email"
+      },
+      "phone": {
+        "pii": true,
+        "classification": "RESTRICTED"
+      }
+    }
+  }
+}
+```
+
+Only include keys that are present in the Satsuma spec. Omit keys with no data.
+
+### satsuma_modelling (DatasetFacet)
+
+Carries Kimball / Data Vault structural metadata.
+
+**Kimball dimension:**
+```json
+{
+  "satsuma_modelling": {
+    "_producer": "...", "_schemaURL": "...",
+    "entityType": "dimension",
+    "conformed": true,
+    "scdType": 2,
+    "naturalKey": "customer_id",
+    "trackedFields": ["email", "phone"],
+    "ignoredFields": ["last_login_channel"],
+    "inferredColumns": ["surrogate_key", "valid_from", "valid_to", "is_current", "row_hash"]
+  }
+}
+```
+
+**Kimball fact:**
+```json
+{
+  "satsuma_modelling": {
+    "entityType": "fact",
+    "grain": ["transaction_id", "line_number"],
+    "dimensionRefs": [
+      { "dimension": "dim_customer", "joinField": "customer_id" },
+      { "dimension": "dim_product", "joinField": "sku" }
+    ],
+    "measures": {
+      "quantity": "additive",
+      "net_amount": "additive",
+      "unit_price": "non_additive"
+    },
+    "inferredColumns": ["dim_customer_key", "dim_product_key", "etl_batch_id", "loaded_at"]
+  }
+}
+```
+
+**Data Vault hub:**
+```json
+{
+  "satsuma_modelling": {
+    "entityType": "hub",
+    "businessKey": "customer_id",
+    "inferredColumns": ["hub_customer_hk", "load_date", "record_source"]
+  }
+}
+```
+
+### satsuma_mergeStrategy (JobFacet)
+
+Carries merge / load strategy from Satsuma mapping metadata.
+
+```json
+{
+  "satsuma_mergeStrategy": {
+    "_producer": "...", "_schemaURL": "...",
+    "strategy": "upsert",
+    "matchOn": ["customer_id"],
+    "onMatch": "update",
+    "onNoMatch": "insert"
+  }
+}
+```
+
+Possible `strategy` values: `upsert`, `append`, `soft_delete`, `full_refresh`.
+Include `deleteFlag` and `deleteTimestamp` for `soft_delete`.
+
+### satsuma_consumer (DatasetFacet)
+
+For report/model consumer schemas.
+
+```json
+{
+  "satsuma_consumer": {
+    "_producer": "...", "_schemaURL": "...",
+    "consumerType": "report",
+    "tool": "looker",
+    "dashboardId": "retail-weekly-001",
+    "refreshSchedule": "Monday 06:00 UTC"
+  }
+}
+```
+
+### satsuma_warnings (DatasetFacet or JobFacet)
+
+Carries `//!` and `//?` comments from the Satsuma spec.
+
+```json
+{
+  "satsuma_warnings": {
+    "_producer": "...", "_schemaURL": "...",
+    "warnings": [
+      { "type": "data_quality", "message": "some records have NULL", "field": "CUST_TYPE" },
+      { "type": "open_question", "message": "mixed formats", "field": "PHONE_NBR" }
+    ]
+  }
+}
+```


### PR DESCRIPTION
## Summary
- Adds five new `agentskills.io`-format skills under `skills/`: `satsuma-explainer`, `satsuma-from-dbt`, `satsuma-to-dbt`, `satsuma-sample-data`, and `satsuma-to-openlineage`. Each is a `SKILL.md` plus a `references/` folder, extracted from `.skill` bundles authored in the Claude web app.
- Adds `skills/README.md` indexing all skills and documenting install paths for Claude Code, Claude Desktop, GitHub Copilot (`.github/skills/`), OpenAI Codex CLI (`~/.codex/skills/` or `.codex/skills/`), and plain web LLMs.
- Wires the new skills into `README.md` (replaces the Excel-only section with a full Agent Skills section), `HOW-DO-I.md` (six new Q&A entries), and `site/index.njk` (FAQ + workflow card now mention the skills suite).

## Test plan
- [ ] Visual sanity check of `README.md` and `HOW-DO-I.md` rendering on GitHub
- [ ] Build the site (`cd site && npm run build`) and confirm `index.njk` renders without template errors
- [ ] Spot-check one skill end-to-end in Claude Code via `~/.claude/skills/` symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)