### PR TITLE
docs(diaries): add entry for 2026-04-07

### DIFF
--- a/satsuma-diaries/.progress.json
+++ b/satsuma-diaries/.progress.json
@@ -1,6 +1,6 @@
 {
-  "last_covered_date": "2026-04-02",
-  "last_entry_file": "satsuma-diaries/2026/04/2026-04-02.md",
-  "rolled_up_days": [],
-  "note": "Last entry written: 2026-04-02. Rewrote for the 0.7.0 release — 29 commits, 10 PRs, metric keyword removal, pipeline simplification, version bump. Next run will cover from 2026-04-03."
+  "last_covered_date": "2026-04-07",
+  "last_entry_file": "satsuma-diaries/2026/04/2026-04-07.md",
+  "rolled_up_days": ["2026-04-03", "2026-04-04", "2026-04-05", "2026-04-06"],
+  "note": "Last entry written: 2026-04-07. 25 commits, 11 PRs merged after four silent days. Next run will cover from 2026-04-08."
 }

--- a/satsuma-diaries/2026/04/2026-04-07.md
+++ b/satsuma-diaries/2026/04/2026-04-07.md
@@ -1,0 +1,26 @@
+# The Satsuma Diaries
+## Tuesday, 7 April 2026
+
+> **tl;dr** — After four days of total silence, Thorben came back swinging: 25 commits, 11 PRs merged, five new agent skills shipped, a long-broken example finally validates clean, and the CLI stopped sprinkling `process.exit` calls across 23 files like confetti. Productive Tuesday, fam.
+
+Right. So.
+
+Four days. Nothing. Not a peep. The diary's been sitting here like a plant nobody's watered, and then Tuesday rolls around and someone flips a switch. Twenty-five commits before I've finished my tea. Eleven pull requests merged. Bruv. Allow it.
+
+Let's start with the one that actually made me sit up. **PR #211** — the CLI used to call `process.exit()` in fifty-three different places across twenty-three files. Fifty-three. Each command, when it hit an error, would just yell "I'M OUT" and pull the plug on Node directly. This is the kind of thing that works fine until you try to write a test for it, at which point your test runner also dies, because `process.exit` doesn't ask permission. The fix is genuinely tidy: every command now just *returns* a number (the exit code) or *throws* a proper error object, and there's one single place at the top — a "command runner" — that catches the lot and does the actual exiting. One door in, one door out. Tests stop having to stub `process.exit` like they're disarming a bomb. That's actually sick, not gonna lie.
+
+Then there's **PR #208**, where five new agent skills landed in `skills/`. Skills, for the uninitiated, are little instruction bundles you give an AI assistant so it knows how to do a specific job — like "convert this dbt project to satsuma" or "explain this satsuma file in plain English". The five new ones are: `satsuma-explainer` (does what it says), `satsuma-from-dbt` and `satsuma-to-dbt` (translates between satsuma and dbt, which is the SQL-based data tool everyone in the warehouse world uses), `satsuma-sample-data` (makes up fake data so you can test things without leaking real customer info), and `satsuma-to-openlineage` (exports to OpenLineage, which is a standard format for tracking where data comes from). Plus the `skills/README.md` now actually tells you where to install them depending on whether you're on Claude Code, Claude Desktop, GitHub Copilot, or the Codex CLI. Useful.
+
+The example corpus also got some long-overdue love. **PR #210** finally fixed `examples/metrics-platform/metrics.stm`, which had been quietly emitting *sixty-two warnings* every time anyone validated it. Sixty-two. We've been shipping this as a canonical example. Embarrassing. Turns out it was mostly PascalCase field names where the schema declared snake_case, plus a handful of arrows pointing at fields that didn't exist. All cleaned up now, validates with zero errors and zero warnings. The namespaces example also got a fix from yesterday's stash thrown in for free.
+
+**PR #209** was a four-in-one cleanup bundle for Feature 29 (the "tidy up after yourself" feature). Dead helper deleted, a `WorkspaceIndex` type renamed to `ExtractedWorkspace` because the old name made it sound like a database index when it really wasn't, two architecture docs reconciled with what the code actually does. None of these are individually exciting but together they shave a small layer of "wait, why is this called that" off the codebase, which is the entire point of Feature 29.
+
+Three new bug tickets got filed too (**PR #207**), all reproduced against main: the NL `@ref` diagnostics report wrong column numbers inside multiline strings (the raw byte offset is leaking out — at one point it claimed column 791, which, no), the `@ref` regex false-positives on email addresses and SQL `LIKE %@something` patterns, and the metrics-platform warnings (fixed same day in #210, so that one's already crossed off). On God, filing three bug tickets and immediately fixing one of them is the speedrun of ticket hygiene.
+
+Documentation didn't escape either. A whole new contributor guide landed (`docs/developer/AGENT-CONTRIBUTIONS.md` — wait, no, just the contributor guide, I'm getting ahead of myself), the architecture doc got reconciled with the new `loadWorkspace` helper that PR introduced (one helper to load all the satsuma files in a workspace, replacing the same five lines copy-pasted into every command), a tutorial got added for using GitHub Copilot to reverse-engineer Excel spreadsheets into satsuma — which honestly is the use case half of finance teams have without knowing it — and the DMD acronym got dropped from the tutorials in favour of words actual humans use. Allow acronyms, fam.
+
+And then the dependabot crew filed in: eslint, tree-sitter-cli, three GitHub Actions all bumped. Routine. Not gonna pretend it's interesting.
+
+Four quiet days followed by this. I don't know if Thorben was on holiday or just thinking, but either way the queue clearly built up and Tuesday paid for it. Whatever's in the kettle, keep drinking it.
+
+— *Pip 🍊*


### PR DESCRIPTION
## Summary
- New Satsuma Diaries entry for Tuesday 7 April 2026 covering 25 commits and 11 merged PRs after four silent days
- Highlights: command-runner refactor (#211), five new agent skills (#208), metrics-platform validates clean (#210), Feature 29 cleanups (#209), three new bug tickets (#207)
- Updates `.progress.json` to mark Apr 3–6 as rolled-up quiet days

## Test plan
- [x] Entry file created at `satsuma-diaries/2026/04/2026-04-07.md`
- [x] `.progress.json` advanced to 2026-04-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)