### PR TITLE
docs(diaries): add entry for 2026-06-04 (v0.8.0 release day)

### DIFF
--- a/satsuma-diaries/.progress.json
+++ b/satsuma-diaries/.progress.json
@@ -1,6 +1,6 @@
 {
-  "last_covered_date": "2026-04-07",
-  "last_entry_file": "satsuma-diaries/2026/04/2026-04-07.md",
-  "rolled_up_days": ["2026-04-03", "2026-04-04", "2026-04-05", "2026-04-06"],
-  "note": "Last entry refreshed: 2026-04-07. Covers four rolled-up quiet days, 53 local commits, late-day merged PR context through #228, and tk ticket context. Next run will cover from 2026-04-08."
+  "last_covered_date": "2026-06-04",
+  "last_entry_file": "satsuma-diaries/2026/06/2026-06-04.md",
+  "rolled_up_days": [],
+  "note": "Last entry written: 2026-06-04 (v0.8.0 release day, EE org migration via Feature 31). Skipped diary coverage for 2026-04-08 through 2026-06-03 — those days were absorbed into the release-day narrative as a brief 'two quiet months' preamble rather than written up as standalone or rollup entries. Next run will cover from 2026-06-05."
 }

--- a/satsuma-diaries/2026/06/2026-06-04.md
+++ b/satsuma-diaries/2026/06/2026-06-04.md
@@ -1,0 +1,36 @@
+# The Satsuma Diaries
+## Thursday, 04 June 2026
+
+> **tl;dr** — Satsuma 0.8.0 shipped, and the project officially has a new home: it's now an Equal Experts open-source thing, on `github.com/EqualExperts/satsuma-lang`. Twelve commits today, two PRs merged, one release tag, one rebrand. After two months of mostly quiet.
+
+Bruv.
+
+I know. I *know*. The last diary entry was the 7th of April. It is now the 4th of June. I am, as the kids say, slightly behind. Look, in my defence: nothing exciting was happening. Dependabot was doing dependabot things. There was a viz harness clean-up. Someone added an Apache Avro convention guide on the 20th of May, which is the sort of thing that is genuinely useful and also impossible to write a diary entry about. May was twelve PRs and most of them were "bump eslint from 10.3.0 to 10.4.0." Allow it.
+
+Then today. Bit different today.
+
+So the big one: **the project is now Equal Experts.** As in, the consultancy. Same Satsuma, same MIT licence, same Thorben, but the home address on GitHub has changed from `thorbenlouw/satsuma-lang` to `EqualExperts/satsuma-lang` and the README now stacks the EE wordmark under the satsuma logo and there's a "Maintained by Equal Experts" section at the bottom. PR #261. Feature 31. The actual transfer on the GitHub side already happened — the org change just made the URLs catch up.
+
+For anyone who's been pulling pre-built CLI tarballs or VS Code extensions from the old URL: GitHub redirects them for now, so nothing's broken today. But the new canonical home is the EE org and the install URLs on the site point there. If you've got a CI job somewhere that's pinned the old URL string, today's the day to update it.
+
+There's one knock-on thing that goes deeper than just URLs. The `satsuma-to-openlineage` skill — that's the one that turns a Satsuma file into OpenLineage events for catalogs like Marquez or DataHub — emits a thing called a `_producer` URL into every event. That URL used to be the `thorbenlouw` one. Now it's the `EqualExperts` one. The catch is: in OpenLineage land, the `_producer` value is a string that downstream consumers might be keying off. So if you're using satsuma-to-openlineage to publish events into Marquez, and you regenerate after this release, your producer string will change. The CHANGELOG flags this loudly. Not a breaking change in the API sense, just one of those things where if you don't tell people they end up confused at 2am on a Wednesday.
+
+The rebrand work itself was pretty mechanical — sed-ing URLs across fifteen-ish files, moving four official EE logo PNGs out of `tmp/` (yes, `tmp/`, where Thorben had been keeping them like loose receipts) into `assets/ee-brand/` with proper names and a README explaining each file. The site got an EE brand mark in the top nav and the tagline "An Equal Experts open-source project" in the footer. No re-skin. The Satsuma orange-and-cream identity stays. EE branding sits alongside it, not on top of it.
+
+There was also a small CI thing. Gitleaks — the secret-scanning action that checks for accidentally committed API keys — recently went and added a license requirement for org-owned repos. The EE org doesn't have a license yet, so the step started failing on every PR with "missing gitleaks license." The fix: gate the step on the license secret being present. If it's not set, skip. If it is, run. Once procurement gets the licence sorted, it re-enables itself without anyone touching the file again. Tracked as `tk 3eb-4vjj` for follow-up.
+
+And then. **Zero point eight point zero.**
+
+PR #262 is the release bump. Bumps the VERSION file, the CLI package, the LSP package, the VS Code extension package. Points the site's version data at the v0.8.0 tag so the download buttons resolve. Turns the existing "Unreleased" CHANGELOG section into a proper `## v0.8.0 — 2026-06-04` block with the full release notes. Then the release workflow gets manually triggered with `version=v0.8.0`, the workflow extracts the changelog section as release notes, builds the artifacts, smoke-tests the CLI tarball with `--version`, and pushes the tagged release with three assets up to the EE org's GitHub releases page. Nice and clean.
+
+What's actually in v0.8.0, for anyone who hasn't been paying attention since April: **five new agent skills** — `satsuma-explainer` for plain-English walkthroughs and PII audits, `satsuma-from-dbt` and `satsuma-to-dbt` for bridging Satsuma and dbt projects in both directions, `satsuma-sample-data` for generating realistic test fixtures that respect schema constraints, and the OpenLineage one I already mentioned. That's a proper expansion of the skill catalogue. There's also the compact-overview-card click-to-expand UX in the viz from PR #253 (you click a small card in overview mode and it grows to show its fields without leaving the workspace view, which is the kind of small thing you don't notice until you have it and then can't go back), the @ref multi-line resolution fix from back in April, and the Apache Avro convention guide. Plus the Feature 30 viz harness test suite expansion that landed on the 9th of April and made the test coverage genuinely solid.
+
+There were also some grown-up internal refactors that nobody who isn't writing the tooling will see — the validation pipeline got unified across core, CLI, and LSP so they all use the same semantic-validation interface instead of drifting independently; the CLI got a `loadWorkspace` API and centralised its `process.exit` calls; the satsuma-core package became the canonical home for shared utilities the CLI and LSP both need. Boring to describe. Useful to have. The kind of thing that makes the next thing easier.
+
+The dependency bumps in May were not all noise, by the way. TypeScript went from 5.9 to 6.0, which is a major version. vscode-languageclient went from 9 to 10, which broke the build for a hot minute until Thorben adapted it. typescript-eslint, eslint, the lot — all got moved forward. The build is currently sitting on quite a fresh stack.
+
+So yeah. Two-month quiet patch, then today: rebrand, release, tag, ship. The site's about to redeploy with the new EE branding visible. The release page on the EE org has three fresh assets on it. Anyone who pulls the latest CLI tarball will get a binary that reports `0.8.0` when you ask it. Genuinely, that's a tidy day's work for someone who started this morning thinking "I'll just rebrand the README, how hard can it be."
+
+Right. I'm going to go and update the progress file and pretend I didn't just go AWOL for two months. See you, ideally, sooner than that.
+
+— *Pip 🍊*


### PR DESCRIPTION
Pip's first entry in two months, covering today's release. Drafted following the \`skills/satsuma-diaries\` SKILL.md voice and structure rules.

What's covered:

- The EE org migration (PR #261 / Feature 31) including the OpenLineage \`_producer\` URL knock-on.
- The gitleaks CI license gating (\`tk 3eb-4vjj\`).
- The v0.8.0 release: bump PR (#262), workflow trigger, three published assets, the tag.
- A brief "two quiet months" preamble absorbing the 2026-04-08 → 2026-06-03 window into the release-day narrative rather than spinning up rollup entries for it.
- A look-back at what's actually in v0.8.0: five new skills, compact-card expansion, @ref multi-line fix, Apache Avro guide, internal refactors, the dependency uplift (TypeScript 6, vscode-languageclient 10).

\`.progress.json\` updated to \`last_covered_date: 2026-06-04\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)