### PR TITLE
fix(fmt): preserve nested each/flatten blocks instead of deleting them (sl-7236)

### DIFF
--- a/.tickets/sl-7236.md
+++ b/.tickets/sl-7236.md
@@ -1,6 +1,6 @@
 ---
 id: sl-7236
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z

--- a/.tickets/sl-7236.md
+++ b/.tickets/sl-7236.md
@@ -1,6 +1,6 @@
 ---
 id: sl-7236
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ formatEachFlattenBlock (satsuma-core/src/format.ts:818-845) child loop only hand
 
 Nested each/flatten blocks survive formatting; corpus/golden fixture added with nested each and flatten blocks; fmt round-trip test covers nesting.
 
+
+## Notes
+
+**2026-06-11T06:22:28Z**
+
+Cause: formatEachFlattenBlock dispatched only on map_arrow/computed_arrow/nested_arrow child types, so nested each_block/flatten_block children (valid per grammar _nested_block_item) fell through every branch and were silently deleted from formatted output.
+Fix: recurse into nested each/flatten sub-blocks in formatEachFlattenBlock; added regression tests (proven failing pre-fix) and a canonical examples/nested-iteration/ pipeline so fmt round-trip and golden sweeps cover nesting (commit eecee7f)

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ The CLI requires a `.stm` file entry point (not a directory). The workspace is d
 | [`metrics-platform/`](metrics-platform/) | `metrics.stm` | Business metrics (MRR, CLV, churn, conversion) as schema blocks with `(metric, ...)` metadata |
 | [`multi-source/`](multi-source/) | `multi-source-hub.stm` | Multi-source arrows, data hub, and three-way join patterns |
 | [`namespaces/`](namespaces/) | `ns-platform.stm` | Namespace blocks, cross-namespace references, and namespace merging |
+| [`nested-iteration/`](nested-iteration/) | `pipeline.stm` | Nested `each`/`flatten` sub-blocks mapping hierarchical dispatch events to a courier manifest |
 | [`protobuf-to-parquet/`](protobuf-to-parquet/) | `pipeline.stm` | Protobuf Kafka commerce events to session-level Parquet |
 | [`reports-and-models/`](reports-and-models/) | `pipeline.stm` | Reports, dashboards, and ML models as first-class pipeline consumers |
 | [`sap-po-to-mfcs/`](sap-po-to-mfcs/) | `pipeline.stm` | SAP ERP purchase order to Oracle MFCS ingestion contract |

--- a/examples/nested-iteration/README.md
+++ b/examples/nested-iteration/README.md
@@ -1,0 +1,14 @@
+# nested-iteration
+
+Demonstrates `each` and `flatten` blocks nested inside an `each` block (spec §4.4 "Nested Mappings"): a warehouse dispatch event with orders, lines, and parcels is mapped to a courier manifest that preserves the order/line hierarchy while flattening parcel contents into one packed-items list per order.
+
+## Key features demonstrated
+
+- `each` block nested inside an `each` block — preserving a two-level source hierarchy in the target
+- `flatten` block nested inside an `each` block — lifting a doubly-nested list into a flat per-element list
+- Relative `.field` paths resolving against the enclosing iteration context
+- Metadata (`note`) on an iteration block header
+
+## Entry point
+
+`pipeline.stm` — main pipeline (imports nothing)

--- a/examples/nested-iteration/pipeline.stm
+++ b/examples/nested-iteration/pipeline.stm
@@ -1,0 +1,105 @@
+// Satsuma v2 — Nested Iteration (each/flatten sub-blocks)
+
+note {
+  """
+  # Nested Iteration
+
+  Demonstrates iteration blocks nested inside other iteration blocks, as
+  described in spec section 4.4 (Nested Mappings):
+
+  1. **Nested `each`** — preserving a two-level hierarchy (orders and their
+     lines) by iterating a list field of the current element.
+  2. **Nested `flatten`** — lifting a doubly-nested list (every content row
+     of every parcel) into a single flat list on the current target element.
+
+  ## Scenario
+  A warehouse management system emits one dispatch event per van departure.
+  Each event carries the dispatched orders, each order its lines and parcels.
+  The courier needs a manifest document that keeps the order/line hierarchy
+  but presents parcel contents as one flat packed-items list per order.
+  """
+}
+
+// --- Source ---
+schema warehouse_dispatch_events (
+  note "Dispatch confirmations from the warehouse management system"
+) {
+  dispatch_id    UUID         (pk, required)
+  dispatched_at  TIMESTAMPTZ  (required)
+
+  orders list_of record {
+    order_no     STRING(20)  (required)
+    courier_ref  STRING(30)
+
+    lines list_of record {
+      sku       STRING(30)  (required)
+      quantity  INT         (required)
+    }
+
+    parcels list_of record {
+      barcode  STRING(40)  (required)
+      contents list_of record {
+        sku    STRING(30)  (required)
+        units  INT         (required)
+      }
+    }
+  }
+}
+
+// --- Target ---
+schema dispatch_manifest_json (
+  format json,
+  note "Courier-facing dispatch manifest — one document per dispatch event"
+) {
+  manifest_id   UUID         (required)
+  generated_at  TIMESTAMPTZ  (required)
+
+  orders list_of record {
+    order_ref    STRING(20)  (required)
+    courier_ref  STRING(30)
+
+    lines list_of record {
+      sku  STRING(30)  (required)
+      qty  INT         (required)
+    }
+
+    // One element per parcel content row, across all parcels in the order
+    packed_items list_of record {
+      sku    STRING(30)  (required)
+      units  INT         (required)
+    }
+  }
+}
+
+// --- Mapping ---
+mapping `dispatch manifest` {
+  note {
+    "Builds the courier manifest from a dispatch event. Orders and their
+     lines keep their hierarchy via nested each blocks; parcel contents are
+     lifted into a flat per-order packed_items list via a nested flatten."
+  }
+
+  source { warehouse_dispatch_events }
+  target { dispatch_manifest_json }
+
+  dispatch_id -> manifest_id
+  dispatched_at -> generated_at
+
+  each orders -> orders (note "One manifest order per dispatched order.") {
+    .order_no -> .order_ref { trim | uppercase }
+    .courier_ref -> .courier_ref { null_if_empty }
+
+    // Nested each: one manifest line per order line, hierarchy preserved
+    each lines -> .lines {
+      .sku -> .sku { trim | uppercase }
+      .quantity -> .qty
+    }
+
+    // Nested flatten: contents is doubly nested under the order (one list
+    // per parcel); flatten lifts every content row into one flat list
+    flatten parcels.contents -> .packed_items {
+      .sku -> .sku { trim | uppercase }
+      .units -> .units
+    }
+  }
+}

--- a/tooling/satsuma-core/src/format.ts
+++ b/tooling/satsuma-core/src/format.ts
@@ -811,7 +811,8 @@ function formatEachFlattenBlock(
 
   line += " {";
 
-  // Inner arrows
+  // Inner items: arrow declarations plus nested each/flatten sub-blocks
+  // (grammar rule _nested_block_item allows iteration blocks to nest).
   const innerLines: string[] = [];
   let prev: SyntaxNode | null = null;
 
@@ -840,6 +841,10 @@ function formatEachFlattenBlock(
       innerLines.push(formatComputedArrow(child, source, indent + 1));
     } else if (child.type === "nested_arrow") {
       innerLines.push(formatNestedArrow(child, source, indent + 1));
+    } else if (child.type === "each_block") {
+      innerLines.push(formatEachFlattenBlock(child, source, indent + 1, "each"));
+    } else if (child.type === "flatten_block") {
+      innerLines.push(formatEachFlattenBlock(child, source, indent + 1, "flatten"));
     }
     prev = child;
   }

--- a/tooling/satsuma-core/test/format.test.js
+++ b/tooling/satsuma-core/test/format.test.js
@@ -582,6 +582,44 @@ describe("edge cases", () => {
     assert.ok(out.includes("  .sku -> .sku { trim }"));
   });
 
+  // Regression for sl-7236: the each/flatten child loop only dispatched on the
+  // three arrow node types, so nested each/flatten sub-blocks (allowed by the
+  // grammar's _nested_block_item) fell through every branch and were silently
+  // deleted — fmt destroyed mapping logic on valid input.
+  it("preserves an each block nested inside an each block", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  each orders -> out_orders {
+    id -> oid
+    each items -> out_items {
+      sku -> out_sku
+    }
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("each orders -> out_orders {"));
+    assert.ok(out.includes("  each items -> out_items {"), "inner each header must survive");
+    assert.ok(out.includes("    sku -> out_sku"), "inner each arrows must survive at depth-2 indent");
+    assert.equal(out, fmt(out), "nested each output must be idempotent");
+  });
+
+  it("preserves a flatten block nested inside an each block", () => {
+    const src = `mapping test {
+  source { s }
+  target { t }
+  each orders -> flat {
+    flatten items -> .rows {
+      name -> name
+    }
+  }
+}`;
+    const out = fmt(src);
+    assert.ok(out.includes("  flatten items -> .rows {"), "inner flatten header must survive");
+    assert.ok(out.includes("    name -> name"), "inner flatten arrows must survive at depth-2 indent");
+    assert.equal(out, fmt(out), "nested flatten output must be idempotent");
+  });
+
   it("handles metric schema block with metric_name and metadata", () => {
     // Metrics are now schema blocks with (metric, metric_name "MRR", ...) metadata.
     // Validates that the formatter handles metric schemas correctly.


### PR DESCRIPTION
## Summary
- Fixes **sl-7236**: `satsuma fmt` silently deleted nested `each`/`flatten` blocks from valid files, permanently destroying mapping logic.
- Root cause: `formatEachFlattenBlock` (`tooling/satsuma-core/src/format.ts`) dispatched only on the three arrow node types; nested `each_block`/`flatten_block` children — valid per the grammar's `_nested_block_item` — fell through every branch and were dropped.
- Fix: recurse into nested each/flatten sub-blocks with increased indent.

## Test coverage
- Two regression tests in `format.test.js` (each-in-each, flatten-in-each), **verified to fail against the unfixed formatter** before the fix was applied.
- New canonical example `examples/nested-iteration/` (spec §4.4 nested mappings: dispatch events → courier manifest) — automatically swept by the fmt idempotency, parse-tree-structure, and golden-parse corpus tests, so nesting is covered permanently. The file validates cleanly and is a fixed point of `satsuma fmt`.
- No tree-sitter corpus changes needed: parse-level nesting was already covered (sl-s6gs cases); this was purely a formatter bug.

## Test results
- satsuma-core: 369/369
- satsuma-cli: 844/844
- satsuma-lsp: 245/245
- tree-sitter corpus (wasm): 284/284

🤖 Generated with [Claude Code](https://claude.com/claude-code)