### PR TITLE
Feature 30: viz test hook foundations

### DIFF
--- a/.tickets/sl-eikr.md
+++ b/.tickets/sl-eikr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-eikr
-status: open
+status: closed
 deps: [sl-0ssj]
 links: []
 created: 2026-04-07T17:28:02Z
@@ -24,3 +24,10 @@ Add stable data-testid hooks and state attributes needed for high-value Playwrig
 - [ ] Nested field rows include enough identity to distinguish dotted paths such as customer.email from another email field.
 - [ ] @satsuma/viz package tests are updated where selector rendering is already covered.
 
+
+## Notes
+
+**2026-04-07T22:37:22Z**
+
+Cause: Playwright assertions for mapping detail needed stable selectors plus disambiguation across source vs target schemas, nested field paths, and nested each/flatten arrows.
+Fix: Distinct testIdPrefix for source/target schema-cards in sz-mapping-detail, column test ids, section-prefixed arrow row ids, each/flatten section ids, dotted-path field ids and data-coverage attribute in sz-schema-card; added viz tests.

--- a/.tickets/sl-tzx6.md
+++ b/.tickets/sl-tzx6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-tzx6
-status: open
+status: in_progress
 deps: [sl-0ssj]
 links: []
 created: 2026-04-07T17:28:01Z

--- a/.tickets/sl-tzx6.md
+++ b/.tickets/sl-tzx6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-tzx6
-status: in_progress
+status: closed
 deps: [sl-0ssj]
 links: []
 created: 2026-04-07T17:28:01Z
@@ -16,10 +16,16 @@ Update the harness recorder so window.__satsumaHarness.events captures the produ
 
 ## Acceptance Criteria
 
-- [ ] A real schema or field click records a navigate event with non-empty URI and numeric line/character position.
-- [ ] A real field-lineage button click records schema ID and field name.
-- [ ] Hovering a real field row records field-hover with schema ID and field name, and hover leave is represented consistently when asserted.
-- [ ] open-mapping, expand-lineage, and export payloads are normalized where covered by the suite.
-- [ ] Existing harness event-log consumers still read a stable JSON object shape.
-- [ ] Synthetic CustomEvent.detail support is either covered at recorder-helper level or removed from the main Playwright path with rationale.
+- [x] A real schema or field click records a navigate event with non-empty URI and numeric line/character position.
+- [x] A real field-lineage button click records schema ID and field name.
+- [x] Hovering a real field row records field-hover with schema ID and field name, and hover leave is represented consistently when asserted.
+- [x] open-mapping, expand-lineage, and export payloads are normalized where covered by the suite.
+- [x] Existing harness event-log consumers still read a stable JSON object shape.
+- [x] Synthetic CustomEvent.detail support is either covered at recorder-helper level or removed from the main Playwright path with rationale.
 
+
+## Notes
+
+**2026-04-07T18:18:42Z**
+
+Cause: The harness recorded CustomEvent.detail directly, but production @satsuma/viz events carry navigate, hover, lineage, and mapping payloads on event instance properties. Fix: Added harness-side event normalization for production event properties while preserving supported CustomEvent payloads, then upgraded harness tests to assert normalized payloads from real UI interactions where existing selectors allow it. (commit e168c4d)

--- a/tooling/satsuma-viz-harness/src/client/app.ts
+++ b/tooling/satsuma-viz-harness/src/client/app.ts
@@ -29,6 +29,32 @@ interface Fixture {
   uri: string;
 }
 
+/** Source location payload emitted when the viz asks an editor to navigate. */
+interface HarnessSourceLocation {
+  uri: string;
+  line: number;
+  character: number;
+}
+
+/** Stable field identity used by hover and lineage interactions. */
+interface HarnessFieldPayload {
+  schemaId: string;
+  fieldName: string | null;
+}
+
+/** Stable mapping identity recorded when the overview asks to open detail. */
+interface HarnessMappingPayload {
+  id: string;
+  sourceRefs: string[];
+  targetRef: string;
+}
+
+/** SVG export payload emitted from the viz toolbar. */
+interface HarnessExportPayload {
+  format: string;
+  content: string;
+}
+
 /**
  * A recorded interaction event emitted by the viz component.
  * Playwright tests assert against this log to verify that specific user
@@ -212,12 +238,134 @@ let vizEl: HTMLElement | null = null;
 /** Mirror of the viz element's data-ready-state attribute. */
 let vizReadyState = "empty";
 
+// ---------- Event normalization ----------
+
 /**
- * Record a viz interaction event in the harness log and update the ready flag.
+ * Return true when a value can be inspected as a plain object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * Read a nested CustomEvent.detail object only when the event is still using
+ * the older synthetic contract. Production viz events store payload fields on
+ * the Event instance itself.
+ */
+function customEventDetail(event: Event): unknown {
+  return "detail" in event ? (event as CustomEvent<unknown>).detail : undefined;
+}
+
+/**
+ * Normalize a source-location-like value into the JSON shape Playwright tests
+ * assert against.
+ */
+function normalizeLocation(value: unknown): HarnessSourceLocation | null {
+  if (!isRecord(value)) return null;
+  const uri = value["uri"];
+  const line = value["line"];
+  const character = value["character"];
+  if (typeof uri !== "string" || typeof line !== "number" || typeof character !== "number") {
+    return null;
+  }
+  return { uri, line, character };
+}
+
+/**
+ * Normalize navigate events from production SzNavigateEvent.location while
+ * preserving detail compatibility for narrow recorder-level tests.
+ */
+function normalizeNavigateEvent(event: Event): HarnessSourceLocation | null {
+  if ("location" in event) {
+    return normalizeLocation((event as Event & { location?: unknown }).location);
+  }
+  const detail = customEventDetail(event);
+  if (isRecord(detail) && "location" in detail) return normalizeLocation(detail["location"]);
+  return normalizeLocation(detail);
+}
+
+/**
+ * Normalize field identity from production event properties first, then from
+ * CustomEvent.detail for compatibility with legacy synthetic recorder tests.
+ */
+function normalizeFieldEvent(event: Event): HarnessFieldPayload | null {
+  const source = ("schemaId" in event || "fieldName" in event)
+    ? event as Event & { schemaId?: unknown; fieldName?: unknown }
+    : customEventDetail(event);
+  if (!isRecord(source)) return null;
+  const schemaId = source["schemaId"];
+  const fieldName = source["fieldName"];
+  if (typeof schemaId !== "string") return null;
+  if (fieldName !== null && typeof fieldName !== "string") return null;
+  return { schemaId, fieldName };
+}
+
+/**
+ * Normalize mapping identity from production SzOpenMappingEvent.mapping, with
+ * detail compatibility for any remaining synthetic recorder checks.
+ */
+function normalizeOpenMappingEvent(event: Event): HarnessMappingPayload | null {
+  const detail = customEventDetail(event);
+  const source = "mapping" in event
+    ? (event as Event & { mapping?: unknown }).mapping
+    : isRecord(detail) && "mapping" in detail
+      ? detail["mapping"]
+      : detail;
+  if (!isRecord(source)) return null;
+  const id = source["id"];
+  const sourceRefs = source["sourceRefs"];
+  const targetRef = source["targetRef"];
+  if (typeof id !== "string" || !Array.isArray(sourceRefs) || typeof targetRef !== "string") {
+    return null;
+  }
+  const normalizedSourceRefs = sourceRefs.filter((value): value is string => typeof value === "string");
+  if (normalizedSourceRefs.length !== sourceRefs.length) return null;
+  return { id, sourceRefs: normalizedSourceRefs, targetRef };
+}
+
+/**
+ * Normalize expand-lineage events from production SzExpandLineageEvent.schemaId
+ * while preserving the legacy detail object shape.
+ */
+function normalizeExpandLineageEvent(event: Event): { schemaId: string } | null {
+  const source = "schemaId" in event
+    ? event as Event & { schemaId?: unknown }
+    : customEventDetail(event);
+  if (!isRecord(source)) return null;
+  const schemaId = source["schemaId"];
+  return typeof schemaId === "string" ? { schemaId } : null;
+}
+
+/**
+ * Normalize SVG export CustomEvent.detail. Export intentionally remains a
+ * CustomEvent because the payload is generated inside the viz toolbar handler.
+ */
+function normalizeExportEvent(event: Event): HarnessExportPayload | null {
+  const detail = customEventDetail(event);
+  if (!isRecord(detail)) return null;
+  const format = detail["format"];
+  const content = detail["content"];
+  if (typeof format !== "string" || typeof content !== "string") return null;
+  return { format, content };
+}
+
+/**
+ * Record a viz interaction event in the harness log.
  * Called from the event handlers attached to the viz element.
  */
 function recordEvent(type: string, detail: unknown): void {
   harness.events.push({ type, detail, timestamp: Date.now() });
+}
+
+/**
+ * Record the normalized JSON payload expected by Playwright assertions.
+ * A null payload is retained when an event shape is invalid so test failures
+ * expose the recorder mismatch instead of silently dropping the interaction.
+ */
+function recordNormalizedEvent(type: string, event: Event, normalize: (event: Event) => unknown): unknown {
+  const detail = normalize(event);
+  recordEvent(type, detail);
+  return detail;
 }
 
 /**
@@ -253,27 +401,29 @@ function ensureVizElement(): HTMLElement {
 
   // Record all interaction events for Playwright assertion.
   el.addEventListener("navigate", (e) => {
-    recordEvent("navigate", (e as CustomEvent).detail);
+    recordNormalizedEvent("navigate", e, normalizeNavigateEvent);
   });
   el.addEventListener("field-hover", (e) => {
-    recordEvent("field-hover", (e as CustomEvent).detail);
+    recordNormalizedEvent("field-hover", e, normalizeFieldEvent);
   });
   el.addEventListener("expand-lineage", (e) => {
-    const detail = (e as CustomEvent).detail as { schemaId?: string };
-    recordEvent("expand-lineage", detail);
+    const detail = recordNormalizedEvent("expand-lineage", e, normalizeExpandLineageEvent);
     // When the user requests lineage expansion from within the viz, switch to
     // the lineage view for the current fixture so the full cross-file model loads.
-    if (harness.fixture && harness.viewMode !== "lineage") {
+    if (detail && harness.fixture && harness.viewMode !== "lineage") {
       setViewMode("lineage");
-    } else if (harness.fixture) {
+    } else if (detail && harness.fixture) {
       void loadFixture(harness.fixture);
     }
   });
   el.addEventListener("field-lineage", (e) => {
-    recordEvent("field-lineage", (e as CustomEvent).detail);
+    recordNormalizedEvent("field-lineage", e, normalizeFieldEvent);
   });
   el.addEventListener("open-mapping", (e) => {
-    recordEvent("open-mapping", (e as CustomEvent).detail);
+    recordNormalizedEvent("open-mapping", e, normalizeOpenMappingEvent);
+  });
+  el.addEventListener("export", (e) => {
+    recordNormalizedEvent("export", e, normalizeExportEvent);
   });
 
   // Clear the placeholder and mount the element.

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -93,6 +93,28 @@ async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
   );
 }
 
+/**
+ * Return recorded harness events of a specific type.
+ * The function is intentionally small so event payload assertions stay
+ * focused on the user interaction each test performs.
+ */
+async function recordedEvents(page: Page, type: string): Promise<HarnessEvent[]> {
+  return page.evaluate(
+    (eventType) => window.__satsumaHarness.events.filter((event) => event.type === eventType),
+    type,
+  );
+}
+
+/**
+ * Open the first overview mapping card and wait for the mapping detail view.
+ */
+async function openFirstMappingDetail(page: Page): Promise<void> {
+  await page.locator("[data-testid^='overview-mapping-card-']").first().click();
+  await expect(page.locator("[data-testid^='mapping-detail-']").first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
 // ---------- Tests ----------
 
 test.describe("Overview view — sfdc-to-snowflake fixture", () => {
@@ -151,35 +173,18 @@ test.describe("Hover and highlight interaction", () => {
   test("field-hover events from the viz are captured in the harness event log", async ({
     page,
   }) => {
-    // Validates that SzFieldHoverEvent — dispatched by the viz when the user
-    // hovers a field row in a schema card — is forwarded to the harness and
-    // becomes observable in window.__satsumaHarness.events.
-    //
-    // We dispatch the event programmatically rather than via DOM hover because
-    // detail-view schema cards live inside a multi-level shadow DOM
-    // (satsuma-viz → sz-mapping-detail → sz-schema-card) that Playwright's CSS
-    // locators cannot pierce to the required depth.  The test validates the
-    // harness event pipeline, not the hover mechanics in the viz component itself.
+    // A real field hover exercises the production SzFieldHoverEvent path and
+    // proves the harness normalizes schemaId/fieldName from event properties.
+    await openFirstMappingDetail(page);
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
 
-    await page.evaluate(() => {
-      const viz = document.querySelector("satsuma-viz");
-      if (viz) {
-        viz.dispatchEvent(
-          new CustomEvent("field-hover", {
-            bubbles: true,
-            composed: true,
-            detail: { schemaId: "Account", fieldName: "id" },
-          }),
-        );
-      }
-    });
+    await page.locator("[data-testid='schema-card-field-id']").first().hover();
 
-    await page.waitForTimeout(300);
-    const events = await page.evaluate(() => window.__satsumaHarness.events);
-    const hoverEvents = events.filter((e) => e.type === "field-hover");
-    // The harness must have captured the dispatched field-hover event.
-    expect(hoverEvents.length).toBeGreaterThan(0);
+    await expect.poll(async () => recordedEvents(page, "field-hover")).toContainEqual(
+      expect.objectContaining({
+        detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
+      }),
+    );
   });
 });
 
@@ -204,40 +209,27 @@ test.describe("Cross-file lineage expansion", () => {
   test("expand-lineage events from the viz are captured in the harness event log", async ({
     page,
   }) => {
-    // Verify that SzExpandLineageEvent — dispatched by the viz component when a
-    // user requests cross-file lineage expansion — is captured by the harness
-    // and becomes observable in window.__satsumaHarness.events.
-    //
-    // We dispatch the event programmatically rather than via a specific UI
-    // interaction because the expand-lineage trigger element varies across fixture
-    // files and view modes.  The test validates the harness event pipeline, not
-    // the particular UI surface that triggers it in the production component.
+    // The current fixture does not expose a stable expand-lineage control yet,
+    // so this remains a recorder-level compatibility test.  It uses a
+    // production-shaped Event property rather than CustomEvent.detail.
     await page.goto("/");
     await page.locator(".toggle-btn[data-mode='single']").click();
     await loadFixture(page, metricsUri);
 
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
 
-    // Dispatch a synthetic expand-lineage event from the <satsuma-viz> element,
-    // matching the shape that SzExpandLineageEvent produces.
     await page.evaluate(() => {
       const viz = document.querySelector("satsuma-viz");
       if (viz) {
-        viz.dispatchEvent(
-          new CustomEvent("expand-lineage", {
-            bubbles: true,
-            composed: true,
-            detail: { schemaId: "test::schema" },
-          }),
-        );
+        const event = new Event("expand-lineage", { bubbles: true, composed: true });
+        Object.defineProperty(event, "schemaId", { value: "test::schema" });
+        viz.dispatchEvent(event);
       }
     });
 
-    await page.waitForTimeout(300);
-    const events = await page.evaluate(() => window.__satsumaHarness.events);
-    const lineageEvents = events.filter((e) => e.type === "expand-lineage");
-    // The harness must have captured the event and recorded it.
-    expect(lineageEvents.length).toBeGreaterThan(0);
+    await expect.poll(async () => recordedEvents(page, "expand-lineage")).toContainEqual(
+      expect.objectContaining({ detail: { schemaId: "test::schema" } }),
+    );
   });
 });
 
@@ -251,35 +243,57 @@ test.describe("Navigation intent", () => {
   test("navigate events from the viz are captured in the harness event log", async ({
     page,
   }) => {
-    // Validates that SzNavigateEvent — dispatched by the viz when the user clicks
-    // a source-location link on a schema card or field label — is forwarded to the
-    // harness and becomes observable in window.__satsumaHarness.events.
-    //
-    // We dispatch the event programmatically rather than by clicking a DOM element
-    // because source-link targets live inside a multi-level shadow DOM
-    // (satsuma-viz → sz-mapping-detail → sz-schema-card) that Playwright's CSS
-    // locators cannot pierce to the required depth.  The test validates the
-    // harness event pipeline, not the click mechanics in the viz component itself.
+    // A real overview schema-header click dispatches SzNavigateEvent with a
+    // SourceLocation property; the harness must normalize it to stable JSON.
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
 
-    await page.evaluate(() => {
-      const viz = document.querySelector("satsuma-viz");
-      if (viz) {
-        viz.dispatchEvent(
-          new CustomEvent("navigate", {
-            bubbles: true,
-            composed: true,
-            detail: { uri: "file:///test.stm", line: 1, character: 0 },
-          }),
-        );
-      }
-    });
+    await page.locator("[data-testid='overview-schema-card-sfdc-opportunity']").click();
 
-    await page.waitForTimeout(300);
-    const events = await page.evaluate(() => window.__satsumaHarness.events);
-    const navEvents = events.filter((e) => e.type === "navigate");
-    // The harness must have captured the dispatched navigate event.
-    expect(navEvents.length).toBeGreaterThan(0);
+    await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          uri: expect.stringContaining("sfdc-to-snowflake/pipeline.stm"),
+          line: expect.any(Number),
+          character: expect.any(Number),
+        }),
+      }),
+    );
+  });
+
+  test("field-lineage events from the viz are captured in the harness event log", async ({
+    page,
+  }) => {
+    // A real field-lineage button click dispatches SzFieldLineageEvent with
+    // field identity properties that the harness must preserve as JSON.
+    await openFirstMappingDetail(page);
+    await page.evaluate(() => window.__satsumaHarness.clearEvents());
+
+    const fieldRow = page.locator("[data-testid='schema-card-field-id']").first();
+    await fieldRow.hover();
+    await fieldRow.locator("[data-testid='schema-card-field-id-lineage']").click();
+
+    await expect.poll(async () => recordedEvents(page, "field-lineage")).toContainEqual(
+      expect.objectContaining({
+        detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
+      }),
+    );
+  });
+
+  test("export events from the viz are captured in the harness event log", async ({ page }) => {
+    // A real toolbar export click emits SVG content through CustomEvent.detail;
+    // the recorder should preserve that supported CustomEvent payload shape.
+    await page.evaluate(() => window.__satsumaHarness.clearEvents());
+
+    await page.locator("[data-testid='toolbar-export']").click();
+
+    await expect.poll(async () => recordedEvents(page, "export")).toContainEqual(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          format: "svg",
+          content: expect.stringContaining("<svg"),
+        }),
+      }),
+    );
   });
 });
 

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -519,9 +519,15 @@ export class SzMappingDetail extends LitElement {
     const sourceHL = this._sourceHighlightFields;
     const targetHL = this._targetHighlightFields;
 
+    // Distinct test-id prefixes for source vs target schema cards keep
+    // Playwright selectors unambiguous when the same schema id appears as both
+    // a source somewhere and a target elsewhere (sl-eikr).
+    const sourcePrefix = `${this.testIdPrefix}-source-schema-card`;
+    const targetPrefix = `${this.testIdPrefix}-target-schema-card`;
+
     return html`
       <div class="layout" data-testid=${this.testIdPrefix}>
-        <div class="column">
+        <div class="column" data-testid=${`${this.testIdPrefix}-source-column`}>
           <div class="column-header">Sources</div>
           ${this.sourceSchemas.map((s) => html`
             <sz-schema-card
@@ -529,18 +535,19 @@ export class SzMappingDetail extends LitElement {
               .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
               .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
               highlightColor="source"
+              test-id-prefix=${`${sourcePrefix}-${sanitizeTestIdSegment(s.qualifiedId)}`}
               content-width
             ></sz-schema-card>
           `)}
         </div>
 
-        <div class="column">
+        <div class="column" data-testid=${`${this.testIdPrefix}-mapping-column`}>
           <div class="column-header">Mapping</div>
           ${this._renderMappingHeader(m)}
           ${this._renderArrowTable(m)}
         </div>
 
-        <div class="column">
+        <div class="column" data-testid=${`${this.testIdPrefix}-target-column`}>
           <div class="column-header">Target</div>
           ${this.targetSchema
             ? html`<sz-schema-card
@@ -548,6 +555,7 @@ export class SzMappingDetail extends LitElement {
                 .mappedFields=${this.targetMappedFields}
                 .highlightFields=${targetHL}
                 highlightColor="target"
+                test-id-prefix=${`${targetPrefix}-${sanitizeTestIdSegment(this.targetSchema.qualifiedId)}`}
                 content-width
               ></sz-schema-card>`
             : nothing}
@@ -611,24 +619,29 @@ export class SzMappingDetail extends LitElement {
             </tr>
           </thead>
           <tbody>
-            ${m.arrows.map((a) => this._renderArrowRow(a))}
-            ${m.eachBlocks.map((eb) => this._renderEachSection(eb))}
-            ${m.flattenBlocks.map((fb) => this._renderFlattenSection(fb))}
+            ${m.arrows.map((a) => this._renderArrowRow(a, ""))}
+            ${m.eachBlocks.map((eb) => this._renderEachSection(eb, ""))}
+            ${m.flattenBlocks.map((fb) => this._renderFlattenSection(fb, ""))}
           </tbody>
         </table>
       </div>
     `;
   }
 
-  private _renderArrowRow(a: ArrowEntry): TemplateResult {
+  // sectionPrefix disambiguates arrow rows that share a target field across
+  // nested each/flatten sections (sl-eikr). Empty string for top-level rows.
+  private _renderArrowRow(a: ArrowEntry, sectionPrefix: string): TemplateResult {
     const hl = this._isArrowHighlighted(a) ? "hl" : "";
     const noteEntry = a.metadata.find((m) => m.key === "note");
     const targetId = sanitizeTestIdSegment(a.targetField);
+    const rowTestId = sectionPrefix
+      ? `${this.testIdPrefix}-arrow-row-${sectionPrefix}-${targetId}`
+      : `${this.testIdPrefix}-arrow-row-${targetId}`;
 
     return html`
       <tr
         class="arrow-row ${hl}"
-        data-testid=${`${this.testIdPrefix}-arrow-row-${targetId}`}
+        data-testid=${rowTestId}
         @click=${() => this._navigate(a.location)}
         @mouseenter=${() => { this._hoveredArrow = a; this._hoveredCardField = null; }}
         @mouseleave=${() => { this._hoveredArrow = null; }}
@@ -645,7 +658,10 @@ export class SzMappingDetail extends LitElement {
         <td><span class="field-ref">${a.targetField}</span></td>
       </tr>
       ${noteEntry
-        ? html`<tr class="arrow-note-row"><td colspan="4"><span class="arrow-note">${unsafeHTML(highlightAtRefs(noteEntry.value))}</span></td></tr>`
+        ? html`<tr
+            class="arrow-note-row"
+            data-testid=${`${rowTestId}-note`}
+          ><td colspan="4"><span class="arrow-note">${unsafeHTML(highlightAtRefs(noteEntry.value))}</span></td></tr>`
         : ""}
     `;
   }
@@ -661,9 +677,14 @@ export class SzMappingDetail extends LitElement {
     return html`<span class="transform-nl">${unsafeHTML(highlightAtRefs(t.text))}</span>`;
   }
 
-  private _renderEachSection(eb: EachBlock): TemplateResult {
+  private _renderEachSection(eb: EachBlock, parentPrefix: string): TemplateResult {
+    const sectionId = sanitizeTestIdSegment(`each-${eb.targetField}`);
+    const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
     return html`
-      <tr class="scope-section">
+      <tr
+        class="scope-section"
+        data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}
+      >
         <td colspan="4">
           <div class="scope-label">
             <span class="scope-tag">each</span>
@@ -671,14 +692,19 @@ export class SzMappingDetail extends LitElement {
           </div>
         </td>
       </tr>
-      ${eb.arrows.map((a) => this._renderArrowRow(a))}
-      ${eb.nestedEach.map((ne) => this._renderEachSection(ne))}
+      ${eb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix))}
+      ${eb.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix))}
     `;
   }
 
-  private _renderFlattenSection(fb: FlattenBlock): TemplateResult {
+  private _renderFlattenSection(fb: FlattenBlock, parentPrefix: string): TemplateResult {
+    const sectionId = sanitizeTestIdSegment(`flatten-${fb.sourceField}`);
+    const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
     return html`
-      <tr class="scope-section">
+      <tr
+        class="scope-section"
+        data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}
+      >
         <td colspan="4">
           <div class="scope-label">
             <span class="scope-tag">flatten</span>
@@ -686,7 +712,7 @@ export class SzMappingDetail extends LitElement {
           </div>
         </td>
       </tr>
-      ${fb.arrows.map((a) => this._renderArrowRow(a))}
+      ${fb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix))}
     `;
   }
 

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -551,8 +551,12 @@ export class SzSchemaCard extends LitElement {
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
     return html`
-      <div class="notes-section">
-        <div class="notes-toggle" @click=${this._toggleNotes}>
+      <div class="notes-section" data-testid=${`${this.testIdPrefix}-notes`}>
+        <div
+          class="notes-toggle"
+          data-testid=${`${this.testIdPrefix}-notes-toggle`}
+          @click=${this._toggleNotes}
+        >
           <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
           <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
         </div>
@@ -578,12 +582,16 @@ export class SzSchemaCard extends LitElement {
     const hlClass = isHighlighted
       ? `hl ${this.highlightColor === "target" ? "hl-target" : "hl-source"}`
       : "";
-    const fieldTestId = `${this.testIdPrefix}-field-${sanitizeTestIdSegment(f.name)}`;
+    // Use the dotted path so nested customer.email is distinguishable from a
+    // sibling top-level email field (sl-eikr).
+    const fieldTestId = `${this.testIdPrefix}-field-${sanitizeTestIdSegment(fieldPath)}`;
+    const coverageState = isMapped ? "mapped" : "unmapped";
 
     return html`
       <div
         class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         data-testid=${fieldTestId}
+        data-coverage=${coverageState}
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
         @mouseenter=${() => this._onFieldHover(fieldPath)}

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -51,6 +51,89 @@ describe("viz automation helpers", () => {
     );
   });
 
+  it("uses the dotted field path in nested field test ids and exposes coverage state", async () => {
+    // Nested fields like customer.email must be selectable separately from a
+    // sibling top-level email field, and Playwright should be able to assert
+    // mapped vs unmapped state via a stable attribute (sl-eikr).
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-customers";
+    card.mappedFields = new Set(["customer.email"]);
+    const child = {
+      name: "email",
+      type: "STRING",
+      constraints: [],
+      notes: [],
+      comments: [],
+      children: [],
+      location: { uri: "file:///t.stm", line: 2, character: 0 },
+    };
+    const parent = {
+      name: "customer",
+      type: "STRUCT",
+      constraints: [],
+      notes: [],
+      comments: [],
+      children: [child],
+      location: { uri: "file:///t.stm", line: 1, character: 0 },
+    };
+    const childTpl = card._renderField(child, 1, "customer");
+    const serialized = [...childTpl.strings, ...childTpl.values.map(String)].join(" ");
+    assert.match(serialized, /src-customers-field-customer-email/);
+    assert.match(serialized, /data-coverage/);
+    assert.match(serialized, /mapped/);
+    // The parent struct must not collide with a top-level "email" segment.
+    assert.ok(!/src-customers-field-email[^-]/.test(serialized));
+  });
+
+  it("gives mapping-detail source and target schema cards distinct testIdPrefix values", async () => {
+    // Source and target schema cards in the mapping detail must be addressable
+    // separately even when the same schema id appears on both sides (sl-eikr).
+    const mod = await import("../dist/satsuma-viz.js");
+    const detail = new mod.SzMappingDetail();
+    const schema = {
+      id: "customers",
+      qualifiedId: "crm::customers",
+      kind: "schema",
+      label: null,
+      fields: [],
+      notes: [],
+      comments: [],
+      metadata: [],
+      location: { uri: "file:///t.stm", line: 0, character: 0 },
+      hasExternalLineage: false,
+      spreads: [],
+    };
+    detail.mapping = {
+      id: "m1",
+      sourceRefs: ["crm::customers"],
+      targetRef: "crm::customers",
+      sourceBlock: null,
+      arrows: [],
+      eachBlocks: [],
+      flattenBlocks: [],
+      metadata: [],
+      location: { uri: "file:///t.stm", line: 0, character: 0 },
+    };
+    detail.sourceSchemas = [schema];
+    detail.targetSchema = schema;
+    const tpl = detail.render();
+    const serialize = (t) => {
+      if (t == null || typeof t !== "object") return String(t ?? "");
+      if (Array.isArray(t)) return t.map(serialize).join(" ");
+      if (t.strings && t.values) {
+        return [...t.strings, ...t.values.map(serialize)].join(" ");
+      }
+      return "";
+    };
+    const serialized = serialize(tpl);
+    assert.match(serialized, /mapping-detail-source-column/);
+    assert.match(serialized, /mapping-detail-mapping-column/);
+    assert.match(serialized, /mapping-detail-target-column/);
+    assert.match(serialized, /mapping-detail-source-schema-card-crm-customers/);
+    assert.match(serialized, /mapping-detail-target-schema-card-crm-customers/);
+  });
+
   it("renders stable selector markers into the schema-card template", async () => {
     const mod = await import("../dist/satsuma-viz.js");
     const schemaCard = new mod.SzSchemaCard();

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -68,15 +68,6 @@ describe("viz automation helpers", () => {
       children: [],
       location: { uri: "file:///t.stm", line: 2, character: 0 },
     };
-    const parent = {
-      name: "customer",
-      type: "STRUCT",
-      constraints: [],
-      notes: [],
-      comments: [],
-      children: [child],
-      location: { uri: "file:///t.stm", line: 1, character: 0 },
-    };
     const childTpl = card._renderField(child, 1, "customer");
     const serialized = [...childTpl.strings, ...childTpl.values.map(String)].join(" ");
     assert.match(serialized, /src-customers-field-customer-email/);


### PR DESCRIPTION
## Summary
- Adds renderer test hooks across `sz-mapping-detail` and `sz-schema-card` (sl-eikr): distinct source/target schema-card prefixes, stable column ids, section-prefixed arrow row ids for nested each/flatten, dotted-path field ids, and a `data-coverage` attribute on field rows.
- Normalizes viz harness event payloads and closes the event recorder ticket (sl-tzx6).
- Audits and breaks down the Feature 30 viz Playwright test backlog and consolidates the tooling architecture docs (sl-wrhz).

## Test plan
- [x] \`npm test\` in \`tooling/satsuma-viz\` (43/43 passing, includes new selector tests)
- [ ] Downstream Playwright tickets (sl-3c2w, sl-cca6, sl-e80e, sl-j4pw, sl-ny3r, sl-xqd5) consume the new hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)