### PR TITLE
fix(core): extract arrow records at arbitrary nesting depth (sl-zl55)

### DIFF
--- a/.tickets/sl-zl55.md
+++ b/.tickets/sl-zl55.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zl55
-status: open
+status: in_progress
 deps: []
 links: [sl-fm0q]
 created: 2026-06-10T23:21:30Z

--- a/.tickets/sl-zl55.md
+++ b/.tickets/sl-zl55.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zl55
-status: in_progress
+status: closed
 deps: []
 links: [sl-fm0q]
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,12 @@ satsuma-core/src/extract.ts:793-797 and 806-810 walk only one level: children of
 
 extractArrowRecords recurses to arbitrary nesting depth; agrees with extractMappings arrow counting; tests cover 3-level nested arrows and nested each/flatten.
 
+
+## Notes
+
+**2026-06-11T09:02:57Z**
+
+**2026-06-11T08:55:00Z**
+
+Cause: extractArrowRecords walked mapping bodies one level deep — nested_arrow children were scanned for map/computed arrows only (nested_arrow children skipped), and each/flatten bodies were scanned for arrows but not nested each/flatten blocks. All arrows below one level vanished from graph, lineage, coverage, and validation, while extractMappings.arrowCount (full-depth descendant walk) disagreed on the same input.
+Fix: Replaced the single-level loops with a recursive collectArrowRecords helper; containers emit their own record and pass their absolute source/target down as path prefixes, accumulating across arbitrary depth. New arrow-records.test.js parses real source via WASM and pins 3-level nesting, nested each/flatten, mixed nesting, and count agreement with extractMappings. (commit 8e404e0)

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -9,7 +9,7 @@
 import { canonicalRef } from "./canonical-ref.js";
 import { classifyTransform, classifyArrow } from "./classify.js";
 import { extractMetadata } from "./meta-extract.js";
-import { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText as cstSourceRefText, sourceRefStructuralText } from "./cst-utils.js";
+import { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefStructuralText } from "./cst-utils.js";
 import type { Classification, FieldDecl, MetaEntry, PipeStep, SyntaxNode } from "./types.js";
 
 // ── Internal field tree ────────────────────────────────────────────────────
@@ -758,6 +758,13 @@ export interface ExtractedArrow {
 
 /**
  * Extract detailed arrow records from all mapping blocks in the CST.
+ *
+ * Arrows nest to arbitrary depth (nested_arrow bodies hold further arrow
+ * declarations; each/flatten bodies hold arrow declarations plus nested
+ * each/flatten blocks — spec §4.4), so the walk recurses through every
+ * container. Each container (nested_arrow, each_block, flatten_block) emits
+ * its own record — for each/flatten this is the list-to-list arrow — and its
+ * children's relative paths are made absolute against the container's paths.
  */
 export function extractArrowRecords(rootNode: SyntaxNode): ExtractedArrow[] {
   const records: ExtractedArrow[] = [];
@@ -766,52 +773,55 @@ export function extractArrowRecords(rootNode: SyntaxNode): ExtractedArrow[] {
     const mappingName = labelText(mappingNode);
     const body = child(mappingNode, "mapping_body");
     if (!body) continue;
-
-    const directArrows = body.namedChildren.filter(
-      (c) => c.type === "map_arrow" || c.type === "computed_arrow",
-    );
-    const nestedArrows = body.namedChildren.filter(
-      (c) => c.type === "nested_arrow",
-    );
-    const eachBlocks = body.namedChildren.filter(
-      (c) => c.type === "each_block",
-    );
-    const flattenBlocks = body.namedChildren.filter(
-      (c) => c.type === "flatten_block",
-    );
-
-    for (const arrow of directArrows) {
-      records.push(extractSingleArrow(arrow, mappingName, namespace, null, null));
-    }
-
-    for (const nested of nestedArrows) {
-      const parentSrc = pathText(child(nested, "src_path"));
-      const parentTgt = pathText(child(nested, "tgt_path"));
-
-      records.push(extractSingleArrow(nested, mappingName, namespace, null, null));
-
-      for (const childArrow of nested.namedChildren) {
-        if (childArrow.type === "map_arrow" || childArrow.type === "computed_arrow") {
-          records.push(extractSingleArrow(childArrow, mappingName, namespace, parentSrc, parentTgt));
-        }
-      }
-    }
-
-    for (const block of [...eachBlocks, ...flattenBlocks]) {
-      const parentSrc = pathText(child(block, "src_path"));
-      const parentTgt = pathText(child(block, "tgt_path"));
-
-      records.push(extractSingleArrow(block, mappingName, namespace, null, null));
-
-      for (const childArrow of block.namedChildren) {
-        if (childArrow.type === "map_arrow" || childArrow.type === "computed_arrow" || childArrow.type === "nested_arrow") {
-          records.push(extractSingleArrow(childArrow, mappingName, namespace, parentSrc, parentTgt));
-        }
-      }
-    }
+    collectArrowRecords(body.namedChildren, mappingName, namespace, null, null, records);
   }
 
   return records;
+}
+
+/**
+ * Recursively collect arrow records from a list of sibling CST nodes,
+ * appending to `records` in document order.
+ *
+ * `parentSrc`/`parentTgt` are the absolute paths of the enclosing container
+ * (null at mapping-body level). A container's own record already has the
+ * parent prefixes applied, so its source/target become the prefixes for the
+ * next level down — accumulating across arbitrary depth (sl-zl55).
+ */
+function collectArrowRecords(
+  nodes: SyntaxNode[],
+  mappingName: string | null,
+  namespace: string | null,
+  parentSrc: string | null,
+  parentTgt: string | null,
+  records: ExtractedArrow[],
+): void {
+  for (const node of nodes) {
+    switch (node.type) {
+      case "map_arrow":
+      case "computed_arrow":
+        records.push(extractSingleArrow(node, mappingName, namespace, parentSrc, parentTgt));
+        break;
+
+      case "nested_arrow":
+      case "each_block":
+      case "flatten_block": {
+        const container = extractSingleArrow(node, mappingName, namespace, parentSrc, parentTgt);
+        records.push(container);
+        // nested_arrow / each / flatten declare exactly one src_path, so the
+        // container's single (already absolute) source is the child prefix.
+        collectArrowRecords(
+          node.namedChildren, mappingName, namespace,
+          container.sources[0] ?? null, container.target, records,
+        );
+        break;
+      }
+
+      default:
+        // src_path / tgt_path / metadata_block etc. — not arrow declarations.
+        break;
+    }
+  }
 }
 
 /**

--- a/tooling/satsuma-core/test/arrow-records.test.js
+++ b/tooling/satsuma-core/test/arrow-records.test.js
@@ -1,0 +1,147 @@
+/**
+ * arrow-records.test.js — Authoritative tests for extractArrowRecords() against
+ * real parsed Satsuma source.
+ *
+ * The grammar allows arrows to nest to arbitrary depth: nested_arrow bodies
+ * hold further arrow declarations, and each/flatten bodies hold arrow
+ * declarations plus nested each/flatten blocks (spec §4.4). These tests pin
+ * the recursive extraction contract — every declared arrow is extracted no
+ * matter how deeply it nests, with source/target paths made absolute by
+ * accumulating the enclosing containers' paths (sl-zl55).
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { initParser, getParser, extractArrowRecords, extractMappings } from "@satsuma/core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+/** Parse source and return the CST root. */
+function rootOf(src) {
+  return getParser().parse(src).rootNode;
+}
+
+/** Map records to a compact "sources -> target" form for path assertions. */
+function pairs(records) {
+  return records.map((r) => `${r.sources.join(",")} -> ${r.target}`);
+}
+
+const MAPPING_HEADER = "mapping m {\n  source { s }\n  target { t }\n";
+
+describe("extractArrowRecords — nested arrow recursion (sl-zl55)", () => {
+  it("extracts all three levels of a doubly-nested arrow with accumulated paths", () => {
+    // Regression: the walk previously stopped one level down — `inner -> b`
+    // and `leaf -> c` were invisible to lineage, coverage, and validation.
+    const root = rootOf(`${MAPPING_HEADER}
+  outer -> a {
+    inner -> b {
+      leaf -> c
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    assert.deepEqual(pairs(records), [
+      "outer -> a",
+      "outer.inner -> a.b",
+      "outer.inner.leaf -> a.b.c",
+    ]);
+  });
+
+  it("extracts arrows inside an each block nested in another each block", () => {
+    // Regression: each/flatten bodies were scanned for arrows but not for
+    // nested each/flatten blocks, so the inner block and its arrows vanished.
+    const root = rootOf(`${MAPPING_HEADER}
+  each orders -> o {
+    each items -> i {
+      sku -> s
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    assert.deepEqual(pairs(records), [
+      "orders -> o",
+      "orders.items -> o.i",
+      "orders.items.sku -> o.i.s",
+    ]);
+  });
+
+  it("extracts arrows from a nested arrow inside an each block", () => {
+    // Mixed nesting: a nested_arrow child of an each block was extracted as a
+    // record, but its own children were dropped because nested_arrow bodies
+    // were never recursed into from the each-block branch.
+    const root = rootOf(`${MAPPING_HEADER}
+  each orders -> o {
+    address -> addr {
+      city -> town
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    assert.deepEqual(pairs(records), [
+      "orders -> o",
+      "orders.address -> o.addr",
+      "orders.address.city -> o.addr.town",
+    ]);
+  });
+
+  it("extracts a flatten block nested inside an each block", () => {
+    // flatten blocks share the each-block body rule, so they must recurse the
+    // same way.
+    const root = rootOf(`${MAPPING_HEADER}
+  each orders -> o {
+    flatten tags -> tag_rows {
+      label -> name
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    assert.deepEqual(pairs(records), [
+      "orders -> o",
+      "orders.tags -> o.tag_rows",
+      "orders.tags.label -> o.tag_rows.name",
+    ]);
+  });
+
+  it("agrees with extractMappings arrowCount for nested arrow declarations", () => {
+    // extractMappings counts map/computed/nested arrows via a full-depth
+    // descendant walk. For a mapping without each/flatten blocks the two
+    // extraction functions must report the same arrows (the disagreement was
+    // the original sl-zl55 symptom).
+    const root = rootOf(`${MAPPING_HEADER}
+  outer -> a {
+    inner -> b {
+      leaf -> c
+      other -> d
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    const [mapping] = extractMappings(root);
+    assert.equal(records.length, mapping.arrowCount);
+  });
+
+  it("emits one container record per each/flatten block on top of declared arrows", () => {
+    // each/flatten containers represent list-to-list arrows and are emitted as
+    // records by design, but extractMappings.arrowCount counts only declared
+    // map/computed/nested arrows. This pins the exact relationship so the two
+    // functions cannot silently drift apart again.
+    const root = rootOf(`${MAPPING_HEADER}
+  each orders -> o {
+    each items -> i {
+      sku -> s
+    }
+  }
+}`);
+    const records = extractArrowRecords(root);
+    const [mapping] = extractMappings(root);
+    const EACH_FLATTEN_BLOCKS = 2;
+    assert.equal(records.length, mapping.arrowCount + EACH_FLATTEN_BLOCKS);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **sl-zl55** (P1): `extractArrowRecords` dropped every arrow nested deeper than one level, so graph edges, field lineage, coverage, and arrow validation were blind to deeply nested mappings.

### Root cause

The walk was three single-level loops over the mapping body: children of a `nested_arrow` were scanned for map/computed arrows only (further `nested_arrow`s skipped), and children of each/flatten blocks were scanned for arrows but not nested each/flatten blocks. Meanwhile `extractMappings.arrowCount` uses a full-depth descendant walk — the two extraction functions disagreed on the same input. The grammar explicitly allows arbitrary nesting (spec §4.4: `_nested_block_item` and `nested_arrow` bodies are recursive).

### Fix

Replace the loops with a recursive `collectArrowRecords` helper in `satsuma-core/src/extract.ts`. Containers (`nested_arrow`, `each_block`, `flatten_block`) emit their own record with parent prefixes applied, and their now-absolute source/target paths become the prefixes for the level below — accumulating across depth so `leaf -> c` inside `inner -> b` inside `outer -> a` extracts as `outer.inner.leaf -> a.b.c`.

### Before / after on the repros

| Input | Before | After |
|---|---|---|
| `outer -> a { inner -> b { leaf -> c } }` | 1 arrow (`s.outer→t.a`) | 3 arrows, fully-qualified nested paths |
| `each orders -> o { each items -> i { sku -> s } }` | 1 arrow (outer each only) | 3 arrows |
| `field-lineage t.a.b.c --upstream` | no connections | `::s.outer.inner.leaf via ::m` |

### Tests

New `satsuma-core/test/arrow-records.test.js` (TDD — all 6 failed pre-fix), parsing real source via the committed WASM: 3-level nested arrows with accumulated paths, nested each-in-each, nested_arrow inside each, flatten inside each, count agreement with `extractMappings.arrowCount` for declared arrows, and the pinned container-record convention for each/flatten. Core suite 388 passing, CLI suite 857 passing, lint clean. Also removed a pre-existing unused import in `extract.ts`.

Linked viz ticket sl-fm0q (nested each hover highlighting) remains open — it's a Lit-component concern needing the Playwright harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)