### PR TITLE
fix(site): correct release asset download URLs

### DIFF
--- a/site/cli.njk
+++ b/site/cli.njk
@@ -602,7 +602,7 @@ permalink: cli.html
           </div>
           <pre>
 <span class="output"># Universal — works on macOS, Linux, and Windows (WASM-based)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli.tgz
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-{{ site.version_tag }}.tgz
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
@@ -619,7 +619,7 @@ permalink: cli.html
             </div>
             <pre>
 <span class="output"># Universal — works on macOS, Linux, and Windows (WASM-based)</span>
-<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli.tgz</pre>
+<span class="prompt">$</span> npm install <span class="flag">-g</span> https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-latest.tgz</pre>
           </div>
         </details>
         <div class="mt-6 flex items-start gap-3 p-4 bg-peach rounded-xl">

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -49,9 +49,9 @@ permalink: learn.html
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the CLI</h3>
           <div class="code-block text-sm mb-4">
             <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># Universal — works on macOS, Linux, and Windows</span>
-npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli.tgz</code></pre>
+npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ site.version_tag }}/satsuma-cli-{{ site.version_tag }}.tgz</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. One universal package works on every platform (WASM-based, no native compilation). Available from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">{{ site.version }} release</a>. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Requires Node.js 18+. One universal package works on every platform (WASM-based, no native compilation). Available from the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">{{ site.version }} release</a>. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/satsuma-cli-latest.tgz" class="text-warm-gray hover:underline">latest unstable build</a>.</p>
         </div>
 
         <!-- Step 2 -->
@@ -60,9 +60,9 @@ npm install -g https://github.com/thorbenlouw/satsuma-lang/releases/download/{{ 
           <h3 class="text-lg font-bold text-charcoal mb-3 mt-2">Install the VS Code extension</h3>
           <div class="code-block text-sm mb-4">
             <pre><code class="font-mono text-charcoal"><span class="text-warm-gray"># Download from the latest release, then:</span>
-code --install-extension vscode-satsuma.vsix</code></pre>
+code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the {{ site.version }} release. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable build</a>. Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more.</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-3">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">vscode-satsuma-{{ site.version_tag }}.vsix</a> from the {{ site.version }} release. Also available: <a href="https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/vscode-satsuma-latest.vsix" class="text-warm-gray hover:underline">latest unstable build</a>. Get syntax highlighting, real-time diagnostics, go-to-definition, IntelliSense, lineage visualisation, and more.</p>
           <a href="vscode.html" class="text-green text-sm font-semibold hover:underline">See all extension features &rarr;</a>
         </div>
 

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -31,9 +31,9 @@ permalink: vscode.html
             Download .vsix ({{ site.version }})
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"/></svg>
           </a>
-          <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" rel="noopener"
+          <a href="https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/vscode-satsuma-latest.vsix" rel="noopener"
              class="inline-flex items-center gap-2 px-6 py-3 bg-warm-gray/10 text-warm-gray font-medium rounded-xl border border-charcoal/10 hover:border-charcoal/20 transition-all text-sm">
-            Latest unstable
+            Latest unstable .vsix
           </a>
           <a href="https://github.com/thorbenlouw/satsuma-lang/tree/main/tooling/vscode-satsuma" target="_blank" rel="noopener"
              class="inline-flex items-center gap-2 px-6 py-3 bg-cream text-charcoal font-semibold rounded-xl border border-charcoal/10 hover:border-charcoal/20 transition-all">
@@ -419,14 +419,14 @@ permalink: vscode.html
             <h3 class="text-lg font-bold text-charcoal">From GitHub Release</h3>
             <span class="px-2 py-0.5 bg-green/10 text-green-dark text-xs font-semibold rounded-full">Recommended</span>
           </div>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">vscode-satsuma.vsix</a> from the {{ site.version }} release (or <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/latest" target="_blank" class="text-warm-gray hover:underline">latest unstable</a>), then install:</p>
+          <p class="text-warm-gray text-sm leading-relaxed mb-4">Download <a href="https://github.com/thorbenlouw/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" class="text-orange hover:underline">vscode-satsuma-{{ site.version_tag }}.vsix</a> from the {{ site.version }} release (or the <a href="https://github.com/thorbenlouw/satsuma-lang/releases/download/latest/vscode-satsuma-latest.vsix" class="text-warm-gray hover:underline">latest unstable build</a>), then install:</p>
           <div class="terminal">
             <div class="terminal-header">
               <span class="terminal-dot red"></span>
               <span class="terminal-dot yellow"></span>
               <span class="terminal-dot green"></span>
             </div>
-            <pre><span class="prompt">$</span> code <span class="flag">--install-extension</span> vscode-satsuma.vsix</pre>
+            <pre><span class="prompt">$</span> code <span class="flag">--install-extension</span> vscode-satsuma-{{ site.version_tag }}.vsix</pre>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Site templates linked to unversioned asset names (`satsuma-cli.tgz`, `vscode-satsuma.vsix`) that don't exist in GitHub releases — actual assets are versioned (e.g. `satsuma-cli-v0.7.0.tgz`, `vscode-satsuma-v0.7.0.vsix`).
- Updated versioned references in `learn.njk`, `cli.njk`, and `vscode.njk` to use `{{ site.version_tag }}` in the filename.
- Pointed "latest unstable" links at the stable direct-download URLs (`satsuma-cli-latest.tgz`, `vscode-satsuma-latest.vsix`) instead of the release tag page.

## Test plan
- [ ] Build the site locally and click each updated link to confirm it resolves to a real asset.
- [ ] Spot-check the rendered hero button on `vscode.html` and the install snippets on `learn.html` and `cli.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)