### PR TITLE
Fix vsix/LSP/viz bug batch: lineage entry files, Windows URI duplicates, empty diagnostics, viz metadata & toggle, formatter commas

### DIFF
--- a/.tickets/sl-1ycv.md
+++ b/.tickets/sl-1ycv.md
@@ -1,0 +1,30 @@
+---
+id: sl-1ycv
+status: open
+deps: []
+links: []
+created: 2026-06-10T21:51:46Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [vscode, cli, lineage]
+---
+# VS Code lineage panels pass workspace directory to CLI, rejected since ADR-022
+
+The 'Satsuma: Show Lineage From...' command fails with: "lineage failed: Error resolving path '<path>': directory arguments are not supported — provide a .stm file instead."
+
+Root cause: ADR-022 (commit 62479fd, 2026-03-31) made the CLI reject directory arguments — the workspace is now defined by a .stm entry file and its transitive imports. The VS Code extension was never updated and still passes directory paths:
+
+- tooling/vscode-satsuma/src/commands/lineage.ts:50-51 resolves workspaceFolders[0].uri.fsPath (a directory) and hands it to SchemaLineagePanel.
+- tooling/vscode-satsuma/src/webview/schema-lineage/panel.ts:112-118 runs 'satsuma lineage --from <schema> <workspacePath> --json' with that directory.
+- tooling/vscode-satsuma/src/webview/field-lineage/panel.ts:133-136 has the identical pattern for 'satsuma field-lineage'.
+- tooling/vscode-satsuma/src/commands/validate.ts, warnings.ts, summary.ts pass NO path; the CLI defaults the path arg to '.' (load-workspace.ts:69, validate.ts:45) which is also a directory, so these commands fail the same way.
+
+The schema-lineage webview shipped 2026-03-29 (4f39116), two days before ADR-022 landed; nothing reconciled the two. Users hit it now because the latest release is the first to bundle the directory-rejecting CLI with the extension.
+
+Fix direction: the extension needs an entry-file resolution strategy instead of directory/cwd args — e.g. the active editor's .stm file, the LSP's known workspace entry, and/or a satsuma.entryFile setting (the platform entry-point convention in CLAUDE.md). Apply it to all six runCli call sites and add regression coverage so extension CLI invocations never pass directories.
+
+## Acceptance Criteria
+
+All extension CLI invocations (schema-lineage, field-lineage, validate, warnings, summary) pass a .stm file path, never a directory or implicit cwd. Lineage panel renders for a multi-file workspace. Tests cover the entry-file resolution logic.
+

--- a/.tickets/sl-1ycv.md
+++ b/.tickets/sl-1ycv.md
@@ -1,6 +1,6 @@
 ---
 id: sl-1ycv
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T21:51:46Z
@@ -28,3 +28,10 @@ Fix direction: the extension needs an entry-file resolution strategy instead of 
 
 All extension CLI invocations (schema-lineage, field-lineage, validate, warnings, summary) pass a .stm file path, never a directory or implicit cwd. Lineage panel renders for a multi-file workspace. Tests cover the entry-file resolution logic.
 
+
+## Notes
+
+**2026-06-10T22:29:52Z**
+
+Cause: ADR-022 (62479fd) made the CLI reject directory arguments, but the extension still passed the workspace folder (schema-lineage and field-lineage panels, viz panel's fieldLineage message) or no path at all (validate/warnings/summary, which the CLI defaults to '.') — every CLI-backed feature failed with 'directory arguments are not supported'.
+Fix: added resolveEntryFile() (commands/entry-file.ts + pure rules in entry-file-logic.ts): active .stm editor wins, else the single workspace .stm file, else a quick pick (shallowest-first, last choice floated to top); all six runCli call sites now pass a .stm entry file and abort rather than fall back to a directory. Unit tests cover the selection rules (test/entry-file-logic.test.js).

--- a/.tickets/sl-6x1o.md
+++ b/.tickets/sl-6x1o.md
@@ -32,3 +32,7 @@ mapping export_to_csv (airflow, note "...") shows 'airflow' and the note in the 
 
 Cause: MappingBlock had no metadata field (extractMapping never read the mapping's metadata_block) and FieldEntry carried only the CONSTRAINT_TAGS-whitelisted constraint keys, dropping all other meta and all kv values — so mapping-level meta (airflow, note, merge strategies) and field governance meta (sensitivity, classification, mask, access_group) were invisible in the viz.
 Fix: added metadata: MetadataEntry[] to MappingBlock and FieldEntry in viz-model; viz-backend now extracts the mapping metadata_block and converts field MetaEntry[] via metaEntriesToViz; the detail header renders mapping meta as labelled rows and field rows render non-constraint meta as key+value pills next to the badges. viz-backend unit tests cover both extractions; Playwright harness covers rendering (mapping-field-meta.test.ts).
+
+**2026-06-10T22:53:10Z**
+
+Follow-up: CI's satsuma-viz suite (automation.test.js, not run locally at first) crashed in _fieldMetaPills on FieldEntry fixtures without the new metadata property. Made the renderer tolerate pre-sl-6x1o payloads ((f.metadata ?? [])), updated the fixtures, and added a legacy-payload regression test.

--- a/.tickets/sl-6x1o.md
+++ b/.tickets/sl-6x1o.md
@@ -1,0 +1,27 @@
+---
+id: sl-6x1o
+status: open
+deps: []
+links: []
+created: 2026-06-10T22:04:35Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, vscode, viz-model]
+---
+# Viz detail view drops mapping-level metadata and non-constraint field meta
+
+(Issue b) In the detailed Mapping Visualisation, mapping-level meta — especially 'note' and 'descr', but also bare tags like 'airflow' — never appears in the central mapping block header; only sources, target, join and filters render. Likewise schema field meta only shows the whitelisted constraint badges (pk, required, pii, indexed, unique, encrypt); key-value meta like 'sensitivity internal' or 'access_group property_facilities' is silently dropped, and even whitelisted kv entries lose their value.
+
+Root causes:
+- tooling/satsuma-viz-model/src/index.ts:79 — MappingBlock has no metadata field; tooling/satsuma-viz-backend/src/viz-model.ts:760 extractMapping never reads the mapping's metadata_block, so '(airflow, note "...")' is dropped at extraction.
+- tooling/satsuma-viz-model/src/index.ts:63-74 — FieldEntry carries only constraints: string[]; extractConstraintsFromMeta (viz-backend/src/viz-model.ts:649) whitelists CONSTRAINT_TAGS and pushes only entry.key for kv entries, discarding values.
+- tooling/satsuma-viz/src/components/sz-mapping-detail.ts:567-611 _renderMappingHeader renders only sourceRefs/targetRef/join/filters.
+- tooling/satsuma-viz/src/components/sz-schema-card.ts:642-685 _renderField renders constraints as badges only. Schema-LEVEL metadata pills already exist as the rendering pattern (sz-schema-card.ts:581-601, feature 34 vertical meta pills).
+
+Fix direction: add metadata: MetadataEntry[] to MappingBlock and FieldEntry in viz-model; extract full metadata in viz-backend (mapping metadata_block + field meta entries); render all mapping meta as rows in the detail header (note/descr wrapped like join/filter) and all field meta as key+value pills alongside the existing constraint badges. Keep PII shield badge behavior.
+
+## Acceptance Criteria
+
+mapping export_to_csv (airflow, note "...") shows 'airflow' and the note in the central mapping header. Field 'CLOSING_DATE DATE (sensitivity internal, access_group property_facilities)' shows both kv pills with values in the schema card. Existing constraint badges unchanged. Unit tests in viz-backend cover mapping/field metadata extraction; Playwright harness covers rendering.
+

--- a/.tickets/sl-6x1o.md
+++ b/.tickets/sl-6x1o.md
@@ -1,6 +1,6 @@
 ---
 id: sl-6x1o
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T22:04:35Z
@@ -25,3 +25,10 @@ Fix direction: add metadata: MetadataEntry[] to MappingBlock and FieldEntry in v
 
 mapping export_to_csv (airflow, note "...") shows 'airflow' and the note in the central mapping header. Field 'CLOSING_DATE DATE (sensitivity internal, access_group property_facilities)' shows both kv pills with values in the schema card. Existing constraint badges unchanged. Unit tests in viz-backend cover mapping/field metadata extraction; Playwright harness covers rendering.
 
+
+## Notes
+
+**2026-06-10T22:45:08Z**
+
+Cause: MappingBlock had no metadata field (extractMapping never read the mapping's metadata_block) and FieldEntry carried only the CONSTRAINT_TAGS-whitelisted constraint keys, dropping all other meta and all kv values — so mapping-level meta (airflow, note, merge strategies) and field governance meta (sensitivity, classification, mask, access_group) were invisible in the viz.
+Fix: added metadata: MetadataEntry[] to MappingBlock and FieldEntry in viz-model; viz-backend now extracts the mapping metadata_block and converts field MetaEntry[] via metaEntriesToViz; the detail header renders mapping meta as labelled rows and field rows render non-constraint meta as key+value pills next to the badges. viz-backend unit tests cover both extractions; Playwright harness covers rendering (mapping-field-meta.test.ts).

--- a/.tickets/sl-akz6.md
+++ b/.tickets/sl-akz6.md
@@ -1,0 +1,31 @@
+---
+id: sl-akz6
+status: open
+deps: []
+links: []
+created: 2026-06-10T21:52:05Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+external-ref: gh-274
+tags: [lsp, windows, diagnostics]
+---
+# LSP duplicate schema/src false positives: workspace files indexed under two URI representations on Windows
+
+GitHub issue #274 (user kiaroa, v0.8.0): in VS Code on Windows, schema/src declarations that are valid per 'satsuma validate' are flagged as duplicate definitions across files in the same repo.
+
+Root cause (user-traced, confirmed plausible in code): the same file gets indexed under two different URI strings, so every definition in it is counted twice and trips core duplicate detection.
+
+- tooling/satsuma-lsp/src/server.ts:488-489 — the initial workspace scan indexes files under pathToFileURL(filePath).toString(), which on Windows yields 'file:///C:/...' (uppercase drive).
+- tooling/satsuma-lsp/src/server.ts:141,159,205 — didOpen/didChange/watched-file events index under the client-supplied document URI, which VS Code sends as 'file:///c%3A/...' (lowercase drive, percent-encoded colon).
+- indexFile (tooling/satsuma-viz-backend/src/workspace-index.ts:291) keys strictly by URI string and removeFile only clears the exact same key, so the two representations coexist as separate indexed files.
+- computeSemanticValidationDiagnostics (tooling/satsuma-lsp/src/semantic-diagnostics.ts:72) then builds the semantic index over the whole wsIndex; buildSemanticIndex detects duplicates by counting definitions per name, so each opened file's definitions appear twice → 'duplicate schema'/'duplicate namespace src' diagnostics.
+
+Fix direction: canonicalize file URIs at every index boundary (one normalization helper in viz-backend's workspace-index used by indexFile/removeFile and the server's scan/didOpen/didChange/watched handlers) — normalize drive-letter case and percent-encoding to a single canonical form. This is shared-core logic per the Core vs Consumer rule, so it belongs in viz-backend/core, with tests covering 'file:///C:/...' vs 'file:///c%3A/...' equivalence.
+
+Also assess while in there: the global wsIndex is not import-scoped when handed to buildSemanticIndex; verify scoping is not a second contributor to the false positives the user describes (defined once standalone and again via each importing file).
+
+## Acceptance Criteria
+
+On Windows-style URI variation (drive letter case, percent-encoded colon), a file opened in the editor produces no duplicate-definition diagnostics for names it defines once. Unit tests exercise both URI forms mapping to one index entry. Repro from gh-274 (multi-file repo with namespace src imported by several mapping files) is clean while 'satsuma validate' stays clean too.
+

--- a/.tickets/sl-akz6.md
+++ b/.tickets/sl-akz6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-akz6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T21:52:05Z
@@ -29,3 +29,10 @@ Also assess while in there: the global wsIndex is not import-scoped when handed 
 
 On Windows-style URI variation (drive letter case, percent-encoded colon), a file opened in the editor produces no duplicate-definition diagnostics for names it defines once. Unit tests exercise both URI forms mapping to one index entry. Repro from gh-274 (multi-file repo with namespace src imported by several mapping files) is clean while 'satsuma validate' stays clean too.
 
+
+## Notes
+
+**2026-06-10T22:23:45Z**
+
+Cause: the workspace index keyed files by raw URI string. On Windows the startup scan indexes under pathToFileURL's spelling (file:///C:/...) while didOpen/didChange index under the client's spelling (file:///c%3A/...), so an opened file existed twice in the index and every definition in it was counted as a duplicate (gh-274).
+Fix: added canonicalizeFileUri() to viz-backend's workspace-index (decode percent-escapes, lowercase Windows drive letter, re-encode via WHATWG URL; browser-safe) and applied it in indexFile/removeFile/walkImportGraph/resolveImportUri; the LSP's semantic-diagnostics adapter canonicalizes the query URI and resolved import URIs so diagnostics match across spellings. Regression tests in viz-backend (uri-canonicalization.test.js) and satsuma-lsp (semantic-diagnostics.test.js).

--- a/.tickets/sl-e40u.md
+++ b/.tickets/sl-e40u.md
@@ -1,6 +1,6 @@
 ---
 id: sl-e40u
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T22:04:54Z
@@ -21,3 +21,10 @@ Fix direction: retitle the command (or add a distinct entry) to 'Satsuma: Overvi
 
 Right-clicking in a .stm editor shows a context-menu entry clearly named for the Overview Visualisation which opens the same view as the eye icon. Command palette and eye tooltip use the same accurate title.
 
+
+## Notes
+
+**2026-06-10T22:46:23Z**
+
+Cause: the editor context menu HAS contributed satsuma.showViz since a369815 (2026-03-26), but it was titled 'Satsuma: Show Mapping Visualization' while the command opens the OVERVIEW visualization — users looking for an 'Overview Visualisation' entry (the eye icon's behavior) could not recognize it.
+Fix: retitled the command to 'Satsuma: Overview Visualization' (palette, editor context menu, and eye-icon tooltip all share it), added an explorer/context entry for .stm files, and updated the extension README command table.

--- a/.tickets/sl-e40u.md
+++ b/.tickets/sl-e40u.md
@@ -1,0 +1,23 @@
+---
+id: sl-e40u
+status: open
+deps: []
+links: []
+created: 2026-06-10T22:04:54Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [vscode, ux]
+---
+# vsix: editor context menu lacks a recognizable 'Satsuma: Overview Visualisation' entry
+
+(Issue e) User expects the editor right-click context menu to offer the Overview Visualisation — the equivalent of the eye icon in the editor title bar — and reports it missing.
+
+Triage: tooling/vscode-satsuma/package.json already contributes satsuma.showViz to editor/context (when editorLangId == satsuma, group satsuma) since commit a369815 (2026-03-26), and the eye icon (editor/title) runs the same command. The entry is titled 'Satsuma: Show Mapping Visualization' although VizPanel opens in OVERVIEW mode — so either (a) the menu item is present but unrecognizable under that title, or (b) the when-clause fails for the user (e.g. file not associated with the satsuma language).
+
+Fix direction: retitle the command (or add a distinct entry) to 'Satsuma: Overview Visualisation' so it matches what it opens; verify the editor/context when-clause fires for .stm files in the packaged vsix; consider an explorer/context entry for .stm files as well.
+
+## Acceptance Criteria
+
+Right-clicking in a .stm editor shows a context-menu entry clearly named for the Overview Visualisation which opens the same view as the eye icon. Command palette and eye tooltip use the same accurate title.
+

--- a/.tickets/sl-q9oj.md
+++ b/.tickets/sl-q9oj.md
@@ -1,0 +1,30 @@
+---
+id: sl-q9oj
+status: closed
+deps: []
+links: []
+created: 2026-06-10T22:04:41Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [formatter, core]
+---
+# Formatter drops commas between source refs in multi-line source blocks
+
+(Issue c) Reformatting a mapping whose source block has multiple refs removes the commas between them.
+
+Root cause: formatSourceBlock in tooling/satsuma-core/src/format.ts:629-657 — the single-line path joins items with ', ' (line 647) but the multi-line path joins with bare newlines (line 656: items.map(item => ind(indent+1) + item).join('\n')), so 'source { a, b }' reflowed to multi-line loses its commas. Multi-ref sources are always forced multi-line (line 650), so every multi-source mapping is affected.
+
+Verify against grammar/spec whether commas are required separators between source_refs (if required, formatter output is invalid syntax; if optional, output still parses but the formatter is not style-preserving/canonical). Fix: emit trailing commas on all but the last item in the multi-line branch, matching the canonical examples corpus. Check formatTargetBlock for the same defect while there.
+
+## Acceptance Criteria
+
+Formatting 'source { store, customers }' (or its multi-line form) preserves commas between refs; output reparses cleanly and formatting is idempotent. Unit test covers multi-ref multi-line source block, and target block if it shares the bug.
+
+
+## Notes
+
+**2026-06-10T22:07:44Z**
+
+Cause: the multi-line branch of formatSourceBlock (satsuma-core/src/format.ts) joined source refs with bare newlines, dropping the commas the author wrote; the single-line branch used ', '. Commas are optional in the grammar so output still parsed, but formatting was not style-preserving and diverged from the canonical corpus style.
+Fix: multi-line source blocks now emit a trailing comma on every ref except the last, matching the single-line style; added regression tests for comma preservation and idempotency in satsuma-core/test/format.test.js.

--- a/.tickets/sl-sme1.md
+++ b/.tickets/sl-sme1.md
@@ -1,6 +1,6 @@
 ---
 id: sl-sme1
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T21:52:14Z
@@ -24,3 +24,10 @@ Fix direction: never publish an empty message. Give bare '//!' a sensible fallba
 
 A file containing a bare '//!' produces a non-empty-message warning diagnostic and no client-side TypeError. Test covers the empty-suffix warning_comment case. No diagnostic publish path can emit an empty message.
 
+
+## Notes
+
+**2026-06-10T22:17:34Z**
+
+Cause: a bare '//!' warning comment produced an LSP diagnostic with message: '' (diagnostics.ts walkComments). vscode.Diagnostic's constructor throws illegalArgument('message must be set') on a falsy message, and vscode-languageclient's batch conversion aborts on the throw, freezing all diagnostics for the file (gh-273).
+Fix: bare '//!' now falls back to 'Warning comment (no text)', and sendMergedDiagnostics applies ensureNonEmptyMessages() as a publish-boundary guard so no producer can ship an empty message. Regression tests added in satsuma-lsp/test/diagnostics.test.js.

--- a/.tickets/sl-sme1.md
+++ b/.tickets/sl-sme1.md
@@ -1,0 +1,26 @@
+---
+id: sl-sme1
+status: open
+deps: []
+links: []
+created: 2026-06-10T21:52:14Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+external-ref: gh-273
+tags: [lsp, vscode, diagnostics]
+---
+# LSP publishes empty-message diagnostics; VS Code client throws 'message must be set' and stalls the diagnostic queue
+
+GitHub issue #273 (user kiaroa, v0.8.0): the extension host logs '[error] Processing diagnostic queue failed. TypeError: message must be set' from new ProtocolDiagnostic → asDiagnostic → convertBatch in vscode-languageclient.
+
+Root cause: vscode.Diagnostic's constructor throws illegalArgument('message must be set') when message is falsy — including the empty string. The Satsuma LSP can publish such a diagnostic: tooling/satsuma-lsp/src/diagnostics.ts:50 maps a warning_comment to message: child.text.replace(/^\/\/!\s*/, ''), so a bare '//!' comment (no text after it) yields message: ''. When the client converts that batch, the constructor throws and the entire diagnostic queue processing fails — diagnostics for the file stop updating, not just the one entry. (The //? path is safe — it always prefixes 'TODO: '.)
+
+The issue title mentions Copilot chat because an AI edit introduced the bare '//!'; any user typing '//!' mid-comment hits it too.
+
+Fix direction: never publish an empty message. Give bare '//!' a sensible fallback message (e.g. 'Warning comment'), and add a defensive guard/assertion at the publishDiagnostics boundary so no diagnostic source can ship message: ''. Add a regression test with a bare '//!' fixture, and audit other diagnostic producers (parse errors, semantic, validate-diagnostics) for empty-message paths.
+
+## Acceptance Criteria
+
+A file containing a bare '//!' produces a non-empty-message warning diagnostic and no client-side TypeError. Test covers the empty-suffix warning_comment case. No diagnostic publish path can emit an empty message.
+

--- a/.tickets/sl-tw0r.md
+++ b/.tickets/sl-tw0r.md
@@ -1,0 +1,23 @@
+---
+id: sl-tw0r
+status: open
+deps: []
+links: []
+created: 2026-06-10T22:04:48Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, vscode]
+---
+# vsix overview: expand arrow on a source card navigates to source code instead of expanding
+
+(Issue d) In the VS Code overview visualization, clicking the expand/collapse arrow on a source schema card jumps to the source code (the editor opens the .stm file and the view loses focus) instead of expanding the card like in the viz harness.
+
+Root cause: _onHeaderClick in tooling/satsuma-viz/src/components/sz-schema-card.ts:781-786 conflates two actions — it toggles _collapsed AND dispatches a navigate event for the schema location on every header click (the toggle arrow at line 591 sits inside the header div whose @click is _onHeaderClick, sz-schema-card.ts:587). In the harness the navigate event has no document-opening listener so only the toggle is visible; in VS Code, webview/viz/viz.ts:16 forwards navigate to the extension which opens the document, so navigation wins.
+
+Fix direction: separate the click targets — the toggle arrow (.header-toggle) should toggle only (stopPropagation), while clicking the title/name navigates. Review the compact-card path too (sz-compact-toggled event, parent-owned compact-expanded property) so overview compact cards expand without navigating.
+
+## Acceptance Criteria
+
+In the VS Code overview, clicking the arrow expands/collapses the card and does not open the source file; clicking the card title still navigates. Behavior matches the viz harness. Playwright harness test covers toggle-without-navigate.
+

--- a/.tickets/sl-tw0r.md
+++ b/.tickets/sl-tw0r.md
@@ -1,6 +1,6 @@
 ---
 id: sl-tw0r
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T22:04:48Z
@@ -21,3 +21,10 @@ Fix direction: separate the click targets — the toggle arrow (.header-toggle) 
 
 In the VS Code overview, clicking the arrow expands/collapses the card and does not open the source file; clicking the card title still navigates. Behavior matches the viz harness. Playwright harness test covers toggle-without-navigate.
 
+
+## Notes
+
+**2026-06-10T22:45:08Z**
+
+Cause: _onHeaderClick / _onCompactHeaderClick in sz-schema-card (and the same pattern in sz-fragment-card) both toggled expansion AND dispatched SzNavigateEvent on every header click. The harness has no document-opening navigate listener so only the toggle was visible there, but VS Code opens the source file on navigate, so expanding a card yanked the editor away and hid the panel.
+Fix: the toggle arrow (.header-toggle) is now its own click target that only toggles (stopPropagation), and the header name/icon only navigates. Harness tests updated to the new contract, including a regression test asserting the arrow expands without firing navigate while the name still navigates.

--- a/docs/developer/SATSUMA-V2-SPEC.md
+++ b/docs/developer/SATSUMA-V2-SPEC.md
@@ -478,8 +478,8 @@ Describe joins in natural language within the source block or as a top-level NL 
 ```
 mapping `opportunity enrichment` {
   source {
-    `sfdc_opportunity`
-    `sfdc_account`
+    `sfdc_opportunity`,
+    `sfdc_account`,
     "Join on sfdc_opportunity.AccountId = sfdc_account.Id"
   }
   target { `snowflake_opps` }

--- a/docs/tutorials/ba-tutorial.md
+++ b/docs/tutorials/ba-tutorial.md
@@ -331,8 +331,8 @@ Enterprise integrations rarely involve just one source. When a mapping draws fro
 ```satsuma
 mapping `opportunity enrichment` {
   source {
-    `sfdc_opportunity`
-    `sfdc_account`
+    `sfdc_opportunity`,
+    `sfdc_account`,
     "Join on sfdc_opportunity.AccountId = sfdc_account.Id"
   }
   target { `snowflake_opps` }

--- a/examples/filter-flatten-governance/filter-flatten-governance.stm
+++ b/examples/filter-flatten-governance/filter-flatten-governance.stm
@@ -143,8 +143,8 @@ mapping `completed orders` {
   }
 
   source {
-    order_events
-    customer_profiles
+    order_events,
+    customer_profiles,
     "Join on @order_events.customer.customer_id = @customer_profiles.customer_id
      WHERE @order_events.order_status = completed"
   }

--- a/examples/filter-flatten-governance/governance.stm
+++ b/examples/filter-flatten-governance/governance.stm
@@ -201,8 +201,8 @@ mapping `customer 360 assembly` {
   }
 
   source {
-    crm_customers
-    finance_transactions
+    crm_customers,
+    finance_transactions,
     "Left join on @crm_customers.customer_id = @finance_transactions.customer_id.
      All CRM customers appear even if they have no transactions."
   }

--- a/examples/metrics-platform/metrics.stm
+++ b/examples/metrics-platform/metrics.stm
@@ -65,7 +65,7 @@ mapping _monthly_recurring_revenue_pipeline {
 
 mapping _customer_lifetime_value_pipeline {
   source {
-    fact_orders
+    fact_orders,
     dim_customer
   }
   target { customer_lifetime_value }
@@ -104,7 +104,7 @@ schema churn_rate (
 
 mapping _churn_rate_pipeline {
   source {
-    fact_subscriptions
+    fact_subscriptions,
     dim_customer
   }
   target { churn_rate }
@@ -148,7 +148,7 @@ schema conversion_rate (
 
 mapping _conversion_rate_pipeline {
   source {
-    fact_opportunities
+    fact_opportunities,
     dim_stage
   }
   target { conversion_rate }
@@ -224,8 +224,8 @@ schema order_revenue (
 
 mapping _order_revenue_pipeline {
   source {
-    fact_orders
-    dim_date
+    fact_orders,
+    dim_date,
     dim_customer
   }
   target { order_revenue }
@@ -276,7 +276,7 @@ schema cart_abandonment_rate (
 
 mapping _cart_abandonment_rate_pipeline {
   source {
-    fact_sessions
+    fact_sessions,
     fact_orders
   }
   target { cart_abandonment_rate }

--- a/examples/multi-source/multi-source-arrows.stm
+++ b/examples/multi-source/multi-source-arrows.stm
@@ -62,7 +62,7 @@ schema financial_summary {
 
 mapping order_to_summary {
   source {
-    orders
+    orders,
     billing
   }
   target { financial_summary }

--- a/examples/multi-source/multi-source-hub.stm
+++ b/examples/multi-source/multi-source-hub.stm
@@ -67,7 +67,7 @@ mapping `crm to analytics` {
 
 mapping `payments to analytics` {
   source {
-    `payment_gateway`
+    `payment_gateway`,
     `crm_system`
   }
   target { `analytics_db` }
@@ -88,7 +88,7 @@ mapping `payments to analytics` {
 
 mapping `crm to notifications` {
   source {
-    `crm_system`
+    `crm_system`,
     `payment_gateway`
   }
   target { `notification_service` }

--- a/examples/multi-source/multi-source-join.stm
+++ b/examples/multi-source/multi-source-join.stm
@@ -117,9 +117,9 @@ schema customer_360 (
 // --- Mapping ---
 mapping `customer 360` {
   source {
-    `crm_customers` (filter "email NOT LIKE `%@test.internal`")
-    `order_transactions` (filter "status IN (`completed`, `refunded`)")
-    `support_tickets` (filter "created_at >= date_sub(now(), interval 12 month)")
+    `crm_customers` (filter "email NOT LIKE `%@test.internal`"),
+    `order_transactions` (filter "status IN (`completed`, `refunded`)"),
+    `support_tickets` (filter "created_at >= date_sub(now(), interval 12 month)"),
     "Join @crm_customers to @order_transactions on @crm_customers.customer_id = @order_transactions.customer_id (left join — customers may have no orders).
      Join @crm_customers to @support_tickets on @crm_customers.customer_id = cast(@support_tickets.customer_id as UUID) (left join — customers may have no tickets)."
   }

--- a/examples/namespaces/ns-merging.stm
+++ b/examples/namespaces/ns-merging.stm
@@ -86,7 +86,7 @@ namespace staging (note "Cleaned and conformed staging area") {
   // Map GL entries — joins to employees across merged namespace
   mapping `stage gl entries` {
     source {
-      `source::finance_gl`
+      `source::finance_gl`,
       `source::hr_employees`
     }
     target { `stg_gl_entries` }
@@ -121,8 +121,8 @@ namespace reporting (note "Executive reporting layer") {
 
   mapping `build budget vs actual` {
     source {
-      `staging::stg_gl_entries`
-      `source::finance_budgets`
+      `staging::stg_gl_entries`,
+      `source::finance_budgets`,
       `staging::stg_employees`
     }
     target { `dept_budget_vs_actual` }

--- a/examples/namespaces/ns-platform.stm
+++ b/examples/namespaces/ns-platform.stm
@@ -187,7 +187,7 @@ namespace mart (note "Business-facing dimensional models") {
   // Build contact dimension from vault
   mapping `build dim_contact` {
     source {
-      `vault::hub_contact`
+      `vault::hub_contact`,
       `vault::sat_contact_details`
     }
     target { `dim_contact` }
@@ -210,9 +210,9 @@ namespace mart (note "Business-facing dimensional models") {
   // Build deal fact from vault
   mapping `build fact_deals` {
     source {
-      `vault::hub_deal`
-      `vault::link_contact_deal`
-      `vault::hub_contact`
+      `vault::hub_deal`,
+      `vault::link_contact_deal`,
+      `vault::hub_contact`,
       `mart::dim_contact`
     }
     target { `fact_deals` }

--- a/examples/reports-and-models/pipeline.stm
+++ b/examples/reports-and-models/pipeline.stm
@@ -74,7 +74,7 @@ mapping _weekly_sales_dashboard_report (
   note "represents the logic of the Looker report's underlying query"
 ) {
   source {
-    fact_orders
+    fact_orders,
     dim_product
   }
   target { weekly_sales_dashboard }
@@ -102,7 +102,7 @@ mapping _churn_predictor_pipeline (
   note "represents the logic of the churn_predictor model's underlying pipeline"
 ) {
   source {
-    dim_customer
+    dim_customer,
     fact_orders
   }
   target { churn_predictor }
@@ -132,8 +132,8 @@ mapping _customer_risk_report_pipeline (
   note "represents the logic of the Tableau report's underlying query"
 ) {
   source {
-    dim_customer
-    fact_orders
+    dim_customer,
+    fact_orders,
     churn_predictor
   }
   target { customer_risk_report }

--- a/examples/sfdc-to-snowflake/pipeline.stm
+++ b/examples/sfdc-to-snowflake/pipeline.stm
@@ -57,7 +57,7 @@ schema snowflake_opps (note "FACT_OPPORTUNITIES — Snowflake Analytics") {
 // --- Mapping ---
 mapping `opportunity ingestion` {
   source {
-    `sfdc_opportunity`
+    `sfdc_opportunity`,
     `fx_spot_rates`
   }
   target { `snowflake_opps` }

--- a/tooling/satsuma-core/src/format.ts
+++ b/tooling/satsuma-core/src/format.ts
@@ -652,8 +652,12 @@ function formatSourceBlock(node: SyntaxNode, source: string, indent: number): st
     }
   }
 
-  // Multi-line
-  const inner = items.map(item => ind(indent + 1) + item).join("\n");
+  // Multi-line. The grammar treats commas between source entries as optional,
+  // but the canonical corpus style is comma-separated — preserve it so
+  // formatting matches the single-line style and round-trips (sl-q9oj).
+  const inner = items
+    .map((item, i) => ind(indent + 1) + item + (i < items.length - 1 ? "," : ""))
+    .join("\n");
   return ind(indent) + "source {\n" + inner + "\n" + ind(indent) + "}";
 }
 

--- a/tooling/satsuma-core/test/format.test.js
+++ b/tooling/satsuma-core/test/format.test.js
@@ -415,6 +415,35 @@ describe("mapping formatting", () => {
     const out = fmt(src);
     assert.ok(out.includes("-> t.computed"));
   });
+
+  // Regression for sl-q9oj: the multi-line branch of formatSourceBlock joined
+  // refs with bare newlines, silently dropping the commas the author wrote.
+  // Commas are optional in the grammar but are the canonical corpus style,
+  // so the formatter must preserve them.
+  it("keeps commas between refs when a multi-ref source block goes multi-line", () => {
+    const src = `mapping test {
+  source { store, customers }
+  target { t }
+  store.id -> t.id
+}`;
+    const out = fmt(src);
+    assert.ok(
+      out.includes("    store,\n    customers\n"),
+      `multi-line source refs should stay comma-separated, got:\n${out}`,
+    );
+  });
+
+  // Formatting must be idempotent: re-formatting formatter output (with its
+  // restored commas) must not change it again.
+  it("formats a multi-ref source block idempotently", () => {
+    const src = `mapping test {
+  source { store, customers }
+  target { t }
+  store.id -> t.id
+}`;
+    const once = fmt(src);
+    assert.equal(fmt(once), once);
+  });
 });
 
 // ── Transform, Metric, Note, Import ──────────────────────────────────────────

--- a/tooling/satsuma-lsp/src/diagnostics.ts
+++ b/tooling/satsuma-lsp/src/diagnostics.ts
@@ -8,6 +8,15 @@ import { nodeRange } from "./parser-utils";
 import { collectParseErrors } from "@satsuma/core";
 
 /**
+ * Fallback text for a bare `//!` marker that carries no message of its own.
+ * Diagnostics must never ship an empty message: vscode's Diagnostic
+ * constructor throws `illegalArgument("message must be set")` on a falsy
+ * message, and one bad entry aborts the client's whole diagnostic batch,
+ * freezing diagnostics for the file (sl-sme1, gh-273).
+ */
+const EMPTY_WARNING_COMMENT_MESSAGE = "Warning comment (no text)";
+
+/**
  * Produce LSP diagnostics from a tree-sitter parse tree.
  *
  * - ERROR / MISSING nodes → Error severity (via collectParseErrors from @satsuma/core)
@@ -34,6 +43,21 @@ export function computeDiagnostics(tree: Tree): Diagnostic[] {
   return diagnostics;
 }
 
+/**
+ * Safety net applied at the publish boundary (see server.ts): returns the
+ * diagnostics with every empty or whitespace-only message replaced by a
+ * placeholder naming the rule code. No producer should emit an empty message,
+ * but if one slips through, this keeps the client's diagnostic pipeline alive
+ * instead of freezing all diagnostics for the file (sl-sme1, gh-273).
+ */
+export function ensureNonEmptyMessages(diags: Diagnostic[]): Diagnostic[] {
+  return diags.map((d) =>
+    d.message.trim()
+      ? d
+      : { ...d, message: d.code ? `Diagnostic '${d.code}' (no message)` : "Diagnostic (no message)" },
+  );
+}
+
 /** Collect //! and //? comments as diagnostics. */
 function walkComments(node: SyntaxNode, out: Diagnostic[]): void {
   // Comments are "extra" nodes in tree-sitter — they can appear at any level.
@@ -43,11 +67,12 @@ function walkComments(node: SyntaxNode, out: Diagnostic[]): void {
     if (!child) continue;
 
     if (child.type === "warning_comment") {
+      const text = child.text.replace(/^\/\/!\s*/, "");
       out.push({
         range: nodeRange(child),
         severity: DiagnosticSeverity.Warning,
         source: "satsuma",
-        message: child.text.replace(/^\/\/!\s*/, ""),
+        message: text || EMPTY_WARNING_COMMENT_MESSAGE,
       });
     } else if (child.type === "question_comment") {
       out.push({

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -22,6 +22,7 @@ import type { Tree } from "./parser-utils";
 import type { WorkspaceIndex, DefinitionEntry } from "./workspace-index";
 import {
   buildImportSuggestion,
+  canonicalizeFileUri,
 } from "./workspace-index";
 import {
   validateSemanticWorkspace,
@@ -73,6 +74,10 @@ export function computeSemanticValidationDiagnostics(
   uri: string,
   wsIndex: WorkspaceIndex,
 ): Diagnostic[] {
+  // The index stores canonical URI keys; the client may send another spelling
+  // of the same file (e.g. percent-encoded Windows drive colon). Canonicalize
+  // before comparing, or this file's diagnostics never match it (sl-akz6).
+  uri = canonicalizeFileUri(uri);
   const fileImports = buildFileImportsMap(wsIndex);
   const semanticIndex = buildSemanticIndex(wsIndex);
   const coreDiags = validateSemanticWorkspace(semanticIndex, {
@@ -148,12 +153,13 @@ function buildFileImportsMap(
   return result;
 }
 
-/** Resolve a relative import path to an absolute file URI. Returns null on failure. */
+/** Resolve a relative import path to an absolute file URI. Returns null on failure.
+ *  Canonicalized so it compares equal to the index's canonical keys (sl-akz6). */
 function resolveImportPathToUri(importerUri: string, pathText: string): string | null {
   try {
     const importerPath = fileURLToPath(importerUri);
     const importerDir = dirname(importerPath);
-    return pathToFileURL(resolve(importerDir, pathText)).toString();
+    return canonicalizeFileUri(pathToFileURL(resolve(importerDir, pathText)).toString());
   } catch {
     return null;
   }

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -13,7 +13,7 @@ import * as path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
 import { getParser, initParser } from "./parser-utils";
 import { setHighlightsSource } from "./semantic-tokens";
-import { computeDiagnostics } from "./diagnostics";
+import { computeDiagnostics, ensureNonEmptyMessages } from "./diagnostics";
 import { computeDocumentSymbols } from "./symbols";
 import { computeFoldingRanges } from "./folding";
 import { computeSemanticTokens, semanticTokensLegend } from "./semantic-tokens";
@@ -469,9 +469,15 @@ function sendMergedDiagnostics(uri: string, tree: Tree): void {
     (d) => !validateKeys.has(`${d.code}:${d.range.start.line}`),
   );
 
+  // Publish-boundary guard: an empty message crashes the VS Code client's
+  // diagnostic conversion and freezes all diagnostics for the file (sl-sme1).
   connection.sendDiagnostics({
     uri,
-    diagnostics: [...parseDiags, ...validateDiags, ...dedupedSemanticDiags],
+    diagnostics: ensureNonEmptyMessages([
+      ...parseDiags,
+      ...validateDiags,
+      ...dedupedSemanticDiags,
+    ]),
   });
 }
 

--- a/tooling/satsuma-lsp/test/diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/diagnostics.test.js
@@ -33,6 +33,22 @@ describe("computeDiagnostics", () => {
     assert.match(warnings[0].message, /known issue/);
   });
 
+  // Regression for sl-sme1 / gh-273: a bare `//!` produced message: "",
+  // which vscode's Diagnostic constructor rejects ("message must be set"),
+  // aborting the client's entire diagnostic batch for the file.
+  it("gives a bare //! comment a non-empty fallback message", () => {
+    const tree = parse(`schema foo {
+  bar STRING //!
+}`);
+    const diags = computeDiagnostics(tree);
+    const warnings = diags.filter((d) => d.severity === 2); // Warning
+    assert.equal(warnings.length, 1);
+    assert.ok(
+      warnings[0].message.trim().length > 0,
+      "bare //! must not produce an empty diagnostic message",
+    );
+  });
+
   it("reports question comments as Hint severity with TODO prefix", () => {
     const tree = parse(`schema foo {
   bar STRING //? should this be INT?
@@ -68,5 +84,30 @@ describe("computeDiagnostics", () => {
     assert.ok(errors.length > 0);
     // Error should be on line 0
     assert.equal(errors[0].range.start.line, 0);
+  });
+});
+
+describe("ensureNonEmptyMessages", () => {
+  const { ensureNonEmptyMessages } = require("../dist/diagnostics");
+  const range = {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 1 },
+  };
+
+  // Publish-boundary safety net for sl-sme1: whatever producer misbehaves,
+  // the server must never hand the client an empty-message diagnostic.
+  it("replaces empty and whitespace-only messages with a placeholder naming the rule code", () => {
+    const out = ensureNonEmptyMessages([
+      { range, severity: 1, source: "satsuma", message: "", code: "missing-import" },
+      { range, severity: 2, source: "satsuma", message: "   " },
+    ]);
+    assert.match(out[0].message, /missing-import/);
+    assert.ok(out[1].message.trim().length > 0);
+  });
+
+  it("passes diagnostics with real messages through unchanged", () => {
+    const diag = { range, severity: 1, source: "satsuma", message: "Syntax error" };
+    const out = ensureNonEmptyMessages([diag]);
+    assert.deepEqual(out, [diag]);
   });
 });

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -225,6 +225,36 @@ mapping m {
     assert.ok(dupDiag, "expected a duplicate-definition diagnostic");
   });
 
+  // Regression for sl-akz6 / gh-274: on Windows the startup scan indexes a
+  // file under pathToFileURL's spelling (file:///C:/...) while didOpen indexes
+  // it under the client's spelling (file:///c%3A/...). Without canonical index
+  // keys the file exists twice and every definition in it is reported as a
+  // duplicate.
+  it("does not report duplicates when the same file is indexed under two Windows URI spellings", () => {
+    const src = `schema orders { id UUID }`;
+    const idx = createWorkspaceIndex();
+    indexFile(idx, "file:///C:/ws/a.stm", parse(src)); // workspace-scan spelling
+    indexFile(idx, "file:///c%3A/ws/a.stm", parse(src)); // didOpen spelling
+    const diags = computeCoreSemanticDiagnostics("file:///c%3A/ws/a.stm", idx);
+    const dup = diags.find((d) => d.code === "duplicate-definition");
+    assert.equal(dup, undefined, "same file under two spellings must not self-duplicate");
+  });
+
+  // Companion to the spelling test: diagnostics must still be FOUND when the
+  // query uses a different spelling than the index — canonicalization must not
+  // trade false positives for false negatives.
+  it("matches a file's diagnostics across URI spellings of the same path", () => {
+    const aSrc = `import { orders } from "b.stm"\nschema orders { id UUID }`;
+    const bSrc = `schema orders { name STRING }`;
+    const idx = createWorkspaceIndex();
+    indexFile(idx, "file:///C:/ws/a.stm", parse(aSrc));
+    indexFile(idx, "file:///C:/ws/b.stm", parse(bSrc));
+    const scoped = createScopedIndex(idx, getImportReachableUris("file:///c%3A/ws/a.stm", idx));
+    const diags = computeCoreSemanticDiagnostics("file:///c%3A/ws/b.stm", scoped);
+    const dupDiag = diags.find((d) => d.code === "duplicate-definition");
+    assert.ok(dupDiag, "expected the genuine duplicate to be reported under the alternate spelling");
+  });
+
   it("returns no diagnostics for a valid single-file workspace", () => {
     const src = `schema customers { id UUID }
 mapping m {

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -231,6 +231,7 @@ function fieldInfoToEntry(fi: FieldInfo, defUri: string): FieldEntry {
     name: fi.name,
     type: fi.type ?? "",
     constraints: [],
+    metadata: [],
     notes: [],
     comments: [],
     children: fi.children.map((c: FieldInfo) => fieldInfoToEntry(c, defUri)),
@@ -320,6 +321,7 @@ function expandedFieldToEntry(decl: FieldDecl): FieldEntry {
     name: decl.name,
     type: decl.type,
     constraints: [],
+    metadata: [],
     notes: [],
     comments: [],
     children: (decl.children ?? []).map(expandedFieldToEntry),
@@ -634,6 +636,7 @@ function fieldDeclToEntry(
     name: decl.name,
     type,
     constraints,
+    metadata: metaEntriesToViz(decl.metadata ?? []),
     notes: cstNode ? extractNotes(uri, cstNode) : [],
     comments: cstNode ? extractComments(uri, cstNode) : [],
     children: fieldChildren,
@@ -828,6 +831,9 @@ function extractMapping(
     }
   }
 
+  // The mapping's own metadata block, e.g. `mapping m (airflow, note "...")`.
+  const meta = child(node, "metadata_block");
+
   return {
     id: name,
     sourceRefs,
@@ -836,6 +842,7 @@ function extractMapping(
     eachBlocks,
     flattenBlocks,
     sourceBlock,
+    metadata: meta ? extractMetadataEntries(meta) : [],
     notes,
     comments: extractComments(uri, node),
     location: nodeLocation(uri, node),

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -97,6 +97,49 @@ export interface WorkspaceIndex {
   indexedFiles: Set<string>;
 }
 
+// ---------- URI canonicalization ----------
+
+/**
+ * Canonical form of a `file://` URI used as a workspace-index key.
+ *
+ * The same file can legitimately arrive under different URI spellings: VS Code
+ * clients send `file:///c%3A/...` (lowercase drive letter, percent-encoded
+ * colon) while Node's `pathToFileURL` produces `file:///C:/...`. Keying the
+ * index by raw strings would index one file under both spellings, and every
+ * definition in it would then be counted twice and reported as a duplicate
+ * (sl-akz6, gh-274).
+ *
+ * Canonicalization: decode percent-escapes, lowercase a leading Windows drive
+ * letter (drive letters are case-insensitive; lowercase matches VS Code's own
+ * convention), then let the WHATWG URL serializer re-encode uniformly.
+ * Non-file and unparseable URIs are returned unchanged. Browser-safe — no
+ * Node `path`/`url`.
+ */
+export function canonicalizeFileUri(uri: string): string {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return uri;
+  }
+  if (url.protocol !== "file:") return uri;
+
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    return uri; // malformed percent-escape — leave the spelling alone
+  }
+  pathname = pathname.replace(
+    /^\/([A-Za-z]):/,
+    (_match, drive: string) => `/${drive.toLowerCase()}:`,
+  );
+
+  const canonical = new URL("file:///");
+  canonical.pathname = pathname; // setter re-encodes uniformly
+  return canonical.toString();
+}
+
 // ---------- Index lifecycle ----------
 
 export function createWorkspaceIndex(): WorkspaceIndex {
@@ -122,7 +165,9 @@ function walkImportGraph(
 ): { reachable: Set<string>; unresolved: string[] } {
   const reachable = new Set<string>();
   const unresolved: string[] = [];
-  const queue = [entryUri];
+  // Canonicalize the entry point so a raw client URI spelling still matches
+  // the canonical keys the index stores (sl-akz6).
+  const queue = [canonicalizeFileUri(entryUri)];
 
   while (queue.length > 0) {
     const uri = queue.pop()!;
@@ -240,7 +285,9 @@ export function buildImportSuggestion(
 /** Resolve an import path relative to the importing file URI. Returns null on failure. */
 function resolveImportUri(importerUri: string, pathText: string): string | null {
   try {
-    return new URL(pathText, importerUri).toString();
+    // Canonicalize so the result matches the index's canonical keys whatever
+    // spelling the import path or importer URI used (sl-akz6).
+    return canonicalizeFileUri(new URL(pathText, importerUri).toString());
   } catch {
     return null;
   }
@@ -288,8 +335,13 @@ function relativeUriPath(fromUri: string, toUri: string): string | null {
   return [...up, ...down].join("/");
 }
 
-/** Index (or re-index) a single file. Replaces any existing entries for the URI. */
+/** Index (or re-index) a single file. Replaces any existing entries for the URI.
+ *  The URI is canonicalized first so the same file arriving under different
+ *  spellings (didOpen vs workspace scan) always replaces, never duplicates,
+ *  its own entries (sl-akz6, gh-274). */
 export function indexFile(index: WorkspaceIndex, uri: string, tree: Tree): void {
+  uri = canonicalizeFileUri(uri);
+
   // Remove old entries for this file first
   removeFile(index, uri);
 
@@ -302,8 +354,10 @@ export function indexFile(index: WorkspaceIndex, uri: string, tree: Tree): void 
   }
 }
 
-/** Remove all entries for a file URI from the index. */
+/** Remove all entries for a file URI from the index (canonicalized first —
+ *  see {@link indexFile}). */
 export function removeFile(index: WorkspaceIndex, uri: string): void {
+  uri = canonicalizeFileUri(uri);
   index.indexedFiles.delete(uri);
   index.imports.delete(uri);
 

--- a/tooling/satsuma-viz-backend/test/uri-canonicalization.test.js
+++ b/tooling/satsuma-viz-backend/test/uri-canonicalization.test.js
@@ -1,0 +1,97 @@
+/**
+ * Tests for canonicalizeFileUri and canonical workspace-index keys (sl-akz6,
+ * gh-274).
+ *
+ * The same file can arrive under different `file://` spellings: VS Code
+ * clients send `file:///c%3A/...` (lowercase drive, percent-encoded colon)
+ * while Node's pathToFileURL produces `file:///C:/...`. The index must key
+ * both to ONE canonical entry, or every definition in an opened file is
+ * counted twice and flagged as a duplicate.
+ */
+const { describe, it, before } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  canonicalizeFileUri,
+  createWorkspaceIndex,
+  indexFile,
+  removeFile,
+  getImportReachableUris,
+} = require("../dist/workspace-index");
+const { initTestParser, parse } = require("./helper");
+
+before(async () => {
+  await initTestParser();
+});
+
+describe("canonicalizeFileUri", () => {
+  // The core gh-274 collision: both Windows spellings must map to one key.
+  it("maps the scan spelling and the VS Code client spelling of a Windows path to the same URI", () => {
+    const scanSpelling = canonicalizeFileUri("file:///C:/Users/bob/ws/a.stm");
+    const clientSpelling = canonicalizeFileUri("file:///c%3A/Users/bob/ws/a.stm");
+    assert.equal(scanSpelling, clientSpelling);
+  });
+
+  // POSIX paths have no drive letter and typically no escapes — the common
+  // macOS/Linux case must be a byte-for-byte no-op.
+  it("leaves an ordinary POSIX file URI unchanged", () => {
+    const uri = "file:///Users/bob/ws/pipeline.stm";
+    assert.equal(canonicalizeFileUri(uri), uri);
+  });
+
+  // Percent-encoding differences beyond the drive colon (e.g. spaces) must
+  // also collapse to one canonical encoding.
+  it("normalizes equivalent percent-encodings of the same path", () => {
+    const encoded = canonicalizeFileUri("file:///ws/My%20Docs/a.stm");
+    const reencoded = canonicalizeFileUri(encoded);
+    assert.equal(reencoded, encoded, "canonical form must be a fixed point");
+  });
+
+  // Canonicalization is a file-URI concern only; other schemes (untitled:
+  // buffers, virtual docs) must pass through untouched.
+  it("returns non-file URIs unchanged", () => {
+    assert.equal(canonicalizeFileUri("untitled:Untitled-1"), "untitled:Untitled-1");
+  });
+
+  it("returns unparseable input unchanged instead of throwing", () => {
+    assert.equal(canonicalizeFileUri("not a uri"), "not a uri");
+  });
+});
+
+describe("workspace index canonical keys", () => {
+  // The actual bug mechanism: didOpen re-indexing the already-scanned file
+  // under the alternate spelling must REPLACE its entries, not duplicate them.
+  it("indexes one file arriving under two URI spellings as a single entry", () => {
+    const idx = createWorkspaceIndex();
+    const src = "schema orders { id UUID }";
+    indexFile(idx, "file:///C:/ws/a.stm", parse(src));
+    indexFile(idx, "file:///c%3A/ws/a.stm", parse(src));
+
+    assert.equal(idx.indexedFiles.size, 1, "one file must occupy one index slot");
+    const defs = idx.definitions.get("orders") ?? [];
+    assert.equal(defs.length, 1, "one definition must not be double-counted");
+  });
+
+  // removeFile must accept either spelling, or stale entries survive a close.
+  it("removes a file's entries when removal uses a different spelling than indexing", () => {
+    const idx = createWorkspaceIndex();
+    indexFile(idx, "file:///C:/ws/a.stm", parse("schema orders { id UUID }"));
+    removeFile(idx, "file:///c%3A/ws/a.stm");
+    assert.equal(idx.indexedFiles.size, 0);
+    assert.equal(idx.definitions.size, 0);
+  });
+
+  // Import reachability seeds from a client-supplied URI; a raw spelling must
+  // still reach the canonical keys the index stores.
+  it("computes import reachability when the entry URI uses an alternate spelling", () => {
+    const idx = createWorkspaceIndex();
+    indexFile(
+      idx,
+      "file:///C:/ws/a.stm",
+      parse(`import { orders } from "b.stm"\nschema customers { id UUID }`),
+    );
+    indexFile(idx, "file:///C:/ws/b.stm", parse("schema orders { id UUID }"));
+
+    const reachable = getImportReachableUris("file:///c%3A/ws/a.stm", idx);
+    assert.equal(reachable.size, 2, "entry file and its import must both be reachable");
+  });
+});

--- a/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
@@ -87,6 +87,7 @@ describe("extractSchema (direct)", () => {
           name: "id",
           type: "INT",
           constraints: ["pk"],
+          metadata: [{ key: "pk", value: "" }],
           notes: [],
           comments: [],
           children: [],
@@ -144,6 +145,7 @@ describe("extractFragment (direct)", () => {
           name: "created_at",
           type: "TIMESTAMP",
           constraints: [],
+          metadata: [],
           notes: [],
           comments: [],
           children: [],
@@ -198,10 +200,28 @@ describe("extractMapping (direct)", () => {
       eachBlocks: [],
       flattenBlocks: [],
       sourceBlock: { schemas: ["s"], joinDescription: null, filters: [] },
+      metadata: [],
       notes: [],
       comments: [],
       location: { uri: URI, line: 2, character: 0 },
     });
+  });
+
+  // Regression for sl-6x1o: meta on the mapping declaration itself — bare
+  // tags like `airflow` and the note text — was dropped at extraction, so the
+  // detail view's header could never show it.
+  it("extracts the mapping's own metadata block (bare tags and note)", () => {
+    const src = "schema s { a INT }\nschema t { b INT }\n" +
+      'mapping export_to_csv (airflow, note "All fields to CSV") {\n' +
+      "  source { s }\n  target { t }\n  a -> b\n}";
+    const { ws, tree } = singleFileIndex(src);
+    const node = findNode(tree.rootNode, "mapping_block");
+    const card = extractMapping(URI, node, null, ws);
+
+    assert.deepStrictEqual(card.metadata, [
+      { key: "airflow", value: "" },
+      { key: "note", value: "All fields to CSV" },
+    ]);
   });
 });
 
@@ -356,6 +376,7 @@ describe("extractFieldEntries (direct)", () => {
         name: "id",
         type: "UUID",
         constraints: ["pk"],
+        metadata: [{ key: "pk", value: "" }],
         notes: [],
         comments: [],
         children: [],
@@ -365,6 +386,7 @@ describe("extractFieldEntries (direct)", () => {
         name: "data",
         type: "record",
         constraints: [],
+        metadata: [],
         notes: [],
         comments: [],
         children: [
@@ -372,6 +394,7 @@ describe("extractFieldEntries (direct)", () => {
             name: "name",
             type: "STRING",
             constraints: [],
+            metadata: [],
             notes: [],
             comments: [],
             children: [],
@@ -384,12 +407,34 @@ describe("extractFieldEntries (direct)", () => {
         name: "tags",
         type: "list_of STRING",
         constraints: [],
+        metadata: [],
         notes: [],
         comments: [],
         children: [],
         location: { uri: URI, line: 5, character: 2 },
       },
     ]);
+  });
+
+  // Regression for sl-6x1o: key-value metadata that is not a recognised
+  // constraint tag (sensitivity, access_group, ...) was silently discarded —
+  // only the CONSTRAINT_TAGS whitelist survived, and even whitelisted kv
+  // entries lost their value. The full entries must be preserved so the card
+  // can render them as pills.
+  it("preserves non-constraint key-value metadata on fields", () => {
+    const src =
+      "schema property {\n" +
+      "  CLOSING_DATE DATE (sensitivity internal, access_group property_facilities)\n" +
+      "}";
+    const body = findNode(root(src), "schema_body");
+    const [field] = extractFieldEntries(URI, body);
+
+    assert.deepStrictEqual(field.metadata, [
+      { key: "sensitivity", value: "internal" },
+      { key: "access_group", value: "property_facilities" },
+    ]);
+    // Neither key is a constraint tag, so the badge list stays empty.
+    assert.deepStrictEqual(field.constraints, []);
   });
 });
 

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -1326,21 +1326,22 @@ test.describe("Compact card expansion in overview", () => {
     await expect(fields).toHaveCount(0);
   });
 
-  test("clicking a compact card header expands fields", async ({ page }) => {
-    // A single click on the compact card header must toggle _compactExpanded
-    // and render the fields list below the header.
+  test("clicking a compact card's toggle arrow expands fields", async ({ page }) => {
+    // A single click on the toggle arrow must request expansion and render
+    // the fields list below the header. The arrow is a dedicated control —
+    // the rest of the header is reserved for navigation (sl-tw0r).
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
-    await card.locator(".header").click();
+    await card.locator(".header-toggle").click();
 
     // At least one field row must now appear inside the card.
     const fields = card.locator("[data-testid$='-field-id']");
     await expect(fields.first()).toBeVisible({ timeout: 5_000 });
   });
 
-  test("clicking the compact card header a second time collapses the fields", async ({ page }) => {
+  test("clicking the toggle arrow a second time collapses the fields", async ({ page }) => {
     // Two clicks must return the card to its compact (fields-hidden) state.
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
-    const header = card.locator(".header");
+    const header = card.locator(".header-toggle");
 
     await header.click();
     // Fields visible after first click.
@@ -1362,13 +1363,13 @@ test.describe("Compact card expansion in overview", () => {
     const heightBefore = await canvas.evaluate((el) => el.getBoundingClientRect().height);
 
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
-    await card.locator(".header").click();
+    await card.locator(".header-toggle").click();
     await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
     await expect
       .poll(async () => canvas.evaluate((el) => el.getBoundingClientRect().height))
       .toBeGreaterThan(heightBefore);
 
-    await card.locator(".header").click();
+    await card.locator(".header-toggle").click();
     await expect(card.locator("[data-testid$='-field-id']")).toHaveCount(0);
     await expect
       .poll(async () => canvas.evaluate((el) => el.getBoundingClientRect().height))
@@ -1385,7 +1386,7 @@ test.describe("Compact card expansion in overview", () => {
     // customer_profiles is exactly the geometry that used to overlap.
     await loadFixture(page, ffgUri);
     const card = page.locator("[data-testid^='overview-schema-card-order-events']");
-    await card.locator(".header").click();
+    await card.locator(".header-toggle").click();
     await expect(card.locator("[data-testid$='-field-event-id']").first()).toBeVisible({
       timeout: 5_000,
     });
@@ -1412,14 +1413,20 @@ test.describe("Compact card expansion in overview", () => {
     assertBoxesDoNotOverlap(boxes);
   });
 
-  test("expanding a compact card still fires a navigate event", async ({ page }) => {
-    // Clicking a compact card header both expands the fields and dispatches
-    // SzNavigateEvent so hosts like VS Code can jump to the schema source.
+  test("the toggle arrow expands without navigating; the header name navigates", async ({ page }) => {
+    // Regression for sl-tw0r: the old combined handler made every expansion
+    // also dispatch SzNavigateEvent, so hosts that open documents on navigate
+    // (VS Code) yanked the editor to the source file whenever a card was
+    // expanded. The arrow must be navigation-silent; navigation intent lives
+    // on the header name.
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
 
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
-    await card.locator(".header").click();
+    await card.locator(".header-toggle").click();
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+    expect(await recordedEvents(page, "navigate")).toEqual([]);
 
+    await card.locator(".header-name").click();
     await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
       expect.objectContaining({
         detail: expect.objectContaining({

--- a/tooling/satsuma-viz-harness/test/mapping-field-meta.test.ts
+++ b/tooling/satsuma-viz-harness/test/mapping-field-meta.test.ts
@@ -1,0 +1,79 @@
+/**
+ * mapping-field-meta.test.ts — all authored metadata is visible in the
+ * detail view (sl-6x1o).
+ *
+ * Two classes of metadata used to vanish silently:
+ *
+ *   1. Meta on the mapping declaration itself — `mapping m (merge upsert,
+ *      match_on customer_id)` — never reached the model, so the central
+ *      mapping header showed only source/target/join/filter.
+ *   2. Field-level key-value meta that is not a recognised constraint tag —
+ *      `classification "CONFIDENTIAL"`, `mask redact` — was dropped by the
+ *      CONSTRAINT_TAGS whitelist, so governance annotations were invisible.
+ *
+ * merge-strategies carries mapping-level meta; governance.stm carries field
+ * kv meta. Both must render.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { libraryUri } from "./harness-env";
+
+const mergeStrategiesUri = libraryUri("merge-strategies/pipeline.stm");
+const governanceUri = libraryUri("filter-flatten-governance/governance.stm");
+
+/** Load a fixture and open the named mapping's detail view. */
+async function openMappingDetail(
+  page: Page,
+  fixtureUri: string,
+  mappingTestId: string,
+): Promise<void> {
+  await page.goto("/");
+  await page.locator("#fixture-picker-btn").click();
+  await page.locator(`.fixture-item[data-uri="${fixtureUri}"]`).click();
+  await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+    "data-ready-state",
+    "ready",
+    { timeout: 20_000 },
+  );
+  // dispatchEvent: overview cards can sit under the minimap overlay.
+  await page
+    .locator(`[data-testid='overview-mapping-card-${mappingTestId}']`)
+    .dispatchEvent("click");
+  await expect(
+    page.locator(`[data-testid='mapping-detail-${mappingTestId}']`).first(),
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test("mapping-level metadata renders in the detail header", async ({ page }) => {
+  // `customer upsert` is declared as (merge upsert, match_on customer_id):
+  // both entries must appear in the central mapping block's header alongside
+  // the source/target rows.
+  await openMappingDetail(page, mergeStrategiesUri, "customer-upsert");
+
+  const header = page.locator("[data-testid='mapping-detail-customer-upsert-header']");
+  await expect(
+    header.locator("[data-testid='mapping-detail-customer-upsert-meta-merge']"),
+  ).toContainText("merge upsert");
+  await expect(
+    header.locator("[data-testid='mapping-detail-customer-upsert-meta-match-on']"),
+  ).toContainText("match_on customer_id");
+});
+
+test("non-constraint field metadata renders as pills on the field row", async ({ page }) => {
+  // crm_customers.first_name is (pii, classification "CONFIDENTIAL",
+  // mask redact): pii stays a constraint badge, and the two kv entries must
+  // appear as key+value pills instead of being silently dropped.
+  await openMappingDetail(page, governanceUri, "customer-360-assembly");
+
+  const fieldRow = page
+    .locator("[data-testid$='-field-first-name']")
+    .first();
+  await expect(fieldRow).toBeVisible();
+
+  const pills = fieldRow.locator(".badge.field-meta");
+  await expect(pills.filter({ hasText: "classification" })).toContainText("CONFIDENTIAL");
+  await expect(pills.filter({ hasText: "mask" })).toContainText("redact");
+
+  // The pii shield badge must be unaffected by the new pills.
+  await expect(fieldRow.locator(".badge.pii")).toBeVisible();
+});

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -66,6 +66,11 @@ export interface FieldEntry {
   type: string;
   /** Metadata tag values that are recognised constraint tags (pk, required, pii, …). */
   constraints: string[];
+  /** ALL metadata entries on the field declaration, including key-value tags
+   *  like `sensitivity internal` that are not constraint tags. Rendered as
+   *  pills next to the constraint badges so no authored metadata is hidden
+   *  (sl-6x1o). Constraint tags also appear here; renderers dedupe. */
+  metadata: MetadataEntry[];
   notes: NoteBlock[];
   comments: CommentEntry[];
   /** Non-empty when the field has record type; contains the nested field declarations. */
@@ -88,6 +93,10 @@ export interface MappingBlock {
   flattenBlocks: FlattenBlock[];
   /** Structured source-block info (multi-schema joins, filters). */
   sourceBlock: SourceBlockInfo | null;
+  /** Metadata entries on the mapping declaration itself, e.g.
+   *  `mapping m (airflow, note "...") { ... }`. Rendered in the detail
+   *  view's mapping header alongside source/target/join (sl-6x1o). */
+  metadata: MetadataEntry[];
   notes: NoteBlock[];
   comments: CommentEntry[];
   location: SourceLocation;

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -227,7 +227,7 @@ export class SzFragmentCard extends LitElement {
           <span class="header-icon">&#9674;</span>
           <span class="header-name">${fr.id}</span>
           <span class="header-count">${fr.fields.length} fields</span>
-          <span class="header-toggle" ?data-collapsed=${this._collapsed}>&#9660;</span>
+          <span class="header-toggle" ?data-collapsed=${this._collapsed} @click=${this._onToggleClick}>&#9660;</span>
         </div>
         <div class="fields">
           ${fr.fields.map((f) => this._renderField(f))}
@@ -271,8 +271,14 @@ export class SzFragmentCard extends LitElement {
     `;
   }
 
-  private _onHeaderClick() {
+  /** Arrow click: collapse/expand only — never navigate (sl-tw0r). */
+  private _onToggleClick(e: Event) {
+    e.stopPropagation();
     this._collapsed = !this._collapsed;
+  }
+
+  /** Header (name/icon) click: navigation intent only (sl-tw0r). */
+  private _onHeaderClick() {
     if (this.fragment) {
       this._navigate(this.fragment.location);
     }

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -605,6 +605,11 @@ export class SzMappingDetail extends LitElement {
               <span class="meta-tag wrap"><span class="label">filter</span> ${f}</span>
             </div>
           `)}
+          ${m.metadata.map((entry) => html`
+            <div class="mapping-meta-row" data-testid=${`${this.testIdPrefix}-meta-${sanitizeTestIdSegment(entry.key)}`}>
+              <span class="meta-tag wrap"><span class="label">${entry.key}</span> ${entry.value}</span>
+            </div>
+          `)}
         </div>
       </div>
     `;

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -728,7 +728,9 @@ export class SzSchemaCard extends LitElement {
    * alone would hide.
    */
   private _fieldMetaPills(f: FieldEntry) {
-    return f.metadata.filter(
+    // Tolerate models serialized before FieldEntry carried metadata (older
+    // LSP servers, cached webview payloads) — render no pills, don't crash.
+    return (f.metadata ?? []).filter(
       (m) => !(m.value === "" && f.constraints.includes(m.key)),
     );
   }

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -128,6 +128,12 @@ export class SzSchemaCard extends LitElement {
       font-size: 12px;
       flex-shrink: 0;
       transition: transform 0.15s ease;
+      /* The arrow is its own click target (toggle only, never navigate —
+         sl-tw0r); pad it so the hit area is comfortably larger than the
+         12px glyph. */
+      padding: 4px 6px;
+      margin: -4px -6px;
+      cursor: pointer;
     }
 
     .header-toggle[data-collapsed] {
@@ -210,6 +216,14 @@ export class SzSchemaCard extends LitElement {
       background: var(--sz-badge-bg);
       color: var(--sz-badge-text);
       line-height: 1.4;
+    }
+
+    /* Field-level metadata pill (sl-6x1o): same chip shape as constraint
+       badges; the key is emphasised so "sensitivity internal" reads as
+       key + value at a glance. */
+    .badge.field-meta .badge-key {
+      font-weight: 700;
+      opacity: 0.85;
     }
 
     .badge.pii {
@@ -588,7 +602,7 @@ export class SzSchemaCard extends LitElement {
           ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
           <span class="header-count">${mappedCount}/${totalFields}</span>
-          <span class="header-toggle" ?data-collapsed=${this._collapsed}>&#9660;</span>
+          <span class="header-toggle" ?data-collapsed=${this._collapsed} @click=${this._onToggleClick}>&#9660;</span>
         </div>
         ${s.label ? html`<div class="label">${s.label}</div>` : ""}
         ${metaPills.length > 0
@@ -675,6 +689,9 @@ export class SzSchemaCard extends LitElement {
               (c) => html`<span class="badge">${c}</span>`
             )}
           ${hasPii ? html`<span class="badge pii" title="PII">&#128737; pii</span>` : ""}
+          ${this._fieldMetaPills(f).map(
+            (m) => html`<span class="badge field-meta" title=${`${m.key} ${m.value}`.trim()}><span class="badge-key">${m.key}</span>${m.value ? ` ${m.value}` : ""}</span>`
+          )}
         </span>
         ${hasWarning
           ? html`<span class="comment-badge warning" title=${this._commentText(f, "warning")}>&#9888;</span>`
@@ -700,6 +717,20 @@ export class SzSchemaCard extends LitElement {
         : ""}
       ${f.children.map((child) => this._renderField(child, depth + 1, fieldPath))}
     `;
+  }
+
+  /**
+   * Metadata entries to render as pills on a field row: everything the author
+   * wrote except bare tags already shown as constraint badges (sl-6x1o).
+   * Key-value entries always render — `sensitivity internal` and
+   * `access_group property_facilities` must be visible, and a kv whose key is
+   * also a constraint tag (e.g. `encrypt aes`) carries a value the badge
+   * alone would hide.
+   */
+  private _fieldMetaPills(f: FieldEntry) {
+    return f.metadata.filter(
+      (m) => !(m.value === "" && f.constraints.includes(m.key)),
+    );
   }
 
   private _commentText(f: FieldEntry, kind: "warning" | "question"): string {
@@ -737,10 +768,10 @@ export class SzSchemaCard extends LitElement {
     return html`
       <div>
         ${this._renderNamespacePill()}
-        <div class="header ${isReport ? "report" : ""}" @click=${this._onCompactHeaderClick}>
+        <div class="header ${isReport ? "report" : ""}" @click=${this._onHeaderClick}>
           ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>
-          <span class="header-toggle" ?data-collapsed=${!this.compactExpanded}>&#9660;</span>
+          <span class="header-toggle" ?data-collapsed=${!this.compactExpanded} @click=${this._onToggleClick}>&#9660;</span>
           <span class="header-count">${totalFields} fields</span>
         </div>
         ${metaPills.length > 0
@@ -759,27 +790,37 @@ export class SzSchemaCard extends LitElement {
     `;
   }
 
-  private _onCompactHeaderClick() {
-    // Request the toggle rather than flipping local state: the parent owns
-    // compactExpanded because it must re-run the overview layout with this
-    // card's new size (expansion re-flows neighbours; it never overlays them).
-    this.dispatchEvent(
-      new CustomEvent<SzCompactToggledDetail>("sz-compact-toggled", {
-        detail: {
-          schemaId: this.schema?.qualifiedId ?? this.schema?.id ?? "",
-          expanded: !this.compactExpanded,
-        },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-    if (this.schema) {
-      this._navigate(this.schema.location);
+  // Header clicks carry two distinct intents that used to be conflated on one
+  // handler: the toggle arrow expands/collapses, the rest of the header
+  // navigates to the schema source. Hosts that open documents on navigate
+  // (VS Code) made the combined handler unusable — expanding a card yanked
+  // the editor to the source file and hid the panel (sl-tw0r).
+
+  /** Arrow click: expand/collapse only — never navigate. */
+  private _onToggleClick(e: Event) {
+    // Stop the click before the header's navigate handler sees it.
+    e.stopPropagation();
+    if (this.compact) {
+      // Request the toggle rather than flipping local state: the parent owns
+      // compactExpanded because it must re-run the overview layout with this
+      // card's new size (expansion re-flows neighbours; it never overlays them).
+      this.dispatchEvent(
+        new CustomEvent<SzCompactToggledDetail>("sz-compact-toggled", {
+          detail: {
+            schemaId: this.schema?.qualifiedId ?? this.schema?.id ?? "",
+            expanded: !this.compactExpanded,
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    } else {
+      this._collapsed = !this._collapsed;
     }
   }
 
+  /** Header (name/icon) click: navigation intent only. */
   private _onHeaderClick() {
-    this._collapsed = !this._collapsed;
     if (this.schema) {
       this._navigate(this.schema.location);
     }

--- a/tooling/satsuma-viz/src/metric-adapter.ts
+++ b/tooling/satsuma-viz/src/metric-adapter.ts
@@ -23,6 +23,7 @@ export function metricFieldEntries(metric: MetricCard): FieldEntry[] {
     name: f.name,
     type: f.type,
     constraints: [],
+    metadata: [],
     notes: f.notes,
     comments: [],
     children: [],

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -114,7 +114,7 @@ Seven commands available via `Ctrl+Shift+P`:
 | **Satsuma: Show Lineage From...** | Pick a schema and trace its downstream lineage |
 | **Satsuma: Show Warnings** | Show all `//!` warnings in the Problems panel |
 | **Satsuma: Show Workspace Summary** | Display workspace statistics |
-| **Satsuma: Show Mapping Visualization** | Open interactive workspace graph webview |
+| **Satsuma: Overview Visualization** | Open the interactive workspace overview (also the eye icon in the editor title bar and the editor/Explorer context menus) |
 | **Satsuma: Show Field Lineage** | Open field-level lineage webview |
 | **Satsuma: Show Mapping Coverage** | Show mapped/unmapped fields with gutter markers |
 

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -80,7 +80,7 @@
       },
       {
         "command": "satsuma.showViz",
-        "title": "Satsuma: Show Mapping Visualization",
+        "title": "Satsuma: Overview Visualization",
         "icon": "$(eye)"
       }
     ],
@@ -121,6 +121,13 @@
           "command": "satsuma.showViz",
           "when": "editorLangId == satsuma",
           "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "satsuma.showViz",
+          "when": "resourceExtname == .stm",
+          "group": "satsuma"
         }
       ]
     },

--- a/tooling/vscode-satsuma/src/commands/entry-file-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/entry-file-logic.ts
@@ -1,0 +1,61 @@
+/**
+ * entry-file-logic.ts — pure entry-file selection rules (no vscode imports).
+ *
+ * Since ADR-022 the Satsuma CLI rejects directory arguments: a workspace is
+ * defined by a .stm entry file plus its transitive imports. Every extension
+ * feature that shells out to the CLI must therefore name a concrete .stm
+ * file. This module owns the *decision rules* for which file that should be;
+ * the vscode wiring (active editor, file search, quick pick) lives in
+ * entry-file.ts so these rules stay unit-testable in plain Node (sl-1ycv).
+ */
+
+/** File extension that marks a Satsuma source file. */
+const STM_EXTENSION = ".stm";
+
+/** Outcome of classifying the available entry-file candidates. */
+export type EntryFileResolution =
+  /** The active editor is a .stm file — use it without prompting. */
+  | { kind: "active"; fsPath: string }
+  /** Exactly one .stm file exists in the workspace — use it without prompting. */
+  | { kind: "single"; fsPath: string }
+  /** Several .stm files and no active one — the caller must ask the user. */
+  | { kind: "ambiguous"; candidates: string[] }
+  /** No .stm files in the workspace at all. */
+  | { kind: "none" };
+
+/**
+ * Decide which .stm file should anchor a CLI invocation.
+ *
+ * Priority: the active editor's file when it is a .stm file (the user is
+ * looking at it — it is the least surprising workspace root), else the only
+ * .stm file when there is exactly one, else an ambiguous result carrying the
+ * candidates ordered for a quick pick. Returns `none` when the workspace has
+ * no .stm files.
+ */
+export function classifyEntryFileCandidates(
+  activeEditorFsPath: string | undefined,
+  workspaceStmFiles: string[],
+): EntryFileResolution {
+  if (activeEditorFsPath && activeEditorFsPath.endsWith(STM_EXTENSION)) {
+    return { kind: "active", fsPath: activeEditorFsPath };
+  }
+  if (workspaceStmFiles.length === 1) {
+    return { kind: "single", fsPath: workspaceStmFiles[0] };
+  }
+  if (workspaceStmFiles.length > 1) {
+    return { kind: "ambiguous", candidates: orderCandidatesForPick(workspaceStmFiles) };
+  }
+  return { kind: "none" };
+}
+
+/**
+ * Order candidate paths for the quick pick: shallowest first, then
+ * alphabetically. Platform entry-point files conventionally live at the
+ * workspace root (e.g. `platform.stm` importing the per-domain pipelines —
+ * see "Platform Lineage Entry Point" in AGENTS.md), so the most likely
+ * entry file sorts to the top.
+ */
+export function orderCandidatesForPick(fsPaths: string[]): string[] {
+  const depth = (p: string) => p.split(/[\\/]/).length;
+  return [...fsPaths].sort((a, b) => depth(a) - depth(b) || a.localeCompare(b));
+}

--- a/tooling/vscode-satsuma/src/commands/entry-file.ts
+++ b/tooling/vscode-satsuma/src/commands/entry-file.ts
@@ -1,0 +1,86 @@
+/**
+ * entry-file.ts — vscode wiring for entry-file resolution (sl-1ycv).
+ *
+ * Owns the editor/workspace lookups and the quick-pick UI around the pure
+ * selection rules in entry-file-logic.ts. Every CLI invocation in the
+ * extension goes through {@link resolveEntryFile} so no call site can fall
+ * back to a directory path, which the CLI rejects since ADR-022.
+ */
+
+import * as vscode from "vscode";
+import { classifyEntryFileCandidates } from "./entry-file-logic";
+
+/**
+ * Cap on the workspace .stm search. Far above any realistic workspace size —
+ * it only guards against pathological folders (e.g. a home directory opened
+ * by accident).
+ */
+const MAX_STM_SEARCH_RESULTS = 200;
+
+/**
+ * The user's last quick-pick choice, offered as the top item next time.
+ * Session-scoped on purpose: a persisted default could silently go stale
+ * when the workspace's entry-point file moves.
+ */
+let lastPickedEntryFile: string | undefined;
+
+/**
+ * Resolve the .stm file that anchors a CLI invocation, prompting only when
+ * the workspace is genuinely ambiguous (several .stm files and none active).
+ * Returns undefined when the user dismisses the prompt or the workspace has
+ * no .stm files — callers must abort their CLI call in that case, never
+ * substitute a directory.
+ */
+export async function resolveEntryFile(): Promise<string | undefined> {
+  const activeDoc = vscode.window.activeTextEditor?.document;
+  const activeFsPath =
+    activeDoc && !activeDoc.isUntitled ? activeDoc.uri.fsPath : undefined;
+
+  const found = await vscode.workspace.findFiles(
+    "**/*.stm",
+    "**/node_modules/**",
+    MAX_STM_SEARCH_RESULTS,
+  );
+
+  const resolution = classifyEntryFileCandidates(
+    activeFsPath,
+    found.map((uri) => uri.fsPath),
+  );
+
+  switch (resolution.kind) {
+    case "active":
+    case "single":
+      return resolution.fsPath;
+
+    case "ambiguous": {
+      // Float the previous choice to the top so repeat invocations are
+      // one keystroke, without skipping the prompt entirely.
+      const ordered = lastPickedEntryFile
+        ? [
+            ...resolution.candidates.filter((c) => c === lastPickedEntryFile),
+            ...resolution.candidates.filter((c) => c !== lastPickedEntryFile),
+          ]
+        : resolution.candidates;
+
+      const picked = await vscode.window.showQuickPick(
+        ordered.map((fsPath) => ({
+          label: vscode.workspace.asRelativePath(fsPath),
+          description: fsPath === lastPickedEntryFile ? "last used" : undefined,
+          fsPath,
+        })),
+        {
+          placeHolder:
+            "Select the Satsuma entry file (the workspace is its transitive imports)",
+        },
+      );
+      if (picked) lastPickedEntryFile = picked.fsPath;
+      return picked?.fsPath;
+    }
+
+    case "none":
+      vscode.window.showInformationMessage(
+        "No .stm files found in this workspace.",
+      );
+      return undefined;
+  }
+}

--- a/tooling/vscode-satsuma/src/commands/lineage.ts
+++ b/tooling/vscode-satsuma/src/commands/lineage.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { getEditorActionContext } from "./action-context";
+import { resolveEntryFile } from "./entry-file";
 import { SchemaLineagePanel } from "../webview/schema-lineage/panel";
 
 interface ShowLineageArgs {
@@ -47,13 +48,14 @@ export function registerLineageCommand(
       }
       if (!selected) return;
 
-      const workspacePath =
-        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ".";
+      // The CLI rejects directories (ADR-022) — resolve a .stm entry file.
+      const entryFilePath = await resolveEntryFile();
+      if (!entryFilePath) return;
 
       SchemaLineagePanel.createOrShow(
         context.extensionUri,
         cliPath,
-        workspacePath,
+        entryFilePath,
         selected,
         direction,
       );

--- a/tooling/vscode-satsuma/src/commands/summary.ts
+++ b/tooling/vscode-satsuma/src/commands/summary.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { runCli } from "./cli-runner";
+import { resolveEntryFile } from "./entry-file";
 
 export function registerSummaryCommand(
   context: vscode.ExtensionContext,
@@ -8,7 +9,11 @@ export function registerSummaryCommand(
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand("satsuma.showSummary", async () => {
-      const result = await runCli(cliPath, ["summary", "--json"]);
+      // See sl-1ycv: the CLI needs a .stm entry file, not the cwd default.
+      const entryFilePath = await resolveEntryFile();
+      if (!entryFilePath) return;
+
+      const result = await runCli(cliPath, ["summary", entryFilePath, "--json"]);
 
       if (result.exitCode !== 0) {
         vscode.window.showWarningMessage(

--- a/tooling/vscode-satsuma/src/commands/validate.ts
+++ b/tooling/vscode-satsuma/src/commands/validate.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { runCli } from "./cli-runner";
+import { resolveEntryFile } from "./entry-file";
 
 export function registerValidateCommand(
   context: vscode.ExtensionContext,
@@ -10,7 +11,12 @@ export function registerValidateCommand(
 
   context.subscriptions.push(
     vscode.commands.registerCommand("satsuma.validateWorkspace", async () => {
-      const result = await runCli(cliPath, ["validate", "--json"]);
+      // The CLI rejects directories and defaults a missing path argument to
+      // "." (ADR-022) — name a .stm entry file explicitly (sl-1ycv).
+      const entryFilePath = await resolveEntryFile();
+      if (!entryFilePath) return;
+
+      const result = await runCli(cliPath, ["validate", entryFilePath, "--json"]);
       diagnostics.clear();
 
       let entries: Array<{

--- a/tooling/vscode-satsuma/src/commands/warnings.ts
+++ b/tooling/vscode-satsuma/src/commands/warnings.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { runCli } from "./cli-runner";
+import { resolveEntryFile } from "./entry-file";
 
 export function registerWarningsCommand(
   context: vscode.ExtensionContext,
@@ -10,7 +11,11 @@ export function registerWarningsCommand(
 
   context.subscriptions.push(
     vscode.commands.registerCommand("satsuma.showWarnings", async () => {
-      const result = await runCli(cliPath, ["warnings", "--json"]);
+      // See sl-1ycv: the CLI needs a .stm entry file, not the cwd default.
+      const entryFilePath = await resolveEntryFile();
+      if (!entryFilePath) return;
+
+      const result = await runCli(cliPath, ["warnings", entryFilePath, "--json"]);
       diagnostics.clear();
 
       try {

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -13,6 +13,7 @@ import { registerWarningsCommand } from "./commands/warnings";
 import { registerSummaryCommand } from "./commands/summary";
 import { registerCoverageCommand } from "./commands/coverage";
 import { getEditorActionContext } from "./commands/action-context";
+import { resolveEntryFile } from "./commands/entry-file";
 import { VizPanel } from "./webview/viz/panel";
 import { FieldLineagePanel } from "./webview/field-lineage/panel";
 
@@ -82,12 +83,10 @@ export function activate(context: ExtensionContext): void {
   // Field Lineage webview (Phase 1 — ELK panel)
   context.subscriptions.push(
     vscode.commands.registerCommand("satsuma.traceFieldLineage", async (args?: { fieldPath?: string }) => {
-      // Pass the active .stm file path so the CLI scopes the workspace via followImports.
-      // Fallback to workspace root only if no file is open (rare edge case).
-      const activeFilePath =
-        vscode.window.activeTextEditor?.document.uri.fsPath ??
-        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ??
-        ".";
+      // The CLI scopes the workspace via the entry file's imports and rejects
+      // directories (ADR-022) — never fall back to a folder path (sl-1ycv).
+      const entryFilePath = await resolveEntryFile();
+      if (!entryFilePath) return;
 
       // Prefer: explicit arg > LSP actionContext > user input
       let fieldPath: string | undefined = args?.fieldPath;
@@ -115,7 +114,7 @@ export function activate(context: ExtensionContext): void {
       FieldLineagePanel.createOrShow(
         context.extensionUri,
         cliPath,
-        activeFilePath,
+        entryFilePath,
         fieldPath,
       );
     }),

--- a/tooling/vscode-satsuma/src/webview/field-lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/field-lineage/panel.ts
@@ -1,7 +1,7 @@
 /**
  * panel.ts — Extension-host side of the Field Lineage webview panel.
  *
- * Drives the panel by calling `satsuma field-lineage <field> <workspace> --json`
+ * Drives the panel by calling `satsuma field-lineage <field> <entry-file.stm> --json`
  * (a single CLI call, not the old hop-by-hop arrows loop) and maintains
  * breadcrumb navigation state as the user re-centres on different fields.
  */
@@ -16,7 +16,7 @@ export class FieldLineagePanel {
   private readonly panel: vscode.WebviewPanel;
   private readonly extensionUri: vscode.Uri;
   private readonly cliPath: string;
-  private readonly workspacePath: string;
+  private readonly entryFilePath: string;
   private breadcrumb: string[] = [];
   private depth = 3;
   private disposables: vscode.Disposable[] = [];
@@ -26,7 +26,7 @@ export class FieldLineagePanel {
   static createOrShow(
     extensionUri: vscode.Uri,
     cliPath: string,
-    workspacePath: string,
+    entryFilePath: string,
     fieldPath: string,
   ): void {
     if (FieldLineagePanel.currentPanel) {
@@ -54,7 +54,7 @@ export class FieldLineagePanel {
       panel,
       extensionUri,
       cliPath,
-      workspacePath,
+      entryFilePath,
       fieldPath,
     );
   }
@@ -65,13 +65,13 @@ export class FieldLineagePanel {
     panel: vscode.WebviewPanel,
     extensionUri: vscode.Uri,
     cliPath: string,
-    workspacePath: string,
+    entryFilePath: string,
     fieldPath: string,
   ) {
     this.panel = panel;
     this.extensionUri = extensionUri;
     this.cliPath = cliPath;
-    this.workspacePath = workspacePath;
+    this.entryFilePath = entryFilePath;
 
     this.panel.webview.html = this.getHtml();
 
@@ -133,7 +133,7 @@ export class FieldLineagePanel {
     const result = await runCli(this.cliPath, [
       "field-lineage",
       bare,
-      this.workspacePath,
+      this.entryFilePath,
       "--json",
       "--depth",
       String(this.depth),

--- a/tooling/vscode-satsuma/src/webview/schema-lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/schema-lineage/panel.ts
@@ -2,7 +2,7 @@
  * panel.ts — Extension-host side of the Schema Lineage webview panel.
  *
  * Replaces the output-channel rendering in src/commands/lineage.ts.
- * Calls `satsuma lineage --from <schema> [workspace] --json`, then sends the
+ * Calls `satsuma lineage --from <schema> <entry-file.stm> --json`, then sends the
  * resulting DAG to the webview for ELK-based pill rendering.
  */
 
@@ -35,7 +35,7 @@ export class SchemaLineagePanel {
   private readonly panel: vscode.WebviewPanel;
   private readonly extensionUri: vscode.Uri;
   private readonly cliPath: string;
-  private readonly workspacePath: string;
+  private readonly entryFilePath: string;
   private disposables: vscode.Disposable[] = [];
 
   // ── Public factory ──────────────────────────────────────────────────────
@@ -43,7 +43,7 @@ export class SchemaLineagePanel {
   static createOrShow(
     extensionUri: vscode.Uri,
     cliPath: string,
-    workspacePath: string,
+    entryFilePath: string,
     schema: string,
     direction: "from" | "to",
   ): void {
@@ -70,7 +70,7 @@ export class SchemaLineagePanel {
       panel,
       extensionUri,
       cliPath,
-      workspacePath,
+      entryFilePath,
       schema,
       direction,
     );
@@ -82,14 +82,14 @@ export class SchemaLineagePanel {
     panel: vscode.WebviewPanel,
     extensionUri: vscode.Uri,
     cliPath: string,
-    workspacePath: string,
+    entryFilePath: string,
     schema: string,
     direction: "from" | "to",
   ) {
     this.panel = panel;
     this.extensionUri = extensionUri;
     this.cliPath = cliPath;
-    this.workspacePath = workspacePath;
+    this.entryFilePath = entryFilePath;
 
     this.panel.webview.html = this.getHtml();
 
@@ -113,7 +113,7 @@ export class SchemaLineagePanel {
       "lineage",
       `--${direction}`,
       schema,
-      this.workspacePath,
+      this.entryFilePath,
       "--json",
     ]);
 

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { join } from "path";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { FieldLineagePanel } from "../field-lineage/panel";
+import { resolveEntryFile } from "../../commands/entry-file";
 import {
   loadExpandedModels,
   loadFullLineageModel,
@@ -171,14 +172,17 @@ export class VizPanel {
     } else if (message.type === "expandLineage" && message.schemaId) {
       this.expandLineage(message.schemaId);
     } else if (message.type === "fieldLineage" && message.fieldPath) {
-      const workspacePath =
-        vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ".";
-      FieldLineagePanel.createOrShow(
-        this.extensionUri,
-        this.cliPath,
-        workspacePath,
-        message.fieldPath,
-      );
+      // The CLI rejects directories (ADR-022) — resolve a .stm entry file
+      // before opening the field-lineage panel (sl-1ycv).
+      void resolveEntryFile().then((entryFilePath) => {
+        if (!entryFilePath || !message.fieldPath) return;
+        FieldLineagePanel.createOrShow(
+          this.extensionUri,
+          this.cliPath,
+          entryFilePath,
+          message.fieldPath,
+        );
+      });
     } else if (message.type === "export" && message.content) {
       this.exportSvg(message.content as string);
     }

--- a/tooling/vscode-satsuma/test/entry-file-logic.test.js
+++ b/tooling/vscode-satsuma/test/entry-file-logic.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests for the pure entry-file selection rules (sl-1ycv).
+ *
+ * Since ADR-022 the CLI rejects directory arguments, so every extension CLI
+ * invocation must name a .stm file. These rules decide which file that is;
+ * regressions here mean the extension either prompts when it shouldn't or
+ * silently picks a surprising workspace root.
+ */
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  classifyEntryFileCandidates,
+  orderCandidatesForPick,
+} = require("../dist/client/commands/entry-file-logic.js");
+
+describe("classifyEntryFileCandidates", () => {
+  // The user is looking at a .stm file — that file is the least surprising
+  // workspace root and must win without prompting.
+  it("uses the active editor's file when it is a .stm file", () => {
+    const res = classifyEntryFileCandidates("/ws/crm/pipeline.stm", [
+      "/ws/crm/pipeline.stm",
+      "/ws/platform.stm",
+    ]);
+    assert.deepEqual(res, { kind: "active", fsPath: "/ws/crm/pipeline.stm" });
+  });
+
+  // A non-.stm active editor (e.g. README.md) must not be passed to the CLI —
+  // that is exactly the class of bad argument ADR-022 rejects.
+  it("ignores a non-.stm active editor and falls through to the workspace files", () => {
+    const res = classifyEntryFileCandidates("/ws/README.md", ["/ws/pipeline.stm"]);
+    assert.deepEqual(res, { kind: "single", fsPath: "/ws/pipeline.stm" });
+  });
+
+  it("uses the only .stm file in the workspace without prompting", () => {
+    const res = classifyEntryFileCandidates(undefined, ["/ws/pipeline.stm"]);
+    assert.deepEqual(res, { kind: "single", fsPath: "/ws/pipeline.stm" });
+  });
+
+  // Multiple candidates and nothing active: the extension must ask rather
+  // than guess (a wrong guess silently changes lineage/validation scope).
+  it("reports ambiguity when several .stm files exist and none is active", () => {
+    const res = classifyEntryFileCandidates(undefined, [
+      "/ws/billing/pipeline.stm",
+      "/ws/platform.stm",
+    ]);
+    assert.equal(res.kind, "ambiguous");
+    assert.equal(res.candidates.length, 2);
+  });
+
+  it("reports none for a workspace without .stm files", () => {
+    assert.deepEqual(classifyEntryFileCandidates(undefined, []), { kind: "none" });
+  });
+});
+
+describe("orderCandidatesForPick", () => {
+  // Platform entry points conventionally live at the workspace root
+  // (platform.stm importing per-domain pipelines), so shallower paths must
+  // sort first to put the likely entry file at the top of the quick pick.
+  it("orders candidates shallowest-first, then alphabetically", () => {
+    const ordered = orderCandidatesForPick([
+      "/ws/crm/deep/nested.stm",
+      "/ws/billing/pipeline.stm",
+      "/ws/platform.stm",
+      "/ws/aardvark.stm",
+    ]);
+    assert.deepEqual(ordered, [
+      "/ws/aardvark.stm",
+      "/ws/platform.stm",
+      "/ws/billing/pipeline.stm",
+      "/ws/crm/deep/nested.stm",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes seven user-reported bugs across the VS Code extension, LSP, viz, and formatter — each with regression tests that would have caught it. Closes #273, closes #274.

## Fixes

### sl-1ycv — VS Code lineage (and validate/warnings/summary) broken: "directory arguments are not supported"
ADR-022 made the CLI reject directory arguments, but the extension still passed the workspace folder (schema-/field-lineage panels) or nothing at all (validate/warnings/summary → CLI defaults to `.`). All six `runCli` call sites now resolve a `.stm` entry file via a new `resolveEntryFile()`: active `.stm` editor → only workspace `.stm` file → quick pick (shallowest-first, platform entry points sort to the top, last choice floated up). **Tests:** `vscode-satsuma/test/entry-file-logic.test.js`.

### sl-akz6 / gh-274 — duplicate schema/`src` false positives on Windows
The workspace index keyed files by raw URI string: the startup scan indexed `file:///C:/...` (Node `pathToFileURL`) while didOpen indexed `file:///c%3A/...` (VS Code client), so an opened file existed twice and every definition tripped duplicate-definition diagnostics. Added browser-safe `canonicalizeFileUri()` in viz-backend's workspace-index, applied at every index boundary; the semantic-diagnostics adapter canonicalizes query URIs so results match either spelling. **Tests:** `viz-backend/test/uri-canonicalization.test.js`, spelling-collision cases in `satsuma-lsp/test/semantic-diagnostics.test.js`.

### sl-sme1 / gh-273 — `TypeError: message must be set` kills the client diagnostic queue
A bare `//!` comment produced a diagnostic with `message: ""`; `vscode.Diagnostic`'s constructor throws on a falsy message and one bad entry aborts the entire batch conversion, freezing diagnostics for the file. Bare `//!` now gets a fallback message, and `ensureNonEmptyMessages()` guards the publish boundary so no producer can ship an empty message. **Tests:** `satsuma-lsp/test/diagnostics.test.js`.

### sl-6x1o — viz drops mapping-level metadata and non-constraint field metadata
`MappingBlock` had no metadata field at all and `FieldEntry` kept only the `CONSTRAINT_TAGS` whitelist (values discarded) — so `mapping m (airflow, note "...")` and governance meta like `classification "CONFIDENTIAL"` were invisible. Both types now carry full `metadata: MetadataEntry[]`; the detail header renders mapping meta as labelled rows, field rows render key+value pills next to the constraint badges. **Tests:** viz-backend builder tests + Playwright `mapping-field-meta.test.ts`.

### sl-tw0r — overview expand arrow jumps to source instead of expanding
Card headers conflated toggle + navigate in one click handler; VS Code opens the document on navigate, so expanding a card yanked the editor away. New contract: **the arrow toggles (navigation-silent), the header name navigates** — applied to schema and fragment cards. Harness tests updated to pin the new contract.

### sl-q9oj — formatter strips commas between source refs in multi-line source blocks
`formatSourceBlock`'s multi-line branch joined refs with bare newlines while the single-line branch used `", "`. Multi-line blocks now keep trailing commas; the 10 corpus examples whose commas the old formatter had already stripped are restored, and the spec §4.7 / BA-tutorial example updated to the comma style. **Tests:** comma-preservation + idempotency cases in `satsuma-core/test/format.test.js`.

> ⚠️ **Spec style call for review:** the spec's §4.7 example was comma-less; the grammar accepts both. I aligned spec + corpus to the comma style since comma removal was reported as a bug and the single-line form already used commas. Shout if you'd rather keep comma-less as canonical.

### sl-e40u — context menu entry unrecognizable
`satsuma.showViz` has been in the editor context menu since March, but titled "Show Mapping Visualization" while it opens the **Overview**. Retitled to "Satsuma: Overview Visualization" (palette, context menu, eye tooltip) and added an `explorer/context` entry for `.stm` files.

## Validation
- satsuma-core: 366 pass · viz-model: 6 pass · viz-backend: 154 pass · satsuma-lsp: 245 pass · satsuma-cli: 844 pass · vscode-satsuma: 14 unit + grammar fixtures pass
- Playwright harness (real Firefox via watcher): **97 passed**, including the new toggle-contract and metadata-rendering tests

## ADR assessment
These changes implement decisions already recorded (ADR-022's file-based workspace model) rather than making new ones. The entry-file resolution heuristic in the extension is the closest call — happy to draft an ADR for it if you think it warrants one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)