### PR TITLE
fix(lsp): ship WASM and highlights.scm in the standalone tarball (sl-vwpr)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,12 @@ jobs:
           npm install -g ./tooling/satsuma-cli/satsuma-cli.tgz
           satsuma --version
 
+          # Install the LSP tarball and drive a real initialize round-trip over
+          # stdio. The server loads its WASM assets inside onInitialize, so this
+          # catches a tarball that installs cleanly but cannot start (sl-vwpr).
+          npm install -g ./tooling/satsuma-lsp/satsuma-lsp.tgz
+          node tooling/satsuma-lsp/scripts/smoke-initialize.js "$(command -v satsuma-lsp)" --stdio
+
       - uses: actions/upload-artifact@v7
         with:
           name: satsuma-cli

--- a/.tickets/sl-vwpr.md
+++ b/.tickets/sl-vwpr.md
@@ -1,0 +1,26 @@
+---
+id: sl-vwpr
+status: closed
+deps: []
+links: []
+created: 2026-06-10T11:16:28Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+external-ref: user-report-v0.9.0
+---
+# satsuma-lsp standalone tarball ships no WASM or highlights.scm — fresh install fails initialize with ENOENT
+
+The v0.9.0 release asset satsuma-lsp-v0.9.0.tgz contains zero .wasm files and no highlights.scm, but dist/server.js hard-codes loading tree-sitter-satsuma.wasm and tree-sitter.wasm from __dirname at initialize (server.ts:71-75). A fresh 'npm install -g satsuma-lsp-*.tgz' therefore fails its initialize request with ENOENT. The VSIX works only because vscode-satsuma/esbuild.js copyAssets() does its own copy into server/dist; the CLI tarball ships its wasm via scripts/prebuild.js + verify-pack.js. The LSP standalone pack path has no asset copy and no tarball verification, and the release smoke test only installs the CLI tarball.
+
+## Acceptance Criteria
+
+1) npm run build in tooling/satsuma-lsp leaves tree-sitter-satsuma.wasm, tree-sitter.wasm (web-tree-sitter runtime, renamed), and highlights.scm in dist/. 2) The packed satsuma-lsp.tgz is verified to contain bin/satsuma-lsp.js, dist/server.js, both wasm files, and highlights.scm, failing the build if any are missing. 3) Release workflow smoke-tests a fresh global install of the LSP tarball with a real LSP initialize round-trip over stdio. 4) build-artifacts.sh uses the verified pack path.
+
+
+## Notes
+
+**2026-06-10T12:01:54Z**
+
+Cause: the LSP standalone pack path had no asset-copy step — esbuild only emits dist/server.js, and only the VS Code extension's own esbuild.js copied the WASM/highlights.scm next to the server bundle. npm pack therefore shipped a tarball whose server fails initialize with ENOENT, and the release smoke test only exercised the CLI tarball.
+Fix: added scripts/copy-assets.js (runs in prebuild) to place tree-sitter-satsuma.wasm, the web-tree-sitter runtime (renamed tree-sitter.wasm), and highlights.scm in dist/; added scripts/pack.js + verify-pack.js mirroring satsuma-cli's verified pack path; build-artifacts.sh now uses npm run pack (and drops the vestigial node_modules symlink replacement — the tarball ships no node_modules); release workflow now smoke-tests a fresh global install of the LSP tarball with a real stdio initialize round-trip (scripts/smoke-initialize.js).

--- a/scripts/build-artifacts.sh
+++ b/scripts/build-artifacts.sh
@@ -49,44 +49,20 @@ fi
 # 2. LSP standalone npm tarball
 # --------------------------------------------------------------------------- #
 
+# The build copies the WASM and highlights.scm assets into dist/ (see
+# tooling/satsuma-lsp/scripts/copy-assets.js); `npm run pack` then packs,
+# renames to a stable filename, and verifies the tarball contents (sl-vwpr).
+# dist/server.js is a self-contained esbuild bundle, so no node_modules are
+# packed and no file:-symlink replacement is needed.
 echo "==> Building and packing LSP server..."
 npm --prefix "$LSP_DIR" run build
-
-# Replace file: symlinks with real copies so the tarball is self-contained.
-# The LSP depends on @satsuma/core, @satsuma/viz-model, and
-# @satsuma/viz-backend via file: links.
-CORE_SRC="$REPO_ROOT/tooling/satsuma-core"
-VIZ_MODEL_SRC="$REPO_ROOT/tooling/satsuma-viz-model"
-VIZ_BACKEND_SRC="$REPO_ROOT/tooling/satsuma-viz-backend"
-
-LSP_CORE_DEST="$LSP_DIR/node_modules/@satsuma/core"
-LSP_VIZ_DEST="$LSP_DIR/node_modules/@satsuma/viz-model"
-LSP_VIZ_BACKEND_DEST="$LSP_DIR/node_modules/@satsuma/viz-backend"
-
-for pair in \
-  "$CORE_SRC:$LSP_CORE_DEST" \
-  "$VIZ_MODEL_SRC:$LSP_VIZ_DEST" \
-  "$VIZ_BACKEND_SRC:$LSP_VIZ_BACKEND_DEST"; do
-  src="${pair%%:*}"
-  dest="${pair##*:}"
-  if [ -L "$dest" ] || [ -d "$dest" ]; then
-    rm -rf "$dest"
-    cp -rf "$src" "$dest"
-    echo "  replaced symlink at $dest with real copy"
-  fi
-done
-
-(cd "$LSP_DIR" && npm pack)
-
-# Rename the versioned tarball to a stable name.
-LSP_TARBALL=$(find "$LSP_DIR" -maxdepth 1 -name 'satsuma-lsp-*.tgz' -o -name 'at-satsuma-lsp-*.tgz' | head -1)
-if [ -z "$LSP_TARBALL" ]; then
-  echo "ERROR: npm pack did not produce a tarball in $LSP_DIR" >&2
-  exit 1
-fi
+npm --prefix "$LSP_DIR" run pack
 
 LSP_STABLE="$LSP_DIR/satsuma-lsp.tgz"
-mv -f "$LSP_TARBALL" "$LSP_STABLE"
+if [ ! -f "$LSP_STABLE" ]; then
+  echo "ERROR: LSP tarball not found at $LSP_STABLE" >&2
+  exit 1
+fi
 
 # --------------------------------------------------------------------------- #
 # 3. CLI standalone npm tarball

--- a/tooling/satsuma-lsp/package.json
+++ b/tooling/satsuma-lsp/package.json
@@ -9,9 +9,11 @@
     "satsuma-lsp": "bin/satsuma-lsp.js"
   },
   "scripts": {
-    "prebuild": "npm --prefix ../satsuma-core run build && npm --prefix ../satsuma-viz-backend run build",
+    "prebuild": "npm --prefix ../satsuma-core run build && npm --prefix ../satsuma-viz-backend run build && node scripts/copy-assets.js",
     "build": "esbuild src/server.ts --bundle --platform=node --target=node20 --outfile=dist/server.js --sourcemap --banner:js='var __import_meta_url = require(\"url\").pathToFileURL(__filename).href;' --define:import.meta.url=__import_meta_url",
     "watch": "npm run build -- --watch",
+    "pack": "node scripts/pack.js",
+    "smoke": "node scripts/smoke-initialize.js",
     "test": "node --test test/**/*.test.js",
     "pretest": "npm --prefix ../satsuma-core run build && npm --prefix ../satsuma-viz-backend run build && tsc",
     "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary --include='dist/**/*.js' --exclude='dist/**/*.d.ts' node --test test/**/*.test.js"

--- a/tooling/satsuma-lsp/scripts/copy-assets.js
+++ b/tooling/satsuma-lsp/scripts/copy-assets.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * copy-assets.js — copy runtime assets into dist/ next to the bundled server.
+ *
+ * server.ts loads three files from __dirname (i.e. next to dist/server.js) at
+ * initialize time:
+ *
+ *   - tree-sitter-satsuma.wasm  (the Satsuma grammar)
+ *   - tree-sitter.wasm          (the web-tree-sitter runtime)
+ *   - highlights.scm            (semantic-token query; optional at runtime)
+ *
+ * esbuild only emits server.js, so without this step a packed tarball ships a
+ * server that fails its initialize request with ENOENT (see sl-vwpr — the
+ * v0.9.0 standalone tarball shipped no WASM at all).
+ *
+ * Run automatically via `npm run prebuild` so both `build` and `watch` leave
+ * dist/ launch-ready. The VS Code extension does NOT consume these copies — it
+ * bundles the server itself and copies the same assets in its own esbuild.js.
+ */
+
+const { copyFileSync, existsSync, mkdirSync } = require("fs");
+const path = require("path");
+
+const lspRoot = path.join(__dirname, "..");
+const treeSitterDir = path.join(lspRoot, "..", "tree-sitter-satsuma");
+const distDir = path.join(lspRoot, "dist");
+
+mkdirSync(distDir, { recursive: true });
+
+const assets = [
+  {
+    src: path.join(treeSitterDir, "tree-sitter-satsuma.wasm"),
+    dest: path.join(distDir, "tree-sitter-satsuma.wasm"),
+    label: "tree-sitter-satsuma.wasm (grammar)",
+  },
+  {
+    // web-tree-sitter 0.26+ renamed its runtime tree-sitter.wasm →
+    // web-tree-sitter.wasm; server.ts still resolves the old name, so the
+    // copy renames it back.
+    src: path.join(lspRoot, "node_modules", "web-tree-sitter", "web-tree-sitter.wasm"),
+    dest: path.join(distDir, "tree-sitter.wasm"),
+    label: "web-tree-sitter.wasm (runtime) → tree-sitter.wasm",
+  },
+  {
+    src: path.join(treeSitterDir, "queries", "highlights.scm"),
+    dest: path.join(distDir, "highlights.scm"),
+    label: "highlights.scm (semantic-token query)",
+  },
+];
+
+for (const { src, dest, label } of assets) {
+  if (!existsSync(src)) {
+    throw new Error(
+      `copy-assets: required asset not found at ${src}. ` +
+        "Run `npm run install:all` from the repo root to build the WASM parser first.",
+    );
+  }
+  copyFileSync(src, dest);
+  console.log(`copy-assets: copied ${label} → dist/`);
+}

--- a/tooling/satsuma-lsp/scripts/pack.js
+++ b/tooling/satsuma-lsp/scripts/pack.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * pack.js — package the standalone LSP server, producing satsuma-lsp.tgz.
+ *
+ * dist/server.js is a self-contained esbuild bundle, so unlike satsuma-cli no
+ * dependencies are bundled into the tarball — packing is just `npm pack`, a
+ * rename to a stable filename, and a content check. The verification step is
+ * the regression guard for sl-vwpr (v0.9.0 shipped a tarball with no WASM,
+ * which fails every initialize request on a fresh install).
+ *
+ * Run via `npm run pack` locally or from scripts/build-artifacts.sh in CI.
+ */
+
+const { execFileSync } = require("child_process");
+const { readdirSync, renameSync } = require("fs");
+const path = require("path");
+
+const lspRoot = path.join(__dirname, "..");
+
+// --- Step 1: run npm pack ---------------------------------------------------
+
+execFileSync("npm", ["pack"], { cwd: lspRoot, stdio: "inherit" });
+
+// --- Step 2: rename to a stable filename ------------------------------------
+
+// The package is named @satsuma/lsp, so npm pack emits satsuma-lsp-<ver>.tgz.
+const [generatedTarball] = readdirSync(lspRoot).filter(
+  (f) => f.startsWith("satsuma-lsp-") && f.endsWith(".tgz"),
+);
+
+if (!generatedTarball) {
+  throw new Error("pack: npm pack did not produce a satsuma-lsp-*.tgz file");
+}
+
+renameSync(path.join(lspRoot, generatedTarball), path.join(lspRoot, "satsuma-lsp.tgz"));
+console.log(`pack: renamed ${generatedTarball} → satsuma-lsp.tgz`);
+
+// --- Step 3: verify the tarball ---------------------------------------------
+
+execFileSync("node", ["scripts/verify-pack.js"], { cwd: lspRoot, stdio: "inherit" });

--- a/tooling/satsuma-lsp/scripts/smoke-initialize.js
+++ b/tooling/satsuma-lsp/scripts/smoke-initialize.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * smoke-initialize.js — drive a real LSP initialize round-trip over stdio.
+ *
+ * Spawns the server command given on the command line (defaulting to this
+ * package's bin entry), sends an `initialize` request framed per the LSP
+ * base protocol, and asserts the response carries server capabilities. This
+ * is the end-to-end check that a fresh install can actually start: the server
+ * loads its WASM assets inside onInitialize, so a broken package (sl-vwpr)
+ * passes `npm install` but fails exactly here.
+ *
+ * Usage:
+ *   node scripts/smoke-initialize.js [command [args...]]
+ *   node scripts/smoke-initialize.js "$(command -v satsuma-lsp)" --stdio
+ *
+ * Exits 0 on success, 1 on failure or after a 30s timeout.
+ */
+
+const { spawn } = require("child_process");
+const path = require("path");
+
+// Allow generous startup time on slow CI runners; WASM compile dominates.
+const TIMEOUT_MS = 30_000;
+
+const [command, ...commandArgs] =
+  process.argv.length > 2
+    ? process.argv.slice(2)
+    : [process.execPath, path.join(__dirname, "..", "bin", "satsuma-lsp.js"), "--stdio"];
+
+const server = spawn(command, commandArgs, { stdio: ["pipe", "pipe", "inherit"] });
+
+const fail = (message) => {
+  console.error(`smoke-initialize: FAIL — ${message}`);
+  server.kill();
+  process.exit(1);
+};
+
+const timer = setTimeout(
+  () => fail(`no initialize response within ${TIMEOUT_MS / 1000}s`),
+  TIMEOUT_MS,
+);
+
+server.on("error", (err) => fail(`could not spawn ${command}: ${err.message}`));
+server.on("exit", (code) => fail(`server exited prematurely (code ${code})`));
+
+// --- Send the initialize request (LSP base-protocol framing) ----------------
+
+const initialize = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: { processId: process.pid, rootUri: null, capabilities: {} },
+});
+server.stdin.write(`Content-Length: ${Buffer.byteLength(initialize)}\r\n\r\n${initialize}`);
+
+// --- Read framed messages until the id:1 response arrives -------------------
+
+let buffer = Buffer.alloc(0);
+
+server.stdout.on("data", (chunk) => {
+  buffer = Buffer.concat([buffer, chunk]);
+
+  // Drain every complete Content-Length-framed message currently buffered.
+  for (;;) {
+    const headerEnd = buffer.indexOf("\r\n\r\n");
+    if (headerEnd === -1) return;
+
+    const header = buffer.subarray(0, headerEnd).toString("utf8");
+    const lengthMatch = header.match(/Content-Length: (\d+)/i);
+    if (!lengthMatch) return fail(`malformed header: ${JSON.stringify(header)}`);
+
+    const bodyStart = headerEnd + 4;
+    const bodyLength = Number(lengthMatch[1]);
+    if (buffer.length < bodyStart + bodyLength) return; // body not yet complete
+
+    const body = buffer.subarray(bodyStart, bodyStart + bodyLength).toString("utf8");
+    buffer = buffer.subarray(bodyStart + bodyLength);
+
+    const message = JSON.parse(body);
+    if (message.id !== 1) continue; // server-initiated notification — skip
+
+    if (message.error) return fail(`initialize error: ${JSON.stringify(message.error)}`);
+    if (!message.result?.capabilities) {
+      return fail(`response has no capabilities: ${body}`);
+    }
+
+    clearTimeout(timer);
+    server.removeAllListeners("exit");
+    console.log("smoke-initialize: OK — server initialized with capabilities");
+    server.kill();
+    process.exit(0);
+  }
+});

--- a/tooling/satsuma-lsp/scripts/verify-pack.js
+++ b/tooling/satsuma-lsp/scripts/verify-pack.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * verify-pack.js — assert that satsuma-lsp.tgz is installable and launch-ready.
+ *
+ * Guards against the sl-vwpr regression: the server loads its WASM and query
+ * assets from next to dist/server.js at initialize time, so a tarball missing
+ * any of them installs cleanly but fails the first LSP request with ENOENT.
+ * Run automatically as the last step of `npm run pack`.
+ */
+
+const { execFileSync } = require("child_process");
+const { existsSync } = require("fs");
+const path = require("path");
+
+const lspRoot = path.join(__dirname, "..");
+const tarballPath = path.join(lspRoot, "satsuma-lsp.tgz");
+
+if (!existsSync(tarballPath)) {
+  throw new Error(`verify-pack: tarball not found at ${tarballPath}`);
+}
+
+const contents = execFileSync("tar", ["-tzf", tarballPath], {
+  cwd: lspRoot,
+  encoding: "utf8",
+});
+
+// Any tarball entry containing '..' would be rejected by npm at install time
+// with TAR_ENTRY_ERROR (symlinked file: dependencies cause this). Fail fast.
+const dotDotEntries = contents.split("\n").filter((e) => e.includes(".."));
+if (dotDotEntries.length > 0) {
+  throw new Error(
+    `verify-pack: tarball contains entries with '..' in their paths — ` +
+      `npm will reject these on install.\n` +
+      dotDotEntries.map((e) => `  ${e}`).join("\n"),
+  );
+}
+
+console.log("verify-pack: no '..' paths in tarball entries");
+
+// Everything the server resolves relative to dist/server.js at runtime, plus
+// the bin entry point. See src/server.ts onInitialize and scripts/copy-assets.js.
+const requiredEntries = [
+  "package/bin/satsuma-lsp.js",
+  "package/dist/server.js",
+  "package/dist/tree-sitter-satsuma.wasm",
+  "package/dist/tree-sitter.wasm",
+  "package/dist/highlights.scm",
+];
+
+for (const entry of requiredEntries) {
+  if (!contents.includes(`${entry}\n`) && !contents.endsWith(entry)) {
+    throw new Error(`verify-pack: required tarball entry missing: ${entry}`);
+  }
+}
+
+console.log("verify-pack: tarball contains bin, server bundle, WASM, and highlights.scm");

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../satsuma-lsp": {
       "name": "@satsuma/lsp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",


### PR DESCRIPTION
## Problem

A user reported that the v0.9.0 `satsuma-lsp` tarball is broken out of the box, and the report checks out: the release asset contains **no `.wasm` files and no `highlights.scm`**, but the server loads `tree-sitter-satsuma.wasm` and `tree-sitter.wasm` from next to `dist/server.js` inside `onInitialize` (`src/server.ts:71-75`). A fresh `npm install` of the tarball therefore fails its first LSP request with ENOENT.

It shipped unnoticed because the asset copy only existed in the VS Code extension's `esbuild.js` (so the VSIX works), and the release smoke test only exercised the CLI tarball.

## Fix

Mirrors the verified pack pipeline `satsuma-cli` already has:

- **`scripts/copy-assets.js`** (run from `prebuild`) places `tree-sitter-satsuma.wasm`, the web-tree-sitter runtime (renamed back to `tree-sitter.wasm`, the name the server resolves), and `highlights.scm` into `dist/`, so build output is launch-ready.
- **`scripts/pack.js` + `scripts/verify-pack.js`** pack, rename to the stable `satsuma-lsp.tgz`, and fail the build if any runtime asset is missing from the tarball or any entry contains `..`.
- **`scripts/build-artifacts.sh`** now delegates to `npm run pack` and drops the `node_modules` symlink replacement — it was vestigial: `dist/server.js` is a self-contained esbuild bundle and the tarball packs no `node_modules` at all.
- **`release.yml`** now smoke-tests a fresh global install of the LSP tarball with a real `initialize` round-trip over stdio (**`scripts/smoke-initialize.js`**) — the exact failure mode the user hit.
- `vscode-satsuma/package-lock.json`: one-line sync of a stale `@satsuma/lsp` version snapshot left over from the 0.9.0 bump.

The extension's own copy step in `vscode-satsuma/esbuild.js` is intentionally untouched: it bundles the server straight from `../satsuma-lsp/src` without running the LSP package build, so it cannot rely on the LSP's `dist/` copies.

## Verification

- `npm run build && npm run pack` in `tooling/satsuma-lsp` passes verification.
- A fresh install from the new tarball into a clean prefix answers `initialize` with capabilities.
- Negative check: deleting the WASM files from that install makes `smoke-initialize.js` fail with the originally reported ENOENT (exit 1) — the new smoke test would have caught v0.9.0.
- All 240 LSP tests pass; repo pre-commit hooks (lint, core/viz-model tests, smoke-tests) pass.

No ADR: this is a packaging bugfix applying the existing CLI pack-and-verify pattern to the LSP, not a new architectural decision.

Closes ticket sl-vwpr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)