### PR TITLE
Unify validation pipeline

### DIFF
--- a/.tickets/sl-bxzg.md
+++ b/.tickets/sl-bxzg.md
@@ -1,6 +1,6 @@
 ---
 id: sl-bxzg
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-04-07T09:42:54Z
@@ -17,3 +17,9 @@ Validation logic is split across core semantic diagnostics, CLI validate, and LS
 
 Single unified validation interface; CLI integration tests unchanged.
 
+## Notes
+
+**2026-04-07T15:36:50Z**
+
+Cause: Validation orchestration still lived in consumer adapters: the CLI computed import reachability before calling core, while the LSP combined a partial core semantic adapter with its own missing-import pass.
+Fix: Added `validateSemanticWorkspace` in `@satsuma/core` as the shared reachability-aware semantic validation entry point, updated CLI and LSP adapters to use it, and pinned the contract with core/LSP/CLI checks. (commit 94eefc5)

--- a/.tickets/sl-bxzg.md
+++ b/.tickets/sl-bxzg.md
@@ -1,6 +1,6 @@
 ---
 id: sl-bxzg
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-04-07T09:42:54Z

--- a/adrs/adr-025-core-semantic-validation-interface.md
+++ b/adrs/adr-025-core-semantic-validation-interface.md
@@ -1,0 +1,35 @@
+# ADR-025 — Core Semantic Validation Interface
+
+**Status:** Accepted
+**Date:** 2026-04-07 (sl-bxzg)
+
+## Context
+
+ADR-020 established that `satsuma-core` should own shared extraction and validation logic, with consumers limited to wiring and output adaptation. ADR-022 established selective transitive import reachability as the workspace scope rule. Before `sl-bxzg`, semantic validation followed those decisions only partially.
+
+The core validator owned the semantic rules in `tooling/satsuma-core/src/validate.ts` through `collectSemanticDiagnostics(index, reachability?)`. The CLI adapter in `tooling/satsuma-cli/src/semantic-warnings.ts` still computed import reachability before calling core, so part of the validation pipeline lived outside the validator. The LSP adapter in `tooling/satsuma-lsp/src/semantic-diagnostics.ts` was split further: it ran a partial core semantic pass against an adapted workspace index, then ran a separate LSP-specific missing-import pass using its own reachability traversal and diagnostic construction.
+
+That split made it easy for validation behavior to diverge. A future change to import-scope checking could be fixed in the CLI path while the LSP missing-import path stayed stale, or vice versa. It also made the architectural boundary harder to explain: core owned the individual rules, but consumers still owned part of the rule orchestration.
+
+Two alternatives were considered. The first was to keep `collectSemanticDiagnostics(index, reachability?)` as the only core API and make each consumer compute reachability consistently. That would preserve the existing signature but keep orchestration duplicated. The second was to move the LSP missing-import diagnostic wording directly into core. That would remove more LSP code, but it would couple core to editor-specific presentation and quick-fix language. Neither was the right boundary.
+
+## Decision
+
+`satsuma-core` owns the shared semantic validation entry point. Consumers should call `validateSemanticWorkspace(index, options)` from `tooling/satsuma-core/src/validate.ts` when they need semantic diagnostics for a workspace. That function computes import reachability from resolved imports when provided, preserves the existing validation rule order, and returns core `SemanticDiagnostic` records.
+
+Consumers still own their index adapters and diagnostic presentation. CLI validation passes its `ExtractedWorkspace` plus `fileImports` into `validateSemanticWorkspace()` and maps the resulting `SemanticDiagnostic[]` to `LintDiagnostic[]`. The LSP builds a core `SemanticIndex` from its editor-oriented `WorkspaceIndex`, passes resolved file imports into `validateSemanticWorkspace()`, and uses an `importScopeDiagnostic` policy to keep its public `missing-import` code and import-suggestion message without reimplementing reachability.
+
+`collectSemanticDiagnostics(index, reachability?)` remains as a compatibility wrapper for existing core-level callers, but new consumer integrations should prefer `validateSemanticWorkspace()` so reachability integration stays in core.
+
+## Consequences
+
+**Positive:**
+- CLI and LSP semantic diagnostics now share one reachability-aware validation pipeline.
+- Core owns validation orchestration as well as individual semantic rules, matching ADR-020's "consumers as thin wiring" direction.
+- LSP can preserve editor-specific diagnostic codes and messages without duplicating the import-scope rule engine.
+- Future validation consumers have a single documented entry point instead of reconstructing reachability and rule ordering themselves.
+
+**Negative:**
+- Core's validation API surface is larger and now includes a presentation hook for import-scope diagnostics.
+- LSP still needs an adapter from its editor-shaped `WorkspaceIndex` to core's `SemanticIndex` until the LSP index carries the same full semantic data as the CLI.
+- Live LSP validation still lacks checks that require full arrow and NL extraction from the CLI workspace model; the on-save CLI subprocess remains the fallback for those cases.

--- a/tooling/satsuma-cli/src/semantic-warnings.ts
+++ b/tooling/satsuma-cli/src/semantic-warnings.ts
@@ -10,7 +10,7 @@
  * separately in commands/validate.ts using collectParseErrors from core.
  */
 
-import { collectSemanticDiagnostics, computeImportReachability } from "@satsuma/core";
+import { validateSemanticWorkspace } from "@satsuma/core";
 import type { SemanticDiagnostic } from "@satsuma/core";
 import type { LintDiagnostic, ExtractedWorkspace } from "./types.js";
 
@@ -23,12 +23,7 @@ import type { LintDiagnostic, ExtractedWorkspace } from "./types.js";
  * import-scope violations are detected (ADR-022).
  */
 export function collectSemanticWarnings(index: ExtractedWorkspace): LintDiagnostic[] {
-  // Compute import-scope reachability when import data is available.
-  // Single-file workspaces or mock indices without fileImports skip the check.
-  const reachability = index.fileImports?.size
-    ? computeImportReachability(index, index.fileImports)
-    : undefined;
-  const semanticDiags = collectSemanticDiagnostics(index, reachability);
+  const semanticDiags = validateSemanticWorkspace(index, { fileImports: index.fileImports });
   return semanticDiags.map(toCLIDiagnostic);
 }
 

--- a/tooling/satsuma-cli/test/load-workspace.test.ts
+++ b/tooling/satsuma-cli/test/load-workspace.test.ts
@@ -33,11 +33,12 @@ import { CommandError, EXIT_PARSE_ERROR } from "#src/command-runner.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLES = resolve(__dirname, "../../../examples");
+const WASM_PATH = resolve(__dirname, "../dist/tree-sitter-satsuma.wasm");
 
 before(async () => {
   // The WASM parser must be initialised once before any parseFile call;
   // otherwise loadWorkspace explodes inside loadFiles.
-  await initParser();
+  await initParser(WASM_PATH);
 });
 
 // ── happy path ───────────────────────────────────────────────────────────────

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -1,5 +1,5 @@
 export { capitalize, normalizeName } from "./string-utils.js";
-export { collectSemanticDiagnostics } from "./validate.js";
+export { collectSemanticDiagnostics, validateSemanticWorkspace } from "./validate.js";
 export { computeImportReachability, computeSymbolDependencies } from "./import-reachability.js";
 export type { ResolvedFileImport, ImportReachability } from "./import-reachability.js";
 export type {
@@ -12,6 +12,9 @@ export type {
   SemanticArrow,
   SemanticNLRef,
   SemanticDuplicate,
+  SemanticValidationOptions,
+  ImportScopeDiagnosticPolicy,
+  ImportScopeViolation,
 } from "./validate.js";
 export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -30,7 +30,8 @@ import { expandSpreads, collectFieldPaths } from "./spread-expand.js";
 import type { SpreadEntity } from "./spread-expand.js";
 import { resolveScopedEntityRef } from "./canonical-ref.js";
 import type { FieldDecl, MetaEntry, PipeStep } from "./types.js";
-import type { ImportReachability } from "./import-reachability.js";
+import { computeImportReachability } from "./import-reachability.js";
+import type { ImportReachability, ResolvedFileImport } from "./import-reachability.js";
 
 // ---------- Output type ----------
 
@@ -129,6 +130,62 @@ export interface SemanticDuplicate {
 }
 
 /**
+ * Policy for a single import-scope violation.
+ *
+ * Most consumers should keep the default. Adapters that need a different
+ * public diagnostic contract (for example, LSP quick-fix wording) can override
+ * the rule/message without reimplementing the import reachability check.
+ */
+export interface ImportScopeDiagnosticPolicy {
+  /** Machine-readable rule code for the emitted diagnostic. */
+  rule?: string;
+  /**
+   * Builds the human-readable message. The input carries the resolved symbol
+   * and definition file so callers can produce actionable import suggestions.
+   */
+  message?: (violation: ImportScopeViolation) => string;
+}
+
+/**
+ * Details for a reference that resolved to a workspace symbol but is not
+ * reachable from the referencing file's import declarations.
+ */
+export interface ImportScopeViolation {
+  /** File containing the out-of-scope reference. */
+  file: string;
+  /** 0-indexed row of the entity or arrow that owns the reference. */
+  row: number;
+  /** Kind of entity containing the reference, e.g. "mapping" or "schema". */
+  entityKind: string;
+  /** Name of the entity containing the reference. */
+  entityName: string;
+  /** Kind of referenced symbol, e.g. "source" or "fragment". */
+  refKind: string;
+  /** Reference text as authored. */
+  ref: string;
+  /** Resolved symbol key in the workspace index. */
+  resolved: string;
+  /** File containing the referenced symbol definition, when the index exposes it. */
+  definitionFile: string | null;
+}
+
+/**
+ * Shared entry-point options for semantic validation.
+ *
+ * Callers can pass already-computed reachability, or pass resolved file imports
+ * and let core compute the reachability graph. Passing neither keeps the
+ * legacy single-workspace behaviour and skips import-scope diagnostics.
+ */
+export interface SemanticValidationOptions {
+  /** Resolved imports by file, used to compute import reachability. */
+  fileImports?: Map<string, ResolvedFileImport[]>;
+  /** Precomputed import reachability, useful when a caller already has it. */
+  reachability?: ImportReachability;
+  /** Optional presentation policy for import-scope diagnostics. */
+  importScopeDiagnostic?: ImportScopeDiagnosticPolicy;
+}
+
+/**
  * Minimal workspace index required by the semantic validator.
  * The CLI WorkspaceIndex satisfies this interface structurally.
  * nlRefData and duplicates are optional — absent means "none found".
@@ -163,6 +220,32 @@ export function collectSemanticDiagnostics(
   index: SemanticIndex,
   reachability?: ImportReachability,
 ): SemanticDiagnostic[] {
+  return collectSemanticDiagnosticsWithOptions(index, { reachability });
+}
+
+/**
+ * Validate a semantic workspace using the shared core pipeline.
+ *
+ * This is the preferred consumer entry point: CLI and LSP adapters provide the
+ * same SemanticIndex shape and, when available, the same resolved import map.
+ * Core then owns the rule order and reachability integration in one place.
+ */
+export function validateSemanticWorkspace(
+  index: SemanticIndex,
+  options: SemanticValidationOptions = {},
+): SemanticDiagnostic[] {
+  const reachability = options.reachability
+    ?? (options.fileImports ? computeImportReachability(index, options.fileImports) : undefined);
+  return collectSemanticDiagnosticsWithOptions(index, {
+    ...options,
+    reachability,
+  });
+}
+
+function collectSemanticDiagnosticsWithOptions(
+  index: SemanticIndex,
+  options: SemanticValidationOptions,
+): SemanticDiagnostic[] {
   const diagnostics: SemanticDiagnostic[] = [];
 
   checkDuplicates(index, diagnostics);
@@ -173,7 +256,9 @@ export function collectSemanticDiagnostics(
   checkArrowFieldRefs(index, diagnostics);
   checkTransformSpreads(index, diagnostics);
   checkRefMetadata(index, diagnostics);
-  if (reachability) checkImportScope(index, reachability, diagnostics);
+  if (options.reachability) {
+    checkImportScope(index, options.reachability, diagnostics, options.importScopeDiagnostic);
+  }
 
   return diagnostics;
 }
@@ -631,6 +716,7 @@ function checkImportScope(
   index: SemanticIndex,
   reachability: ImportReachability,
   diagnostics: SemanticDiagnostic[],
+  policy: ImportScopeDiagnosticPolicy = {},
 ): void {
   const allDefinitions = new Map<string, unknown>([
     ...index.schemas as Map<string, unknown>,
@@ -655,14 +741,25 @@ function checkImportScope(
     const reachable = reachability.reachableSymbols.get(file);
     if (!reachable) return; // No reachability data for this file
     if (reachable.has(resolved)) return; // In scope — all good
+    const violation: ImportScopeViolation = {
+      file,
+      row,
+      entityKind,
+      entityName,
+      refKind,
+      ref,
+      resolved,
+      definitionFile: definitionFileFor(lookupMap.get(resolved)),
+    };
 
     diagnostics.push({
       file,
       line: row + 1,
       column: 1,
       severity: "error",
-      rule: "import-scope",
-      message: `${capitalize(entityKind)} '${entityName}' references ${refKind} '${resolved}' which is not reachable from this file's imports`,
+      rule: policy.rule ?? "import-scope",
+      message: policy.message?.(violation)
+        ?? `${capitalize(entityKind)} '${entityName}' references ${refKind} '${resolved}' which is not reachable from this file's imports`,
     });
   }
 
@@ -722,14 +819,29 @@ function checkImportScope(
               line: arrow.line + 1,
               column: 1,
               severity: "error",
-              rule: "import-scope",
-              message: `Arrow in mapping '${arrow.mapping}' references transform '${resolved}' which is not reachable from this file's imports`,
+              rule: policy.rule ?? "import-scope",
+              message: policy.message?.({
+                file: arrow.file,
+                row: arrow.line,
+                entityKind: "arrow",
+                entityName: arrow.mapping ?? "<anonymous>",
+                refKind: "transform",
+                ref: spreadName,
+                resolved,
+                definitionFile: definitionFileFor(index.transforms.get(resolved)),
+              }) ?? `Arrow in mapping '${arrow.mapping}' references transform '${resolved}' which is not reachable from this file's imports`,
             });
           }
         }
       }
     }
   }
+}
+
+function definitionFileFor(definition: unknown): string | null {
+  if (!definition || typeof definition !== "object") return null;
+  const file = (definition as { file?: unknown }).file;
+  return typeof file === "string" ? file : null;
 }
 
 // ---------- Helpers ----------

--- a/tooling/satsuma-core/test/validate.test.js
+++ b/tooling/satsuma-core/test/validate.test.js
@@ -10,7 +10,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { collectSemanticDiagnostics } from "@satsuma/core";
+import { collectSemanticDiagnostics, validateSemanticWorkspace } from "@satsuma/core";
 
 // ---------- Test helper ----------
 
@@ -420,5 +420,65 @@ describe("ref metadata target diagnostics", () => {
     const diags = collectSemanticDiagnostics(index);
     const refDiags = diags.filter((d) => d.rule === "undefined-ref" && d.message.includes("crm_customers"));
     assert.equal(refDiags.length, 0);
+  });
+});
+
+// ---------- Shared validation entry point ----------
+
+describe("validateSemanticWorkspace", () => {
+  it("computes import reachability and applies the default import-scope rule", () => {
+    // This pins the shared consumer contract: callers pass resolved imports,
+    // core computes reachability, and out-of-scope symbols use the CLI rule.
+    const index = makeIndex({
+      schemas: [
+        { name: "customers", file: "/workspace/customers.stm" },
+      ],
+      mappings: [
+        { name: "load customers", file: "/workspace/load.stm", sources: ["customers"], targets: ["customers"] },
+      ],
+    });
+    const diags = validateSemanticWorkspace(index, {
+      fileImports: new Map([
+        ["/workspace/load.stm", []],
+        ["/workspace/customers.stm", []],
+      ]),
+    });
+
+    assert.equal(diags.length, 2);
+    assert.deepEqual(
+      diags.map((d) => d.rule),
+      ["import-scope", "import-scope"],
+    );
+    assert.ok(
+      diags.every((d) => d.message.includes("customers") && d.severity === "error"),
+      "both mapping refs should be reported as out of import scope",
+    );
+  });
+
+  it("allows consumers to customize import-scope presentation without changing the rule engine", () => {
+    // LSP diagnostics keep their historic public code/message while using the
+    // same reachability algorithm as CLI validation.
+    const index = makeIndex({
+      schemas: [
+        { name: "orders", file: "file:///workspace/orders.stm" },
+      ],
+      mappings: [
+        { name: "load orders", file: "file:///workspace/load.stm", sources: ["orders"], targets: [] },
+      ],
+    });
+    const diags = validateSemanticWorkspace(index, {
+      fileImports: new Map([
+        ["file:///workspace/load.stm", []],
+        ["file:///workspace/orders.stm", []],
+      ]),
+      importScopeDiagnostic: {
+        rule: "missing-import",
+        message: (violation) => `${violation.resolved} from ${violation.definitionFile}`,
+      },
+    });
+
+    assert.equal(diags.length, 1);
+    assert.equal(diags[0].rule, "missing-import");
+    assert.equal(diags[0].message, "orders from file:///workspace/orders.stm");
   });
 });

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -1,22 +1,15 @@
 /**
  * semantic-diagnostics.ts — LSP-specific semantic diagnostics
  *
- * Provides two diagnostic sources:
+ * Adapts the LSP/viz-backend workspace index into @satsuma/core's shared
+ * semantic validation contract. Core owns rule order and import reachability;
+ * this module owns only LSP-specific range/severity conversion and the
+ * quick-fix-style message used for out-of-scope imports.
  *
- * 1. **Missing-import diagnostics** (LSP-specific): detects references to symbols
- *    that exist in the workspace but are not reachable via the file's import
- *    graph. Uses satsuma-core's computeImportReachability for symbol-level
- *    scope enforcement (ADR-022): importing a symbol brings only that symbol
- *    and its transitive dependencies into scope, not all symbols from the
- *    imported file.
- *
- * 2. **Core semantic diagnostics** (via adapter): runs a subset of core's
- *    collectSemanticDiagnostics() directly against the LSP workspace index,
- *    providing real-time validation without a CLI subprocess. Arrow-level
- *    checks and NL @ref validation are not available through this path —
- *    those require full arrow extraction that the LSP workspace index does
- *    not currently maintain. The CLI subprocess (validate-diagnostics.ts)
- *    remains as a fallback for those checks on save.
+ * Arrow field checks and NL @ref validation are still incomplete in the live
+ * LSP path because the LSP workspace index does not maintain full arrow/NL
+ * extraction data. The CLI subprocess (validate-diagnostics.ts) remains the
+ * on-save fallback for those full-workspace checks.
  */
 
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -31,8 +24,7 @@ import {
   buildImportSuggestion,
 } from "./workspace-index";
 import {
-  collectSemanticDiagnostics,
-  computeImportReachability,
+  validateSemanticWorkspace,
 } from "@satsuma/core";
 import type {
   SemanticIndex,
@@ -42,6 +34,7 @@ import type {
   SemanticMetric,
   SemanticDiagnostic,
   ResolvedFileImport,
+  ImportScopeViolation,
 } from "@satsuma/core";
 
 // ---------- Missing-import diagnostics (LSP-specific) ----------
@@ -66,75 +59,52 @@ export function computeMissingImportDiagnostics(
   uri: string,
   wsIndex: WorkspaceIndex,
 ): Diagnostic[] {
-  // Build the data structures needed for symbol-level reachability.
-  const fileImports = buildFileImportsMap(wsIndex);
-  const semanticIndex = buildSemanticIndex(wsIndex);
-  const reachability = computeImportReachability(semanticIndex, fileImports);
-  const reachableSymbols = reachability.reachableSymbols.get(uri) ?? new Set<string>();
-
-  const diagnostics: Diagnostic[] = [];
-
-  for (const [name, refs] of wsIndex.references) {
-    // Only consider references that come from this file and are structural
-    // (source/target/spread/metric_source) — not arrow field paths or import names
-    const fileRefs = refs.filter(
-      (r) =>
-        r.uri === uri &&
-        (r.context === "source" ||
-          r.context === "target" ||
-          r.context === "spread" ||
-          r.context === "metric_source"),
-    );
-    if (fileRefs.length === 0) continue;
-
-    const globalDefs = wsIndex.definitions.get(name);
-    // If not defined anywhere, let core semantic validation handle it
-    if (!globalDefs || globalDefs.length === 0) continue;
-
-    // Already reachable via imports (symbol-level check) — no problem
-    if (reachableSymbols.has(name)) continue;
-
-    // Symbol exists in workspace but is not reachable from this file's import graph
-    const defUri = globalDefs[0]!.uri;
-    const suggestion = buildImportSuggestion(uri, name, defUri);
-
-    for (const ref of fileRefs) {
-      diagnostics.push({
-        range: ref.range,
-        severity: DiagnosticSeverity.Error,
-        code: "missing-import",
-        source: "satsuma",
-        message: `'${name}' is not imported. Add: ${suggestion}`,
-      });
-    }
-  }
-
-  return diagnostics;
+  return computeSemanticValidationDiagnostics(uri, wsIndex)
+    .filter((d) => d.code === "missing-import");
 }
 
 // ---------- Core semantic diagnostics (adapter) ----------
 
 /**
- * Run core's collectSemanticDiagnostics() against the LSP workspace index
- * and return LSP Diagnostic[] for the specified file.
- *
- * Coverage: duplicate definitions, undefined fragment spreads, undefined
- * mapping source/target refs, undefined metric source refs, ref metadata
- * targets. Arrow field-not-in-schema and NL @ref checks are NOT covered —
- * the LSP workspace index does not maintain arrow extraction data. The CLI
- * subprocess fallback (validate-diagnostics.ts) covers those on save.
+ * Run the shared core semantic validation pipeline against the LSP workspace
+ * index and return diagnostics for the specified file.
  */
-export function computeCoreSemanticDiagnostics(
+export function computeSemanticValidationDiagnostics(
   uri: string,
   wsIndex: WorkspaceIndex,
 ): Diagnostic[] {
+  const fileImports = buildFileImportsMap(wsIndex);
   const semanticIndex = buildSemanticIndex(wsIndex);
-  const coreDiags = collectSemanticDiagnostics(semanticIndex);
+  const coreDiags = validateSemanticWorkspace(semanticIndex, {
+    fileImports,
+    importScopeDiagnostic: {
+      rule: "missing-import",
+      message: (violation) => missingImportMessage(uri, violation),
+    },
+  });
 
   // Filter to diagnostics for the specified file and convert to LSP format
   return coreDiags
     .filter((d) => d.file === uri)
     .map(semanticDiagToLsp);
+}
+
+/**
+ * Backward-compatible wrapper kept for tests and call sites that still name
+ * the old adapter. It now uses the unified core validation entry point.
+ */
+export function computeCoreSemanticDiagnostics(
+  uri: string,
+  wsIndex: WorkspaceIndex,
+): Diagnostic[] {
+  return computeSemanticValidationDiagnostics(uri, wsIndex)
+    .filter((d) => d.code !== "missing-import");
+}
+
+function missingImportMessage(uri: string, violation: ImportScopeViolation): string {
+  const defUri = violation.definitionFile ?? uri;
+  const suggestion = buildImportSuggestion(uri, violation.resolved, defUri);
+  return `'${violation.resolved}' is not imported. Add: ${suggestion}`;
 }
 
 /** Map a core SemanticDiagnostic to an LSP Diagnostic. */
@@ -247,7 +217,7 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
           break;
         case "metric":
           if (!metrics.has(name)) {
-            metrics.set(name, defEntryToMetric(entry));
+            metrics.set(name, defEntryToMetric(entry, wsIndex));
           }
           break;
         case "transform":
@@ -336,11 +306,23 @@ function defEntryToMapping(
 }
 
 /** Convert a DefinitionEntry with kind "metric" to a SemanticMetric. */
-function defEntryToMetric(entry: DefinitionEntry): SemanticMetric {
-  // Sources are tracked via metric_source references in the workspace index
+function defEntryToMetric(
+  entry: DefinitionEntry,
+  wsIndex: WorkspaceIndex,
+): SemanticMetric {
+  const sources: string[] = [];
+  for (const [refName, refs] of wsIndex.references) {
+    for (const ref of refs) {
+      if (ref.uri === entry.uri && ref.context === "metric_source" && !sources.includes(refName)) {
+        sources.push(refName);
+      }
+    }
+  }
+
   return {
     namespace: entry.namespace ?? undefined,
     file: entry.uri,
     row: entry.range.start.line,
+    sources,
   };
 }

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -30,7 +30,7 @@ import {
   getImportReachableUris,
   createScopedIndex,
 } from "./workspace-index";
-import { computeMissingImportDiagnostics, computeCoreSemanticDiagnostics } from "./semantic-diagnostics";
+import { computeSemanticValidationDiagnostics } from "./semantic-diagnostics";
 import { computeDefinition } from "./definition";
 import { computeReferences } from "./references";
 import { computeCompletions } from "./completion";
@@ -446,8 +446,8 @@ function scopeIndex(uri: string): WorkspaceIndex {
 }
 
 /**
- * Send parse diagnostics merged with cached validate diagnostics,
- * core semantic diagnostics, and missing-import diagnostics.
+ * Send parse diagnostics merged with cached validate diagnostics and the shared
+ * core semantic validation adapter.
  *
  * Core semantic diagnostics run directly against the workspace index (no
  * subprocess). The CLI subprocess (validate-diagnostics.ts) provides
@@ -457,8 +457,7 @@ function scopeIndex(uri: string): WorkspaceIndex {
 function sendMergedDiagnostics(uri: string, tree: Tree): void {
   const parseDiags = computeDiagnostics(tree);
   const validateDiags = validateDiagCache.get(uri) ?? [];
-  const coreSemanticDiags = computeCoreSemanticDiagnostics(uri, scopeIndex(uri));
-  const missingImportDiags = computeMissingImportDiagnostics(tree, uri, wsIndex);
+  const semanticDiags = computeSemanticValidationDiagnostics(uri, wsIndex);
 
   // Deduplicate: core semantic diagnostics may overlap with CLI validate
   // diagnostics. Use rule + line as the dedup key, preferring CLI results
@@ -466,13 +465,13 @@ function sendMergedDiagnostics(uri: string, tree: Tree): void {
   const validateKeys = new Set(
     validateDiags.map((d) => `${d.code}:${d.range.start.line}`),
   );
-  const dedupedCoreDiags = coreSemanticDiags.filter(
+  const dedupedSemanticDiags = semanticDiags.filter(
     (d) => !validateKeys.has(`${d.code}:${d.range.start.line}`),
   );
 
   connection.sendDiagnostics({
     uri,
-    diagnostics: [...parseDiags, ...validateDiags, ...dedupedCoreDiags, ...missingImportDiags],
+    diagnostics: [...parseDiags, ...validateDiags, ...dedupedSemanticDiags],
   });
 }
 


### PR DESCRIPTION
## Summary
- Add core validateSemanticWorkspace as the shared reachability-aware semantic validation entry point
- Route CLI and LSP semantic diagnostics through the core interface while preserving LSP missing-import presentation
- Add ADR-025 documenting the core semantic validation boundary and close sl-bxzg

## Tests
- npm --prefix tooling/satsuma-core test
- npm --prefix tooling/satsuma-lsp test
- npm --prefix tooling/satsuma-cli run test:typecheck
- npm --prefix tooling/satsuma-cli test -- --test-name-pattern "validate"
- npm --prefix tooling/satsuma-cli test -- test/load-workspace.test.ts

Closes sl-bxzg