### PR TITLE
fix: bare pipe-text @refs invisible to NL extraction and the reference index (bptar-l6n8)

### DIFF
--- a/.tickets/bptar-l6n8.md
+++ b/.tickets/bptar-l6n8.md
@@ -1,0 +1,26 @@
+---
+id: bptar-l6n8
+status: closed
+deps: []
+links: []
+created: 2026-06-11T07:15:34Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [bug-hunt, core, nl-ref]
+---
+# core: bare @refs in unquoted pipe text invisible to NL ref extraction and LSP indexing
+
+The grammar parses bare (unquoted) pipe text structurally: 'a -> b { derived from @b }' yields (pipe_text (identifier) (identifier) (at_ref (identifier))). But extractNLRefData (satsuma-core/src/nl-ref.ts) only collects nl_string/multiline_string nodes from pipe steps, so the already-parsed at_ref node is ignored — the ref never reaches nl-refs output, lineage, or validation. Control: the quoted form '{ "derived from @b" }' extracts fine. Same blind spot in satsuma-viz-backend workspace-index indexNlRefs, which regex-scans NL strings only, so find-references/rename miss bare-text @refs. Found adjacent to sl-74m6 (which fixed lookbehind prefixes and map-literal values but not this).
+
+## Acceptance Criteria
+
+extractNLRefData emits ref items for at_ref nodes in bare pipe text (arrow and transform bodies); refs resolve and validate like quoted ones; workspace index registers bare at_refs as nl references with @-sigil-excluded ranges so rename round-trips; tests for both layers.
+
+
+## Notes
+
+**2026-06-11T07:25:46Z**
+
+Cause: the grammar parses unquoted pipe text structurally — '{ derived from @b }' yields an at_ref node, not an nl_string — but both core extractNLRefData (pipe-step walkers) and the viz-backend workspace index's indexNlRefs collected/regex-scanned only nl_string/multiline_string nodes, so bare refs never reached nl-refs output, lineage, validation, find-references, or rename.
+Fix: core's pipe-step helper (now nlRefNodesInPipeStep) also yields at_ref nodes, with a shared nlRefText payload helper keeping position math identical to the quoted form; viz-backend indexNlRefs indexes at_ref nodes directly as "nl" references with the @ sigil excluded from the stored range (sl-xf3f contract). Real-parser tests cover arrow/transform bodies, multiple refs per step, backtick names, position anchoring, index ranges, and a rename round trip.

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -483,13 +483,18 @@ function extractMappingNLRefs(mappingNode: SyntaxNode, namespace: string | null,
   walkArrowsForNL(body, mappingName, namespace, null, results);
 }
 
-// Collect the NL string nodes carried by a single pipe step. A step is one of
-// three shapes: pipe_text (NL strings are direct children), a map literal
-// (NL strings live inside each entry's key and value — sl-74m6: refs in
-// `map { "x": "see @customers.id" }` must reach lineage and validation), or a
-// fragment spread (never carries NL text).
-function nlStringNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
-  const isNL = (n: SyntaxNode) => n.type === "nl_string" || n.type === "multiline_string";
+// Collect the ref-bearing nodes carried by a single pipe step. A step is one
+// of three shapes: pipe_text (NL strings and bare at_refs are direct
+// children), a map literal (NL strings live inside each entry's key and
+// value — sl-74m6: refs in `map { "x": "see @customers.id" }` must reach
+// lineage and validation), or a fragment spread (never carries NL text).
+//
+// Bare at_refs matter because the grammar parses unquoted pipe text
+// structurally: `a -> b { derived from @b }` yields an at_ref node with no
+// surrounding NL string, so a string-only walk never sees it (bptar-l6n8).
+function nlRefNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
+  const isNL = (n: SyntaxNode) =>
+    n.type === "nl_string" || n.type === "multiline_string" || n.type === "at_ref";
   const inner = step.namedChildren[0];
   if (!inner) return [];
   if (inner.type === "pipe_text") return inner.namedChildren.filter(isNL);
@@ -500,6 +505,18 @@ function nlStringNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
       .flatMap((part) => part.namedChildren.filter(isNL));
   }
   return [];
+}
+
+// The text payload of one ref-bearing node, or null when it cannot contain a
+// ref. Quoted NL strings are unwrapped from their delimiters; a bare at_ref
+// keeps its "@name" text verbatim so the downstream regex scan finds the ref
+// at offset zero, making position math identical to the quoted case.
+function nlRefText(node: SyntaxNode): string | null {
+  const text =
+    node.type === "multiline_string" ? node.text.slice(3, -3) :
+    node.type === "nl_string" ? node.text.slice(1, -1) :
+    node.text; // at_ref
+  return text.includes("`") || /@[a-zA-Z_`]/.test(text) ? text : null;
 }
 
 function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | null, results: NLRefDataItemNoFile[]): void {
@@ -513,11 +530,9 @@ function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | n
 
   for (const step of pipeChain.namedChildren) {
     if (step.type === "pipe_step") {
-      for (const nlNode of nlStringNodesInPipeStep(step)) {
-        const text = nlNode.type === "multiline_string"
-          ? nlNode.text.slice(3, -3)
-          : nlNode.text.slice(1, -1);
-        if (text.includes("`") || /@[a-zA-Z_`]/.test(text)) {
+      for (const nlNode of nlRefNodesInPipeStep(step)) {
+        const text = nlRefText(nlNode);
+        if (text !== null) {
           results.push({
             text,
             mapping: `transform:${transformName}`,
@@ -671,11 +686,9 @@ function walkArrowsForNL(
       if (pipeChain) {
         for (const step of pipeChain.namedChildren) {
           if (step.type === "pipe_step") {
-            for (const nlNode of nlStringNodesInPipeStep(step)) {
-              const text = nlNode.type === "multiline_string"
-                ? nlNode.text.slice(3, -3)
-                : nlNode.text.slice(1, -1);
-              if (text.includes("`") || /@[a-zA-Z_`]/.test(text)) {
+            for (const nlNode of nlRefNodesInPipeStep(step)) {
+              const text = nlRefText(nlNode);
+              if (text !== null) {
                 results.push({
                   text,
                   mapping: mappingName,

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -370,3 +370,64 @@ describe("extractNLRefData — map literal NL strings (sl-74m6)", () => {
     assert.deepEqual(nlRefItems(src), []);
   });
 });
+
+// ── extractNLRefData — bare pipe-text at_refs (bptar-l6n8) ────────────────────
+//
+// The grammar parses unquoted pipe text structurally, so `{ derived from @b }`
+// produces an at_ref node with no surrounding NL string. The walker previously
+// collected only nl_string/multiline_string nodes, making bare refs invisible
+// to nl-refs output, lineage, and validation while the quoted form worked.
+
+describe("extractNLRefData — bare pipe-text at_refs (bptar-l6n8)", () => {
+  before(async () => {
+    await initParser(WASM_PATH);
+  });
+
+  function nlRefItems(src) {
+    return extractNLRefData(getParser().parse(src).rootNode);
+  }
+
+  it("extracts a bare @ref from an arrow transform body", () => {
+    // The ticket repro: same prose as the quoted control below, minus quotes.
+    const items = nlRefItems("mapping m {\n  a -> b { derived from @src.col }\n}");
+    assert.equal(items.length, 1);
+    assert.equal(items[0].text, "@src.col");
+    assert.equal(items[0].mapping, "m");
+    assert.equal(items[0].targetField, "b");
+  });
+
+  it("extracts a bare @ref from a transform block body", () => {
+    // Transforms share the pipe-step walker — bare refs must surface there too.
+    const items = nlRefItems("transform t {\n  uppercase | take from @customers.id\n}");
+    assert.equal(items.length, 1);
+    assert.equal(items[0].text, "@customers.id");
+    assert.equal(items[0].mapping, "transform:t");
+  });
+
+  it("extracts every bare @ref when one pipe step holds several", () => {
+    // Each at_ref is its own CST node; all of them must become items, each
+    // anchored at its own position for diagnostics.
+    const items = nlRefItems("mapping m {\n  a -> b { @x plus @y }\n}");
+    assert.deepEqual(items.map((i) => i.text), ["@x", "@y"]);
+    assert.notEqual(items[0].column, items[1].column);
+  });
+
+  it("extracts a bare backtick-named @ref", () => {
+    // @`order id` is the backtick at_ref grammar branch; the item text keeps
+    // the raw form so downstream extractAtRefs/normalization applies once.
+    const items = nlRefItems("mapping m {\n  a -> b { lookup @`order id` }\n}");
+    assert.equal(items.length, 1);
+    assert.equal(items[0].text, "@`order id`");
+  });
+
+  it("anchors a bare @ref so position math matches the quoted form", () => {
+    // For quoted items, column points at the opening delimiter and
+    // computeNLRefPosition's +1 lands on the @. A bare item has no delimiter,
+    // so its column is the @ itself and the same +1 yields the 1-based column.
+    const src = "mapping m {\n  a -> b { from @z }\n}";
+    const [item] = nlRefItems(src);
+    const pos = computeNLRefPosition(item, item.text.indexOf("@"));
+    assert.equal(pos.line, 2); // 1-based line of the arrow
+    assert.equal(pos.column, src.split("\n")[1].indexOf("@") + 1); // 1-based @ column
+  });
+});

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -235,6 +235,33 @@ schema customers {
     );
   });
 
+  it("rewrites a bare @ref in unquoted pipe text without deleting the @ sigil", () => {
+    // bptar-l6n8: bare pipe text parses to a structural at_ref node, not an
+    // nl_string, so the rename pipeline never saw it — `{ derived from
+    // @customers }` kept the old name after a rename while the quoted form
+    // was rewritten.
+    const bSource =
+      'mapping `m` {\n  source { customers }\n  target { dim }\n  a -> b { derived from @customers }\n}';
+    const { index, trees } = buildIndex({
+      "file:///a.stm": "schema customers {\n  id UUID\n}",
+      "file:///b.stm": bSource,
+    });
+    const edit = computeRename(
+      trees["file:///a.stm"],
+      0,
+      8,
+      "file:///a.stm",
+      index,
+      "clients",
+    );
+    assert.ok(edit);
+    const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
+    assert.ok(
+      renamed.includes("derived from @clients"),
+      `expected bare at_ref to be renamed with @ intact, got: ${renamed}`,
+    );
+  });
+
   it("preserves the dotted tail of an arrow path whose first segment matches the renamed name", () => {
     // sl-xf3f: arrow paths were indexed under their first segment but with the
     // range of the WHOLE path node, so renaming a schema named "address"

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -734,6 +734,33 @@ describe("NL string reference indexing", () => {
     const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
     assert.equal(refs.length, 1);
   });
+
+  // bptar-l6n8: bare (unquoted) pipe text parses to structural at_ref nodes,
+  // not nl_strings, so the regex-over-strings walk never saw them and
+  // find-references/rename skipped bare-text refs entirely.
+
+  it("indexes a bare @ref in unquoted pipe text, range excluding the @ sigil", () => {
+    const line = '  a -> b { derived from @customers }';
+    const source = `mapping test {\n  source { customers }\n  target { dim }\n${line}\n}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+    // sl-xf3f contract: rename replaces the range verbatim, so the @ must
+    // stay outside it.
+    assert.equal(refs[0].range.start.line, 3);
+    assert.equal(refs[0].range.start.character, line.indexOf("@") + 1);
+    assert.equal(refs[0].range.end.character, line.indexOf("@") + 1 + "customers".length);
+  });
+
+  it("indexes a bare backtick-named @ref under its unquoted name", () => {
+    // Backtick delimiters are stripped from the keyed name, mirroring the
+    // quoted-string regex path, so lookups by the plain name find it.
+    const idx = buildIndex({
+      "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  a -> b { lookup @`order id` }\n}",
+    });
+    const refs = (idx.references.get("order id") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
 });
 
 describe("transform spread indexing in arrows", () => {

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -926,12 +926,17 @@ function extractArrowFieldName(pathNode: SyntaxNode): string | null {
 const NL_AT_REF_RE = createAtRefRegex();
 
 /**
- * Index every @ref inside NL strings under `node` as an "nl" reference.
+ * Index every @ref inside NL prose under `node` as an "nl" reference.
  *
  * Called once per file with the root node (sl-ellp): NL prose carrying refs
  * lives not only in arrow bodies but in `(note "...")` metadata tags, `note`
  * blocks at any level, and metadata value strings — all of which rename and
  * find-references must reach, or renames leave stale prose behind.
+ *
+ * Refs come in two CST shapes: regex matches inside quoted NL strings, and
+ * structural at_ref nodes that the grammar parses out of bare (unquoted)
+ * pipe text — `a -> b { derived from @b }` has no nl_string at all, so a
+ * string-only walk missed it entirely (bptar-l6n8).
  */
 function indexNlRefs(
   index: WorkspaceIndex,
@@ -939,6 +944,27 @@ function indexNlRefs(
   node: SyntaxNode,
 ): void {
   walkDescendants(node, (n) => {
+    if (n.type === "at_ref") {
+      // Strip the leading @ and any backtick delimiters, mirroring the
+      // regex path below.
+      const refName = n.text.slice(1).replace(/`([^`]+)`/g, "$1");
+
+      // As below, the @ sigil stays outside the stored range (sl-xf3f).
+      // An at_ref never spans lines, so a simple column bump is safe.
+      addReference(index, refName, {
+        uri,
+        range: Range.create(
+          n.startPosition.row,
+          n.startPosition.column + 1,
+          n.endPosition.row,
+          n.endPosition.column,
+        ),
+        name: refName,
+        context: "nl",
+      });
+      return;
+    }
+
     if (n.type !== "nl_string" && n.type !== "multiline_string") return;
 
     const text = n.text;


### PR DESCRIPTION
## Summary

The grammar parses unquoted pipe text structurally — `a -> b { derived from @b }` yields `(pipe_text (identifier) (identifier) (at_ref ...))` — but both NL-ref consumers only looked at quoted NL strings:

- **core `extractNLRefData`** collected `nl_string`/`multiline_string` nodes from pipe steps, so the already-parsed `at_ref` never reached `nl-refs` output, lineage, or validation. The quoted form `{ "derived from @b" }` worked; the bare form silently returned nothing.
- **viz-backend `indexNlRefs`** regex-scanned NL string text only, so find-references and rename skipped bare-text refs (rename left `@oldname` stale in unquoted prose).

Spotted adjacent to sl-74m6, which fixed lookbehind prefixes and map-literal values but not this shape. Raised as ticket `bptar-l6n8` (in this PR).

## Changes

- `satsuma-core/src/nl-ref.ts` — the pipe-step helper (now `nlRefNodesInPipeStep`) also yields `at_ref` nodes; a shared `nlRefText` payload helper unwraps quoted strings and passes `@name` text through verbatim, so the downstream regex scan and position math work identically for both shapes. Applies to arrow and transform bodies.
- `satsuma-viz-backend/src/workspace-index.ts` — `indexNlRefs` indexes `at_ref` nodes directly as `"nl"` references, with the `@` sigil excluded from the stored range per the sl-xf3f rename contract; backtick delimiters stripped from the keyed name to match the regex path.

## Testing

- satsuma-core: 387 pass — new real-parser cases: bare ref in arrow body, transform body, several refs in one step, backtick names, position-anchor parity with the quoted form
- satsuma-lsp: 273 pass — index range/keying for bare and backtick refs, rename round trip through bare pipe text
- satsuma-viz-backend: 157 pass; satsuma-cli: 857 pass (no golden-output regressions)
- End-to-end: `satsuma nl-refs` on a bare-ref mapping now reports the ref resolved as a dotted-field

🤖 Generated with [Claude Code](https://claude.com/claude-code)