### PR TITLE
fix(cli): load command modules via file:// URL for Windows ESM (gh-265)

### DIFF
--- a/.tickets/sl-2a7k.md
+++ b/.tickets/sl-2a7k.md
@@ -1,8 +1,8 @@
 ---
 id: sl-2a7k
-status: closed
+status: in_progress
 deps: []
-links: []
+links: [sl-vmqv]
 created: 2026-06-09T22:02:56Z
 type: bug
 priority: 1
@@ -17,18 +17,3 @@ satsuma CLI fails to start on Windows. index.ts:75 passes a raw OS path (join(__
 
 Command modules are imported via a file:// URL (pathToFileURL) on all platforms; no platform branching; regression test pins the file:// invariant; existing CLI integration tests still pass.
 
-
-## Notes
-
-**2026-06-09T22:09:25Z**
-
-**2026-06-09T22:10:00Z**
-
-Cause: index.ts passed a raw OS path (join(__dirname, cmd)) to dynamic import(); Node ESM rejects bare drive-letter specifiers on Windows (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol c:). POSIX tolerated it, so it never surfaced on macOS/Linux.
-Fix: extracted commandModuleSpecifier() in command-loader.ts wrapping the path with pathToFileURL().href; index.ts imports command modules via that file:// URL. Added command-loader.test.ts pinning the file:// invariant.
-
-**2026-06-09T22:13:19Z**
-
-**2026-06-09T22:25:00Z**
-
-Folded a second, independent Windows bug into the same PR (#268): satsuma-lsp/validate-diagnostics.ts built file:// URIs via string concat (\"file://\" + encodeURI(path)), malformed for Windows drive paths so validate diagnostics never matched the open document. Replaced with pathToFileURL(); exported pathToFileUri and added round-trip regression coverage.

--- a/.tickets/sl-2a7k.md
+++ b/.tickets/sl-2a7k.md
@@ -1,0 +1,28 @@
+---
+id: sl-2a7k
+status: closed
+deps: []
+links: []
+created: 2026-06-09T22:02:56Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+external-ref: gh-265
+---
+# CLI crashes on Windows: dynamic import() needs file:// URL
+
+satsuma CLI fails to start on Windows. index.ts:75 passes a raw OS path (join(__dirname, cmd) -> 'C:\...\commands\summary.js') to a dynamic import(). Node's ESM loader rejects bare drive-letter specifiers (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol 'c:'); absolute specifiers must be file:// URLs. POSIX absolute paths are tolerated, so the bug never surfaced on macOS/Linux. Crash fires on the first loop iteration before any command runs, so 'satsuma' with no args dies.
+
+## Acceptance Criteria
+
+Command modules are imported via a file:// URL (pathToFileURL) on all platforms; no platform branching; regression test pins the file:// invariant; existing CLI integration tests still pass.
+
+
+## Notes
+
+**2026-06-09T22:09:25Z**
+
+**2026-06-09T22:10:00Z**
+
+Cause: index.ts passed a raw OS path (join(__dirname, cmd)) to dynamic import(); Node ESM rejects bare drive-letter specifiers on Windows (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol c:). POSIX tolerated it, so it never surfaced on macOS/Linux.
+Fix: extracted commandModuleSpecifier() in command-loader.ts wrapping the path with pathToFileURL().href; index.ts imports command modules via that file:// URL. Added command-loader.test.ts pinning the file:// invariant.

--- a/.tickets/sl-2a7k.md
+++ b/.tickets/sl-2a7k.md
@@ -26,3 +26,9 @@ Command modules are imported via a file:// URL (pathToFileURL) on all platforms;
 
 Cause: index.ts passed a raw OS path (join(__dirname, cmd)) to dynamic import(); Node ESM rejects bare drive-letter specifiers on Windows (ERR_UNSUPPORTED_ESM_URL_SCHEME, protocol c:). POSIX tolerated it, so it never surfaced on macOS/Linux.
 Fix: extracted commandModuleSpecifier() in command-loader.ts wrapping the path with pathToFileURL().href; index.ts imports command modules via that file:// URL. Added command-loader.test.ts pinning the file:// invariant.
+
+**2026-06-09T22:13:19Z**
+
+**2026-06-09T22:25:00Z**
+
+Folded a second, independent Windows bug into the same PR (#268): satsuma-lsp/validate-diagnostics.ts built file:// URIs via string concat (\"file://\" + encodeURI(path)), malformed for Windows drive paths so validate diagnostics never matched the open document. Replaced with pathToFileURL(); exported pathToFileUri and added round-trip regression coverage.

--- a/.tickets/sl-vmqv.md
+++ b/.tickets/sl-vmqv.md
@@ -1,0 +1,23 @@
+---
+id: sl-vmqv
+status: open
+deps: []
+links: [sl-2a7k]
+created: 2026-06-09T22:15:23Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+external-ref: gh-265
+---
+# Add Windows job to CI matrix to catch platform path/URL bugs
+
+All CI jobs in .github/workflows/ci.yml run on ubuntu-latest. The Windows-only CLI startup crash (gh-265 / sl-2a7k) and the malformed Windows diagnostic URI in satsuma-lsp shipped undetected because nothing exercises the toolchain on Windows. This class of bug (raw OS paths used where file:// URLs are required, path-separator assumptions, drive-letter handling) is invisible to a Linux-only matrix.
+
+## Design
+
+Add a windows-latest job (or a windows-latest shard to the existing test matrix). Keep it focused: it does not need full coverage reporting — a smoke job that builds the workspace (npm run install:all) and runs the CLI integration suite plus the satsuma-lsp suite is enough to catch path/URL regressions, since those are the consumers that spawn the CLI and build file:// URIs. Mind Windows specifics: bash vs pwsh default shell (set 'shell: bash' on steps that use POSIX syntax), CRLF/line-ending differences in golden fixture comparisons, and slower npm installs. Use fail-fast: false so a Windows failure does not mask Linux results.
+
+## Acceptance Criteria
+
+ci.yml runs at least the CLI integration tests and the satsuma-lsp tests on windows-latest on every PR; the job is required for merge; a deliberately reintroduced raw-path import() (the gh-265 regression) would fail this job; README/CONTRIBUTING note the supported CI platforms if such a list exists.
+

--- a/tooling/satsuma-cli/src/command-loader.ts
+++ b/tooling/satsuma-cli/src/command-loader.ts
@@ -1,0 +1,37 @@
+/**
+ * command-loader — resolves CLI command modules to importable specifiers.
+ *
+ * Each command lives in its own module under src/commands/ and is loaded at
+ * startup with a dynamic `import()`. This module owns the single rule for
+ * turning an on-disk module path into a specifier that Node's ESM loader will
+ * accept on every platform.
+ *
+ * It does NOT own command registration or dispatch — that stays in index.ts.
+ */
+
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Build the `import()` specifier for a command module, given the entry point's
+ * directory and the module's path relative to it.
+ *
+ * The specifier is always a `file://` URL. This matters on Windows: Node's ESM
+ * loader rejects a bare absolute path like `C:\…\commands\summary.js` with
+ * ERR_UNSUPPORTED_ESM_URL_SCHEME, because it reads the drive letter `C:` as a
+ * URL scheme. Absolute `import()` specifiers must be `file://` URLs there.
+ * POSIX absolute paths happen to be tolerated, which is why the bug only ever
+ * surfaced on Windows (gh-265). `pathToFileURL` produces a valid URL on both,
+ * so no platform branching is needed.
+ *
+ * @param entryDir            Directory of the CLI entry point (its __dirname).
+ * @param relativeModulePath  Module path relative to entryDir, e.g.
+ *                            "commands/summary.js".
+ * @returns A `file://` URL string suitable for `import()`.
+ */
+export function commandModuleSpecifier(
+  entryDir: string,
+  relativeModulePath: string,
+): string {
+  return pathToFileURL(join(entryDir, relativeModulePath)).href;
+}

--- a/tooling/satsuma-cli/src/index.ts
+++ b/tooling/satsuma-cli/src/index.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import { initParser } from "./parser.js";
+import { commandModuleSpecifier } from "./command-loader.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -72,7 +73,9 @@ const commands = [
 ];
 
 for (const cmd of commands) {
-  const mod = await import(join(__dirname, cmd)) as { register: (program: Command) => void };
+  // Import via a file:// URL, not a raw path: Node's ESM loader rejects bare
+  // absolute paths like "C:\…\summary.js" on Windows (gh-265). See command-loader.
+  const mod = await import(commandModuleSpecifier(__dirname, cmd)) as { register: (program: Command) => void };
   mod.register(program);
 }
 

--- a/tooling/satsuma-cli/test/command-loader.test.ts
+++ b/tooling/satsuma-cli/test/command-loader.test.ts
@@ -1,0 +1,46 @@
+/**
+ * command-loader.test.ts — Unit tests for src/command-loader.ts
+ *
+ * Guards the gh-265 regression: the CLI entry point must hand `import()` a
+ * file:// URL, never a bare OS path. On Windows, Node's ESM loader rejects a
+ * bare absolute path (it reads the drive letter as a URL scheme), which crashed
+ * the CLI at startup before any command could run.
+ *
+ * The crash is Windows-only and cannot be reproduced on the POSIX CI host, so we
+ * pin the platform-independent invariant that prevents it: the specifier is a
+ * file:// URL that round-trips back to the requested on-disk path.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { commandModuleSpecifier } from "#src/command-loader.js";
+
+describe("commandModuleSpecifier", () => {
+  it("returns a file:// URL, not a bare path", () => {
+    // The core gh-265 invariant: a bare absolute path is what Node's ESM loader
+    // rejects on Windows. Requiring the file:// scheme is what keeps it valid.
+    const spec = commandModuleSpecifier("/opt/satsuma/dist", "commands/summary.js");
+    assert.ok(spec.startsWith("file://"), `expected a file:// URL, got: ${spec}`);
+  });
+
+  it("round-trips back to the joined on-disk path", () => {
+    // The URL must point at exactly the module we asked for — encoding the
+    // directory and relative module path without corrupting them.
+    const dir = "/opt/satsuma/dist";
+    const rel = "commands/lineage.js";
+    const spec = commandModuleSpecifier(dir, rel);
+    assert.equal(fileURLToPath(spec), join(dir, rel));
+  });
+
+  it("percent-encodes characters that are unsafe in a URL path", () => {
+    // Directories can contain spaces (e.g. Windows "Program Files"); a raw
+    // path concatenated into a URL would break, so the result must be encoded
+    // yet still decode back to the original path.
+    const dir = "/opt/My Tools/satsuma";
+    const spec = commandModuleSpecifier(dir, "commands/fmt.js");
+    assert.ok(!spec.includes(" "), "spaces must be percent-encoded in the URL");
+    assert.equal(fileURLToPath(spec), join(dir, "commands/fmt.js"));
+  });
+});

--- a/tooling/satsuma-lsp/src/validate-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/validate-diagnostics.ts
@@ -5,7 +5,7 @@ import {
   Position,
 } from "vscode-languageserver";
 import { execFile } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 /** Shape of a single entry from `satsuma validate --json`. */
 interface ValidateEntry {
@@ -100,7 +100,18 @@ export async function runValidate(
   });
 }
 
-function pathToFileUri(fsPath: string): string {
-  // Use a simple conversion — the file paths from validate are absolute
-  return "file://" + encodeURI(fsPath).replace(/#/g, "%23");
+/**
+ * Convert an absolute filesystem path (as emitted by `satsuma validate --json`)
+ * into a `file://` URI that matches the editor's document URIs.
+ *
+ * Exported for direct testing of the URI invariant. We delegate to Node's
+ * `pathToFileURL` rather than hand-building the URL: on Windows a path like
+ * `C:\proj\x.stm` must become `file:///c:/proj/x.stm`, but string concatenation
+ * (`"file://" + path`) leaves the drive colon and backslashes raw, producing a
+ * malformed URI that never matches the open document — so diagnostics silently
+ * fail to attach. `pathToFileURL` also percent-encodes URL-significant
+ * characters (spaces, `?`, `#`) that naive encoding mishandles. (gh-265)
+ */
+export function pathToFileUri(fsPath: string): string {
+  return pathToFileURL(fsPath).toString();
 }

--- a/tooling/satsuma-lsp/test/validate-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/validate-diagnostics.test.js
@@ -1,6 +1,30 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
-const { runValidate } = require("../dist/validate-diagnostics");
+const { fileURLToPath, pathToFileURL } = require("node:url");
+const { runValidate, pathToFileUri } = require("../dist/validate-diagnostics");
+
+describe("pathToFileUri", () => {
+  // The Windows symptom (a `C:\…` path becoming a malformed `file://C:\…`
+  // URI that never matches the open document, so diagnostics silently fail
+  // to attach) cannot be reproduced on the POSIX CI host, because
+  // pathToFileURL is platform-bound. These cases pin the platform-independent
+  // invariant that prevents it: a canonical file:// URL that round-trips. (gh-265)
+
+  it("produces a canonical file:// URL, not a hand-built string", () => {
+    // Locks the implementation to Node's pathToFileURL. The previous
+    // `"file://" + encodeURI(path)` is what mishandled Windows drive paths.
+    assert.equal(pathToFileUri("/proj/x.stm"), pathToFileURL("/proj/x.stm").toString());
+  });
+
+  it("round-trips a path containing URL-significant characters", () => {
+    // `?` is the POSIX proxy for the Windows drive-colon breakage: encodeURI
+    // left it raw, so the old code yielded `file:///a?b.stm` where `?b.stm`
+    // parses as a query string and fileURLToPath loses it. pathToFileURL
+    // encodes it, so the URI round-trips to the exact input.
+    const p = "/proj/weird?name #1/x.stm";
+    assert.equal(fileURLToPath(pathToFileUri(p)), p);
+  });
+});
 
 describe("runValidate", () => {
   it("returns empty map when CLI produces no output", async () => {


### PR DESCRIPTION
Fixes #265 — the `satsuma` CLI crashes at startup on Windows, which also takes down every CLI-backed feature of the VS Code extension. This PR fixes that root cause plus a second, independent Windows bug found while auditing the same code path.

## 1. CLI startup crash (the reported issue)

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... On Windows, absolute paths
must be valid file:// URLs. Received protocol 'c:'
```

`index.ts` built command-module specifiers with `join(__dirname, cmd)`, producing a raw OS path like `C:\…\commands\summary.js`. Node's ESM loader rejects bare absolute paths in dynamic `import()` on Windows — it reads the drive letter `C:` as a URL scheme. POSIX absolute paths happen to be tolerated, which is why it only surfaced on Windows. The crash fires on the first loop iteration, before any command runs, so `satsuma` with no args dies.

**Fix:** extract `commandModuleSpecifier()` into a small documented `command-loader.ts` that wraps the path with `pathToFileURL(...).href`. `index.ts` imports command modules through it. Valid on every platform — no branching.

## 2. Malformed Windows diagnostic URIs in the LSP (found while auditing)

`satsuma-lsp/validate-diagnostics.ts` mapped CLI file paths back to document URIs by hand: `"file://" + encodeURI(path)`. On Windows that leaves the drive colon and backslashes raw (`file://C:\proj\x.stm`), so the URI never matches the editor's document URI and validate diagnostics silently fail to attach — even once the CLI no longer crashes.

**Fix:** use Node's `pathToFileURL`, which yields the canonical `file:///c:/proj/x.stm` form (and correctly percent-encodes spaces, `?`, `#`). The sibling modules `server.ts` and `semantic-diagnostics.ts` already do this — this spot was the outlier.

## Why this matters for the VS Code extension

The extension's own code is Windows-safe (it uses `asAbsolutePath` + a forked LSP process and `vscode.Uri.file`, not absolute-path `import()`). But it shells out to the `satsuma` CLI for command-palette actions and live `validate` diagnostics, so bug #1 broke all of those on Windows. Both fixes here are needed for the extension to work on Windows.

## Testing

- `command-loader.test.ts` and new `pathToFileUri` cases in `validate-diagnostics.test.js` pin the platform-independent invariant each fix guarantees: a canonical `file://` URL that round-trips back to the requested path. The crashes are Windows-only and can't be reproduced on the POSIX CI host, so the tests guard the contract rather than the symptom.
- CLI suite green (844); LSP suite green (240); built CLI verified loading all commands end-to-end.

Closes sl-2a7k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)