### PR TITLE
fix(cli): stop dropping same-line arrows that share a target (sl-201z)

### DIFF
--- a/.tickets/sl-201z.md
+++ b/.tickets/sl-201z.md
@@ -1,6 +1,6 @@
 ---
 id: sl-201z
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:28Z
@@ -17,3 +17,12 @@ Arrow dedup key is file:line:target in satsuma-cli/src/commands/graph-builder.ts
 
 Dedup keys include sources in all three sites; graph/field-lineage/nl-refs report both same-line arrows; regression test with two arrows sharing line and target.
 
+
+## Notes
+
+**2026-06-11T07:07:47Z**
+
+**2026-06-11T07:10:00Z**
+
+Cause: Three fieldArrows walk sites (graph-builder, field-lineage, nl-ref-extract) deduplicated arrow records by file:line:target, which collides for two distinct arrows on one line sharing a target field; the second arrow was silently dropped from graph edges, lineage, and declared-arrow coverage. diff-engine's file:line:sources:target key had the same flaw for arrows also sharing sources.
+Fix: Added distinctArrowRecords() to index-builder, deduplicating by object reference (records are shared, never cloned, across index keys — same pattern core validate.ts uses), and switched all four sites to it. Regression fixture covers graph, field-lineage, and summary nl-derived coverage. (commit 0239e89)

--- a/.tickets/sl-201z.md
+++ b/.tickets/sl-201z.md
@@ -1,6 +1,6 @@
 ---
 id: sl-201z
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-06-11T02:40:28Z

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -16,7 +16,7 @@ import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
 import { parsePositiveInt } from "../option-parsers.js";
-import { resolveIndexKey, canonicalKey } from "../index-builder.js";
+import { resolveIndexKey, canonicalKey, distinctArrowRecords } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import { expandEntityFields } from "../spread-expand.js";
 import { collectFieldNames, findFieldByPath, qualifyField } from "@satsuma/core";
@@ -144,41 +144,35 @@ Examples:
  */
 function buildFieldEdgeGraph(index: ExtractedWorkspace): FieldEdgeEntry[] {
   const edges: FieldEdgeEntry[] = [];
-  const seen = new Set<string>();
 
-  // Declared arrows from the field arrows index
-  for (const [, records] of index.fieldArrows) {
-    for (const record of records) {
-      const dedupKey = `${record.file}:${record.line}:${record.target}`;
-      if (seen.has(dedupKey)) continue;
-      seen.add(dedupKey);
+  // Declared arrows from the field arrows index, deduplicated by reference
+  // (see distinctArrowRecords for why a positional key is not a safe identity).
+  for (const record of distinctArrowRecords(index.fieldArrows)) {
+    const mappingKey = canonicalKey(
+      record.namespace ? `${record.namespace}::${record.mapping}` : (record.mapping ?? ""),
+    );
 
-      const mappingKey = canonicalKey(
-        record.namespace ? `${record.namespace}::${record.mapping}` : (record.mapping ?? ""),
-      );
+    const mapping = index.mappings.get(
+      record.namespace ? `${record.namespace}::${record.mapping}` : (record.mapping ?? ""),
+    );
+    const sourceSchemas = mapping?.sources ?? [];
+    const targetSchemas = mapping?.targets ?? [];
 
-      const mapping = index.mappings.get(
-        record.namespace ? `${record.namespace}::${record.mapping}` : (record.mapping ?? ""),
-      );
-      const sourceSchemas = mapping?.sources ?? [];
-      const targetSchemas = mapping?.targets ?? [];
+    const toField = record.target
+      ? canonicalKey(qualifyField(record.target, targetSchemas))
+      : null;
+    if (!toField) continue;
 
-      const toField = record.target
-        ? canonicalKey(qualifyField(record.target, targetSchemas))
+    for (const src of record.sources.length > 0 ? record.sources : [null]) {
+      const fromField = src
+        ? canonicalKey(qualifyField(src, sourceSchemas))
         : null;
-      if (!toField) continue;
-
-      for (const src of record.sources.length > 0 ? record.sources : [null]) {
-        const fromField = src
-          ? canonicalKey(qualifyField(src, sourceSchemas))
-          : null;
-        edges.push({
-          from: fromField,
-          to: toField,
-          via_mapping: mappingKey,
-          classification: record.classification,
-        });
-      }
+      edges.push({
+        from: fromField,
+        to: toField,
+        via_mapping: mappingKey,
+        classification: record.classification,
+      });
     }
   }
 

--- a/tooling/satsuma-cli/src/commands/graph-builder.ts
+++ b/tooling/satsuma-cli/src/commands/graph-builder.ts
@@ -11,7 +11,7 @@
  */
 
 import { resolve } from "node:path";
-import { canonicalKey, qualifyField } from "../index-builder.js";
+import { canonicalKey, distinctArrowRecords, qualifyField } from "../index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
 import { extractAtRefs, classifyRef, resolveRef, resolveAllNLRefs } from "../nl-ref-extract.js";
 import type { ExtractedWorkspace, FieldDecl } from "../types.js";
@@ -408,44 +408,37 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
   const edges: FieldEdge[] = [];
   const unresolvedNl: Array<{ scope: string; arrow: string; text: string; file: string; line: number }> = [];
 
-  // Iterate all arrow records via the fieldArrows index.
-  // fieldArrows duplicates records under multiple keys, so deduplicate here.
-  const seen = new Set<string>();
+  // Iterate all arrow records via the fieldArrows index. distinctArrowRecords
+  // deduplicates the multi-key registrations by reference — see its doc-comment
+  // for why a positional key is not a safe identity here.
+  for (const record of distinctArrowRecords(index.fieldArrows)) {
+    const mappingKey = record.namespace
+      ? `${record.namespace}::${record.mapping}`
+      : (record.mapping ?? "");
 
-  for (const [_key, records] of index.fieldArrows) {
-    for (const record of records) {
-      // Deduplicate — same arrow record may appear under multiple keys
-      const dedupKey = `${record.file}:${record.line}:${record.target}`;
-      if (seen.has(dedupKey)) continue;
-      seen.add(dedupKey);
-
-      const mappingKey = record.namespace
-        ? `${record.namespace}::${record.mapping}`
-        : (record.mapping ?? "");
-
-      if (nsFilter) {
-        const mapping = index.mappings.get(mappingKey);
-        if (mapping?.namespace !== nsFilter) {
-          // Still include if the mapping touches schemas in the namespace
-          const touchesNs = (mapping?.sources ?? []).some((s) => includedNodeIds.has(s)) ||
-            (mapping?.targets ?? []).some((t) => includedNodeIds.has(t));
-          if (!touchesNs) continue;
-        }
-      }
-
-      // Resolve source and target schema names
+    if (nsFilter) {
       const mapping = index.mappings.get(mappingKey);
-      const sourceSchemas = mapping?.sources ?? [];
-      const targetSchemas = mapping?.targets ?? [];
+      if (mapping?.namespace !== nsFilter) {
+        // Still include if the mapping touches schemas in the namespace
+        const touchesNs = (mapping?.sources ?? []).some((s) => includedNodeIds.has(s)) ||
+          (mapping?.targets ?? []).some((t) => includedNodeIds.has(t));
+        if (!touchesNs) continue;
+      }
+    }
 
-      const fromFields = record.sources.length > 0
-        ? record.sources.map((s) => canonicalKey(qualifyField(s, sourceSchemas)))
-        : [null];
-      const toField = record.target
-        ? canonicalKey(qualifyField(record.target, targetSchemas))
-        : null;
+    // Resolve source and target schema names
+    const mapping = index.mappings.get(mappingKey);
+    const sourceSchemas = mapping?.sources ?? [];
+    const targetSchemas = mapping?.targets ?? [];
 
-      for (const fromField of fromFields) {
+    const fromFields = record.sources.length > 0
+      ? record.sources.map((s) => canonicalKey(qualifyField(s, sourceSchemas)))
+      : [null];
+    const toField = record.target
+      ? canonicalKey(qualifyField(record.target, targetSchemas))
+      : null;
+
+    for (const fromField of fromFields) {
       const edge: FieldEdge = {
         from: fromField,
         to: toField,
@@ -468,18 +461,17 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
       }
 
       edges.push(edge);
-      } // end for fromFields
+    }
 
-      // Track unresolved NL for the output section — all transforms are NL
-      if (record.classification === "nl" && record.steps.length > 0) {
-        unresolvedNl.push({
-          scope: `mapping ${mappingKey}`,
-          arrow: `-> ${record.target ?? "?"}`,
-          text: record.steps.map((s) => s.text).join(" "),
-          file: record.file,
-          line: record.line + 1,
-        });
-      }
+    // Track unresolved NL for the output section — all transforms are NL
+    if (record.classification === "nl" && record.steps.length > 0) {
+      unresolvedNl.push({
+        scope: `mapping ${mappingKey}`,
+        arrow: `-> ${record.target ?? "?"}`,
+        text: record.steps.map((s) => s.text).join(" "),
+        file: record.file,
+        line: record.line + 1,
+      });
     }
   }
 

--- a/tooling/satsuma-cli/src/diff-engine.ts
+++ b/tooling/satsuma-cli/src/diff-engine.ts
@@ -26,6 +26,7 @@ import type {
   TransformRecord,
   ExtractedWorkspace,
 } from "./types.js";
+import { distinctArrowRecords } from "./index-builder.js";
 
 /** Collect note texts for a given parent name from an index's notes. */
 function noteTextsForParent(index: ExtractedWorkspace, parentName: string): Set<string> {
@@ -75,18 +76,12 @@ export function diffIndex(indexA: ExtractedWorkspace, indexB: ExtractedWorkspace
  */
 function collectArrowsByMapping(index: ExtractedWorkspace): Map<string, ArrowRecord[]> {
   const byMapping = new Map<string, ArrowRecord[]>();
-  const seen = new Set<string>();
 
-  for (const [, records] of index.fieldArrows) {
-    for (const r of records) {
-      const dedupKey = `${r.file}:${r.line}:${r.sources.join(",")}:${r.target}`;
-      if (seen.has(dedupKey)) continue;
-      seen.add(dedupKey);
-      const key = r.namespace ? `${r.namespace}::${r.mapping}` : (r.mapping ?? "");
-      if (!byMapping.has(key)) byMapping.set(key, []);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
-      byMapping.get(key)!.push(r);
-    }
+  for (const r of distinctArrowRecords(index.fieldArrows)) {
+    const key = r.namespace ? `${r.namespace}::${r.mapping}` : (r.mapping ?? "");
+    if (!byMapping.has(key)) byMapping.set(key, []);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
+    byMapping.get(key)!.push(r);
   }
 
   return byMapping;

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -520,6 +520,29 @@ function buildFieldArrows(arrowRecords: ArrowRecord[], mappings: Map<string, Map
 }
 
 /**
+ * Iterate the distinct arrow records in a `fieldArrows` index.
+ *
+ * `buildFieldArrows` registers the *same* record object under several key
+ * forms (canonical, schema-prefixed, bare path, leaf name), so any consumer
+ * walking the whole index must deduplicate. Records are shared by reference
+ * across keys — never cloned — so identity comparison is the exact dedup
+ * criterion. Content-derived keys are NOT safe here: two distinct arrows can
+ * share file, line, and target (e.g. `a -> x { trim } b -> x { upper }` on
+ * one line), and a positional key silently drops the second arrow from
+ * graph/lineage output (sl-201z).
+ */
+export function* distinctArrowRecords(fieldArrows: Map<string, ArrowRecord[]>): Generator<ArrowRecord> {
+  const seen = new Set<ArrowRecord>();
+  for (const records of fieldArrows.values()) {
+    for (const record of records) {
+      if (seen.has(record)) continue;
+      seen.add(record);
+      yield record;
+    }
+  }
+}
+
+/**
  * Build a reference graph from the extracted items.
  */
 function buildReferenceGraph({ schemas, metrics, mappings }: {

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -33,7 +33,7 @@ import type {
 } from "@satsuma/core";
 import type { MappingRecord, NLRefData, ExtractedWorkspace } from "./types.js";
 import { expandEntityFields } from "./spread-expand.js";
-import { canonicalKey, qualifyField } from "./index-builder.js";
+import { canonicalKey, distinctArrowRecords, qualifyField } from "./index-builder.js";
 
 // Re-export pure functions and types directly.
 export { extractAtRefs, computeNLRefPosition, classifyRef, extractNLRefData };
@@ -102,34 +102,29 @@ export function countNlDerivedEdgesByMapping(index: ExtractedWorkspace): Map<str
   // Pre-qualify all declared arrow source/target fields so they can be compared
   // against canonical nl ref names without re-running the full graph builder.
   const declaredCoverage = new Set<string>();
-  const seenArrow = new Set<string>();
 
-  for (const [, records] of index.fieldArrows) {
-    for (const record of records) {
-      // fieldArrows stores each record under multiple keys — deduplicate by position.
-      const arrowDedupKey = `${record.file}:${record.line}:${record.target}`;
-      if (seenArrow.has(arrowDedupKey)) continue;
-      seenArrow.add(arrowDedupKey);
+  // fieldArrows stores each record under multiple keys — distinctArrowRecords
+  // deduplicates by reference (a positional key would collapse distinct
+  // same-line arrows; see its doc-comment).
+  for (const record of distinctArrowRecords(index.fieldArrows)) {
+    // Only declared (non-synthetic) arrows can cover an nl-derived edge.
+    if (record.classification === "nl-derived") continue;
 
-      // Only declared (non-synthetic) arrows can cover an nl-derived edge.
-      if (record.classification === "nl-derived") continue;
+    const mappingKey = record.namespace
+      ? `${record.namespace}::${record.mapping}`
+      : (record.mapping ?? "");
+    const mapping = index.mappings.get(mappingKey);
+    const sourceSchemas = mapping?.sources ?? [];
+    const targetSchemas = mapping?.targets ?? [];
 
-      const mappingKey = record.namespace
-        ? `${record.namespace}::${record.mapping}`
-        : (record.mapping ?? "");
-      const mapping = index.mappings.get(mappingKey);
-      const sourceSchemas = mapping?.sources ?? [];
-      const targetSchemas = mapping?.targets ?? [];
+    const toField = record.target
+      ? canonicalKey(qualifyField(record.target, targetSchemas))
+      : null;
+    if (!toField) continue;
 
-      const toField = record.target
-        ? canonicalKey(qualifyField(record.target, targetSchemas))
-        : null;
-      if (!toField) continue;
-
-      for (const src of record.sources) {
-        const fromField = canonicalKey(qualifyField(src, sourceSchemas));
-        declaredCoverage.add(`${fromField}|${toField}|${mappingKey}`);
-      }
+    for (const src of record.sources) {
+      const fromField = canonicalKey(qualifyField(src, sourceSchemas));
+      declaredCoverage.add(`${fromField}|${toField}|${mappingKey}`);
     }
   }
 

--- a/tooling/satsuma-cli/test/canonical-ref.test.ts
+++ b/tooling/satsuma-cli/test/canonical-ref.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { canonicalRef, canonicalEntityName } from "@satsuma/core";
-import { canonicalKey, resolveCanonicalKey, resolveScopedEntityRef, resolveIndexKey } from "#src/index-builder.js";
+import { buildIndex, canonicalKey, distinctArrowRecords, resolveCanonicalKey, resolveScopedEntityRef, resolveIndexKey } from "#src/index-builder.js";
 
 describe("canonicalRef", () => {
   it("returns ::schema.field when no namespace", () => {
@@ -170,5 +170,67 @@ describe("resolveIndexKey", () => {
   it("returns null for unqualified name with no matches", () => {
     const result = resolveIndexKey("nonexistent", map);
     assert.equal(result, null);
+  });
+});
+
+// ── distinctArrowRecords ─────────────────────────────────────────────────────
+
+describe("distinctArrowRecords", () => {
+  /** Minimal arrow record for buildIndex; only identity-relevant fields vary. */
+  const arrow = (sources: string[], target: string) => ({
+    mapping: "m",
+    namespace: null,
+    sources,
+    target,
+    transform_raw: "",
+    steps: [],
+    classification: "none" as const,
+    derived: false,
+    line: 13,
+    file: "test.stm",
+  });
+
+  const fileData = (arrowRecords: any[]) => ({
+    filePath: "test.stm",
+    errorCount: 0,
+    schemas: [
+      { name: "s", namespace: null, fields: [], row: 0 },
+      { name: "t", namespace: null, fields: [], row: 1 },
+    ],
+    metrics: [],
+    mappings: [{ name: "m", namespace: null, sources: ["s"], targets: ["t"], arrowCount: arrowRecords.length, row: 2 }],
+    fragments: [],
+    transforms: [],
+    warnings: [],
+    questions: [],
+    arrowRecords,
+    namespaces: [],
+  });
+
+  it("yields each record exactly once despite multi-key registration", () => {
+    // buildFieldArrows indexes one record under canonical, schema-prefixed,
+    // bare, and leaf key forms — a whole-index walk must not multiply it.
+    const index = buildIndex([fileData([arrow(["a"], "x")])]);
+    const records = [...distinctArrowRecords(index.fieldArrows)];
+    assert.equal(records.length, 1);
+  });
+
+  it("keeps two same-line arrows that share a target (sl-201z)", () => {
+    // Two distinct arrows on one line targeting the same field share file,
+    // line, and target — any positional dedup key collapses them. Identity
+    // must be by record reference, so both survive.
+    const index = buildIndex([fileData([arrow(["a"], "x"), arrow(["b"], "x")])]);
+    const records = [...distinctArrowRecords(index.fieldArrows)];
+    assert.equal(records.length, 2);
+    assert.deepEqual(records.map((r) => r.sources[0]).sort(), ["a", "b"]);
+  });
+
+  it("keeps two same-line arrows that share both sources and target", () => {
+    // Even a content key including sources (file:line:sources:target) cannot
+    // distinguish `a -> x { trim }` from `a -> x { upper }` on one line.
+    // Reference identity keeps both records.
+    const index = buildIndex([fileData([arrow(["a"], "x"), arrow(["a"], "x")])]);
+    const records = [...distinctArrowRecords(index.fieldArrows)];
+    assert.equal(records.length, 2);
   });
 });

--- a/tooling/satsuma-cli/test/field-lineage.test.ts
+++ b/tooling/satsuma-cli/test/field-lineage.test.ts
@@ -134,3 +134,21 @@ describe("field-lineage with typeless fields", () => {
     assert.ok(stdout.includes("branch"), "spread field should appear after typeless field");
   });
 });
+
+// ---------------------------------------------------------------------------
+// sl-201z: same-line arrows sharing a target must not be collapsed
+// ---------------------------------------------------------------------------
+describe("field-lineage same-line arrows sharing a target (sl-201z)", () => {
+  it("reports upstream connections from both arrows on one line", async () => {
+    // Bug sl-201z: the field-edge graph deduplicated arrow records by
+    // file:line:target, dropping the second of two same-line arrows that
+    // target the same field — lineage showed 1 of 2 upstream connections.
+    const fixture = resolve(FIXTURES, "same-line-arrows.stm");
+    const { stdout, code } = await run("field-lineage", "t.x", fixture, "--json", "--upstream");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const upstreamFields = (data.upstream as any[]).map((e) => e.field).sort();
+    assert.deepEqual(upstreamFields, ["::s.a", "::s.b"],
+      "both same-line arrows should contribute an upstream connection");
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/same-line-arrows.stm
+++ b/tooling/satsuma-cli/test/fixtures/same-line-arrows.stm
@@ -1,0 +1,20 @@
+// Regression fixture for sl-201z: two distinct arrows on one line sharing a
+// target field. Positional dedup keys (file:line:target) collapse these into
+// one arrow, silently dropping `b -> x` from graph/lineage/coverage output.
+// The NL @b ref on the second arrow annotates its own declared source, so it
+// must be suppressed by declared-arrow coverage — not counted as nl-derived.
+schema s {
+  a STRING
+  b STRING
+}
+
+schema t {
+  x STRING
+}
+
+mapping m {
+  source { s }
+  target { t }
+
+  a -> x { trim } b -> x { "derived from @b" }
+}

--- a/tooling/satsuma-cli/test/graph.test.ts
+++ b/tooling/satsuma-cli/test/graph.test.ts
@@ -544,3 +544,23 @@ describe("satsuma graph vs summary (nl-derived count consistency)", () => {
       "summary arrowCount sum should equal graph stats.arrows for the same workspace");
   });
 });
+
+// ---------------------------------------------------------------------------
+// sl-201z: same-line arrows sharing a target must not be collapsed
+// ---------------------------------------------------------------------------
+describe("satsuma graph (same-line arrows sharing a target, sl-201z)", () => {
+  it("reports both arrows when two arrows on one line target the same field", async () => {
+    // Bug sl-201z: arrow records were deduplicated by file:line:target, which
+    // collides for two distinct arrows written on one line targeting the same
+    // field — the second arrow was silently dropped from edges and stats.
+    const fixture = resolve(FIXTURES, "same-line-arrows.stm");
+    const { stdout, code } = await run("graph", "--json", fixture);
+    assert.ok(code === 0 || code === 2, `expected exit 0 or 2, got ${code}`);
+    const data = JSON.parse(stdout);
+    const pairs = (data.edges as any[]).map((e) => `${e.from}->${e.to}`);
+    assert.ok(pairs.includes("::s.a->::t.x"), "edge from s.a should be present");
+    assert.ok(pairs.includes("::s.b->::t.x"),
+      "edge from s.b (same line, same target as s.a->x) should be present");
+    assert.equal(data.stats.arrows, 2, "both same-line arrows should be counted");
+  });
+});

--- a/tooling/satsuma-cli/test/summary.test.ts
+++ b/tooling/satsuma-cli/test/summary.test.ts
@@ -92,3 +92,24 @@ describe("satsuma summary", () => {
     assert.doesNotMatch(stderr, /Unhandled error:/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// sl-201z: declared-arrow coverage must see both same-line arrows
+// ---------------------------------------------------------------------------
+describe("summary nl-derived coverage with same-line arrows (sl-201z)", () => {
+  it("suppresses an nl ref covered by the second of two same-line declared arrows", async () => {
+    // Bug sl-201z: declared-coverage collection deduplicated arrow records by
+    // file:line:target, dropping `b -> x` when it shares a line and target
+    // with `a -> x`. The @b ref annotating its own declared source was then
+    // wrongly counted as an extra nl-derived arrow.
+    const fixture = resolve(__dirname, "fixtures/same-line-arrows.stm");
+    const { stdout, code } = await run("summary", "--json", fixture);
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const mapping = (data.mappings as any[]).find((m) => m.name === "::m");
+    assert.ok(mapping, "mapping ::m should be reported");
+    assert.equal(mapping.arrowCount, 2, "only the two declared arrows should be counted");
+    assert.equal(mapping.nlDerivedArrowCount, undefined,
+      "@b annotates its own declared arrow and must not count as nl-derived");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **sl-201z** (P1): two distinct arrows written on one line targeting the same field (`a -> x { trim } b -> x { uppercase }` — legal syntax that validates cleanly) were silently collapsed into one by graph, field-lineage, and nl-derived coverage counting. Silent data loss in lineage output.

### Root cause

`fieldArrows` registers the *same* arrow record object under multiple key forms (canonical, schema-prefixed, bare, leaf), so consumers walking the whole index must deduplicate. Three sites used a positional key `file:line:target`, which collides for distinct same-line arrows sharing a target. `diff-engine`'s `file:line:sources:target` variant had the same flaw one step removed (same-line arrows sharing sources *and* target, e.g. differing only in transform).

### Fix

- Add `distinctArrowRecords()` to `index-builder.ts`, deduplicating **by object reference** — records are shared, never cloned, across index keys, so identity is the exact dedup criterion. This matches the `Set<SemanticArrow>` pattern `satsuma-core`'s `validate.ts` already uses for the same walk.
- Switch all four walk sites (graph-builder, field-lineage, nl-ref-extract, diff-engine) to it.

### Before / after on the repro

| Surface | Before | After |
|---|---|---|
| `graph --json` stats.arrows / edges | 1 / `s.a→t.x` only | 2 / both edges |
| `field-lineage t.x --upstream` | 1 connection | 2 connections |
| `summary --json` (NL ref covered by 2nd arrow) | arrowCount 3 + spurious `nlDerivedArrowCount: 1` | arrowCount 2 |
| `mapping --json` arrowCount (control) | 2 | 2 |

### Tests

- Unit tests for `distinctArrowRecords` (multi-key registration yields one record; same-line arrows sharing target survive; arrows identical in sources+target survive).
- Regression fixture `same-line-arrows.stm` exercised through `graph --json`, `field-lineage --json`, and `summary --json` (the nl-derived coverage path) — the summary case verified to fail pre-fix (overcounted nl-derived).
- Full CLI suite: 857 tests pass; lint and smoke tests pass via pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)