### PR TITLE
fix(nl-ref): anchor @ref regex and share multiline position helper

### DIFF
--- a/.tickets/sl-2ji3.md
+++ b/.tickets/sl-2ji3.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2ji3
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-04-02T15:15:33Z
@@ -30,3 +30,12 @@ nl-ref.ts:664-669 already has a multiline-aware calculation that correctly handl
 - Multiline NL ref tests cover @refs on lines 2+ of triple-quoted strings
 - Existing single-line NL ref diagnostics remain correct
 
+
+## Notes
+
+**2026-04-07T15:21:50Z**
+
+**2026-04-07T15:21:50Z**
+
+Cause: validate.ts and lint-engine.ts computed diagnostic positions for NL @refs as 'item.line + 1, item.column + offset + 1', which ignored newlines inside multiline ("""...""") strings. resolveAllNLRefs already had a multiline-aware calculation but it was duplicated inline.
+Fix: Extracted the calculation into a shared satsuma-core helper computeNLRefPosition(item, offset) returning 1-based {line, column}. validate.ts (both push sites), lint-engine.ts (checkHiddenSourceInNl + checkUnresolvedNlRef), and resolveAllNLRefs all call it now, so positions stay consistent everywhere. New unit tests cover the same-line case, the continuation-line case, and the column-reset behaviour that originally regressed.

--- a/.tickets/sl-gl21.md
+++ b/.tickets/sl-gl21.md
@@ -1,6 +1,6 @@
 ---
 id: sl-gl21
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-04-02T15:15:27Z
@@ -26,3 +26,12 @@ Needs a design decision: should the fix be a regex-level lookbehind (e.g. requir
 - @refs at start of string, after whitespace, or after punctuation like ( are still extracted
 - Existing NL ref tests continue to pass
 
+
+## Notes
+
+**2026-04-07T15:21:41Z**
+
+**2026-04-07T15:21:41Z**
+
+Cause: AT_REF_RE had no lookbehind, so any '@' followed by an identifier matched — including email addresses (user@example.com) and SQL LIKE wildcards (%@test.internal), producing spurious unresolved-nl-ref warnings.
+Fix: Added a lookbehind that only allows '@' at start-of-string, after whitespace, or after a small set of opening/separator punctuation '([{,;'. The pattern is now exported from satsuma-core as AT_REF_PATTERN with a createAtRefRegex() factory; LSP (definition.ts, semantic-tokens.ts), satsuma-viz (markdown.ts), and satsuma-viz-backend (workspace-index.ts) all import it instead of duplicating the regex. New unit tests in core/test/nl-ref.test.js cover email/wildcard/digit/underscore prefixes plus the start-of-string and opening-punctuation acceptance cases. Validating examples/multi-source/multi-source-join.stm now reports zero warnings.

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -10,6 +10,7 @@
 import { capitalize, stripNLRefScopePrefix } from "@satsuma/core";
 import {
   extractAtRefs,
+  computeNLRefPosition,
   classifyRef,
   resolveRef,
   isSchemaInMappingSources,
@@ -86,6 +87,7 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
       }
 
       if (referencedSchema && !isSchemaInMappingSources(referencedSchema, mapping)) {
+        const { line, column } = computeNLRefPosition(item, offset);
         const displayRef = item.namespace && referencedSchema.startsWith(`${item.namespace}::`)
           ? referencedSchema.slice(item.namespace.length + 2)
           : referencedSchema;
@@ -101,8 +103,8 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
           : `Added '${displayRef}' to source list of mapping '${mappingKey}'`;
         diagnostics.push({
           file: item.file,
-          line: item.line + 1,
-          column: item.column + offset + 1,
+          line,
+          column,
           severity: "error",
           rule: "hidden-source-in-nl",
           message: `NL reference \`${ref}\` in mapping '${mappingKey}' is not declared in its source or target list`,
@@ -416,10 +418,11 @@ function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
 
       const resolution = resolveRef(ref, mappingContext, index);
       if (!resolution.resolved) {
+        const { line, column } = computeNLRefPosition(item, offset);
         diagnostics.push({
           file: item.file,
-          line: item.line + 1,
-          column: item.column + offset + 1,
+          line,
+          column,
           severity: "warning",
           rule: "unresolved-nl-ref",
           message: `NL reference \`${ref}\` in ${scopeLabel} '${displayName}' does not resolve to any known identifier`,

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -17,6 +17,7 @@
 
 import {
   extractAtRefs,
+  computeNLRefPosition,
   classifyRef,
   resolveRef as _resolveRef,
   extractNLRefData,
@@ -35,7 +36,7 @@ import { expandEntityFields } from "./spread-expand.js";
 import { canonicalKey, qualifyField } from "./index-builder.js";
 
 // Re-export pure functions and types directly.
-export { extractAtRefs, classifyRef, extractNLRefData };
+export { extractAtRefs, computeNLRefPosition, classifyRef, extractNLRefData };
 export type { AtRef, RefClassification, Resolution, ResolvedNLRef };
 
 // ── ExtractedWorkspace → DefinitionLookup bridge ──────────────────────────────────

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -49,7 +49,10 @@ export {
   makeEntityRefResolver,
 } from "./spread-expand.js";
 export {
+  AT_REF_PATTERN,
+  createAtRefRegex,
   extractAtRefs,
+  computeNLRefPosition,
   classifyRef,
   resolveRef,
   extractNLRefData,

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -106,8 +106,68 @@ function canonicalKey(key: string): string {
 
 // ── Extraction ────────────────────────────────────────────────────────────────
 
-// @ref pattern: @identifier, @schema.field, @ns::schema.field, @`backtick`.field
-const AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+// @ref pattern: @identifier, @schema.field, @ns::schema.field, @`backtick`.field.
+//
+// The lookbehind requires the @ to be at start-of-string, after whitespace, or
+// after a small set of opening/separator punctuation. Without it, email-like
+// patterns (`user@example.com`) and SQL LIKE wildcards (`%@test.internal`)
+// produced spurious matches and false-positive unresolved-nl-ref warnings
+// (sl-gl21). The allowed prefix set intentionally excludes `%`, letters,
+// digits, `_` and `.` so that `%@foo` and `user@bar` are not extracted, while
+// `(@foo`, `[@foo`, `, @foo` and start-of-string `@foo` still are.
+//
+// AT_REF_PATTERN is the canonical source. Consumers that need a fresh regex
+// instance (because /g state is mutable) should call createAtRefRegex(); this
+// is the single source of truth shared by core, the LSP, the viz backend and
+// the viz UI to avoid drift between copies.
+export const AT_REF_PATTERN = "(?<=^|[\\s(\\[{,;])@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*";
+
+/**
+ * Build a fresh global @ref regex. Always returns a new instance so callers
+ * never share `lastIndex` state with each other.
+ */
+export function createAtRefRegex(): RegExp {
+  return new RegExp(AT_REF_PATTERN, "g");
+}
+
+const AT_REF_RE = createAtRefRegex();
+
+/**
+ * Compute the 1-based (line, column) of an @ref inside an NL string, given
+ * the string's start position and the byte offset of the @ within the string.
+ *
+ * Multiline NL strings (`"""..."""`) may contain @refs on any line of the body.
+ * A naive `column = startColumn + offset` calculation only works on the first
+ * line — once a newline is crossed, the column resets relative to the start of
+ * that line. This helper handles both cases and is the single source of truth
+ * for diagnostic positions of NL refs (sl-2ji3).
+ *
+ * @param item   The NL ref source item; only `text`, `line`, `column` are read.
+ *               `item.line` and `item.column` are 0-based (CST positions).
+ * @param offset Byte offset of the `@` character within `item.text`.
+ * @returns      1-based `{line, column}` suitable for diagnostic reporting.
+ */
+export function computeNLRefPosition(
+  item: { text: string; line: number; column: number },
+  offset: number,
+): { line: number; column: number } {
+  const textBefore = item.text.slice(0, offset);
+  const newlines = (textBefore.match(/\n/g) ?? []).length;
+  const line = item.line + newlines + 1;
+  let column: number;
+  if (newlines > 0) {
+    // After a newline the column resets — count from the last `\n` in the
+    // prefix to the @ character. The `\n` itself sits at index `lastNl`, so
+    // the next character is column 1, giving `offset - lastNl`.
+    const lastNl = textBefore.lastIndexOf("\n");
+    column = offset - lastNl;
+  } else {
+    // No newline crossed — the @ is on the same line as the string opener,
+    // so add the offset to the string's start column (+1 to make 1-based).
+    column = item.column + offset + 1;
+  }
+  return { line, column };
+}
 
 /**
  * Extract @ref mentions from a single NL string.
@@ -657,16 +717,11 @@ export function resolveAllNLRefs(
       const classification = classifyRef(ref);
       const resolution = resolveRef(ref, mappingContext, lookup);
 
-      const textBefore = item.text.slice(0, offset);
-      const newlines = (textBefore.match(/\n/g) ?? []).length;
-      const line = item.line + newlines;
-      let column: number;
-      if (newlines > 0) {
-        const lastNl = textBefore.lastIndexOf("\n");
-        column = offset - lastNl;
-      } else {
-        column = item.column + 1 + offset;
-      }
+      // Use the shared helper, then convert back to the 0-based line that
+      // ResolvedNLRef has historically returned (consumers add +1 themselves).
+      const pos = computeNLRefPosition(item, offset);
+      const line = pos.line - 1;
+      const column = pos.column;
 
       results.push({
         ref,

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -24,7 +24,7 @@
  */
 
 import { capitalize } from "./string-utils.js";
-import { extractAtRefs, classifyRef, resolveRef, isSchemaInMappingSources, stripNLRefScopePrefix } from "./nl-ref.js";
+import { extractAtRefs, classifyRef, resolveRef, isSchemaInMappingSources, stripNLRefScopePrefix, computeNLRefPosition } from "./nl-ref.js";
 import type { DefinitionLookup } from "./nl-ref.js";
 import { expandSpreads, collectFieldPaths } from "./spread-expand.js";
 import type { SpreadEntity } from "./spread-expand.js";
@@ -339,13 +339,14 @@ function checkNLRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): v
     for (const { ref, offset } of refs) {
       const classification = classifyRef(ref);
       const resolution = resolveRef(ref, mappingContext, lookup);
+      const { line, column } = computeNLRefPosition(item, offset);
 
       if (!resolution.resolved) {
         // Rule name "unresolved-nl-ref" matches lint-engine.ts for consistency (sl-tslm).
         diagnostics.push({
           file: item.file,
-          line: item.line + 1,
-          column: item.column + offset + 1,
+          line,
+          column,
           severity: "warning",
           rule: "unresolved-nl-ref",
           message: `NL reference \`${ref}\` in ${displayScope} does not resolve to any known identifier`,
@@ -357,8 +358,8 @@ function checkNLRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): v
         if (referencedSchema && !isSchemaInMappingSources(referencedSchema, mapping)) {
           diagnostics.push({
             file: item.file,
-            line: item.line + 1,
-            column: item.column + offset + 1,
+            line,
+            column,
             severity: "warning",
             rule: "nl-ref-not-in-source",
             message: `NL reference \`${ref}\` in mapping '${mappingKey}' is not declared in its source or target list`,

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -5,7 +5,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  AT_REF_PATTERN,
+  createAtRefRegex,
   extractAtRefs,
+  computeNLRefPosition,
   classifyRef,
   resolveRef,
   resolveAllNLRefs,
@@ -34,6 +37,121 @@ describe("extractAtRefs()", () => {
   it("returns empty for text with no refs", () => {
     const refs = extractAtRefs("plain text with no references");
     assert.deepEqual(refs, []);
+  });
+
+  // sl-gl21: the @ref regex previously matched any @ followed by an identifier,
+  // producing false positives inside email addresses and SQL LIKE wildcards.
+  // The lookbehind anchors @ to start-of-string, whitespace, or specific
+  // opening/separator punctuation. These cases lock that contract in place.
+
+  it("does not extract @refs from email-like patterns (sl-gl21)", () => {
+    // user@example.com — the `r` before @ is a word char, so the lookbehind fails.
+    const refs = extractAtRefs("contact user@example.com for details");
+    assert.deepEqual(refs, []);
+  });
+
+  it("does not extract @refs from SQL LIKE wildcards like %@foo (sl-gl21)", () => {
+    // The example that triggered the original report:
+    // `email LIKE %@test.internal` inside a note. `%` must not be allowed
+    // before @ — only whitespace and a small set of opening punctuation.
+    const refs = extractAtRefs("filter where email LIKE %@test.internal");
+    assert.deepEqual(refs, []);
+  });
+
+  it("does not extract @refs after a digit or underscore", () => {
+    // Guards against accidentally widening the allowed prefix set: digits,
+    // letters and underscore are all word chars and must remain disallowed.
+    assert.deepEqual(extractAtRefs("v2@version"), []);
+    assert.deepEqual(extractAtRefs("name_@suffix"), []);
+  });
+
+  it("extracts @ref at start of string", () => {
+    // Start-of-string is one of the explicitly allowed positions.
+    const refs = extractAtRefs("@customer_id is the key");
+    assert.deepEqual(refs.map(r => r.ref), ["customer_id"]);
+  });
+
+  it("extracts @refs after opening punctuation like ( [ { , ;", () => {
+    // Acceptance criterion from sl-gl21: opening punctuation must still
+    // qualify as a valid prefix so refs in parenthesised text resolve.
+    assert.deepEqual(extractAtRefs("coalesce(@a, @b)").map(r => r.ref), ["a", "b"]);
+    assert.deepEqual(extractAtRefs("[@a; @b]").map(r => r.ref), ["a", "b"]);
+    assert.deepEqual(extractAtRefs("{@a}").map(r => r.ref), ["a"]);
+  });
+
+  it("extracts @refs across multiple lines (after newline counts as whitespace)", () => {
+    // \n is part of \s, so refs at the start of a continuation line in a
+    // triple-quoted NL string must still be extracted. This pairs with the
+    // multiline-position helper exercised below.
+    const refs = extractAtRefs("first line\n@second_line ref");
+    assert.deepEqual(refs.map(r => r.ref), ["second_line"]);
+  });
+});
+
+// ── createAtRefRegex / AT_REF_PATTERN ─────────────────────────────────────────
+
+describe("createAtRefRegex()", () => {
+  it("returns a fresh regex instance each call", () => {
+    // Two consumers must not share /g state — sharing the same RegExp object
+    // across modules historically caused intermittent missed matches when one
+    // consumer left lastIndex non-zero.
+    const a = createAtRefRegex();
+    const b = createAtRefRegex();
+    assert.notEqual(a, b);
+    a.exec("@x");
+    assert.equal(b.lastIndex, 0);
+  });
+
+  it("AT_REF_PATTERN compiles to the same shape as the regex", () => {
+    // The exported pattern string is what non-core consumers (LSP, viz)
+    // would inline if they need a custom-flagged regex. It must compile and
+    // produce equivalent matches to createAtRefRegex().
+    const re = new RegExp(AT_REF_PATTERN, "g");
+    assert.equal(re.exec("@foo")?.[0], "@foo");
+  });
+});
+
+// ── computeNLRefPosition ──────────────────────────────────────────────────────
+
+describe("computeNLRefPosition()", () => {
+  // sl-2ji3: the validator previously reported diagnostic positions for @refs
+  // inside multiline NL strings using a naive `item.line + 1, item.column +
+  // offset + 1` formula. That ignored newlines, so an @ref on line 3 of a
+  // triple-quoted body got reported at the line of the opening `"""`.
+
+  it("reports a 1-based single-line position for refs on the opener line", () => {
+    // The NL string starts at row=10, col=4. An @ref at offset 5 within the
+    // text sits on the same line, so column is the start column + offset + 1.
+    const item = { text: "see @foo here", line: 10, column: 4 };
+    const pos = computeNLRefPosition(item, item.text.indexOf("@"));
+    assert.deepEqual(pos, { line: 11, column: 9 });
+  });
+
+  it("reports the correct line for an @ref on a continuation line of a multiline string", () => {
+    // Multiline body of a """...""" string starting at file row 5. The @ref
+    // is on the third logical line of the body, so line should be 5+2+1 = 8.
+    const item = {
+      text: "first line\nsecond line\n@third_ref here",
+      line: 5,
+      column: 0,
+    };
+    const offset = item.text.indexOf("@");
+    const pos = computeNLRefPosition(item, offset);
+    assert.equal(pos.line, 8);
+    // Column 1 because the @ is the first character on its line.
+    assert.equal(pos.column, 1);
+  });
+
+  it("uses the per-line column rather than the byte offset on continuation lines", () => {
+    // The bug from sl-2ji3 was that column was reported as `startColumn +
+    // offset` even after newlines, producing huge bogus columns. Here the @
+    // sits 4 chars into its own line, so column must be 5 (1-based), not the
+    // byte offset relative to the string start.
+    const item = { text: "first\n    @ref end", line: 2, column: 8 };
+    const offset = item.text.indexOf("@");
+    const pos = computeNLRefPosition(item, offset);
+    assert.equal(pos.line, 4);  // 2 + 1 newline + 1 (1-based)
+    assert.equal(pos.column, 5);
   });
 });
 

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -1,4 +1,5 @@
 import { Location } from "vscode-languageserver";
+import { createAtRefRegex } from "@satsuma/core";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText } from "./parser-utils";
 import {
@@ -484,7 +485,7 @@ function getMappingSchemaRefs(
 
 // ---------- NL reference detection ----------
 
-const AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+const AT_REF_RE = createAtRefRegex();
 
 /**
  * Check if the cursor is on an @ref reference inside an NL string.

--- a/tooling/satsuma-lsp/src/semantic-tokens.ts
+++ b/tooling/satsuma-lsp/src/semantic-tokens.ts
@@ -5,6 +5,7 @@ import {
   SemanticTokensLegend,
 } from "vscode-languageserver";
 import type { Tree, Query } from "web-tree-sitter";
+import { createAtRefRegex } from "@satsuma/core";
 import { getLanguage, createQuery } from "./parser-utils";
 import type { SyntaxNode } from "./parser-utils";
 
@@ -194,7 +195,7 @@ export function computeSemanticTokens(tree: Tree): { data: number[] } {
 
 // ---------- NL reference extraction ----------
 
-const AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+const AT_REF_RE = createAtRefRegex();
 
 /** Unique identity for a CST node (by position). */
 function nodeId(node: SyntaxNode): string {

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -23,6 +23,7 @@ import {
   entryText,
   extractFieldTree,
   isMetricSchema,
+  createAtRefRegex,
 } from "@satsuma/core";
 import type { FieldDecl } from "@satsuma/core";
 
@@ -681,7 +682,7 @@ function extractArrowFieldName(pathNode: SyntaxNode): string | null {
   return firstSegment || null;
 }
 
-const NL_AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+const NL_AT_REF_RE = createAtRefRegex();
 
 function indexNlRefs(
   index: WorkspaceIndex,

--- a/tooling/satsuma-viz/src/markdown.ts
+++ b/tooling/satsuma-viz/src/markdown.ts
@@ -1,8 +1,11 @@
+import { createAtRefRegex } from "@satsuma/core/nl-ref";
+
 /**
- * @ref pattern matching — mirrors AT_REF_RE from @satsuma/core/nl-ref.
- * Matches @identifier, @schema.field, @ns::schema.field, and @`backtick` variants.
+ * @ref pattern matching — single source of truth lives in @satsuma/core/nl-ref.
+ * A fresh regex instance is created so that mutating /g state in this module
+ * cannot collide with other consumers of the shared pattern.
  */
-const AT_REF_RE = /@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*/g;
+const AT_REF_RE = createAtRefRegex();
 
 /** HTML-escape special characters to prevent injection. */
 function escapeHtml(s: string): string {


### PR DESCRIPTION
## Summary
- Consolidates the @ref regex into `AT_REF_PATTERN` / `createAtRefRegex()` in `@satsuma/core` so LSP, viz, and viz-backend stop carrying drift-prone copies.
- Adds a lookbehind to suppress @ref matches inside email addresses and SQL LIKE wildcards (sl-gl21).
- Extracts a shared `computeNLRefPosition` helper used by `validate`, `lint-engine`, and `resolveAllNLRefs` so diagnostic positions for @refs inside multiline NL strings report the correct line/column (sl-2ji3).

## Test plan
- [x] New unit tests in `satsuma-core/test/nl-ref.test.js` cover email/wildcard/digit/underscore prefixes, start-of-string, opening punctuation, multiline column reset
- [x] `npm test` green in core (309), cli (887), lsp (217), viz (41), viz-backend (118)
- [x] `validate examples/multi-source/multi-source-join.stm` reports zero warnings