### PR TITLE
fix: four P3 bug-hunt fixes — CLI error contract, option validation, LSP word-end cursors, CLI docs drift

### DIFF
--- a/.tickets/sl-00rw.md
+++ b/.tickets/sl-00rw.md
@@ -1,6 +1,6 @@
 ---
 id: sl-00rw
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z
@@ -17,3 +17,10 @@ satsuma-cli/src/commands/summary.ts:55 is the only async command not wrapped in 
 
 summary wrapped in runCommand; error output matches other commands; piped --json not truncated.
 
+
+## Notes
+
+**2026-06-11T06:15:21Z**
+
+Cause: summary.ts was the only command whose .action() handler was not wrapped in runCommand, so loadWorkspace failures escaped to the index.ts unhandledRejection net — gaining an 'Unhandled error:' prefix and bypassing the flushAndExit stdout drain.
+Fix: wrapped the handler in runCommand like every other command; added a subprocess regression test asserting a bare 'Error resolving path' message on stderr with exit code 2.

--- a/.tickets/sl-bvd0.md
+++ b/.tickets/sl-bvd0.md
@@ -1,6 +1,6 @@
 ---
 id: sl-bvd0
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z

--- a/.tickets/sl-bvd0.md
+++ b/.tickets/sl-bvd0.md
@@ -1,6 +1,6 @@
 ---
 id: sl-bvd0
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z
@@ -17,3 +17,10 @@ parseInt with no NaN/range check in satsuma-cli/src/commands/lineage.ts:48, fiel
 
 Non-numeric or out-of-range values for --depth/--budget exit with a usage error; tests for banana/-1/0 inputs.
 
+
+## Notes
+
+**2026-06-11T06:19:49Z**
+
+Cause: lineage --depth, field-lineage --depth, and context --budget coerced values with bare parseInt and no NaN/range check, so non-numeric or non-positive input silently changed behaviour (NaN depth printed only the start node; NaN budget disabled budgeting).
+Fix: added src/option-parsers.ts with a strict parsePositiveInt coercion (anchored digit pattern, >= 1) that raises Commander's InvalidArgumentError as a standard usage error; wired into all three options. Unit tests pin the parser contract and subprocess tests pin the wiring for banana/-1/0.

--- a/.tickets/sl-ogd5.md
+++ b/.tickets/sl-ogd5.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ogd5
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-06-11T02:41:30Z

--- a/.tickets/sl-ogd5.md
+++ b/.tickets/sl-ogd5.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ogd5
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:30Z
@@ -17,3 +17,10 @@ definition.ts:22, hover.ts:22, references.ts:22, completion.ts:25, rename.ts:25/
 
 All position handlers resolve the identifier when the cursor sits at its end; shared position-adjust helper with tests.
 
+
+## Notes
+
+**2026-06-11T06:24:47Z**
+
+Cause: all seven position-based handlers (definition, hover, references, completion, rename x2, action-context) passed the raw LSP position to descendantForPosition; tree-sitter ranges are half-open, so a cursor immediately after an identifier's last character resolved to the following node and every feature failed at word end.
+Fix: added nodeAtPosition to satsuma-lsp parser-utils — returns the node at the raw position when it is a word token, otherwise retries one column left and prefers a word token there (whitespace-separated and punctuation cursors unaffected). All seven call sites now resolve through it. Unit tests pin the resolver's boundary behaviour; definition and hover gain end-of-identifier regression cases.

--- a/.tickets/sl-w1dr.md
+++ b/.tickets/sl-w1dr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-w1dr
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z

--- a/.tickets/sl-w1dr.md
+++ b/.tickets/sl-w1dr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-w1dr
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z
@@ -17,3 +17,10 @@ The CLI now exposes 22 commands. SATSUMA-CLI.md documents 21 — nl-refs is miss
 
 nl-refs documented in SATSUMA-CLI.md; all command-count claims accurate (or de-numbered); doc check covers the count.
 
+
+## Notes
+
+**2026-06-11T06:28:30Z**
+
+Cause: the CLI grew to 22 commands but SATSUMA-CLI.md never gained an nl-refs entry, and AGENTS.md/README.md/tutorials/PROJECT-OVERVIEW.md carried stale hardcoded counts (16, 17, 21) with no check to stop the drift.
+Fix: documented nl-refs in the SATSUMA-CLI.md Structural Primitives table; de-numbered every command-count claim in living docs so there is no number left to drift; added test/docs.test.ts which parses the command list from 'satsuma --help' and fails if any registered command is missing from SATSUMA-CLI.md (verified to fail when the nl-refs row is removed).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Summary
 
-Satsuma is a domain-specific language for source-to-target data mapping. The repository contains the language specification, a canonical example corpus, a tree-sitter parser, a 16-command CLI for structural extraction and validation, and a VS Code syntax highlighting extension.
+Satsuma is a domain-specific language for source-to-target data mapping. The repository contains the language specification, a canonical example corpus, a tree-sitter parser, a multi-command CLI for structural extraction and validation, and a VS Code syntax highlighting extension.
 
 All tooling is parser-backed. Downstream tools should be built on the tree-sitter CST and stable AST conventions rather than ad hoc text processing.
 
@@ -10,7 +10,7 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 
 - `SATSUMA-V2-SPEC.md`: authoritative language specification (v2)
 - `PROJECT-OVERVIEW.md`: product vision, motivation, and roadmap
-- `SATSUMA-CLI.md`: CLI command reference (16 commands)
+- `SATSUMA-CLI.md`: CLI command reference
 - `AI-AGENT-REFERENCE.md`: compact grammar and agent-oriented Satsuma guidance (v2) — also available via `satsuma agent-reference`
 - `HOW-DO-I.md`: question-based index to all guides and conventions
 - `ROADMAP.md`: deferred work items, ideas, and convention docs still to write

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ and 4 role-specific playbooks adapt it to how you actually work:
 | [05 — Mapping Blocks](lessons/05-mappings.md) | Arrows, transforms, value maps, multi-source mappings |
 | [06 — Natural Language Transforms](lessons/06-nl-transforms.md) | When to formalize vs. keep it natural, `@ref` references |
 | [07 — Nested Data, Arrays, and Complex Shapes](lessons/07-nested-mappings.md) | Dotted paths, array notation, nested arrow blocks |
-| [08 — The Satsuma CLI](lessons/08-satsuma-cli.md) | 16 commands as the agent's deterministic toolkit |
+| [08 — The Satsuma CLI](lessons/08-satsuma-cli.md) | The CLI as the agent's deterministic toolkit |
 | [09 — Human-Agent Workflows](lessons/09-agent-workflows.md) | Impact analysis, coverage checks, PII audits, change review |
 | [10 — End-to-End Delivery](lessons/10-real-world-workflows.md) | The full delivery loop from gathering to versioned source of truth |
 
@@ -261,7 +261,7 @@ Start with Lesson 01 or jump to a [suggested reading path](lessons/README.md#sug
 
 - [SATSUMA-V2-SPEC.md](docs/developer/SATSUMA-V2-SPEC.md): authoritative language specification
 - [PROJECT-OVERVIEW.md](docs/product-owner/PROJECT-OVERVIEW.md): problem statement, vision, and roadmap
-- [SATSUMA-CLI.md](SATSUMA-CLI.md): CLI command reference (21 commands for structural extraction, analysis, and validation)
+- [SATSUMA-CLI.md](SATSUMA-CLI.md): CLI command reference (structural extraction, analysis, and validation)
 - [AI-AGENT-REFERENCE.md](AI-AGENT-REFERENCE.md): compact grammar and quick reference for agents (also available via `satsuma agent-reference`)
 - [docs/tutorials/](docs/tutorials/): role-based tutorials (BA, data engineer, integration engineer) plus a [Copilot + Excel reverse-engineering workflow](docs/tutorials/copilot-excel-reverse-engineering-tutorial.md)
 - [USE_CASES.md](docs/product-owner/USE_CASES.md): practical scenarios and personas
@@ -289,7 +289,7 @@ What exists today:
 - the Satsuma v2 language specification
 - a canonical example corpus (20 `.stm` files covering major integration patterns)
 - a tree-sitter parser (245 corpus tests, all examples parse clean)
-- a TypeScript CLI (`satsuma`) with 21 commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
+- a TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting) and TextMate grammar
 - `satsuma lint` with 3 rules (hidden NL source refs, unresolved NL refs, duplicate definitions) and `--fix` support

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -47,6 +47,7 @@ Fine-grained extraction — slice below block level to get specific arrows, NL c
 | `arrows <schema.field>` | All arrows involving a field, with transform classification | `satsuma arrows loyalty_sfdc.LoyaltyTier` |
 | `field-lineage <schema.field>` | Full upstream + downstream field lineage chain in one command | `satsuma field-lineage sat_customer_demographics.loyalty_tier --json` |
 | `nl <scope>` | NL content (notes, transforms, comments) in a scope | `satsuma nl "demographics to mart"` |
+| `nl-refs [path]` | All `@ref` references in NL transform bodies, with resolution status | `satsuma nl-refs pipeline.stm --unresolved` |
 | `meta <scope>` | Metadata entries for a block or field | `satsuma meta loyalty_sfdc.Email` |
 | `fields <schema>` | Field list with types and metadata | `satsuma fields sat_customer_demographics` |
 | `match-fields --source <s> --target <t>` | Normalized name comparison between two schemas | `satsuma match-fields --source loyalty_sfdc --target sat_customer_demographics` |

--- a/docs/product-owner/PROJECT-OVERVIEW.md
+++ b/docs/product-owner/PROJECT-OVERVIEW.md
@@ -250,7 +250,7 @@ How we'll know Satsuma is working:
 - Canonical example library covering major integration patterns (16 `.stm` files)
 - AI-oriented quick reference and compact grammar for prompts ([AI-AGENT-REFERENCE.md](../../AI-AGENT-REFERENCE.md))
 - Tree-sitter parser (482 corpus tests)
-- TypeScript CLI (`satsuma`) with 17 commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](../../SATSUMA-CLI.md)
+- TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](../../SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - `satsuma lint` with 3 policy rules and `--fix` support
 - VS Code extension with LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting)

--- a/docs/tutorials/data-engineer-tutorial.md
+++ b/docs/tutorials/data-engineer-tutorial.md
@@ -455,5 +455,5 @@ If you are ready to adopt Satsuma in your data engineering workflow, here is a p
 - **[Kimball conventions](../data-modelling/kimball/README.md)** — dimensional modelling tokens and patterns
 - **[Data Vault conventions](../data-modelling/datavault/README.md)** — hub, satellite, and link patterns
 - **[Merge strategy conventions](../conventions-for-merge-strategy/README.md)** — upsert, append, soft delete, full refresh
-- **[CLI reference](../../SATSUMA-CLI.md)** — the 16-command CLI for validation, extraction, and lineage
+- **[CLI reference](../../SATSUMA-CLI.md)** — the Satsuma CLI for validation, extraction, and lineage
 - **[Using Satsuma without CLI](../using-satsuma-without-cli.md)** — working with web LLMs and no installation

--- a/docs/tutorials/integration-engineer-tutorial.md
+++ b/docs/tutorials/integration-engineer-tutorial.md
@@ -455,7 +455,7 @@ The more integrations you document this way, the more value compounds. Your team
 - [BA Tutorial](ba-tutorial.md) — full syntax walkthrough from scratch
 - [Schema format conventions](../conventions-for-schema-formats/README.md) — metadata conventions for XML, JSON, COBOL, EDI, Protobuf, HL7, and more
 - [Using Satsuma without CLI](../using-satsuma-without-cli.md) — workflow for web LLMs without tooling
-- [CLI reference](../../SATSUMA-CLI.md) — the 16-command CLI for validation, extraction, and lineage
+- [CLI reference](../../SATSUMA-CLI.md) — the Satsuma CLI for validation, extraction, and lineage
 - [XML-to-Parquet example](../../examples/xml-to-parquet/pipeline.stm) — XML with namespaces and XPath
 - [EDI-to-JSON example](../../examples/edi-to-json/pipeline.stm) — EDI 856 with segment filters and data gaps
 - [COBOL-to-Avro example](../../examples/cobol-to-avro/pipeline.stm) — mainframe copybook to Kafka events

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -21,6 +21,7 @@
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, EXIT_NOT_FOUND } from "../command-runner.js";
+import { parsePositiveInt } from "../option-parsers.js";
 import { extractAtRefs } from "../nl-ref-extract.js";
 import { extractNLContent } from "../nl-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -39,7 +40,7 @@ export function register(program: Command): void {
   program
     .command("context <query> [path]")
     .description("Rank and emit blocks relevant to a query from a Satsuma file and its imports")
-    .option("--budget <n>", "token budget", (v: string) => parseInt(v, 10), 4000)
+    .option("--budget <n>", "token budget", parsePositiveInt, 4000)
     .option("--compact", "omit notes and transform bodies")
     .option("--json", "emit ranked JSON list")
     .addHelpText("after", `

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -15,6 +15,7 @@
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
+import { parsePositiveInt } from "../option-parsers.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
@@ -40,7 +41,7 @@ export function register(program: Command): void {
     .description("Trace the full upstream and downstream lineage of a single field")
     .option("--upstream", "only upstream chain")
     .option("--downstream", "only downstream chain")
-    .option("--depth <n>", "maximum traversal depth", (v: string) => parseInt(v, 10), 10)
+    .option("--depth <n>", "maximum traversal depth", parsePositiveInt, 10)
     .option("--json", "structured JSON output")
     .addHelpText("after", `
 Traces all fields that flow into (upstream) and out of (downstream) the given

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -18,6 +18,7 @@
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
+import { parsePositiveInt } from "../option-parsers.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { buildFullGraph } from "../schema-graph.js";
 import type { FullGraph } from "../schema-graph.js";
@@ -45,7 +46,7 @@ export function register(program: Command): void {
     .description("Trace data lineage through a Satsuma file and its imports")
     .option("--from <name>", "start node for downstream walk")
     .option("--to <name>", "target node for upstream BFS")
-    .option("--depth <n>", "maximum recursion depth", (v: string) => parseInt(v, 10), 10)
+    .option("--depth <n>", "maximum recursion depth", parsePositiveInt, 10)
     .option("--compact", "print names only")
     .option("--json", "emit {nodes, edges} DAG")
     .addHelpText("after", `

--- a/tooling/satsuma-cli/src/commands/summary.ts
+++ b/tooling/satsuma-cli/src/commands/summary.ts
@@ -15,6 +15,7 @@
 
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
+import { runCommand } from "../command-runner.js";
 import { canonicalKey } from "../index-builder.js";
 import { expandEntityFields } from "../spread-expand.js";
 import { countNlDerivedEdgesByMapping } from "../nl-ref-extract.js";
@@ -52,7 +53,7 @@ Examples:
   satsuma summary pipeline.stm           # human overview
   satsuma summary pipeline.stm --json    # structured index
   satsuma summary pipeline.stm --compact # names only`)
-    .action(async (pathArg: string | undefined, opts: { compact?: boolean; json?: boolean }) => {
+    .action(runCommand(async (pathArg: string | undefined, opts: { compact?: boolean; json?: boolean }) => {
       const { files: parsed, index } = await loadWorkspace(pathArg);
 
       if (opts.json) {
@@ -62,7 +63,7 @@ Examples:
       } else {
         printDefault(index, parsed.length);
       }
-    });
+    }));
 }
 
 // ── Formatters ────────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/option-parsers.ts
+++ b/tooling/satsuma-cli/src/option-parsers.ts
@@ -1,0 +1,42 @@
+/**
+ * option-parsers.ts — Shared coercion functions for Commander option values.
+ *
+ * Owns the argument-validation layer that sits between the raw CLI string
+ * and a command handler: a handler that declares `--depth <n>` through one
+ * of these parsers can trust it receives a number in range, never NaN.
+ *
+ * Why this exists (sl-bvd0): the numeric options used bare `parseInt`, so
+ * `--depth banana` became NaN and `--budget banana` silently disabled the
+ * budget — garbage input changed behaviour instead of failing. Throwing
+ * Commander's InvalidArgumentError here makes bad values surface as a
+ * standard usage error (message + help via showHelpAfterError, exit 1),
+ * the same way Commander reports an unknown option.
+ *
+ * This module owns option *coercion* only — exit policy for handler
+ * failures stays in command-runner.ts.
+ */
+
+import { InvalidArgumentError } from "commander";
+
+// Strictly positive decimal integers only. Anchored so trailing garbage
+// ("12abc") and signs/decimals ("-1", "3.5") are rejected rather than
+// silently truncated by parseInt.
+const POSITIVE_INT_PATTERN = /^[0-9]+$/;
+
+/**
+ * Commander coercion for options that must be a positive integer (>= 1),
+ * such as `--depth` and `--budget`. Zero is rejected: a zero depth or
+ * budget would make the command emit nothing, which is never what the
+ * user meant.
+ *
+ * @param value  raw option value as typed on the command line.
+ * @returns the parsed integer.
+ * @throws InvalidArgumentError for anything that is not a whole number >= 1.
+ */
+export function parsePositiveInt(value: string): number {
+  const parsed = POSITIVE_INT_PATTERN.test(value) ? parseInt(value, 10) : NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new InvalidArgumentError("Expected a positive whole number (1 or greater).");
+  }
+  return parsed;
+}

--- a/tooling/satsuma-cli/test/docs.test.ts
+++ b/tooling/satsuma-cli/test/docs.test.ts
@@ -1,0 +1,54 @@
+/**
+ * docs.test.ts — Keeps the CLI reference (SATSUMA-CLI.md) in sync with the
+ * commands the binary actually registers.
+ *
+ * Regression coverage for sl-w1dr: the CLI grew to 22 commands while
+ * SATSUMA-CLI.md documented 21 (nl-refs was missing) and other docs still
+ * claimed 16. Living docs no longer hardcode a command count; this test is
+ * the check that every shipped command is documented, so a newly registered
+ * command fails CI until its reference entry exists.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { run as runCli } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+const CLI_REFERENCE = resolve(__dirname, "../../../SATSUMA-CLI.md");
+
+// Commander adds an implicit `help` subcommand; it is CLI plumbing, not part
+// of the documented command surface.
+const IMPLICIT_COMMANDS = new Set(["help"]);
+
+/** Parse registered command names from the `Commands:` section of --help. */
+function commandNamesFromHelp(helpText: string): string[] {
+  const commandsSection = helpText.slice(helpText.indexOf("Commands:"));
+  const names = [...commandsSection.matchAll(/^ {2}([a-z][a-z-]*)/gm)]
+    .map((m) => m[1]!)
+    .filter((name) => !IMPLICIT_COMMANDS.has(name));
+  return [...new Set(names)];
+}
+
+describe("SATSUMA-CLI.md command coverage", () => {
+  it("documents every command the CLI registers", async () => {
+    const { stdout, code } = await runCli(CLI, "--help");
+    assert.equal(code, 0);
+
+    const names = commandNamesFromHelp(stdout);
+    // Sanity floor: if help parsing ever breaks, fail loudly here rather
+    // than silently asserting nothing below.
+    assert.ok(names.length >= 20, `expected to parse a full command list from --help, got ${names.length}`);
+
+    const reference = readFileSync(CLI_REFERENCE, "utf8");
+    const undocumented = names.filter((name) => !reference.includes(`\`${name}`));
+    assert.deepEqual(
+      undocumented,
+      [],
+      `commands missing from SATSUMA-CLI.md: ${undocumented.join(", ")}`,
+    );
+  });
+});

--- a/tooling/satsuma-cli/test/option-parsers.test.ts
+++ b/tooling/satsuma-cli/test/option-parsers.test.ts
@@ -1,0 +1,69 @@
+/**
+ * option-parsers.test.ts — Coverage for shared Commander option coercions.
+ *
+ * Unit-tests the parsePositiveInt contract once, then verifies through the
+ * built CLI that each numeric option (--depth, --budget) is actually wired
+ * through the parser — regression coverage for sl-bvd0, where bare parseInt
+ * let garbage values silently change command behaviour (NaN depth printed
+ * only the start node; NaN budget disabled the budget entirely).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { InvalidArgumentError } from "commander";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parsePositiveInt } from "../src/option-parsers.js";
+import { run as runCli } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+const LINEAGE_CHAIN = resolve(__dirname, "fixtures/lineage-chain.stm");
+const PLATFORM = resolve(__dirname, "fixtures/platform.stm");
+
+const run = (...args: string[]) => runCli(CLI, ...args);
+
+describe("parsePositiveInt", () => {
+  it("parses positive whole numbers", () => {
+    // The happy path must return a real number, not a string, so handlers
+    // can use it directly in depth/budget arithmetic.
+    assert.equal(parsePositiveInt("1"), 1);
+    assert.equal(parsePositiveInt("4000"), 4000);
+  });
+
+  it("rejects values that are not whole numbers >= 1", () => {
+    // Each rejected shape was previously accepted by bare parseInt:
+    // "banana" -> NaN, "-1" -> -1, "0" -> 0, "12abc" -> 12, "3.5" -> 3.
+    // All must now raise Commander's usage error instead of silently
+    // changing behaviour.
+    for (const bad of ["banana", "-1", "0", "12abc", "3.5", ""]) {
+      assert.throws(() => parsePositiveInt(bad), InvalidArgumentError, `expected "${bad}" to be rejected`);
+    }
+  });
+});
+
+describe("numeric options reject garbage as a usage error", () => {
+  it("lineage --depth banana exits non-zero with an invalid-argument message", async () => {
+    // Before sl-bvd0 this printed only the start node and exited 0.
+    const { stderr, code } = await run("lineage", "--from", "source_a", "--depth", "banana", LINEAGE_CHAIN);
+
+    assert.notEqual(code, 0);
+    assert.match(stderr, /option '--depth <n>' argument 'banana' is invalid/);
+  });
+
+  it("field-lineage --depth -1 exits non-zero with an invalid-argument message", async () => {
+    // Negative depths previously walked nothing and annotated the start node [?].
+    const { stderr, code } = await run("field-lineage", "schema_b.field_b", "--depth", "-1", LINEAGE_CHAIN);
+
+    assert.notEqual(code, 0);
+    assert.match(stderr, /option '--depth <n>' argument '-1' is invalid/);
+  });
+
+  it("context --budget 0 exits non-zero with an invalid-argument message", async () => {
+    // A NaN/zero budget previously disabled budgeting and emitted all blocks.
+    const { stderr, code } = await run("context", "customer", "--budget", "0", PLATFORM);
+
+    assert.notEqual(code, 0);
+    assert.match(stderr, /option '--budget <n>' argument '0' is invalid/);
+  });
+});

--- a/tooling/satsuma-cli/test/summary.test.ts
+++ b/tooling/satsuma-cli/test/summary.test.ts
@@ -79,4 +79,16 @@ describe("satsuma summary", () => {
     assert.equal(data.questionCount, 0);
     assert.equal(data.totalErrors, 0);
   });
+
+  it("reports an unresolvable path as a bare CommandError message, not an unhandled rejection", async () => {
+    // Regression for sl-00rw: summary was the only command not wrapped in
+    // runCommand, so loadWorkspace failures escaped to the unhandledRejection
+    // net and were prefixed "Unhandled error:" — breaking the error-message
+    // contract shared by every other command.
+    const { stderr, code } = await run("summary", "/nonexistent/path.stm");
+
+    assert.equal(code, 2);
+    assert.match(stderr, /^Error resolving path/);
+    assert.doesNotMatch(stderr, /Unhandled error:/);
+  });
 });

--- a/tooling/satsuma-lsp/src/action-context.ts
+++ b/tooling/satsuma-lsp/src/action-context.ts
@@ -1,5 +1,5 @@
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { child, children, labelText } from "./parser-utils";
+import { child, children, labelText, nodeAtPosition } from "./parser-utils";
 import { findNodeContext, type NodeContext } from "./definition";
 import type { WorkspaceIndex } from "./workspace-index";
 import { sourceRefText } from "@satsuma/core";
@@ -18,10 +18,7 @@ export function computeActionContext(
   _uri: string,
   _index: WorkspaceIndex,
 ): ActionContext {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) {
     return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
   }

--- a/tooling/satsuma-lsp/src/completion.ts
+++ b/tooling/satsuma-lsp/src/completion.ts
@@ -3,7 +3,7 @@ import {
   CompletionItemKind,
 } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { child } from "./parser-utils";
+import { child, nodeAtPosition } from "./parser-utils";
 import { sourceRefStructuralText } from "@satsuma/core";
 import {
   WorkspaceIndex,
@@ -22,10 +22,7 @@ export function computeCompletions(
   _uri: string,
   index: WorkspaceIndex,
 ): CompletionItem[] {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return [];
 
   const ctx = detectCompletionContext(node);

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -1,7 +1,7 @@
 import { Location } from "vscode-languageserver";
 import { createAtRefRegex, fieldNameText, qualifiedNameText, sourceRefText } from "@satsuma/core";
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { child, children, labelText } from "./parser-utils";
+import { child, children, labelText, nodeAtPosition } from "./parser-utils";
 import {
   WorkspaceIndex,
   resolveDefinition,
@@ -19,10 +19,7 @@ export function computeDefinition(
   uri: string,
   index: WorkspaceIndex,
 ): Location | Location[] | null {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return null;
 
   // Check if cursor is on an @ref inside an NL string

--- a/tooling/satsuma-lsp/src/hover.ts
+++ b/tooling/satsuma-lsp/src/hover.ts
@@ -1,6 +1,6 @@
 import { Hover, MarkupKind } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
-import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
+import { nodeRange, child, children, labelText, stringText, nodeAtPosition } from "./parser-utils";
 import { isMetricSchema } from "@satsuma/core";
 
 // Maximum number of fields shown in a schema/fragment hover preview.
@@ -19,10 +19,7 @@ export function computeHover(
   line: number,
   character: number,
 ): Hover | null {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return null;
 
   // Walk up the tree to find a meaningful hover target

--- a/tooling/satsuma-lsp/src/parser-utils.ts
+++ b/tooling/satsuma-lsp/src/parser-utils.ts
@@ -76,6 +76,48 @@ export function parseSource(source: string): Tree {
   return tree;
 }
 
+// ---------- Cursor-position node resolution ----------
+
+// A node is "word-like" if it is a leaf token whose text contains at least
+// one word character — identifiers, field names, labels, string tokens.
+// Punctuation tokens ("." "{" "->") are not word-like, so the end-of-word
+// retry in nodeAtPosition never hijacks a cursor that legitimately sits on
+// punctuation or in open space.
+const WORD_CHAR = /\w/;
+
+function isWordToken(node: Node): boolean {
+  return node.childCount === 0 && WORD_CHAR.test(node.text);
+}
+
+/**
+ * Resolve the CST node the user means when their cursor is at the given
+ * LSP position.
+ *
+ * tree-sitter node ranges are half-open, so `descendantForPosition` with
+ * the raw position resolves a cursor sitting immediately *after* the last
+ * character of an identifier to the *following* node — which made
+ * go-to-definition, hover, references, rename, completion, and code
+ * actions fail at word end while working mid-word (sl-ogd5). Like
+ * standard LSP servers, when the node at the raw position is not itself
+ * a word token we retry one column to the left and prefer a word token
+ * found there. Mid-word and word-start cursors are unaffected: the raw
+ * position already resolves to the word token. Cursors separated from
+ * the previous word by whitespace are also unaffected: the left retry
+ * lands on the whitespace, which resolves to a non-leaf parent.
+ *
+ * All position-based handlers must resolve their start node through this
+ * helper rather than calling `descendantForPosition` directly.
+ */
+export function nodeAtPosition(tree: Tree, line: number, character: number): Node | null {
+  const exact = tree.rootNode.descendantForPosition({ row: line, column: character });
+  if (exact && isWordToken(exact)) return exact;
+  if (character > 0) {
+    const left = tree.rootNode.descendantForPosition({ row: line, column: character - 1 });
+    if (left && isWordToken(left)) return left;
+  }
+  return exact ?? null;
+}
+
 // ---------- CST → LSP helpers ----------
 
 /** Convert a tree-sitter node span to an LSP Range. */

--- a/tooling/satsuma-lsp/src/references.ts
+++ b/tooling/satsuma-lsp/src/references.ts
@@ -1,5 +1,6 @@
 import { Location } from "vscode-languageserver";
 import type { Tree } from "./parser-utils";
+import { nodeAtPosition } from "./parser-utils";
 import { findNodeContext } from "./definition";
 import {
   WorkspaceIndex,
@@ -19,10 +20,7 @@ export function computeReferences(
   index: WorkspaceIndex,
   includeDeclaration: boolean,
 ): Location[] {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return [];
 
   const ctx = findNodeContext(node);

--- a/tooling/satsuma-lsp/src/rename.ts
+++ b/tooling/satsuma-lsp/src/rename.ts
@@ -4,7 +4,7 @@ import {
   TextEdit,
 } from "vscode-languageserver";
 import type { Tree } from "./parser-utils";
-import { nodeRange } from "./parser-utils";
+import { nodeRange, nodeAtPosition } from "./parser-utils";
 import { findNodeContext, NodeContext } from "./definition";
 import {
   WorkspaceIndex,
@@ -22,10 +22,7 @@ export function prepareRename(
   _uri: string,
   _index: WorkspaceIndex,
 ): { range: Range; placeholder: string } | null {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return null;
 
   const ctx = findNodeContext(node);
@@ -59,10 +56,7 @@ export function computeRename(
   index: WorkspaceIndex,
   newName: string,
 ): WorkspaceEdit | null {
-  const node = tree.rootNode.descendantForPosition({
-    row: line,
-    column: character,
-  });
+  const node = nodeAtPosition(tree, line, character);
   if (!node) return null;
 
   const ctx = findNodeContext(node);

--- a/tooling/satsuma-lsp/test/definition.test.js
+++ b/tooling/satsuma-lsp/test/definition.test.js
@@ -58,6 +58,32 @@ mapping \`test\` {
     }
   });
 
+  it("jumps to definition when the cursor sits at the end of the identifier (sl-ogd5)", () => {
+    // tree-sitter ranges are half-open: before nodeAtPosition, a cursor
+    // immediately after "customers" resolved to the following node and
+    // go-to-definition returned null at word end while working mid-word.
+    const result = definition(
+      {
+        "file:///a.stm": `schema customers {
+  id UUID (pk)
+  name VARCHAR
+}
+mapping \`test\` {
+  source { customers }
+  target { dim }
+  id -> id
+}`,
+      },
+      "file:///a.stm",
+      5,
+      20, // cursor immediately after the final "s" of "customers"
+    );
+    assert.ok(result, "expected a definition at end-of-identifier cursor");
+    const loc = Array.isArray(result) ? result[0] : result;
+    assert.equal(loc.uri, "file:///a.stm");
+    assert.equal(loc.range.start.line, 0);
+  });
+
   it("jumps from target ref to schema definition", () => {
     const result = definition(
       {

--- a/tooling/satsuma-lsp/test/hover.test.js
+++ b/tooling/satsuma-lsp/test/hover.test.js
@@ -31,6 +31,18 @@ describe("computeHover", () => {
     assert.ok(md.includes("*(pk)*"));
   });
 
+  it("shows the schema summary when the cursor sits at the end of the block label (sl-ogd5)", () => {
+    // Word-end regression: column 16 is immediately after the final "s" of
+    // "customers"; hover must resolve the label, not the following node.
+    const md = hover(
+      "schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}",
+      0,
+      16,
+    );
+    assert.ok(md, "expected hover content at end-of-identifier cursor");
+    assert.ok(md.includes("**schema** `customers`"));
+  });
+
   it("shows fragment summary on block label", () => {
     const md = hover(
       "fragment audit {\n  created_at TIMESTAMPTZ\n  updated_at TIMESTAMPTZ\n}",

--- a/tooling/satsuma-lsp/test/parser-utils.test.js
+++ b/tooling/satsuma-lsp/test/parser-utils.test.js
@@ -1,0 +1,69 @@
+/**
+ * parser-utils.test.js — Coverage for nodeAtPosition, the shared
+ * cursor-position resolver used by every position-based LSP handler.
+ *
+ * Regression suite for sl-ogd5: tree-sitter ranges are half-open, so the
+ * raw descendantForPosition lookup resolved a cursor immediately after the
+ * last character of an identifier to the *following* node, making all
+ * position-based features fail at word end while working mid-word.
+ */
+const { describe, it, before } = require("node:test");
+const assert = require("node:assert/strict");
+const { initTestParser, parse } = require("./helper");
+const { nodeAtPosition } = require("../dist/parser-utils");
+
+before(async () => { await initTestParser(); });
+
+// Column reference for the fixture below (line 4):
+//   "  source { customers }"
+//    0123456789…
+// "customers" spans columns 11–20 (end-exclusive).
+const SOURCE = `schema customers {
+  id UUID (pk)
+}
+mapping \`test\` {
+  source { customers }
+  target { dim }
+  id -> id
+}`;
+
+describe("nodeAtPosition", () => {
+  it("resolves the identifier when the cursor sits immediately after its last character", () => {
+    // The core sl-ogd5 case: position 20 is the half-open end of
+    // "customers", where the raw lookup returns the following node.
+    const tree = parse(SOURCE);
+    const node = nodeAtPosition(tree, 4, 20);
+    assert.equal(node.text, "customers");
+  });
+
+  it("resolves the identifier for mid-word and word-start cursors", () => {
+    // Guards that the end-of-word retry does not disturb the positions
+    // that already worked before the fix.
+    const tree = parse(SOURCE);
+    assert.equal(nodeAtPosition(tree, 4, 15).text, "customers");
+    assert.equal(nodeAtPosition(tree, 4, 11).text, "customers");
+  });
+
+  it("treats a cursor after a word-then-whitespace boundary as end of that word only when adjacent", () => {
+    // Line 6 is "  id -> id". Column 4 sits immediately after "id" → the
+    // word wins. Column 5 is separated from "id" by a space → the retry
+    // must not reach back across the whitespace.
+    const tree = parse(SOURCE);
+    assert.equal(nodeAtPosition(tree, 6, 4).text, "id");
+    assert.notEqual(nodeAtPosition(tree, 6, 5).text, "id");
+  });
+
+  it("leaves cursors on punctuation on the punctuation node", () => {
+    // Column 6 is inside "->" on line 6. The word-token preference must
+    // not pull the cursor off a punctuation token the user is actually on.
+    const tree = parse(SOURCE);
+    assert.equal(nodeAtPosition(tree, 6, 6).text, "->");
+  });
+
+  it("returns a node for column 0 without attempting a negative retry", () => {
+    // Word-start at the line origin: there is no column -1 to retry, and
+    // the raw position already resolves the token.
+    const tree = parse(SOURCE);
+    assert.equal(nodeAtPosition(tree, 0, 0).text, "schema");
+  });
+});


### PR DESCRIPTION
Fixes four P3 tickets from the 2026-06 bug hunt (tagged `bug-hunt`).

## sl-00rw — cli: summary bypasses runCommand error contract
`summary` was the only command whose handler was not wrapped in `runCommand`, so workspace-load failures escaped to the `unhandledRejection` net: messages gained an `Unhandled error:` prefix and exit skipped the stdout drain that prevents truncated piped `--json`. Now wrapped like every other command, with a subprocess regression test.

## sl-bvd0 — cli: --depth/--budget accept garbage
`lineage --depth`, `field-lineage --depth`, and `context --budget` used bare `parseInt`, so `banana`/`-1`/`0` silently changed behaviour (NaN depth printed only the start node; NaN budget disabled budgeting). Added `src/option-parsers.ts` with a strict `parsePositiveInt` coercion that raises Commander's `InvalidArgumentError` as a standard usage error. Unit tests pin the parser; subprocess tests pin the wiring.

## sl-ogd5 — lsp: position handlers fail at end-of-identifier cursor
tree-sitter ranges are half-open, so all seven position-based handlers resolved a cursor immediately after an identifier's last character to the *following* node — go-to-definition, hover, references, completion, rename, and code actions failed at word end. Added a shared `nodeAtPosition` resolver in `parser-utils.ts` (retry one column left, prefer word tokens; punctuation and whitespace-separated cursors unaffected) and routed all handlers through it. Unit tests cover the boundary behaviour; definition/hover gain end-of-word regression cases.

## sl-w1dr — docs: CLI command count drift
Documented `nl-refs` in SATSUMA-CLI.md (the one missing command), de-numbered every hardcoded command-count claim in living docs (AGENTS.md, README.md, PROJECT-OVERVIEW.md, both tutorials — they said 16/17/21 against 22 real commands), and added `test/docs.test.ts`, which parses the command list from `satsuma --help` and fails when a registered command has no SATSUMA-CLI.md entry (verified to fail with the `nl-refs` row removed).

## Notes
- Rebased onto main after the parallel P0 fixes (sl-xf3f, sl-7236) merged; full LSP (258) and CLI (851) suites pass post-rebase.
- ADR assessment: not warranted — bug fixes that preserve the existing design; the two new helpers are tactical utilities documented inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)