### PR TITLE
fix: P3 bug-hunt batch 2 — NL ref blind spots, note indexing, LSP/viz/vscode minor fixes

### DIFF
--- a/.tickets/sl-0tgo.md
+++ b/.tickets/sl-0tgo.md
@@ -1,6 +1,6 @@
 ---
 id: sl-0tgo
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:30Z
@@ -17,3 +17,10 @@ Three small confirmed issues. (1) server.ts:147-152 — closing a modified-but-u
 
 Close re-indexes from disk; hidden-rule checks replaced with reachable node types (with tests proving the branches fire); codelens counts distinct mappings.
 
+
+## Notes
+
+**2026-06-11T07:00:02Z**
+
+Cause: (1) onDidClose kept whatever buffer content was last indexed, including unsaved edits the user discarded; (2) definition.ts and completion.ts tested for "_source_entry" / "_arrow_transform_body", hidden grammar rules that inline away and never appear as node types; (3) findMappingsUsing deduped reference sites by uri:line, double-counting mappings that name a schema in both source and target blocks.
+Fix: (1) close now re-indexes from disk via reindexFromDisk (removing files with no on-disk presence); (2) dead checks removed/replaced — target detection uses the real direct parent, and empty arrow bodies (parsed as declaration-less nested_arrow) get pipe completions; (3) source/target references now carry their containing mapping's qualified name and findMappingsUsing dedups on it. Tests added for empty-arrow-body completions and source+target single-mapping counting.

--- a/.tickets/sl-74m6.md
+++ b/.tickets/sl-74m6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-74m6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ Two extraction blind spots in satsuma-core/src/nl-ref.ts. (1) :123 AT_REF_PATTER
 
 Refs after quote/=/: are extracted; refs in map literal string values are extracted and validated; tests for each prefix character and map values.
 
+
+## Notes
+
+**2026-06-11T06:46:08Z**
+
+Cause: the sl-gl21 lookbehind fix excluded quotes, `=` and `:` from the allowed @ref prefix set as unintended collateral, and the pipe-step NL scanners only looked inside pipe_text nodes, so NL strings inside map literal entries were never reached.
+Fix: added `"'=:` to the AT_REF_PATTERN lookbehind class (with rationale comment), and extracted a shared nlStringNodesInPipeStep() helper used by both the transform and arrow walkers that also descends into map_entry keys/values. Tests cover each new prefix character and map-literal extraction via the real parser.

--- a/.tickets/sl-ebs9.md
+++ b/.tickets/sl-ebs9.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ebs9
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:42:20Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/viz-model.ts:390-446 — collectTopLevelComments walks o
 
 Namespaced standalone //! and //? comments attach to the correct block; warnings pane counts match satsuma warnings; test.
 
+
+## Notes
+
+**2026-06-11T07:03:12Z**
+
+Cause: collectTopLevelComments iterated only root.children and findPrecedingBlock resolved block names against the global namespace group (the namespaceMap parameter was accepted and ignored), so standalone //! and //? comments between blocks inside a namespace never attached to anything and were dropped from the model.
+Fix: extracted the sibling-walk into collectSiblingComments(uri, siblings, group) and now run it once for the file root against the global group and once per namespace_block against that namespace's group; findPrecedingBlock takes the scope group. Tests cover the global control case and a namespaced //!+//? pair attaching to the preceding schema.

--- a/.tickets/sl-ellp.md
+++ b/.tickets/sl-ellp.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ellp
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:30Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/workspace-index.ts:832-862 indexNlRefs walks only mappin
 
 NL refs in note tags, note blocks, and metadata value strings are indexed; rename updates them; find-references lists them.
 
+
+## Notes
+
+**2026-06-11T06:53:17Z**
+
+Cause: indexNlRefs was called only with each mapping's mapping_body node, so @refs in NL prose outside arrow bodies — (note "...") metadata tags, note blocks at any level, metadata value strings — never entered the reference index, and rename/find-references skipped them.
+Fix: indexFile now runs indexNlRefs once over the whole file root (covering note tags, note blocks, namespaced content, and metadata values), the per-mapping-body call was removed to avoid double-indexing, and NL prose refs are tagged with a new "nl" reference context instead of mislabelled "arrow". Tests pin note-tag/note-block/namespace/standalone indexing, no-double-indexing, and rename round-trips through note text.

--- a/.tickets/sl-wlta.md
+++ b/.tickets/sl-wlta.md
@@ -1,6 +1,6 @@
 ---
 id: sl-wlta
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z
@@ -17,3 +17,10 @@ Three small confirmed issues. (1) cli-runner.ts exitCode uses Number(error.code)
 
 ENOENT reports a clear "CLI not found" message; save dialog defaults inside the workspace; dead escapeHtml removed.
 
+
+## Notes
+
+**2026-06-11T07:08:11Z**
+
+Cause: (1) cli-runner coerced execFile's error.code with Number(), so string errnos (ENOENT when the CLI is not installed) yielded "exit code NaN" in messages; (2) exportSvg passed a bare relative Uri.file which resolves to the filesystem root, opening the save dialog at "/"; (3) field-lineage.ts and schema-lineage.ts each carried an escapeHtml that nothing called and that did not escape quotes.
+Fix: (1) added vscode-free cli-runner-logic.ts with exitCodeFrom (string errno -> 1, never NaN) and spawnFailureMessage (ENOENT -> install/cliPath hint surfaced via stderr to every caller toast), unit-tested; (2) save dialog now defaults to <workspaceRoot>/mapping-viz.svg, or the dialog default when no workspace is open; (3) both dead escapeHtml functions removed.

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -116,11 +116,16 @@ function canonicalKey(key: string): string {
 // digits, `_` and `.` so that `%@foo` and `user@bar` are not extracted, while
 // `(@foo`, `[@foo`, `, @foo` and start-of-string `@foo` still are.
 //
+// Quotes, `=` and `:` are allowed prefixes (sl-74m6): NL prose legitimately
+// abuts refs against them — `"@customers" table`, `where id =@customers.id`,
+// `key:@customers.id` — and none of those shapes overlap the email/wildcard
+// false positives the lookbehind exists to block.
+//
 // AT_REF_PATTERN is the canonical source. Consumers that need a fresh regex
 // instance (because /g state is mutable) should call createAtRefRegex(); this
 // is the single source of truth shared by core, the LSP, the viz backend and
 // the viz UI to avoid drift between copies.
-export const AT_REF_PATTERN = "(?<=^|[\\s(\\[{,;])@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*";
+export const AT_REF_PATTERN = "(?<=^|[\\s(\\[{,;\"'=:])@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*";
 
 /**
  * Build a fresh global @ref regex. Always returns a new instance so callers
@@ -478,6 +483,25 @@ function extractMappingNLRefs(mappingNode: SyntaxNode, namespace: string | null,
   walkArrowsForNL(body, mappingName, namespace, null, results);
 }
 
+// Collect the NL string nodes carried by a single pipe step. A step is one of
+// three shapes: pipe_text (NL strings are direct children), a map literal
+// (NL strings live inside each entry's key and value — sl-74m6: refs in
+// `map { "x": "see @customers.id" }` must reach lineage and validation), or a
+// fragment spread (never carries NL text).
+function nlStringNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
+  const isNL = (n: SyntaxNode) => n.type === "nl_string" || n.type === "multiline_string";
+  const inner = step.namedChildren[0];
+  if (!inner) return [];
+  if (inner.type === "pipe_text") return inner.namedChildren.filter(isNL);
+  if (inner.type === "map_literal") {
+    return inner.namedChildren
+      .filter((e) => e.type === "map_entry")
+      .flatMap((e) => e.namedChildren)            // map_key and map_value parts
+      .flatMap((part) => part.namedChildren.filter(isNL));
+  }
+  return [];
+}
+
 function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | null, results: NLRefDataItemNoFile[]): void {
   const lbl = transformNode.namedChildren.find((c) => c.type === "block_label");
   const inner = lbl?.namedChildren[0];
@@ -489,11 +513,7 @@ function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | n
 
   for (const step of pipeChain.namedChildren) {
     if (step.type === "pipe_step") {
-      const innerNode = step.namedChildren[0];
-      const nlNodes = innerNode?.type === "pipe_text"
-        ? innerNode.namedChildren.filter((k) => k.type === "nl_string" || k.type === "multiline_string")
-        : [];
-      for (const nlNode of nlNodes) {
+      for (const nlNode of nlStringNodesInPipeStep(step)) {
         const text = nlNode.type === "multiline_string"
           ? nlNode.text.slice(3, -3)
           : nlNode.text.slice(1, -1);
@@ -651,11 +671,7 @@ function walkArrowsForNL(
       if (pipeChain) {
         for (const step of pipeChain.namedChildren) {
           if (step.type === "pipe_step") {
-            const innerNode = step.namedChildren[0];
-            const nlNodes2 = innerNode?.type === "pipe_text"
-              ? innerNode.namedChildren.filter((k) => k.type === "nl_string" || k.type === "multiline_string")
-              : [];
-            for (const nlNode of nlNodes2) {
+            for (const nlNode of nlStringNodesInPipeStep(step)) {
               const text = nlNode.type === "multiline_string"
                 ? nlNode.text.slice(3, -3)
                 : nlNode.text.slice(1, -1);

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -3,17 +3,26 @@
  */
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   AT_REF_PATTERN,
   createAtRefRegex,
   extractAtRefs,
+  extractNLRefData,
   computeNLRefPosition,
   classifyRef,
   resolveRef,
   resolveAllNLRefs,
   stripNLRefScopePrefix,
 } from "../dist/nl-ref.js";
+import { initParser, getParser } from "../dist/parser.js";
+
+// Real-parser cases below (sl-74m6) parse minimal Satsuma snippets against the
+// committed grammar WASM, mirroring the bootstrap in parse-errors.test.js.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
 
 // ── extractAtRefs ─────────────────────────────────────────────────────────────
 
@@ -77,6 +86,29 @@ describe("extractAtRefs()", () => {
     assert.deepEqual(extractAtRefs("coalesce(@a, @b)").map(r => r.ref), ["a", "b"]);
     assert.deepEqual(extractAtRefs("[@a; @b]").map(r => r.ref), ["a", "b"]);
     assert.deepEqual(extractAtRefs("{@a}").map(r => r.ref), ["a"]);
+  });
+
+  // sl-74m6: quotes, `=` and `:` were excluded from the lookbehind as collateral
+  // of the sl-gl21 fix, silently dropping refs that abut them in real NL prose.
+  // None of these shapes overlap the email/wildcard false positives sl-gl21
+  // exists to block, so they must be extracted.
+
+  it("extracts a @ref immediately after a double or single quote (sl-74m6)", () => {
+    // Prose like `"@customers" table` quotes the ref itself — the ref must
+    // still reach lineage and validation.
+    assert.deepEqual(extractAtRefs('"@customers" table').map(r => r.ref), ["customers"]);
+    assert.deepEqual(extractAtRefs("'@customers' table").map(r => r.ref), ["customers"]);
+  });
+
+  it("extracts a @ref immediately after = (sl-74m6)", () => {
+    // SQL-ish condition text with no space around the operator:
+    // `where id =@customers.id`.
+    assert.deepEqual(extractAtRefs("where id =@customers.id").map(r => r.ref), ["customers.id"]);
+  });
+
+  it("extracts a @ref immediately after : (sl-74m6)", () => {
+    // Key/value prose with no space after the colon: `key:@customers.id`.
+    assert.deepEqual(extractAtRefs("key:@customers.id").map(r => r.ref), ["customers.id"]);
   });
 
   it("extracts @refs across multiple lines (after newline counts as whitespace)", () => {
@@ -283,5 +315,58 @@ describe("stripNLRefScopePrefix", () => {
   it("returns mapping names without scope prefix unchanged", () => {
     assert.equal(stripNLRefScopePrefix("crm sync"), "crm sync");
     assert.equal(stripNLRefScopePrefix("ns::load data"), "ns::load data");
+  });
+});
+
+// ── extractNLRefData — map literal NL strings (sl-74m6) ──────────────────────
+//
+// Real-parser tests: a map literal is a structured pipe-step shape, so mock
+// CSTs would just restate the implementation. These parse minimal mappings and
+// assert the walker reaches the NL strings inside map entries — previously only
+// pipe_text steps were scanned and refs in map values escaped lineage entirely.
+
+describe("extractNLRefData — map literal NL strings (sl-74m6)", () => {
+  before(async () => {
+    await initParser(WASM_PATH);
+  });
+
+  function nlRefItems(src) {
+    return extractNLRefData(getParser().parse(src).rootNode);
+  }
+
+  it("extracts a @ref inside a map literal string value", () => {
+    // The ticket repro: a ref mentioned in a map value must produce an NL ref
+    // item attributed to the arrow's target field.
+    const src = 'mapping m {\n  a -> b { map { "x": "see @customers.id" } }\n}';
+    const items = nlRefItems(src);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].text, "see @customers.id");
+    assert.equal(items[0].mapping, "m");
+    assert.equal(items[0].targetField, "b");
+  });
+
+  it("extracts a @ref inside a map literal string key", () => {
+    // Keys are condition text and may also reference fields; they must not be
+    // a blind spot either.
+    const src = 'mapping m {\n  a -> b { map { "matches @customers.tier": "gold" } }\n}';
+    const items = nlRefItems(src);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].text, "matches @customers.tier");
+  });
+
+  it("extracts a @ref from a map literal in a transform body", () => {
+    // Transforms share the pipe-step walker with arrows — the map-literal fix
+    // must apply there too.
+    const src = 'transform grade {\n  map { "a": "top tier per @customers.tier" }\n}';
+    const items = nlRefItems(src);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].mapping, "transform:grade");
+  });
+
+  it("ignores map literal values with no refs or backticks", () => {
+    // The walker pre-filters NL strings: plain map values must not generate
+    // NL ref items (they would inflate nl-refs output with noise).
+    const src = 'mapping m {\n  a -> b { map { "r": "retail", "w": "wholesale" } }\n}';
+    assert.deepEqual(nlRefItems(src), []);
   });
 });

--- a/tooling/satsuma-lsp/src/completion.ts
+++ b/tooling/satsuma-lsp/src/completion.ts
@@ -63,7 +63,18 @@ function detectCompletionContext(node: SyntaxNode): CompletionContext | null {
     }
 
     // Inside a pipe chain → suggest transform functions
-    if (current.type === "pipe_chain" || current.type === "_arrow_transform_body") {
+    if (current.type === "pipe_chain") {
+      return { kind: "pipe_chain" };
+    }
+
+    // Inside the empty braces of an arrow body (`a -> b {  }`): the grammar
+    // parses this as a nested_arrow with no declarations (its transform-body
+    // form requires at least one pipe step), so the cursor lands on the
+    // nested_arrow node itself. The user has just opened a transform body —
+    // suggest pipe functions (sl-0tgo). Arrows with actual nested declarations
+    // resolve deeper nodes first, so this only fires for empty bodies.
+    if (current.type === "nested_arrow" && !child(current, "map_arrow") &&
+        !child(current, "computed_arrow") && !child(current, "nested_arrow")) {
       return { kind: "pipe_chain" };
     }
 

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -79,9 +79,9 @@ function tryContext(node: SyntaxNode): NodeContext | null {
     case "source_ref": {
       const name = sourceRefText(node);
       if (!name) return null;
-      const parentType = node.parent?.type;
-      const inTarget = parentType === "target_block" ||
-        (parentType === "_source_entry" && node.parent?.parent?.type === "target_block");
+      // _source_entry is a hidden grammar rule that inlines away, so a
+      // source_ref's parent is the source_block/target_block itself (sl-0tgo).
+      const inTarget = node.parent?.type === "target_block";
       return {
         kind: inTarget ? "target_ref" : "source_ref",
         name,

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -147,9 +147,34 @@ documents.onDidChangeContent((change) => {
 documents.onDidClose((event) => {
   trees.delete(event.document.uri);
   validateDiagCache.delete(event.document.uri);
-  // Keep the file in the index (it's still on disk) — just clear the tree cache
+  // The index may hold modified-but-unsaved buffer content the user just
+  // discarded by closing; re-index from what is actually on disk (sl-0tgo).
+  reindexFromDisk(event.document.uri);
   connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
 });
+
+/**
+ * Replace a file's index entries with its on-disk content. Files that have no
+ * on-disk presence (non-file schemes, deleted or never-saved files) are
+ * removed from the index instead — their last indexed content no longer
+ * corresponds to anything the user can navigate to.
+ */
+function reindexFromDisk(uri: string): void {
+  let fsPath: string;
+  try {
+    fsPath = fileURLToPath(uri);
+  } catch {
+    removeFile(wsIndex, uri);
+    return;
+  }
+  try {
+    const content = fs.readFileSync(fsPath, "utf-8");
+    const tree = getParser().parse(content);
+    if (tree) indexFile(wsIndex, uri, tree);
+  } catch {
+    removeFile(wsIndex, uri);
+  }
+}
 
 // Run satsuma validate on save
 documents.onDidSave(async (event) => {

--- a/tooling/satsuma-lsp/test/codelens.test.js
+++ b/tooling/satsuma-lsp/test/codelens.test.js
@@ -51,6 +51,23 @@ describe("computeCodeLenses", () => {
     assert.ok(result.some((lens) => lens.command.title.includes("used in 2 mapping(s)")));
   });
 
+  it("counts a mapping once when it uses the schema as both source and target", () => {
+    // sl-0tgo: findMappingsUsing deduped reference sites by line, so a mapping
+    // naming the schema in its source AND target blocks counted twice. The
+    // lens must report distinct mappings.
+    const result = lenses(
+      {
+        "file:///a.stm": "schema customers {\n  id UUID\n}",
+        "file:///b.stm": "mapping `self` {\n  source { customers }\n  target { customers }\n  id -> id\n}",
+      },
+      "file:///a.stm",
+    );
+    assert.ok(
+      result.some((lens) => lens.command.title.includes("used in 1 mapping(s)")),
+      `expected one distinct mapping, got: ${result.map((l) => l.command.title).join("; ")}`,
+    );
+  });
+
   it("adds clickable lineage actions for schemas", () => {
     const result = lenses(
       { "file:///a.stm": "schema customers {\n  id UUID\n}" },

--- a/tooling/satsuma-lsp/test/completion.test.js
+++ b/tooling/satsuma-lsp/test/completion.test.js
@@ -101,6 +101,24 @@ schema customers {
     assert.ok(items.every((i) => i.kind === 14)); // CompletionItemKind.Keyword = 14
   });
 
+  it("suggests transform functions inside an empty arrow body", () => {
+    // sl-0tgo: the old check tested for "_arrow_transform_body", a hidden
+    // grammar rule that never surfaces as a node type, so the branch was
+    // unreachable. `a -> b {  }` parses as a nested_arrow with no
+    // declarations and the cursor lands on the nested_arrow node itself —
+    // the user just opened a transform body and expects pipe functions.
+    const items = complete(
+      {
+        "file:///a.stm": "mapping m {\n  source { s }\n  target { t }\n  a -> b {  }\n}",
+      },
+      "file:///a.stm",
+      3,
+      11, // cursor between the empty braces
+    );
+    const labels = items.map((i) => i.label);
+    assert.ok(labels.includes("trim"), "expected pipe-function completions in empty arrow body");
+  });
+
   it("suggests transform functions in pipe chain", () => {
     const items = complete(
       {

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -205,6 +205,36 @@ schema customers {
     );
   });
 
+  it("rewrites @refs inside note tags and note blocks", () => {
+    // sl-ellp: NL refs in note metadata and note blocks were never indexed, so
+    // renaming a schema left its name stale in prose documentation. Both note
+    // shapes must be rewritten alongside structural references.
+    const bSource =
+      'schema dim (note "fed by @customers") {\n  id UUID\n  note { "joins against @customers" }\n}';
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+      "file:///b.stm": bSource,
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
+    assert.ok(
+      renamed.includes('"fed by @clients"'),
+      `expected note tag ref to be renamed, got: ${renamed}`,
+    );
+    assert.ok(
+      renamed.includes('"joins against @clients"'),
+      `expected note block ref to be renamed, got: ${renamed}`,
+    );
+  });
+
   it("preserves the dotted tail of an arrow path whose first segment matches the renamed name", () => {
     // sl-xf3f: arrow paths were indexed under their first segment but with the
     // range of the WHOLE path node, so renaming a schema named "address"

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -584,7 +584,7 @@ describe("reference range precision (sl-xf3f)", () => {
   -> name { "see @customers here" }
 }`;
     const idx = buildIndex({ "file:///a.stm": source });
-    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "arrow");
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
     assert.equal(refs.length, 1);
     // A range including the @ deletes the sigil on rename, breaking the ref.
     assert.equal(textAt(source, refs[0].range), "customers");
@@ -600,18 +600,18 @@ describe("NL string reference indexing", () => {
   -> display_name { "Use @FIRST_NM and @LAST_NM" }
 }`,
     });
-    const firstRefs = (idx.references.get("FIRST_NM") || []).filter((r) => r.context === "arrow");
-    assert.ok(firstRefs.length >= 1, "expected arrow ref for @FIRST_NM");
-    const lastRefs = (idx.references.get("LAST_NM") || []).filter((r) => r.context === "arrow");
-    assert.ok(lastRefs.length >= 1, "expected arrow ref for @LAST_NM");
+    const firstRefs = (idx.references.get("FIRST_NM") || []).filter((r) => r.context === "nl");
+    assert.ok(firstRefs.length >= 1, "expected nl ref for @FIRST_NM");
+    const lastRefs = (idx.references.get("LAST_NM") || []).filter((r) => r.context === "nl");
+    assert.ok(lastRefs.length >= 1, "expected nl ref for @LAST_NM");
   });
 
   it("indexes @refs with backtick-delimited names", () => {
     const idx = buildIndex({
       "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  -> name { \"Use @`first name` here\" }\n}",
     });
-    const refs = (idx.references.get("first name") || []).filter((r) => r.context === "arrow");
-    assert.ok(refs.length >= 1, "expected arrow ref for @`first name`");
+    const refs = (idx.references.get("first name") || []).filter((r) => r.context === "nl");
+    assert.ok(refs.length >= 1, "expected nl ref for @`first name`");
   });
 
   it("indexes @refs in multiline NL strings", () => {
@@ -627,12 +627,75 @@ describe("NL string reference indexing", () => {
   }
 }`,
     });
-    const addrRefs = (idx.references.get("ADDR_LINE_1") || []).filter((r) => r.context === "arrow");
-    assert.ok(addrRefs.length >= 1, "expected arrow ref for @ADDR_LINE_1");
-    const stateRefs = (idx.references.get("STATE_PROV") || []).filter((r) => r.context === "arrow");
-    assert.ok(stateRefs.length >= 1, "expected arrow ref for @STATE_PROV");
+    const addrRefs = (idx.references.get("ADDR_LINE_1") || []).filter((r) => r.context === "nl");
+    assert.ok(addrRefs.length >= 1, "expected nl ref for @ADDR_LINE_1");
+    const stateRefs = (idx.references.get("STATE_PROV") || []).filter((r) => r.context === "nl");
+    assert.ok(stateRefs.length >= 1, "expected nl ref for @STATE_PROV");
   });
 
+  // sl-ellp: indexNlRefs used to walk only mapping bodies, so @refs in note
+  // tags, note blocks, and metadata values were invisible to find-references
+  // and rename — renames left stale prose behind. These cases pin the
+  // file-wide walk.
+
+  it("indexes @refs in a mapping-level (note ...) metadata tag", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test (note "joins against @customers") {
+  source { customers }
+  target { dim }
+}`,
+    });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
+
+  it("indexes @refs in a schema-level note block", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `schema dim {
+  id UUID
+  note { "sourced from @customers nightly" }
+}`,
+    });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
+
+  it("indexes @refs in a standalone top-level note block", () => {
+    const idx = buildIndex({
+      "file:///a.stm": 'note { "platform feeds @customers downstream" }',
+    });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
+
+  it("indexes @refs in note blocks inside a namespace", () => {
+    // Namespaced content goes through a different dispatch path than global
+    // blocks; the file-wide NL walk must reach it regardless.
+    const idx = buildIndex({
+      "file:///a.stm": `namespace crm {
+  schema dim {
+    id UUID
+    note { "see @customers" }
+  }
+}`,
+    });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
+
+  it("does not double-index @refs in arrow-body NL strings", () => {
+    // The file-wide walk replaced the per-mapping-body walk; if both ran, every
+    // arrow NL ref would appear twice and rename would produce overlapping edits.
+    const idx = buildIndex({
+      "file:///a.stm": `mapping test {
+  source { customers }
+  target { dim }
+  -> name { "see @customers here" }
+}`,
+    });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
 });
 
 describe("transform spread indexing in arrows", () => {

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -385,17 +385,39 @@ function processTopLevelBlock(
 
 /**
  * Collect warning_comment and question_comment nodes that appear as siblings
- * of top-level blocks. Attach them to the preceding schema/mapping/etc.
+ * of blocks — at the file root and inside namespace blocks (sl-ebs9) — and
+ * attach each to the nearest preceding schema/mapping/metric/fragment of the
+ * same scope. Comments inside a namespace must resolve against that
+ * namespace's group, not the global one, or they vanish from the model and
+ * the warnings/questions pane undercounts.
  */
 function collectTopLevelComments(
   uri: string,
   root: SyntaxNode,
   globalNs: NamespaceGroup,
-  _namespaceMap: Map<string, NamespaceGroup>,
+  namespaceMap: Map<string, NamespaceGroup>,
 ): void {
-  const allNodes = root.children;
-  for (let i = 0; i < allNodes.length; i++) {
-    const node = allNodes[i]!;
+  collectSiblingComments(uri, root.children, globalNs);
+
+  for (const node of root.namedChildren) {
+    if (node.type !== "namespace_block") continue;
+    const nsName = node.childForFieldName?.("name")?.text ?? null;
+    const group = nsName ? namespaceMap.get(nsName) : undefined;
+    if (group) {
+      collectSiblingComments(uri, node.children, group);
+    }
+  }
+}
+
+/** Attach each standalone //! and //? among `siblings` to the nearest
+ *  preceding block found in `group`. */
+function collectSiblingComments(
+  uri: string,
+  siblings: SyntaxNode[],
+  group: NamespaceGroup,
+): void {
+  for (let i = 0; i < siblings.length; i++) {
+    const node = siblings[i]!;
     if (node.type !== "warning_comment" && node.type !== "question_comment") {
       continue;
     }
@@ -406,7 +428,7 @@ function collectTopLevelComments(
     };
 
     // Attach to the nearest preceding schema/mapping/metric/fragment
-    const target = findPrecedingBlock(allNodes, i, globalNs);
+    const target = findPrecedingBlock(siblings, i, group);
     if (target) {
       target.push(entry);
     }
@@ -416,29 +438,29 @@ function collectTopLevelComments(
 function findPrecedingBlock(
   allNodes: SyntaxNode[],
   commentIndex: number,
-  globalNs: NamespaceGroup,
+  group: NamespaceGroup,
 ): CommentEntry[] | null {
   // Walk backwards from the comment to find the preceding block
   for (let j = commentIndex - 1; j >= 0; j--) {
     const prev = allNodes[j]!;
     if (prev.type === "schema_block") {
       const name = labelText(prev);
-      const schema = globalNs.schemas.find((s) => s.id === name);
+      const schema = group.schemas.find((s) => s.id === name);
       if (schema) return schema.comments;
     }
     if (prev.type === "mapping_block") {
       const name = labelText(prev);
-      const mapping = globalNs.mappings.find((m) => m.id === name);
+      const mapping = group.mappings.find((m) => m.id === name);
       if (mapping) return mapping.comments;
     }
     if (prev.type === "schema_block" && isMetricSchema(child(prev, "metadata_block"))) {
       const name = labelText(prev);
-      const metric = globalNs.metrics.find((m) => m.id === name);
+      const metric = group.metrics.find((m) => m.id === name);
       if (metric) return metric.comments;
     }
     if (prev.type === "fragment_block") {
       const name = labelText(prev);
-      const frag = globalNs.fragments.find((f) => f.id === name);
+      const frag = group.fragments.find((f) => f.id === name);
       if (frag) return frag.comments;
     }
   }

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -75,6 +75,10 @@ export interface ReferenceEntry {
    *  src/tgt path references; "nl" marks @refs found inside NL prose strings
    *  (arrow bodies, note tags/blocks, metadata values — sl-ellp). */
   context: "source" | "target" | "spread" | "import" | "arrow" | "nl" | "metric_source";
+  /** Qualified name of the mapping whose source/target block contains this
+   *  reference. Set only for "source"/"target" contexts; lets consumers count
+   *  distinct mappings rather than reference sites (sl-0tgo). */
+  container?: string;
 }
 
 export interface ImportEntry {
@@ -496,10 +500,13 @@ export function findMappingsUsing(
   const mappingRefs = refs.filter(
     (r) => r.context === "source" || r.context === "target",
   );
-  // Deduplicate by URI + parent mapping (approximate: use URI since each mapping body is in one file)
+  // Deduplicate by the containing mapping, not by reference site — a mapping
+  // that names the schema in both its source and target blocks is still one
+  // mapping (sl-0tgo). The uri:line fallback covers entries indexed before
+  // container existed (none in practice, but keeps the function total).
   const seen = new Set<string>();
   for (const ref of mappingRefs) {
-    seen.add(`${ref.uri}:${ref.range.start.line}`);
+    seen.add(ref.container ?? `${ref.uri}:${ref.range.start.line}`);
   }
   return [...seen];
 }
@@ -649,10 +656,19 @@ function indexMappingRefs(
   index: WorkspaceIndex,
   uri: string,
   mappingNode: SyntaxNode,
-  _namespace: string | null,
+  namespace: string | null,
 ): void {
   const body = child(mappingNode, "mapping_body");
   if (!body) return;
+
+  // Identity of the containing mapping, recorded on each source/target ref so
+  // consumers can count distinct mappings rather than reference sites
+  // (sl-0tgo). Anonymous mappings fall back to their position, which is
+  // unique per mapping.
+  const mappingName = labelText(mappingNode);
+  const container = mappingName
+    ? (namespace ? `${namespace}::${mappingName}` : mappingName)
+    : `<anon>@${uri}:${mappingNode.startPosition.row}`;
 
   for (const ch of body.namedChildren) {
     if (ch.type === "source_block") {
@@ -664,6 +680,7 @@ function indexMappingRefs(
             range: nodeRange(ref),
             name,
             context: "source",
+            container,
           });
         }
       }
@@ -676,6 +693,7 @@ function indexMappingRefs(
             range: nodeRange(ref),
             name,
             context: "target",
+            container,
           });
         }
       }

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -71,8 +71,10 @@ export interface ReferenceEntry {
   range: Range;
   /** Canonical referenced name, qualified when authored that way. */
   name: string;
-  /** Semantic usage context for downstream queries. */
-  context: "source" | "target" | "spread" | "import" | "arrow" | "metric_source";
+  /** Semantic usage context for downstream queries. "arrow" marks structural
+   *  src/tgt path references; "nl" marks @refs found inside NL prose strings
+   *  (arrow bodies, note tags/blocks, metadata values — sl-ellp). */
+  context: "source" | "target" | "spread" | "import" | "arrow" | "nl" | "metric_source";
 }
 
 export interface ImportEntry {
@@ -352,6 +354,10 @@ export function indexFile(index: WorkspaceIndex, uri: string, tree: Tree): void 
   for (const node of root.namedChildren) {
     indexTopLevel(index, uri, node, null);
   }
+
+  // Index @refs inside NL prose once for the whole file — note tags, note
+  // blocks, metadata values, and arrow bodies alike (sl-ellp).
+  indexNlRefs(index, uri, root);
 }
 
 /** Remove all entries for a file URI from the index (canonicalized first —
@@ -680,11 +686,9 @@ function indexMappingRefs(
     indexArrowSpreadRefs(index, uri, ch);
   }
 
-  // Index field-level references from arrow src_path / tgt_path nodes
+  // Index field-level references from arrow src_path / tgt_path nodes.
+  // (@refs in NL strings are indexed file-wide by indexFile, not here.)
   indexArrowFieldRefs(index, uri, body);
-
-  // Index @refs and backtick refs inside NL strings in arrows
-  indexNlRefs(index, uri, body);
 }
 
 function indexArrowSpreadRefs(
@@ -882,12 +886,20 @@ function extractArrowFieldName(pathNode: SyntaxNode): string | null {
 
 const NL_AT_REF_RE = createAtRefRegex();
 
+/**
+ * Index every @ref inside NL strings under `node` as an "nl" reference.
+ *
+ * Called once per file with the root node (sl-ellp): NL prose carrying refs
+ * lives not only in arrow bodies but in `(note "...")` metadata tags, `note`
+ * blocks at any level, and metadata value strings — all of which rename and
+ * find-references must reach, or renames leave stale prose behind.
+ */
 function indexNlRefs(
   index: WorkspaceIndex,
   uri: string,
-  body: SyntaxNode,
+  node: SyntaxNode,
 ): void {
-  walkDescendants(body, (n) => {
+  walkDescendants(node, (n) => {
     if (n.type !== "nl_string" && n.type !== "multiline_string") return;
 
     const text = n.text;
@@ -911,7 +923,7 @@ function indexNlRefs(
         uri,
         range,
         name: refName,
-        context: "arrow",
+        context: "nl",
       });
     }
 

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -484,6 +484,30 @@ describe("comments", () => {
     ];
     assert.ok(allComments.some((c) => c.kind === "question"));
   });
+
+  it("attaches a standalone comment between top-level blocks to the preceding block", () => {
+    // Control case for the namespaced fix below: standalone //! siblings of
+    // global blocks attach to the nearest preceding schema.
+    const model = vizModel(
+      "schema s {\n  id INT\n}\n//! needs review\nschema t {\n  id INT\n}",
+    );
+    const s = model.namespaces[0].schemas.find((x) => x.id === "s");
+    assert.equal(s.comments.length, 1);
+    assert.equal(s.comments[0].kind, "warning");
+  });
+
+  it("attaches standalone comments inside a namespace to the preceding block (sl-ebs9)", () => {
+    // collectTopLevelComments walked only root children and resolved blocks
+    // against the global group, so //! and //? between blocks inside a
+    // namespace vanished from the model and the warnings pane undercounted.
+    const model = vizModel(
+      "namespace crm {\n  schema s {\n    id INT\n  }\n  //! stale source\n  //? still needed?\n  schema t {\n    id INT\n  }\n}",
+    );
+    const ns = model.namespaces.find((n) => n.name === "crm");
+    const s = ns.schemas.find((x) => x.id === "s");
+    assert.equal(s.comments.length, 2);
+    assert.deepEqual(s.comments.map((c) => c.kind).sort(), ["question", "warning"]);
+  });
 });
 
 // ---------- External lineage ----------

--- a/tooling/vscode-satsuma/src/commands/cli-runner-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/cli-runner-logic.ts
@@ -1,0 +1,45 @@
+/**
+ * cli-runner-logic.ts — pure error-normalization rules for CLI invocations.
+ *
+ * Owns the mapping from execFile's error shapes to the exit code and stderr
+ * text the extension surfaces to users. Kept free of vscode imports so the
+ * rules are unit-testable outside the extension host (same pattern as
+ * entry-file-logic.ts). cli-runner.ts owns the actual process spawning.
+ */
+
+/** The subset of execFile's callback error this module inspects. */
+export interface SpawnError {
+  /** Numeric exit code for non-zero process exits; a string errno (e.g.
+   *  "ENOENT") when the process could not be spawned at all. Node's
+   *  ExecFileException also permits null. */
+  code?: number | string | null;
+  message?: string;
+}
+
+/**
+ * Normalize execFile's error into a numeric exit code. error.code is a number
+ * for non-zero process exits but a string (e.g. "ENOENT") for spawn failures —
+ * Number("ENOENT") produced "exit code NaN" in user-facing messages (sl-wlta).
+ */
+export function exitCodeFrom(error: SpawnError | null): number {
+  if (!error) return 0;
+  return typeof error.code === "number" ? error.code : 1;
+}
+
+/**
+ * A user-actionable message for spawn failures, which never produce stderr of
+ * their own; returns null for success and ordinary non-zero exits. ENOENT —
+ * the satsuma CLI missing from PATH — is the most common new-user failure and
+ * gets a specific install hint; callers surface this text directly in their
+ * warning toasts.
+ */
+export function spawnFailureMessage(
+  error: SpawnError | null,
+  cliPath: string,
+): string | null {
+  if (!error || typeof error.code !== "string") return null;
+  if (error.code === "ENOENT") {
+    return `Satsuma CLI not found at "${cliPath}". Install it (npm install -g satsuma-cli) or point the satsuma.cliPath setting at the executable.`;
+  }
+  return `Failed to run the Satsuma CLI (${error.code}): ${error.message ?? "unknown error"}`;
+}

--- a/tooling/vscode-satsuma/src/commands/cli-runner.ts
+++ b/tooling/vscode-satsuma/src/commands/cli-runner.ts
@@ -1,5 +1,6 @@
 import { execFile } from "child_process";
 import { workspace } from "vscode";
+import { exitCodeFrom, spawnFailureMessage } from "./cli-runner-logic";
 
 export interface CliResult {
   stdout: string;
@@ -27,8 +28,8 @@ export function runCli(
       (error, stdout, stderr) => {
         resolve({
           stdout: stdout ?? "",
-          stderr: stderr ?? "",
-          exitCode: error?.code ? Number(error.code) : error ? 1 : 0,
+          stderr: spawnFailureMessage(error, cliPath) ?? stderr ?? "",
+          exitCode: exitCodeFrom(error),
         });
       },
     );

--- a/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
@@ -522,12 +522,6 @@ function formatMappingKey(key: string): string {
   return key.startsWith("::") ? key.slice(2) : key;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 // Minimal ELK type stubs for the @ts-nocheck context
 interface ElkNode {

--- a/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
@@ -298,12 +298,6 @@ function buildArrowMarker(): SVGMarkerElement {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 // Minimal ELK type stubs for the @ts-nocheck context
 interface ElkNode {

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -189,8 +189,14 @@ export class VizPanel {
   }
 
   private async exportSvg(content: string): Promise<void> {
+    // A bare relative Uri.file resolves to the filesystem root, opening the
+    // save dialog at "/" (sl-wlta). Default into the workspace instead; with
+    // no workspace open, let the dialog choose its own starting location.
+    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
     const uri = await vscode.window.showSaveDialog({
-      defaultUri: vscode.Uri.file("mapping-viz.svg"),
+      defaultUri: workspaceRoot
+        ? vscode.Uri.joinPath(workspaceRoot, "mapping-viz.svg")
+        : undefined,
       filters: { "SVG files": ["svg"] },
     });
     if (uri) {

--- a/tooling/vscode-satsuma/test/cli-runner-logic.test.js
+++ b/tooling/vscode-satsuma/test/cli-runner-logic.test.js
@@ -1,0 +1,58 @@
+/**
+ * Tests for the pure CLI error-normalization rules (sl-wlta).
+ *
+ * execFile's error.code is a number for non-zero process exits but a string
+ * errno for spawn failures. The old `Number(error.code)` coercion produced
+ * "exit code NaN" messages for ENOENT — the most common new-user failure,
+ * hit whenever the satsuma CLI is not installed. These rules guarantee a
+ * numeric exit code and an actionable message for that case.
+ */
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  exitCodeFrom,
+  spawnFailureMessage,
+} = require("../dist/client/commands/cli-runner-logic.js");
+
+describe("exitCodeFrom", () => {
+  it("returns 0 when the process exited cleanly", () => {
+    assert.equal(exitCodeFrom(null), 0);
+  });
+
+  it("passes through a numeric non-zero exit code", () => {
+    assert.equal(exitCodeFrom({ code: 2 }), 2);
+  });
+
+  it("maps a string errno to exit code 1, never NaN", () => {
+    // The regression under test: Number("ENOENT") is NaN.
+    const code = exitCodeFrom({ code: "ENOENT", message: "spawn satsuma ENOENT" });
+    assert.equal(code, 1);
+    assert.ok(!Number.isNaN(code));
+  });
+
+  it("treats an error without a code as exit 1", () => {
+    // e.g. the 15s timeout kills the process: error.code is undefined.
+    assert.equal(exitCodeFrom({ message: "killed" }), 1);
+  });
+});
+
+describe("spawnFailureMessage", () => {
+  it("names the missing CLI and how to install it for ENOENT", () => {
+    const msg = spawnFailureMessage({ code: "ENOENT" }, "satsuma");
+    assert.match(msg, /Satsuma CLI not found at "satsuma"/);
+    assert.match(msg, /satsuma\.cliPath/);
+  });
+
+  it("reports other spawn errnos with their code", () => {
+    const msg = spawnFailureMessage({ code: "EACCES", message: "permission denied" }, "/opt/satsuma");
+    assert.match(msg, /EACCES/);
+    assert.match(msg, /permission denied/);
+  });
+
+  it("returns null for ordinary non-zero exits so real stderr is shown", () => {
+    // A failing validate run produces its own stderr; the synthetic message
+    // must not mask it.
+    assert.equal(spawnFailureMessage({ code: 1, message: "exit 1" }, "satsuma"), null);
+    assert.equal(spawnFailureMessage(null, "satsuma"), null);
+  });
+});


### PR DESCRIPTION
## Summary

Second batch of P3 fixes from the June 2026 bug hunt (follow-up to #282). Five tickets, one commit each:

- **sl-74m6 (core)** — NL @ref extraction missed refs immediately after quotes, `=`, or `:` (unintended collateral of the sl-gl21 lookbehind), and never looked inside `map { ... }` literal entries. The lookbehind now allows those prefixes, and a shared `nlStringNodesInPipeStep()` helper descends into map-literal keys/values for both arrow and transform pipe chains.
- **sl-ellp (lsp/viz-backend)** — `indexNlRefs` walked only mapping bodies, so @refs in `(note "...")` tags, `note` blocks, and metadata values were invisible to find-references and rename, leaving stale prose after renames. The walk now runs file-wide from `indexFile`, and NL prose refs carry a new honest `"nl"` reference context instead of `"arrow"`.
- **sl-0tgo (lsp)** — three minor issues: closing a modified-but-unsaved document now re-indexes from disk (previously the discarded buffer content lingered in the index); dead checks on hidden grammar rules `_source_entry`/`_arrow_transform_body` removed/replaced with reachable node types (empty arrow bodies now get pipe completions); the schema codelens counts distinct mappings via a new `container` field on source/target references instead of double-counting a mapping that names the schema in both blocks.
- **sl-ebs9 (viz-backend)** — standalone `//!`/`//?` comments between blocks inside a namespace were dropped from the viz model (`collectTopLevelComments` walked only root children and resolved against the global group). The sibling walk now also runs per namespace block against that namespace's group.
- **sl-wlta (vscode)** — `Number(error.code)` turned ENOENT spawn failures into "exit code NaN"; users now get a clear "Satsuma CLI not found… install or set satsuma.cliPath" message (logic extracted to a vscode-free, unit-tested `cli-runner-logic.ts`). The SVG export save dialog defaults inside the workspace instead of the filesystem root. Two dead, quote-unsafe `escapeHtml` helpers removed.

## Testing

- satsuma-core: 376 pass (new lookbehind-prefix and map-literal extraction tests, real-parser backed)
- satsuma-cli: 851 pass
- satsuma-viz-backend: 157 pass (namespaced comment attachment tests)
- satsuma-lsp: 266 pass (note-tag/note-block/namespace NL indexing, no-double-index, rename round-trip, empty-arrow-body completion, distinct-mapping codelens)
- vscode-satsuma: 21 unit + tmGrammar fixtures/golden pass (cli-runner-logic tests)

No ADR: all changes are bugfixes; the two additive index-contract fields (`"nl"` context, `container`) document themselves in `ReferenceEntry`.

Remaining open P3 bug-hunt tickets after this PR: sl-0nvt, sl-2gle, sl-xb85 (grammar — need spec decisions), sl-fm0q, sl-sewl (viz Lit components — need the human-in-the-loop Playwright harness), sl-jar4 (vscode VizPanel refresh races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)