### PR TITLE
feat(viz): expand compact overview cards on click to reveal fields

### DIFF
--- a/features/30-viz-test-suite-expansion/PRD.md
+++ b/features/30-viz-test-suite-expansion/PRD.md
@@ -126,6 +126,17 @@ The suite should include the following groups.
 - Clicking an arrow row records a navigation event for that arrow's source location.
 - Clicking export records an `export` event and verifies the SVG payload is non-empty, if export remains supported in the harness.
 
+#### Compact card expansion (overview)
+
+Compact schema cards in overview mode are click-to-expand: clicking the card header reveals the schema's fields inline without leaving the overview. This makes the harness useful for presenting schema structure to colleagues — previously clicking a compact card did nothing visible in the harness (though it still dispatches `SzNavigateEvent` for VS Code).
+
+- A compact card shows no field rows on initial load.
+- Clicking the header expands the fields list; clicking again collapses it.
+- Expanding a compact card grows the canvas height so fields are never clipped by the viewport boundary. The canvas height is re-measured from actual positioned-card DOM bounds after each toggle.
+- Expanding a compact card still dispatches a `navigate` event so VS Code integration continues to work.
+
+Implementation: `_compactExpanded` state in `sz-schema-card`; `_overviewCanvasHeight` reactive state in `satsuma-viz` updated on `sz-compact-toggled` event via DOM measurement in `_onCompactToggled()`.
+
 #### Filters and lineage mode
 
 - Namespace filter narrows `ns-platform` to one namespace and hides cards from the others.
@@ -212,6 +223,7 @@ Update the harness docs so contributors know:
     - `npm --prefix tooling/satsuma-viz-backend run test`
     - `npm --prefix tooling/satsuma-viz-harness run build`
     - Playwright via the existing sentinel watcher workflow
+11. Compact card expansion in overview mode is covered by Playwright tests: initial collapsed state, expand on click, collapse on second click, canvas height grows after expansion, `navigate` event fires on expand.
 
 ---
 

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
         "typescript": "^6.0.2"
       }
     },
@@ -37,6 +38,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
         "typescript": "^6.0.2"
       }
     },

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
         "typescript": "^6.0.2"
       }
     },
@@ -43,6 +44,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
         "typescript": "^5.9.3"
       }
     },
@@ -52,6 +54,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
         "typescript": "^6.0.2"
       }
     },

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -64,6 +64,8 @@ let reportsUri: string;
 let sapUri: string;
 /** Filter / flatten / governance fixture — multi-source joins, flatten, notes. */
 let ffgUri: string;
+/** buy-to-om-order contract fixture — used for compact card expansion tests. */
+let buyToOmUri: string;
 
 /**
  * Resolve fixture URIs before tests run.  The harness API serves the full list;
@@ -81,7 +83,9 @@ test.beforeAll(async ({ request }) => {
   const sap = find("sap-po-to-mfcs/pipeline.stm");
   const ffg = find("filter-flatten-governance/filter-flatten-governance.stm");
 
-  if (!sfdc || !metrics || !nsPlatform || !reports || !sap || !ffg) {
+  const buyToOm = find("contracts/buy-to-om-order.stm");
+
+  if (!sfdc || !metrics || !nsPlatform || !reports || !sap || !ffg || !buyToOm) {
     throw new Error("Required fixtures not found in /api/fixtures");
   }
 
@@ -91,6 +95,7 @@ test.beforeAll(async ({ request }) => {
   reportsUri = reports.uri;
   sapUri = sap.uri;
   ffgUri = ffg.uri;
+  buyToOmUri = buyToOm.uri;
 });
 
 /**
@@ -1243,3 +1248,87 @@ test.describe("Geometry sanity — overview layout invariants", () => {
 // single-file vs lineage card-visibility behaviour is tightened, add a
 // describe block here that asserts a specific imported card is hidden in
 // single-file mode and visible in lineage mode.
+
+test.describe("Compact card expansion in overview", () => {
+  // Uses buy-to-om-order.stm: two compact schema cards (buy_order, om_order)
+  // with enough fields to make expansion meaningful.
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.locator(".toggle-btn[data-mode='single']").click();
+    await loadFixture(page, buyToOmUri);
+  });
+
+  test("compact schema card shows no fields initially", async ({ page }) => {
+    // Compact cards in overview mode display only the schema name and a field
+    // count.  The fields list must be absent until the user clicks the header.
+    const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
+    await expect(card).toBeVisible();
+
+    // The fields section is rendered only when _compactExpanded is true.
+    // In the initial state the card renders no field-row elements.
+    const fields = card.locator("[data-testid$='-field-id']");
+    await expect(fields).toHaveCount(0);
+  });
+
+  test("clicking a compact card header expands fields", async ({ page }) => {
+    // A single click on the compact card header must toggle _compactExpanded
+    // and render the fields list below the header.
+    const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
+    await card.locator(".header").click();
+
+    // At least one field row must now appear inside the card.
+    const fields = card.locator("[data-testid$='-field-id']");
+    await expect(fields.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("clicking the compact card header a second time collapses the fields", async ({ page }) => {
+    // Two clicks must return the card to its compact (fields-hidden) state.
+    const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
+    const header = card.locator(".header");
+
+    await header.click();
+    // Fields visible after first click.
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+
+    await header.click();
+    // Fields gone after second click.
+    await expect(card.locator("[data-testid$='-field-id']")).toHaveCount(0);
+  });
+
+  test("expanding a compact card grows the overview canvas height", async ({ page }) => {
+    // When fields expand, _onCompactToggled re-measures the positioned cards
+    // and updates _overviewCanvasHeight.  The canvas element's inline height
+    // style must be larger after expansion than before.
+    const canvas = page.locator(".canvas");
+    const heightBefore = await canvas.evaluate((el) => el.getBoundingClientRect().height);
+
+    const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
+    await card.locator(".header").click();
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+
+    // Wait for the canvas resize to propagate (triggered via updateComplete in _onCompactToggled).
+    await page.waitForTimeout(200);
+    const heightAfter = await canvas.evaluate((el) => el.getBoundingClientRect().height);
+
+    expect(heightAfter).toBeGreaterThan(heightBefore);
+  });
+
+  test("expanding a compact card still fires a navigate event", async ({ page }) => {
+    // Clicking a compact card header both expands the fields and dispatches
+    // SzNavigateEvent so hosts like VS Code can jump to the schema source.
+    await page.evaluate(() => window.__satsumaHarness.clearEvents());
+
+    const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
+    await card.locator(".header").click();
+
+    await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          uri: expect.stringContaining("buy-to-om-order.stm"),
+          line: expect.any(Number),
+        }),
+      }),
+    );
+  });
+});

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -453,6 +453,10 @@ export class SzSchemaCard extends LitElement {
   @state()
   private _collapsed = false;
 
+  /** Whether a compact card has been expanded by the user to reveal its fields. */
+  @state()
+  private _compactExpanded = false;
+
   @state()
   private _notesExpanded = true;
 
@@ -680,9 +684,10 @@ export class SzSchemaCard extends LitElement {
     return html`
       <div>
         ${this._renderNamespacePill()}
-        <div class="header ${isReport ? "report" : ""}" @click=${() => this._navigate(s.location)}>
+        <div class="header ${isReport ? "report" : ""}" @click=${this._onCompactHeaderClick}>
           ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>
+          <span class="header-toggle" ?data-collapsed=${!this._compactExpanded}>&#9660;</span>
           <span class="header-count">${totalFields} fields</span>
         </div>
         ${metaPills.length > 0
@@ -692,8 +697,23 @@ export class SzSchemaCard extends LitElement {
               )}
             </div>`
           : ""}
+        ${this._compactExpanded
+          ? html`<div class="fields">
+              ${s.fields.map((f) => this._renderField(f, 0))}
+            </div>`
+          : ""}
       </div>
     `;
+  }
+
+  private _onCompactHeaderClick() {
+    this._compactExpanded = !this._compactExpanded;
+    this.style.overflow = this._compactExpanded ? "visible" : "";
+    // Notify the parent viz so it can grow the canvas to fit the expanded fields.
+    this.dispatchEvent(new Event("sz-compact-toggled", { bubbles: true, composed: true }));
+    if (this.schema) {
+      this._navigate(this.schema.location);
+    }
   }
 
   private _onHeaderClick() {

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -708,6 +708,10 @@ export class SatsumaViz extends LitElement {
   @state()
   private _overviewLayout: OverviewLayoutResult | null = null;
 
+  /** Canvas height for overview mode — starts at layout height but grows when compact cards expand. */
+  @state()
+  private _overviewCanvasHeight = 0;
+
   @state()
   private _selectedMapping: MappingBlock | null = null;
 
@@ -875,6 +879,7 @@ export class SatsumaViz extends LitElement {
       ]);
       this._layout = detail;
       this._overviewLayout = overview;
+      this._overviewCanvasHeight = overview.height;
     } catch {
       this._layoutError = true;
     }
@@ -1149,6 +1154,21 @@ export class SatsumaViz extends LitElement {
     this._panY = 0;
   }
 
+  /** Grow the overview canvas height to fit any compact cards that have been expanded. */
+  private _onCompactToggled() {
+    // Wait for Lit to re-render the expanded fields before measuring.
+    void this.updateComplete.then(() => {
+      const canvas = this.renderRoot?.querySelector?.(".canvas") as HTMLElement | null;
+      if (!canvas || !this._overviewLayout) return;
+      const cards = Array.from(canvas.querySelectorAll(".positioned-card")) as HTMLElement[];
+      let maxBottom = this._overviewLayout.height;
+      for (const card of cards) {
+        maxBottom = Math.max(maxBottom, card.offsetTop + card.offsetHeight);
+      }
+      this._overviewCanvasHeight = maxBottom;
+    });
+  }
+
   private _fit() {
     const viewport = this.renderRoot?.querySelector?.(".viewport") as HTMLElement | null;
     const canvas = this.renderRoot?.querySelector?.(".canvas") as HTMLElement | null;
@@ -1330,7 +1350,8 @@ export class SatsumaViz extends LitElement {
   /** Render the overview: compact schema cards + thick overview edges. */
   private _renderOverview(overview: OverviewLayoutResult, namespaces: NamespaceGroup[]) {
     return html`
-      <div class="canvas" style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;">
+      <div class="canvas" style="width: ${overview.width + 48}px; height: ${this._overviewCanvasHeight + 48}px; padding: 24px;"
+        @sz-compact-toggled=${this._onCompactToggled}>
         <!-- Overview SVG edge layer (filtered to visible nodes) -->
         <sz-overview-edge-layer
           style="left: 24px; top: 0; z-index: 30;"


### PR DESCRIPTION
## Summary

- Clicking a compact schema card header in the overview now toggles the fields list inline, so users can inspect schema contents without switching to the mapping detail view
- Fixes three nested clipping layers that each needed independent solutions (shadow DOM overflow, fixed canvas height, viewport clipping)
- The `navigate` event still fires on click so VS Code integration is unaffected

## How it works

Three clipping layers each required a separate fix:

1. **`:host { overflow: hidden }` on the card shadow root** — overridden via `this.style.overflow` directly on the element when expanded
2. **Canvas fixed height from layout computation** — replaced with `_overviewCanvasHeight` reactive state, initialised from `overview.height`
3. **`.viewport { overflow: hidden }` clipping the canvas** — solved by growing the canvas to fit expanded cards via DOM re-measurement in `_onCompactToggled()`, triggered by a bubbling `sz-compact-toggled` event dispatched from the card

## Test plan

- [x] 5 new Playwright tests in `harness.test.ts` (compact card expansion describe block):
  - compact card shows no fields initially
  - clicking header expands fields
  - clicking header again collapses fields
  - canvas height grows after expansion
  - navigate event still fires on expand
- [x] All 45 Playwright tests pass (`45 passed (26.3s)`)
- [x] All 43 viz unit tests pass
- [x] Feature 30 PRD updated: compact card expansion documented in Scope §4 and added as acceptance criterion 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)