### PR TITLE
feat(viz): Feature 32 — light mode & VS Code theme integration

### DIFF
--- a/.tickets/sl-7b29.md
+++ b/.tickets/sl-7b29.md
@@ -1,0 +1,17 @@
+---
+id: sl-7b29
+status: open
+deps: [sl-wxac]
+links: []
+created: 2026-06-09T20:43:00Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-wyr1
+---
+# Feature 32 Phase 4: Playwright theme coverage + both-theme gallery
+
+## Acceptance Criteria
+
+computed-colour assertions both themes; representative audit tokens; manifest.json entries carry theme
+

--- a/.tickets/sl-7b29.md
+++ b/.tickets/sl-7b29.md
@@ -1,6 +1,6 @@
 ---
 id: sl-7b29
-status: open
+status: closed
 deps: [sl-wxac]
 links: []
 created: 2026-06-09T20:43:00Z
@@ -15,3 +15,9 @@ parent: sl-wyr1
 
 computed-colour assertions both themes; representative audit tokens; manifest.json entries carry theme
 
+
+## Notes
+
+**2026-06-09T21:16:11Z**
+
+Added the Theme switching describe group to harness.test.ts: ?theme=light/dark computed --sz-bg (rgb(255,250,245) / rgb(30,30,30)), prefers-color-scheme fallback via emulated colorScheme, header toggle restyling chrome+component with a recorded theme-change event, and representative audit tokens (report header --sz-report, overview edge --sz-edge-default) switching colour. screenshots.spec.ts now captures every named shot in both themes with a theme manifest field. Full Playwright suite green: 61 passed (40 firefox + 21 screenshots... 20 shots×2 themes). The audit-token test caught and drove the edge-layer theme-inheritance fix.

--- a/.tickets/sl-dknl.md
+++ b/.tickets/sl-dknl.md
@@ -82,3 +82,9 @@ Today a single click on the compact header both toggles fields and dispatches `n
 - The `canvas height grows` Playwright test no longer uses `page.waitForTimeout`; it polls on the canvas bounding rect.
 - Tests (`npm --prefix tooling/satsuma-viz run test`, viz-harness Playwright via the sentinel workflow) pass locally.
 
+
+## Notes
+
+**2026-06-09T21:15:24Z**
+
+Pre-existing bug found during Feature 32: commit ff366cf added the compact-card-expansion Playwright tests referencing fixture contracts/buy-to-om-order.stm but never committed the fixture. Since harness.test.ts resolves all fixtures in a shared beforeAll, the missing file made the ENTIRE firefox harness suite (40 tests) throw and not-run on main. Fixed by authoring the intended canonical example examples/contracts/buy-to-om-order.stm (buy_order → om_order, validates clean). All 40 firefox tests now execute and pass.

--- a/.tickets/sl-go45.md
+++ b/.tickets/sl-go45.md
@@ -1,0 +1,17 @@
+---
+id: sl-go45
+status: open
+deps: [sl-o05i]
+links: []
+created: 2026-06-09T20:43:00Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-wyr1
+---
+# Feature 32 Phase 3: VS Code theme integration with live switching
+
+## Acceptance Criteria
+
+VizTheme+vizThemeForKind maps all four ColorThemeKind; envelopes carry theme; onDidChangeActiveColorTheme posts setTheme; viz.css has no --sz-* decls; tests updated
+

--- a/.tickets/sl-go45.md
+++ b/.tickets/sl-go45.md
@@ -1,6 +1,6 @@
 ---
 id: sl-go45
-status: open
+status: closed
 deps: [sl-o05i]
 links: []
 created: 2026-06-09T20:43:00Z
@@ -15,3 +15,9 @@ parent: sl-wyr1
 
 VizTheme+vizThemeForKind maps all four ColorThemeKind; envelopes carry theme; onDidChangeActiveColorTheme posts setTheme; viz.css has no --sz-* decls; tests updated
 
+
+## Notes
+
+**2026-06-09T20:47:56Z**
+
+Cause: theme was a lossy isDark boolean sampled only at data-load time, and viz.css re-declared a drifted dark palette under body.dark — two sources of truth, no live switching. Fix: replaced isDark with VizTheme + vizThemeForKind (all four ColorThemeKind values mapped, default dark); envelopes and the vizModel/expandedModels messages carry theme; panel.ts subscribes to onDidChangeActiveColorTheme and posts a dedicated setTheme message (disposed with the panel); viz.ts assigns vizEl.theme and the body.dark token block was deleted from viz.css. Unit tests cover the full mapping + envelope shape. NOTE: manual VS Code GUI verification (light/dark/live-switch/HighContrastLight) still needs a human Extension-Host run — cannot be exercised in the agent sandbox.

--- a/.tickets/sl-o05i.md
+++ b/.tickets/sl-o05i.md
@@ -1,0 +1,23 @@
+---
+id: sl-o05i
+status: closed
+deps: []
+links: []
+created: 2026-06-09T20:43:00Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-wyr1
+---
+# Feature 32 Phase 2: theme contract on <satsuma-viz>
+
+## Acceptance Criteria
+
+reflected theme property defaults to light; :host([theme=dark]) engages; unit tests for default + reflection
+
+
+## Notes
+
+**2026-06-09T20:44:51Z**
+
+Cause: the <satsuma-viz> component had no theme contract; the light palette in tokens.css worked only by accident because no consumer set a theme attribute. Fix: added a reflected `theme` property (default "light") to SatsumaViz so :host([theme="dark"]) is the single switching mechanism, plus unit tests for the default value and the reflection contract (commit pending).

--- a/.tickets/sl-wxac.md
+++ b/.tickets/sl-wxac.md
@@ -1,0 +1,17 @@
+---
+id: sl-wxac
+status: open
+deps: []
+links: []
+created: 2026-06-09T20:43:00Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-wyr1
+---
+# Feature 32 Phase 4: harness light mode
+
+## Acceptance Criteria
+
+?theme=light|dark deterministic; prefers-color-scheme fallback; header toggle restyles chrome+component; light .tok-* colours; __satsumaHarness.theme + theme-change events
+

--- a/.tickets/sl-wxac.md
+++ b/.tickets/sl-wxac.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wxac
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-09T20:43:00Z
@@ -15,3 +15,9 @@ parent: sl-wyr1
 
 ?theme=light|dark deterministic; prefers-color-scheme fallback; header toggle restyles chrome+component; light .tok-* colours; __satsumaHarness.theme + theme-change events
 
+
+## Notes
+
+**2026-06-09T21:15:49Z**
+
+Harness light mode: chrome colours + .tok-* syntax colours moved to CSS variables with a light variant under body[data-theme=light]; added a Light/Dark header toggle; theme resolution ?theme= → prefers-color-scheme → dark; __satsumaHarness.theme + theme-change events. Also fixed a latent server bug: the GET / → /index.html redirect dropped the query string, making ?theme= (and ?fixture=/?mode=) silent no-ops — now preserved. Verified via Playwright (all theme tests pass).

--- a/.tickets/sl-wyr1.md
+++ b/.tickets/sl-wyr1.md
@@ -1,0 +1,14 @@
+---
+id: sl-wyr1
+status: open
+deps: []
+links: []
+created: 2026-06-09T20:43:00Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+---
+# Feature 32: viz light mode & VS Code theme integration
+
+Make light and dark first-class themes for the mapping viz, driven by the VS Code colour theme with live switching. Single palette source of truth in tokens.css. See features/32-viz-light-mode/PRD.md
+

--- a/.tickets/sl-wyr1.md
+++ b/.tickets/sl-wyr1.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wyr1
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-09T20:43:00Z
@@ -12,3 +12,9 @@ assignee: Thorben Louw
 
 Make light and dark first-class themes for the mapping viz, driven by the VS Code colour theme with live switching. Single palette source of truth in tokens.css. See features/32-viz-light-mode/PRD.md
 
+
+## Notes
+
+**2026-06-09T21:16:48Z**
+
+All six phases complete: Phase 1 tokenize (8f5752c, pre-existing), Phase 2 component theme property (sl-o05i), Phase 3 VS Code integration + live switching (sl-go45), Phase 4 harness light mode + server query fix (sl-wxac), Phase 6 Playwright + both-theme gallery (sl-7b29). Plus two fixes surfaced by the work: missing buy-to-om-order fixture (sl-dknl) and edge-layer theme-inheritance defect. Full Playwright suite green (61 passed); satsuma-viz (47) and vscode-satsuma viz-integration (8) unit suites green. Remaining manual step: VS Code Extension-Host GUI verification of live theme switching (cannot run in agent sandbox).

--- a/adrs/adr-026-viz-theme-contract.md
+++ b/adrs/adr-026-viz-theme-contract.md
@@ -1,0 +1,87 @@
+# ADR-026 — Viz Theme Contract: Component Owns Rendering, Consumers Select
+
+**Status:** Accepted
+**Date:** 2026-06-09 (sl-wyr1)
+
+## Context
+
+The mapping visualization (`tooling/satsuma-viz/`, see ADR-012) ships a warm
+cream/orange light palette as the `:host` defaults in
+`tooling/satsuma-viz/src/tokens.css`, with dark overrides under
+`:host([theme="dark"])`. Before Feature 32, the theming story around those
+tokens was incomplete and had drifted into two sources of truth.
+
+The VS Code webview never set the component's `theme` attribute. Instead
+`tooling/vscode-satsuma/src/webview/viz/viz.css` re-declared the dark tokens
+under a `body.dark satsuma-viz` selector with *different* values than
+`tokens.css` (e.g. `--sz-text-muted: #858585` vs the canonical `#9D9D9D`), so
+every palette change had to be made twice and the two copies diverged. The host
+side carried theme as a lossy `isDark: boolean` baked into the VizModel
+envelope, coupling theme to data loads, and there was no
+`onDidChangeActiveColorTheme` subscription, so switching the editor theme with a
+panel open left a stale palette until refresh. The standalone harness was
+dark-only and could not exercise or test light mode at all.
+
+Two structural questions had to be answered. First, *who owns theming* — should
+each consumer (VS Code webview, harness) restate token values, or should the
+component be the single styled surface? Second, *how is the palette selected* —
+via a class/attribute on an ancestor, via consumer-side CSS overrides, or via a
+property on the component itself. Letting consumers override tokens (the
+`body.dark` approach) was the status quo and was explicitly rejected because it
+had already produced drift. Adopting VS Code `--vscode-*` variables inside the
+component was rejected because the component must render identically in the
+standalone harness, which has no VS Code variables.
+
+## Decision
+
+The component owns theming; consumers own detection. `<satsuma-viz>` exposes a
+reflected `theme: "light" | "dark"` property (default `"light"`) in
+`tooling/satsuma-viz/src/satsuma-viz.ts`. Reflection to the `theme` attribute is
+the *only* palette-switching mechanism: it engages the `:host([theme="dark"])`
+block in `tokens.css`, which is the single source of truth for both palettes.
+Consumers never restate token values — they detect which theme to use and assign
+the property.
+
+Token values are defined once, on the `<satsuma-viz>` host, and inherited.
+Nested component shadow roots (schema cards, edge layers, mapping detail) must
+**not** inject `tokens.css` into their own styles; CSS custom properties pierce
+shadow boundaries, so they inherit the host's themed values. Injecting the
+tokens locally pins the light `:host` defaults onto a nested host that never
+carries `theme="dark"`, freezing that subtree in light mode — the defect fixed
+for the edge layers in this feature. Two test guards in
+`tooling/satsuma-viz/test/theme.test.js` enforce the contract permanently: every
+colour-bearing light token must have a dark counterpart, and no raw colour
+literal may appear in component styles outside `tokens.css`.
+
+Consumers detect and select. In VS Code, `vizThemeForKind` in
+`tooling/vscode-satsuma/src/webview/viz/integration.ts` maps every
+`ColorThemeKind` to a `VizTheme`; the envelope carries `theme` instead of
+`isDark`; and `panel.ts` subscribes to `onDidChangeActiveColorTheme` and posts a
+dedicated `{ type: "setTheme", theme }` message (decoupled from data loads) so an
+open panel restyles live. The standalone harness resolves its theme from a
+`?theme=` URL parameter, then `prefers-color-scheme`, then dark, and exposes it
+on the automation contract for Playwright.
+
+## Consequences
+
+**Positive:**
+- Both palettes are defined exactly once, in `tokens.css`; the parity and
+  no-literal tests make drift a build failure rather than a review catch.
+- Theme is decoupled from data: live editor-theme changes restyle an open VS
+  Code panel without a reload, and theme no longer rides inside the VizModel
+  envelope.
+- The component renders identically in any host (VS Code, harness, a bare embed)
+  because it depends on its own `theme` attribute, not host-specific variables.
+- Nested components inherit the palette automatically, so a new sub-component is
+  themed correctly by default as long as it does not re-inject the tokens.
+
+**Negative:**
+- A nested component that injects `tokens.css` into its own shadow root silently
+  breaks dark mode for its subtree; the rule is enforced by code review and the
+  audit-token Playwright test rather than by the type system.
+- High-contrast VS Code themes fold into the nearest base palette
+  (`HighContrast` → dark, `HighContrastLight` → light); a dedicated
+  high-contrast palette is deferred future work.
+- The separate field-lineage and schema-lineage webview panels still use their
+  own `isDark` handling and do not yet follow this contract; migrating them is a
+  tracked follow-up.

--- a/examples/contracts/buy-to-om-order.stm
+++ b/examples/contracts/buy-to-om-order.stm
@@ -21,26 +21,26 @@ note {
 
 // --- Source: procurement purchase order ---
 schema buy_order (note "Purchase order raised in the procurement system") {
-  id           ID            (pk)
-  supplier_ref STRING(40)    (required)
-  order_date   DATE
-  currency     STRING(3)     (default GBP)
-  net_amount   DECIMAL(12,2)
-  tax_amount   DECIMAL(12,2)
-  status       PICKLIST      (enum {draft, submitted, approved, cancelled})
-  buyer_email  STRING(120)
+  id            ID             (pk)
+  supplier_ref  STRING(40)     (required)
+  order_date    DATE
+  currency      STRING(3)      (default GBP)
+  net_amount    DECIMAL(12,2)
+  tax_amount    DECIMAL(12,2)
+  status        PICKLIST       (enum {draft, submitted, approved, cancelled})
+  buyer_email   STRING(120)
 }
 
 // --- Target: order-management order ---
 schema om_order (note "Canonical order consumed by the OM platform") {
-  order_key     VARCHAR(36)   (pk)
-  vendor_id     VARCHAR(40)   (indexed)
-  placed_on     DATE
-  gross_total   NUMBER(12,2)  (note "Net amount plus tax")
-  currency_code VARCHAR(3)    (default GBP)
-  state         VARCHAR(20)   (enum {open, fulfilled, void})
-  contact_email VARCHAR(120)
-  imported_at   TIMESTAMP_NTZ
+  order_key      VARCHAR(36)    (pk)
+  vendor_id      VARCHAR(40)    (indexed)
+  placed_on      DATE
+  gross_total    NUMBER(12,2)   (note "Net amount plus tax")
+  currency_code  VARCHAR(3)     (default GBP)
+  state          VARCHAR(20)    (enum {open, fulfilled, void})
+  contact_email  VARCHAR(120)
+  imported_at    TIMESTAMP_NTZ
 }
 
 // --- Mapping ---
@@ -56,10 +56,7 @@ mapping `buy to om order` {
   order_date -> placed_on
 
   // --- Money ---
-  net_amount -> gross_total {
-    "Add @net_amount and @tax_amount"
-    | round 2
-  }
+  net_amount -> gross_total { "Add @net_amount and @tax_amount" | round 2 }
   currency -> currency_code
 
   // --- Lifecycle normalization ---
@@ -76,7 +73,5 @@ mapping `buy to om order` {
   // --- Contact + metadata ---
   buyer_email -> contact_email { lowercase }
 
-  -> imported_at {
-    "Set to the ingestion time in UTC."
-  }
+  -> imported_at { "Set to the ingestion time in UTC." }
 }

--- a/examples/contracts/buy-to-om-order.stm
+++ b/examples/contracts/buy-to-om-order.stm
@@ -1,0 +1,82 @@
+// Satsuma v2 — Procurement Buy Order → Order-Management Order
+//
+// A deliberately small two-schema contract: a procurement-side purchase order
+// (`buy_order`) mapped onto an order-management order (`om_order`). It exists as
+// a compact, self-contained fixture for the viz harness compact-card-expansion
+// tests (two schemas, one mapping, enough fields per card that expanding a
+// compact overview card visibly grows the canvas).
+
+note {
+  """
+  # Buy Order → OM Order
+
+  Maps a procurement `buy_order` raised in the purchasing system onto the
+  canonical `om_order` consumed by the order-management platform.
+
+  ## Notes
+  - Monetary totals are consolidated: `gross_total` is the net plus tax.
+  - Order `status` is normalised onto the OM lifecycle `state`.
+  """
+}
+
+// --- Source: procurement purchase order ---
+schema buy_order (note "Purchase order raised in the procurement system") {
+  id           ID            (pk)
+  supplier_ref STRING(40)    (required)
+  order_date   DATE
+  currency     STRING(3)     (default GBP)
+  net_amount   DECIMAL(12,2)
+  tax_amount   DECIMAL(12,2)
+  status       PICKLIST      (enum {draft, submitted, approved, cancelled})
+  buyer_email  STRING(120)
+}
+
+// --- Target: order-management order ---
+schema om_order (note "Canonical order consumed by the OM platform") {
+  order_key     VARCHAR(36)   (pk)
+  vendor_id     VARCHAR(40)   (indexed)
+  placed_on     DATE
+  gross_total   NUMBER(12,2)  (note "Net amount plus tax")
+  currency_code VARCHAR(3)    (default GBP)
+  state         VARCHAR(20)   (enum {open, fulfilled, void})
+  contact_email VARCHAR(120)
+  imported_at   TIMESTAMP_NTZ
+}
+
+// --- Mapping ---
+mapping `buy to om order` {
+  source { `buy_order` }
+  target { `om_order` }
+
+  // --- Identifiers ---
+  id -> order_key
+  supplier_ref -> vendor_id
+
+  // --- Dates ---
+  order_date -> placed_on
+
+  // --- Money ---
+  net_amount -> gross_total {
+    "Add @net_amount and @tax_amount"
+    | round 2
+  }
+  currency -> currency_code
+
+  // --- Lifecycle normalization ---
+  status -> state {
+    map {
+      draft: "open"
+      submitted: "open"
+      approved: "fulfilled"
+      cancelled: "void"
+      _: "open"
+    }
+  }
+
+  // --- Contact + metadata ---
+  buyer_email -> contact_email { lowercase }
+
+  -> imported_at {
+    "Set to the ingestion time in UTC."
+  }
+}

--- a/features/32-viz-light-mode/AUDIT.md
+++ b/features/32-viz-light-mode/AUDIT.md
@@ -1,0 +1,97 @@
+# Feature 32 — Phase 1 Colour-Literal Audit
+
+> Artifact for Task 1 ("Audit colour literals in satsuma-viz"). Records every
+> hex/rgba/gradient colour literal that existed in `tooling/satsuma-viz/src/`
+> component styles, its classification, and the token it now resolves to.
+> Task 2 acted on this audit: every literal below is now a `var(--sz-…)`
+> reference, enforced permanently by `test/theme.test.js`.
+
+## Method
+
+- Scanned all `static styles = css\`…\`` blocks and inline SVG styles in
+  `satsuma-viz.ts`, `components/`, and `edges/`.
+- Cross-checked against `tokens.css` to find literals that were already token
+  *fallbacks* (`var(--x, <literal>)`) versus literals hardcoded with no token.
+- Verified post-refactor that no colour literal survives outside `tokens.css`
+  (`grep` + the no-literal-colours test) and that no referenced colour token is
+  undefined.
+
+## Classification
+
+### A. Literals that were redundant token fallbacks (fallback removed)
+
+These already pointed at a defined token; the trailing literal was dead unless
+the token was missing. The fallback is removed so `tokens.css` is the only
+source. Light values below are byte-identical to the removed fallbacks, so
+light mode is unchanged.
+
+| Literal (light) | Token |
+|---|---|
+| `#FFFAF5` | `--sz-bg` |
+| `#fff` (card/gear fills) | `--sz-card-bg` / `--sz-gear-bg` |
+| `#2D2A26` | `--sz-text` |
+| `#6B6560` | `--sz-text-muted`, `--sz-edge-bare-stroke` |
+| `#F2913D` | `--sz-orange` |
+| `#D97726` | `--sz-orange-dark`, `--sz-arrow-stroke` |
+| `#5A9E6F` | `--sz-green` / `--sz-arrow-nl-stroke` |
+| `#8E5BB0` | `--sz-violet` |
+| `#C45D22` | `--sz-warning` / `--sz-warning-icon` |
+| `#4A8A5B` | `--sz-at-ref` |
+| `#4A4744` | `--sz-edge-default` |
+| `#FFF3E8` | `--sz-namespace-bg`, `--sz-badge-bg` |
+| `#FEF3CD` | `--sz-warning-bg` |
+| `#E8F0FE` | `--sz-question-bg` |
+| `#7C6BAE` | `--sz-question-icon` |
+| `#DCECF6` | `--sz-namespace-pill-bg` |
+| `#0A354C` | `--sz-namespace-pill-text` |
+| `rgba(45,42,38,0.08)` | `--sz-card-border` |
+| `rgba(45,42,38,0.15)` | `--sz-card-border-strong` |
+| `rgba(45,42,38,0.06)` | (card shadow) `--sz-card-shadow` |
+| `rgba(196,93,34,0.2 / 0.3)` | `--sz-warning-border-soft` / `-strong` |
+| `rgba(124,107,174,0.2 / 0.3)` | `--sz-question-border-soft` / `-strong` |
+| `rgba(255,255,255,0.6)` | `--sz-icon-overlay-soft` |
+| `rgba(0,0,0,0.2)` | `--sz-icon-divider` |
+| `rgba(255,255,255,0.88)` | `--sz-namespace-pill-chip-bg` |
+
+### B. Hardcoded literals promoted to new tokens (no token existed)
+
+These had no token at all and were the gaps called out in PRD Problem 3. New
+light + dark tokens were added to `tokens.css`.
+
+| Literal (light) | New token | Used for |
+|---|---|---|
+| `#4A90B8` | `--sz-report` | report card header (was an undefined-var fallback `var(--sz-report, #4A90B8)`) |
+| `linear-gradient(135deg, rgba(16,80,104,.98), rgba(10,53,76,.98))` | `--sz-overview-mapping-bg` | overview mapping card background |
+| `linear-gradient(45deg, rgba(255,255,255,.06), rgba(255,255,255,0))` | `--sz-overview-mapping-gloss` | overview mapping card gloss |
+| `rgba(8,36,52,0.35)` | `--sz-overview-mapping-border` | overview mapping card border |
+| `0 8px 20px rgba(10,53,76,0.18)` | `--sz-overview-mapping-shadow` | overview mapping card shadow |
+| `rgba(217,119,38,0.4)` | `--sz-edge-highlight-glow` | highlighted overview edge drop-shadow |
+| `rgba(45,42,38,0.03)` | `--sz-row-hover-bg` | field-row hover / zebra wash |
+| `rgba(45,42,38,0.05 / 0.06)` | `--sz-row-active-bg` | pressed/selected row wash |
+| `rgba(242,145,61,0.12)` | `--sz-accent-wash` | orange-tinted backgrounds |
+| `rgba(90,158,111,0.12)` | `--sz-green-wash` | green-tinted backgrounds |
+
+### C. Theme-independent allowlist
+
+**Empty.** No colour literal in component styles is genuinely
+theme-independent — every one mapped to a token (A) or became one (B). The
+no-literal-colours test therefore runs with no allowlist; any future literal
+fails the build.
+
+## Defect found and fixed during the audit
+
+`--sz-edge-nl` was referenced in `edges/sz-edge-layer.ts` and
+`edges/sz-overview-edge-layer.ts` but **never defined** in `tokens.css` — it
+was only ever an undefined-var fallback (`var(--sz-edge-nl, #5A9E6F)`), exactly
+like `--sz-report`. The partial refactor stripped the fallback, which would
+have left NL edges uncoloured. Fixed by pointing all three references at the
+canonical `--sz-arrow-nl-stroke` (`#5A9E6F` light / `#6DBF82` dark), per the
+PRD ("SVG edge styles … switch to `var(--sz-arrow-nl-stroke)`").
+
+## `viz.css` reconciliation
+
+Deferred to Phase 3 as the PRD sequences it. The divergent
+`body.dark satsuma-viz` block in `vscode-satsuma/src/webview/viz/viz.css` is
+untouched here; promoting/deleting it is Task 4's work. This audit only
+establishes that `tokens.css` now holds canonical values for every component
+literal.

--- a/features/32-viz-light-mode/PRD.md
+++ b/features/32-viz-light-mode/PRD.md
@@ -1,0 +1,336 @@
+# Feature 32 — Viz Light Mode & VS Code Theme Integration
+
+> **Status: DRAFT (2026-06-05) — awaiting review**
+
+## Goal
+
+Make light and dark first-class, equally-supported themes for the Satsuma
+mapping visualization, driven automatically by the user's VS Code colour theme
+preference — including live switching when the user changes theme with a panel
+open. The primary success criterion is: **a user on a light VS Code theme sees
+a coherent, fully-styled light viz; a user on a dark theme sees the dark viz;
+switching themes updates an open panel immediately; and both palettes are
+defined exactly once, in `tooling/satsuma-viz/src/tokens.css`.**
+
+## Background
+
+The component already *has* a light palette: the `:host` defaults in
+`tooling/satsuma-viz/src/tokens.css` are the warm cream/orange site design
+language (`--sz-bg: #FFFAF5`, `--sz-orange: #F2913D`, …), with dark overrides
+under `:host([theme="dark"])`. But the theming story around it is incomplete
+and inconsistent, so light mode today works only by accident, and only
+partially. This feature finishes the job rather than inventing a new palette.
+
+Feature 31 (`features/31-alignment-with-ee-brand/PRD.md`) resolved the brand
+question: **co-brand, do not re-skin** — Satsuma keeps its warm
+orange/peach/cream identity. The light palette in this feature is therefore
+the existing token set, completed and contrast-checked, not a redesign.
+
+## Problem
+
+1. **Two divergent sources of truth for the dark palette.** The canonical dark
+   tokens live in `tooling/satsuma-viz/src/tokens.css` (`:host([theme="dark"])`),
+   but the VS Code webview never sets the `theme` attribute. Instead
+   `tooling/vscode-satsuma/src/webview/viz/viz.css` re-declares the tokens under
+   a `body.dark satsuma-viz` selector with *different values* (e.g.
+   `--sz-text-muted: #858585` vs the canonical `#9D9D9D`; rgba washes for
+   `--sz-namespace-bg` vs the canonical solid `#2D2520`; no accent or arrow
+   overrides at all, so dark mode in VS Code silently keeps light-mode arrows).
+   Every palette change must be made twice and drifts.
+
+2. **No live theme switching.** The theme is sampled from
+   `vscode.window.activeColorTheme.kind` only when a VizModel is loaded
+   (`tooling/vscode-satsuma/src/webview/viz/panel.ts:114,198`). There is no
+   `onDidChangeActiveColorTheme` subscription anywhere in the extension, so a
+   user who switches VS Code theme with the viz open keeps the stale palette
+   until they refresh.
+
+3. **Hardcoded colours bypass the token system**, so neither palette fully
+   applies. Known offenders in `tooling/satsuma-viz/src/`:
+   - `components/sz-schema-card.ts:67` — `.header.report` uses
+     `var(--sz-report, #4A90B8)`, but `--sz-report` is never defined in
+     `tokens.css`; the fallback literal is the de-facto value in both themes.
+   - `satsuma-viz.ts:170-174` — the overview mapping card uses a hardcoded
+     navy gradient, border, and shadow with no dark variant.
+   - `satsuma-viz.ts:1229-1233` — SVG edge styles hardcode `#5A9E6F` (NL
+     edges), `#6B6560` (bare edges, scope labels, gear icon), and `#fff`
+     (gear circle fill), ignoring `--sz-arrow-nl-stroke` and friends.
+   - ~15 rgba washes across `sz-schema-card.ts` and `satsuma-viz.ts`
+     (row hover/zebra `rgba(45, 42, 38, …)`, accent washes
+     `rgba(242, 145, 61, …)`, `rgba(90, 158, 111, …)`) tuned for light
+     backgrounds and never overridden for dark.
+
+4. **The harness cannot exercise light mode.** The standalone harness chrome
+   (`tooling/satsuma-viz-harness/src/client/index.html`) is dark-only, and the
+   mounted `<satsuma-viz>` never receives a `theme` attribute — today it
+   renders the *light* component palette inside dark chrome. There is no theme
+   toggle, no URL parameter, no automation-contract surface, and therefore no
+   Playwright coverage for theming at all.
+
+5. **The renderer theme contract is a lossy boolean.** `isDark: boolean`
+   (`tooling/vscode-satsuma/src/webview/viz/integration.ts:24,33`) is baked
+   into the VizModel envelope, coupling theme to data loads and leaving no room
+   for future theme kinds.
+
+## Design Principles
+
+1. **One palette definition.** `tooling/satsuma-viz/src/tokens.css` is the
+   single source of truth for both themes. Consumers (VS Code webview,
+   harness) select a theme; they never restate token values.
+2. **The component owns theming; consumers own detection.** `<satsuma-viz>`
+   exposes a `theme` attribute and renders correctly for it. Detecting *which*
+   theme to use (VS Code theme kind, OS preference, toggle) is consumer logic.
+3. **Follow the editor, no in-viz override.** In VS Code the viz always tracks
+   the editor theme. No setting, no toggle — zero configuration.
+4. **Keep the Satsuma identity.** The light palette is the existing warm
+   cream/orange token set (per Feature 31's co-brand decision), completed and
+   contrast-checked — not a re-skin and not the VS Code `--vscode-*` palette.
+5. **Every colour is a named token.** No raw hex/rgba literals in component
+   styles outside `tokens.css`; every token defined for light is defined for
+   dark. Both rules are enforced by tests, not convention.
+
+## Non-Goals
+
+- Re-skinning the viz to the Equal Experts palette (explicitly rejected by
+  Feature 31).
+- Dedicated high-contrast palettes. `HighContrast` maps to dark and
+  `HighContrastLight` maps to light; bespoke HC tokens are future work.
+- Adopting VS Code `--vscode-*` theme variables inside the component. The
+  component must render identically in the standalone harness, which has no
+  VS Code variables (the webview's `.error-message` shell style may keep
+  `--vscode-errorForeground`).
+- Theming the separate field-lineage and schema-lineage webview panels
+  (`tooling/vscode-satsuma/src/webview/field-lineage/`, `…/schema-lineage/`).
+  They have their own `isDark` handling today; migrating them to this contract
+  is a follow-up ticket, not part of this feature.
+- A user-facing theme setting or toggle in the VS Code extension.
+
+## Design
+
+### Theme contract on `<satsuma-viz>`
+
+The component gains a reflected `theme` property:
+
+```typescript
+/** Visual theme. Reflected to the `theme` attribute so tokens.css
+ *  `:host([theme="dark"])` overrides apply. Default: "light". */
+@property({ reflect: true }) theme: "light" | "dark" = "light";
+```
+
+This makes the existing `:host([theme="dark"])` selector in `tokens.css` the
+*only* switching mechanism. The `body.dark satsuma-viz` override block in
+`tooling/vscode-satsuma/src/webview/viz/viz.css` is deleted.
+
+### VS Code theme mapping
+
+`integration.ts` replaces the boolean with an explicit renderer theme type and
+maps all four `ColorThemeKind` values:
+
+| `ColorThemeKind` | value | renderer theme |
+|---|---|---|
+| `Light` | 1 | `light` |
+| `Dark` | 2 | `dark` |
+| `HighContrast` | 3 | `dark` |
+| `HighContrastLight` | 4 | `light` |
+
+```typescript
+export type VizTheme = "light" | "dark";
+export function vizThemeForKind(kind: ThemeKind): VizTheme;
+```
+
+The envelope field `isDark: boolean` becomes `theme: VizTheme`. (Today
+`HighContrastLight` falls through to light only because the boolean check
+doesn't match it — the mapping becomes intentional and documented.)
+
+### Live theme switching
+
+`panel.ts` subscribes to `vscode.window.onDidChangeActiveColorTheme` while the
+panel is open (disposed with the panel) and posts a dedicated message,
+decoupling theme from data loads:
+
+```
+{ type: "setTheme", theme: "light" | "dark" }
+```
+
+The webview entry (`viz.ts`) handles `setTheme` by assigning `vizEl.theme`.
+`vizModel` messages carry `theme` too (replacing `isDark`) so the initial load
+needs no second message.
+
+### Completing the palette
+
+New tokens close every gap found in the audit (Problem 3). Proposed values —
+final values are confirmed against the screenshot gallery during review:
+
+| Token | Light | Dark | Used for |
+|---|---|---|---|
+| `--sz-report` | `#4A90B8` | `#6FB3D9` | report card header (today an undefined-var fallback) |
+| `--sz-overview-mapping-bg` | existing navy gradient | deepened navy gradient | overview mapping card background |
+| `--sz-overview-mapping-border` | `rgba(8, 36, 52, 0.35)` | `rgba(255, 255, 255, 0.12)` | overview mapping card border |
+| `--sz-edge-bare-stroke` | `#6B6560` | `#9D9D9D` | bare edges, scope labels, gear icon |
+| `--sz-gear-bg` | `#FFFFFF` | `#252526` | gear circle fill on transform edges |
+| `--sz-row-hover-bg` | `rgba(45, 42, 38, 0.03)` | `rgba(255, 255, 255, 0.04)` | field-row hover / zebra washes |
+| `--sz-row-active-bg` | `rgba(45, 42, 38, 0.06)` | `rgba(255, 255, 255, 0.08)` | pressed/selected row washes |
+| `--sz-accent-wash` | `rgba(242, 145, 61, 0.12)` | `rgba(242, 168, 96, 0.16)` | orange-tinted backgrounds |
+| `--sz-green-wash` | `rgba(90, 158, 111, 0.12)` | `rgba(109, 191, 130, 0.16)` | green-tinted backgrounds |
+
+The audit task enumerates the complete literal-by-literal list; the table
+above is the known set, not a cap. SVG edge styles in `satsuma-viz.ts`
+switch to `var(--sz-arrow-nl-stroke)` / new tokens.
+
+Where `viz.css` and `tokens.css` dark values currently disagree, the
+`tokens.css` value wins by default; any deliberate preference for a `viz.css`
+value (e.g. the rgba namespace washes) must be promoted into `tokens.css` and
+justified in the PR using before/after gallery screenshots.
+
+**Contrast requirement:** all `--sz-text*` / background token pairs in both
+themes must meet WCAG AA for normal text (4.5:1). Decorative pairings (white
+on `--sz-orange` card headers) are exempt but must be ≥ 3:1.
+
+### Harness light mode
+
+The harness becomes the place where both themes are exercised and tested:
+
+- **Theme resolution order:** `?theme=light|dark` URL parameter (deterministic
+  for Playwright) → `prefers-color-scheme` media query → dark (current
+  default).
+- A **Light/Dark toggle** in the header chrome, alongside the existing
+  view-mode toggles, sets the `theme` attribute on `<satsuma-viz>` and a
+  `data-theme` attribute on `<body>`.
+- The harness chrome CSS custom properties (`--color-bg`, `--color-surface`,
+  …) gain a light variant under `body[data-theme="light"]`, including a
+  light-tuned set of the `.tok-*` syntax-highlighting colours (the current
+  Tokyo Night-aligned set stays for dark).
+- **Automation contract:** `window.__satsumaHarness.theme` exposes the active
+  theme, and toggle changes append a `theme-change` entry to
+  `window.__satsumaHarness.events`.
+
+### Test plan
+
+1. **Token parity (unit, `tooling/satsuma-viz/test/`).** Parse `tokens.css`;
+   assert every colour-bearing token declared in the `:host` light block has a
+   counterpart in `:host([theme="dark"])`. Guards every future token addition.
+2. **No-literal-colours (unit, `tooling/satsuma-viz/test/`).** Scan the static
+   `styles` blocks of all components for hex/rgba colour literals outside an
+   explicit allowlist (e.g. SVG icon detail strokes that are
+   theme-independent). Fails when a new hardcoded colour sneaks in.
+3. **Theme property (unit, `tooling/satsuma-viz/test/`, dom-shim).** `theme`
+   defaults to `"light"` and reflects to the attribute, so the
+   `:host([theme="dark"])` selector engages.
+4. **Theme kind mapping (unit, `tooling/vscode-satsuma/test/viz-integration.test.js`).**
+   `vizThemeForKind` maps all four `ColorThemeKind` values per the table;
+   envelopes carry `theme` instead of `isDark`. Extends the existing
+   `isDarkTheme` cases.
+5. **Playwright (`tooling/satsuma-viz-harness/test/harness.test.ts`,
+   human-in-the-loop sentinel protocol — see CLAUDE.md):**
+   - `?theme=light` renders `<satsuma-viz theme="light">` with computed
+     background `rgb(255, 250, 245)`; `?theme=dark` gives `rgb(30, 30, 30)`.
+   - With no URL parameter, the theme follows Playwright's emulated
+     `colorScheme`.
+   - The toggle flips the attribute, restyles the chrome, and records a
+     `theme-change` automation event.
+   - Representative tokenized elements (report header, bare edge stroke)
+     change computed colour between themes — proving the audit tokens apply,
+     not just `--sz-bg`.
+6. **Screenshot gallery (`tooling/satsuma-viz-harness/test/screenshots.spec.ts`).**
+   Every named shot is captured in both themes; `manifest.json` entries gain a
+   `theme` field. The gallery is the review artifact for palette sign-off.
+
+## Phased Delivery
+
+### Phase 1 — Tokenize all hardcoded colours
+
+No behaviour change; pure refactor of `tooling/satsuma-viz/`.
+
+- [ ] Audit and enumerate every colour literal in component styles (the
+      Problem 3 list is the starting point, not the cap).
+- [ ] Add the new tokens to `tokens.css` (light + dark) and replace literals
+      with `var(--sz-…)`.
+- [ ] Add the token-parity and no-literal-colours tests; both pass.
+- [ ] Dark-mode gallery screenshots show no unintended visual change.
+
+### Phase 2 — Theme contract on the component
+
+- [ ] Add the reflected `theme` property to `<satsuma-viz>` (default
+      `"light"`).
+- [ ] Unit test: default value and attribute reflection.
+
+### Phase 3 — VS Code integration
+
+- [ ] `integration.ts`: add `VizTheme` + `vizThemeForKind`; envelopes carry
+      `theme`; delete `isDarkTheme`/`isDark`.
+- [ ] `panel.ts`: subscribe to `onDidChangeActiveColorTheme` (disposed with
+      the panel); post `setTheme` on change.
+- [ ] `viz.ts`: assign `vizEl.theme` from `vizModel` and `setTheme` messages;
+      remove the `body.dark` class logic.
+- [ ] `viz.css`: delete the `body.dark satsuma-viz` token block; promote any
+      deliberately-kept divergent values into `tokens.css` first.
+- [ ] Update `test/viz-integration.test.js` per the test plan.
+- [ ] Manual check in VS Code: light theme, dark theme, switch with panel
+      open, `HighContrastLight`.
+
+### Phase 4 — Harness light mode + Playwright coverage
+
+- [ ] Theme resolution (URL param → `prefers-color-scheme` → dark) and the
+      header toggle; `theme` attribute set on `<satsuma-viz>`.
+- [ ] Light variant of harness chrome custom properties and `.tok-*` syntax
+      colours.
+- [ ] Automation contract: `__satsumaHarness.theme` + `theme-change` events.
+- [ ] Playwright tests per the test plan, run via the sentinel-file protocol.
+- [ ] Screenshot gallery captures both themes; manifest gains `theme`.
+
+## Success Criteria
+
+1. **Single source of truth.** Both palettes are defined only in
+   `tooling/satsuma-viz/src/tokens.css`; `viz.css` contains no `--sz-*`
+   declarations; the parity and no-literal tests enforce this permanently.
+2. **VS Code fidelity.** All four `ColorThemeKind` values map to the correct
+   renderer theme, verified by unit tests.
+3. **Live switching.** Changing the VS Code theme with a viz panel open
+   restyles it without reload or refresh.
+4. **Complete palettes.** Every visual element — including report headers,
+   overview mapping cards, bare/NL edges, gear icons, and row washes —
+   changes appropriately between themes; no light-tuned colour survives into
+   dark mode or vice versa.
+5. **Accessible light mode.** Text/background token pairs meet WCAG AA (4.5:1)
+   in both themes; documented exemptions are ≥ 3:1.
+6. **Testable theming.** The harness can deterministically render either theme
+   via URL parameter, the automation contract exposes it, and Playwright
+   asserts computed colours in both themes.
+7. **Review artifact.** The screenshot gallery covers every named shot in both
+   themes for human/VLM palette sign-off.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Converging `viz.css` dark values onto `tokens.css` changes dark-mode appearance in VS Code | Users see subtle dark-theme shifts | Phase 1 + 3 gallery screenshots reviewed before/after; deliberate keeps promoted into `tokens.css` |
+| rgba washes tuned for light look muddy on dark backgrounds | Poor dark-mode contrast on hover/zebra rows | Dark-specific wash values (white-based rgba); gallery review |
+| Playwright runs are human-in-the-loop only (ARM macOS sandbox) | Slower verification loop | Sentinel-file protocol already established; unit tests cover everything not requiring a browser |
+| White-on-orange card headers fail strict AA | Accessibility complaint | Documented ≥ 3:1 decorative exemption; revisit under a future HC feature |
+| `setTheme` racing the initial `vizModel` message | Brief theme flash on load | `vizModel` carries `theme`; `setTheme` only fires on change events |
+
+## Dependencies
+
+- `tooling/satsuma-viz/src/tokens.css` token structure (Feature 23).
+- Harness automation contract and sentinel-file Playwright workflow
+  (Feature 29/30).
+- Feature 31's co-brand decision (palette identity stays).
+- VS Code API: `vscode.window.onDidChangeActiveColorTheme`,
+  `ColorThemeKind` (all current values exist since VS Code 1.56).
+
+## File Locations
+
+| Artifact | Path | Change |
+|---|---|---|
+| Design tokens (both palettes) | `tooling/satsuma-viz/src/tokens.css` | new tokens; canonical values |
+| Viz component root | `tooling/satsuma-viz/src/satsuma-viz.ts` | `theme` property; literals → tokens |
+| Schema card | `tooling/satsuma-viz/src/components/sz-schema-card.ts` | literals → tokens |
+| Token parity / no-literal / theme tests | `tooling/satsuma-viz/test/theme.test.js` | new |
+| Host-side theme mapping | `tooling/vscode-satsuma/src/webview/viz/integration.ts` | `VizTheme`, `vizThemeForKind`, envelope change |
+| Panel (theme subscription) | `tooling/vscode-satsuma/src/webview/viz/panel.ts` | `onDidChangeActiveColorTheme` → `setTheme` |
+| Webview entry | `tooling/vscode-satsuma/src/webview/viz/viz.ts` | assign `vizEl.theme`; drop `body.dark` |
+| Webview shell styles | `tooling/vscode-satsuma/src/webview/viz/viz.css` | delete token override block |
+| Theme mapping tests | `tooling/vscode-satsuma/test/viz-integration.test.js` | extend |
+| Harness chrome + toggle | `tooling/satsuma-viz-harness/src/client/index.html`, `app.ts` | light variant, toggle, URL param, contract |
+| Harness Playwright tests | `tooling/satsuma-viz-harness/test/harness.test.ts` | theme test group |
+| Screenshot gallery | `tooling/satsuma-viz-harness/test/screenshots.spec.ts` | both-theme capture; manifest `theme` field |

--- a/features/32-viz-light-mode/PRD.md
+++ b/features/32-viz-light-mode/PRD.md
@@ -1,6 +1,9 @@
 # Feature 32 — Viz Light Mode & VS Code Theme Integration
 
-> **Status: DRAFT (2026-06-05) — awaiting review**
+> **Status: IMPLEMENTED (2026-06-09).** All phases delivered (epic `sl-wyr1`).
+> Remaining manual step: VS Code Extension-Host GUI verification of live theme
+> switching (light / dark / live-switch / HighContrastLight), which cannot run
+> in the agent sandbox.
 
 ## Goal
 

--- a/features/32-viz-light-mode/TODO.md
+++ b/features/32-viz-light-mode/TODO.md
@@ -103,7 +103,7 @@ PRD reference:
 - Design / Harness light mode
 - Phase 4
 
-### 6. Playwright theme coverage and both-theme gallery
+### 6. Playwright theme coverage and both-theme gallery — ✅ done (`sl-7b29`)
 
 Add the theme test group to `harness.test.ts` and capture every named
 gallery shot in both themes with a `theme` manifest field.

--- a/features/32-viz-light-mode/TODO.md
+++ b/features/32-viz-light-mode/TODO.md
@@ -1,0 +1,120 @@
+# Feature 32 — Viz Light Mode: Task Breakdown
+
+Epic: _(tk epic to be created on PRD approval)_
+
+Tasks map 1:1 to PRD phases plus an audit task. tk ticket IDs are added next
+to each task title when the tickets are created.
+
+## Suggested Dependency Order
+
+1. Audit colour literals (task 1)
+2. Tokenize hardcoded colours + guard tests (task 2)
+3. Theme contract on the component (task 3)
+4. VS Code integration (task 4) and harness light mode (task 5) — parallel
+5. Playwright theme coverage + both-theme gallery (task 6)
+
+---
+
+### 1. Audit colour literals in satsuma-viz — ✅ done (see `AUDIT.md`)
+
+Enumerate every hex/rgba colour literal in `tooling/satsuma-viz/src/`
+component styles, classify each (needs a new token / maps to an existing
+token / theme-independent allowlist), and propose dark-mode values for the
+new tokens.
+
+Scope:
+- all `static styles` blocks and inline SVG styles in `satsuma-viz.ts`,
+  `components/`, `edges/`
+- reconcile the divergent `viz.css` dark values against `tokens.css`
+  (PRD: "Completing the palette" — tokens.css wins unless promoted)
+
+Acceptance criteria:
+- audit notes added to this directory listing every literal with file:line,
+  its classification, and proposed light/dark token values
+- the allowlist (theme-independent literals) is explicit and justified
+
+PRD reference:
+- Problem (3)
+- Design / Completing the palette
+
+### 2. Tokenize hardcoded colours and add guard tests — ✅ done
+
+Implement Phase 1: add the new tokens to `tokens.css` (light + dark),
+replace literals per the audit, and add the token-parity and
+no-literal-colours tests.
+
+Scope:
+- `tooling/satsuma-viz/src/tokens.css`, `satsuma-viz.ts`,
+  `components/sz-schema-card.ts`, edge layers
+- new `tooling/satsuma-viz/test/theme.test.js`
+
+Acceptance criteria:
+- no colour literal outside `tokens.css` except the documented allowlist
+- token-parity test passes: every colour token in the light block has a dark
+  counterpart
+- dark-mode gallery screenshots show no unintended visual change
+
+PRD reference:
+- Phase 1
+- Test plan (1, 2)
+
+### 3. Theme contract on `<satsuma-viz>`
+
+Implement Phase 2: reflected `theme` property, default `"light"`.
+
+Acceptance criteria:
+- `theme` reflects to the attribute so `:host([theme="dark"])` engages
+- unit tests for default value and reflection (dom-shim)
+
+PRD reference:
+- Design / Theme contract
+- Phase 2; Test plan (3)
+
+### 4. VS Code theme integration with live switching
+
+Implement Phase 3: `VizTheme` + `vizThemeForKind`, `theme` in envelopes,
+`onDidChangeActiveColorTheme` → `setTheme` message, webview assigns
+`vizEl.theme`, delete the `viz.css` token override block.
+
+Acceptance criteria:
+- all four `ColorThemeKind` values map per the PRD table (unit tested)
+- switching VS Code theme with a panel open restyles it without reload
+- `viz.css` contains no `--sz-*` declarations
+- manual verification notes for light / dark / live-switch /
+  `HighContrastLight` recorded in the ticket
+
+PRD reference:
+- Design / VS Code theme mapping, Live theme switching
+- Phase 3; Test plan (4)
+
+### 5. Harness light mode
+
+Implement Phase 4 chrome work: theme resolution (URL param →
+`prefers-color-scheme` → dark), header toggle, light chrome variant
+including light `.tok-*` syntax colours, `theme` attribute on the component,
+automation contract (`__satsumaHarness.theme`, `theme-change` events).
+
+Acceptance criteria:
+- `?theme=light|dark` deterministically selects the theme
+- toggle restyles chrome + component and records an automation event
+- syntax highlighting is readable in both themes
+
+PRD reference:
+- Design / Harness light mode
+- Phase 4
+
+### 6. Playwright theme coverage and both-theme gallery
+
+Add the theme test group to `harness.test.ts` and capture every named
+gallery shot in both themes with a `theme` manifest field.
+
+Acceptance criteria:
+- computed-colour assertions for both themes, including representative
+  audit tokens (report header, bare edge stroke), pass via the
+  sentinel-file protocol
+- `screenshots/manifest.json` entries carry `theme`; both-theme gallery
+  reviewed for palette sign-off
+
+PRD reference:
+- Test plan (5, 6)
+- Phase 4; Success criteria (6, 7)

--- a/features/32-viz-light-mode/TODO.md
+++ b/features/32-viz-light-mode/TODO.md
@@ -1,6 +1,6 @@
 # Feature 32 — Viz Light Mode: Task Breakdown
 
-Epic: _(tk epic to be created on PRD approval)_
+Epic: `sl-wyr1`
 
 Tasks map 1:1 to PRD phases plus an audit task. tk ticket IDs are added next
 to each task title when the tickets are created.
@@ -58,7 +58,7 @@ PRD reference:
 - Phase 1
 - Test plan (1, 2)
 
-### 3. Theme contract on `<satsuma-viz>`
+### 3. Theme contract on `<satsuma-viz>` — ✅ done (`sl-o05i`)
 
 Implement Phase 2: reflected `theme` property, default `"light"`.
 

--- a/features/32-viz-light-mode/TODO.md
+++ b/features/32-viz-light-mode/TODO.md
@@ -70,7 +70,7 @@ PRD reference:
 - Design / Theme contract
 - Phase 2; Test plan (3)
 
-### 4. VS Code theme integration with live switching
+### 4. VS Code theme integration with live switching — ✅ done (`sl-go45`)
 
 Implement Phase 3: `VizTheme` + `vizThemeForKind`, `theme` in envelopes,
 `onDidChangeActiveColorTheme` → `setTheme` message, webview assigns

--- a/features/32-viz-light-mode/TODO.md
+++ b/features/32-viz-light-mode/TODO.md
@@ -87,7 +87,7 @@ PRD reference:
 - Design / VS Code theme mapping, Live theme switching
 - Phase 3; Test plan (4)
 
-### 5. Harness light mode
+### 5. Harness light mode — ✅ done (`sl-wxac`)
 
 Implement Phase 4 chrome work: theme resolution (URL param →
 `prefers-color-scheme` → dark), header toggle, light chrome variant

--- a/tooling/satsuma-viz-harness/src/client/app.ts
+++ b/tooling/satsuma-viz-harness/src/client/app.ts
@@ -12,6 +12,7 @@
  * Automation contract (exposed on window.__satsumaHarness):
  *   fixture     — currently loaded fixture URI, or null
  *   viewMode    — "lineage" | "single"
+ *   theme       — "light" | "dark", the active chrome + component theme
  *   events      — array of recorded interaction events
  *   ready       — true once the viz has reached the "ready" state
  *   clearEvents — helper to reset the event log between assertions
@@ -19,6 +20,11 @@
  * URL parameters for headless use (e.g. Playwright tests):
  *   ?fixture=<encoded-uri>   — auto-selects a fixture on load
  *   ?mode=lineage|single     — overrides the default view mode
+ *   ?theme=light|dark        — forces the theme (deterministic for Playwright);
+ *                              otherwise prefers-color-scheme decides, then dark
+ *
+ * Theme changes (via the header toggle) append a `theme-change` event to the
+ * event log so Playwright can assert the switch was observed.
  */
 
 // ---------- Types ----------
@@ -70,9 +76,14 @@ interface HarnessEvent {
  * The automation API exposed on window.__satsumaHarness.
  * All Playwright tests assert against this object rather than VS Code APIs.
  */
+/** The two renderer themes the harness and component support. */
+type HarnessTheme = "light" | "dark";
+
 export interface SatsumaHarness {
   fixture: string | null;
   viewMode: "lineage" | "single";
+  /** Active theme applied to both the chrome (body[data-theme]) and the viz component. */
+  theme: HarnessTheme;
   events: HarnessEvent[];
   ready: boolean;
   clearEvents(): void;
@@ -89,6 +100,7 @@ declare global {
 const harness: SatsumaHarness = {
   fixture: null,
   viewMode: "lineage",
+  theme: "dark",
   events: [],
   ready: false,
   clearEvents() { this.events = []; },
@@ -117,6 +129,7 @@ const sourceCodeEl      = getRequired("source-code");
 const vizContainer      = getRequired("viz-container");
 const readyBadge        = getRequired("harness-ready-badge");
 const viewModeToggle    = getRequired("view-mode-toggle");
+const themeToggle       = getRequired("theme-toggle");
 
 // ---------- Syntax highlighting ----------
 
@@ -390,6 +403,9 @@ function ensureVizElement(): HTMLElement {
   // under automation.  The satsuma-viz component uses this to skip CSS transitions
   // and emit layout-complete signals synchronously.
   el.setAttribute("test-mode", "");
+  // Mount with the currently-resolved theme so the component palette matches the
+  // chrome from the first paint (the component defaults to light otherwise).
+  el.setAttribute("theme", harness.theme);
 
   // Monitor ready-state changes via MutationObserver so Playwright can wait
   // for `data-ready-state="ready"` on the root element.
@@ -553,6 +569,52 @@ viewModeToggle.addEventListener("click", (e) => {
   const mode = btn.dataset["mode"] as "lineage" | "single" | undefined;
   if (mode && mode !== harness.viewMode) setViewMode(mode);
 });
+
+// ---------- Theme management ----------
+
+/**
+ * Resolve the initial theme deterministically.
+ * Order (per Feature 32): `?theme=` URL parameter → `prefers-color-scheme`
+ * media query → dark (the historical harness default).  The URL parameter
+ * makes Playwright runs deterministic regardless of the runner's OS setting.
+ */
+function resolveInitialTheme(): HarnessTheme {
+  const param = new URLSearchParams(window.location.search).get("theme");
+  if (param === "light" || param === "dark") return param;
+  if (window.matchMedia?.("(prefers-color-scheme: light)").matches) return "light";
+  return "dark";
+}
+
+/**
+ * Apply a theme to both the chrome and the viz component so they never diverge.
+ * Sets `data-theme` on <body> (drives the chrome CSS variable overrides) and the
+ * `theme` attribute on <satsuma-viz> (drives the component's tokens.css palette),
+ * and updates the toggle's active button.
+ *
+ * @param record  When true, append a `theme-change` automation event. The
+ *                initial resolution passes false so the log starts clean; user
+ *                toggles pass true so Playwright can assert the switch occurred.
+ */
+function applyTheme(theme: HarnessTheme, record: boolean): void {
+  harness.theme = theme;
+  document.body.dataset["theme"] = theme;
+  if (vizEl) vizEl.setAttribute("theme", theme);
+  for (const btn of themeToggle.querySelectorAll<HTMLButtonElement>(".toggle-btn")) {
+    btn.classList.toggle("active", btn.dataset["theme"] === theme);
+  }
+  if (record) recordEvent("theme-change", { theme });
+}
+
+themeToggle.addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest<HTMLButtonElement>(".toggle-btn");
+  if (!btn) return;
+  const theme = btn.dataset["theme"] as HarnessTheme | undefined;
+  if (theme && theme !== harness.theme) applyTheme(theme, true);
+});
+
+// Resolve and apply the theme synchronously at module load so the chrome paints
+// in the correct palette before the fixture list and viz mount.
+applyTheme(resolveInitialTheme(), false);
 
 // ---------- Startup ----------
 

--- a/tooling/satsuma-viz-harness/src/client/index.html
+++ b/tooling/satsuma-viz-harness/src/client/index.html
@@ -7,10 +7,18 @@
   <style>
     /* ── Reset and base ──────────────────────────────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    /*
+     * Chrome theming.  The harness chrome (header, panels, source view) has its
+     * OWN palette, independent of the satsuma-viz component tokens.  Dark is the
+     * default (declared on :root); the light variant lives under
+     * body[data-theme="light"].  app.ts sets data-theme on <body> AND the
+     * `theme` attribute on <satsuma-viz>, so chrome and component always agree.
+     */
     :root {
       --header-height: 44px;
       --source-width: 448px;
       --font-mono: "JetBrains Mono", "Fira Code", ui-monospace, monospace;
+      /* Dark chrome (default). */
       --color-bg: #0f1117;
       --color-surface: #1a1d27;
       --color-surface-2: #22273a;
@@ -20,6 +28,56 @@
       --color-accent: #5b7fde;
       --color-accent-hover: #7094e8;
       --color-selected: #1d2d54;
+      --color-ready-bg: #0d2b1a;
+      --color-ready-text: #3fb950;
+      --color-ready-border: #2ea043;
+      /* Syntax token colours (dark — aligned with Tokyo Night). */
+      --tok-comment: #4a5274;
+      --tok-comment-warn: #e0af68;
+      --tok-comment-q: #9d86e9;
+      --tok-string: #9ece6a;
+      --tok-kw: #7aa2f7;
+      --tok-type: #73daca;
+      --tok-pipeline: #e0af68;
+      --tok-boolean: #ff9e64;
+      --tok-number: #ff9e64;
+      --tok-arrow: #89ddff;
+      --tok-backtick: #73daca;
+      --tok-ref: #bb9af7;
+    }
+
+    /*
+     * Light chrome variant.  Warm cream/orange to co-brand with the satsuma-viz
+     * light palette (Feature 31 identity).  The syntax token colours are
+     * re-tuned for legibility on the cream background — the dark Tokyo Night set
+     * (e.g. #9ece6a strings, #7aa2f7 keywords) is too low-contrast on #FFFAF5.
+     */
+    body[data-theme="light"] {
+      --color-bg: #FFFAF5;
+      --color-surface: #FFF3E8;
+      --color-surface-2: #F5E6D3;
+      --color-border: #E5D5C3;
+      --color-text: #2D2A26;
+      --color-text-muted: #8A7E72;
+      --color-accent: #D97726;
+      --color-accent-hover: #C45D22;
+      --color-selected: #FFE0C7;
+      --color-ready-bg: #E6F4EA;
+      --color-ready-text: #2E7D46;
+      --color-ready-border: #5A9E6F;
+      /* Syntax token colours (light) — darker, saturated for contrast on cream. */
+      --tok-comment: #8A8077;
+      --tok-comment-warn: #B5740A;
+      --tok-comment-q: #7C5CBF;
+      --tok-string: #3F7A4F;
+      --tok-kw: #2D6BB8;
+      --tok-type: #0E7C7B;
+      --tok-pipeline: #B5740A;
+      --tok-boolean: #C25A1C;
+      --tok-number: #C25A1C;
+      --tok-arrow: #1A7FA8;
+      --tok-backtick: #0E7C7B;
+      --tok-ref: #8E5BB0;
     }
     html, body {
       height: 100%; overflow: hidden;
@@ -63,7 +121,7 @@
       background: var(--color-surface-2); color: var(--color-text-muted); border: 1px solid var(--color-border);
       white-space: nowrap;
     }
-    #harness-ready-badge.ready { background: #0d2b1a; color: #3fb950; border-color: #2ea043; }
+    #harness-ready-badge.ready { background: var(--color-ready-bg); color: var(--color-ready-text); border-color: var(--color-ready-border); }
 
     /* ── Panel shared ────────────────────────────────────────────────────── */
     .panel-toolbar {
@@ -162,23 +220,24 @@
       height: 100%; color: var(--color-text-muted); font-style: italic; font-size: 12px;
     }
 
-    /* ── Syntax highlighting token colours (dark theme) ─────────────────── */
-    /* Colours are aligned with Tokyo Night for readability on dark backgrounds. */
-    .tok-comment      { color: #4a5274; font-style: italic; }
-    .tok-comment-warn { color: #e0af68; font-style: italic; } /* //! warning */
-    .tok-comment-q    { color: #9d86e9; font-style: italic; } /* //? question */
-    .tok-string       { color: #9ece6a; }
-    .tok-string-triple { color: #9ece6a; }
-    .tok-kw           { color: #7aa2f7; font-weight: 600; }   /* block + import keywords */
-    .tok-type         { color: #73daca; }                      /* STRING, INT, UUID… */
-    .tok-pipeline     { color: #e0af68; }                      /* trim, lowercase… */
-    .tok-boolean      { color: #ff9e64; }                      /* true, false, null */
-    .tok-number       { color: #ff9e64; }
-    .tok-arrow        { color: #89ddff; }                      /* -> */
-    .tok-spread       { color: #89ddff; }                      /* ... */
-    .tok-pipe         { color: #89ddff; }                      /* | */
-    .tok-backtick     { color: #73daca; }                      /* `identifier` */
-    .tok-ref          { color: #bb9af7; }                      /* @ref in NL strings */
+    /* ── Syntax highlighting token colours ──────────────────────────────── */
+    /* Colours resolve from CSS variables so both the dark (:root) and light
+     * (body[data-theme="light"]) syntax palettes are defined in one place. */
+    .tok-comment      { color: var(--tok-comment); font-style: italic; }
+    .tok-comment-warn { color: var(--tok-comment-warn); font-style: italic; } /* //! warning */
+    .tok-comment-q    { color: var(--tok-comment-q); font-style: italic; } /* //? question */
+    .tok-string       { color: var(--tok-string); }
+    .tok-string-triple { color: var(--tok-string); }
+    .tok-kw           { color: var(--tok-kw); font-weight: 600; }   /* block + import keywords */
+    .tok-type         { color: var(--tok-type); }                    /* STRING, INT, UUID… */
+    .tok-pipeline     { color: var(--tok-pipeline); }                /* trim, lowercase… */
+    .tok-boolean      { color: var(--tok-boolean); }                 /* true, false, null */
+    .tok-number       { color: var(--tok-number); }
+    .tok-arrow        { color: var(--tok-arrow); }                   /* -> */
+    .tok-spread       { color: var(--tok-arrow); }                   /* ... */
+    .tok-pipe         { color: var(--tok-arrow); }                   /* | */
+    .tok-backtick     { color: var(--tok-backtick); }                /* `identifier` */
+    .tok-ref          { color: var(--tok-ref); }                     /* @ref in NL strings */
   </style>
 </head>
 <body>
@@ -188,6 +247,10 @@
       <div class="toggle-group" id="view-mode-toggle">
         <button class="toggle-btn active" data-mode="lineage" title="Full transitive import lineage">lineage</button>
         <button class="toggle-btn"        data-mode="single"  title="Single file only">single</button>
+      </div>
+      <div class="toggle-group" id="theme-toggle">
+        <button class="toggle-btn" data-theme="light" title="Light theme">light</button>
+        <button class="toggle-btn" data-theme="dark"  title="Dark theme">dark</button>
       </div>
       <span id="harness-ready-badge">idle</span>
     </header>

--- a/tooling/satsuma-viz-harness/src/server.ts
+++ b/tooling/satsuma-viz-harness/src/server.ts
@@ -187,7 +187,11 @@ function makeHandler(
     // ── Static routes ──────────────────────────────────────────────────────
 
     if (rawPath === "/" || rawPath === "") {
-      res.writeHead(302, { Location: "/index.html" });
+      // Preserve the query string across the redirect so client-side URL
+      // parameters (?theme=, ?fixture=, ?mode=) survive a hit to the bare root.
+      // Dropping it here previously made ?theme= a silent no-op.
+      const suffix = rawQuery ? `?${rawQuery}` : "";
+      res.writeHead(302, { Location: `/index.html${suffix}` });
       res.end();
       return;
     }

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -1332,3 +1332,171 @@ test.describe("Compact card expansion in overview", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Theme switching (Feature 32)
+//
+// Proves the light/dark theme contract end-to-end in a real browser: the
+// `?theme=` URL parameter deterministically selects the palette, the
+// prefers-color-scheme fallback works, the header toggle restyles both chrome
+// and component while recording an automation event, and representative
+// tokenized elements (not just --sz-bg) change colour between themes.
+// ---------------------------------------------------------------------------
+
+/** Computed background-color of the <satsuma-viz> host (drives off --sz-bg). */
+async function vizHostBackground(page: Page): Promise<string> {
+  return page
+    .locator("satsuma-viz")
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
+}
+
+/** Read a computed style property of the first element matching a selector. */
+async function computedStyle(
+  page: Page,
+  selector: string,
+  property: string,
+): Promise<string> {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate(
+      (el, prop) => getComputedStyle(el).getPropertyValue(prop),
+      property,
+    );
+}
+
+test.describe("Theme switching — URL parameter", () => {
+  test("?theme=light renders the light component palette", async ({ page }) => {
+    // The light --sz-bg token is #FFFAF5 → rgb(255, 250, 245). Asserting the
+    // host's computed background proves the component received theme="light"
+    // and the tokens.css :host defaults (light) are in effect.
+    await page.goto("/?theme=light");
+    await loadFixture(page, sfdcUri);
+
+    await expect(page.locator("satsuma-viz")).toHaveAttribute("theme", "light");
+    expect(await vizHostBackground(page)).toBe("rgb(255, 250, 245)");
+    expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("light");
+  });
+
+  test("?theme=dark renders the dark component palette", async ({ page }) => {
+    // The dark --sz-bg token is #1E1E1E → rgb(30, 30, 30). This is the
+    // :host([theme="dark"]) override engaging via the reflected attribute.
+    await page.goto("/?theme=dark");
+    await loadFixture(page, sfdcUri);
+
+    await expect(page.locator("satsuma-viz")).toHaveAttribute("theme", "dark");
+    expect(await vizHostBackground(page)).toBe("rgb(30, 30, 30)");
+    expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("dark");
+  });
+});
+
+test.describe("Theme switching — prefers-color-scheme fallback", () => {
+  // With no ?theme= parameter the harness falls back to the emulated
+  // colorScheme. Playwright drives the media query via test.use({ colorScheme }).
+  test.describe("emulated light scheme", () => {
+    test.use({ colorScheme: "light" });
+    test("adopts light when the OS prefers light and no parameter is set", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await loadFixture(page, sfdcUri);
+      expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("light");
+      await expect(page.locator("satsuma-viz")).toHaveAttribute("theme", "light");
+    });
+  });
+
+  test.describe("emulated dark scheme", () => {
+    test.use({ colorScheme: "dark" });
+    test("adopts dark when the OS prefers dark and no parameter is set", async ({
+      page,
+    }) => {
+      await page.goto("/");
+      await loadFixture(page, sfdcUri);
+      expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("dark");
+      await expect(page.locator("satsuma-viz")).toHaveAttribute("theme", "dark");
+    });
+  });
+});
+
+test.describe("Theme switching — header toggle", () => {
+  test("toggling to light restyles chrome + component and records a theme-change event", async ({
+    page,
+  }) => {
+    // Start in dark, toggle to light. The toggle must flip the component's
+    // theme attribute, the chrome's body[data-theme] (which restyles the
+    // chrome background via CSS variables), AND append a theme-change event so
+    // automation can observe the switch.
+    await page.goto("/?theme=dark");
+    await loadFixture(page, sfdcUri);
+    await page.evaluate(() => window.__satsumaHarness.clearEvents());
+
+    // Dark chrome background before the switch (#0f1117 → rgb(15, 17, 23)).
+    const bodyBgBefore = await page
+      .locator("body")
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bodyBgBefore).toBe("rgb(15, 17, 23)");
+
+    await page.locator("#theme-toggle .toggle-btn[data-theme='light']").click();
+
+    // Component attribute and chrome data-theme both flip to light.
+    await expect(page.locator("satsuma-viz")).toHaveAttribute("theme", "light");
+    await expect(page.locator("body")).toHaveAttribute("data-theme", "light");
+
+    // Chrome background restyled to the light cream (#FFFAF5 → rgb(255,250,245)).
+    const bodyBgAfter = await page
+      .locator("body")
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(bodyBgAfter).toBe("rgb(255, 250, 245)");
+
+    // The switch is observable in the automation event log.
+    await expect.poll(async () => recordedEvents(page, "theme-change")).toContainEqual(
+      expect.objectContaining({ detail: { theme: "light" } }),
+    );
+  });
+});
+
+test.describe("Theme switching — representative audit tokens", () => {
+  test("report header and overview edge stroke change colour between themes", async ({
+    page,
+  }) => {
+    // --sz-bg flipping is necessary but not sufficient: the audit promoted many
+    // other tokens. This asserts two representative ones — the report-card
+    // header (--sz-report) and the overview edge stroke (--sz-edge-default) —
+    // resolve to different computed colours in light vs dark, proving the full
+    // token set switches, not just the page background.
+    // Overview schema cards render compact, so the report header carries no
+    // -header testid — locate it by its `.header.report` class inside the
+    // card's shadow DOM (Playwright pierces open shadow roots for CSS
+    // descendant combinators, as the existing `.header` click tests rely on).
+    const reportHeader =
+      "[data-testid='overview-schema-card-weekly-sales-dashboard'] .header.report";
+    const overviewEdge = "sz-overview-edge-layer path.overview-path";
+
+    await page.goto("/?theme=light");
+    await page.locator(".toggle-btn[data-mode='single']").click();
+    await loadFixture(page, reportsUri);
+    const reportHeaderLight = await computedStyle(page, reportHeader, "background-color");
+    const edgeStrokeLight = await computedStyle(page, overviewEdge, "stroke");
+
+    // --sz-report light is #4A90B8 → rgb(74, 144, 184): the exact promoted token.
+    expect(reportHeaderLight).toBe("rgb(74, 144, 184)");
+    // Edge stroke resolves to a real colour (its exact token depends on whether
+    // the first edge is a bare/map or NL edge — both differ between themes).
+    expect(edgeStrokeLight).toMatch(/^rgb\(/);
+
+    await page.goto("/?theme=dark");
+    await page.locator(".toggle-btn[data-mode='single']").click();
+    await loadFixture(page, reportsUri);
+    const reportHeaderDark = await computedStyle(page, reportHeader, "background-color");
+    const edgeStrokeDark = await computedStyle(page, overviewEdge, "stroke");
+
+    // --sz-report dark is #6FB3D9 → rgb(111, 179, 217).
+    expect(reportHeaderDark).toBe("rgb(111, 179, 217)");
+    expect(edgeStrokeDark).toMatch(/^rgb\(/);
+
+    // The audit tokens switch with the theme — neither element keeps its
+    // light-mode colour in dark mode.
+    expect(reportHeaderDark).not.toBe(reportHeaderLight);
+    expect(edgeStrokeDark).not.toBe(edgeStrokeLight);
+  });
+});

--- a/tooling/satsuma-viz-harness/test/screenshots.spec.ts
+++ b/tooling/satsuma-viz-harness/test/screenshots.spec.ts
@@ -51,6 +51,8 @@ interface ManifestEntry {
   fixture: string;
   /** View mode the harness was in when the shot was taken. */
   viewMode: "single" | "lineage";
+  /** Theme the shot was captured in — both are captured for palette sign-off. */
+  theme: "light" | "dark";
   /** Free-form description of the UI state captured (overview, detail, filter, …). */
   uiState: string;
   /** Viewport the shot was rendered at. */
@@ -60,6 +62,9 @@ interface ManifestEntry {
   /** Playwright test step name (used to correlate shots back to this file). */
   step: string;
 }
+
+/** Both themes are captured for every named shot (Feature 32 palette sign-off). */
+const THEMES = ["light", "dark"] as const;
 
 // In-memory manifest accumulated across all steps in this file. Written to
 // disk in afterAll so a partial run still leaves whatever it managed to
@@ -145,6 +150,7 @@ async function capture(
     file: string;
     fixture: string;
     viewMode: "single" | "lineage";
+    theme: "light" | "dark";
     uiState: string;
     step: string;
   },
@@ -155,6 +161,7 @@ async function capture(
     file: args.file,
     fixture: args.fixture,
     viewMode: args.viewMode,
+    theme: args.theme,
     uiState: args.uiState,
     viewport: REVIEW_VIEWPORT,
     timestamp: new Date().toISOString(),
@@ -168,156 +175,172 @@ async function capture(
 // Tests are kept independent so a single failure does not block the rest of
 // the gallery from being captured.
 
-test.describe("Screenshot review artifacts", () => {
-  test.use({ viewport: REVIEW_VIEWPORT });
+// Every named shot is captured once per theme. The ?theme= URL parameter
+// deterministically selects the palette (see app.ts resolveInitialTheme), and
+// the file name + manifest entry carry the theme so a reviewer can line up the
+// light and dark versions of each shot side by side.
+for (const theme of THEMES) {
+  test.describe(`Screenshot review artifacts (${theme})`, () => {
+    test.use({ viewport: REVIEW_VIEWPORT });
 
-  test("sfdc-overview-single", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, sfdcUri);
-    await capture(page, {
-      file: "sfdc-overview-single.png",
-      fixture: "sfdc-to-snowflake/pipeline.stm",
-      viewMode: "single",
-      uiState: "overview",
-      step: "sfdc-overview-single",
+    test(`sfdc-overview-single-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, sfdcUri);
+      await capture(page, {
+        file: `sfdc-overview-single-${theme}.png`,
+        fixture: "sfdc-to-snowflake/pipeline.stm",
+        viewMode: "single",
+        theme,
+        uiState: "overview",
+        step: `sfdc-overview-single-${theme}`,
+      });
+    });
+
+    test(`sfdc-detail-opportunity-ingestion-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, sfdcUri);
+      await openMapping(page, "opportunity-ingestion");
+      await capture(page, {
+        file: `sfdc-detail-opportunity-ingestion-${theme}.png`,
+        fixture: "sfdc-to-snowflake/pipeline.stm",
+        viewMode: "single",
+        theme,
+        uiState: "detail:opportunity-ingestion",
+        step: `sfdc-detail-opportunity-ingestion-${theme}`,
+      });
+    });
+
+    test(`namespaces-overview-lineage-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      // Default mode is lineage; ns-platform shows all namespaces in lineage mode.
+      await loadFixture(page, nsPlatformUri);
+      await capture(page, {
+        file: `namespaces-overview-lineage-${theme}.png`,
+        fixture: "namespaces/ns-platform.stm",
+        viewMode: "lineage",
+        theme,
+        uiState: "overview:all-namespaces",
+        step: `namespaces-overview-lineage-${theme}`,
+      });
+    });
+
+    test(`namespaces-detail-namespaced-mapping-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await loadFixture(page, nsPlatformUri);
+      await openMapping(page, "load-hub-contact");
+      await capture(page, {
+        file: `namespaces-detail-namespaced-mapping-${theme}.png`,
+        fixture: "namespaces/ns-platform.stm",
+        viewMode: "lineage",
+        theme,
+        uiState: "detail:vault::load-hub-contact",
+        step: `namespaces-detail-namespaced-mapping-${theme}`,
+      });
+    });
+
+    test(`metrics-overview-lineage-all-files-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await loadFixture(page, metricsUri);
+      await capture(page, {
+        file: `metrics-overview-lineage-all-files-${theme}.png`,
+        fixture: "metrics-platform/metrics.stm",
+        viewMode: "lineage",
+        theme,
+        uiState: "overview:file-filter=all",
+        step: `metrics-overview-lineage-all-files-${theme}`,
+      });
+    });
+
+    test(`metrics-overview-file-filter-sources-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await loadFixture(page, metricsUri);
+
+      // Drive the file filter to the metric_sources.stm option, mirroring the
+      // approach used in the toolbar file-filter test in harness.test.ts.
+      const fileFilter = page.locator("[data-testid='toolbar-file-filter']");
+      const options = await fileFilter
+        .locator("option")
+        .evaluateAll((opts) =>
+          (opts as HTMLOptionElement[]).map((o) => ({
+            value: o.value,
+            label: o.textContent,
+          })),
+        );
+      const sourcesOption = options.find((o) => o.label?.includes("metric_sources.stm"));
+      if (!sourcesOption) {
+        throw new Error(`metric_sources.stm option not found; got ${JSON.stringify(options)}`);
+      }
+      await fileFilter.selectOption(sourcesOption.value);
+      await waitForReady(page);
+
+      await capture(page, {
+        file: `metrics-overview-file-filter-sources-${theme}.png`,
+        fixture: "metrics-platform/metrics.stm",
+        viewMode: "lineage",
+        theme,
+        uiState: "overview:file-filter=metric_sources.stm",
+        step: `metrics-overview-file-filter-sources-${theme}`,
+      });
+    });
+
+    test(`reports-overview-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, reportsUri);
+      await capture(page, {
+        file: `reports-overview-${theme}.png`,
+        fixture: "reports-and-models/pipeline.stm",
+        viewMode: "single",
+        theme,
+        uiState: "overview",
+        step: `reports-overview-${theme}`,
+      });
+    });
+
+    test(`filter-flatten-detail-completed-orders-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, ffgUri);
+      await openMapping(page, "completed-orders");
+      await capture(page, {
+        file: `filter-flatten-detail-completed-orders-${theme}.png`,
+        fixture: "filter-flatten-governance/filter-flatten-governance.stm",
+        viewMode: "single",
+        theme,
+        uiState: "detail:completed-orders",
+        step: `filter-flatten-detail-completed-orders-${theme}`,
+      });
+    });
+
+    test(`filter-flatten-detail-order-line-facts-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, ffgUri);
+      await openMapping(page, "order-line-facts");
+      await capture(page, {
+        file: `filter-flatten-detail-order-line-facts-${theme}.png`,
+        fixture: "filter-flatten-governance/filter-flatten-governance.stm",
+        viewMode: "single",
+        theme,
+        uiState: "detail:order-line-facts",
+        step: `filter-flatten-detail-order-line-facts-${theme}`,
+      });
+    });
+
+    test(`sap-po-layout-stability-${theme}`, async ({ page }) => {
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, sapUri);
+      await capture(page, {
+        file: `sap-po-layout-stability-${theme}.png`,
+        fixture: "sap-po-to-mfcs/pipeline.stm",
+        viewMode: "single",
+        theme,
+        uiState: "overview",
+        step: `sap-po-layout-stability-${theme}`,
+      });
     });
   });
-
-  test("sfdc-detail-opportunity-ingestion", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, sfdcUri);
-    await openMapping(page, "opportunity-ingestion");
-    await capture(page, {
-      file: "sfdc-detail-opportunity-ingestion.png",
-      fixture: "sfdc-to-snowflake/pipeline.stm",
-      viewMode: "single",
-      uiState: "detail:opportunity-ingestion",
-      step: "sfdc-detail-opportunity-ingestion",
-    });
-  });
-
-  test("namespaces-overview-lineage", async ({ page }) => {
-    await page.goto("/");
-    // Default mode is lineage; ns-platform shows all namespaces in lineage mode.
-    await loadFixture(page, nsPlatformUri);
-    await capture(page, {
-      file: "namespaces-overview-lineage.png",
-      fixture: "namespaces/ns-platform.stm",
-      viewMode: "lineage",
-      uiState: "overview:all-namespaces",
-      step: "namespaces-overview-lineage",
-    });
-  });
-
-  test("namespaces-detail-namespaced-mapping", async ({ page }) => {
-    await page.goto("/");
-    await loadFixture(page, nsPlatformUri);
-    await openMapping(page, "load-hub-contact");
-    await capture(page, {
-      file: "namespaces-detail-namespaced-mapping.png",
-      fixture: "namespaces/ns-platform.stm",
-      viewMode: "lineage",
-      uiState: "detail:vault::load-hub-contact",
-      step: "namespaces-detail-namespaced-mapping",
-    });
-  });
-
-  test("metrics-overview-lineage-all-files", async ({ page }) => {
-    await page.goto("/");
-    await loadFixture(page, metricsUri);
-    await capture(page, {
-      file: "metrics-overview-lineage-all-files.png",
-      fixture: "metrics-platform/metrics.stm",
-      viewMode: "lineage",
-      uiState: "overview:file-filter=all",
-      step: "metrics-overview-lineage-all-files",
-    });
-  });
-
-  test("metrics-overview-file-filter-sources", async ({ page }) => {
-    await page.goto("/");
-    await loadFixture(page, metricsUri);
-
-    // Drive the file filter to the metric_sources.stm option, mirroring the
-    // approach used in the toolbar file-filter test in harness.test.ts.
-    const fileFilter = page.locator("[data-testid='toolbar-file-filter']");
-    const options = await fileFilter
-      .locator("option")
-      .evaluateAll((opts) =>
-        (opts as HTMLOptionElement[]).map((o) => ({
-          value: o.value,
-          label: o.textContent,
-        })),
-      );
-    const sourcesOption = options.find((o) => o.label?.includes("metric_sources.stm"));
-    if (!sourcesOption) {
-      throw new Error(`metric_sources.stm option not found; got ${JSON.stringify(options)}`);
-    }
-    await fileFilter.selectOption(sourcesOption.value);
-    await waitForReady(page);
-
-    await capture(page, {
-      file: "metrics-overview-file-filter-sources.png",
-      fixture: "metrics-platform/metrics.stm",
-      viewMode: "lineage",
-      uiState: "overview:file-filter=metric_sources.stm",
-      step: "metrics-overview-file-filter-sources",
-    });
-  });
-
-  test("reports-overview", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, reportsUri);
-    await capture(page, {
-      file: "reports-overview.png",
-      fixture: "reports-and-models/pipeline.stm",
-      viewMode: "single",
-      uiState: "overview",
-      step: "reports-overview",
-    });
-  });
-
-  test("filter-flatten-detail-completed-orders", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, ffgUri);
-    await openMapping(page, "completed-orders");
-    await capture(page, {
-      file: "filter-flatten-detail-completed-orders.png",
-      fixture: "filter-flatten-governance/filter-flatten-governance.stm",
-      viewMode: "single",
-      uiState: "detail:completed-orders",
-      step: "filter-flatten-detail-completed-orders",
-    });
-  });
-
-  test("filter-flatten-detail-order-line-facts", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, ffgUri);
-    await openMapping(page, "order-line-facts");
-    await capture(page, {
-      file: "filter-flatten-detail-order-line-facts.png",
-      fixture: "filter-flatten-governance/filter-flatten-governance.stm",
-      viewMode: "single",
-      uiState: "detail:order-line-facts",
-      step: "filter-flatten-detail-order-line-facts",
-    });
-  });
-
-  test("sap-po-layout-stability", async ({ page }) => {
-    await page.goto("/");
-    await setSingleFileMode(page);
-    await loadFixture(page, sapUri);
-    await capture(page, {
-      file: "sap-po-layout-stability.png",
-      fixture: "sap-po-to-mfcs/pipeline.stm",
-      viewMode: "single",
-      uiState: "overview",
-      step: "sap-po-layout-stability",
-    });
-  });
-});
+}

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -12,12 +12,12 @@ export class SzFragmentCard extends LitElement {
       box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius, 8px);
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
     }
 
     .header {
@@ -25,8 +25,8 @@ export class SzFragmentCard extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 10px 12px;
-      background: var(--sz-green, #5A9E6F);
-      color: #fff;
+      background: var(--sz-green);
+      color: var(--sz-text-on-accent);
       cursor: pointer;
       user-select: none;
     }
@@ -70,32 +70,32 @@ export class SzFragmentCard extends LitElement {
       align-items: center;
       gap: 6px;
       padding: 3px 12px;
-      height: var(--sz-field-height, 28px);
+      height: var(--sz-field-height);
       cursor: pointer;
     }
 
     .field-row:hover {
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
     }
 
     .spread-icon {
       font-size: 11px;
-      color: var(--sz-green, #5A9E6F);
+      color: var(--sz-green);
       flex-shrink: 0;
     }
 
     .field-name {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 12px;
       font-weight: 500;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       flex: 1;
     }
 
     .field-type {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       flex-shrink: 0;
     }
 
@@ -106,13 +106,13 @@ export class SzFragmentCard extends LitElement {
     }
 
     .badge {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 10px;
       font-weight: 500;
       padding: 1px 5px;
-      border-radius: var(--sz-badge-radius, 4px);
-      background: var(--sz-badge-bg, #FFF3E8);
-      color: var(--sz-badge-text, #D97726);
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-badge-bg);
+      color: var(--sz-badge-text);
       line-height: 1.4;
     }
 
@@ -122,7 +122,7 @@ export class SzFragmentCard extends LitElement {
     }
 
     .notes-section {
-      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-top: 1px dashed var(--sz-card-border);
       padding: 6px 12px;
     }
 
@@ -132,13 +132,13 @@ export class SzFragmentCard extends LitElement {
       gap: 6px;
       cursor: pointer;
       font-size: 12px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       user-select: none;
       padding: 2px 0;
     }
 
     .notes-toggle:hover {
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
 
     .notes-toggle .arrow {
@@ -151,9 +151,9 @@ export class SzFragmentCard extends LitElement {
     }
 
     .note-content {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 12px;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       line-height: 1.5;
       padding: 4px 0 2px 22px;
       white-space: pre-wrap;
@@ -178,11 +178,11 @@ export class SzFragmentCard extends LitElement {
 
   private _renderNamespacePill() {
     if (this.namespaceLabel) {
-      return html`<div style="padding: 8px 12px 0; background: var(--sz-green, #5A9E6F);">
-          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+      return html`<div style="padding: 8px 12px 0; background: var(--sz-green);">
+          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);">${this.namespaceLabel}</span>
         </div>`;
     }
-    if (this.compact) return html`<div style="height:24px;background:var(--sz-green, #5A9E6F);border-radius:var(--sz-card-radius, 8px) var(--sz-card-radius, 8px) 0 0;"></div>`;
+    if (this.compact) return html`<div style="height:24px;background:var(--sz-green);border-radius:var(--sz-card-radius) var(--sz-card-radius) 0 0;"></div>`;
     return html``;
   }
 

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -51,7 +51,7 @@ export class SzMappingDetail extends LitElement {
   static override styles = css`
     :host {
       display: block;
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
     }
 
     .layout {
@@ -83,17 +83,17 @@ export class SzMappingDetail extends LitElement {
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       padding: 0 4px 4px;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
     }
 
     /* Mapping header */
     .mapping-header {
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      border-radius: var(--sz-card-radius, 8px);
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      border-radius: var(--sz-card-radius);
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
       width: max-content;
       min-width: 100%;
@@ -104,8 +104,8 @@ export class SzMappingDetail extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 10px 12px;
-      background: var(--sz-orange, #F2913D);
-      color: #fff;
+      background: var(--sz-orange);
+      color: var(--sz-text-on-accent);
       font-size: 14px;
       font-weight: 600;
       cursor: pointer;
@@ -120,7 +120,7 @@ export class SzMappingDetail extends LitElement {
       flex-direction: column;
       gap: 6px;
       padding: 8px 12px;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
     }
 
     .mapping-meta-row {
@@ -134,13 +134,13 @@ export class SzMappingDetail extends LitElement {
       font-size: 11px;
       padding: 2px 8px;
       border-radius: 4px;
-      background: var(--sz-badge-bg, #FFF3E8);
-      color: var(--sz-text-muted, #6B6560);
+      background: var(--sz-badge-bg);
+      color: var(--sz-text-muted);
       max-width: 100%;
     }
 
     .meta-tag .label {
-      color: var(--sz-orange-dark, #D97726);
+      color: var(--sz-orange-dark);
       font-weight: 500;
     }
 
@@ -163,15 +163,15 @@ export class SzMappingDetail extends LitElement {
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       text-align: left;
       padding: 6px 12px;
-      border-bottom: 2px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 2px solid var(--sz-card-border);
     }
 
     .arrow-table td {
       padding: 5px 12px;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
       font-size: 12px;
       vertical-align: top;
     }
@@ -182,7 +182,7 @@ export class SzMappingDetail extends LitElement {
     }
 
     .arrow-table tr:hover {
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
     }
 
     /* Cross-highlighting on arrow rows */
@@ -192,7 +192,7 @@ export class SzMappingDetail extends LitElement {
 
     :host([has-highlight]) .arrow-table tr.arrow-row.hl {
       opacity: 1;
-      background: rgba(242, 145, 61, 0.08);
+      background: var(--sz-accent-wash);
     }
 
     :host([has-highlight]) .arrow-table tr.arrow-row.hl .field-ref {
@@ -203,7 +203,7 @@ export class SzMappingDetail extends LitElement {
       font-family: var(--sz-font-mono, monospace);
       font-size: 12px;
       font-weight: 500;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       white-space: normal;
       word-break: break-word;
       overflow-wrap: anywhere;
@@ -232,7 +232,7 @@ export class SzMappingDetail extends LitElement {
       display: inline-block;
       font-style: italic;
       font-size: 11px;
-      color: var(--sz-green, #5A9E6F);
+      color: var(--sz-green);
       max-width: 400px;
       white-space: normal;
       word-break: break-word;
@@ -242,18 +242,18 @@ export class SzMappingDetail extends LitElement {
 
     .transform-bare {
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
     }
 
     /* @ref highlights inside NL transform text */
     .at-ref {
       font-weight: 600;
       font-style: normal;
-      color: var(--sz-at-ref, #4A8A5B);
+      color: var(--sz-at-ref);
     }
 
     .arrow-icon {
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       font-size: 11px;
     }
 
@@ -263,13 +263,13 @@ export class SzMappingDetail extends LitElement {
     }
 
     .arrow-note {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 11px;
       font-style: italic;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       line-height: 1.4;
       padding: 2px 8px;
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
       border-radius: 3px;
       max-width: 400px;
       word-break: break-word;
@@ -287,24 +287,24 @@ export class SzMappingDetail extends LitElement {
       padding: 6px 12px;
       font-size: 11px;
       font-weight: 600;
-      color: var(--sz-text-muted, #6B6560);
-      background: var(--sz-namespace-bg, #FFF3E8);
-      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      color: var(--sz-text-muted);
+      background: var(--sz-namespace-bg);
+      border-top: 1px dashed var(--sz-card-border);
     }
 
     .scope-label .scope-tag {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 10px;
       padding: 1px 6px;
       border-radius: 3px;
-      background: var(--sz-orange-dark, #D97726);
-      color: #fff;
+      background: var(--sz-orange-dark);
+      color: var(--sz-text-on-accent);
     }
 
     .scope-fields {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 11px;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
   `;
 
@@ -570,11 +570,11 @@ export class SzMappingDetail extends LitElement {
     return html`
       <div class="mapping-header" data-testid=${`${this.testIdPrefix}-header`}>
         ${this.namespaceLabel
-          ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange, #F2913D);">
+          ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange);">
               <span
                 class="meta-tag"
                 data-testid=${`${this.testIdPrefix}-namespace-label`}
-                style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);"
+                style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
               >${this.namespaceLabel}</span>
             </div>`
           : nothing}

--- a/tooling/satsuma-viz/src/components/sz-metric-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-metric-card.ts
@@ -18,12 +18,12 @@ export class SzMetricCard extends LitElement {
       box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius, 8px);
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
     }
 
     .header {
@@ -31,8 +31,8 @@ export class SzMetricCard extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 10px 12px;
-      background: var(--sz-violet, #8E5BB0);
-      color: #fff;
+      background: var(--sz-violet);
+      color: var(--sz-text-on-accent);
       cursor: pointer;
       user-select: none;
     }
@@ -64,8 +64,8 @@ export class SzMetricCard extends LitElement {
     .meta {
       padding: 4px 12px 6px;
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      color: var(--sz-text-muted);
+      border-bottom: 1px solid var(--sz-card-border);
       line-height: 1.5;
     }
 
@@ -87,12 +87,12 @@ export class SzMetricCard extends LitElement {
       align-items: center;
       gap: 6px;
       padding: 3px 12px;
-      height: var(--sz-field-height, 28px);
+      height: var(--sz-field-height);
       cursor: pointer;
     }
 
     .field-row:hover {
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
     }
 
     .measure-icon {
@@ -100,22 +100,22 @@ export class SzMetricCard extends LitElement {
       text-align: center;
       font-size: 13px;
       font-weight: 600;
-      color: var(--sz-violet, #8E5BB0);
+      color: var(--sz-violet);
       flex-shrink: 0;
     }
 
     .field-name {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 12px;
       font-weight: 500;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       flex: 1;
     }
 
     .field-type {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       flex-shrink: 0;
     }
 
@@ -126,7 +126,7 @@ export class SzMetricCard extends LitElement {
     }
 
     .notes-section {
-      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-top: 1px dashed var(--sz-card-border);
       padding: 6px 12px;
     }
 
@@ -136,13 +136,13 @@ export class SzMetricCard extends LitElement {
       gap: 6px;
       cursor: pointer;
       font-size: 12px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       user-select: none;
       padding: 2px 0;
     }
 
     .notes-toggle:hover {
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
 
     .notes-toggle .arrow {
@@ -155,9 +155,9 @@ export class SzMetricCard extends LitElement {
     }
 
     .note-content {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 12px;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       line-height: 1.5;
       padding: 4px 0 2px 22px;
       white-space: pre-wrap;
@@ -182,11 +182,11 @@ export class SzMetricCard extends LitElement {
 
   private _renderNamespacePill() {
     if (this.namespaceLabel) {
-      return html`<div style="padding: 8px 12px 0; background: var(--sz-violet, #8E5BB0);">
-          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);">${this.namespaceLabel}</span>
+      return html`<div style="padding: 8px 12px 0; background: var(--sz-violet);">
+          <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);">${this.namespaceLabel}</span>
         </div>`;
     }
-    if (this.compact) return html`<div style="height:24px;background:var(--sz-violet, #8E5BB0);border-radius:var(--sz-card-radius, 8px) var(--sz-card-radius, 8px) 0 0;"></div>`;
+    if (this.compact) return html`<div style="height:24px;background:var(--sz-violet);border-radius:var(--sz-card-radius) var(--sz-card-radius) 0 0;"></div>`;
     return html``;
   }
 

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -39,12 +39,12 @@ export class SzSchemaCard extends LitElement {
       box-sizing: border-box;
       min-width: var(--sz-card-min-width, 240px);
       max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius, 8px);
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
     }
 
     :host([content-width]) {
@@ -57,14 +57,14 @@ export class SzSchemaCard extends LitElement {
       align-items: center;
       gap: 8px;
       padding: 10px 12px;
-      background: var(--sz-orange, #F2913D);
-      color: #fff;
+      background: var(--sz-orange);
+      color: var(--sz-text-on-accent);
       cursor: pointer;
       user-select: none;
     }
 
     .header.report {
-      background: var(--sz-report, #4A90B8);
+      background: var(--sz-report);
     }
 
     .header-icon {
@@ -77,8 +77,8 @@ export class SzSchemaCard extends LitElement {
       font-size: 14px;
       font-weight: 600;
       flex: 1;
-      overflow: var(--sz-header-name-overflow, hidden);
-      text-overflow: var(--sz-header-name-overflow-mode, ellipsis);
+      overflow: var(--sz-header-name-overflow);
+      text-overflow: var(--sz-header-name-overflow-mode);
       white-space: nowrap;
     }
 
@@ -101,9 +101,9 @@ export class SzSchemaCard extends LitElement {
     .label {
       padding: 4px 12px 6px;
       font-size: 12px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       font-style: italic;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
       max-width: 400px;
       word-break: break-word;
     }
@@ -117,45 +117,45 @@ export class SzSchemaCard extends LitElement {
       align-items: center;
       gap: 6px;
       padding: 3px 12px;
-      height: var(--sz-field-height, 28px);
+      height: var(--sz-field-height);
       cursor: pointer;
     }
 
     .field-row:hover {
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
     }
 
     .port {
-      width: var(--sz-port-size, 8px);
-      height: var(--sz-port-size, 8px);
+      width: var(--sz-port-size);
+      height: var(--sz-port-size);
       border-radius: 50%;
       flex-shrink: 0;
     }
 
     .port.mapped {
-      background: var(--sz-orange-dark, #D97726);
+      background: var(--sz-orange-dark);
     }
 
     .port.unmapped {
-      border: 1.5px solid var(--sz-text-muted, #6B6560);
+      border: 1.5px solid var(--sz-text-muted);
       background: transparent;
     }
 
     .field-name {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 12px;
       font-weight: 500;
-      color: var(--sz-text, #2D2A26);
-      flex: var(--sz-field-name-flex, 1);
-      overflow: var(--sz-field-name-overflow, hidden);
-      text-overflow: var(--sz-field-name-overflow-mode, ellipsis);
+      color: var(--sz-text);
+      flex: var(--sz-field-name-flex);
+      overflow: var(--sz-field-name-overflow);
+      text-overflow: var(--sz-field-name-overflow-mode);
       white-space: nowrap;
     }
 
     .field-type {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       flex-shrink: 0;
     }
 
@@ -166,19 +166,19 @@ export class SzSchemaCard extends LitElement {
     }
 
     .badge {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 10px;
       font-weight: 500;
       padding: 1px 5px;
-      border-radius: var(--sz-badge-radius, 4px);
-      background: var(--sz-badge-bg, #FFF3E8);
-      color: var(--sz-badge-text, #D97726);
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-badge-bg);
+      color: var(--sz-badge-text);
       line-height: 1.4;
     }
 
     .badge.pii {
-      background: var(--sz-warning-bg, #FEF3CD);
-      color: var(--sz-warning-icon, #C45D22);
+      background: var(--sz-warning-bg);
+      color: var(--sz-warning-icon);
     }
 
     .comment-badge {
@@ -195,13 +195,13 @@ export class SzSchemaCard extends LitElement {
     }
 
     .comment-badge.warning {
-      background: var(--sz-warning-bg, #FEF3CD);
-      color: var(--sz-warning-icon, #C45D22);
+      background: var(--sz-warning-bg);
+      color: var(--sz-warning-icon);
     }
 
     .comment-badge.question {
-      background: var(--sz-question-bg, #E8F0FE);
-      color: var(--sz-question-icon, #7C6BAE);
+      background: var(--sz-question-bg);
+      color: var(--sz-question-icon);
     }
 
     .nested {
@@ -226,23 +226,23 @@ export class SzSchemaCard extends LitElement {
       flex-wrap: wrap;
       gap: 4px;
       padding: 4px 12px 6px;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
     }
 
     .meta-pill {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 10px;
       font-weight: 500;
       padding: 1px 6px;
-      border-radius: var(--sz-badge-radius, 4px);
-      background: var(--sz-namespace-bg, #FFF3E8);
-      color: var(--sz-text-muted, #6B6560);
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-namespace-bg);
+      color: var(--sz-text-muted);
       line-height: 1.4;
       white-space: nowrap;
     }
 
     .meta-pill .meta-key {
-      color: var(--sz-orange-dark, #D97726);
+      color: var(--sz-orange-dark);
     }
 
     .spread-indicator {
@@ -251,8 +251,8 @@ export class SzSchemaCard extends LitElement {
       gap: 4px;
       padding: 3px 12px;
       font-size: 11px;
-      color: var(--sz-green, #5A9E6F);
-      border-top: 1px dotted var(--sz-green, #5A9E6F);
+      color: var(--sz-green);
+      border-top: 1px dotted var(--sz-green);
     }
 
     .spread-indicator .spread-icon {
@@ -260,7 +260,7 @@ export class SzSchemaCard extends LitElement {
     }
 
     .notes-section {
-      border-top: 1px dashed var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-top: 1px dashed var(--sz-card-border);
       padding: 6px 12px;
     }
 
@@ -270,13 +270,13 @@ export class SzSchemaCard extends LitElement {
       gap: 6px;
       cursor: pointer;
       font-size: 12px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       user-select: none;
       padding: 2px 0;
     }
 
     .notes-toggle:hover {
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
 
     .notes-toggle .arrow {
@@ -289,9 +289,9 @@ export class SzSchemaCard extends LitElement {
     }
 
     .note-content {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 12px;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       line-height: 1.5;
       padding: 4px 0 2px 22px;
       word-break: break-word;
@@ -325,9 +325,9 @@ export class SzSchemaCard extends LitElement {
     }
 
     .note-content code {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 11px;
-      background: rgba(45, 42, 38, 0.06);
+      background: var(--sz-row-active-bg);
       padding: 1px 4px;
       border-radius: 3px;
     }
@@ -349,7 +349,7 @@ export class SzSchemaCard extends LitElement {
       border: none;
       border-radius: 3px;
       background: transparent;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       cursor: pointer;
       flex-shrink: 0;
       padding: 0;
@@ -362,8 +362,8 @@ export class SzSchemaCard extends LitElement {
     }
 
     .lineage-btn:hover {
-      background: rgba(242, 145, 61, 0.12);
-      color: var(--sz-orange-dark, #D97726);
+      background: var(--sz-accent-wash);
+      color: var(--sz-orange-dark);
     }
 
     /* Cross-highlighting */
@@ -377,11 +377,11 @@ export class SzSchemaCard extends LitElement {
     }
 
     :host([has-highlight]) .field-row.hl.hl-source {
-      background: rgba(242, 145, 61, 0.12);
+      background: var(--sz-accent-wash);
     }
 
     :host([has-highlight]) .field-row.hl.hl-target {
-      background: rgba(90, 158, 111, 0.12);
+      background: var(--sz-green-wash);
     }
 
     :host([has-highlight]) .field-row.hl .field-name {
@@ -395,13 +395,13 @@ export class SzSchemaCard extends LitElement {
 
     /* Shaded note row displayed beneath a field that has notes. */
     .field-note {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 11px;
       font-style: italic;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       line-height: 1.4;
       padding: 2px 12px 4px 38px;
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
       max-width: 400px;
       word-break: break-word;
     }
@@ -481,20 +481,20 @@ export class SzSchemaCard extends LitElement {
       // (sl-3c2w) so Playwright can assert qualified namespace rendering
       // without text matching against a positioned <span>.
       return html`<div
-          style="padding: 8px 12px 0; background: var(--sz-orange, #F2913D);"
+          style="padding: 8px 12px 0; background: var(--sz-orange);"
           data-testid=${`${this.testIdPrefix}-namespace-pill`}
         >
           <span
             data-testid=${`${this.testIdPrefix}-namespace-label`}
-            style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:rgba(255,255,255,0.88);color:var(--sz-orange-dark, #D97726);"
+            style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
           >${this.namespaceLabel}</span>
         </div>`;
     }
     if (this.compact) {
       const bg = this.schema && this._isReport(this.schema)
-        ? "var(--sz-report, #4A90B8)"
-        : "var(--sz-orange, #F2913D)";
-      return html`<div style="height:24px;background:${bg};border-radius:var(--sz-card-radius, 8px) var(--sz-card-radius, 8px) 0 0;"></div>`;
+        ? "var(--sz-report)"
+        : "var(--sz-orange)";
+      return html`<div style="height:24px;background:${bg};border-radius:var(--sz-card-radius) var(--sz-card-radius) 0 0;"></div>`;
     }
     return html``;
   }
@@ -504,15 +504,15 @@ export class SzSchemaCard extends LitElement {
       // Chart/report icon
       return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
         <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-        <rect x="4" y="8" width="2" height="4" rx="0.5" fill="rgba(255,255,255,0.6)"/>
-        <rect x="7" y="5" width="2" height="7" rx="0.5" fill="rgba(255,255,255,0.6)"/>
-        <rect x="10" y="7" width="2" height="5" rx="0.5" fill="rgba(255,255,255,0.6)"/>
+        <rect x="4" y="8" width="2" height="4" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
+        <rect x="7" y="5" width="2" height="7" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
+        <rect x="10" y="7" width="2" height="5" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
       </svg>`;
     }
     // Table/schema icon
     return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
       <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-      <line x1="1" y1="6" x2="15" y2="6" stroke="rgba(0,0,0,0.2)" stroke-width="1"/>
+      <line x1="1" y1="6" x2="15" y2="6" stroke="var(--sz-icon-divider)" stroke-width="1"/>
     </svg>`;
   }
 

--- a/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
@@ -6,19 +6,23 @@
  * gear icons at the midpoint for transform detail.
  */
 
-import { LitElement, html, svg, css, unsafeCSS, type SVGTemplateResult } from "lit";
+import { LitElement, html, svg, css, type SVGTemplateResult } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { customElement, property, state } from "lit/decorators.js";
 import type { LayoutEdge } from "../layout/elk-layout.js";
 import { highlightAtRefs } from "../markdown.js";
-import tokens from "../tokens.css";
 import { SzNavigateEvent } from "../satsuma-viz.js";
 
 @customElement("sz-edge-layer")
 export class SzEdgeLayer extends LitElement {
   static override styles = css`
-    ${unsafeCSS(tokens)}
-
+    /*
+     * Do NOT inject tokens.css here. The colour tokens are inherited from the
+     * <satsuma-viz> host, whose theme attribute selects the palette. Defining
+     * tokens.css locally would pin the light :host defaults onto this
+     * edge-layer host (which never carries theme="dark"), freezing edges in
+     * light mode in both themes.
+     */
     :host {
       display: block;
       position: absolute;

--- a/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
@@ -45,12 +45,12 @@ export class SzEdgeLayer extends LitElement {
     }
 
     .edge-path.nl {
-      stroke: var(--sz-edge-nl, #5A9E6F);
+      stroke: var(--sz-arrow-nl-stroke);
       stroke-dasharray: 6 3;
     }
 
     .edge-path.bare {
-      stroke: var(--sz-text-muted, #6B6560);
+      stroke: var(--sz-text-muted);
       stroke-width: 1;
     }
 
@@ -60,34 +60,34 @@ export class SzEdgeLayer extends LitElement {
     }
 
     .gear-circle {
-      fill: var(--sz-card-bg, #fff);
-      stroke: var(--sz-text-muted, #6B6560);
+      fill: var(--sz-card-bg);
+      stroke: var(--sz-text-muted);
       stroke-width: 1;
     }
 
     .gear-icon {
-      fill: var(--sz-text-muted, #6B6560);
+      fill: var(--sz-text-muted);
       font-size: 10px;
       text-anchor: middle;
       dominant-baseline: central;
     }
 
     .gear-group:hover .gear-circle {
-      stroke: var(--sz-orange, #F2913D);
-      fill: var(--sz-badge-bg, #FFF3E8);
+      stroke: var(--sz-orange);
+      fill: var(--sz-badge-bg);
     }
 
     .gear-group:hover .gear-icon {
-      fill: var(--sz-orange, #F2913D);
+      fill: var(--sz-orange);
     }
 
     .transform-card {
       position: absolute;
       pointer-events: all;
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
-      border-radius: var(--sz-card-radius, 8px);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
+      border-radius: var(--sz-card-radius);
       padding: 8px 12px;
       font-size: 11px;
       max-width: 280px;
@@ -95,18 +95,18 @@ export class SzEdgeLayer extends LitElement {
     }
 
     .transform-card .label {
-      font-family: var(--sz-font-sans, system-ui);
+      font-family: var(--sz-font-sans);
       font-size: 10px;
       font-weight: 600;
       text-transform: uppercase;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       margin-bottom: 4px;
       letter-spacing: 0.04em;
     }
 
     .transform-card .step-text {
-      font-family: var(--sz-font-mono, monospace);
-      color: var(--sz-text, #2D2A26);
+      font-family: var(--sz-font-mono);
+      color: var(--sz-text);
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -114,7 +114,7 @@ export class SzEdgeLayer extends LitElement {
     /* @ref highlights inside NL transform steps */
     .transform-card .at-ref {
       font-weight: 600;
-      color: var(--sz-at-ref, #4A8A5B);
+      color: var(--sz-at-ref);
     }
 
     .transform-card .step {
@@ -125,24 +125,24 @@ export class SzEdgeLayer extends LitElement {
     }
 
     .transform-card .step-sep {
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
     }
 
     .scope-label {
-      font-family: var(--sz-font-mono, monospace);
+      font-family: var(--sz-font-mono);
       font-size: 9px;
       font-weight: 600;
-      fill: var(--sz-text-muted, #6B6560);
+      fill: var(--sz-text-muted);
       text-anchor: middle;
       pointer-events: none;
     }
 
     .scope-label.each {
-      fill: var(--sz-orange-dark, #D97726);
+      fill: var(--sz-orange-dark);
     }
 
     .scope-label.flatten {
-      fill: var(--sz-green, #5A9E6F);
+      fill: var(--sz-green);
     }
 
     /* Dimmed edges when highlighting a field */

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -42,7 +42,7 @@ export class SzOverviewEdgeLayer extends LitElement {
     .overview-path {
       fill: none;
       stroke-width: 3;
-      stroke: var(--sz-edge-default, #4A4744);
+      stroke: var(--sz-edge-default);
       pointer-events: stroke;
       transition: stroke-width 0.15s ease, stroke 0.15s ease, opacity 0.15s ease, filter 0.15s ease;
       opacity: 0.55;
@@ -54,10 +54,10 @@ export class SzOverviewEdgeLayer extends LitElement {
     }
 
     .overview-path.highlighted {
-      stroke: var(--sz-edge-nl, #5A9E6F);
+      stroke: var(--sz-arrow-nl-stroke);
       stroke-width: 4;
       opacity: 1;
-      filter: drop-shadow(0 0 4px rgba(217, 119, 38, 0.4));
+      filter: drop-shadow(0 0 4px var(--sz-edge-highlight-glow));
     }
 
     .overview-path.highlighted:hover {
@@ -71,13 +71,13 @@ export class SzOverviewEdgeLayer extends LitElement {
 
     .anchor-dot {
       pointer-events: none;
-      fill: var(--sz-edge-default, #4A4744);
+      fill: var(--sz-edge-default);
       opacity: 0.55;
       transition: fill 0.15s ease, opacity 0.15s ease;
     }
 
     .anchor-dot.highlighted {
-      fill: var(--sz-edge-nl, #5A9E6F);
+      fill: var(--sz-arrow-nl-stroke);
       opacity: 1;
     }
 
@@ -89,9 +89,9 @@ export class SzOverviewEdgeLayer extends LitElement {
     .tooltip {
       position: absolute;
       pointer-events: none;
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
       border-radius: 6px;
       padding: 8px 10px;
       font-size: 11px;
@@ -101,17 +101,17 @@ export class SzOverviewEdgeLayer extends LitElement {
 
     .tooltip-name {
       font-weight: 600;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       margin-bottom: 2px;
     }
 
     .tooltip-detail {
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
     }
 
     .tooltip-count {
-      font-family: var(--sz-font-mono, monospace);
-      color: var(--sz-orange-dark, #D97726);
+      font-family: var(--sz-font-mono);
+      color: var(--sz-orange-dark);
     }
   `;
 

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -6,11 +6,10 @@
  * SzOpenMappingEvent. Hover shows a tooltip with mapping summary.
  */
 
-import { LitElement, html, svg, css, unsafeCSS, type SVGTemplateResult } from "lit";
+import { LitElement, html, svg, css, type SVGTemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { OverviewEdge } from "../layout/elk-layout.js";
 import type { MappingBlock } from "../model.js";
-import tokens from "../tokens.css";
 
 /** Event dispatched when a user clicks an overview edge to open a mapping detail. */
 export class SzOpenMappingEvent extends Event {
@@ -24,8 +23,13 @@ export class SzOpenMappingEvent extends Event {
 @customElement("sz-overview-edge-layer")
 export class SzOverviewEdgeLayer extends LitElement {
   static override styles = css`
-    ${unsafeCSS(tokens)}
-
+    /*
+     * Do NOT inject tokens.css here. The colour tokens (--sz-edge-default,
+     * --sz-arrow-nl-stroke, …) are inherited from the <satsuma-viz> host, whose
+     * theme attribute selects the palette. Defining tokens.css locally would
+     * pin the light :host defaults onto this edge-layer host (which never
+     * carries theme="dark"), freezing edges in light mode in both themes.
+     */
     :host {
       display: block;
       position: absolute;

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -165,13 +165,11 @@ export class SatsumaViz extends LitElement {
       box-sizing: border-box;
       min-height: 44px;
       padding: 0 40px 0 12px;
-      border-radius: var(--sz-card-radius, 8px);
-      background:
-        linear-gradient(135deg, rgba(16, 80, 104, 0.98), rgba(10, 53, 76, 0.98)),
-        linear-gradient(45deg, rgba(255,255,255,0.06), rgba(255,255,255,0));
-      border: 1px solid rgba(8, 36, 52, 0.35);
-      color: #fff;
-      box-shadow: 0 8px 20px rgba(10, 53, 76, 0.18);
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-overview-mapping-bg), var(--sz-overview-mapping-gloss);
+      border: 1px solid var(--sz-overview-mapping-border);
+      color: var(--sz-text-on-accent);
+      box-shadow: var(--sz-overview-mapping-shadow);
       font-size: 13px;
       font-weight: 600;
       white-space: nowrap;
@@ -249,10 +247,10 @@ export class SatsumaViz extends LitElement {
 
     .file-notes {
       margin: 16px 24px 0;
-      border-radius: var(--sz-card-radius, 8px);
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
     }
 
@@ -265,11 +263,11 @@ export class SatsumaViz extends LitElement {
       user-select: none;
       font-size: 13px;
       font-weight: 600;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
 
     .file-notes-toggle:hover {
-      background: rgba(45, 42, 38, 0.03);
+      background: var(--sz-row-hover-bg);
     }
 
     .file-notes-toggle .arrow {
@@ -285,10 +283,10 @@ export class SatsumaViz extends LitElement {
       padding: 8px 12px 8px 34px;
       font-size: 12px;
       line-height: 1.5;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       white-space: pre-wrap;
       word-break: break-word;
-      border-top: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-top: 1px solid var(--sz-card-border);
     }
 
     /* Toolbar */
@@ -297,9 +295,9 @@ export class SatsumaViz extends LitElement {
       align-items: center;
       gap: 2px;
       padding: 6px 12px;
-      background: var(--sz-card-bg, #fff);
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      font-family: var(--sz-font-sans, system-ui);
+      background: var(--sz-card-bg);
+      border-bottom: 1px solid var(--sz-card-border);
+      font-family: var(--sz-font-sans);
       font-size: 12px;
       position: sticky;
       top: 0;
@@ -309,7 +307,7 @@ export class SatsumaViz extends LitElement {
     .toolbar-title {
       font-weight: 600;
       font-size: 13px;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
       margin-right: 12px;
       padding: 4px 0;
     }
@@ -317,7 +315,7 @@ export class SatsumaViz extends LitElement {
     .toolbar-sep {
       width: 1px;
       height: 20px;
-      background: var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      background: var(--sz-card-border);
       margin: 0 6px;
     }
 
@@ -329,7 +327,7 @@ export class SatsumaViz extends LitElement {
       border: 1px solid transparent;
       border-radius: 4px;
       background: transparent;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       cursor: pointer;
       font-size: 12px;
       font-family: inherit;
@@ -338,14 +336,14 @@ export class SatsumaViz extends LitElement {
     }
 
     .toolbar-btn:hover {
-      background: rgba(45, 42, 38, 0.05);
-      color: var(--sz-text, #2D2A26);
+      background: var(--sz-row-active-bg);
+      color: var(--sz-text);
     }
 
     .toolbar-btn[data-active] {
-      background: var(--sz-badge-bg, #FFF3E8);
-      color: var(--sz-orange-dark, #D97726);
-      border-color: var(--sz-orange-dark, #D97726);
+      background: var(--sz-badge-bg);
+      color: var(--sz-orange-dark);
+      border-color: var(--sz-orange-dark);
     }
 
     .toolbar-spacer {
@@ -354,10 +352,10 @@ export class SatsumaViz extends LitElement {
 
     .toolbar-select {
       padding: 4px 8px;
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border: 1px solid var(--sz-card-border);
       border-radius: 4px;
-      background: var(--sz-card-bg, #fff);
-      color: var(--sz-text, #2D2A26);
+      background: var(--sz-card-bg);
+      color: var(--sz-text);
       font-size: 12px;
       font-family: inherit;
       cursor: pointer;
@@ -411,9 +409,9 @@ export class SatsumaViz extends LitElement {
       bottom: 12px;
       right: 12px;
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      color: var(--sz-text-muted);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
       padding: 2px 8px;
       border-radius: 4px;
       pointer-events: none;
@@ -432,10 +430,10 @@ export class SatsumaViz extends LitElement {
       align-items: center;
       gap: 4px;
       padding: 4px 12px;
-      background: var(--sz-namespace-bg, #FFF3E8);
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      background: var(--sz-namespace-bg);
+      border-bottom: 1px solid var(--sz-card-border);
       font-size: 11px;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       overflow-x: auto;
     }
 
@@ -447,40 +445,40 @@ export class SatsumaViz extends LitElement {
       border-radius: 4px;
       cursor: pointer;
       white-space: nowrap;
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
     }
 
     .breadcrumb-item:hover {
-      border-color: var(--sz-orange-dark, #D97726);
-      color: var(--sz-orange-dark, #D97726);
+      border-color: var(--sz-orange-dark);
+      color: var(--sz-orange-dark);
     }
 
     .breadcrumb-item.primary {
       font-weight: 600;
-      color: var(--sz-text, #2D2A26);
+      color: var(--sz-text);
     }
 
     .breadcrumb-sep {
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       font-size: 10px;
     }
 
     .breadcrumb-collapse {
       margin-left: auto;
       padding: 2px 8px;
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border: 1px solid var(--sz-card-border);
       border-radius: 4px;
       background: transparent;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       cursor: pointer;
       font-size: 11px;
       font-family: inherit;
     }
 
     .breadcrumb-collapse:hover {
-      background: rgba(45, 42, 38, 0.05);
-      color: var(--sz-text, #2D2A26);
+      background: var(--sz-row-active-bg);
+      color: var(--sz-text);
     }
 
     /* Slide-in animation for expanded cards */
@@ -514,8 +512,8 @@ export class SatsumaViz extends LitElement {
     .notes-pane {
       width: 280px;
       flex-shrink: 0;
-      border-left: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      background: var(--sz-bg, #FFFAF5);
+      border-left: 1px solid var(--sz-card-border);
+      background: var(--sz-bg);
       overflow-y: auto;
       padding: 12px;
       display: flex;
@@ -526,18 +524,18 @@ export class SatsumaViz extends LitElement {
     .notes-pane-header {
       font-size: 12px;
       font-weight: 600;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       text-transform: uppercase;
       letter-spacing: 0.05em;
       padding-bottom: 4px;
-      border-bottom: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      border-bottom: 1px solid var(--sz-card-border);
     }
 
     .notes-pane-section {
       font-size: 10px;
       font-weight: 600;
       text-transform: uppercase;
-      color: var(--sz-text-muted, #6B6560);
+      color: var(--sz-text-muted);
       margin-top: 6px;
     }
 
@@ -554,15 +552,15 @@ export class SatsumaViz extends LitElement {
     }
 
     .comment-card.warning {
-      background: var(--sz-warning-bg, #FEF3CD);
-      border: 1px solid rgba(196, 93, 34, 0.2);
-      color: var(--sz-warning-icon, #C45D22);
+      background: var(--sz-warning-bg);
+      border: 1px solid var(--sz-warning-border-soft);
+      color: var(--sz-warning-icon);
     }
 
     .comment-card.question {
-      background: var(--sz-question-bg, #E8F0FE);
-      border: 1px solid rgba(124, 107, 174, 0.2);
-      color: var(--sz-question-icon, #7C6BAE);
+      background: var(--sz-question-bg);
+      border: 1px solid var(--sz-question-border-soft);
+      color: var(--sz-question-icon);
     }
 
     .comment-card-source {
@@ -576,9 +574,9 @@ export class SatsumaViz extends LitElement {
       padding: 8px 10px;
       font-size: 12px;
       line-height: 1.5;
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
-      color: var(--sz-text, #2D2A26);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      color: var(--sz-text);
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -602,15 +600,15 @@ export class SatsumaViz extends LitElement {
     }
 
     .block-comment-badge.warning {
-      background: var(--sz-warning-bg, #FEF3CD);
-      color: var(--sz-warning-icon, #C45D22);
-      border: 1px solid rgba(196, 93, 34, 0.3);
+      background: var(--sz-warning-bg);
+      color: var(--sz-warning-icon);
+      border: 1px solid var(--sz-warning-border-strong);
     }
 
     .block-comment-badge.question {
-      background: var(--sz-question-bg, #E8F0FE);
-      color: var(--sz-question-icon, #7C6BAE);
-      border: 1px solid rgba(124, 107, 174, 0.3);
+      background: var(--sz-question-bg);
+      color: var(--sz-question-icon);
+      border: 1px solid var(--sz-question-border-strong);
     }
 
     .block-comment-badge:hover {
@@ -621,13 +619,13 @@ export class SatsumaViz extends LitElement {
     /* Source block join/filter labels */
     .source-block-label {
       position: absolute;
-      background: var(--sz-badge-bg, #FFF3E8);
-      border: 1px dashed var(--sz-orange-dark, #D97726);
+      background: var(--sz-badge-bg);
+      border: 1px dashed var(--sz-orange-dark);
       border-radius: 4px;
       padding: 3px 8px;
       font-size: 10px;
-      font-family: var(--sz-font-mono, monospace);
-      color: var(--sz-orange-dark, #D97726);
+      font-family: var(--sz-font-mono);
+      color: var(--sz-orange-dark);
       white-space: nowrap;
       z-index: 40;
     }
@@ -639,10 +637,10 @@ export class SatsumaViz extends LitElement {
       right: 12px;
       width: 160px;
       height: 100px;
-      background: var(--sz-card-bg, #fff);
-      border: 1px solid var(--sz-card-border, rgba(45, 42, 38, 0.08));
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
       border-radius: 4px;
-      box-shadow: var(--sz-card-shadow, 0 2px 8px rgba(45, 42, 38, 0.06));
+      box-shadow: var(--sz-card-shadow);
       overflow: hidden;
       cursor: pointer;
       z-index: 80;
@@ -650,21 +648,21 @@ export class SatsumaViz extends LitElement {
 
     .minimap-viewport {
       position: absolute;
-      border: 1.5px solid var(--sz-orange, #F2913D);
-      background: rgba(242, 145, 61, 0.08);
+      border: 1.5px solid var(--sz-orange);
+      background: var(--sz-accent-wash);
       border-radius: 1px;
       pointer-events: none;
     }
 
     .source-block-filter {
       position: absolute;
-      background: var(--sz-question-bg, #E8F0FE);
-      border: 1px solid rgba(124, 107, 174, 0.2);
+      background: var(--sz-question-bg);
+      border: 1px solid var(--sz-question-border-soft);
       border-radius: 4px;
       padding: 2px 6px;
       font-size: 10px;
-      font-family: var(--sz-font-mono, monospace);
-      color: var(--sz-question-icon, #7C6BAE);
+      font-family: var(--sz-font-mono);
+      color: var(--sz-question-icon);
       white-space: nowrap;
       z-index: 40;
     }
@@ -1226,24 +1224,24 @@ export class SatsumaViz extends LitElement {
 <svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">
   <style>
     .edge-path { fill: none; stroke-width: 1.5; }
-    .edge-path.nl { stroke: #5A9E6F; stroke-dasharray: 6 3; }
-    .edge-path.bare { stroke: #6B6560; stroke-width: 1; }
-    .scope-label { font-family: monospace; font-size: 9px; font-weight: 600; fill: #6B6560; text-anchor: middle; }
-    .gear-circle { fill: #fff; stroke: #6B6560; stroke-width: 1; }
-    .gear-icon { fill: #6B6560; font-size: 10px; text-anchor: middle; dominant-baseline: central; }
-    rect.card { fill: #fff; stroke: rgba(45,42,38,0.08); rx: 8; }
+    .edge-path.nl { stroke: var(--sz-arrow-nl-stroke); stroke-dasharray: 6 3; }
+    .edge-path.bare { stroke: var(--sz-edge-bare-stroke); stroke-width: 1; }
+    .scope-label { font-family: monospace; font-size: 9px; font-weight: 600; fill: var(--sz-edge-bare-stroke); text-anchor: middle; }
+    .gear-circle { fill: var(--sz-gear-bg); stroke: var(--sz-edge-bare-stroke); stroke-width: 1; }
+    .gear-icon { fill: var(--sz-edge-bare-stroke); font-size: 10px; text-anchor: middle; dominant-baseline: central; }
+    rect.card { fill: var(--sz-card-bg); stroke: var(--sz-card-border); rx: 8; }
     rect.header { rx: 8; }
-    text.card-name { font-family: system-ui; font-size: 14px; font-weight: 600; fill: #fff; }
-    text.field-name { font-family: monospace; font-size: 12px; fill: #2D2A26; }
-    text.field-type { font-family: monospace; font-size: 11px; fill: #6B6560; }
+    text.card-name { font-family: system-ui; font-size: 14px; font-weight: 600; fill: var(--sz-text-on-accent); }
+    text.field-name { font-family: monospace; font-size: 12px; fill: var(--sz-text); }
+    text.field-type { font-family: monospace; font-size: 11px; fill: var(--sz-text-muted); }
   </style>
-  <rect width="${w}" height="${h}" fill="#FFFAF5"/>
+  <rect width="${w}" height="${h}" fill="var(--sz-bg)"/>
   ${edgeSvgContent}
   ${[...this._layout.nodes.values()].map((n) => `
   <g transform="translate(${n.x},${n.y})">
-    <rect class="card" width="${n.width}" height="${n.height}" fill="#fff" stroke="rgba(45,42,38,0.08)" rx="8"/>
-    <rect class="header" width="${n.width}" height="40" fill="#F2913D" rx="8"/>
-    <rect x="0" y="32" width="${n.width}" height="8" fill="#F2913D"/>
+    <rect class="card" width="${n.width}" height="${n.height}" fill="var(--sz-card-bg)" stroke="var(--sz-card-border)" rx="8"/>
+    <rect class="header" width="${n.width}" height="40" fill="var(--sz-orange)" rx="8"/>
+    <rect x="0" y="32" width="${n.width}" height="8" fill="var(--sz-orange)"/>
     <text class="card-name" x="12" y="26">${n.id}</text>
   </g>`).join("")}
 </svg>`;
@@ -1425,7 +1423,7 @@ export class SatsumaViz extends LitElement {
                   <div class="overview-mapping-card" data-testid=${`overview-mapping-card-${sanitizeTestIdSegment(m.id)}`} style="${!ns.name ? "padding-top:24px;" : ""}" title=${m.id}>
                     <div style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0;">
                       ${ns.name
-                        ? html`<span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:999px;background:#DCECF6;color:#0A354C;">${ns.name}</span>`
+                        ? html`<span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:999px;background:var(--sz-namespace-pill-bg);color:var(--sz-namespace-pill-text);">${ns.name}</span>`
                         : ""}
                       <div style="display:flex;align-items:center;gap:8px;min-width:0;">
                         <svg class="overview-mapping-icon" viewBox="0 0 16 16" fill="currentColor">
@@ -1717,7 +1715,7 @@ export class SatsumaViz extends LitElement {
               <rect
                 x=${n.x * scale} y=${n.y * scale}
                 width=${n.width * scale} height=${n.height * scale}
-                fill="var(--sz-card-border, rgba(45,42,38,0.15))"
+                fill="var(--sz-card-border-strong)"
                 rx="1"
               />
             `

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -691,6 +691,16 @@ export class SatsumaViz extends LitElement {
   @property({ type: Object })
   model: VizModel | null = null;
 
+  /**
+   * Visual theme. Reflected to the `theme` attribute so the
+   * `:host([theme="dark"])` overrides in tokens.css apply — this is the *only*
+   * switching mechanism for the palette. Consumers (VS Code webview, harness)
+   * detect which theme to use and assign it; the component owns rendering.
+   * Default `"light"`, matching the warm cream/orange `:host` token defaults.
+   */
+  @property({ reflect: true })
+  theme: "light" | "dark" = "light";
+
   @property({ type: Boolean, attribute: "test-mode", reflect: true })
   testMode = false;
 

--- a/tooling/satsuma-viz/src/tokens.css
+++ b/tooling/satsuma-viz/src/tokens.css
@@ -10,6 +10,15 @@
   --sz-card-shadow: 0 2px 8px rgba(45, 42, 38, 0.06);
   --sz-namespace-bg: #FFF3E8;
   --sz-namespace-border: #F5E6D3;
+  --sz-row-hover-bg: rgba(45, 42, 38, 0.03);
+  --sz-row-active-bg: rgba(45, 42, 38, 0.06);
+  --sz-accent-wash: rgba(242, 145, 61, 0.12);
+  --sz-green-wash: rgba(90, 158, 111, 0.12);
+  --sz-warning-border-soft: rgba(196, 93, 34, 0.2);
+  --sz-warning-border-strong: rgba(196, 93, 34, 0.3);
+  --sz-question-border-soft: rgba(124, 107, 174, 0.2);
+  --sz-question-border-strong: rgba(124, 107, 174, 0.3);
+  --sz-card-border-strong: rgba(45, 42, 38, 0.15);
 
   /* --- Accents --- */
   --sz-orange: #F2913D;
@@ -17,10 +26,17 @@
   --sz-green: #5A9E6F;
   --sz-violet: #8E5BB0;
   --sz-warning: #C45D22;
+  --sz-report: #4A90B8;
+  --sz-edge-default: #4A4744;
+  --sz-edge-bare-stroke: #6B6560;
+  --sz-at-ref: #4A8A5B;
 
   /* --- Text --- */
   --sz-text: #2D2A26;
   --sz-text-muted: #6B6560;
+  --sz-text-on-accent: #FFFFFF;
+  --sz-icon-overlay-soft: rgba(255, 255, 255, 0.6);
+  --sz-icon-divider: rgba(0, 0, 0, 0.2);
 
   /* --- Badges --- */
   --sz-badge-bg: #FFF3E8;
@@ -33,6 +49,15 @@
   /* --- Arrows --- */
   --sz-arrow-stroke: #D97726;
   --sz-arrow-nl-stroke: #5A9E6F;
+  --sz-gear-bg: #FFFFFF;
+  --sz-overview-mapping-bg: linear-gradient(135deg, rgba(16, 80, 104, 0.98), rgba(10, 53, 76, 0.98));
+  --sz-overview-mapping-gloss: linear-gradient(45deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0));
+  --sz-overview-mapping-border: rgba(8, 36, 52, 0.35);
+  --sz-overview-mapping-shadow: 0 8px 20px rgba(10, 53, 76, 0.18);
+  --sz-edge-highlight-glow: rgba(217, 119, 38, 0.4);
+  --sz-namespace-pill-bg: #DCECF6;
+  --sz-namespace-pill-text: #0A354C;
+  --sz-namespace-pill-chip-bg: rgba(255, 255, 255, 0.88);
   --sz-arrow-width: 2px;
 
   /* --- Typography --- */
@@ -60,15 +85,31 @@
   --sz-card-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   --sz-namespace-bg: #2D2520;
   --sz-namespace-border: #3D3530;
+  --sz-row-hover-bg: rgba(255, 255, 255, 0.04);
+  --sz-row-active-bg: rgba(255, 255, 255, 0.08);
+  --sz-accent-wash: rgba(242, 168, 96, 0.16);
+  --sz-green-wash: rgba(109, 191, 130, 0.16);
+  --sz-warning-border-soft: rgba(224, 112, 64, 0.28);
+  --sz-warning-border-strong: rgba(224, 112, 64, 0.4);
+  --sz-question-border-soft: rgba(160, 140, 200, 0.24);
+  --sz-question-border-strong: rgba(160, 140, 200, 0.36);
+  --sz-card-border-strong: rgba(255, 255, 255, 0.15);
 
   --sz-orange: #F2A860;
   --sz-orange-dark: #E89040;
   --sz-green: #6DBF82;
   --sz-violet: #A878C8;
   --sz-warning: #E07040;
+  --sz-report: #6FB3D9;
+  --sz-edge-default: #9D9D9D;
+  --sz-edge-bare-stroke: #9D9D9D;
+  --sz-at-ref: #82C995;
 
   --sz-text: #D4D4D4;
   --sz-text-muted: #9D9D9D;
+  --sz-text-on-accent: #FFFFFF;
+  --sz-icon-overlay-soft: rgba(255, 255, 255, 0.72);
+  --sz-icon-divider: rgba(255, 255, 255, 0.35);
 
   --sz-badge-bg: #3D3020;
   --sz-badge-text: #E89040;
@@ -79,4 +120,13 @@
 
   --sz-arrow-stroke: #E89040;
   --sz-arrow-nl-stroke: #6DBF82;
+  --sz-gear-bg: #252526;
+  --sz-overview-mapping-bg: linear-gradient(135deg, rgba(14, 62, 84, 0.98), rgba(8, 39, 58, 0.98));
+  --sz-overview-mapping-gloss: linear-gradient(45deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0));
+  --sz-overview-mapping-border: rgba(255, 255, 255, 0.12);
+  --sz-overview-mapping-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  --sz-edge-highlight-glow: rgba(242, 168, 96, 0.36);
+  --sz-namespace-pill-bg: #27465A;
+  --sz-namespace-pill-text: #CFE7F5;
+  --sz-namespace-pill-chip-bg: rgba(255, 255, 255, 0.22);
 }

--- a/tooling/satsuma-viz/test/theme.test.js
+++ b/tooling/satsuma-viz/test/theme.test.js
@@ -1,3 +1,4 @@
+import "./dom-shim.js";
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 import fs from "node:fs";
@@ -72,6 +73,36 @@ describe("theme token parity", () => {
       missing,
       [],
       `Missing dark token overrides: ${missing.join(", ")}`,
+    );
+  });
+});
+
+describe("satsuma-viz theme property", () => {
+  it("defaults to the light theme", async () => {
+    // The warm cream/orange :host token defaults ARE the light palette, so the
+    // component must default to "light" — a consumer that never sets a theme
+    // (e.g. a bare embed) still renders a coherent, fully-styled light viz.
+    const mod = await import("../dist/satsuma-viz.js");
+    const el = new mod.SatsumaViz();
+    assert.equal(el.theme, "light");
+  });
+
+  it("reflects theme to the `theme` attribute so :host([theme=\"dark\"]) engages", async () => {
+    // Reflection is the ONLY palette-switching mechanism: assigning theme must
+    // write the `theme` attribute on the host so the tokens.css
+    // `:host([theme="dark"])` override block applies. If reflect were dropped,
+    // dark mode would silently keep the light palette.
+    const mod = await import("../dist/satsuma-viz.js");
+    const options = mod.SatsumaViz.elementProperties.get("theme");
+    assert.ok(options, "theme must be a declared reactive property");
+    assert.equal(options.reflect, true, "theme must reflect to an attribute");
+    // Lit derives the attribute name from the property name (lowercased) unless
+    // overridden; the dark selector keys off exactly `theme`, so the derived
+    // attribute must not be disabled or renamed.
+    assert.notEqual(options.attribute, false);
+    assert.ok(
+      options.attribute === undefined || options.attribute === "theme",
+      `theme must reflect to the "theme" attribute, got ${String(options.attribute)}`,
     );
   });
 });

--- a/tooling/satsuma-viz/test/theme.test.js
+++ b/tooling/satsuma-viz/test/theme.test.js
@@ -1,0 +1,104 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const workspaceRoot = path.resolve(import.meta.dirname, "..");
+const srcRoot = path.join(workspaceRoot, "src");
+const tokensPath = path.join(srcRoot, "tokens.css");
+
+const COLOR_VALUE_RE = /#(?:[0-9a-fA-F]{3,8})\b|rgba?\(|hsla?\(|linear-gradient\(|drop-shadow\(/;
+const COLOR_LITERAL_RE = /#(?:[0-9a-fA-F]{3,8})\b|rgba?\(/g;
+
+function parseTokenBlockTokens(blockText) {
+  const tokenMap = new Map();
+  const tokenRegex = /--([a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  for (const match of blockText.matchAll(tokenRegex)) {
+    tokenMap.set(`--${match[1]}`, match[2].trim());
+  }
+  return tokenMap;
+}
+
+function getTokensByBlock() {
+  const css = fs.readFileSync(tokensPath, "utf8");
+  const lightMatch = css.match(/:host\s*\{([\s\S]*?)\n\}/);
+  const darkMatch = css.match(/:host\(\[theme="dark"\]\)\s*\{([\s\S]*?)\n\}/);
+  assert.ok(lightMatch, "Expected to find :host token block in tokens.css");
+  assert.ok(darkMatch, "Expected to find :host([theme=\"dark\"]) token block in tokens.css");
+
+  return {
+    light: parseTokenBlockTokens(lightMatch[1]),
+    dark: parseTokenBlockTokens(darkMatch[1]),
+  };
+}
+
+function listTsFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const out = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listTsFiles(full));
+      continue;
+    }
+    if (entry.isFile() && full.endsWith(".ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectCssTemplateBlocks(fileText) {
+  const blocks = [];
+  const cssBlockRegex = /\bcss`([\s\S]*?)`;/g;
+  for (const match of fileText.matchAll(cssBlockRegex)) {
+    blocks.push(match[1]);
+  }
+  return blocks;
+}
+
+describe("theme token parity", () => {
+  it("defines dark overrides for every light color-bearing token", () => {
+    const { light, dark } = getTokensByBlock();
+
+    const requiredDarkTokens = [...light.entries()]
+      .filter(([, value]) => COLOR_VALUE_RE.test(value))
+      .map(([name]) => name)
+      .sort();
+
+    const missing = requiredDarkTokens.filter((tokenName) => !dark.has(tokenName));
+
+    assert.deepEqual(
+      missing,
+      [],
+      `Missing dark token overrides: ${missing.join(", ")}`,
+    );
+  });
+});
+
+describe("component style color literals", () => {
+  it("does not use raw hex/rgba literals in css template blocks outside tokens.css", () => {
+    const files = listTsFiles(srcRoot);
+    const violations = [];
+
+    for (const filePath of files) {
+      if (filePath === tokensPath) continue;
+      const source = fs.readFileSync(filePath, "utf8");
+      const cssBlocks = collectCssTemplateBlocks(source);
+
+      for (const block of cssBlocks) {
+        const literals = [...block.matchAll(COLOR_LITERAL_RE)].map((m) => m[0]);
+        if (literals.length === 0) continue;
+
+        const relPath = path.relative(workspaceRoot, filePath);
+        violations.push(`${relPath}: ${[...new Set(literals)].join(", ")}`);
+      }
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `Raw color literals found in component styles:\n${violations.join("\n")}`,
+    );
+  });
+});

--- a/tooling/vscode-satsuma/src/webview/viz/integration.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/integration.ts
@@ -14,14 +14,26 @@ const VIZ_LINKED_FILES_REQUEST = "satsuma/vizLinkedFiles";
 
 export type ThemeKind = number;
 
+/**
+ * Renderer theme accepted by the `<satsuma-viz>` `theme` attribute. The
+ * component defines exactly two palettes (light, dark); high-contrast VS Code
+ * themes fold into the nearest of the two until a dedicated HC palette exists.
+ */
+export type VizTheme = "light" | "dark";
+
+// VS Code `ColorThemeKind` numeric values (stable since VS Code 1.56). We mirror
+// them as named constants rather than importing the enum so this host-only
+// module stays free of the `vscode` namespace and remains unit-testable in Node.
+const LIGHT_THEME_KIND = 1;
 const DARK_THEME_KIND = 2;
 const HIGH_CONTRAST_THEME_KIND = 3;
+const HIGH_CONTRAST_LIGHT_THEME_KIND = 4;
 
 export interface VizModelEnvelope<TModel> {
   /** Serialized VizModel payload returned by the LSP. */
   payload: TModel;
-  /** Whether the current VS Code theme should use dark renderer tokens. */
-  isDark: boolean;
+  /** Renderer theme the webview should apply for this model. */
+  theme: VizTheme;
 }
 
 export interface ExpandedModelsEnvelope<TModel> {
@@ -29,18 +41,35 @@ export interface ExpandedModelsEnvelope<TModel> {
   schemaId: string;
   /** Additional VizModels from linked files, filtered to non-null results. */
   models: TModel[];
-  /** Whether the current VS Code theme should use dark renderer tokens. */
-  isDark: boolean;
+  /** Renderer theme the webview should apply for these models. */
+  theme: VizTheme;
 }
 
 /**
- * Convert the active VS Code theme into the renderer's dark-mode flag.
+ * Map an active VS Code `ColorThemeKind` to a renderer theme.
+ *
+ * | ColorThemeKind        | value | renderer theme |
+ * |-----------------------|-------|----------------|
+ * | Light                 | 1     | light          |
+ * | Dark                  | 2     | dark           |
+ * | HighContrast          | 3     | dark           |
+ * | HighContrastLight     | 4     | light          |
+ *
+ * High-contrast kinds fold into the nearest base palette (a dedicated HC
+ * palette is explicit future work, per the feature's non-goals). Unknown
+ * kinds default to dark, matching the historical fallback.
  */
-export function isDarkTheme(kind: ThemeKind): boolean {
-  return (
-    kind === DARK_THEME_KIND ||
-    kind === HIGH_CONTRAST_THEME_KIND
-  );
+export function vizThemeForKind(kind: ThemeKind): VizTheme {
+  switch (kind) {
+    case LIGHT_THEME_KIND:
+    case HIGH_CONTRAST_LIGHT_THEME_KIND:
+      return "light";
+    case DARK_THEME_KIND:
+    case HIGH_CONTRAST_THEME_KIND:
+      return "dark";
+    default:
+      return "dark";
+  }
 }
 
 /**
@@ -55,7 +84,7 @@ export async function loadFullLineageModel<TModel>(
   if (!model) return null;
   return {
     payload: model,
-    isDark: isDarkTheme(themeKind),
+    theme: vizThemeForKind(themeKind),
   };
 }
 
@@ -77,7 +106,7 @@ export async function loadExpandedModels<TModel>(
     return {
       schemaId,
       models: [],
-      isDark: isDarkTheme(themeKind),
+      theme: vizThemeForKind(themeKind),
     };
   }
 
@@ -92,7 +121,7 @@ export async function loadExpandedModels<TModel>(
   return {
     schemaId,
     models: resolvedModels,
-    isDark: isDarkTheme(themeKind),
+    theme: vizThemeForKind(themeKind),
   };
 }
 

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -5,6 +5,7 @@ import { FieldLineagePanel } from "../field-lineage/panel";
 import {
   loadExpandedModels,
   loadFullLineageModel,
+  vizThemeForKind,
 } from "./integration";
 
 export class VizPanel {
@@ -82,6 +83,17 @@ export class VizPanel {
     );
     this.disposables.push(editorWatcher);
 
+    // Live theme switching: when the user changes their VS Code colour theme
+    // while the panel is open, push the new renderer theme to the webview so it
+    // restyles without a reload. Decoupled from data loads — see _setTheme.
+    const themeWatcher = vscode.window.onDidChangeActiveColorTheme((theme) => {
+      this.panel.webview.postMessage({
+        type: "setTheme",
+        theme: vizThemeForKind(theme.kind),
+      });
+    });
+    this.disposables.push(themeWatcher);
+
     // Clean up on dispose
     this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
 
@@ -127,7 +139,7 @@ export class VizPanel {
       this.panel.webview.postMessage({
         type: "vizModel",
         payload: modelEnvelope.payload,
-        isDark: modelEnvelope.isDark,
+        theme: modelEnvelope.theme,
       });
     } catch (err) {
       this.panel.webview.postMessage({
@@ -207,7 +219,7 @@ export class VizPanel {
         type: "expandedModels",
         schemaId: expandedEnvelope.schemaId,
         models: expandedEnvelope.models,
-        isDark: expandedEnvelope.isDark,
+        theme: expandedEnvelope.theme,
       });
     } catch (err) {
       this.panel.webview.postMessage({

--- a/tooling/vscode-satsuma/src/webview/viz/viz.css
+++ b/tooling/vscode-satsuma/src/webview/viz/viz.css
@@ -28,20 +28,11 @@ satsuma-viz {
   font-size: 14px;
 }
 
-/* Dark theme override — applied via body.dark class */
-body.dark satsuma-viz {
-  --sz-bg: #1e1e1e;
-  --sz-text: #d4d4d4;
-  --sz-text-muted: #858585;
-  --sz-card-bg: #252526;
-  --sz-card-border: rgba(255, 255, 255, 0.1);
-  --sz-card-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-  --sz-namespace-bg: rgba(242, 145, 61, 0.08);
-  --sz-namespace-border: rgba(242, 145, 61, 0.2);
-  --sz-badge-bg: rgba(242, 145, 61, 0.15);
-  --sz-badge-text: #f2a968;
-  --sz-warning-bg: rgba(254, 243, 205, 0.12);
-  --sz-warning-icon: #e6a34e;
-  --sz-question-bg: rgba(124, 107, 174, 0.12);
-  --sz-question-icon: #a593cf;
-}
+/*
+ * Theme tokens are NOT declared here. Both palettes live exclusively in
+ * tooling/satsuma-viz/src/tokens.css and are selected via the component's
+ * reflected `theme` attribute (set in viz.ts). The former `body.dark
+ * satsuma-viz` override block was removed as part of Feature 32 because its
+ * values had drifted from the canonical tokens.css dark palette; the canonical
+ * values now win in every consumer.
+ */

--- a/tooling/vscode-satsuma/src/webview/viz/viz.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/viz.ts
@@ -61,16 +61,18 @@ window.addEventListener("message", (event) => {
   const msg = event.data;
 
   if (msg.type === "vizModel") {
-    // Apply theme
-    if (msg.isDark) {
-      document.body.classList.add("dark");
-    } else {
-      document.body.classList.remove("dark");
-    }
+    // The component owns theming: assign its `theme` attribute and let the
+    // tokens.css `:host([theme="dark"])` overrides do the switching. The
+    // envelope carries the theme so the initial load needs no second message.
+    if (msg.theme) vizEl.theme = msg.theme;
 
     // Set model on the component
     vizEl.model = msg.payload;
+  } else if (msg.type === "setTheme") {
+    // Live theme switch pushed by the host when the editor theme changes.
+    if (msg.theme) vizEl.theme = msg.theme;
   } else if (msg.type === "expandedModels") {
+    if (msg.theme) vizEl.theme = msg.theme;
     vizEl.addExpandedModels(msg.schemaId, msg.models);
   } else if (msg.type === "error") {
     root.textContent = "";

--- a/tooling/vscode-satsuma/test/viz-integration.test.js
+++ b/tooling/vscode-satsuma/test/viz-integration.test.js
@@ -2,7 +2,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
-  isDarkTheme,
+  vizThemeForKind,
   loadFullLineageModel,
   loadExpandedModels,
   buildFieldLineagePath,
@@ -15,15 +15,27 @@ const ColorThemeKind = {
   HighContrastLight: 4,
 };
 
-describe("isDarkTheme", () => {
-  it("treats dark and high-contrast themes as dark renderer themes", () => {
-    assert.equal(isDarkTheme(ColorThemeKind.Dark), true);
-    assert.equal(isDarkTheme(ColorThemeKind.HighContrast), true);
+describe("vizThemeForKind", () => {
+  it("maps Light and HighContrastLight to the light renderer theme", () => {
+    // Both light-family kinds must resolve to the warm cream/orange light
+    // palette. HighContrastLight is the case that used to fall through to light
+    // only because the old boolean check didn't match it — the mapping is now
+    // intentional and documented.
+    assert.equal(vizThemeForKind(ColorThemeKind.Light), "light");
+    assert.equal(vizThemeForKind(ColorThemeKind.HighContrastLight), "light");
   });
 
-  it("keeps light themes out of dark renderer mode", () => {
-    assert.equal(isDarkTheme(ColorThemeKind.Light), false);
-    assert.equal(isDarkTheme(ColorThemeKind.HighContrastLight), false);
+  it("maps Dark and HighContrast to the dark renderer theme", () => {
+    // Both dark-family kinds fold into the dark palette until a dedicated
+    // high-contrast palette exists (feature non-goal).
+    assert.equal(vizThemeForKind(ColorThemeKind.Dark), "dark");
+    assert.equal(vizThemeForKind(ColorThemeKind.HighContrast), "dark");
+  });
+
+  it("defaults unknown kinds to dark", () => {
+    // A future or unrecognized ColorThemeKind must not crash the webview; it
+    // falls back to dark, matching the historical default.
+    assert.equal(vizThemeForKind(99), "dark");
   });
 });
 
@@ -51,7 +63,7 @@ describe("loadFullLineageModel", () => {
     ]);
     assert.deepEqual(envelope, {
       payload: { uri: "file:///platform.stm", namespaces: [] },
-      isDark: true,
+      theme: "dark",
     });
   });
 
@@ -115,7 +127,7 @@ describe("loadExpandedModels", () => {
     assert.deepEqual(envelope, {
       schemaId: "customers",
       models: [{ uri: "file:///crm.stm" }],
-      isDark: false,
+      theme: "light",
     });
   });
 
@@ -137,7 +149,7 @@ describe("loadExpandedModels", () => {
     assert.deepEqual(envelope, {
       schemaId: "customers",
       models: [],
-      isDark: true,
+      theme: "dark",
     });
   });
 });


### PR DESCRIPTION
Completes **Feature 32 — Viz Light Mode & VS Code Theme Integration** (epic `sl-wyr1`). Makes light and dark first-class, equally-supported themes for the mapping visualization, driven by the user's VS Code colour theme with live switching, with both palettes defined exactly once in `tooling/satsuma-viz/src/tokens.css`.

See `features/32-viz-light-mode/PRD.md` for the full design.

## What's in this PR

**Phase 2 — component theme contract** (`sl-o05i`)
- Reflected `theme: "light" | "dark"` property on `<satsuma-viz>` (default `"light"`), making `:host([theme="dark"])` the single switching mechanism.

**Phase 3 — VS Code integration with live switching** (`sl-go45`)
- `VizTheme` + `vizThemeForKind` map all four `ColorThemeKind` values (Light/HCLight → light, Dark/HighContrast → dark, unknown → dark).
- Envelopes/messages carry `theme` instead of the lossy `isDark` boolean.
- `panel.ts` subscribes to `onDidChangeActiveColorTheme` (disposed with the panel) and posts a dedicated `setTheme` message → theme changes restyle an open panel without reload.
- Deleted the drifted `body.dark satsuma-viz` token block from `viz.css`; `tokens.css` is now the only palette source.

**Phase 4 — harness light mode** (`sl-wxac`)
- Chrome colours and `.tok-*` syntax colours moved to CSS variables with a light variant; Light/Dark header toggle; `?theme=` → `prefers-color-scheme` → dark resolution; `__satsumaHarness.theme` + `theme-change` automation events.
- Fixed a latent server bug: the `GET /` → `/index.html` redirect dropped the query string, making `?theme=` (and `?fixture=`/`?mode=`) silent no-ops.

**Phase 6 — Playwright coverage + both-theme gallery** (`sl-7b29`)
- Theme test group asserting computed colours in both themes (incl. representative audit tokens), prefers-color-scheme fallback, and toggle restyling + event.
- Screenshot gallery captures every named shot in both themes with a `theme` manifest field.

## Fixes surfaced by the work
- **Missing fixture** (`sl-dknl`): commit `ff366cf` added compact-card Playwright tests referencing `examples/contracts/buy-to-om-order.stm` but never committed the fixture — this had made the *entire* firefox harness suite (40 tests) throw and not-run on `main`. Added the intended canonical example; all 40 now execute and pass.
- **Edge-layer theme defect**: the edge-layer components injected `tokens.css` into their own shadow roots, pinning the light palette so edges/arrows never switched to dark. Now they inherit the palette from the `<satsuma-viz>` host. Caught by the new audit-token theme test.

## Testing
- `satsuma-viz` unit suite: 47 passed.
- `vscode-satsuma` viz-integration unit suite: 8 passed.
- Playwright (sentinel protocol, Firefox): **61 passed** — semantic theme tests + both-theme screenshot gallery.

## Not done in this PR (out of scope / manual)
- VS Code Extension-Host **GUI** verification of live theme switching (light / dark / live-switch / HighContrastLight) — cannot run in the agent sandbox; needs a human Extension-Host run.
- Theming the separate field-lineage / schema-lineage webview panels (explicit PRD non-goal; follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)