### PR TITLE
fix(lsp): rename no longer clobbers @ sigils or dotted arrow paths (sl-xf3f)

### DIFF
--- a/.tickets/sl-xf3f.md
+++ b/.tickets/sl-xf3f.md
@@ -1,6 +1,6 @@
 ---
 id: sl-xf3f
-status: open
+status: in_progress
 deps: []
 links: [sl-p256]
 created: 2026-06-11T02:41:29Z

--- a/.tickets/sl-xf3f.md
+++ b/.tickets/sl-xf3f.md
@@ -1,6 +1,6 @@
 ---
 id: sl-xf3f
-status: in_progress
+status: closed
 deps: []
 links: [sl-p256]
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ Two reference-index entries store ranges wider than the name they are keyed unde
 
 Reference ranges cover exactly the identifier being renamed (@ preserved, path segments preserved); rename round-trip tests for NL refs and dotted arrow paths; find-references no longer reports field-path false positives.
 
+
+## Notes
+
+**2026-06-11T06:22:37Z**
+
+Cause: Two reference-index entry kinds in the shared workspace index (satsuma-viz-backend/src/workspace-index.ts) stored ranges wider than the name they were keyed under — NL @refs kept the @ sigil in the range, and arrow first-segment entries used the whole src_path/tgt_path node range — and rename.ts replaces the stored range verbatim.
+Fix: Ranges now cover exactly the keyed identifier, derived from CST path-segment nodes: bare entries span only the first segment, full-path entries exclude the leading dot / ns:: prefix, and NL @ref ranges start one character past the @. Round-trip rename tests and exact-range index tests added. (commit a7a7fc6)

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -65,6 +65,29 @@ describe("prepareRename", () => {
   });
 });
 
+/**
+ * Apply a WorkspaceEdit's TextEdits for one file to its source text.
+ * Edits are applied bottom-up so earlier edits do not shift later ranges.
+ * Supports single-line ranges only — sufficient for these tests.
+ */
+function applyEdits(source, edits) {
+  const lines = source.split("\n");
+  const sorted = [...edits].sort(
+    (a, b) =>
+      b.range.start.line - a.range.start.line ||
+      b.range.start.character - a.range.start.character,
+  );
+  for (const e of sorted) {
+    assert.equal(e.range.start.line, e.range.end.line, "expected single-line edit");
+    const line = lines[e.range.start.line];
+    lines[e.range.start.line] =
+      line.slice(0, e.range.start.character) +
+      e.newText +
+      line.slice(e.range.end.character);
+  }
+  return lines.join("\n");
+}
+
 describe("computeRename", () => {
   it("renames schema definition and all references", () => {
     const { index, trees } = buildIndex({
@@ -154,6 +177,58 @@ schema customers {
       "customers",
     );
     assert.equal(edit, null);
+  });
+
+  it("rewrites @refs in NL strings without deleting the @ sigil", () => {
+    // sl-xf3f: the NL ref index stored the range of the whole "@name" match,
+    // so rename replaced the sigil too, turning "@customers" into "clients"
+    // and breaking the ref. The round trip must keep the @.
+    const bSource =
+      'mapping `m` {\n  source { customers }\n  target { dim }\n  -> name { "from @customers" }\n}';
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+      "file:///b.stm": bSource,
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
+    assert.ok(
+      renamed.includes('"from @clients"'),
+      `expected NL ref to keep its @ sigil, got: ${renamed}`,
+    );
+  });
+
+  it("preserves the dotted tail of an arrow path whose first segment matches the renamed name", () => {
+    // sl-xf3f: arrow paths were indexed under their first segment but with the
+    // range of the WHOLE path node, so renaming a schema named "address"
+    // rewrote "address.street -> s" to "location -> s", silently destroying
+    // ".street". (That the field segment is matched at all is kind-blind
+    // overreach tracked separately in sl-p256 — this test pins that whatever
+    // is rewritten, the rest of the path survives.)
+    const source =
+      "schema address {\n  street VARCHAR\n}\nmapping `m` {\n  source { src }\n  target { dim }\n  address.street -> s\n}";
+    const { index, trees } = buildIndex({ "file:///a.stm": source });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "location",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(source, edit.changes["file:///a.stm"]);
+    assert.ok(
+      renamed.includes("location.street -> s"),
+      `expected the .street tail to survive the rename, got: ${renamed}`,
+    );
   });
 
   it("renames from a reference site", () => {

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -517,6 +517,80 @@ describe("arrow field path indexing", () => {
   });
 });
 
+describe("reference range precision (sl-xf3f)", () => {
+  // Rename replaces a reference's stored range verbatim, so every range must
+  // cover exactly the text keyed under the reference name — a wider range
+  // makes rename destroy neighbouring text. These tests pin the exact spans.
+
+  /** Slice the source text covered by a single-line range. */
+  function textAt(source, range) {
+    assert.equal(range.start.line, range.end.line, "expected single-line range");
+    const line = source.split("\n")[range.start.line];
+    return line.slice(range.start.character, range.end.character);
+  }
+
+  it("bare first-segment reference covers only the first path segment, not the dotted tail", () => {
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  address.street -> s
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("address") || []).filter((r) => r.context === "arrow");
+    assert.equal(refs.length, 1);
+    // A whole-path range here would turn "address.street" into "<newName>"
+    // on rename, silently deleting ".street".
+    assert.equal(textAt(source, refs[0].range), "address");
+  });
+
+  it("full-path reference covers the dotted path without the ns:: prefix", () => {
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  crm::address.street -> s
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    // First-segment entry skips the namespace qualifier entirely
+    const bareRefs = (idx.references.get("address") || []).filter((r) => r.context === "arrow");
+    assert.equal(bareRefs.length, 1);
+    assert.equal(textAt(source, bareRefs[0].range), "address");
+    // Full-path entry is keyed without the ns:: prefix, so its range must
+    // exclude the prefix too.
+    const pathRefs = (idx.references.get("address.street") || []).filter((r) => r.context === "arrow");
+    assert.equal(pathRefs.length, 1);
+    assert.equal(textAt(source, pathRefs[0].range), "address.street");
+  });
+
+  it("relative-path reference excludes the leading dot from the stored range", () => {
+    const source = `mapping test {
+  source { orders }
+  target { dim }
+  items -> line_items {
+    .sku -> product_sku
+  }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("sku") || []).filter((r) => r.context === "arrow");
+    assert.equal(refs.length, 1);
+    // The dot is path syntax, not part of the field name — a range including
+    // it would leave "<newName>" glued to the arrow with no dot after rename.
+    assert.equal(textAt(source, refs[0].range), "sku");
+  });
+
+  it("NL @ref reference range excludes the @ sigil", () => {
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  -> name { "see @customers here" }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "arrow");
+    assert.equal(refs.length, 1);
+    // A range including the @ deletes the sigil on rename, breaking the ref.
+    assert.equal(textAt(source, refs[0].range), "customers");
+  });
+});
+
 describe("NL string reference indexing", () => {
   it("indexes @refs in NL strings", () => {
     const idx = buildIndex({

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -727,10 +727,19 @@ function indexArrowFieldRefs(
 
     if (!fieldName) return;
 
-    // Bare field name — existing behaviour
+    // Rename replaces a reference's stored range verbatim, so each range must
+    // cover exactly the text keyed under the entry's name. Storing the whole
+    // path node here clobbered everything around the name: renaming a schema
+    // "address" rewrote the arrow "address.street -> s" to "<new> -> s",
+    // silently deleting ".street" (sl-xf3f). It also made find-references
+    // highlight whole dotted paths for a bare-name query.
+    const firstSegmentRange = arrowFirstSegmentRange(n) ?? nodeRange(n);
+    const fullPathRange = arrowFullPathRange(n) ?? nodeRange(n);
+
+    // Bare field name — range covers the first path segment only
     addReference(index, fieldName, {
       uri,
-      range: nodeRange(n),
+      range: firstSegmentRange,
       name: fieldName,
       context: "arrow",
     });
@@ -741,7 +750,7 @@ function indexArrowFieldRefs(
         const qualKey = `${schema}.${fullPath}`;
         addReference(index, qualKey, {
           uri,
-          range: nodeRange(n),
+          range: fullPathRange,
           name: qualKey,
           context: "arrow",
         });
@@ -751,13 +760,57 @@ function indexArrowFieldRefs(
       if (fullPath !== fieldName) {
         addReference(index, fullPath, {
           uri,
-          range: nodeRange(n),
+          range: fullPathRange,
           name: fullPath,
           context: "arrow",
         });
       }
     }
   });
+}
+
+/**
+ * The CST node for the first field segment of a src_path/tgt_path — the
+ * `identifier` or `backtick_name` whose text extractArrowFieldName returns.
+ * Skips the namespace qualifier of a namespaced_path and the leading dot of a
+ * relative_field_path. Returns null on unexpected shapes (error recovery).
+ */
+function arrowFirstSegmentNode(pathNode: SyntaxNode): SyntaxNode | null {
+  const inner = pathNode.namedChildren[0];
+  if (!inner) return null;
+  // namespaced_path = identifier "::" seg ("." seg)* — its first named child
+  // is the namespace, so the field's first segment is the second. Every other
+  // path form (field_path, backtick_path, relative_field_path) starts
+  // directly with its first segment.
+  const seg =
+    inner.type === "namespaced_path"
+      ? inner.namedChildren[1]
+      : inner.namedChildren[0];
+  return seg ?? null;
+}
+
+/** Range of exactly the first path segment of a src_path/tgt_path node. */
+function arrowFirstSegmentRange(pathNode: SyntaxNode): Range | null {
+  const seg = arrowFirstSegmentNode(pathNode);
+  return seg ? nodeRange(seg) : null;
+}
+
+/**
+ * Range of the dotted field path as keyed by extractArrowFullPath: from the
+ * first field segment to the end of the path. The leading dot of relative
+ * paths and the `ns::` prefix of namespaced paths are not part of the keyed
+ * name, so they must stay outside the range a rename rewrites (sl-xf3f).
+ */
+function arrowFullPathRange(pathNode: SyntaxNode): Range | null {
+  const inner = pathNode.namedChildren[0];
+  const seg = arrowFirstSegmentNode(pathNode);
+  if (!inner || !seg) return null;
+  return Range.create(
+    seg.startPosition.row,
+    seg.startPosition.column,
+    inner.endPosition.row,
+    inner.endPosition.column,
+  );
 }
 
 /** Extract the schemas named in a source_block or target_block within a mapping body. */
@@ -849,7 +902,11 @@ function indexNlRefs(
       const rawRef = match[0].slice(1);
       const refName = rawRef.replace(/`([^`]+)`/g, "$1");
 
-      const range = offsetToRange(text, match.index, match[0].length, startRow, startCol);
+      // The @ sigil is not part of the keyed name, so it must stay outside
+      // the stored range — rename replaces the range verbatim, and including
+      // the sigil turned "@customers" into "clients", breaking the ref
+      // (sl-xf3f). Skip one character past the @.
+      const range = offsetToRange(text, match.index + 1, match[0].length - 1, startRow, startCol);
       addReference(index, refName, {
         uri,
         range,


### PR DESCRIPTION
## Summary

Fixes sl-xf3f: two reference-index entry kinds in the shared workspace index (`tooling/satsuma-viz-backend/src/workspace-index.ts`) stored ranges wider than the name they were keyed under, and rename replaces the stored range verbatim — producing destructive edits through a normal prepare-approved VS Code rename:

- **NL `@refs`** stored the range of the whole match including the `@`, so renaming schema `customers` → `clients` turned `"@customers"` into `"clients"`, deleting the sigil and breaking the ref.
- **Arrow path first segments** were indexed under the bare segment name but with the range of the whole `src_path`/`tgt_path` node, so renaming a schema named `address` rewrote `address.street -> s` to `location -> s`, silently destroying `.street`. The same whole-path range made Find All References highlight entire dotted paths for bare-name queries.

## Fix

Reference ranges now cover exactly the keyed identifier, derived from CST path-segment nodes rather than whole-node spans:

- the bare-name entry spans only the first path segment (`arrowFirstSegmentRange`);
- the full-path and schema-qualified entries exclude the leading dot of relative paths and the `ns::` prefix of namespaced paths (`arrowFullPathRange`), matching the text the entry is keyed under;
- NL `@ref` ranges start one character past the sigil.

## Tests

- Rename round-trip tests: `@customers` → `@clients` keeps the sigil; `address.street -> s` keeps its dotted tail.
- Exact-range index tests for plain dotted, namespaced (`ns::`), relative (`.field`) paths and NL `@refs`.
- All six new tests fail against the previous ranges (verified by stashing the fix).
- Full suites green: viz-backend 154, lsp 251, viz 65, cli 844.

Closes sl-xf3f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)