### PR TITLE
refactor(cli): centralise process.exit in a single command runner (sl-3291)

### DIFF
--- a/.tickets/sl-3291.md
+++ b/.tickets/sl-3291.md
@@ -17,3 +17,12 @@ parent: sl-63ix
 
 Command handlers return exit codes; single top-level dispatcher calls process.exit().
 
+
+## Notes
+
+**2026-04-07T13:17:19Z**
+
+**2026-04-07T13:17:19Z**
+
+Cause: 53 inline process.exit() calls across 23 CLI command files made handlers untestable without process stubs and made the CLI un-embeddable in another process.
+Fix: Introduced src/command-runner.ts with CommandError + runCommand wrapper. All 21 commands now wrap their .action() in runCommand and either return a numeric exit code or throw CommandError. errors.ts (loadFiles, notFound) and load-workspace.ts also throw CommandError instead of exiting. Down to two intentional process.exit sites: the runner itself (single dispatcher), and an unhandledRejection safety net in index.ts for failures before dispatch. Runner also flushes stdout/stderr before exit, fixing latent --json truncation past ~64KiB. errors.test.ts and load-workspace.test.ts rewritten to drop process.exit stub plumbing in favour of asserting thrown CommandErrors directly; new command-runner.test.ts pins the four runner branches.

--- a/.tickets/sl-3291.md
+++ b/.tickets/sl-3291.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3291
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-04-07T09:42:36Z

--- a/features/29-codebase-and-test-cleanup/TODO.md
+++ b/features/29-codebase-and-test-cleanup/TODO.md
@@ -32,10 +32,10 @@ parallelisable — there is no enforced ordering except where noted.
 - [x] Grep for "temporary", "shim", "migration" in source headers across all packages.
 - [x] For each: either delete the shim and update callers, or remove the temporary marker and add a comment justifying its continued existence. (sl-y0sz: rejustified `nl-ref-extract.ts` and `spread-expand.ts` as permanent WorkspaceIndex→core-callback bridges; the stale "will be collapsed in sl-n4wb" claim is gone — sl-n4wb is closed and the bridges remain by design.)
 
-### 6. Reduce `process.exit()` usage in CLI commands *(stretch — may split)*
-- [ ] Count current `process.exit()` calls and bucket them by reason (validation failure, IO error, unknown command, etc.).
-- [ ] Refactor command handlers to return a structured result with `exitCode`; let a single top-level dispatcher call `process.exit()` once.
-- [ ] Update tests to assert on returned codes rather than spawning subprocesses where unit-level testing now suffices.
+### 6. Reduce `process.exit()` usage in CLI commands *(done — sl-3291)*
+- [x] Count current `process.exit()` calls and bucket them by reason. (53 inline calls across 23 files: not-found lookups, parse/IO errors, soft "no results" exits, validate/lint findings.)
+- [x] Refactor command handlers to return a structured result with `exitCode`; let a single top-level dispatcher call `process.exit()` once. (Landed as `src/command-runner.ts` exposing `CommandError` + `runCommand`. Two intentional exit sites remain: the runner and an `unhandledRejection` safety net in `index.ts` for failures before dispatch.)
+- [x] Update tests to assert on returned codes rather than spawning subprocesses where unit-level testing now suffices. (`errors.test.ts` and `load-workspace.test.ts` rewritten to assert thrown `CommandError`s directly, dropping all `process.exit` stub plumbing. New `command-runner.test.ts` pins the four runner branches. Integration tests unchanged — they remain the contract.)
 
 ### 7. Unify the three-headed validation pipeline *(stretch — may split)*
 - [ ] Document where the three pipelines diverge today (core semantic diagnostics, CLI `validate`, LSP diagnostic adapter).

--- a/satsuma-lang-contributor-guide.md
+++ b/satsuma-lang-contributor-guide.md
@@ -245,11 +245,9 @@ The `ARCHITECTURE.md` states: "satsuma-viz has no dependency on core, CLI, or LS
 
 Both `satsuma-cli/src/spread-expand.ts` and `satsuma-cli/src/nl-ref-extract.ts` are thin bridge modules that adapt the CLI's `ExtractedWorkspace` to core's callback-based APIs (per ADR-005 / ADR-006). Earlier drafts of this guide called them temporary shims slated for removal in sl-n4wb; that ticket closed and the bridges were rejustified as permanent in sl-y0sz. They are the canonical place where CLI-shaped data meets core's callbacks — exactly one well-named module per callback interface — and they are not technical debt.
 
-### 9. Excessive `process.exit()` — 74 Calls
+### 9. (Resolved) Excessive `process.exit()` — Was 53 Calls
 
-The CLI has 74 `process.exit()` calls scattered across command handlers and error utilities. Most are in individual command files — when a schema isn't found, the command calls `notFound()` which calls `process.exit(1)`. This makes the CLI essentially untestable at the function level for error paths (you can't unit-test a function that kills the process). The integration test suite works around this by spawning subprocesses.
-
-A conventional pattern would be to throw typed errors and have a single top-level catch in `index.ts` that maps error types to exit codes.
+Resolved in sl-3291. The CLI used to have 53 inline `process.exit()` calls across 23 command files, making error paths essentially untestable without subprocess spawning. They were replaced with a single dispatcher in `satsuma-cli/src/command-runner.ts`: handlers either return a numeric exit code or throw a `CommandError`, and `runCommand` catches both and exits exactly once via `flushAndExit` (which drains stdout/stderr first — also fixed a latent `--json` truncation past ~64KiB on piped output). `errors.ts` (`loadFiles`, `notFound`) and `load-workspace.ts` throw `CommandError` instead of exiting. Down to two intentional exit sites: the runner itself, and an `unhandledRejection` safety net in `index.ts` for failures *before* dispatch. The `errors.test.ts` and `load-workspace.test.ts` rewrites dropped all `process.exit` stub plumbing in favour of asserting thrown `CommandError`s directly.
 
 ### 10. Two Workspace Index Shapes (Now Distinctly Named)
 
@@ -319,9 +317,9 @@ An earlier version of this guide listed "kill the shims" as a target. After sl-n
 
 The CLI's batch result type was renamed from `WorkspaceIndex` to `ExtractedWorkspace` in sl-erxz. The viz-backend keeps `WorkspaceIndex` because it is the naturally editor-shaped index. No further action.
 
-### 4. Replace `process.exit()` with Typed Errors
+### 4. (Resolved) Replace `process.exit()` with Typed Errors
 
-Create an error hierarchy (`NotFoundError`, `ParseError`, etc.) and throw from command handlers. Add a single `try/catch` in `index.ts` that maps error types to exit codes. This makes all command logic unit-testable without subprocess spawning.
+Resolved in sl-3291. The CLI now has a single dispatcher (`src/command-runner.ts`) with a `CommandError` class and a `runCommand` wrapper around every Commander `.action()`. Handlers return a numeric exit code or throw `CommandError`; the runner catches both, prints to the requested stream, drains stdout/stderr, and exits once. See "Resolved Issue 9" above.
 
 ### 5. Break Up `viz-model.ts`
 
@@ -399,10 +397,10 @@ async function schemaCommand(name: string, pathArg: string | undefined) {
 }
 ```
 
-The "entity lookup + not-found + suggestion" half is still per-command because the error formatting varies meaningfully across the 16 commands (different JSON shapes, different kinds of suggestion). A full `CommandContext` harness would be the next step, but it should probably be tackled together with R7 (typed errors) — the two refactors touch the same call sites and the right shape of the harness depends on whether commands throw or print + exit.
+The "entity lookup + not-found + suggestion" half is still per-command because the error formatting varies meaningfully across the 16 commands (different JSON shapes, different kinds of suggestion). A full `CommandContext` harness would be the next step; now that R7 has landed (sl-3291) every command throws `CommandError` consistently, so the harness shape is no longer blocked on the exit-policy decision.
 
-**R7. Replace `process.exit()` with typed errors.**
-Create `NotFoundError`, `ParseError`, and `ValidationError` classes. Have commands throw instead of calling `process.exit()`. Add a single `try/catch` in `index.ts` that maps error types to exit codes. This makes all command logic unit-testable without spawning subprocesses. The integration tests continue to work unchanged. Phase this in command-by-command.
+**R7. (Done — sl-3291) Replace `process.exit()` with typed errors.**
+Landed: `src/command-runner.ts` exposes `CommandError` + `runCommand`. Every command's `.action()` is wrapped, every handler either returns a numeric exit code or throws `CommandError`, and the runner is the single place that calls `process.exit`. The integration tests continue to work unchanged. Two intentional exit sites remain (runner + pre-dispatch safety net), both documented in their files.
 
 **R8. Merge the two graph builders.**
 `src/graph-builder.ts` (113 lines) builds schema-level graphs. `src/commands/graph-builder.ts` (618 lines) builds schema+field-level graphs. They share node-collection and NL-ref-edge-promotion logic with no code sharing. Merge into a single module with a `schemaOnly` option. Extract the NL-ref edge promotion into a shared function and reuse it in `lint-engine.ts` and `nl-ref-extract.ts::countNlDerivedEdgesByMapping` as well, eliminating the triplication.
@@ -440,7 +438,7 @@ This one change would eliminate: the two parallel workspace types, the CLI ↔ c
 
 ### 2. Result types, not `process.exit()`
 
-From day one, every function that can fail would return `Result<T, SatsumaError>` (or throw a typed error — either pattern works in TypeScript). No function would ever call `process.exit()`. The CLI entry point would be a thin shell that calls the real logic, catches errors, and maps them to exit codes and stderr messages. This makes every piece of logic testable without subprocess spawning, and it makes the CLI embeddable as a library (which matters for the VS Code extension integration and for programmatic consumers).
+From day one, every function that can fail would return `Result<T, SatsumaError>` (or throw a typed error — either pattern works in TypeScript). No function would ever call `process.exit()`. The CLI entry point would be a thin shell that calls the real logic, catches errors, and maps them to exit codes and stderr messages. This makes every piece of logic testable without subprocess spawning, and it makes the CLI embeddable as a library (which matters for the VS Code extension integration and for programmatic consumers). The throw-typed-error half of this landed retroactively in sl-3291 — see `src/command-runner.ts`.
 
 ### 3. The grammar would own the node-type string constants
 

--- a/tooling/satsuma-cli/src/command-runner.ts
+++ b/tooling/satsuma-cli/src/command-runner.ts
@@ -1,0 +1,175 @@
+/**
+ * command-runner.ts — Top-level dispatcher for CLI command handlers
+ *
+ * Owns the single point in the CLI where `process.exit` is called. Every
+ * Commander `.action(...)` handler is wrapped in {@link runCommand}, which
+ * normalises three completion paths:
+ *
+ *   1. The handler returns normally — exit with code 0 (or the numeric value
+ *      it returned, for handlers that need to surface a non-zero "soft"
+ *      result like `validate` or `lint` reporting findings).
+ *   2. The handler throws a {@link CommandError} — print its message to the
+ *      requested stream and exit with the carried code. This is the path
+ *      handlers use for "expected" failures like *not found*, bad arguments,
+ *      or unreadable input. The message is part of the contract; the runner
+ *      does not decorate it.
+ *   3. The handler throws anything else — print `Unhandled error: <msg>` to
+ *      stderr and exit 2. This is the safety net for genuine bugs (a parser
+ *      crash, a TypeError) so they don't escape silently.
+ *
+ * Why this exists: before sl-3291 the CLI had 53 inline `process.exit` calls
+ * scattered across 23 files. That made it impossible to write tests against
+ * the error paths without stubbing the global `process` object, and made it
+ * impossible for the CLI to be embedded in another process (each handler
+ * unilaterally killed the host). Concentrating the exit policy here means:
+ *
+ *   • handlers are pure functions of their inputs, returning or throwing —
+ *     trivially testable without process stubs;
+ *   • exit codes are uniform across commands (no command can quietly drift
+ *     to a non-standard convention);
+ *   • the rules for "what counts as an error" live in one place that a
+ *     reader can find by following any handler's wrapper.
+ *
+ * The constants here are the single source of truth for CLI exit codes;
+ * `errors.ts` re-exports them for backward compatibility with callers that
+ * import them from the older location.
+ */
+
+/** Successful run — no errors, no findings worth surfacing. */
+export const EXIT_OK = 0;
+
+/**
+ * "Not found" — a lookup failed (schema, mapping, field, transform, …) or
+ * a query returned no results. Distinct from a parse failure: the workspace
+ * was loaded fine, the user just asked about something that does not exist.
+ */
+export const EXIT_NOT_FOUND = 1;
+
+/**
+ * Parse error, bad argument, unreadable input, or "validate/lint reported
+ * an error-severity finding". The CLI deliberately collapses these into a
+ * single non-zero code so shell scripts can treat any "real problem" with
+ * `if ! satsuma …; then`. Distinguishing them at the script level is the
+ * job of `--json` output, not the exit code.
+ */
+export const EXIT_PARSE_ERROR = 2;
+
+/**
+ * Structured failure raised by command handlers and shared utilities.
+ *
+ * Throwing a `CommandError` is the canonical way for a handler to abort
+ * with a user-facing message. The runner catches it, writes `message` to
+ * the chosen stream, and exits with `code`. Handlers must never call
+ * `process.exit` directly — that responsibility belongs to {@link runCommand}.
+ *
+ * The empty-message case (`new CommandError("", code)`) is supported for
+ * the situation where the handler has already printed multi-line output
+ * (e.g. per-file parse warnings from `loadFiles`) and only needs to signal
+ * the exit code. The runner skips printing in that case.
+ */
+export class CommandError extends Error {
+  /**
+   * @param message  human-readable failure message; may be empty if the
+   *                 handler has already produced its own output.
+   * @param code     exit code to surface to the shell (use the EXIT_*
+   *                 constants exported by this module).
+   * @param stream   output stream for `message`. Defaults to stderr;
+   *                 commands that emit JSON-shaped errors on the
+   *                 success channel pass `"stdout"`.
+   */
+  constructor(
+    message: string,
+    public readonly code: number,
+    public readonly stream: "stderr" | "stdout" = "stderr",
+  ) {
+    super(message);
+    this.name = "CommandError";
+  }
+}
+
+/**
+ * Shape of a Commander action handler after wrapping.
+ *
+ * Handlers may be sync or async. The return value is interpreted as an
+ * exit code: `void` / `undefined` means "success" (exit 0); a number is
+ * passed straight through to `process.exit`. This lets handlers express
+ * "soft" non-zero exits (e.g. validate exiting 2 because findings were
+ * reported) without throwing.
+ */
+export type CommandHandler<Args extends unknown[]> =
+  (...args: Args) => Promise<number | void> | number | void;
+
+/**
+ * Wrap a Commander `.action(...)` handler so it participates in the
+ * single-dispatcher exit policy described in the module header.
+ *
+ * Usage:
+ * ```ts
+ * program.command("foo")
+ *   .action(runCommand(async (arg, opts) => {
+ *     if (!arg) throw new CommandError("missing argument", EXIT_PARSE_ERROR);
+ *     return doWork(arg) ? EXIT_OK : EXIT_NOT_FOUND;
+ *   }));
+ * ```
+ *
+ * After this wrapper, the handler should not contain any reference to
+ * `process.exit`. If you find yourself reaching for one, throw a
+ * `CommandError` or return a numeric code instead.
+ */
+export function runCommand<Args extends unknown[]>(
+  handler: CommandHandler<Args>,
+): (...args: Args) => Promise<void> {
+  return async (...args: Args): Promise<void> => {
+    // Compute the exit code from one of three completion paths, then
+    // flush + exit exactly once below. Keeping the exit out of the
+    // try/catch prevents the wrapper from accidentally catching its
+    // own teardown (a real bug we hit during development: a throwing
+    // process.exit stub re-entered the unknown-error branch).
+    let code: number;
+    try {
+      const handlerReturn = await handler(...args);
+      code = typeof handlerReturn === "number" ? handlerReturn : EXIT_OK;
+    } catch (err: unknown) {
+      if (err instanceof CommandError) {
+        if (err.message) {
+          const sink = err.stream === "stdout" ? console.log : console.error;
+          sink(err.message);
+        }
+        code = err.code;
+      } else {
+        // Unknown error — surface it as an unhandled crash so the bug
+        // is visible in CI logs and shell scripts. We deliberately don't
+        // try to be clever about formatting: anything reaching this
+        // branch is by definition unexpected.
+        const message = (err as { message?: string })?.message ?? String(err);
+        console.error(`Unhandled error: ${message}`);
+        code = EXIT_PARSE_ERROR;
+      }
+    }
+    await flushAndExit(code);
+  };
+}
+
+/**
+ * Drain stdout and stderr before calling `process.exit`.
+ *
+ * Why this matters: when stdout is piped to another process (or to a
+ * test harness reading the child's output), Node buffers writes and
+ * `process.exit` can fire before the buffer is flushed, truncating the
+ * tail of large `--json` payloads. Several commands emit multi-megabyte
+ * graphs, so the truncation is observable in practice — see the
+ * `graph.test.ts` regression that motivated this drain.
+ *
+ * The empty-write callback fires when each stream's internal buffer is
+ * empty, which is the cheapest way to wait for a flush without taking
+ * a hard dependency on the `tty` vs `pipe` distinction. We do both
+ * streams in parallel because there's no ordering constraint between
+ * them at exit time.
+ */
+async function flushAndExit(code: number): Promise<never> {
+  await Promise.all([
+    new Promise<void>((r) => process.stdout.write("", () => r())),
+    new Promise<void>((r) => process.stderr.write("", () => r())),
+  ]);
+  process.exit(code);
+}

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -13,6 +13,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -48,13 +49,13 @@ Examples:
   satsuma arrows hub_customer.email                  # all arrows for this field
   satsuma arrows hub_customer.email --as-source      # only outbound arrows
   satsuma arrows pos::stores.STORE_ID --json         # namespace-qualified`)
-    .action(async (fieldRef: string, pathArg: string | undefined, opts: { asSource?: boolean; asTarget?: boolean; json?: boolean }) => {
+    .action(runCommand(async (fieldRef: string, pathArg: string | undefined, opts: { asSource?: boolean; asTarget?: boolean; json?: boolean }) => {
       const dot = fieldRef.indexOf(".");
       if (dot === -1) {
-        console.error(
+        throw new CommandError(
           `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
+          EXIT_PARSE_ERROR,
         );
-        process.exit(2);
       }
 
       const schemaName = fieldRef.slice(0, dot);
@@ -65,12 +66,12 @@ Examples:
       // Validate schema exists
       const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
       if (!resolvedSchema) {
-        console.error(`Schema '${schemaName}' not found.`);
         const close = [...index.schemas.keys()].find(
           (k) => k.toLowerCase() === schemaName.toLowerCase(),
         );
-        if (close) console.error(`Did you mean '${close}'?`);
-        process.exit(1);
+        const lines = [`Schema '${schemaName}' not found.`];
+        if (close) lines.push(`Did you mean '${close}'?`);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
 
       // Validate field exists in schema (including fragment spread fields and nested children)
@@ -80,16 +81,14 @@ Examples:
       const fieldExists = findFieldByPath(allFields, fieldName) ||
         collectAllFieldNames(allFields).includes(fieldName);
       if (!fieldExists) {
-        console.error(
-          `Field '${fieldName}' not found in schema '${schemaName}'.`,
-        );
         // Suggest close matches from top-level and nested fields
         const allNames = collectAllFieldNames(allFields);
         const close = allNames.find(
           (n) => n.toLowerCase() === fieldName.toLowerCase(),
         );
-        if (close) console.error(`Did you mean '${close}'?`);
-        process.exit(1);
+        const lines = [`Field '${fieldName}' not found in schema '${schemaName}'.`];
+        if (close) lines.push(`Did you mean '${close}'?`);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
 
       // Find matching arrows using schema-qualified key
@@ -241,7 +240,7 @@ Examples:
 
       if (arrows.length === 0) {
         console.log(`No arrows found for '${fieldRef}'.`);
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
 
       if (opts.json) {
@@ -318,7 +317,7 @@ Examples:
       // Pass the resolved schema key so printDefault can match against index
       // entries even when the user queried with a bare (unqualified) name (sl-ltv6).
       printDefault(fieldRef, arrows, index, resolvedSchema.key);
-    });
+    }));
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -20,6 +20,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, EXIT_NOT_FOUND } from "../command-runner.js";
 import { extractAtRefs } from "../nl-ref-extract.js";
 import { extractNLContent } from "../nl-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -51,7 +52,7 @@ Examples:
   satsuma context "loyalty tier" --budget 8000       # larger context window
   satsuma context "pii email" --compact              # compact output
   satsuma context "order" --json                     # all scores as JSON`)
-    .action(async (query: string, pathArg: string | undefined, opts: { budget: number; compact?: boolean; json?: boolean }) => {
+    .action(runCommand(async (query: string, pathArg: string | undefined, opts: { budget: number; compact?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       const terms = tokenize(query);
@@ -90,7 +91,7 @@ Examples:
 
       if (emitted.length === 0) {
         console.log("No relevant blocks found.");
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
 
       console.log(`// Context for: ${query}  (${used} tokens, ${emitted.length} blocks)`);
@@ -99,7 +100,7 @@ Examples:
         console.log(block);
         console.log();
       }
-    });
+    }));
 }
 
 // ── Scoring ───────────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Command } from "commander";
+import { runCommand, CommandError, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex } from "../index-builder.js";
@@ -79,14 +80,19 @@ Examples:
   satsuma diff old.stm new.stm --stat               # summary counts
   satsuma diff old.stm new.stm --json               # full structural delta
   satsuma diff old.stm new.stm --names-only         # just changed block names`)
-    .action(async (pathA: string, pathB: string, opts: { json?: boolean; namesOnly?: boolean; stat?: boolean }) => {
+    .action(runCommand(async (pathA: string, pathB: string, opts: { json?: boolean; namesOnly?: boolean; stat?: boolean }) => {
       let filesA: string[], filesB: string[];
       try {
         filesA = await resolveInput(pathA, { followImports: false });
         filesB = await resolveInput(pathB, { followImports: false });
       } catch (err: unknown) {
-        console.error(`Error resolving paths: ${(err as Error).message}`);
-        process.exit(2);
+        // diff is one of the three commands that resolve directly rather
+        // than through loadWorkspace — it needs `followImports: false` and
+        // two separate inputs (see load-workspace.ts header).
+        throw new CommandError(
+          `Error resolving paths: ${(err as Error).message}`,
+          EXIT_PARSE_ERROR,
+        );
       }
 
       const indexA = buildIndex(filesA.map((f) => parseFile(f)));
@@ -125,7 +131,7 @@ Examples:
       }
 
       printDefault(delta);
-    });
+    }));
 }
 
 function printStat(delta: Delta): void {

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -14,6 +14,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -59,7 +60,7 @@ Examples:
   satsuma field-lineage s2.a --upstream          # only upstream chain
   satsuma field-lineage s2.a --json              # structured output
   satsuma field-lineage ns::s2.a --downstream    # namespace-qualified`)
-    .action(async (fieldRef: string, pathArg: string | undefined, opts: {
+    .action(runCommand(async (fieldRef: string, pathArg: string | undefined, opts: {
       upstream?: boolean;
       downstream?: boolean;
       depth: number;
@@ -67,10 +68,10 @@ Examples:
     }) => {
       const dot = fieldRef.indexOf(".");
       if (dot === -1) {
-        console.error(
+        throw new CommandError(
           `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
+          EXIT_PARSE_ERROR,
         );
-        process.exit(2);
       }
 
       const schemaName = fieldRef.slice(0, dot);
@@ -81,8 +82,7 @@ Examples:
       // Resolve the schema
       const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
       if (!resolvedSchema) {
-        console.error(`Schema '${schemaName}' not found.`);
-        process.exit(1);
+        throw new CommandError(`Schema '${schemaName}' not found.`, EXIT_NOT_FOUND);
       }
 
       // Validate field exists (including spread fields)
@@ -92,8 +92,10 @@ Examples:
       const fieldExists = findFieldByPath(allFields, fieldName) ||
         collectAllFieldNames(allFields).includes(fieldName);
       if (!fieldExists) {
-        console.error(`Field '${fieldName}' not found in schema '${schemaName}'.`);
-        process.exit(1);
+        throw new CommandError(
+          `Field '${fieldName}' not found in schema '${schemaName}'.`,
+          EXIT_NOT_FOUND,
+        );
       }
 
       const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
@@ -129,7 +131,7 @@ Examples:
       }
 
       printDefault(result, doUpstream, doDownstream);
-    });
+    }));
 }
 
 // ── Field-edge graph ──────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -12,6 +12,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
 import { addPathAndPrefixes } from "@satsuma/core";
@@ -41,7 +42,7 @@ Examples:
   satsuma fields hub_customer --with-meta                        # include tags
   satsuma fields hub_customer --unmapped-by 'load hub_customer'  # coverage gaps
   satsuma fields pos::stores --json                              # namespace-qualified`)
-    .action(async (schemaName: string, pathArg: string | undefined, opts: { withMeta?: boolean; unmappedBy?: string; json?: boolean }) => {
+    .action(runCommand(async (schemaName: string, pathArg: string | undefined, opts: { withMeta?: boolean; unmappedBy?: string; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       // Search schemas first, then fragments, then metrics
@@ -58,12 +59,12 @@ Examples:
       }
       if (!resolved) {
         const allKeys = [...index.schemas.keys(), ...index.fragments.keys(), ...index.metrics.keys()];
-        console.error(`'${schemaName}' not found in schemas, fragments, or metrics.`);
         const close = allKeys.find(
           (k) => k.toLowerCase() === schemaName.toLowerCase(),
         );
-        if (close) console.error(`Did you mean '${close}'?`);
-        process.exit(1);
+        const lines = [`'${schemaName}' not found in schemas, fragments, or metrics.`];
+        if (close) lines.push(`Did you mean '${close}'?`);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
       const resolvedSchemaName = resolved.key;
 
@@ -88,13 +89,13 @@ Examples:
       if (opts.unmappedBy) {
         const resolvedMapping = resolveIndexKey(opts.unmappedBy, index.mappings);
         if (!resolvedMapping) {
-          console.error(`Mapping '${opts.unmappedBy}' not found.`);
           const close = [...index.mappings.keys()].find(
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by outer opts.unmappedBy check
             (k) => k.toLowerCase() === opts.unmappedBy!.toLowerCase(),
           );
-          if (close) console.error(`Did you mean '${close}'?`);
-          process.exit(1);
+          const lines = [`Mapping '${opts.unmappedBy}' not found.`];
+          if (close) lines.push(`Did you mean '${close}'?`);
+          throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
         }
 
         const mappedFields = getMappedFieldNames(resolvedMapping.key, resolvedSchemaName, index);
@@ -121,7 +122,7 @@ Examples:
       }
 
       printDefault(resolvedSchemaName, fields, opts);
-    });
+    }));
 }
 
 function deepCopyFields(fields: FieldDecl[]): FieldWithTags[] {

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -17,6 +17,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { findBlockNode } from "../cst-query.js";
 import { resolveScopedEntityRef } from "../index-builder.js";
 import type { ExtractedWorkspace, ParsedFile, SyntaxNode } from "../types.js";
@@ -61,15 +62,17 @@ Examples:
   satsuma find --tag measure --in metric     # measure fields in metrics only
   satsuma find --tag ref --json              # all foreign key refs as JSON
   satsuma find --tag enum --compact          # compact one-per-line output`)
-    .action(async (pathArg: string | undefined, opts: { tag: string; in?: string; compact?: boolean; json?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { tag: string; in?: string; compact?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       const tag = opts.tag.toLowerCase();
       const scope = opts.in ?? "all";
       const validScopes = ["all", "schema", "metric", "fragment"];
       if (!validScopes.includes(scope)) {
-        console.error(`Invalid scope '${scope}'. Valid scopes: ${validScopes.join(", ")}`);
-        process.exit(1);
+        throw new CommandError(
+          `Invalid scope '${scope}'. Valid scopes: ${validScopes.join(", ")}`,
+          EXIT_NOT_FOUND,
+        );
       }
       const matches = searchTag(index, parsedFiles, tag, scope);
 
@@ -83,8 +86,11 @@ Examples:
         printDefault(matches);
       }
 
-      if (matches.length === 0) process.exit(1);
-    });
+      // "No matches" is a non-zero exit so shell pipelines can use
+      // `if satsuma find … --tag pii; then` to detect coverage. The
+      // body output (or `[]` JSON) has already been emitted above.
+      if (matches.length === 0) return EXIT_NOT_FOUND;
+    }));
 }
 
 // ── Search logic ──────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/fmt.ts
+++ b/tooling/satsuma-cli/src/commands/fmt.ts
@@ -17,6 +17,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { relative } from "node:path";
 import type { Command } from "commander";
+import { runCommand, CommandError, EXIT_OK, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { resolveInput } from "../workspace.js";
 import { parseFile, parseSource } from "../parser.js";
 import { format } from "../format.js";
@@ -38,12 +39,13 @@ Examples:
   satsuma fmt --check pipeline.stm           # CI mode — exit 1 if any file would change
   satsuma fmt --diff file.stm                # show what would change without writing
   cat file.stm | satsuma fmt --stdin         # pipe mode`)
-    .action(async (
+    .action(runCommand(async (
       pathArg: string | undefined,
       opts: { check?: boolean; diff?: boolean; stdin?: boolean }
     ) => {
       if (opts.stdin) {
-        return handleStdin();
+        handleStdin();
+        return;
       }
 
       const root = pathArg ?? ".";
@@ -51,13 +53,16 @@ Examples:
       try {
         files = await resolveInput(root);
       } catch (err: unknown) {
-        console.error(`Error: ${(err as Error).message}`);
-        process.exit(2);
+        // fmt is the third command that bypasses loadWorkspace: it needs
+        // to tolerate parse errors per-file (skipping rather than aborting)
+        // and uses a slightly different "Error: ..." prefix from the rest
+        // of the CLI. The resolve failure itself is still a hard exit.
+        throw new CommandError(`Error: ${(err as Error).message}`, EXIT_PARSE_ERROR);
       }
 
       if (files.length === 0) {
-        // No files to format — success
-        process.exit(0);
+        // Nothing to format — that's a success, not a failure.
+        return EXIT_OK;
       }
 
       let wouldChange = 0;
@@ -92,15 +97,19 @@ Examples:
         }
       }
 
+      // Surface a hard failure if every input was unparseable (no formatting
+      // happened and no --check assertion was made). This catches the case
+      // of running `satsuma fmt` on a directory of broken files.
       if (parseErrors > 0 && wouldChange === 0 && !opts.check) {
-        process.exit(2);
+        return EXIT_PARSE_ERROR;
       }
 
+      // --check is the CI assertion mode: exit 1 if anything would change.
       if (opts.check && wouldChange > 0) {
         console.error(`\n${wouldChange} file(s) would be reformatted`);
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
-    });
+    }));
 }
 
 /** Return the shorter of the relative and absolute path. */
@@ -116,8 +125,7 @@ function handleStdin(): void {
   const { tree, errorCount } = parseSource(src);
 
   if (errorCount > 0) {
-    console.error(`stdin: parse error (${errorCount} error(s))`);
-    process.exit(2);
+    throw new CommandError(`stdin: parse error (${errorCount} error(s))`, EXIT_PARSE_ERROR);
   }
 
   const formatted = format(tree, src);

--- a/tooling/satsuma-cli/src/commands/graph.ts
+++ b/tooling/satsuma-cli/src/commands/graph.ts
@@ -12,6 +12,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { buildFullGraph } from "../graph-builder.js";
 import { buildWorkspaceGraph } from "./graph-builder.js";
 import { printDefault, printCompact } from "./graph-format.js";
@@ -64,7 +65,7 @@ Examples:
   satsuma graph pipeline.stm --json --schema-only    # topology only
   satsuma graph pipeline.stm --json --namespace crm  # one namespace
   satsuma graph pipeline.stm --compact               # minimal output`)
-    .action(async (pathArg: string | undefined, opts: GraphOpts) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: GraphOpts) => {
       const root = pathArg ?? ".";
       const { index } = await loadWorkspace(root);
       const schemaGraph = buildFullGraph(index);
@@ -82,9 +83,10 @@ Examples:
         printDefault(graph);
       }
 
+      // The runner flushes stdout/stderr before exit, so we don't need
+      // a manual drain here even though `--json` payloads can be large.
       if (index.totalErrors > 0) {
-        await new Promise<void>((r) => process.stdout.write("", () => r()));
-        process.exit(2);
+        return EXIT_PARSE_ERROR;
       }
-    });
+    }));
 }

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -17,6 +17,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { buildFullGraph } from "../graph-builder.js";
 import type { FullGraph } from "../graph-builder.js";
@@ -65,31 +66,35 @@ Examples:
   satsuma lineage --to mart_customer_360           # what feeds mart_customer_360?
   satsuma lineage --from pos::stores --depth 3     # namespace-qualified, limited depth
   satsuma lineage --from hub_customer --json       # DAG as JSON`)
-    .action(async (pathArg: string | undefined, opts: { from?: string; to?: string; depth: number; compact?: boolean; json?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { from?: string; to?: string; depth: number; compact?: boolean; json?: boolean }) => {
       if (!opts.from && !opts.to) {
-        console.error("Provide --from <name> or --to <name>.");
-        process.exit(1);
+        throw new CommandError("Provide --from <name> or --to <name>.", EXIT_NOT_FOUND);
       }
 
       if (opts.from && opts.to) {
-        console.error("Cannot specify both --from and --to. Use one at a time.");
-        process.exit(1);
+        throw new CommandError(
+          "Cannot specify both --from and --to. Use one at a time.",
+          EXIT_NOT_FOUND,
+        );
       }
 
       const { index } = await loadWorkspace(pathArg);
       const graph = buildFullGraph(index);
 
+      // Build a "node not found" CommandError that respects the JSON
+      // contract: JSON callers receive `{"error": ...}` on stdout so the
+      // payload still parses; text callers get the message on stderr.
+      const nodeNotFound = (queried: string): CommandError => {
+        const msg = `Node '${queried}' not found.`;
+        if (opts.json) {
+          return new CommandError(JSON.stringify({ error: msg }, null, 2), EXIT_NOT_FOUND, "stdout");
+        }
+        return new CommandError(msg, EXIT_NOT_FOUND);
+      };
+
       if (opts.from) {
         const resolved = resolveIndexKey(opts.from, graph.nodes);
-        if (!resolved) {
-          const msg = `Node '${opts.from}' not found.`;
-          if (opts.json) {
-            console.log(JSON.stringify({ error: msg }, null, 2));
-          } else {
-            console.error(msg);
-          }
-          process.exit(1);
-        }
+        if (!resolved) throw nodeNotFound(opts.from);
         const start = resolved.key;
         const dag = buildDownstream(graph, start, opts.depth);
         if (opts.json) {
@@ -102,20 +107,13 @@ Examples:
       } else {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by opts.to existence check in enclosing branch
         const resolvedTo = resolveIndexKey(opts.to!, graph.nodes);
-        if (!resolvedTo) {
-          const msg = `Node '${opts.to}' not found.`;
-          if (opts.json) {
-            console.log(JSON.stringify({ error: msg }, null, 2));
-          } else {
-            console.error(msg);
-          }
-          process.exit(1);
-        }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: same guard
+        if (!resolvedTo) throw nodeNotFound(opts.to!);
         const target = resolvedTo.key;
         const dag = buildUpstream(graph, target, opts.depth);
         if (dag.nodes.length === 0) {
           console.log(`No upstream path found to '${target}'.`);
-          process.exit(1);
+          return EXIT_NOT_FOUND;
         }
         if (opts.json) {
           console.log(JSON.stringify(dag, null, 2));
@@ -125,7 +123,7 @@ Examples:
           printUpstreamFlat(dag, target);
         }
       }
-    });
+    }));
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -20,6 +20,7 @@
 import type { Command } from "commander";
 import { readFileSync, writeFileSync } from "fs";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { runLint, applyFixes, RULES } from "../lint-engine.js";
 import type { LintFix } from "../types.js";
 
@@ -52,7 +53,7 @@ Examples:
   satsuma lint pipeline.stm --fix            # auto-fix fixable issues
   satsuma lint --rules                       # list available rules
   satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only`)
-    .action(async (pathArg: string | undefined, opts: { json?: boolean; fix?: boolean; select?: string; ignore?: string; quiet?: boolean; rules?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { json?: boolean; fix?: boolean; select?: string; ignore?: string; quiet?: boolean; rules?: boolean }) => {
       // --rules: list available rules and exit
       if (opts.rules) {
         for (const r of RULES) {
@@ -107,9 +108,14 @@ Examples:
       const errorCount = diagnostics.filter((d) => d.severity === "error").length;
       const fixableCount = diagnostics.filter((d) => d.fixable).length;
 
+      // Soft exit code: lint uses 2 for "any error-severity finding"
+      // and 0 otherwise. Warning-severity rules never push the exit
+      // non-zero — that's documented in the command help.
+      const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
+
       // --quiet: exit code only
       if (opts.quiet) {
-        process.exit(errorCount > 0 ? 2 : 0);
+        return exitCode;
       }
 
       // --json: structured output
@@ -125,7 +131,7 @@ Examples:
           },
         };
         console.log(JSON.stringify(payload, null, 2));
-        process.exit(errorCount > 0 ? 2 : 0);
+        return exitCode;
       }
 
       // Text output
@@ -170,6 +176,6 @@ Examples:
         );
       }
 
-      process.exit(errorCount > 0 ? 2 : 0);
-    });
+      return exitCode;
+    }));
 }

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -12,6 +12,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
 import { extractMetadata, canonicalEntityName, classifyTransform } from "@satsuma/core";
@@ -32,20 +33,21 @@ Examples:
   satsuma mapping 'load hub_customer'                # full mapping
   satsuma mapping 'load hub_customer' --arrows-only  # just src → tgt
   satsuma mapping 'load hub_customer' --json         # structured output`)
-    .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; arrowsOnly?: boolean; json?: boolean }) => {
+    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; arrowsOnly?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       const resolved = resolveIndexKey(name, index.mappings);
       if (!resolved) {
         const keys = [...index.mappings.keys()];
         const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
+        const lines: string[] = [];
         if (close) {
-          console.error(`Mapping '${name}' not found. Did you mean '${close}'?`);
+          lines.push(`Mapping '${name}' not found. Did you mean '${close}'?`);
         } else {
-          console.error(`Mapping '${name}' not found.`);
-          if (keys.length > 0) console.error(`Available: ${keys.join(", ")}`);
+          lines.push(`Mapping '${name}' not found.`);
+          if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
         }
-        process.exit(1);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
       const entry = resolved.entry;
 
@@ -59,7 +61,7 @@ Examples:
       } else {
         printDefault(entry, mappingNode, opts.compact);
       }
-    });
+    }));
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/match-fields.ts
+++ b/tooling/satsuma-cli/src/commands/match-fields.ts
@@ -11,6 +11,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { matchFields } from "../normalize.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -40,29 +41,26 @@ Examples:
   satsuma match-fields --source crm --target warehouse
   satsuma match-fields --source pos::stores --target hub_store --matched-only
   satsuma match-fields --source crm --target warehouse --json`)
-    .action(async (pathArg: string | undefined, opts: { source: string; target: string; matchedOnly?: boolean; unmatchedOnly?: boolean; json?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { source: string; target: string; matchedOnly?: boolean; unmatchedOnly?: boolean; json?: boolean }) => {
       const { index } = await loadWorkspace(pathArg);
 
-      // Validate schemas
-      const resolvedNames: Record<string, { key: string; entry: SchemaRecord }> = {};
-      for (const name of [opts.source, opts.target]) {
+      // Resolve and validate both schemas. Hand-rolling the resolution
+      // here (instead of looping) lets TypeScript narrow `srcResolved` /
+      // `tgtResolved` to non-null after each guard, which is cleaner than
+      // the previous loop + non-null assertion dance.
+      const resolveSchema = (name: string): { key: string; entry: SchemaRecord } => {
         const resolved = resolveIndexKey(name, index.schemas);
-        if (!resolved) {
-          console.error(`Schema '${name}' not found.`);
-          const close = [...index.schemas.keys()].find(
-            (k) => k.toLowerCase() === name.toLowerCase(),
-          );
-          if (close) console.error(`Did you mean '${close}'?`);
-          process.exit(1);
-        }
-        resolvedNames[name] = resolved;
-      }
+        if (resolved) return resolved;
+        const close = [...index.schemas.keys()].find(
+          (k) => k.toLowerCase() === name.toLowerCase(),
+        );
+        const lines = [`Schema '${name}' not found.`];
+        if (close) lines.push(`Did you mean '${close}'?`);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+      };
 
-      // Safe: opts.source and opts.target are resolved in the loop above, which exits on failure
-      /* eslint-disable @typescript-eslint/no-non-null-assertion */
-      const srcEntry = resolvedNames[opts.source]!.entry;
-      const tgtEntry = resolvedNames[opts.target]!.entry;
-      /* eslint-enable @typescript-eslint/no-non-null-assertion */
+      const srcEntry = resolveSchema(opts.source).entry;
+      const tgtEntry = resolveSchema(opts.target).entry;
       const srcFields = [
         ...srcEntry.fields,
         ...expandEntityFields(srcEntry, srcEntry.namespace ?? null, index),
@@ -136,5 +134,5 @@ Examples:
         console.log("Target-only:");
         for (const f of result.targetOnly) console.log(`  ${f}`);
       }
-    });
+    }));
 }

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -11,6 +11,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { extractMetadata } from "@satsuma/core";
 import type { MetaEntry } from "@satsuma/core";
@@ -49,7 +50,7 @@ Examples:
   satsuma meta 'load hub_store'              # mapping metadata
   satsuma meta hub_customer --tags-only      # just tag tokens
   satsuma meta pos::stores.STORE_ID --json   # namespace-qualified`)
-    .action(async (scope: string, pathArg: string | undefined, opts: { tagsOnly?: boolean; json?: boolean }) => {
+    .action(runCommand(async (scope: string, pathArg: string | undefined, opts: { tagsOnly?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       let result: MetaResult;
@@ -79,7 +80,7 @@ Examples:
       }
 
       printDefault(result);
-    });
+    }));
 }
 
 function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: ExtractedWorkspace): MetaResult {
@@ -96,7 +97,6 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: E
   if (metricResolved && !schemaResolved) { blockTypes.push("schema_block"); resolvedName = metricResolved.key; }
 
   if (blockTypes.length === 0) {
-    console.error(`'${blockName}' not found as a schema, mapping, or metric.`);
     const allNames = [
       ...index.schemas.keys(),
       ...index.mappings.keys(),
@@ -105,8 +105,9 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: E
     const close = allNames.find(
       (k) => k.toLowerCase() === blockName.toLowerCase(),
     );
-    if (close) console.error(`Did you mean '${close}'?`);
-    process.exit(1);
+    const lines = [`'${blockName}' not found as a schema, mapping, or metric.`];
+    if (close) lines.push(`Did you mean '${close}'?`);
+    throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
   }
 
   const resolvedEntry =
@@ -182,8 +183,10 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
     bodyType = "schema_body";
   }
   if (!resolved) {
-    console.error(`'${entityName}' not found in schemas, fragments, or metrics.`);
-    process.exit(1);
+    throw new CommandError(
+      `'${entityName}' not found in schemas, fragments, or metrics.`,
+      EXIT_NOT_FOUND,
+    );
   }
 
   const entity = resolved.entry;
@@ -201,10 +204,10 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
   }
 
   if (!field) {
-    console.error(
+    throw new CommandError(
       `Field '${fieldPath}' not found in '${entityName}'.`,
+      EXIT_NOT_FOUND,
     );
-    process.exit(1);
   }
 
   // If the field came from a fragment spread, look up metadata from the fragment's CST

--- a/tooling/satsuma-cli/src/commands/metric.ts
+++ b/tooling/satsuma-cli/src/commands/metric.ts
@@ -13,6 +13,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
 import { canonicalEntityName } from "@satsuma/core";
@@ -32,20 +33,21 @@ Examples:
   satsuma metric daily_sales                         # full metric
   satsuma metric daily_sales --sources               # just source schemas
   satsuma metric analytics::daily_sales --json       # namespace-qualified`)
-    .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; sources?: boolean; json?: boolean }) => {
+    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; sources?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       const resolved = resolveIndexKey(name, index.metrics);
       if (!resolved) {
         const keys = [...index.metrics.keys()];
         const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
+        const lines: string[] = [];
         if (close) {
-          console.error(`Metric '${name}' not found. Did you mean '${close}'?`);
+          lines.push(`Metric '${name}' not found. Did you mean '${close}'?`);
         } else {
-          console.error(`Metric '${name}' not found.`);
-          if (keys.length > 0) console.error(`Available: ${keys.join(", ")}`);
+          lines.push(`Metric '${name}' not found.`);
+          if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
         }
-        process.exit(1);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
       const entry = resolved.entry;
       const resolvedName = resolved.key;
@@ -62,7 +64,7 @@ Examples:
       } else {
         printDefault(entry, metricNode, opts.compact);
       }
-    });
+    }));
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/nl-refs.ts
+++ b/tooling/satsuma-cli/src/commands/nl-refs.ts
@@ -13,6 +13,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import type { ResolvedNLRef } from "../nl-ref-extract.js";
@@ -47,7 +48,7 @@ Examples:
   satsuma nl-refs pipeline.stm                       # all refs in file and imports
   satsuma nl-refs --mapping 'load hub_customer'      # refs in one mapping
   satsuma nl-refs pipeline.stm --unresolved --json   # broken refs as JSON`)
-    .action(async (pathArg: string | undefined, opts: { mapping?: string; json?: boolean; unresolved?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { mapping?: string; json?: boolean; unresolved?: boolean }) => {
       const { index } = await loadWorkspace(pathArg);
 
       let refs = resolveAllNLRefs(index);
@@ -56,8 +57,7 @@ Examples:
       if (opts.mapping) {
         const resolved = resolveIndexKey(opts.mapping, index.mappings);
         if (!resolved) {
-          console.error(`Mapping '${opts.mapping}' not found.`);
-          process.exit(1);
+          throw new CommandError(`Mapping '${opts.mapping}' not found.`, EXIT_NOT_FOUND);
         }
         refs = refs.filter((r) => r.mapping === resolved.key);
       }
@@ -70,17 +70,16 @@ Examples:
       if (opts.json) {
         const out = refs.map((r) => ({ ...r, line: r.line + 1 }));
         console.log(JSON.stringify(out, null, 2));
-        if (refs.length === 0) process.exit(1);
-        return;
+        return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
       }
 
       if (refs.length === 0) {
         console.log("No NL @ref references found.");
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
 
       printDefault(refs);
-    });
+    }));
 }
 
 function printDefault(refs: ResolvedNLRef[]): void {

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -11,6 +11,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { extractNLContent } from "../nl-extract.js";
 import type { NLItem } from "../nl-extract.js";
@@ -50,7 +51,7 @@ Examples:
   satsuma nl all pipeline.stm                # all NL in file and imports
   satsuma nl all pipeline.stm --kind warning # only //! warnings
   satsuma nl hub_customer --json             # structured output`)
-    .action(async (scope: string, pathArg: string | undefined, opts: { kind?: string; json?: boolean }) => {
+    .action(runCommand(async (scope: string, pathArg: string | undefined, opts: { kind?: string; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       let items: NLItemWithFile[];
@@ -77,7 +78,7 @@ Examples:
       }
 
       printDefault(items);
-    });
+    }));
 }
 
 function extractFromAll(parsedFiles: ParsedFile[]): NLItemWithFile[] {
@@ -98,7 +99,6 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: E
   const transformResolved = resolveIndexKey(blockName, index.transforms);
 
   if (!schemaResolved && !mappingResolved && !metricResolved && !transformResolved) {
-    console.error(`'${blockName}' not found as a schema, mapping, metric, or transform.`);
     const allNames = [
       ...index.schemas.keys(),
       ...index.mappings.keys(),
@@ -108,8 +108,9 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: E
     const close = allNames.find(
       (k) => k.toLowerCase() === blockName.toLowerCase(),
     );
-    if (close) console.error(`Did you mean '${close}'?`);
-    process.exit(1);
+    const lines = [`'${blockName}' not found as a schema, mapping, metric, or transform.`];
+    if (close) lines.push(`Did you mean '${close}'?`);
+    throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
   }
 
   // Collect NL content from ALL matching blocks (schema, mapping, metric, transform)
@@ -149,8 +150,7 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
 
   const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
   if (!resolvedSchema) {
-    console.error(`Schema '${schemaName}' not found.`);
-    process.exit(1);
+    throw new CommandError(`Schema '${schemaName}' not found.`, EXIT_NOT_FOUND);
   }
 
   const schema = resolvedSchema.entry;
@@ -159,10 +159,10 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
     ? schemaHasFieldByPath(schema.fields, pathSegments)
     : schemaHasField(schema.fields, leafName);
   if (!fieldExists) {
-    console.error(
+    throw new CommandError(
       `Field '${fieldPath}' not found in schema '${schemaName}'.`,
+      EXIT_NOT_FOUND,
     );
-    process.exit(1);
   }
 
   const items: NLItemWithFile[] = [];

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -12,6 +12,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { findBlockNode } from "../cst-query.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -33,7 +34,7 @@ Examples:
   satsuma schema hub_customer                        # full schema
   satsuma schema hub_customer --fields-only          # one field per line
   satsuma schema pos::stores --json                  # namespace-qualified`)
-    .action(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; fieldsOnly?: boolean; json?: boolean }) => {
+    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; fieldsOnly?: boolean; json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       const resolved = resolveIndexKey(name, index.schemas);
@@ -51,16 +52,19 @@ Examples:
           errorMsg = `Schema '${name}' not found.`;
         }
         if (opts.json) {
+          // JSON callers want the error on the same channel as success
+          // output so they can pipe `satsuma schema … --json | jq` and
+          // still parse the response. Hand the JSON-shaped message to the
+          // runner with stream: "stdout".
           const errorObj: Record<string, unknown> = { error: errorMsg };
           if (keys.length > 0) errorObj.available = keys;
-          console.log(JSON.stringify(errorObj, null, 2));
-        } else {
-          console.error(errorMsg);
-          if (keys.length > 0 && !(ambiguous && ambiguous.length > 1) && !close) {
-            console.error(`Available: ${keys.join(", ")}`);
-          }
+          throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
         }
-        process.exit(1);
+        const lines: string[] = [errorMsg];
+        if (keys.length > 0 && !(ambiguous && ambiguous.length > 1) && !close) {
+          lines.push(`Available: ${keys.join(", ")}`);
+        }
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
       const entry = resolved.entry;
 
@@ -77,7 +81,7 @@ Examples:
       } else {
         printDefault(entry, schemaNode, opts.compact);
       }
-    });
+    }));
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/validate.ts
+++ b/tooling/satsuma-cli/src/commands/validate.ts
@@ -12,6 +12,7 @@
 import { dirname, resolve } from "node:path";
 import { statSync } from "node:fs";
 import type { Command } from "commander";
+import { runCommand, CommandError, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { resolveInput } from "../workspace.js";
 import { parseFile } from "../parser.js";
 import { buildIndex, extractFileData } from "../index-builder.js";
@@ -40,19 +41,27 @@ Examples:
   satsuma validate pipeline.stm --json       # structured diagnostics
   satsuma validate pipeline.stm --quiet      # exit code only
   satsuma validate pipeline.stm --errors-only  # suppress warnings`)
-    .action(async (pathArg: string | undefined, opts: { json?: boolean; errorsOnly?: boolean; quiet?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { json?: boolean; errorsOnly?: boolean; quiet?: boolean }) => {
       const root = pathArg ?? ".";
       let files: string[];
       try {
         files = await resolveInput(root);
       } catch (err: unknown) {
+        // `validate` predates loadWorkspace and is one of the three
+        // commands that resolve the input directly (see load-workspace.ts
+        // header for why). Its `--json` mode reports the resolve failure
+        // as a one-element diagnostics array on stdout so jq pipelines
+        // still parse; the text mode prints to stderr like every other
+        // resolve failure.
         const msg = `Error resolving path: ${(err as Error).message}`;
         if (opts.json) {
-          console.log(JSON.stringify([{ severity: "error", message: msg }], null, 2));
-        } else {
-          console.error(msg);
+          throw new CommandError(
+            JSON.stringify([{ severity: "error", message: msg }], null, 2),
+            EXIT_PARSE_ERROR,
+            "stdout",
+          );
         }
-        process.exit(2);
+        throw new CommandError(msg, EXIT_PARSE_ERROR);
       }
 
       // Parse each file and extract data immediately (tree-sitter reuses a
@@ -147,8 +156,13 @@ Examples:
         (d) => d.severity === "warning",
       ).length;
 
+      // Soft exit code: validate uses 2 for "any error-severity finding"
+      // and 0 otherwise. Warnings never push the exit non-zero — that's
+      // documented in the command help.
+      const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
+
       if (opts.quiet) {
-        process.exit(errorCount > 0 ? 2 : 0);
+        return exitCode;
       }
 
       if (opts.json) {
@@ -160,7 +174,7 @@ Examples:
             warnings: warnCount,
           },
         }, null, 2));
-        process.exit(errorCount > 0 ? 2 : 0);
+        return exitCode;
       }
 
       if (diagnostics.length === 0) {
@@ -190,6 +204,6 @@ Examples:
         `${errorCount} error${errorCount !== 1 ? "s" : ""}, ${warnCount} warning${warnCount !== 1 ? "s" : ""} in ${extracted.length} file${extracted.length !== 1 ? "s" : ""}`,
       );
 
-      process.exit(errorCount > 0 ? 2 : 0);
-    });
+      return exitCode;
+    }));
 }

--- a/tooling/satsuma-cli/src/commands/warnings.ts
+++ b/tooling/satsuma-cli/src/commands/warnings.ts
@@ -14,6 +14,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, EXIT_NOT_FOUND } from "../command-runner.js";
 import type { WarningRecord, QuestionRecord } from "../types.js";
 
 export function register(program: Command): void {
@@ -34,7 +35,7 @@ Examples:
   satsuma warnings pipeline.stm              # //! warnings in file and imports
   satsuma warnings pipeline.stm --questions  # //? questions instead
   satsuma warnings pipeline.stm --json       # structured output`)
-    .action(async (pathArg: string | undefined, opts: { questions?: boolean; json?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { questions?: boolean; json?: boolean }) => {
       const { index } = await loadWorkspace(pathArg);
 
       // By default show both //! and //? comments; --questions shows only //?
@@ -55,13 +56,12 @@ Examples:
           ...(item.parent ? { block: item.parent, blockType: item.parentType } : {}),
         }));
         console.log(JSON.stringify({ kind, count: jsonItems.length, items: jsonItems }, null, 2));
-        if (items.length === 0) process.exit(1);
-        return;
+        return items.length === 0 ? EXIT_NOT_FOUND : undefined;
       }
 
       if (items.length === 0) {
         console.log(`No ${kind} comments found.`);
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
 
       // Group by file
@@ -80,5 +80,5 @@ Examples:
         }
         console.log();
       }
-    });
+    }));
 }

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -15,6 +15,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { stripNLRefScopePrefix } from "@satsuma/core";
@@ -47,7 +48,7 @@ Examples:
   satsuma where-used hub_customer                    # who references this schema?
   satsuma where-used audit_fields                    # where is this fragment spread?
   satsuma where-used trim_and_lower --json           # transform refs as JSON`)
-    .action(async (name: string, pathArg: string | undefined, opts: { json?: boolean }) => {
+    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { json?: boolean }) => {
       const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
       // Determine entity type — resolve namespace-qualified lookups
@@ -68,14 +69,15 @@ Examples:
         ];
         const close = allNames.find((k) => k.toLowerCase() === name.toLowerCase());
         if (opts.json) {
+          // JSON consumers parse stdout, so the error must land there too —
+          // see schema.ts for the same pattern.
           const errorObj: Record<string, unknown> = { error: errorMsg };
           if (close) errorObj.suggestion = close;
-          console.log(JSON.stringify(errorObj, null, 2));
-        } else {
-          console.error(errorMsg);
-          if (close) console.error(`Did you mean '${close}'?`);
+          throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
         }
-        process.exit(1);
+        const lines = [errorMsg];
+        if (close) lines.push(`Did you mean '${close}'?`);
+        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
       }
 
       const refs = gatherRefs(resolvedName, index, parsedFiles, isSchema, isFragment, isTransform);
@@ -85,19 +87,18 @@ Examples:
         // query so that bare-name lookups produce the qualified form, e.g.
         // "crm::customers" not "::customers" (sl-b0mq).
         console.log(JSON.stringify({ name: canonicalKey(resolvedName), refs }, null, 2));
-        if (refs.length === 0) process.exit(1);
-        return;
+        return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
       }
 
       if (refs.length === 0) {
         // Use resolvedName in text output too so the header always shows the
         // canonical qualified name regardless of how the user queried (sl-wfgx).
         console.log(`No references to '${resolvedName}' found.`);
-        process.exit(1);
+        return EXIT_NOT_FOUND;
       }
 
       printDefault(resolvedName, refs);
-    });
+    }));
 }
 
 // ── Reference gathering ───────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/errors.ts
+++ b/tooling/satsuma-cli/src/errors.ts
@@ -1,21 +1,44 @@
 /**
- * errors.ts — Shared error handling utilities for the Satsuma CLI
+ * errors.ts — Shared error helpers used by CLI command handlers
  *
- * Exit codes:
- *   0  success
- *   1  not found / no results
- *   2  parse error / invalid input
+ * This module owns three things, all of them user-facing failure shapes
+ * that more than one command needs:
+ *
+ *   • {@link loadFiles} — parses a list of `.stm` paths, warns on partial
+ *     parse errors (so commands can still operate on broken workspaces),
+ *     and aborts the command if *any* file is unreadable.
+ *   • {@link findSuggestion} — case-insensitive "did you mean?" suggestion
+ *     used by every "not found" message in the CLI.
+ *   • {@link notFound} — convenience helper that builds a multi-line
+ *     "not found / did you mean / available list" message and throws.
+ *
+ * It does *not* own exit codes or process.exit. Both have moved to
+ * `command-runner.ts`, which is now the single dispatcher that calls
+ * `process.exit`. The exit-code constants are re-exported here so older
+ * imports keep compiling — see sl-3291.
  */
 
 import type { ParsedFile } from "./types.js";
+import { CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "./command-runner.js";
 
-export const EXIT_NOT_FOUND = 1;
-export const EXIT_PARSE_ERROR = 2;
+// Re-export the exit codes so callers that previously imported them from
+// errors.ts keep working. New code should import them directly from
+// command-runner.ts.
+export { EXIT_NOT_FOUND, EXIT_PARSE_ERROR };
 
 /**
- * Load and parse all .stm files from a resolved path list.
- * On parse errors, prints a warning to stderr and continues (partial parse).
- * Exits with EXIT_PARSE_ERROR if ANY file fails to be read.
+ * Parse a list of resolved `.stm` paths.
+ *
+ * Files with parse errors are kept (a per-file warning is printed to
+ * stderr) so commands can still inspect a partially-broken workspace —
+ * this matches the long-standing per-command behaviour and is what every
+ * downstream tool here expects.
+ *
+ * If *any* file fails to be read at all, this throws a {@link CommandError}
+ * with code {@link EXIT_PARSE_ERROR}. The per-file errors have already been
+ * printed to stderr by the time the throw happens, so the thrown error
+ * carries an empty message — the runner will skip printing and just
+ * propagate the exit code.
  */
 export function loadFiles(
   files: string[],
@@ -37,13 +60,23 @@ export function loadFiles(
     }
   }
 
-  if (hasReadError) process.exit(EXIT_PARSE_ERROR);
+  if (hasReadError) {
+    // Per-file errors have already been written to stderr above; an
+    // empty-message CommandError just signals the exit code without
+    // double-printing.
+    throw new CommandError("", EXIT_PARSE_ERROR);
+  }
   return parsed;
 }
 
 /**
- * Suggest a close match from a list of available names.
- * Returns the suggestion string or null.
+ * Suggest a close match from a list of available names. Returns the
+ * suggestion string, or null if nothing reasonable is available.
+ *
+ * The matching rule is intentionally simple — case-insensitive exact
+ * match first, falling back to a 3-character prefix match. This is
+ * good enough for the "did you mean schemaname?" case the CLI uses
+ * it for; full edit-distance ranking would just produce more noise.
  */
 export function findSuggestion(name: string, available: string[]): string | null {
   // Case-insensitive exact match
@@ -58,19 +91,31 @@ export function findSuggestion(name: string, available: string[]): string | null
 }
 
 /**
- * Print a "not found" error with an optional suggestion and exit 1.
+ * Build a multi-line "not found" message and throw a {@link CommandError}
+ * with code {@link EXIT_NOT_FOUND}. Returns `never` so callers can use it
+ * as a terminal expression in narrowing branches.
+ *
+ * The message includes a "did you mean?" line when {@link findSuggestion}
+ * returns a useful match, and an "Available: a, b, c" line when there are
+ * 10 or fewer alternatives (otherwise it just shows the count, to avoid
+ * dumping hundreds of names into the user's terminal).
  */
 export function notFound(kind: string, name: string, available: string[]): never {
   const suggestion = findSuggestion(name, available);
+  const lines: string[] = [];
+
   if (suggestion && suggestion !== name) {
-    console.error(`${kind} '${name}' not found. Did you mean '${suggestion}'?`);
+    lines.push(`${kind} '${name}' not found. Did you mean '${suggestion}'?`);
   } else {
-    console.error(`${kind} '${name}' not found.`);
+    lines.push(`${kind} '${name}' not found.`);
   }
-  if (available.length > 0 && available.length <= 10) {
-    console.error(`Available: ${available.join(", ")}`);
-  } else if (available.length > 10) {
-    console.error(`(${available.length} ${kind.toLowerCase()}s in workspace)`);
+
+  const MAX_INLINE_AVAILABLE = 10; // beyond this we show a count instead
+  if (available.length > 0 && available.length <= MAX_INLINE_AVAILABLE) {
+    lines.push(`Available: ${available.join(", ")}`);
+  } else if (available.length > MAX_INLINE_AVAILABLE) {
+    lines.push(`(${available.length} ${kind.toLowerCase()}s in workspace)`);
   }
-  process.exit(EXIT_NOT_FOUND);
+
+  throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
 }

--- a/tooling/satsuma-cli/src/index.ts
+++ b/tooling/satsuma-cli/src/index.ts
@@ -32,7 +32,13 @@ program
   .version(pkg.version)
   .showHelpAfterError(true);
 
-// Unhandled rejections go to stderr with exit 2
+// Last-resort safety net for promise rejections that escape the runner.
+// Every command handler is wrapped in `runCommand` (see command-runner.ts),
+// which catches both CommandError and unknown errors and exits with the
+// right code. This handler exists only for the narrow window *before*
+// dispatch — e.g. if a dynamic command import below throws, or a future
+// top-level await rejects. Inside that window we have no runner to lean
+// on, so we mirror its formatting and exit code here.
 process.on("unhandledRejection", (err: unknown) => {
   console.error(`Unhandled error: ${(err as { message?: string })?.message ?? String(err)}`);
   process.exit(2);

--- a/tooling/satsuma-cli/src/load-workspace.ts
+++ b/tooling/satsuma-cli/src/load-workspace.ts
@@ -20,7 +20,8 @@
 
 import { resolveInput } from "./workspace.js";
 import { parseFile } from "./parser.js";
-import { loadFiles, EXIT_PARSE_ERROR } from "./errors.js";
+import { loadFiles } from "./errors.js";
+import { CommandError, EXIT_PARSE_ERROR } from "./command-runner.js";
 import { buildIndex } from "./index-builder.js";
 import type { ExtractedWorkspace, ParsedFile } from "./types.js";
 
@@ -42,13 +43,16 @@ export interface LoadWorkspaceOptions {
 }
 
 /**
- * Resolve a path argument and load the full workspace, exiting with a
- * standard message on the common failure modes:
+ * Resolve a path argument and load the full workspace, throwing a
+ * {@link CommandError} on the common failure modes:
  *
  *   • `resolveInput` throws (bad path, directory argument, …) →
- *     `Error resolving path '<arg>': <message>` on stderr, exit code 2.
- *   • A file cannot be read → handled by {@link loadFiles} (warn on stderr,
- *     exit code 2).
+ *     `CommandError("Error resolving path '<arg>': <message>", EXIT_PARSE_ERROR)`.
+ *   • A file cannot be read → {@link loadFiles} prints per-file warnings to
+ *     stderr and throws an empty-message `CommandError(EXIT_PARSE_ERROR)`.
+ *
+ * Both branches surface to the user via {@link runCommand}, which is the
+ * single place in the CLI that calls `process.exit`.
  *
  * Files with parse errors are kept (a warning is printed) so commands can
  * still operate on partially-broken workspaces; this matches the long-
@@ -68,8 +72,10 @@ export async function loadWorkspace(
   try {
     filePaths = await resolveInput(root, { followImports: options.followImports ?? true });
   } catch (err: unknown) {
-    console.error(`Error resolving path '${root}': ${(err as Error).message}`);
-    process.exit(EXIT_PARSE_ERROR);
+    throw new CommandError(
+      `Error resolving path '${root}': ${(err as Error).message}`,
+      EXIT_PARSE_ERROR,
+    );
   }
 
   const files = loadFiles(filePaths, parseFile);

--- a/tooling/satsuma-cli/test/command-runner.test.ts
+++ b/tooling/satsuma-cli/test/command-runner.test.ts
@@ -1,0 +1,188 @@
+/**
+ * command-runner.test.ts — Unit tests for the CLI's exit dispatcher
+ *
+ * `runCommand` is the single point in the CLI that calls `process.exit`.
+ * Every command handler funnels through it, so the contract pinned here
+ * is what those handlers depend on:
+ *
+ *   • a handler that returns nothing exits 0;
+ *   • a handler that returns a number exits with that number;
+ *   • a handler that throws CommandError prints the message on the
+ *     requested stream and exits with the carried code;
+ *   • an empty-message CommandError signals exit code without printing
+ *     (used by callers like `loadFiles` that already wrote per-file
+ *     warnings to stderr);
+ *   • any other thrown error becomes "Unhandled error: …" on stderr
+ *     with code 2 — the safety net for genuine bugs that escape a
+ *     handler.
+ *
+ * Process.exit is observed via a throwing stub. This is the *one* test
+ * file in the suite that needs that pattern; everything else can now
+ * simply assert the thrown CommandError directly.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import {
+  runCommand,
+  CommandError,
+  EXIT_OK,
+  EXIT_NOT_FOUND,
+  EXIT_PARSE_ERROR,
+} from "#src/command-runner.js";
+
+// ── process.exit / console capture ──────────────────────────────────────────
+
+class ExitCalled extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+let originalExit: typeof process.exit;
+let originalErr: typeof console.error;
+let originalLog: typeof console.log;
+let stderrLines: string[];
+let stdoutLines: string[];
+
+beforeEach(() => {
+  originalExit = process.exit;
+  originalErr = console.error;
+  originalLog = console.log;
+  stderrLines = [];
+  stdoutLines = [];
+  // A throwing stub is the closest faithful substitute for `(code) => never`.
+  process.exit = ((code?: number): never => {
+    throw new ExitCalled(code ?? 0);
+  }) as typeof process.exit;
+  console.error = (...args: unknown[]) => {
+    stderrLines.push(args.map((a) => String(a)).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    stdoutLines.push(args.map((a) => String(a)).join(" "));
+  };
+});
+
+afterEach(() => {
+  process.exit = originalExit;
+  console.error = originalErr;
+  console.log = originalLog;
+});
+
+// Convenience: run a wrapped handler and capture the exit code that the
+// stub throws. Any other thrown error fails the test.
+async function runAndExpectExit(
+  handler: () => Promise<number | void> | number | void,
+): Promise<number> {
+  const wrapped = runCommand(handler);
+  try {
+    await wrapped();
+  } catch (err) {
+    if (err instanceof ExitCalled) return err.code;
+    throw err;
+  }
+  throw new Error("expected runCommand to call process.exit, but it returned normally");
+}
+
+// ── return-value cases ──────────────────────────────────────────────────────
+
+describe("runCommand return values", () => {
+  it("exits 0 when the handler returns void", async () => {
+    // The most common case: a successful command that printed its output
+    // and has nothing more to say. The wrapper must default void → EXIT_OK.
+    const code = await runAndExpectExit(() => { /* no-op */ });
+    assert.equal(code, EXIT_OK);
+    assert.deepEqual(stderrLines, []);
+    assert.deepEqual(stdoutLines, []);
+  });
+
+  it("forwards a numeric return value as the exit code", async () => {
+    // Handlers like `validate --quiet` or `find` use this to surface a
+    // soft non-zero exit ("findings present" / "no matches") without
+    // throwing.
+    const code = await runAndExpectExit(() => EXIT_NOT_FOUND);
+    assert.equal(code, EXIT_NOT_FOUND);
+  });
+
+  it("awaits an async handler before exiting", async () => {
+    // Async handlers must be awaited — otherwise the wrapper would exit
+    // on the dangling promise and lose the return value entirely.
+    const code = await runAndExpectExit(async () => {
+      await new Promise((r) => setImmediate(r));
+      return EXIT_PARSE_ERROR;
+    });
+    assert.equal(code, EXIT_PARSE_ERROR);
+  });
+});
+
+// ── CommandError cases ──────────────────────────────────────────────────────
+
+describe("runCommand CommandError handling", () => {
+  it("prints the message to stderr and exits with the carried code", async () => {
+    // The canonical "expected failure" path: a handler throws a structured
+    // CommandError and the wrapper does the printing + exit on its behalf.
+    // Verifies both halves of the contract handlers depend on.
+    const code = await runAndExpectExit(() => {
+      throw new CommandError("schema 'foo' not found", EXIT_NOT_FOUND);
+    });
+    assert.equal(code, EXIT_NOT_FOUND);
+    assert.deepEqual(stderrLines, ["schema 'foo' not found"]);
+    assert.deepEqual(stdoutLines, []);
+  });
+
+  it("routes message to stdout when stream is 'stdout'", async () => {
+    // JSON-mode commands need their error payloads on the success channel
+    // so consumers can pipe through `jq` without losing the body. The
+    // wrapper must honour the stream selector — this pins that.
+    const payload = JSON.stringify({ error: "not found" });
+    const code = await runAndExpectExit(() => {
+      throw new CommandError(payload, EXIT_NOT_FOUND, "stdout");
+    });
+    assert.equal(code, EXIT_NOT_FOUND);
+    assert.deepEqual(stdoutLines, [payload]);
+    assert.deepEqual(stderrLines, []);
+  });
+
+  it("skips printing when the message is empty", async () => {
+    // Used by helpers like `loadFiles` that have already printed
+    // per-file warnings and only need to signal the final exit code.
+    // Without this branch the empty line would still be written.
+    const code = await runAndExpectExit(() => {
+      throw new CommandError("", EXIT_PARSE_ERROR);
+    });
+    assert.equal(code, EXIT_PARSE_ERROR);
+    assert.deepEqual(stderrLines, []);
+    assert.deepEqual(stdoutLines, []);
+  });
+});
+
+// ── unknown-error safety net ────────────────────────────────────────────────
+
+describe("runCommand unknown-error safety net", () => {
+  it("formats arbitrary thrown errors as 'Unhandled error: …' and exits 2", async () => {
+    // Anything that's not a CommandError represents a genuine bug — a
+    // TypeError, a parser crash, an assertion failure. We want those
+    // visible in CI logs with a stable prefix and a non-zero exit, not
+    // swallowed silently.
+    const code = await runAndExpectExit(() => {
+      throw new TypeError("undefined is not a function");
+    });
+    assert.equal(code, EXIT_PARSE_ERROR);
+    assert.equal(stderrLines.length, 1);
+    assert.match(stderrLines[0]!, /^Unhandled error: undefined is not a function$/);
+  });
+
+  it("stringifies non-Error throws so the user sees something useful", async () => {
+    // Code that throws bare strings or numbers is wrong, but the wrapper
+    // must still produce a readable message rather than `[object Object]`.
+    const code = await runAndExpectExit(() => {
+      // Throwing a bare string (non-Error) is wrong code, but the runner
+      // must still produce a readable message rather than [object Object].
+      const oops: unknown = "something went wrong";
+      throw oops;
+    });
+    assert.equal(code, EXIT_PARSE_ERROR);
+    assert.equal(stderrLines.length, 1);
+    assert.match(stderrLines[0]!, /Unhandled error: something went wrong/);
+  });
+});

--- a/tooling/satsuma-cli/test/errors.test.ts
+++ b/tooling/satsuma-cli/test/errors.test.ts
@@ -1,67 +1,114 @@
 /**
- * errors.test.js — Unit tests for src/errors.js utilities.
+ * errors.test.ts — Unit tests for src/errors.ts
+ *
+ * The behaviours pinned here are the contract that command handlers
+ * depend on:
+ *
+ *   • findSuggestion's case-insensitive exact-then-prefix matching;
+ *   • loadFiles' partial-success policy (warn on parse errors, abort on
+ *     read failures via CommandError);
+ *   • notFound's message shape (suggestion line, available list vs count
+ *     fallback) and exit code.
+ *
+ * These tests no longer need to stub `process.exit` — every failure
+ * surface is now expressed via thrown CommandError, which is observable
+ * directly. The exit-dispatcher behaviour itself is covered in
+ * command-runner.test.ts.
  */
 
 import assert from "node:assert/strict";
-import { describe, it, beforeEach, afterEach } from "node:test";
-import { findSuggestion, loadFiles, notFound, EXIT_NOT_FOUND } from "#src/errors.js";
+import { describe, it } from "node:test";
+import { findSuggestion, loadFiles, notFound } from "#src/errors.js";
+import { CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "#src/command-runner.js";
+
+// ── findSuggestion ──────────────────────────────────────────────────────────
 
 describe("findSuggestion", () => {
-  it("returns exact case-insensitive match", () => {
-    assert.equal(findSuggestion("Orders", ["orders", "customers"]), "orders");
+  it("returns case-insensitive exact match in preference to a prefix match", () => {
+    // 'ORDERS' matches 'orders' exactly when lowercased — must beat any
+    // prefix-only candidate so the user sees the most relevant hint.
+    assert.equal(findSuggestion("ORDERS", ["orders", "order_items"]), "orders");
   });
 
-  it("returns prefix match when no exact match", () => {
-    const result = findSuggestion("cust", ["customers", "orders"]);
-    assert.equal(result, "customers");
+  it("falls back to a 3-character prefix match when no exact match exists", () => {
+    // The prefix rule is what catches typos like 'cust' → 'customers'.
+    assert.equal(findSuggestion("cust", ["customers", "orders"]), "customers");
   });
 
-  it("returns null when no match", () => {
+  it("returns null when neither rule applies", () => {
+    // No exact match, no usable prefix → no suggestion. The caller will
+    // fall through to the bare "not found" message.
     assert.equal(findSuggestion("xyz", ["orders", "customers"]), null);
   });
 
-  it("prefers exact over prefix", () => {
-    // "orders" exactly matches "ORDERS" case-insensitively
-    const result = findSuggestion("ORDERS", ["orders", "order_items"]);
-    assert.equal(result, "orders");
-  });
-
-  it("handles empty available list", () => {
+  it("returns null when the available list is empty", () => {
+    // Edge case: an empty workspace shouldn't crash the matcher.
     assert.equal(findSuggestion("anything", []), null);
-  });
-
-  it("returns null when name is shorter than 3 chars and no exact match", () => {
-    // .slice(0,3) on a 2-char name yields 2 chars, still matches prefix
-    assert.equal(findSuggestion("or", ["orders", "customers"]), "orders");
   });
 });
 
 // ── loadFiles ───────────────────────────────────────────────────────────────
 
 describe("loadFiles", () => {
-  it("returns parsed files for successful parses", () => {
+  it("returns successfully parsed files when every parse succeeds", () => {
+    // The happy path: every file parses cleanly, every result flows
+    // through. Pins that loadFiles preserves order and shape.
     const mockParse = (f: string) => ({ filePath: f, tree: {}, errorCount: 0 });
-    const result = loadFiles(["a.stm", "b.stm"], mockParse as any);
+    const result = loadFiles(["a.stm", "b.stm"], mockParse as never);
     assert.equal(result.length, 2);
-    assert.equal(result[0].filePath, "a.stm");
+    assert.equal(result[0]!.filePath, "a.stm");
   });
 
-  it("continues on parse errors and warns on stderr", () => {
-    const stderrOutput: string[] = [];
+  it("warns on parse errors but keeps the file in the result list", () => {
+    // Partial-parse policy: a file with parse errors is still useful for
+    // commands that walk the CST, so loadFiles must not drop it. The
+    // warning goes to stderr.
+    const stderrCaptured: string[] = [];
     const origWrite = process.stderr.write;
-    process.stderr.write = ((s: string) => { stderrOutput.push(s); return true; }) as any;
+    process.stderr.write = ((s: string) => { stderrCaptured.push(s); return true; }) as never;
     try {
       const mockParse = (f: string) => ({ filePath: f, tree: {}, errorCount: 2 });
-      const result = loadFiles(["bad.stm"], mockParse as any);
-      assert.equal(result.length, 1, "should still return the parsed file");
-      assert.ok(stderrOutput.some((s) => s.includes("2 parse error")));
+      const result = loadFiles(["bad.stm"], mockParse as never);
+      assert.equal(result.length, 1);
+      assert.ok(
+        stderrCaptured.some((s) => s.includes("2 parse error")),
+        "expected per-file parse-error warning on stderr",
+      );
     } finally {
       process.stderr.write = origWrite;
     }
   });
 
-  it("returns empty array for empty file list", () => {
-    const result = loadFiles([], () => ({ filePath: "", tree: {}, errorCount: 0 }) as any);
+  it("throws CommandError(EXIT_PARSE_ERROR) when a file cannot be read", () => {
+    // The hard-failure path: any read failure aborts the command. The
+    // per-file error is emitted directly by the helper (the throw carries
+    // an empty message because the runner would otherwise double-print).
+    const stderrCaptured: string[] = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = ((s: string) => { stderrCaptured.push(s); return true; }) as never;
+    try {
+      const mockParse = (_f: string) => { throw new Error("ENOENT"); };
+      assert.throws(
+        () => loadFiles(["missing.stm"], mockParse as never),
+        (err: unknown) =>
+          err instanceof CommandError &&
+          err.code === EXIT_PARSE_ERROR &&
+          err.message === "",
+      );
+      assert.ok(
+        stderrCaptured.some((s) => s.includes("could not read or parse missing.stm")),
+        "expected per-file read-error message on stderr before the throw",
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+  });
+
+  it("returns an empty array for an empty file list", () => {
+    // Edge case: zero inputs is a no-op success, not an error. Some
+    // commands compose loadFiles with a filter that may legitimately
+    // produce no paths.
+    const result = loadFiles([], () => ({ filePath: "", tree: {}, errorCount: 0 }) as never);
     assert.equal(result.length, 0);
   });
 });
@@ -69,58 +116,51 @@ describe("loadFiles", () => {
 // ── notFound ────────────────────────────────────────────────────────────────
 
 describe("notFound", () => {
-  let stderrOutput: string[];
-  let origWrite: typeof process.stderr.write;
-  let origExit: typeof process.exit;
-
-  beforeEach(() => {
-    stderrOutput = [];
-    origWrite = process.stderr.write;
-    origExit = process.exit;
-    process.stderr.write = ((s: string) => { stderrOutput.push(s); return true; }) as any;
+  it("includes a 'did you mean' suggestion when one is available", () => {
+    // The most user-visible thing this helper does. The suggestion comes
+    // from findSuggestion, so this also covers the wiring between the
+    // two without re-testing the matching rules themselves.
+    assert.throws(
+      () => notFound("Schema", "ORDERS", ["orders", "customers"]),
+      (err: unknown) =>
+        err instanceof CommandError &&
+        err.code === EXIT_NOT_FOUND &&
+        err.message.includes("Did you mean 'orders'"),
+    );
   });
 
-  afterEach(() => {
-    process.stderr.write = origWrite;
-    process.exit = origExit;
+  it("lists every alternative when there are 10 or fewer", () => {
+    // Up to MAX_INLINE_AVAILABLE the user gets the full list inline,
+    // because dumping it is cheaper than making them re-query.
+    assert.throws(
+      () => notFound("Schema", "xyz", ["a", "b", "c"]),
+      (err: unknown) =>
+        err instanceof CommandError &&
+        err.message.includes("Available: a, b, c"),
+    );
   });
 
-  it("prints suggestion when close match exists", () => {
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => { exitCode = code; throw new Error("exit"); }) as any;
-    try {
-      notFound("Schema", "ORDERS", ["orders", "customers"]);
-    } catch { /* expected exit */ }
-    assert.ok(stderrOutput.some((s) => s.includes("Did you mean 'orders'")));
-    assert.equal(exitCode, EXIT_NOT_FOUND);
-  });
-
-  it("lists available items when 10 or fewer", () => {
-    let exitCode: number | undefined;
-    process.exit = ((code: number) => { exitCode = code; throw new Error("exit"); }) as any;
-    try {
-      notFound("Schema", "xyz", ["a", "b", "c"]);
-    } catch { /* expected exit */ }
-    assert.ok(stderrOutput.some((s) => s.includes("Available: a, b, c")));
-    assert.equal(exitCode, EXIT_NOT_FOUND);
-  });
-
-  it("shows count when more than 10 items available", () => {
-    process.exit = (() => { throw new Error("exit"); }) as any;
+  it("collapses long lists into a count to avoid wall-of-text output", () => {
+    // Beyond 10 alternatives the inline list is more noise than signal,
+    // so we show the count instead. Pins the threshold and the wording.
     const many = Array.from({ length: 15 }, (_, i) => `s${i}`);
-    try {
-      notFound("Schema", "xyz", many);
-    } catch { /* expected exit */ }
-    assert.ok(stderrOutput.some((s) => s.includes("15 schemas in workspace")));
+    assert.throws(
+      () => notFound("Schema", "xyz", many),
+      (err: unknown) =>
+        err instanceof CommandError &&
+        err.message.includes("15 schemas in workspace"),
+    );
   });
 
-  it("omits suggestion when name matches an available entry exactly", () => {
-    process.exit = (() => { throw new Error("exit"); }) as any;
-    try {
-      notFound("Schema", "orders", ["orders", "customers"]);
-    } catch { /* expected exit */ }
-    // Should say "not found." without "Did you mean" since the suggestion === name
-    assert.ok(stderrOutput.some((s) => s.includes("not found.")));
-    assert.ok(!stderrOutput.some((s) => s.includes("Did you mean")));
+  it("omits the 'did you mean' line when the query exactly matches an entry", () => {
+    // A user querying the canonical name shouldn't be told they meant
+    // exactly what they typed. Guards against an old regression in
+    // findSuggestion's exact-match branch.
+    assert.throws(
+      () => notFound("Schema", "orders", ["orders", "customers"]),
+      (err: unknown) =>
+        err instanceof CommandError &&
+        !err.message.includes("Did you mean"),
+    );
   });
 });

--- a/tooling/satsuma-cli/test/load-workspace.test.ts
+++ b/tooling/satsuma-cli/test/load-workspace.test.ts
@@ -2,73 +2,37 @@
  * load-workspace.test.ts — Unit tests for the shared CLI workspace loader
  *
  * `loadWorkspace` is the single point through which 18 of 21 CLI commands
- * resolve, parse, and index a workspace. The behaviours under test here are
- * the contract those commands rely on:
+ * resolve, parse, and index a workspace. The contract pinned here is what
+ * those commands rely on:
  *
  *   • a successful load returns both the parsed files and the assembled
  *     `ExtractedWorkspace` index, with the same data shape an inline
  *     resolveInput / parseFile / buildIndex sequence used to produce;
- *   • a resolution failure (bad path, directory argument) is reported with
- *     the standard `Error resolving path '<arg>': ...` message and exits the
- *     process with `EXIT_PARSE_ERROR`;
+ *   • a resolution failure (bad path, directory argument) is reported via
+ *     a CommandError carrying the standard `Error resolving path '<arg>': …`
+ *     message and EXIT_PARSE_ERROR;
  *   • `followImports: false` disables transitive import resolution so the
  *     loader can be used by tools that compare two single files;
  *   • a `pathArg` of `undefined` resolves the current working directory,
  *     mirroring how every CLI command treats a missing positional path.
  *
- * Process exits are observed via a `process.exit` stub so the test runner
- * is not killed; we assert on the exit code and the captured stderr.
+ * After sl-3291, error paths are observed by asserting on the thrown
+ * CommandError directly — no process.exit stubbing required. The dispatcher
+ * behaviour is covered in command-runner.test.ts.
  */
 
 import assert from "node:assert/strict";
-import { describe, it, before, beforeEach, afterEach } from "node:test";
+import { describe, it, before } from "node:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { initParser } from "#src/parser.js";
 import { loadWorkspace } from "#src/load-workspace.js";
+import { CommandError, EXIT_PARSE_ERROR } from "#src/command-runner.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLES = resolve(__dirname, "../../../examples");
-
-// ── process-exit stub ────────────────────────────────────────────────────────
-//
-// `loadWorkspace` calls `process.exit` on resolve / load failures. The tests
-// replace it with a throwing stub so the assertions can observe the exit
-// without aborting the test runner. `console.error` is captured for the same
-// reason — we want to assert on the message body without polluting test
-// output.
-
-class ExitCalled extends Error {
-  constructor(public code: number) {
-    super(`process.exit(${code})`);
-  }
-}
-
-let originalExit: typeof process.exit;
-let originalError: typeof console.error;
-let stderrLines: string[];
-
-beforeEach(() => {
-  originalExit = process.exit;
-  originalError = console.error;
-  stderrLines = [];
-  // The cast is required because process.exit is typed as `(code) => never`;
-  // a throwing stub is the closest faithful substitute that still satisfies
-  // the never-returning contract.
-  process.exit = ((code?: number): never => {
-    throw new ExitCalled(code ?? 0);
-  }) as typeof process.exit;
-  console.error = (msg: unknown) => {
-    stderrLines.push(String(msg));
-  };
-});
-
-afterEach(() => {
-  process.exit = originalExit;
-  console.error = originalError;
-});
 
 before(async () => {
   // The WASM parser must be initialised once before any parseFile call;
@@ -80,8 +44,8 @@ before(async () => {
 
 describe("loadWorkspace", () => {
   it("returns parsed files and an index whose schemas reflect the source", async () => {
-    // A real example file with known schemas — verifies the round-trip from
-    // path argument to a populated ExtractedWorkspace.
+    // A real example file with known schemas — verifies the round-trip
+    // from path argument to a populated ExtractedWorkspace.
     const entry = resolve(EXAMPLES, "lib/common.stm");
     const { files, index } = await loadWorkspace(entry);
 
@@ -92,24 +56,20 @@ describe("loadWorkspace", () => {
 
   it("treats an undefined pathArg as the current working directory", async () => {
     // CLI commands that omit `[path]` pass undefined; the loader must
-    // mirror the historical `pathArg ?? "."` behaviour from the inline
-    // sequences it replaces. We point cwd at a directory containing a
-    // single .stm file and verify the loader picks it up via the default.
+    // mirror the historical `pathArg ?? "."` behaviour. We point cwd at
+    // a directory and verify the rejection path includes the default
+    // path string — proving the default was applied.
     const tmp = mkdtempSync(join(tmpdir(), "satsuma-loadws-"));
     writeFileSync(join(tmp, "x.stm"), "schema s { f string }\n");
-    // The default `.` resolves to a directory, which `resolveInput` rejects
-    // (ADR-022). We assert the rejection path here — proving the default is
-    // being applied — rather than constructing an entry-file fixture.
     const prevCwd = process.cwd();
     try {
       process.chdir(tmp);
       await assert.rejects(
         () => loadWorkspace(undefined),
-        (err: Error) => err instanceof ExitCalled && err.code === 2,
-      );
-      assert.ok(
-        stderrLines.some((l) => /Error resolving path '\.':/.test(l)),
-        `expected default path '.' in stderr, got: ${stderrLines.join(" | ")}`,
+        (err: unknown) =>
+          err instanceof CommandError &&
+          err.code === EXIT_PARSE_ERROR &&
+          /Error resolving path '\.':/.test(err.message),
       );
     } finally {
       process.chdir(prevCwd);
@@ -119,8 +79,8 @@ describe("loadWorkspace", () => {
 
   it("forwards followImports: false to skip transitive resolution", async () => {
     // The diff command needs to compare two files in isolation. Verifies
-    // the option flows through to resolveInput and we get exactly one file
-    // back even when the entry imports others.
+    // the option flows through to resolveInput and we get exactly one
+    // file back even when the entry imports others.
     const entry = resolve(__dirname, "fixtures/import-entry.stm");
     const { files } = await loadWorkspace(entry, { followImports: false });
     assert.equal(files.length, 1, "followImports: false must yield only the entry file");
@@ -131,32 +91,30 @@ describe("loadWorkspace", () => {
 // ── failure modes ────────────────────────────────────────────────────────────
 
 describe("loadWorkspace failure handling", () => {
-  it("reports a directory argument with the standard message and exits 2", async () => {
-    // ADR-022: directory arguments are rejected by resolveInput. The loader
-    // is responsible for catching that throw and presenting it consistently
-    // — this is the test that pins the message format every command shares.
+  it("rejects directory arguments with the standard message and EXIT_PARSE_ERROR", async () => {
+    // ADR-022: directory arguments are rejected by resolveInput. The
+    // loader catches that and surfaces it as a CommandError with the
+    // canonical message format every command shares.
     await assert.rejects(
       () => loadWorkspace(EXAMPLES),
-      (err: Error) => err instanceof ExitCalled && err.code === 2,
+      (err: unknown) =>
+        err instanceof CommandError &&
+        err.code === EXIT_PARSE_ERROR &&
+        /^Error resolving path '/.test(err.message) &&
+        /directory arguments are not supported/.test(err.message),
     );
-    assert.equal(stderrLines.length, 1);
-    assert.match(stderrLines[0]!, /^Error resolving path '/);
-    assert.match(stderrLines[0]!, /directory arguments are not supported/);
   });
 
   it("includes the user-supplied path argument verbatim in the error message", async () => {
     // The previous inline sequences printed `Error resolving path: <msg>`
     // without the path itself, which made shell scripts harder to debug
-    // when multiple commands chained. Pinning the new format here so a
-    // future drive-by change cannot silently regress it.
+    // when multiple commands were chained. Pinning the new format here
+    // so a future drive-by change cannot silently regress it.
     const bogus = "/definitely/does/not/exist.stm";
     await assert.rejects(
       () => loadWorkspace(bogus),
-      (err: Error) => err instanceof ExitCalled && err.code === 2,
-    );
-    assert.ok(
-      stderrLines.some((l) => l.includes(`'${bogus}'`)),
-      `expected the bogus path to appear in the error message: ${stderrLines.join(" | ")}`,
+      (err: unknown) =>
+        err instanceof CommandError && err.message.includes(`'${bogus}'`),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Replaces 53 inline `process.exit()` calls across 23 CLI files with a single top-level dispatcher (`src/command-runner.ts`). Handlers now return a numeric exit code or throw `CommandError`; the runner catches both and exits exactly once.
- Drops all `process.exit` stub plumbing from `errors.test.ts` and `load-workspace.test.ts` — they now assert thrown `CommandError`s directly. Adds `command-runner.test.ts` to pin the four runner branches.
- Bonus: the runner's universal stdout/stderr drain before exit fixes latent `--json` truncation past ~64KiB on piped output (the per-command flush hack in `graph.ts` is now unnecessary and removed).

Down from 53 inline exits to 2 documented sites: the runner itself, and an `unhandledRejection` safety net in `index.ts` for failures *before* dispatch.

Closes sl-3291.

## Test plan

- [x] `npm run build` (CLI + core) clean
- [x] `npm run lint:js` clean
- [x] `npm test` — 887/887 passing, including new `command-runner.test.ts` and rewritten `errors`/`load-workspace` tests
- [x] Integration tests (subprocess + exit codes) unchanged and passing — they're the contract this refactor preserves

🤖 Generated with [Claude Code](https://claude.com/claude-code)