### PR TITLE
fix(lsp): rename no longer deletes source_ref metadata or spread sigils (sl-kf1r)

### DIFF
--- a/.tickets/sl-kf1r.md
+++ b/.tickets/sl-kf1r.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kf1r
-status: in_progress
+status: closed
 deps: []
 links: [sl-xf3f]
 created: 2026-06-11T06:32:46Z
@@ -17,3 +17,10 @@ Two more reference-index entry kinds in satsuma-viz-backend/src/workspace-index.
 
 source_ref reference ranges cover only the name node (qualified_name/backtick_name/identifier), never the metadata block; fragment_spread reference ranges cover only the spread_label; rename round-trip tests prove metadata blocks and ... sigils survive; both spread indexing sites (mapping bodies and schema/fragment bodies) covered.
 
+
+## Notes
+
+**2026-06-11T06:39:45Z**
+
+Cause: Same destructive-rename class as sl-xf3f — source/target reference entries stored nodeRange(source_ref) which includes the optional metadata_block, and both fragment-spread indexing sites stored nodeRange(fragment_spread) which includes the "..." sigil; rename.ts replaces the stored range verbatim.
+Fix: source/target ranges now cover only the name node inside source_ref (sourceRefNameRange helper), and both spread sites store the spread_label range only. Rename round-trip tests prove the metadata block and the spread sigil survive; exact-range index tests pin the spans. (commit 377e0c8)

--- a/.tickets/sl-kf1r.md
+++ b/.tickets/sl-kf1r.md
@@ -1,0 +1,19 @@
+---
+id: sl-kf1r
+status: in_progress
+deps: []
+links: [sl-xf3f]
+created: 2026-06-11T06:32:46Z
+type: bug
+priority: 0
+assignee: Thorben Louw
+tags: [bug-hunt, lsp]
+---
+# lsp: rename clobbers source_ref metadata and fragment spread sigils — whole-node reference ranges
+
+Two more reference-index entry kinds in satsuma-viz-backend/src/workspace-index.ts store ranges wider than the name they are keyed under, and rename.ts replaces the stored range verbatim (same destructive-edit class as sl-xf3f). (1) Source/target refs (indexMappingRefs ~656/668) store nodeRange(source_ref), and source_ref = name + optional metadata_block — renaming schema customers -> clients turns 'source { customers (note "refreshed daily") }' into 'source { clients }', silently deleting the metadata/note. (2) Fragment spreads (indexArrowSpreadRefs ~701 and indexSpreadRefs ~969) store nodeRange(fragment_spread), which includes the '...' sigil — renaming fragment audit_fields -> tracking_fields turns '...audit_fields' into 'tracking_fields', deleting the sigil and leaving an invalid declaration. Both proven via prepare-approved computeRename round trips against current main (197ac2e). Import-name and metric_source entries already store exact ranges. Same wide ranges also make Find All References highlight metadata blocks and spread sigils.
+
+## Acceptance Criteria
+
+source_ref reference ranges cover only the name node (qualified_name/backtick_name/identifier), never the metadata block; fragment_spread reference ranges cover only the spread_label; rename round-trip tests prove metadata blocks and ... sigils survive; both spread indexing sites (mapping bodies and schema/fragment bodies) covered.
+

--- a/.tickets/sl-xf3f.md
+++ b/.tickets/sl-xf3f.md
@@ -2,7 +2,7 @@
 id: sl-xf3f
 status: closed
 deps: []
-links: [sl-p256]
+links: [sl-p256, sl-kf1r]
 created: 2026-06-11T02:41:29Z
 type: bug
 priority: 0

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -231,6 +231,54 @@ schema customers {
     );
   });
 
+  it("preserves a source ref's metadata block when renaming the referenced schema", () => {
+    // sl-kf1r: source/target refs were indexed with the range of the whole
+    // source_ref node, which includes the optional metadata block — renaming
+    // customers -> clients turned `customers (note "refreshed daily")` into
+    // `clients`, silently deleting the note.
+    const source =
+      'schema customers {\n  id UUID\n}\nmapping `m` {\n  source { customers (note "refreshed daily") }\n  target { dim }\n  id -> id\n}';
+    const { index, trees } = buildIndex({ "file:///a.stm": source });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(source, edit.changes["file:///a.stm"]);
+    assert.ok(
+      renamed.includes('source { clients (note "refreshed daily") }'),
+      `expected the metadata block to survive the rename, got: ${renamed}`,
+    );
+  });
+
+  it("preserves the ... sigil when renaming a fragment used as a spread", () => {
+    // sl-kf1r: spread refs were indexed with the range of the whole
+    // fragment_spread node, which includes the "..." sigil — renaming the
+    // fragment turned "...audit_fields" into "tracking_fields", deleting the
+    // sigil and leaving an invalid declaration.
+    const source =
+      "fragment audit_fields {\n  ts TIMESTAMP\n}\nschema customers {\n  id UUID\n  ...audit_fields\n}";
+    const { index, trees } = buildIndex({ "file:///a.stm": source });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      10,
+      "file:///a.stm",
+      index,
+      "tracking_fields",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(source, edit.changes["file:///a.stm"]);
+    assert.ok(
+      renamed.includes("...tracking_fields"),
+      `expected the spread sigil to survive the rename, got: ${renamed}`,
+    );
+  });
+
   it("renames from a reference site", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -589,6 +589,44 @@ describe("reference range precision (sl-xf3f)", () => {
     // A range including the @ deletes the sigil on rename, breaking the ref.
     assert.equal(textAt(source, refs[0].range), "customers");
   });
+
+  it("source ref range covers only the name, not its metadata block", () => {
+    // sl-kf1r: source_ref = name + optional metadata_block. A range spanning
+    // the whole source_ref deletes the metadata on rename.
+    const source = `mapping test {
+  source { customers (note "refreshed daily") }
+  target { dim }
+  id -> id
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "source");
+    assert.equal(refs.length, 1);
+    assert.equal(textAt(source, refs[0].range), "customers");
+  });
+
+  it("fragment spread range covers only the label, not the ... sigil", () => {
+    // sl-kf1r: fragment_spread = "..." + spread_label. A range including the
+    // sigil deletes it on rename, leaving an invalid declaration. Covers both
+    // indexing sites: schema bodies and mapping arrow bodies.
+    const source = `fragment audit_fields {
+  ts TIMESTAMP
+}
+schema customers {
+  id UUID
+  ...audit_fields
+}
+mapping test {
+  source { customers }
+  target { dim }
+  id -> id { ...audit_fields }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("audit_fields") || []).filter((r) => r.context === "spread");
+    assert.equal(refs.length, 2);
+    for (const ref of refs) {
+      assert.equal(textAt(source, ref.range), "audit_fields");
+    }
+  });
 });
 
 describe("NL string reference indexing", () => {

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -655,7 +655,7 @@ function indexMappingRefs(
         if (name) {
           addReference(index, name, {
             uri,
-            range: nodeRange(ref),
+            range: sourceRefNameRange(ref),
             name,
             context: "source",
           });
@@ -667,7 +667,7 @@ function indexMappingRefs(
         if (name) {
           addReference(index, name, {
             uri,
-            range: nodeRange(ref),
+            range: sourceRefNameRange(ref),
             name,
             context: "target",
           });
@@ -687,6 +687,24 @@ function indexMappingRefs(
   indexNlRefs(index, uri, body);
 }
 
+/**
+ * Range of the name node inside a source_ref — the qualified_name,
+ * backtick_name, or identifier that sourceRefStructuralText reads. A
+ * source_ref may also carry a metadata_block (`customers (note "...")`);
+ * rename replaces the stored range verbatim, so the range must cover only
+ * the name or the metadata is deleted along with it (sl-kf1r). Falls back
+ * to the whole node on unexpected shapes (error recovery).
+ */
+function sourceRefNameRange(ref: SyntaxNode): Range {
+  const nameNode = ref.namedChildren.find(
+    (c) =>
+      c.type === "qualified_name" ||
+      c.type === "backtick_name" ||
+      c.type === "identifier",
+  );
+  return nameNode ? nodeRange(nameNode) : nodeRange(ref);
+}
+
 function indexArrowSpreadRefs(
   index: WorkspaceIndex,
   uri: string,
@@ -697,10 +715,13 @@ function indexArrowSpreadRefs(
     if (n.type === "fragment_spread") {
       const sl = child(n, "spread_label");
       const name = sl ? spreadLabelText(sl) : null;
-      if (name) {
+      if (name && sl) {
         addReference(index, name, {
           uri,
-          range: nodeRange(n),
+          // Range covers the spread_label only — the "..." sigil is spread
+          // syntax, not part of the fragment name, and must survive a rename
+          // (sl-kf1r).
+          range: nodeRange(sl),
           name,
           context: "spread",
         });
@@ -965,10 +986,11 @@ function indexSpreadRefs(
   for (const spread of children(body, "fragment_spread")) {
     const sl = child(spread, "spread_label");
     const name = sl ? spreadLabelText(sl) : null;
-    if (name) {
+    if (name && sl) {
       addReference(index, name, {
         uri,
-        range: nodeRange(spread),
+        // Spread_label only — the "..." sigil must survive a rename (sl-kf1r).
+        range: nodeRange(sl),
         name,
         context: "spread",
       });


### PR DESCRIPTION
## Summary

Fixes sl-kf1r (follow-up to sl-xf3f / #281, same destructive-edit class): two more reference-index entry kinds in the shared workspace index stored ranges wider than the name they were keyed under, and rename replaces the stored range verbatim:

- **Source/target refs** stored `nodeRange(source_ref)`, and a `source_ref` is `name + optional metadata_block` — renaming schema `customers` → `clients` turned `source { customers (note "refreshed daily") }` into `source { clients }`, silently deleting the metadata.
- **Fragment spreads** (both indexing sites: schema bodies via `indexSpreadRefs`, mapping arrow bodies via `indexArrowSpreadRefs`) stored `nodeRange(fragment_spread)`, which includes the `...` sigil — renaming fragment `audit_fields` → `tracking_fields` turned `...audit_fields` into `tracking_fields`, deleting the sigil and leaving an invalid declaration.

Both proven with prepare-approved `computeRename` round trips against main before the fix.

## Fix

- Source/target reference ranges now cover only the name node inside the `source_ref` (`qualified_name` / `backtick_name` / `identifier`) via a new `sourceRefNameRange` helper.
- Both spread sites store the `spread_label` range only.

Import-name and metric-source entries were audited and already store exact ranges.

## Tests

- Rename round-trips: the metadata block and the `...` sigil survive the rename.
- Exact-range index tests: source ref with metadata, and spreads at both indexing sites.
- All four new tests fail against the previous ranges (verified by stashing the fix).
- Full suites green: viz-backend 155, lsp 255, viz 65, cli 844.

Closes sl-kf1r.

🤖 Generated with [Claude Code](https://claude.com/claude-code)