### PR TITLE
fix: namespace-qualification bug batch (sl-1don, sl-njej, sl-aeae, sl-ak00, sl-iqud)

### DIFF
--- a/.tickets/sl-1don.md
+++ b/.tickets/sl-1don.md
@@ -1,6 +1,6 @@
 ---
 id: sl-1don
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ satsuma-core/src/validate.ts:413 — isNoteContext tests mappingKey.startsWith("
 
 Note-block refs inside namespaces produce no source-membership warnings; internal note: scope keys never appear in user-facing messages; namespaced + global note tests.
 
+
+## Notes
+
+**2026-06-11T10:49:19Z**
+
+Cause: checkNLRefs tested the namespace-qualified mappingKey (`crm::note:schema:foo`) for the `note:` scope prefix, so namespaced notes were never recognised as note contexts — resolvable refs hit the source-membership check against an undefined mapping and the internal scope key leaked into the user-facing message.
+Fix: test `item.mapping` (unqualified) for the `note:` prefix in satsuma-core validate.ts; regression tests cover namespaced note resolution and the human-readable scope label.

--- a/.tickets/sl-aeae.md
+++ b/.tickets/sl-aeae.md
@@ -1,6 +1,6 @@
 ---
 id: sl-aeae
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:53Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/viz-model.ts:1490-1492 — mappingKey = id@location.uri 
 
 Mapping dedup key includes namespace (or qualified id); both same-named mappings survive merge; test.
 
+
+## Notes
+
+**2026-06-11T11:25:00Z**
+
+Cause: mergeVizModels deduped mappings by `id@location.uri`; MappingBlock.id is unqualified, so same-named mappings in different namespaces of one file collided and the second was dropped.
+Fix: dedup key now includes the namespace group name (`ns::id@uri`); regression test merges a file with `load` in two namespaces.

--- a/.tickets/sl-ak00.md
+++ b/.tickets/sl-ak00.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ak00
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:53Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/viz-model.ts:1470-1535 (dedup) with injectImportedSchema
 
 Full definitions win over stubs regardless of merge order; pii/metadata/labels survive lineage merge; regression test.
 
+
+## Notes
+
+**2026-06-11T11:25:00Z**
+
+Cause: the merge sorts the primary model first with first-wins dedup, but the primary model holds only the stub injected by injectImportedSchemaStubs — so the stub (null label, empty metadata/notes/constraints incl. pii) beat the upstream full definition, contradicting the doc comment's "naturally superseded" claim.
+Fix: stubs are now explicitly marked (`SchemaCard.isStub`) and mergeVizModels upgrades a kept stub in place when a full definition arrives from a later model; primary-wins is unchanged for genuine duplicate definitions. Regression tests cover label/owner metadata, pii constraints, and the duplicate-definition tie.

--- a/.tickets/sl-iqud.md
+++ b/.tickets/sl-iqud.md
@@ -1,6 +1,6 @@
 ---
 id: sl-iqud
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:53Z
@@ -17,3 +17,10 @@ satsuma-viz/src/field-coverage.ts:34-49 — resolveSchemaLocalFieldPath only str
 
 Prefixed paths match against both authored and qualified schema ids; namespaced multi-source coverage test.
 
+
+## Notes
+
+**2026-06-11T11:40:00Z**
+
+Cause: resolveSchemaLocalFieldPath only stripped the namespace-qualified schema.qualifiedId prefix, but arrows keep authored bare-id text ("customers.id") while the backend qualifies sourceRefs ("crm::customers") — the prefix never matched, so every prefixed source field in a namespaced multi-source mapping was reported unmapped.
+Fix: schemaRefPrefixes() matches both the qualified and authored bare form for the owning schema AND for the sibling-schema exclusion check in satsuma-viz field-coverage.ts. Tests cover bare/qualified resolution, sibling exclusion, and a namespaced multi-source coverage repro.

--- a/.tickets/sl-njej.md
+++ b/.tickets/sl-njej.md
@@ -1,6 +1,6 @@
 ---
 id: sl-njej
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:29Z
@@ -17,3 +17,10 @@ satsuma-cli/src/commands/field-lineage.ts:191-194 — resolveAllNLRefs already r
 
 field-lineage shows nl-derived edges inside namespaces, matching graph output; regression test with namespaced NL ref lineage.
 
+
+## Notes
+
+**2026-06-11T11:05:00Z**
+
+Cause: resolveAllNLRefs returns nlRef.mapping already namespace-qualified, but field-lineage re-prefixed it with nlRef.namespace, producing `ns::ns::load`; the mapping lookup failed and the nl-derived edge was silently skipped (same trap as sl-qxn5 in arrows.ts).
+Fix: use nlRef.mapping directly in field-lineage.ts; documented the invariant on the ResolvedNLRef.mapping type field in core so future consumers don't re-qualify. Regression test with namespaced NL ref fixture.

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -183,9 +183,10 @@ function buildFieldEdgeGraph(index: ExtractedWorkspace): FieldEdgeEntry[] {
     if (!nlRef.resolved || !nlRef.resolvedTo || nlRef.resolvedTo.kind !== "field") continue;
     if (!nlRef.targetField) continue;
 
-    const rawMappingKey = nlRef.namespace
-      ? `${nlRef.namespace}::${nlRef.mapping}`
-      : nlRef.mapping;
+    // nlRef.mapping is already namespace-qualified by resolveAllNLRefs —
+    // prepending nlRef.namespace again would produce "crm::crm::load" and
+    // make the mapping lookup fail, silently dropping the edge (sl-njej).
+    const rawMappingKey = nlRef.mapping;
     const mapping = index.mappings.get(rawMappingKey);
     if (!mapping) continue;
 

--- a/tooling/satsuma-cli/test/field-lineage.test.ts
+++ b/tooling/satsuma-cli/test/field-lineage.test.ts
@@ -152,3 +152,23 @@ describe("field-lineage same-line arrows sharing a target (sl-201z)", () => {
       "both same-line arrows should contribute an upstream connection");
   });
 });
+
+// ---------------------------------------------------------------------------
+// sl-njej: NL-derived edges inside namespaces
+// ---------------------------------------------------------------------------
+describe("field-lineage NL-derived edges in namespaced mappings (sl-njej)", () => {
+  it("reports an nl-derived upstream edge for an @ref inside a namespaced mapping", async () => {
+    // Bug sl-njej: resolveAllNLRefs returns nlRef.mapping already namespace-
+    // qualified, but field-lineage re-prefixed it with nlRef.namespace,
+    // producing "ns::ns::load_s2" — the mapping lookup failed and the
+    // nl-derived edge was silently dropped (graph showed it; field-lineage didn't).
+    const fixture = resolve(FIXTURES, "ns-nl-lineage.stm");
+    const { stdout, code } = await run("field-lineage", "ns::s2.x", fixture, "--json", "--upstream");
+    assert.equal(code, 0, `expected exit 0\n${stdout}`);
+    const data = JSON.parse(stdout);
+    const nlEdges = (data.upstream as any[]).filter((e) => e.classification === "nl-derived");
+    assert.equal(nlEdges.length, 1, `expected one nl-derived upstream edge, got: ${JSON.stringify(data.upstream)}`);
+    assert.equal(nlEdges[0].field, "ns::s1.a");
+    assert.equal(nlEdges[0].via_mapping, "ns::load_s2");
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/ns-nl-lineage.stm
+++ b/tooling/satsuma-cli/test/fixtures/ns-nl-lineage.stm
@@ -1,0 +1,18 @@
+namespace ns {
+
+schema s1 {
+  a INTEGER
+  b INTEGER
+}
+
+schema s2 {
+  x INTEGER
+}
+
+mapping `load_s2` {
+  source { s1 }
+  target { s2 }
+  -> x { "derived from @s1.a plus b" }
+}
+
+}

--- a/tooling/satsuma-cli/test/nl-ref-validate.test.ts
+++ b/tooling/satsuma-cli/test/nl-ref-validate.test.ts
@@ -366,6 +366,57 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
     assert.equal(nlWarnings.length, 0, "Refs in schema-scoped notes should not warn");
   });
 
+  it("does not warn for resolvable refs in namespaced note blocks (sl-1don)", () => {
+    // Bug sl-1don: the note-context check tested the namespace-qualified key
+    // ("crm::note:schema:foo"), which never starts with "note:", so namespaced
+    // notes were treated as mapping contexts and resolvable schema refs hit the
+    // source-membership check against an undefined mapping.
+    const index = makeIndex({
+      schemas: [
+        { name: "crm::foo", namespace: "crm", fields: [{ name: "id" }] },
+        { name: "crm::other", namespace: "crm", fields: [{ name: "key" }] },
+      ],
+      nlRefData: [{
+        text: "derived from @other",
+        mapping: "note:schema:foo",
+        namespace: "crm",
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    assert.equal(nlWarnings.length, 0, "Resolvable refs in namespaced notes should not warn");
+  });
+
+  it("never leaks the internal note: scope prefix into namespaced note messages (sl-1don)", () => {
+    // Unresolvable refs in namespaced notes should warn with a human-readable
+    // scope ("schema 'crm::foo'"), not the internal key ("crm::note:schema:foo").
+    const index = makeIndex({
+      schemas: [
+        { name: "crm::foo", namespace: "crm", fields: [{ name: "id" }] },
+      ],
+      nlRefData: [{
+        text: "needs @does_not_exist provisioned",
+        mapping: "note:schema:foo",
+        namespace: "crm",
+        targetField: null,
+        file: "test.stm",
+        line: 5,
+        column: 2,
+      }],
+    });
+
+    const warnings = collectSemanticWarnings(index);
+    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref");
+    assert.equal(nlWarnings.length, 1, "Unresolvable ref in a namespaced note should still warn");
+    assert.ok(nlWarnings[0].message.includes("schema 'crm::foo'"), `message names the schema scope: ${nlWarnings[0].message}`);
+    assert.ok(!nlWarnings[0].message.includes("note:"), `internal note: prefix must not leak: ${nlWarnings[0].message}`);
+  });
+
   it("still warns for unresolved refs inside mapping notes", () => {
     const index = makeIndex({
       schemas: [

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -81,7 +81,12 @@ export interface ResolvedNLRef {
   classification: RefClassification;
   resolved: boolean;
   resolvedTo: { kind: string; name: string } | null;
+  /** Index key of the owning mapping, ALREADY namespace-qualified
+   * ("crm::load") when the mapping lives in a namespace. Do not prepend
+   * `namespace` again — double-qualifying breaks lookups (sl-qxn5, sl-njej). */
   mapping: string;
+  /** Namespace the ref was authored in, kept for scope-aware resolution.
+   * Informational alongside `mapping`, which already embeds it. */
   namespace: string | null;
   targetField: string | null;
   /** Propagated from the source NLRefDataItem. "source_block" means the ref

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -409,8 +409,10 @@ function checkNLRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): v
 
     // Note contexts have no source/target list, so hidden-source checks are
     // suppressed. Unresolved-ref checks still apply — an @ref in a note should
-    // resolve to some known workspace entity.
-    const isNoteContext = mappingKey.startsWith("note:");
+    // resolve to some known workspace entity. Tested against item.mapping, not
+    // mappingKey: the key is namespace-qualified first ("crm::note:schema:foo"),
+    // which would hide the note: scope prefix for namespaced notes (sl-1don).
+    const isNoteContext = item.mapping.startsWith("note:");
 
     // Build a human-readable scope label for diagnostic messages.
     // Strip internal prefixes (e.g. "note:metric:") so messages say

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -196,6 +196,7 @@ function injectImportedSchemaStubs(
         character: schemaDef.range.start.character,
       },
       hasExternalLineage: true,
+      isStub: true,
       spreads: [],
     };
 
@@ -1489,10 +1490,14 @@ function nodeLocation(uri: string, node: SyntaxNode): SourceLocation {
  * full transitive lineage reachable from `primaryUri`.
  *
  * The primary file's entities appear first and win any dedup ties. Schemas are
- * deduped by `qualifiedId`, mappings by `id` + source URI, metrics by
- * `qualifiedId`, and fragments by `id`. This means stub schemas injected by
- * `injectImportedSchemaStubs` are naturally superseded when the upstream file's
- * full definition is present.
+ * deduped by `qualifiedId`, mappings by namespace + `id` + source URI, metrics
+ * by `qualifiedId`, and fragments by `id`.
+ *
+ * One exception to first-wins: a stub schema (injected by
+ * `injectImportedSchemaStubs` when the defining file is absent from a
+ * per-file model) is replaced in place by the full definition from a later
+ * model. The primary model sorts first and contains the stub, so without the
+ * upgrade the stub's empty label/metadata/constraints would win (sl-ak00).
  *
  * @param primaryUri - The file URI that anchors the lineage view.
  * @param models     - One VizModel per import-reachable file (including the primary).
@@ -1511,15 +1516,19 @@ export function mergeVizModels(
     a.uri === primaryUri ? -1 : b.uri === primaryUri ? 1 : 0,
   );
 
-  // Global dedup sets — track what has already been included.
-  const seenSchemas = new Set<string>();
+  // Global dedup state — track what has already been included. Schemas keep a
+  // reference to their merged position so a stub can be upgraded in place when
+  // the full definition arrives from a later model (sl-ak00).
+  const keptSchemas = new Map<string, { group: NamespaceGroup; index: number }>();
   const seenMappings = new Set<string>();
   const seenMetrics = new Set<string>();
   const seenFragments = new Set<string>();
 
-  /** Dedup key for a mapping: id + source URI (same name in different files = different mappings). */
-  const mappingKey = (m: MappingBlock): string =>
-    `${m.id}@${m.location.uri}`;
+  /** Dedup key for a mapping: namespace + id + source URI. MappingBlock.id is
+   * unqualified, so the namespace group's name must be part of the key or
+   * same-named mappings in different namespaces of one file collide (sl-aeae). */
+  const mappingKey = (nsName: string | null, m: MappingBlock): string =>
+    `${nsName ?? ""}::${m.id}@${m.location.uri}`;
 
   // Accumulate merged namespace groups keyed by namespace name (null = global).
   const nsMap = new Map<string | null, NamespaceGroup>();
@@ -1538,13 +1547,17 @@ export function mergeVizModels(
       const target = getOrCreate(ns.name);
 
       for (const s of ns.schemas) {
-        if (!seenSchemas.has(s.qualifiedId)) {
-          seenSchemas.add(s.qualifiedId);
+        const kept = keptSchemas.get(s.qualifiedId);
+        if (!kept) {
+          keptSchemas.set(s.qualifiedId, { group: target, index: target.schemas.length });
           target.schemas.push(s);
+        } else if (kept.group.schemas[kept.index]!.isStub && !s.isStub) {
+          // Upgrade a kept stub to the full definition (see doc comment above).
+          kept.group.schemas[kept.index] = s;
         }
       }
       for (const m of ns.mappings) {
-        const key = mappingKey(m);
+        const key = mappingKey(ns.name, m);
         if (!seenMappings.has(key)) {
           seenMappings.add(key);
           target.mappings.push(m);

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -987,6 +987,91 @@ namespace billing {
     const nsNames = result.namespaces.map(ns => ns.name).sort();
     assert.deepStrictEqual(nsNames, ["billing", "crm"]);
   });
+
+  it("keeps same-named mappings from different namespaces of one file (sl-aeae)", () => {
+    // Bug sl-aeae: the mapping dedup key was id@uri, omitting the namespace.
+    // Two mappings named "load" in namespaces a and b of the same file
+    // collided and the second was dropped from the merged model.
+    const modelA = vizModel(`
+namespace a {
+  schema s1 { id INT }
+  schema t1 { id INT }
+  mapping load { source { s1 } target { t1 } id -> id }
+}
+namespace b {
+  schema s2 { id INT }
+  schema t2 { id INT }
+  mapping load { source { s2 } target { t2 } id -> id }
+}`, "file:///a.stm");
+    const modelB = vizModel("schema unrelated { id INT }", "file:///b.stm");
+
+    const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
+    const nsA = result.namespaces.find((ns) => ns.name === "a");
+    const nsB = result.namespaces.find((ns) => ns.name === "b");
+    assert.equal(nsA.mappings.length, 1, "namespace a keeps its load mapping");
+    assert.equal(nsB.mappings.length, 1, "namespace b keeps its load mapping");
+  });
+});
+
+// ---------- Stub upgrade in lineage merge (sl-ak00) ----------
+
+describe("lineage merge stub upgrade (sl-ak00)", () => {
+  // Bug sl-ak00: the merge sorts the primary model first and dedup was
+  // first-wins, but the primary model contains only a STUB of each imported
+  // schema. The stub beat the upstream full definition, so labels, metadata,
+  // notes, and field constraints (including pii) vanished in lineage mode.
+  const FILES = {
+    "file:///upstream.stm": `schema customers (note "Customer Master", owner "crm-team") {
+  id INT (pk)
+  email VARCHAR (pii)
+}`,
+    "file:///main.stm": `import { customers } from "./upstream.stm"
+schema dim_customers { id INT email VARCHAR }
+mapping load_dim {
+  source { customers }
+  target { dim_customers }
+  id -> id
+  email -> email
+}`,
+  };
+
+  it("replaces the primary file's stub with the upstream full definition", () => {
+    const result = vizModelFullLineage(FILES, "file:///main.stm");
+    const customers = result.namespaces
+      .flatMap((ns) => ns.schemas)
+      .find((s) => s.qualifiedId === "customers");
+    assert.ok(customers, "customers schema present in merged model");
+    assert.ok(!customers.isStub, "merged card must be the full definition, not the stub");
+    assert.equal(customers.label, "Customer Master", "label from upstream definition survives");
+    assert.ok(
+      customers.metadata.some((m) => m.key === "owner"),
+      `owner metadata survives, got: ${JSON.stringify(customers.metadata)}`,
+    );
+  });
+
+  it("preserves pii field constraints from the upstream definition", () => {
+    const result = vizModelFullLineage(FILES, "file:///main.stm");
+    const customers = result.namespaces
+      .flatMap((ns) => ns.schemas)
+      .find((s) => s.qualifiedId === "customers");
+    const email = customers.fields.find((f) => f.name === "email");
+    assert.ok(email, "email field present");
+    assert.ok(
+      email.constraints.includes("pii"),
+      `pii constraint survives the merge, got: ${JSON.stringify(email.constraints)}`,
+    );
+  });
+
+  it("still lets the primary file win when both models hold full definitions", () => {
+    // The stub upgrade must not change the existing primary-wins rule for
+    // genuinely duplicated definitions across files.
+    const m1 = vizModel("schema foo { id INT }", "file:///a.stm");
+    const m2 = vizModel("schema foo { id INT\nname VARCHAR }", "file:///b.stm");
+    const result = mergeVizModels("file:///a.stm", [m1, m2]);
+    const schemas = result.namespaces.flatMap((ns) => ns.schemas);
+    assert.equal(schemas.length, 1);
+    assert.equal(schemas[0].fields.length, 1, "primary model's full definition still wins");
+  });
 });
 
 // ---------- Full lineage (vizModelFullLineage) ----------

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -55,6 +55,11 @@ export interface SchemaCard {
   location: SourceLocation;
   /** True when the schema is referenced as a source or target in an import block. */
   hasExternalLineage: boolean;
+  /** True for placeholder cards injected for imported schemas whose defining
+   *  file is not part of the model (no label, metadata, notes, or field
+   *  constraints). Multi-file merges replace stubs with the full definition
+   *  when the defining file is present (sl-ak00). Absent means false. */
+  isStub?: boolean;
   /** Names of fragments spread into this schema (resolved before sending to the client). */
   spreads: string[];
 }

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -23,11 +23,27 @@ export function schemaHasFieldPath(schema: SchemaCard, fieldPath: string): boole
 }
 
 /**
+ * Prefixes under which an arrow may reference fields of a schema: the
+ * qualified id and, for namespaced schemas, the authored bare id. Arrows keep
+ * authored text ("customers.id" inside namespace crm) while the backend
+ * resolves sourceRefs and qualifiedId to "crm::customers" — matching only the
+ * qualified form would miss every bare-prefixed ref in a namespaced mapping
+ * (sl-iqud).
+ */
+function schemaRefPrefixes(schemaId: string): string[] {
+  const namespaceEnd = schemaId.lastIndexOf("::");
+  if (namespaceEnd < 0) return [schemaId];
+  return [schemaId, schemaId.slice(namespaceEnd + 2)];
+}
+
+/**
  * Resolve an arrow field reference to the schema-local dotted field path for a
- * specific schema card.
+ * specific schema card. Schema prefixes match in both authored (bare) and
+ * namespace-qualified form.
  *
  * Examples:
  * - `customer_profiles.region` + schema `customer_profiles` -> `region`
+ * - `customers.id` + schema `crm::customers` -> `id`
  * - `customer.email` + schema `order_events` -> `customer.email`
  * - `other_schema.id` + schema `order_events` -> null
  */
@@ -36,12 +52,16 @@ export function resolveSchemaLocalFieldPath(
   schema: SchemaCard,
   sourceRefs: string[],
 ): string | null {
-  if (fieldRef.startsWith(`${schema.qualifiedId}.`)) {
-    return fieldRef.slice(schema.qualifiedId.length + 1);
+  for (const prefix of schemaRefPrefixes(schema.qualifiedId)) {
+    if (fieldRef.startsWith(`${prefix}.`)) {
+      return fieldRef.slice(prefix.length + 1);
+    }
   }
 
   const explicitOtherSchema = sourceRefs.some(
-    (sourceRef) => sourceRef !== schema.qualifiedId && fieldRef.startsWith(`${sourceRef}.`),
+    (sourceRef) =>
+      sourceRef !== schema.qualifiedId &&
+      schemaRefPrefixes(sourceRef).some((prefix) => fieldRef.startsWith(`${prefix}.`)),
   );
   if (explicitOtherSchema) return null;
 

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -99,4 +99,80 @@ describe("field-coverage helpers", () => {
     assert.equal(sourceSet.has("customer.email"), true);
     assert.equal(targetMapped.has("customer_email"), true);
   });
+
+  it("strips authored bare-id prefixes for namespaced schemas (sl-iqud)", () => {
+    // Bug sl-iqud: arrows keep authored text ("customers.id") while the
+    // backend qualifies schema ids ("crm::customers"). Matching only the
+    // qualified prefix made every prefixed ref in a namespaced mapping
+    // unresolvable, so the whole schema was reported unmapped.
+    const customers = schema("customers", [field("id")], "crm::customers");
+    assert.equal(
+      mod.resolveSchemaLocalFieldPath("customers.id", customers, ["crm::customers", "crm::orders"]),
+      "id",
+    );
+    // The qualified form must keep working too — cross-namespace refs are
+    // authored fully qualified.
+    assert.equal(
+      mod.resolveSchemaLocalFieldPath("crm::customers.id", customers, ["crm::customers", "crm::orders"]),
+      "id",
+    );
+  });
+
+  it("treats a bare-id prefix of a sibling source schema as not local (sl-iqud)", () => {
+    // A ref authored against the OTHER namespaced source schema must not fall
+    // through to the field-path check of this schema.
+    const customers = schema("customers", [field("orders", [field("id")])], "crm::customers");
+    assert.equal(
+      mod.resolveSchemaLocalFieldPath("orders.id", customers, ["crm::customers", "crm::orders"]),
+      null,
+    );
+  });
+
+  it("covers both schemas of a namespaced multi-source mapping (sl-iqud)", () => {
+    // End-to-end coverage repro from the ticket: a namespaced join mapping
+    // with bare-prefixed arrow refs left sourceMapped empty for both schemas.
+    const customers = schema("customers", [field("id"), field("email")], "crm::customers");
+    const orders = schema("orders", [field("customer_id"), field("total")], "crm::orders");
+    const target = schema("customer_orders", [field("email"), field("total")], "crm::customer_orders");
+    const mapping = {
+      id: "join_orders",
+      sourceRefs: ["crm::customers", "crm::orders"],
+      targetRef: "crm::customer_orders",
+      arrows: [
+        {
+          sourceFields: ["customers.email"],
+          targetField: "email",
+          transform: null,
+          metadata: [],
+          comments: [],
+          location: loc,
+        },
+        {
+          sourceFields: ["orders.total"],
+          targetField: "total",
+          transform: null,
+          metadata: [],
+          comments: [],
+          location: loc,
+        },
+      ],
+      eachBlocks: [],
+      flattenBlocks: [],
+      sourceBlock: null,
+      notes: [],
+      comments: [],
+      location: loc,
+    };
+
+    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
+      mapping,
+      [customers, orders],
+      target,
+    );
+
+    assert.deepEqual([...sourceMapped.get("crm::customers")], ["email"]);
+    assert.deepEqual([...sourceMapped.get("crm::orders")], ["total"]);
+    assert.equal(targetMapped.has("email"), true);
+    assert.equal(targetMapped.has("total"), true);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the five remaining open siblings of the namespace-qualification asymmetry family from the June bug hunt (#279) — the same root-cause cluster as the already-merged sl-98cz (#290). Each fix has a regression test that was verified to fail against the pre-fix code.

- **sl-1don (core)**: `checkNLRefs` tested the namespace-qualified key (`crm::note:schema:foo`) for the `note:` scope prefix, so namespaced note blocks were validated as mapping contexts — producing bogus `nl-ref-not-in-source` warnings that leaked the internal scope key. Now tests the unqualified `item.mapping`.
- **sl-njej (cli)**: field-lineage re-prefixed the already-qualified `nlRef.mapping` with the namespace (`ns::ns::load`), so every nl-derived edge inside a namespace was silently dropped while `graph` showed it. Also documents the already-qualified invariant on `ResolvedNLRef.mapping` — this trap has now bitten two consumers (sl-qxn5, sl-njej).
- **sl-aeae (viz-backend)**: the lineage-merge mapping dedup key omitted the namespace (`id@uri`), dropping same-named mappings from different namespaces of one file. Key now includes the namespace group name.
- **sl-ak00 (viz-backend)**: the first-wins merge let the primary file's injected stub beat the upstream full definition, wiping labels, metadata, and field constraints (including `pii`) in lineage mode. Stubs are now explicitly marked (`SchemaCard.isStub`, additive optional field) and upgraded in place when the full definition arrives; primary-wins is unchanged for genuine duplicates.
- **sl-iqud (viz)**: field coverage only stripped the qualified schema prefix, but arrows keep authored bare-id text (`customers.id` vs `crm::customers`), so namespaced multi-source mappings reported every prefixed field unmapped. Prefix matching now accepts both forms, including in the sibling-schema exclusion check.

## Test plan

- [x] New regression tests for each ticket; all verified red on pre-fix code
- [x] Full suites green: core 396, viz-model 6, viz-backend 163, viz 68, lsp 273, cli 867
- [x] End-to-end CLI repros confirmed for sl-1don and sl-njej (warning gone / edge restored)
- [x] Tickets closed with root-cause notes; `.tickets/` included in each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)