### PR TITLE
docs: add viz test suite expansion plan

### DIFF
--- a/.tickets/sl-0jva.md
+++ b/.tickets/sl-0jva.md
@@ -1,0 +1,18 @@
+---
+id: sl-0jva
+status: open
+deps: []
+links: []
+created: 2026-04-07T16:57:29Z
+type: epic
+priority: 2
+assignee: Thorben Louw
+tags: [feature-30, viz, tests, playwright]
+---
+# Feature 30: viz test suite expansion
+
+Expand the standalone viz harness into a high-value browser test suite covering real interactions, fixture families, complex mapping detail views, geometry sanity checks, and screenshot artifacts for human/VLM review.
+
+## Acceptance Criteria
+
+Feature 30 PRD and TODO exist; implementation tasks can be mirrored into child tk tickets; the epic remains open until the expanded viz test suite is implemented and verified.

--- a/features/30-viz-test-suite-expansion/PRD.md
+++ b/features/30-viz-test-suite-expansion/PRD.md
@@ -1,0 +1,226 @@
+# Feature 30 - Viz Test Suite Expansion
+
+> **Status: PLANNED** (2026-04-07)
+
+## Goal
+
+Expand the standalone viz harness into a high-value browser test suite that catches real regressions in the rendered mapping visualization, not just ready-state or event-plumbing smoke failures.
+
+The primary success criterion is:
+
+**A contributor can run the local Playwright harness and get actionable evidence that overview rendering, mapping detail rendering, field coverage, interactions, filters, complex fixtures, and visual alignment still behave correctly.**
+
+This feature builds on the completed Feature 29 harness. It does not change the renderer architecture. It uses the existing `tooling/satsuma-viz-harness/` package as the browser test host and improves the suite around it.
+
+---
+
+## Problem
+
+The viz harness exists, but the current browser coverage is still shallow for the things most likely to regress:
+
+1. **Several tests validate synthetic events instead of real UI interactions.** Tests dispatch `CustomEvent` objects directly from `<satsuma-viz>`, so they can pass even if real clicks and hovers no longer emit the production event shape.
+2. **Detail view coverage proves only that a detail view appears.** It does not assert that the correct source schemas, target schema, arrow rows, transforms, notes, and field-coverage indicators are present.
+3. **Layout drift is not checked directly.** The suite has one larger-fixture ready-state test, but it does not assert geometry sanity such as card bounds, node ordering, non-overlap, or mapping nodes sitting between source and target schemas.
+4. **Namespace rendering is undercovered.** Namespaced cards and mappings add namespace-pill height and use qualified IDs. They need explicit coverage because those dimensions and selectors differ from non-namespaced cards.
+5. **Reports and metrics are undercovered.** The viz renders vanilla schemas, report/model schemas, and metric schemas with different card metadata and dimensions. The suite should cover all three user-visible card families.
+6. **Complex mappings are undercovered.** Nested child records, list/flatten blocks, source joins, notes, NL `@ref` highlighting, computed arrows, and multi-source mappings are exactly where visual inspection matters most.
+7. **There is no structured screenshot workflow.** Humans need screen grabs for quick review, markup, and feeding visual requirements back to a VLM. Today screenshots are incidental failure artifacts, not curated review outputs.
+
+---
+
+## Design Principles
+
+1. **Assert behaviour, not pixels.** Use selectors, text, event payloads, and geometry sanity checks for automated pass/fail. Use screenshots for human review, not brittle golden image comparison.
+2. **Test the production path.** Tests should load real `.stm` fixtures through `@satsuma/viz-backend`, the harness HTTP API, and the real `<satsuma-viz>` component.
+3. **Prefer canonical examples, add curated fixtures only when needed.** Existing examples should anchor the suite. Add small purpose-built fixtures only when no canonical file isolates the behaviour.
+4. **One invariant per test.** Keep each Playwright case easy to diagnose. A failing test should point at a specific broken contract, not a broad "viz looks wrong" bucket.
+5. **Browser tests cover browser-only risk.** Model extraction and graph semantics belong in unit tests. Playwright covers user-visible rendering, interactions, event payloads, layout geometry, and screenshot review artifacts.
+6. **Human review is part of the workflow.** The suite should save named screenshots for key states so a reviewer can mark up visual issues and pass them to a VLM with the corresponding fixture and test name.
+
+---
+
+## Scope
+
+### 1. Harness event contract
+
+Fix the harness event recorder so it captures the production event payloads emitted by `@satsuma/viz`, not only `CustomEvent.detail`.
+
+Required event payloads:
+
+- `navigate`: source URI, line, and character
+- `field-hover`: schema ID and field name, including `null` on hover leave when asserted
+- `field-lineage`: schema ID and field name
+- `open-mapping`: mapping identity when emitted through the edge layer or equivalent interaction
+- `expand-lineage`: schema ID, if the renderer exposes the interaction in the fixture under test
+- `export`: exported SVG metadata, if export is included in the suite
+
+The recorder should preserve a stable JSON shape in `window.__satsumaHarness.events` so Playwright can assert payloads without VS Code APIs.
+
+### 2. Stable test hooks for deep rendered content
+
+Add missing `data-testid` coverage where the current deep shadow DOM makes real interactions awkward or brittle.
+
+Required hooks:
+
+- overview schema cards
+- overview mapping nodes/cards
+- mapping detail root, header, source column, mapping column, target column
+- mapping detail source and target schema cards with distinct prefixes
+- mapping detail arrow rows
+- mapping detail `each` and `flatten` section rows
+- schema-card field rows and lineage buttons, including nested field paths
+- field coverage ports/circles, with stable mapped/unmapped state selectors or attributes
+- transform text and highlighted `@ref` spans
+- notes and note toggles where user-visible
+- toolbar filters and actions already in place (`Fit`, namespace filter, file filter, export)
+
+### 3. Fixture matrix
+
+The expanded suite must intentionally cover both simple and complex render paths.
+
+Recommended canonical fixtures:
+
+| Fixture | Purpose |
+| --- | --- |
+| `examples/sfdc-to-snowflake/pipeline.stm` | Non-namespaced vanilla schemas, imported lookup source, one named mapping, file notes, computed arrows, NL `@ref` transforms, map transform |
+| `examples/namespaces/ns-platform.stm` | Namespaced schemas and mappings, namespace-qualified source/target refs, namespace filter, extra namespace-pill height |
+| `examples/metrics-platform/metrics.stm` | Metrics as schema cards, cross-file lineage mode, file filter across `metrics.stm` and `metric_sources.stm` |
+| `examples/reports-and-models/pipeline.stm` | Report/model schemas, report metadata, consumer mappings, report-card height and metadata rendering |
+| `examples/filter-flatten-governance/filter-flatten-governance.stm` | Nested child records, list fields, source joins with NL join text, mapping notes, flatten sections, governance metadata, field coverage indicators |
+| `examples/sap-po-to-mfcs/pipeline.stm` | Larger real-world layout stability and screenshot review |
+
+If these fixtures do not isolate a required behaviour cleanly, add a small fixture under the harness package, not under canonical `examples/`, unless the example itself is broadly useful documentation.
+
+### 4. Automated Playwright coverage
+
+The suite should include the following groups.
+
+#### Overview rendering
+
+- Non-namespaced overview renders expected schema cards and mapping card for `sfdc-to-snowflake`.
+- Namespaced overview renders expected qualified cards and mapping nodes for `ns-platform`.
+- Metrics overview renders metric cards and source schema cards in lineage mode for `metrics-platform`.
+- Reports overview renders report/model cards for `reports-and-models`.
+
+#### Mapping detail rendering
+
+- Clicking a real overview mapping card opens the expected detail view.
+- Detail view for `opportunity ingestion` shows source schemas, target schema, expected arrow rows, computed arrows, map transform, NL transform text, and highlighted `@ref` spans.
+- Detail view for a namespaced mapping shows the namespace label and qualified source/target names.
+- Detail view for `completed orders` shows multiple source schemas, join text from the source block, mapping notes, nested field paths, and expected field coverage.
+- Detail view for `order line facts` shows the `flatten` section, nested child source fields, and target rows such as `line_number`, `sku`, `quantity`, and `line_total`.
+
+#### Field coverage and highlighting
+
+- Mapped fields render mapped coverage circles/ports; unmapped fields render unmapped circles/ports.
+- Hovering a real arrow row highlights the corresponding source and target field rows.
+- Hovering a real source field highlights the arrow row and target field for that mapping.
+- Hovering a real target field highlights upstream source fields for a multi-source mapping.
+- Nested child fields use stable field-path identity rather than only the leaf field name.
+
+#### Interaction events
+
+- Clicking a real schema header or field row records a `navigate` event with non-empty URI and numeric position.
+- Clicking a real field lineage button records a `field-lineage` event with schema ID and field name.
+- Hovering a real field row records `field-hover` with schema ID and field name.
+- Clicking an arrow row records a navigation event for that arrow's source location.
+- Clicking export records an `export` event and verifies the SVG payload is non-empty, if export remains supported in the harness.
+
+#### Filters and lineage mode
+
+- Namespace filter narrows `ns-platform` to one namespace and hides cards from the others.
+- File filter in `metrics-platform` lineage mode narrows to `metrics.stm`, then to `metric_sources.stm`, then back to all files.
+- Single-file mode vs lineage mode produces a visible model difference for an import-reaching fixture.
+
+#### Geometry sanity
+
+For at least one non-namespaced fixture, one namespaced fixture, one metrics/report fixture, and one complex fixture:
+
+- all positioned cards have positive width and height
+- no positioned card has `NaN`, `Infinity`, or missing coordinates
+- mapping nodes are horizontally between visible source and target schema cards in overview
+- major cards in small fixtures do not overlap
+- all cards fit within the rendered canvas bounds
+- namespace-card geometry accounts for namespace-pill height rather than clipping the card header or fields
+- detail-view columns are ordered source -> mapping -> target
+- long names and notes do not overflow their parent card bounds in the tested viewport
+
+### 5. Screenshot artifacts for human and VLM review
+
+Add a deterministic screenshot workflow that runs as part of the local harness test process or as a separate Playwright project/script.
+
+Required review shots:
+
+- `sfdc-overview-single.png`
+- `sfdc-detail-opportunity-ingestion.png`
+- `namespaces-overview-lineage.png`
+- `namespaces-detail-namespaced-mapping.png`
+- `metrics-overview-lineage-all-files.png`
+- `metrics-overview-file-filter-sources.png`
+- `reports-overview.png`
+- `filter-flatten-detail-completed-orders.png`
+- `filter-flatten-detail-order-line-facts.png`
+- `sap-po-layout-stability.png`
+
+Each screenshot run should also write a small manifest, for example `screenshots/manifest.json`, containing:
+
+- screenshot file name
+- fixture path
+- view mode (`single` or `lineage`)
+- UI state (`overview`, `detail`, selected mapping, filter state)
+- viewport size
+- timestamp
+- test name or script step name
+
+The screenshots are not golden baselines. They are review artifacts. They should be easy to attach to a PR, annotate manually, or feed to a VLM with the manifest as visual context.
+
+### 6. Documentation and workflow
+
+Update the harness docs so contributors know:
+
+- Playwright still runs through the sentinel watcher on local developer machines
+- screenshot artifacts are intentionally produced for human review
+- screenshots are not pixel-equality baselines
+- how to find the screenshot output directory and manifest
+- which fixtures are intentionally covered by the suite and why
+
+---
+
+## Non-Goals
+
+- Pixel-perfect visual regression testing in CI.
+- Replacing unit tests for `@satsuma/viz-backend` or `@satsuma/viz` layout helpers.
+- Full browser matrix testing. Firefox-only remains acceptable unless the harness environment becomes more reliable across Chromium/WebKit.
+- Running Playwright in GitHub Actions. This remains a local developer-machine workflow unless a later feature changes the browser environment story.
+- Visual editing, drag-to-map, or authoring changes.
+
+---
+
+## Acceptance Criteria
+
+1. The harness event recorder captures production `@satsuma/viz` event payloads for real UI interactions.
+2. Synthetic event tests are removed or demoted to harness-recorder unit coverage; the main Playwright suite uses real clicks and hovers wherever practical.
+3. Stable test hooks exist for mapping detail source/target cards, arrow rows, nested fields, field lineage buttons, coverage circles/ports, transform text, and section rows.
+4. Playwright coverage includes both non-namespaced and namespaced fixtures, explicitly covering the namespace-pill card height path.
+5. Playwright coverage includes vanilla schemas/mappings, metrics, report/model schemas, and a complex nested mapping with source joins and notes.
+6. Automated assertions cover field coverage circles/ports and at least two real hover/highlight paths.
+7. Automated assertions include geometry sanity checks for overview and detail views, without relying on full-image pixel comparison.
+8. The local screenshot workflow emits named PNG artifacts and a manifest describing fixture, state, viewport, and test step.
+9. README or package-level documentation explains how to run the expanded suite and where to find screenshot artifacts.
+10. Relevant local checks pass:
+    - `npm --prefix tooling/satsuma-viz run test`
+    - `npm --prefix tooling/satsuma-viz-backend run test`
+    - `npm --prefix tooling/satsuma-viz-harness run build`
+    - Playwright via the existing sentinel watcher workflow
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Deep shadow DOM makes real interactions brittle | Tests regress into synthetic event checks | Add targeted stable `data-testid` prefixes and small automation helpers that traverse shadow roots deliberately |
+| ELK layout coordinates vary slightly | Geometry tests become flaky | Assert relative order, positive dimensions, and non-overlap tolerances rather than exact coordinates |
+| Screenshot artifacts are mistaken for golden baselines | Review workflow becomes noisy | Document that screenshots are human-review artifacts and keep pass/fail logic in semantic assertions |
+| The suite becomes too slow for local use | Contributors stop running it | Keep the main suite focused, put screenshot capture in a separate tagged project or script if needed |
+| Canonical examples change | UI tests fail for legitimate fixture edits | Make assertions behaviour-oriented and update the fixture matrix when canonical examples evolve |

--- a/features/30-viz-test-suite-expansion/TODO.md
+++ b/features/30-viz-test-suite-expansion/TODO.md
@@ -1,0 +1,376 @@
+# Feature 30 TODO
+
+PRD: [PRD.md](./PRD.md)
+
+This TODO breaks Feature 30 into implementation tasks that should be mirrored in
+`tk` tickets when picked up. Each task should include `.tickets/` changes in the
+commit that implements it.
+
+## Task Breakdown
+
+Epic: `sl-0jva` - Feature 30: viz test suite expansion
+
+### 1. Audit current harness coverage and selector gaps
+
+Document the current `tooling/satsuma-viz-harness/test/harness.test.ts`
+coverage and the renderer selectors needed to replace synthetic event tests
+with real interactions.
+
+Scope:
+
+- list each current Playwright test and whether it asserts real UI behaviour,
+  synthetic event plumbing, ready state, or layout smoke coverage
+- identify missing selectors in `tooling/satsuma-viz/src/` for mapping detail
+  source/target cards, nested field rows, coverage circles/ports, transforms,
+  `each`/`flatten` rows, and notes
+- identify which canonical fixture should own each new behaviour case
+- decide whether any small harness-only fixtures are needed
+
+Acceptance criteria:
+
+- audit notes are added to the implementing ticket or to a short docs note in
+  the feature folder
+- every planned Playwright test maps to a fixture and a user-visible invariant
+- no synthetic-only event test remains as the recommended implementation path
+
+PRD reference:
+
+- Problem
+- Scope / Stable test hooks for deep rendered content
+- Scope / Fixture matrix
+
+### 2. Fix the harness event recorder contract
+
+Update the harness recorder so `window.__satsumaHarness.events` captures real
+production event payloads emitted by `@satsuma/viz`.
+
+Scope:
+
+- normalize `navigate` events from `SzNavigateEvent.location`
+- normalize `field-hover` events from `SzFieldHoverEvent.schemaId` and
+  `SzFieldHoverEvent.fieldName`
+- normalize `field-lineage` events from `SzFieldLineageEvent.schemaId` and
+  `SzFieldLineageEvent.fieldName`
+- normalize `open-mapping`, `expand-lineage`, and `export` event payloads as
+  needed
+- preserve compatibility with `CustomEvent.detail` only where it is genuinely
+  still used
+- add focused tests for the normalization helper if the logic is factored out
+
+Acceptance criteria:
+
+- a real click on a schema/field records a non-empty `navigate` event
+- a real field-lineage button click records schema ID and field name
+- existing harness event log consumers still read a stable JSON object shape
+
+PRD reference:
+
+- Scope / Harness event contract
+- Acceptance Criteria 1 and 2
+
+### 3. Add renderer test hooks for mapping detail and field coverage
+
+Add stable selectors and attributes needed for high-value Playwright assertions
+without relying on brittle deep shadow DOM queries.
+
+Scope:
+
+- give mapping detail source and target schema cards distinct `testIdPrefix`
+  values
+- add stable test IDs for mapping detail source, mapping, and target columns
+- add stable test IDs for `each` and `flatten` section rows
+- expose field coverage state through a selector or attribute on the port/circle
+  element (`mapped` vs `unmapped`)
+- ensure nested field rows include enough identity to distinguish dotted paths
+  such as `customer.email` from another `email`
+- add test IDs for transform text and highlighted `@ref` spans if current
+  selectors are not sufficient
+
+Acceptance criteria:
+
+- Playwright can locate a specific source field, target field, coverage
+  indicator, arrow row, and transform in mapping detail without manual event
+  dispatch
+- selector names are stable and based on normalized schema/field/mapping IDs
+- package-local `@satsuma/viz` tests are updated where selector rendering is
+  already covered
+
+PRD reference:
+
+- Scope / Stable test hooks for deep rendered content
+- Scope / Field coverage and highlighting
+
+### 4. Replace synthetic event tests with real interaction tests
+
+Rewrite the event-oriented harness tests to interact with the actual UI.
+
+Scope:
+
+- click a real schema header or field row and assert a `navigate` event payload
+- click a real field lineage button and assert a `field-lineage` event payload
+- hover a real field row and assert `field-hover`
+- click a real arrow row and assert a navigation event
+- keep only a small recorder-level unit test for synthetic/custom event
+  compatibility if needed
+
+Acceptance criteria:
+
+- the main Playwright suite no longer passes purely by dispatching synthetic
+  `CustomEvent` objects from `<satsuma-viz>`
+- real UI interaction failures produce actionable Playwright assertions
+- every new `test()` block opens with a purpose comment per repo test standards
+
+PRD reference:
+
+- Scope / Automated Playwright coverage / Interaction events
+- Acceptance Criteria 1 and 2
+
+### 5. Expand overview coverage across fixture families
+
+Add overview tests for non-namespaced, namespaced, metrics, reports, and larger
+fixtures.
+
+Scope:
+
+- `sfdc-to-snowflake/pipeline.stm`: assert vanilla schema and mapping overview
+  content in single-file mode
+- `namespaces/ns-platform.stm`: assert namespaced cards and mapping nodes render
+  with qualified IDs and namespace labels
+- `metrics-platform/metrics.stm`: assert metric cards and imported source cards
+  render in lineage mode
+- `reports-and-models/pipeline.stm`: assert report/model card metadata is visible
+- `sap-po-to-mfcs/pipeline.stm`: assert larger overview reaches ready state and
+  passes geometry sanity checks
+
+Acceptance criteria:
+
+- overview tests cover both namespace and non-namespace card height paths
+- metrics and reports are explicitly asserted, not only incidentally loaded
+- larger fixture test checks more than `data-ready-state="ready"`
+
+PRD reference:
+
+- Scope / Fixture matrix
+- Scope / Automated Playwright coverage / Overview rendering
+
+### 6. Add mapping detail coverage for canonical mappings
+
+Add detail-view assertions for representative mappings.
+
+Scope:
+
+- `opportunity ingestion` in `sfdc-to-snowflake/pipeline.stm`:
+  - expected source schemas and target schema
+  - expected arrow rows (`amount_usd`, `arr_value`, `pipeline_stage`,
+    `is_closed`, `ingested_at`)
+  - computed arrows and map transform
+  - transform text and highlighted `@ref` spans
+- one namespaced mapping in `namespaces/ns-platform.stm`:
+  - namespace label
+  - qualified source and target names
+  - detail column ordering
+- `completed orders` in `filter-flatten-governance.stm`:
+  - multiple sources
+  - source join text
+  - mapping note
+  - nested child fields
+  - governance/PII indicators where visible
+- `order line facts` in `filter-flatten-governance.stm`:
+  - `flatten` section row
+  - nested source child fields
+  - target rows `line_number`, `sku`, `quantity`, and `line_total`
+
+Acceptance criteria:
+
+- detail tests verify content inside the detail view, not only that the detail
+  root is visible
+- complex mapping coverage includes nested child records, notes, and sources
+  with joins
+- tests stay fixture-grounded and avoid duplicating VizModel unit tests
+
+PRD reference:
+
+- Scope / Automated Playwright coverage / Mapping detail rendering
+
+### 7. Add field coverage and highlighting tests
+
+Assert the visual contracts that make mapping detail useful.
+
+Scope:
+
+- mapped target fields show mapped coverage indicators
+- unmapped target fields show unmapped coverage indicators
+- hovering an arrow row highlights the matching source and target field rows
+- hovering a source field highlights the arrow row and mapped target field
+- hovering a target field highlights upstream source fields
+- nested field paths are matched by dotted path, not only leaf field name
+
+Acceptance criteria:
+
+- at least one non-nested mapping and one nested mapping are covered
+- field coverage indicators are asserted through stable selectors or attributes
+- hover assertions validate visible state, not only event-log entries
+
+PRD reference:
+
+- Scope / Automated Playwright coverage / Field coverage and highlighting
+
+### 8. Add filter and lineage-mode tests
+
+Cover toolbar filtering and import-reachable model differences.
+
+Scope:
+
+- namespace filter on `ns-platform.stm`:
+  - select one namespace such as `mart`
+  - assert unrelated namespace cards are hidden
+  - reset to all namespaces
+- file filter on `metrics-platform/metrics.stm` in lineage mode:
+  - show all files
+  - select `metrics.stm`
+  - select `metric_sources.stm`
+  - reset to all files
+- single-file vs lineage mode:
+  - assert an imported-source card appears only in lineage mode for a chosen
+    fixture
+
+Acceptance criteria:
+
+- filters are exercised through real toolbar controls
+- tests wait on the viz ready state after each filter/mode transition
+- assertions are based on visible cards and mapping nodes
+
+PRD reference:
+
+- Scope / Automated Playwright coverage / Filters and lineage mode
+
+### 9. Add geometry sanity helpers and tests
+
+Create reusable Playwright helpers for layout sanity assertions.
+
+Scope:
+
+- read positioned-card bounding boxes from the viz shadow root
+- assert positive dimensions and finite coordinates
+- assert small-fixture cards do not overlap beyond a small tolerance
+- assert overview mapping nodes sit horizontally between source and target
+  schema cards
+- assert detail columns are ordered source -> mapping -> target
+- assert cards fit within the canvas bounds for the tested viewport
+- assert namespace card content is not clipped by namespace-pill height
+
+Acceptance criteria:
+
+- geometry helpers are reusable and documented in the test file
+- geometry tests avoid exact ELK coordinates
+- at least one non-namespaced, one namespaced, one metrics/report, and one
+  complex fixture are covered
+
+PRD reference:
+
+- Scope / Automated Playwright coverage / Geometry sanity
+
+### 10. Add screenshot review workflow
+
+Add a deterministic screenshot script or Playwright project that emits named
+review artifacts and a manifest.
+
+Scope:
+
+- capture the required PRD screenshot list:
+  - `sfdc-overview-single.png`
+  - `sfdc-detail-opportunity-ingestion.png`
+  - `namespaces-overview-lineage.png`
+  - `namespaces-detail-namespaced-mapping.png`
+  - `metrics-overview-lineage-all-files.png`
+  - `metrics-overview-file-filter-sources.png`
+  - `reports-overview.png`
+  - `filter-flatten-detail-completed-orders.png`
+  - `filter-flatten-detail-order-line-facts.png`
+  - `sap-po-layout-stability.png`
+- write `screenshots/manifest.json` with fixture path, view mode, UI state,
+  viewport, timestamp, and test/script step name
+- keep screenshot artifacts out of normal source control unless a later ticket
+  deliberately adds curated reference images
+- document how a human should mark up screenshots and feed them back to a VLM
+  as visual requirements
+
+Acceptance criteria:
+
+- screenshot workflow can run through the local watcher or a documented package
+  script
+- generated file names are deterministic
+- screenshots are review artifacts, not golden pass/fail baselines
+
+PRD reference:
+
+- Scope / Screenshot artifacts for human and VLM review
+- Acceptance Criteria 8 and 9
+
+### 11. Update harness docs
+
+Update developer-facing documentation for the expanded suite.
+
+Scope:
+
+- update README viz harness section or add a package-level harness README
+- document the existing sentinel watcher workflow with absolute-path reminder
+- document the fixture matrix and why each fixture exists in the suite
+- document screenshot output directory and manifest shape
+- clarify that Playwright remains local-only and not part of GitHub Actions
+
+Acceptance criteria:
+
+- a contributor can run the tests and screenshot workflow from docs alone
+- docs distinguish automated assertions from human-review screenshots
+- docs mention the known browser limitation that keeps Firefox as the default
+  local browser target
+
+PRD reference:
+
+- Scope / Documentation and workflow
+- Non-Goals
+
+### 12. Verification and cleanup
+
+Run the relevant package checks and close any incidental breakage introduced by
+the expanded suite.
+
+Scope:
+
+- run `npm --prefix tooling/satsuma-viz run test`
+- run `npm --prefix tooling/satsuma-viz-backend run test`
+- run `npm --prefix tooling/satsuma-viz-harness run build`
+- run Playwright through the existing sentinel watcher workflow
+- inspect screenshot artifacts manually before closing the feature
+- update TODO checkboxes and ticket notes with root cause/fix summaries as
+  tasks complete
+
+Acceptance criteria:
+
+- all relevant automated tests pass locally
+- Playwright result output is captured in `.playwright-results.txt`
+- screenshot artifacts and manifest exist for the required review states
+- no unrelated generated artifacts are staged
+
+PRD reference:
+
+- Acceptance Criteria 10
+
+## Suggested Dependency Order
+
+1. Audit current harness coverage and selector gaps
+2. Fix the harness event recorder contract
+3. Add renderer test hooks for mapping detail and field coverage
+4. Replace synthetic event tests with real interaction tests
+5. Expand overview coverage across fixture families
+6. Add mapping detail coverage for canonical mappings
+7. Add field coverage and highlighting tests
+8. Add filter and lineage-mode tests
+9. Add geometry sanity helpers and tests
+10. Add screenshot review workflow
+11. Update harness docs
+12. Verification and cleanup
+
+Tasks 5 through 9 can be parallelized after tasks 2 and 3 land, as long as each
+ticket owns disjoint test cases or coordinates shared helper changes explicitly.


### PR DESCRIPTION
## Summary
- Add Feature 30 PRD for expanding viz harness coverage around real browser interactions, fixture families, geometry sanity checks, and screenshot review artifacts.
- Add Feature 30 TODO with ticket-sized implementation tasks and link it to new epic ticket sl-0jva.

## Verification
- node_modules/.bin/markdownlint-cli2 features/30-viz-test-suite-expansion/PRD.md features/30-viz-test-suite-expansion/TODO.md