### PR TITLE
Consolidate duplicated consumer utilities

### DIFF
--- a/.tickets/sl-znn1.md
+++ b/.tickets/sl-znn1.md
@@ -1,6 +1,6 @@
 ---
 id: sl-znn1
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-04-07T09:42:36Z
@@ -17,3 +17,9 @@ Audit CLI and LSP for duplicated utilities; move canonical impls (with tests) in
 
 No utility function exists in two consumer packages. Dependency graph unchanged. All tests pass.
 
+## Notes
+
+**2026-04-07T15:56:36Z**
+
+Cause: CLI and LSP consumer packages still carried local copies of Satsuma CST reference text helpers and field path utilities after the core extraction work. This made the shared extraction contract easier to drift across command and editor surfaces.
+Fix: Moved `qualifyField`, `findFieldByPath`, and `collectFieldNames` into `satsuma-core`, reused existing core CST helpers from LSP files, deleted consumer helper bodies, and added focused core tests plus the Feature 29 audit checklist update. (commit d402314)

--- a/.tickets/sl-znn1.md
+++ b/.tickets/sl-znn1.md
@@ -1,6 +1,6 @@
 ---
 id: sl-znn1
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-04-07T09:42:36Z

--- a/features/29-codebase-and-test-cleanup/TODO.md
+++ b/features/29-codebase-and-test-cleanup/TODO.md
@@ -9,10 +9,10 @@ parallelisable — there is no enforced ordering except where noted.
 ## Code cleanup
 
 ### 1. Consolidate duplicated utilities into `satsuma-core`
-- [ ] Audit `satsuma-cli/src/` and `satsuma-lsp/src/` for utilities that exist in both. Produce a list with line counts.
-- [ ] For each duplicate, move the canonical implementation (with its tests) into `satsuma-core` and update both consumers to import from core.
-- [ ] Delete the consumer-side copies and their now-redundant tests.
-- [ ] Verify the dependency graph is unchanged (no consumer → consumer imports introduced).
+- [x] Audit `satsuma-cli/src/` and `satsuma-lsp/src/` for utilities that exist in both. Produced list (sl-znn1): LSP `sourceRefText` copies in `action-context.ts` (~14 lines), `completion.ts` (~16), `coverage.ts` (~14), `codelens.ts` (~13), and `definition.ts` (~11); LSP `qualifiedNameText` copy in `definition.ts` (~5); LSP `fieldNameText` / `fieldNameTextDef` copies in `symbols.ts` and `definition.ts` (~6 each); LSP `walkDescendants` local copy in `codelens.ts` (~6); CLI `qualifyField` copies in `index-builder.ts` (~35) and `field-lineage.ts` (~21); CLI `findFieldByPath` / `collectAllFieldNames` copies in `arrows.ts` (~25 combined) and `field-lineage.ts` (~22 combined).
+- [x] For each duplicate, move the canonical implementation (with its tests) into `satsuma-core` and update both consumers to import from core. `sourceRefText`, `sourceRefStructuralText`, `qualifiedNameText`, `fieldNameText`, `walkDescendants`, and `resolveScopedEntityRef` already lived in core and consumers now import them; `qualifyField`, `findFieldByPath`, and `collectFieldNames` now live in core with focused tests.
+- [x] Delete the consumer-side copies and their now-redundant tests. Deleted the consumer helper bodies; existing consumer tests remain because they exercise command/LSP behaviour, not duplicate helper units.
+- [x] Verify the dependency graph is unchanged (no consumer → consumer imports introduced). CLI and LSP import from `@satsuma/core`; no new consumer-to-consumer imports were added.
 
 ### 2. Resolve `WorkspaceIndex` naming collision
 - [x] Identify the two `WorkspaceIndex` types and document what each represents. (CLI's was an extraction-result struct: schemas/mappings/arrows/etc. produced by running extractors. viz-backend's is a definition/reference cross-file index used by the LSP and viz harness for navigation.)

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -17,7 +17,8 @@ import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../c
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
-import type { ExtractedWorkspace, ArrowRecord, FieldDecl } from "../types.js";
+import { collectFieldNames, findFieldByPath } from "@satsuma/core";
+import type { ExtractedWorkspace, ArrowRecord } from "../types.js";
 
 export function register(program: Command): void {
   program
@@ -78,11 +79,11 @@ Examples:
       const schema = resolvedSchema.entry;
       const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
       const allFields = [...schema.fields, ...spreadFields];
-      const fieldExists = findFieldByPath(allFields, fieldName) ||
-        collectAllFieldNames(allFields).includes(fieldName);
+      const fieldExists = findFieldByPath(allFields, fieldName) !== null ||
+        collectFieldNames(allFields).includes(fieldName);
       if (!fieldExists) {
         // Suggest close matches from top-level and nested fields
-        const allNames = collectAllFieldNames(allFields);
+        const allNames = collectFieldNames(allFields);
         const close = allNames.find(
           (n) => n.toLowerCase() === fieldName.toLowerCase(),
         );
@@ -117,7 +118,7 @@ Examples:
           const pathExistsInSchema = (rawPath: string): boolean => {
             const bare = rawPath.replace(/^\./, "");
             const path = bare.startsWith(schemaKey + ".") ? bare.slice(schemaKey.length + 1) : bare;
-            return findFieldByPath(allFields, path) || collectAllFieldNames(allFields).includes(path);
+            return findFieldByPath(allFields, path) !== null || collectFieldNames(allFields).includes(path);
           };
 
           const asSourceMatch = mapping.sources.includes(schemaKey) &&
@@ -359,35 +360,6 @@ function findFieldArrows(fieldKey: string, index: ExtractedWorkspace): ArrowReco
     }
   }
   return results;
-}
-
-/**
- * Check if a field exists at a given path, supporting dotted notation
- * for nested record/list children (e.g. "address.street").
- */
-function findFieldByPath(fields: FieldDecl[], path: string): boolean {
-  const segments = path.split(".");
-  let current = fields;
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    const field = current.find((f) => f.name === seg);
-    if (!field) return false;
-    if (i < segments.length - 1) {
-      if (!field.children || field.children.length === 0) return false;
-      current = field.children;
-    }
-  }
-  return true;
-}
-
-/** Collect all field names including nested children (bare names only). */
-function collectAllFieldNames(fields: FieldDecl[]): string[] {
-  const names: string[] = [];
-  for (const f of fields) {
-    names.push(f.name);
-    if (f.children) names.push(...collectAllFieldNames(f.children));
-  }
-  return names;
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -18,7 +18,8 @@ import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../c
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
-import type { ExtractedWorkspace, FieldDecl } from "../types.js";
+import { collectFieldNames, findFieldByPath, qualifyField } from "@satsuma/core";
+import type { ExtractedWorkspace } from "../types.js";
 
 interface FieldEdgeEntry {
   from: string | null; // canonical field path or null for derived/no-source
@@ -89,8 +90,8 @@ Examples:
       const schema = resolvedSchema.entry;
       const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
       const allFields = [...schema.fields, ...spreadFields];
-      const fieldExists = findFieldByPath(allFields, fieldName) ||
-        collectAllFieldNames(allFields).includes(fieldName);
+      const fieldExists = findFieldByPath(allFields, fieldName) !== null ||
+        collectFieldNames(allFields).includes(fieldName);
       if (!fieldExists) {
         throw new CommandError(
           `Field '${fieldName}' not found in schema '${schemaName}'.`,
@@ -223,27 +224,6 @@ function buildFieldEdgeGraph(index: ExtractedWorkspace): FieldEdgeEntry[] {
   return edges;
 }
 
-/**
- * Qualify a bare field name with its schema, handling leading dots (nested fields)
- * and already-qualified paths.
- */
-function qualifyField(field: string, schemas: string[]): string {
-  if (schemas.length === 0) return field;
-  if (field.includes("::")) return field; // already canonical
-  if (field.startsWith(".")) return `${schemas[0]}.${field.slice(1)}`;
-  const dotIdx = field.indexOf(".");
-  if (dotIdx > 0) {
-    const prefix = field.slice(0, dotIdx);
-    if (schemas.includes(prefix)) return field;
-    for (const s of schemas) {
-      const nsIdx = s.indexOf("::");
-      const bare = nsIdx !== -1 ? s.slice(nsIdx + 2) : s;
-      if (bare === prefix) return field;
-    }
-  }
-  return `${schemas[0]}.${field}`;
-}
-
 // ── Traversal ─────────────────────────────────────────────────────────────────
 
 /**
@@ -308,32 +288,6 @@ function traceDownstream(
       queue.push({ field: edge.to, depth: depth + 1 });
     }
   }
-}
-
-// ── Schema/field helpers ──────────────────────────────────────────────────────
-
-function findFieldByPath(fields: FieldDecl[], path: string): boolean {
-  const segments = path.split(".");
-  let current = fields;
-  for (let i = 0; i < segments.length; i++) {
-    const seg = segments[i];
-    const field = current.find((f) => f.name === seg);
-    if (!field) return false;
-    if (i < segments.length - 1) {
-      if (!field.children || field.children.length === 0) return false;
-      current = field.children;
-    }
-  }
-  return true;
-}
-
-function collectAllFieldNames(fields: FieldDecl[]): string[] {
-  const names: string[] = [];
-  for (const f of fields) {
-    names.push(f.name);
-    if (f.children) names.push(...collectAllFieldNames(f.children));
-  }
-  return names;
 }
 
 // ── Formatters ────────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -8,6 +8,7 @@
 import { dirname, resolve } from "node:path";
 import {
   canonicalRef,
+  resolveScopedEntityRef,
   extractSchemas,
   extractMetrics,
   extractMappings,
@@ -20,6 +21,7 @@ import {
   extractImports,
   extractNotes,
 } from "@satsuma/core";
+export { qualifyField, resolveScopedEntityRef } from "@satsuma/core";
 import type { ResolvedFileImport } from "@satsuma/core";
 import { extractNLRefData } from "./nl-ref-extract.js";
 import type {
@@ -130,56 +132,6 @@ export function canonicalKey(key: string): string {
 export function resolveCanonicalKey(canonical: string): string {
   if (canonical.startsWith("::")) return canonical.slice(2);
   return canonical;
-}
-
-/**
- * Qualify a raw field name by prepending the mapping's primary schema.
- *
- * Handles three cases:
- *  - Nested fields (`.field`): strip the leading dot and prefix with the first schema.
- *  - Already-qualified fields (`schema.field` or `ns::schema.field`): pass through.
- *  - Bare field names: prefix with the first schema in the list.
- *
- * Used wherever raw field names from ArrowRecord or NLRef need to be compared
- * against canonical ::schema.field keys.
- */
-export function qualifyField(field: string, schemas: string[]): string {
-  if (schemas.length === 0) return field;
-
-  // Nested field: strip leading dot, prepend first schema
-  if (field.startsWith(".")) {
-    return `${schemas[0]}.${field.slice(1)}`;
-  }
-
-  // Multi-source: field may already be schema-qualified (e.g. "crm.customer_id")
-  const dotIdx = field.indexOf(".");
-  if (dotIdx > 0) {
-    const prefix = field.slice(0, dotIdx);
-    if (schemas.includes(prefix)) {
-      // Already qualified — don't double-prefix
-      return field;
-    }
-    // Check if prefix matches the bare name of a namespace-qualified schema
-    for (const s of schemas) {
-      const nsIdx = s.indexOf("::");
-      const bare = nsIdx !== -1 ? s.slice(nsIdx + 2) : s;
-      if (bare === prefix) return field;
-    }
-  }
-
-  return `${schemas[0]}.${field}`;
-}
-
-export function resolveScopedEntityRef(ref: string, currentNs: string | null, entityMap: Map<string, unknown>): string | null {
-  if (ref.includes("::")) {
-    return entityMap.has(ref) ? ref : null;
-  }
-  if (currentNs) {
-    const nsKey = `${currentNs}::${ref}`;
-    if (entityMap.has(nsKey)) return nsKey;
-  }
-  if (entityMap.has(ref)) return ref;
-  return null;
 }
 
 export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWorkspace {

--- a/tooling/satsuma-core/src/canonical-ref.ts
+++ b/tooling/satsuma-core/src/canonical-ref.ts
@@ -42,6 +42,36 @@ export function canonicalEntityName(entity: { namespace?: string | null; name: s
 }
 
 /**
+ * Qualify a raw mapping field path by prepending the mapping's primary schema.
+ *
+ * Handles the field forms emitted by arrow and NL-ref extraction:
+ * - `.field` paths inherit the first schema and drop the leading dot.
+ * - `schema.field` and `ns::schema.field` paths are already qualified.
+ * - Bare fields are attached to the first schema in the mapping side.
+ */
+export function qualifyField(field: string, schemas: string[]): string {
+  if (schemas.length === 0) return field;
+  if (field.includes("::")) return field;
+
+  if (field.startsWith(".")) {
+    return `${schemas[0]}.${field.slice(1)}`;
+  }
+
+  const dotIdx = field.indexOf(".");
+  if (dotIdx > 0) {
+    const prefix = field.slice(0, dotIdx);
+    if (schemas.includes(prefix)) return field;
+    for (const schema of schemas) {
+      const nsIdx = schema.indexOf("::");
+      const bare = nsIdx !== -1 ? schema.slice(nsIdx + 2) : schema;
+      if (bare === prefix) return field;
+    }
+  }
+
+  return `${schemas[0]}.${field}`;
+}
+
+/**
  * Resolve an entity reference against a namespace-keyed entity map.
  *
  * Resolution order:

--- a/tooling/satsuma-core/src/cst-utils.ts
+++ b/tooling/satsuma-core/src/cst-utils.ts
@@ -100,7 +100,7 @@ export function qualifiedNameText(node: SyntaxNode | null | undefined): string |
 export function sourceRefText(node: SyntaxNode | null | undefined): string | null {
   if (!node) return null;
   const qn = child(node, "qualified_name");
-  if (qn) return qualifiedNameText(qn);
+  if (qn) return qualifiedNameText(qn) ?? qn.text;
   const bn = child(node, "backtick_name");
   if (bn) return bn.text.slice(1, -1);
   const id = child(node, "identifier");
@@ -120,7 +120,7 @@ export function sourceRefText(node: SyntaxNode | null | undefined): string | nul
 export function sourceRefStructuralText(node: SyntaxNode | null | undefined): string | null {
   if (!node) return null;
   const qn = child(node, "qualified_name");
-  if (qn) return qualifiedNameText(qn);
+  if (qn) return qualifiedNameText(qn) ?? qn.text;
   const bn = child(node, "backtick_name");
   if (bn) return bn.text.slice(1, -1);
   const id = child(node, "identifier");

--- a/tooling/satsuma-core/src/field-utils.ts
+++ b/tooling/satsuma-core/src/field-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * field-utils.ts — field tree helpers shared by Satsuma consumers.
+ *
+ * These functions operate on the smallest common shape of extracted field
+ * records so CLI commands, LSP features, and future consumers can reuse the
+ * same nested-field traversal rules without coupling to one package's record
+ * type.
+ */
+
+/** Minimal field-tree shape required by the shared traversal helpers. */
+export interface FieldTreeNode {
+  /** Field name with Satsuma quoting already stripped by the extractor. */
+  name: string;
+  /** Nested children for record/list_of record fields. */
+  children?: FieldTreeNode[];
+}
+
+/**
+ * Return the field node at a dotted path, or null when any segment is missing.
+ *
+ * Accepts either `"address.street"` or `["address", "street"]` so callers
+ * that have already parsed user input do not need to re-join and split it.
+ */
+export function findFieldByPath<T extends FieldTreeNode>(
+  fields: T[],
+  path: string | string[],
+): T | null {
+  const segments = Array.isArray(path) ? path : path.split(".");
+  let current: FieldTreeNode[] = fields;
+  let found: FieldTreeNode | null = null;
+
+  for (const segment of segments) {
+    found = current.find((field) => field.name === segment) ?? null;
+    if (!found) return null;
+    current = found.children ?? [];
+  }
+
+  return found as T | null;
+}
+
+/**
+ * Collect every field name in a tree, including nested child names.
+ *
+ * The returned names are bare leaf/container names, not dotted paths. This
+ * preserves the historical command fallback that accepts a nested field by leaf
+ * name when a fully dotted path is not available.
+ */
+export function collectFieldNames(fields: FieldTreeNode[]): string[] {
+  const names: string[] = [];
+  for (const field of fields) {
+    names.push(field.name);
+    if (field.children) names.push(...collectFieldNames(field.children));
+  }
+  return names;
+}

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -1,4 +1,6 @@
 export { capitalize, normalizeName } from "./string-utils.js";
+export { findFieldByPath, collectFieldNames } from "./field-utils.js";
+export type { FieldTreeNode } from "./field-utils.js";
 export { collectSemanticDiagnostics, validateSemanticWorkspace } from "./validate.js";
 export { computeImportReachability, computeSymbolDependencies } from "./import-reachability.js";
 export type { ResolvedFileImport, ImportReachability } from "./import-reachability.js";
@@ -27,7 +29,7 @@ export { format } from "./format.js";
 export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
 export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";
 export { classifyTransform, classifyArrow } from "./classify.js";
-export { canonicalRef, canonicalEntityName, resolveScopedEntityRef } from "./canonical-ref.js";
+export { canonicalRef, canonicalEntityName, qualifyField, resolveScopedEntityRef } from "./canonical-ref.js";
 export { extractMetadata } from "./meta-extract.js";
 export {
   extractFieldTree,

--- a/tooling/satsuma-core/test/canonical-ref.test.js
+++ b/tooling/satsuma-core/test/canonical-ref.test.js
@@ -4,7 +4,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { canonicalRef, canonicalEntityName } from "../dist/canonical-ref.js";
+import { canonicalRef, canonicalEntityName, qualifyField } from "../dist/canonical-ref.js";
 
 describe("canonicalRef()", () => {
   it("returns ::schema.field when no namespace", () => {
@@ -43,5 +43,23 @@ describe("canonicalEntityName()", () => {
 
   it("returns :: when name is null", () => {
     assert.equal(canonicalEntityName({ name: null }), "::");
+  });
+});
+
+describe("qualifyField()", () => {
+  it("prefixes a bare field with the mapping side's primary schema", () => {
+    assert.equal(qualifyField("customer_id", ["orders"]), "orders.customer_id");
+  });
+
+  it("qualifies leading-dot nested paths without retaining the synthetic dot", () => {
+    assert.equal(qualifyField(".address.street", ["customers"]), "customers.address.street");
+  });
+
+  it("leaves fields qualified by a namespace-qualified schema name unchanged", () => {
+    assert.equal(qualifyField("customers.id", ["crm::customers"]), "customers.id");
+  });
+
+  it("leaves fully namespace-qualified field paths unchanged", () => {
+    assert.equal(qualifyField("crm::customers.id", ["crm::customers"]), "crm::customers.id");
   });
 });

--- a/tooling/satsuma-core/test/cst-utils.test.js
+++ b/tooling/satsuma-core/test/cst-utils.test.js
@@ -271,6 +271,12 @@ describe("sourceRefText()", () => {
     assert.equal(sourceRefText(ref), "crm::orders");
   });
 
+  it("falls back to qualified_name text when a recovered tree has an incomplete qualified child", () => {
+    const qn = n("qualified_name", [ident("crm")], "crm::");
+    const ref = n("source_ref", [qn], "crm::");
+    assert.equal(sourceRefText(ref), "crm::");
+  });
+
   it("strips backticks from a source_ref with a backtick_name child", () => {
     const ref = n("source_ref", [backtick("my entity")], "`my entity`");
     assert.equal(sourceRefText(ref), "my entity");
@@ -298,6 +304,12 @@ describe("sourceRefStructuralText()", () => {
     const qn = n("qualified_name", [ident("crm"), ident("orders")], "crm::orders");
     const ref = n("source_ref", [qn], "crm::orders");
     assert.equal(sourceRefStructuralText(ref), "crm::orders");
+  });
+
+  it("falls back to recovered qualified_name text for structural source refs", () => {
+    const qn = n("qualified_name", [ident("crm")], "crm::");
+    const ref = n("source_ref", [qn], "crm::");
+    assert.equal(sourceRefStructuralText(ref), "crm::");
   });
 
   it("ignores nl_string join descriptions inside a source_ref", () => {

--- a/tooling/satsuma-core/test/field-utils.test.js
+++ b/tooling/satsuma-core/test/field-utils.test.js
@@ -1,0 +1,44 @@
+/**
+ * field-utils.test.js — Unit tests for shared field tree helpers.
+ *
+ * These helpers are intentionally tested in satsuma-core because both CLI
+ * commands and editor features need the same nested-field traversal semantics.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { collectFieldNames, findFieldByPath } from "../dist/field-utils.js";
+
+const fields = [
+  {
+    name: "customer",
+    children: [
+      { name: "id" },
+      {
+        name: "address",
+        children: [{ name: "street" }],
+      },
+    ],
+  },
+  { name: "status" },
+];
+
+describe("findFieldByPath()", () => {
+  it("returns the nested field so callers can distinguish an existing path from a missing one", () => {
+    assert.deepEqual(findFieldByPath(fields, "customer.address.street"), { name: "street" });
+  });
+
+  it("accepts pre-split path segments without changing traversal semantics", () => {
+    assert.deepEqual(findFieldByPath(fields, ["customer", "id"]), { name: "id" });
+  });
+
+  it("returns null when an intermediate segment is not a field", () => {
+    assert.equal(findFieldByPath(fields, "customer.missing.street"), null);
+  });
+});
+
+describe("collectFieldNames()", () => {
+  it("collects bare names from every level for command fallbacks that accept leaf names", () => {
+    assert.deepEqual(collectFieldNames(fields), ["customer", "id", "address", "street", "status"]);
+  });
+});

--- a/tooling/satsuma-lsp/src/action-context.ts
+++ b/tooling/satsuma-lsp/src/action-context.ts
@@ -2,6 +2,7 @@ import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText } from "./parser-utils";
 import { findNodeContext, type NodeContext } from "./definition";
 import type { WorkspaceIndex } from "./workspace-index";
+import { sourceRefText } from "@satsuma/core";
 
 export interface ActionContext {
   schemaName: string | null;
@@ -70,20 +71,6 @@ function extractTargetSchema(mappingNode: SyntaxNode): string | null {
       }
     }
   }
-  return null;
-}
-
-function sourceRefText(ref: SyntaxNode): string | null {
-  const qn = child(ref, "qualified_name");
-  if (qn) {
-    const ids = qn.namedChildren.filter((c) => c.type === "identifier");
-    if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
-    if (ids.length === 1 && ids[0]) return ids[0].text;
-  }
-  const bn = child(ref, "backtick_name");
-  if (bn) return bn.text.slice(1, -1);
-  const id = child(ref, "identifier");
-  if (id) return id.text;
   return null;
 }
 

--- a/tooling/satsuma-lsp/src/codelens.ts
+++ b/tooling/satsuma-lsp/src/codelens.ts
@@ -4,8 +4,8 @@ import {
   Range,
 } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { nodeRange, child, children, labelText } from "./parser-utils";
-import { isMetricSchema } from "@satsuma/core";
+import { nodeRange, child, children, labelText, walkDescendants } from "./parser-utils";
+import { isMetricSchema, sourceRefStructuralText } from "@satsuma/core";
 import {
   WorkspaceIndex,
   findReferences,
@@ -193,7 +193,7 @@ function extractRefNames(body: SyntaxNode, blockType: string): string[] {
     if (block.type !== blockType) continue;
     for (const ref of block.namedChildren) {
       if (ref.type === "source_ref") {
-        const text = sourceRefText(ref);
+        const text = sourceRefStructuralText(ref);
         if (text) names.push(text);
       }
     }
@@ -217,20 +217,6 @@ function countArrows(body: SyntaxNode): number {
   return count;
 }
 
-function sourceRefText(ref: SyntaxNode): string | null {
-  const qn = child(ref, "qualified_name");
-  if (qn) {
-    const ids = qn.namedChildren.filter((c) => c.type === "identifier");
-    if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
-    return qn.text;
-  }
-  const bn = child(ref, "backtick_name");
-  if (bn) return bn.text.slice(1, -1);
-  const id = child(ref, "identifier");
-  if (id) return id.text;
-  return null;
-}
-
 function lineRange(node: SyntaxNode): Range {
   return Range.create(
     node.startPosition.row,
@@ -238,11 +224,4 @@ function lineRange(node: SyntaxNode): Range {
     node.startPosition.row,
     node.startPosition.column,
   );
-}
-
-function walkDescendants(node: SyntaxNode, fn: (n: SyntaxNode) => void): void {
-  for (const ch of node.namedChildren) {
-    fn(ch);
-    walkDescendants(ch, fn);
-  }
 }

--- a/tooling/satsuma-lsp/src/completion.ts
+++ b/tooling/satsuma-lsp/src/completion.ts
@@ -4,6 +4,7 @@ import {
 } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child } from "./parser-utils";
+import { sourceRefStructuralText } from "@satsuma/core";
 import {
   WorkspaceIndex,
   allBlockNames,
@@ -311,7 +312,7 @@ function findMappingSchemasFromBody(
       // Extract source_ref children
       for (const ref of ch.namedChildren) {
         if (ref.type === "source_ref") {
-          const name = sourceRefText(ref);
+          const name = sourceRefStructuralText(ref);
           if (name) schemas.push(name);
         }
       }
@@ -319,22 +320,6 @@ function findMappingSchemasFromBody(
   }
 
   return schemas;
-}
-
-function sourceRefText(ref: SyntaxNode): string | null {
-  const qn = child(ref, "qualified_name");
-  if (qn) {
-    const ids = qn.namedChildren.filter((c) => c.type === "identifier");
-    if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
-    return qn.text;
-  }
-  const bn = child(ref, "backtick_name");
-  if (bn) return bn.text.slice(1, -1);
-  const id = child(ref, "identifier");
-  if (id) return id.text;
-  const ns = child(ref, "nl_string");
-  if (ns) return ns.text.slice(1, -1);
-  return null;
 }
 
 function isInsideNode(inner: SyntaxNode, outer: SyntaxNode): boolean {

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -24,7 +24,7 @@ import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText } from "./parser-utils";
 import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
-import { addPathAndPrefixes, isCoveredFieldPath } from "@satsuma/core";
+import { addPathAndPrefixes, isCoveredFieldPath, sourceRefStructuralText } from "@satsuma/core";
 
 // Re-export shared types from core so existing LSP code that imports from
 // this module continues to work without import path changes.
@@ -237,7 +237,7 @@ function getSchemaIdsFromBlock(body: SyntaxNode, blockType: "source_block" | "ta
     if (node.type === blockType) {
       const ids: string[] = [];
       for (const ref of children(node, "source_ref")) {
-        const name = sourceRefText(ref);
+        const name = sourceRefStructuralText(ref);
         if (name) ids.push(name);
       }
       return ids;
@@ -258,18 +258,4 @@ function resolveSchema(
 function pathText(node: SyntaxNode): string {
   const text = node.text;
   return text.startsWith("`") && text.endsWith("`") ? text.slice(1, -1) : text;
-}
-
-function sourceRefText(ref: SyntaxNode): string | null {
-  const qn = child(ref, "qualified_name");
-  if (qn) {
-    const ids = qn.namedChildren.filter((c) => c.type === "identifier");
-    if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
-    if (ids.length === 1 && ids[0]) return ids[0].text;
-    return qn.text;
-  }
-  const bn = child(ref, "backtick_name");
-  if (bn) return bn.text.slice(1, -1);
-  const id = child(ref, "identifier");
-  return id ? id.text : null;
 }

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -1,5 +1,5 @@
 import { Location } from "vscode-languageserver";
-import { createAtRefRegex } from "@satsuma/core";
+import { createAtRefRegex, fieldNameText, qualifiedNameText, sourceRefText } from "@satsuma/core";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText } from "./parser-utils";
 import {
@@ -128,7 +128,7 @@ function tryContext(node: SyntaxNode): NodeContext | null {
     }
 
     case "field_name": {
-      const name = fieldNameTextDef(node);
+      const name = fieldNameText(node);
       if (!name) return null;
       const block = findEnclosingBlock(node);
       const blockName = block ? labelText(block) : null;
@@ -372,27 +372,9 @@ function findEnclosingBlock(node: SyntaxNode): SyntaxNode | null {
 
 // ---------- Text extraction ----------
 
-function sourceRefText(ref: SyntaxNode): string | null {
-  const qn = child(ref, "qualified_name");
-  if (qn) return qualifiedNameText(qn);
-  const bn = child(ref, "backtick_name");
-  if (bn) return bn.text.slice(1, -1);
-  const id = child(ref, "identifier");
-  if (id) return id.text;
-  const ns = child(ref, "nl_string");
-  if (ns) return ns.text.slice(1, -1);
-  return null;
-}
-
-function qualifiedNameText(qn: SyntaxNode): string {
-  const ids = qn.namedChildren.filter((c) => c.type === "identifier");
-  if (ids.length >= 2 && ids[0] && ids[1]) return `${ids[0].text}::${ids[1].text}`;
-  return qn.text;
-}
-
 function spreadLabelText(node: SyntaxNode): string | null {
   const qn = child(node, "qualified_name");
-  if (qn) return qualifiedNameText(qn);
+  if (qn) return qualifiedNameText(qn) ?? qn.text;
   const quoted = child(node, "backtick_name");
   if (quoted) return quoted.text.slice(1, -1);
   const ids = node.namedChildren.filter((c) => c.type === "identifier");
@@ -402,7 +384,7 @@ function spreadLabelText(node: SyntaxNode): string | null {
 
 function importNameText(node: SyntaxNode): string | null {
   const qn = child(node, "qualified_name");
-  if (qn) return qualifiedNameText(qn);
+  if (qn) return qualifiedNameText(qn) ?? qn.text;
   const quoted = child(node, "backtick_name");
   if (quoted) return quoted.text.slice(1, -1);
   const id = child(node, "identifier");
@@ -415,13 +397,6 @@ function importPathText(node: SyntaxNode): string | null {
   const text = node.text;
   if (text.startsWith('"') && text.endsWith('"')) return text.slice(1, -1);
   return text;
-}
-
-function fieldNameTextDef(node: SyntaxNode): string | null {
-  const inner = node.namedChildren[0];
-  if (!inner) return node.text;
-  if (inner.type === "backtick_name") return inner.text.slice(1, -1);
-  return inner.text;
 }
 
 // ---------- Arrow field helpers ----------

--- a/tooling/satsuma-lsp/src/symbols.ts
+++ b/tooling/satsuma-lsp/src/symbols.ts
@@ -4,7 +4,7 @@ import {
 } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
-import { isMetricSchema } from "@satsuma/core";
+import { fieldNameText, isMetricSchema } from "@satsuma/core";
 
 /** Map of CST block type → LSP SymbolKind. */
 const BLOCK_SYMBOL_KIND: Record<string, SymbolKind> = {
@@ -232,13 +232,6 @@ function symbolDetail(node: SyntaxNode): string | undefined {
     }
   }
   return undefined;
-}
-
-function fieldNameText(nameNode: SyntaxNode): string | null {
-  const inner = nameNode.namedChildren[0];
-  if (!inner) return nameNode.text;
-  if (inner.type === "backtick_name") return inner.text;
-  return inner.text;
 }
 
 function spreadLabelText(node: SyntaxNode): string | null {


### PR DESCRIPTION
Closes sl-znn1.

## Summary
- move shared field helpers into satsuma-core and export them
- replace duplicated CLI/LSP CST helper bodies with core imports
- document the Feature 29 audit list and close the ticket

## Tests
- npm --prefix tooling/satsuma-core test
- npm --prefix tooling/satsuma-cli test
- npm --prefix tooling/satsuma-lsp test
- ./scripts/run-repo-checks.sh (fails only at Python tests because local python3 lacks pytest: /opt/homebrew/opt/python@3.14/bin/python3.14: No module named pytest)