### PR TITLE
Raise coverage gates for Feature 29

### DIFF
--- a/.tickets/sl-5xsy.md
+++ b/.tickets/sl-5xsy.md
@@ -1,6 +1,6 @@
 ---
 id: sl-5xsy
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-04-07T09:43:10Z
@@ -17,3 +17,10 @@ Measure current coverage on core/CLI/LSP. Raise gates to current rounded down to
 
 Coverage gates raised in .c8rc.json (or per-package equivalents); CI passes.
 
+
+## Notes
+
+**2026-04-07T16:26:49Z**
+
+Cause: Coverage gates were still at the old CLI-only 70% threshold and core/LSP had no package-level c8 gate, so CI would not catch meaningful coverage regressions across the main tooling packages.
+Fix: Measured current line coverage for core, CLI, and LSP, added core/LSP c8 configs, raised the CLI gate, and documented the measured thresholds in Feature 29 TODO (commit 2a20742).

--- a/.tickets/sl-63ix.md
+++ b/.tickets/sl-63ix.md
@@ -1,6 +1,6 @@
 ---
 id: sl-63ix
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-04-07T09:42:21Z
@@ -12,3 +12,10 @@ assignee: Thorben Louw
 
 Consolidation pass surfaced by 2026-04-05 audit. See features/29-codebase-and-test-cleanup/PRD.md and TODO.md.
 
+
+## Notes
+
+**2026-04-07T16:26:49Z**
+
+Cause: Feature 29 remained open while its final child tickets were being completed; PR 222 covered the recovery corpus and thin command tests, and sl-5xsy covered the remaining coverage-gate work.
+Fix: Rebasing the session branch onto origin/main plus PR 222 left all child tickets closed, then sl-5xsy raised and verified the coverage gates so the Feature 29 cleanup epic can close (commit 2a20742).

--- a/features/29-codebase-and-test-cleanup/TODO.md
+++ b/features/29-codebase-and-test-cleanup/TODO.md
@@ -94,8 +94,8 @@ parallelisable — there is no enforced ordering except where noted.
 - [x] Each file: build a workspace index from a minimal multi-file source map, invoke the handler, assert on the response shape. Added 9 tests against multi-file workspace indexes.
 
 ### 18. Raise coverage gates
-- [ ] Measure current coverage on `satsuma-core`, `satsuma-cli`, and `satsuma-lsp`.
-- [ ] Update `.c8rc.json` (or per-package equivalents) to set the gate to (current coverage rounded down to the nearest 5%) for each package, with a target floor of 85% for core.
+- [x] Measure current coverage on `satsuma-core`, `satsuma-cli`, and `satsuma-lsp`. Measured line coverage after PR 222 and `origin/main`: core 80.96%, CLI 92.05%, LSP 88.53%.
+- [x] Update `.c8rc.json` (or per-package equivalents) to set the gate to (current coverage rounded down to the nearest 5%) for each package, with a target floor of 85% for core. Added core/LSP package configs and raised CLI's existing gate: core 80%, CLI 90%, LSP 85%. Core is below the aspirational 85% floor today, so the gate follows the measured-coverage rule rather than setting CI to fail.
 
 ## Out of scope (tracked separately)
 

--- a/tooling/satsuma-cli/.c8rc.json
+++ b/tooling/satsuma-cli/.c8rc.json
@@ -9,6 +9,6 @@
     "node_modules/**"
   ],
   "check-coverage": true,
-  "lines": 70,
+  "lines": 90,
   "reports-dir": "coverage"
 }

--- a/tooling/satsuma-core/.c8rc.json
+++ b/tooling/satsuma-core/.c8rc.json
@@ -1,0 +1,7 @@
+{
+  "include": ["dist/**/*.js"],
+  "exclude": ["dist/**/*.d.ts"],
+  "check-coverage": true,
+  "lines": 80,
+  "reports-dir": "coverage"
+}

--- a/tooling/satsuma-lsp/.c8rc.json
+++ b/tooling/satsuma-lsp/.c8rc.json
@@ -1,0 +1,7 @@
+{
+  "include": ["dist/**/*.js"],
+  "exclude": ["dist/**/*.d.ts"],
+  "check-coverage": true,
+  "lines": 85,
+  "reports-dir": "coverage"
+}


### PR DESCRIPTION
## Summary
- add package-level c8 coverage gates for satsuma-core and satsuma-lsp
- raise the existing satsuma-cli line coverage gate from 70% to 90%
- document measured coverage and close sl-5xsy plus the Feature 29 epic

## Coverage
- satsuma-core: 80.91% lines, gate 80%
- satsuma-cli: 92.05% lines, gate 90%
- satsuma-lsp: 88.53% lines, gate 85%

## Tests
- npm --prefix tooling/satsuma-core run test:coverage
- npm --prefix tooling/satsuma-cli run test:coverage
- npm --prefix tooling/satsuma-lsp run test:coverage

ADR: not warranted; this changes test/CI coverage thresholds, not architecture.