### PR TITLE
fix(core): resolve bare @field refs against namespaced source schemas (sl-98cz)

### DIFF
--- a/.tickets/sl-98cz.md
+++ b/.tickets/sl-98cz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-98cz
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ extractMappings (satsuma-core/src/extract.ts:425-427) namespace-qualifies mappin
 
 Bare and dotted @refs against source schemas resolve inside namespaces; test with namespaced mapping using bare field refs on both source and target side.
 
+
+## Notes
+
+**2026-06-11T08:58:55Z**
+
+Cause: extractMappings records source names exactly as authored (bare inside namespaces) while the workspace index keys schemas qualified, and core resolveRef looked context schemas up raw — so bare/dotted @field refs against namespaced source schemas never resolved at the core level. The shipped CLI and viz paths were masked by consumer-side patches (index-builder resolveScopedEntityRef, viz-model resolveMappingRef), but the core API contract remained a trap for any consumer that did not pre-qualify.
+Fix: added contextSchemaKey() in core nl-ref.ts — context schema names without "::" are tried namespace-qualified first (when that key exists in the lookup), falling back to the raw name for global schemas — and applied it at the dotted-field and bare-identifier lookup sites; resolvedTo names report the qualified key. Documented the extraction-time source/target qualification asymmetry at the extractMappings site. Tests pin the ticket repro (bare and dotted refs, source and target side) and the global-schema fallback.

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -422,6 +422,11 @@ export function extractMappings(rootNode: SyntaxNode): ExtractedMapping[] {
         allDescendants(body, "nested_arrow").length;
     }
 
+    // Targets are namespace-qualified here; sources are intentionally left as
+    // authored. Extraction has no workspace knowledge to decide whether a bare
+    // source name is namespace-local or global, so resolution-time consumers
+    // qualify them against the index instead (core resolveRef's
+    // contextSchemaKey, the CLI's resolveScopedEntityRef — sl-98cz).
     const qualifiedTargets = targets.map((t) =>
       namespace && !t.includes("::") ? `${namespace}::${t}` : t,
     );

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -327,6 +327,25 @@ function hasFieldWithSpreads(schema: SchemaLike, fieldName: string, lookup: Defi
  *    Then tried as a schema/fragment/transform name (with namespace prefix if
  *    the mapping is inside a namespace block).
  */
+/**
+ * Resolve a mapping-context schema name to the key it is indexed under.
+ *
+ * Source/target lists come from extraction, which records names exactly as
+ * authored: a bare name inside a namespaced mapping ("customers") usually
+ * refers to a sibling schema indexed under "ns::customers". Looking it up
+ * raw made every bare @field ref against a namespaced source schema report
+ * as unresolved (sl-98cz). Try the namespace-qualified form first, then fall
+ * back to the raw name so global schemas referenced from inside a namespace
+ * still resolve.
+ */
+function contextSchemaKey(name: string, namespace: string | null, lookup: DefinitionLookup): string {
+  if (namespace && !name.includes("::")) {
+    const qualified = `${namespace}::${name}`;
+    if (lookup.hasSchema(qualified)) return qualified;
+  }
+  return name;
+}
+
 export function resolveRef(ref: string, mappingContext: MappingContext, lookup: DefinitionLookup): Resolution {
   const classification = classifyRef(ref);
 
@@ -355,14 +374,15 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
 
     const allSchemas = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
     for (const s of allSchemas) {
-      const schema = lookup.getSchema(s);
+      const key = contextSchemaKey(s, mappingContext.namespace, lookup);
+      const schema = lookup.getSchema(key);
       if (schema && hasNestedFieldPath(schema.fields, ref)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
       }
       if (schema?.hasSpreads) {
         const expanded = getExpandedFields(schema, lookup);
         if (hasNestedFieldPath([...schema.fields, ...expanded], ref)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
         }
       }
     }
@@ -371,9 +391,10 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
       const nsIdx = s.indexOf("::");
       const baseName = nsIdx !== -1 ? s.slice(nsIdx + 2) : s;
       if (baseName === schemaName || s === schemaName) {
-        const schema = lookup.getSchema(s);
+        const key = contextSchemaKey(s, mappingContext.namespace, lookup);
+        const schema = lookup.getSchema(key);
         if (schema && hasFieldWithSpreads(schema, fieldName, lookup)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${fieldName}` } };
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
         }
       }
     }
@@ -405,9 +426,10 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
   // Bare identifier
   const allSchemaNames = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
   for (const s of allSchemaNames) {
-    const schema = lookup.getSchema(s);
+    const key = contextSchemaKey(s, mappingContext.namespace, lookup);
+    const schema = lookup.getSchema(key);
     if (schema && hasFieldWithSpreads(schema, ref, lookup)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(s)}.${ref}` } };
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
     }
   }
 

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -257,6 +257,50 @@ describe("resolveRef()", () => {
     assert.equal(r.resolved, true);
     assert.equal(r.resolvedTo.kind, "field");
   });
+
+  // sl-98cz: extraction records source/target lists exactly as authored, so a
+  // namespaced mapping's bare source name ("customers") arrives unqualified
+  // while the index keys the schema "crm::customers". resolveRef must try the
+  // namespace-qualified form before giving up, or every bare @field ref against
+  // a namespaced source schema becomes a false unresolved-nl-ref warning.
+
+  it("resolves a bare field against an unqualified source name inside a namespace (sl-98cz)", () => {
+    const lookup = makeLookup({
+      "crm::customers": { fields: [{ name: "account_id" }], hasSpreads: false },
+      "crm::tgt": { fields: [{ name: "id" }], hasSpreads: false },
+    });
+    // The ticket repro: sources raw, targets pre-qualified (extractMappings
+    // qualifies only targets), both fields must resolve symmetrically.
+    const ctx = { sources: ["customers"], targets: ["crm::tgt"], namespace: "crm" };
+    const src = resolveRef("account_id", ctx, lookup);
+    assert.equal(src.resolved, true);
+    assert.equal(src.resolvedTo.name, "crm::customers.account_id");
+    const tgt = resolveRef("id", ctx, lookup);
+    assert.equal(tgt.resolved, true);
+    assert.equal(tgt.resolvedTo.name, "crm::tgt.id");
+  });
+
+  it("resolves a dotted field against an unqualified source name inside a namespace (sl-98cz)", () => {
+    const lookup = makeLookup({
+      "crm::customers": { fields: [{ name: "account_id" }], hasSpreads: false },
+    });
+    const ctx = { sources: ["customers"], targets: [], namespace: "crm" };
+    const r = resolveRef("customers.account_id", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "crm::customers.account_id");
+  });
+
+  it("falls back to the global schema when the namespace-qualified name does not exist (sl-98cz)", () => {
+    // A namespaced mapping may legitimately source a global schema; namespace
+    // qualification must not shadow it when no sibling schema exists.
+    const lookup = makeLookup({
+      "::shared_ref": { fields: [{ name: "code" }], hasSpreads: false },
+    });
+    const ctx = { sources: ["::shared_ref"], targets: [], namespace: "crm" };
+    const r = resolveRef("code", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::shared_ref.code");
+  });
 });
 
 // ── resolveAllNLRefs ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes `sl-98cz` (P1, bug-hunt): bare and dotted `@field` refs against source schemas inside namespaces reported as `unresolved-nl-ref` at the core level.

**Root cause.** `extractMappings` records source names exactly as authored — bare (`customers`) inside a namespaced mapping — while the workspace index keys schemas qualified (`crm::customers`). Core `resolveRef` looked context schema names up raw, so source-side refs never found their schema (targets worked because extraction blindly qualifies them).

**Why the shipped CLI didn't show it.** Both downstream paths carry consumer-side patches — the CLI's `index-builder` runs `resolveScopedEntityRef` over mapping sources, and viz-model runs `resolveMappingRef` — so `satsuma validate`/`nl-refs` already resolved the ticket's repro. But the core API contract (`extractMappings` + `resolveRef`) remained a trap for any consumer that doesn't pre-qualify, which is exactly the kind of duplicated compensation the Core-vs-Consumer rule says belongs in core.

## Changes

- `satsuma-core/src/nl-ref.ts` — new `contextSchemaKey()` helper: a context schema name without `::` is tried namespace-qualified first (when that key exists in the lookup), falling back to the raw name so global schemas referenced from inside a namespace still resolve. Applied at the dotted-field and bare-identifier lookup sites; `resolvedTo` names now report the qualified key.
- `satsuma-core/src/extract.ts` — documented the intentional source/target qualification asymmetry at the `extractMappings` site the ticket cited (extraction has no workspace knowledge to qualify sources safely).

## Testing

- satsuma-core: 390 pass — new cases pin the ticket repro (bare ref on source and target side resolving symmetrically to qualified names), dotted refs against unqualified source names, and the global-schema fallback when no namespace-local sibling exists
- Consumers unaffected (they pass already-qualified names, for which the helper is a no-op): satsuma-cli 857, satsuma-viz-backend 159, satsuma-lsp 273 — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)