### PR TITLE
fix(viz-backend): resolve namespaced fragment spreads, preserve unresolvable ones (sl-22ym)

### DIFF
--- a/.tickets/sl-22ym.md
+++ b/.tickets/sl-22ym.md
@@ -1,6 +1,6 @@
 ---
 id: sl-22ym
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:53Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/viz-model.ts:261-289 — resolveAndStripSpreads keys fra
 
 Namespaced spreads expand correctly; unresolvable spreads are preserved/flagged rather than erased; namespaced spread test.
 
+
+## Notes
+
+**2026-06-11T07:23:03Z**
+
+Cause: resolveAndStripSpreads built the fragment lookup keyed by namespace-qualified ids (crm::audit) but invoked core expandEntityFields with currentNs=null, so a bare ...audit spread inside a namespace never resolved; the spread list was then unconditionally cleared, erasing both the fields and any trace of the spread.
+Fix: pass the namespace group's name as the resolution context so bare same-namespace spreads expand, and only remove spreads that actually resolved — unresolvable ones stay on the SchemaCard, which the frontend already renders as a '… spreads X' indicator. Regression tests for both behaviours.

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -254,9 +254,13 @@ function fieldInfoToEntry(fi: FieldInfo, defUri: string): FieldEntry {
  * Pre-resolve all fragment spreads into schema fields, then strip fragment
  * nodes from every namespace group.
  *
- * Resolution is cross-namespace (a schema in `src` can spread `common::frag`)
- * and transitive (a fragment may itself spread another fragment). Core's
- * expandEntityFields() handles cycle detection and diamond-shaped graphs.
+ * Resolution is cross-namespace (a schema in `src` can spread `common::frag`),
+ * namespace-relative (a bare `...frag` resolves within the schema's own
+ * namespace first), and transitive (a fragment may itself spread another
+ * fragment). Core's expandEntityFields() handles cycle detection and
+ * diamond-shaped graphs. Spreads that resolve are replaced by their fields and
+ * removed; spreads that don't resolve are left in place so the schema card can
+ * surface the dangling reference instead of silently dropping it.
  */
 function resolveAndStripSpreads(namespaces: NamespaceGroup[]): void {
   // Build a flat entity lookup for spread resolution across all namespaces.
@@ -273,15 +277,19 @@ function resolveAndStripSpreads(namespaces: NamespaceGroup[]): void {
   const resolveRef = makeEntityRefResolver(entityMap);
   const lookupFragment = (key: string) => entityMap.get(key) ?? null;
 
-  // Expand schema spreads using core and append resulting fields.
+  // Expand schema spreads using core and append resulting fields. The schema's
+  // own namespace is the resolution context, so a bare `...audit` inside
+  // `namespace crm` finds the fragment keyed `crm::audit` (sl-22ym).
   for (const ns of namespaces) {
     for (const s of ns.schemas) {
       if (s.spreads.length === 0) continue;
       const spreadEntity = schemaToSpreadEntity(s);
-      const expanded = expandEntityFields(spreadEntity, null, resolveRef, lookupFragment);
+      const expanded = expandEntityFields(spreadEntity, ns.name, resolveRef, lookupFragment);
       const extraFields: FieldEntry[] = expanded.map((ef) => expandedFieldToEntry(ef));
       s.fields = [...s.fields, ...extraFields];
-      s.spreads = [];
+      // Keep spreads that could not be resolved: the schema card renders them
+      // as a "… spreads X" indicator, which beats silently losing the reference.
+      s.spreads = s.spreads.filter((name) => resolveRef(name, ns.name) === null);
     }
     // Fragments are resolved away — remove them so the viz never renders them.
     ns.fragments = [];

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -671,6 +671,50 @@ namespace src {
     assert.ok(names.includes("name"), "direct field name should be present");
   });
 
+  it("resolves bare spreads of a fragment in the same namespace (sl-22ym)", () => {
+    // A bare `...audit` inside `namespace crm` must resolve to crm::audit.
+    // Regression: expansion ran with currentNs=null so the namespace-qualified
+    // fragment key was never tried and the spread's fields were silently lost.
+    const src = `
+namespace crm {
+  fragment audit {
+    created_at  x
+  }
+  schema customers {
+    ...audit
+    id  x
+  }
+}
+`;
+    const model = vizModel(src);
+    const crmNs = model.namespaces.find((ns) => ns.name === "crm");
+    const schema = crmNs.schemas.find((s) => s.qualifiedId === "crm::customers");
+    const names = schema.fields.map((f) => f.name);
+    assert.ok(names.includes("created_at"), "same-namespace spread field should be resolved");
+    assert.ok(names.includes("id"), "direct field id should be present");
+    assert.deepEqual(schema.spreads, [], "resolved spread should be cleared");
+  });
+
+  it("preserves unresolvable spreads so the card still shows the reference", () => {
+    // A spread naming a fragment that doesn't exist cannot be expanded, but it
+    // must not be silently erased either — the schema card renders remaining
+    // `spreads` entries as a visible "… spreads X" indicator.
+    const src = `
+schema s1 {
+  ...does_not_exist
+  id  x
+}
+`;
+    const model = vizModel(src);
+    const schema = model.namespaces[0].schemas[0];
+    assert.deepEqual(schema.spreads, ["does_not_exist"], "unresolvable spread should be preserved");
+    assert.deepEqual(
+      schema.fields.map((f) => f.name),
+      ["id"],
+      "no phantom fields should be added",
+    );
+  });
+
   it("preserves direct fields alongside spread fields", () => {
     const src = `
 namespace common {


### PR DESCRIPTION
## Summary
- `resolveAndStripSpreads` keyed fragments by namespace-qualified id (`crm::audit`, set by `extractFragment`) but called core's `expandEntityFields` with `currentNs = null`, so a bare `...audit` spread inside `namespace crm` could never resolve. The spread list was then unconditionally cleared, so the schema card showed neither the fragment's fields nor any hint a spread existed.
- Fix: pass the namespace group's name as the resolution context (matching every CLI call site, which already passes `entity.namespace ?? null`), and only remove spreads that actually resolved. Unresolvable spreads stay on the `SchemaCard`, which `sz-schema-card` already renders as a visible "… spreads X" indicator.

## Testing
- New regression tests: bare same-namespace spread expands; unresolvable spread is preserved (not erased) with no phantom fields.
- `satsuma-viz-backend`: 159/159 pass. `satsuma-viz`: 65/65 pass. Pre-commit hooks (incl. lineage smoke tests) pass.

Closes sl-22ym.

🤖 Generated with [Claude Code](https://claude.com/claude-code)