### PR TITLE
fix(core): core bug batch — metadata truncation, NL ref positions, backtick refs, qualified spread fields

### DIFF
--- a/.tickets/sl-cvx9.md
+++ b/.tickets/sl-cvx9.md
@@ -1,6 +1,6 @@
 ---
 id: sl-cvx9
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ satsuma-core/src/meta-extract.ts:26-31 — when any nl_string child exists in a 
 
 Mixed value_text round-trips fully (quoted strings plus surrounding tokens); tests for default "x" if null and multi-string values.
 
+
+## Notes
+
+**2026-06-11T12:26:18Z**
+
+Cause: normalizeMetadataValue returned only the first nl_string/backtick child of a value_text, discarding every other token in legally mixed values like (default "unknown" if null).
+Fix: unwrap delimiters only when a single child spans the entire value_text; mixed values now return the verbatim source text (quotes preserved). The whole-text quote-strip fallback no longer fires on multi-token values. (commit pending on fix/core-bug-batch)

--- a/.tickets/sl-g6ga.md
+++ b/.tickets/sl-g6ga.md
@@ -1,6 +1,6 @@
 ---
 id: sl-g6ga
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ satsuma-core/src/nl-ref.ts:182 strips backticks (rawRef.replace) and classifyRef
 
 Backtick-quoted refs are treated as literal names regardless of embedded . or ::; resolution tests for field names containing dots and ::.
 
+
+## Notes
+
+**2026-06-11T12:45:56Z**
+
+Cause: extractAtRefs flattened backtick quoting before classification/resolution, so classifyRef keyed off '.'/'::' embedded in literal names — @`tax.rate` classified dotted-field and failed to resolve.
+Fix: AtRef now carries a raw (backtick-preserving) form; a backtick-aware parseRef tokenizer in core nl-ref.ts treats quoted spans as opaque segments, classifyRef/resolveRef derive classification and splitting from separators outside backticks, and all consumers (core validate, CLI lint/schema-graph/graph-builder, viz-model) classify/resolve on the raw form. Literal names match exactly and never as nested paths.

--- a/.tickets/sl-kkao.md
+++ b/.tickets/sl-kkao.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kkao
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ satsuma-core/src/validate.ts:547-553 (prefixed path collection) and :975-980 (re
 
 Schema-qualified spread-inherited fields validate clean; error message names the schema the path is qualified with; multi-source + spread test.
 
+
+## Notes
+
+**2026-06-11T12:51:00Z**
+
+Cause: checkArrowFieldRefs built schema-qualified path sets (multi-source prefix loop) and resolveFieldPath's qualified branch from declared fields only — fragment-spread expansion only fed the unqualified set, so s2.created_at warned while created_at validated clean. The message also always named the first source schema.
+Fix: per-source spread expansion now feeds the authored-prefix path set, resolveFieldPath expands the qualified schema's spreads (shared makeSpreadLookups helper), and blamedSourceSchema names the schema the path is qualified with. Verified end-to-end: the ticket repro validates clean via the CLI.

--- a/.tickets/sl-o3ea.md
+++ b/.tickets/sl-o3ea.md
@@ -1,6 +1,6 @@
 ---
 id: sl-o3ea
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:21:30Z
@@ -17,3 +17,10 @@ satsuma-core/src/nl-ref.ts:167 — NL text passed in has the opening delimiter s
 
 Reported column points exactly at the @ for single-line strings, first line of multiline strings, and post-newline refs; regression tests for all three.
 
+
+## Notes
+
+**2026-06-11T12:32:25Z**
+
+Cause: NL ref items strip the opening string delimiter from their text, but computeNLRefPosition's first-line branch added the offset to the column of the delimiter, reporting refs 1 column short (3 for multiline strings).
+Fix: every NLRefDataItem now records the opening delimiterWidth (3 for triple-quoted, 1 for quoted, 0 for bare at_refs) and computeNLRefPosition adds it back in the no-newline branch. Regression tests cover single-line, multiline first-line, post-newline, note blocks, standalone notes, transform bodies, and bare refs.

--- a/tooling/satsuma-cli/src/commands/graph-builder.ts
+++ b/tooling/satsuma-cli/src/commands/graph-builder.ts
@@ -350,9 +350,11 @@ function extractNlSchemaRefs(
   const schemas: string[] = [];
   const allDeclared = new Set([...mappingContext.sources, ...mappingContext.targets]);
 
-  for (const { ref } of refs) {
-    const classification = classifyRef(ref);
-    const resolution = resolveRef(ref, mappingContext, index);
+  for (const { raw } of refs) {
+    // raw keeps backtick quoting so literal names with "." / "::" classify
+    // and resolve correctly (sl-g6ga).
+    const classification = classifyRef(raw);
+    const resolution = resolveRef(raw, mappingContext, index);
     if (!resolution.resolved) continue;
 
     let canonicalSchema: string | null = null;

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -58,9 +58,11 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
       namespace: item.namespace,
     };
 
-    for (const { ref, offset } of refs) {
-      const classification = classifyRef(ref);
-      const resolution = resolveRef(ref, mappingContext, index);
+    for (const { ref, raw, offset } of refs) {
+      // raw keeps backtick quoting so literal names with "." / "::" classify
+      // and resolve correctly (sl-g6ga); ref is the flattened display form.
+      const classification = classifyRef(raw);
+      const resolution = resolveRef(raw, mappingContext, index);
 
       if (!resolution.resolved) continue;
 
@@ -402,7 +404,7 @@ function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
       scopeLabel = "transform";
     }
 
-    for (const { ref, offset } of refs) {
+    for (const { ref, raw, offset } of refs) {
       // Skip known pipeline function names — they appear in transform bodies and
       // are interpreted by the runtime, not resolved to workspace identifiers.
       if (KNOWN_PIPELINE_FUNCTIONS.has(ref)) continue;
@@ -416,7 +418,9 @@ function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
         if (metric && metric.fields.some((f) => f.name === ref)) continue;
       }
 
-      const resolution = resolveRef(ref, mappingContext, index);
+      // Resolve on the raw form — backticked literal names must not be
+      // re-split on "." or "::" (sl-g6ga).
+      const resolution = resolveRef(raw, mappingContext, index);
       if (!resolution.resolved) {
         const { line, column } = computeNLRefPosition(item, offset);
         diagnostics.push({

--- a/tooling/satsuma-cli/src/schema-graph.ts
+++ b/tooling/satsuma-cli/src/schema-graph.ts
@@ -79,9 +79,11 @@ export function buildFullGraph(index: ExtractedWorkspace): FullGraph {
         namespace: item.namespace,
       };
 
-      for (const { ref } of refs) {
-        const classification = classifyRef(ref);
-        const resolution = resolveRef(ref, mappingContext, index);
+      for (const { raw } of refs) {
+        // raw keeps backtick quoting so literal names with "." / "::"
+        // classify and resolve correctly (sl-g6ga).
+        const classification = classifyRef(raw);
+        const resolution = resolveRef(raw, mappingContext, index);
         if (!resolution.resolved) continue;
 
         let canonicalSchema: string | null = null;

--- a/tooling/satsuma-core/src/meta-extract.ts
+++ b/tooling/satsuma-core/src/meta-extract.ts
@@ -15,6 +15,11 @@ export type { MetaEntry };
  * The grammar wraps key/value payloads in `value_text`, so quoted string values
  * often arrive as `value_text.text === "\"INTERNAL\""`. Downstream JSON
  * consumers expect the value without those source delimiters.
+ *
+ * Delimiters are stripped ONLY when the whole value is a single quoted string.
+ * `value_text` legally mixes tokens (`default "unknown" if null`), and mixed
+ * values must round-trip verbatim — quoted parts included — rather than being
+ * truncated to the first string child (sl-cvx9).
  */
 function normalizeMetadataValue(valueNode: SyntaxNode | null | undefined): string {
   if (!valueNode) return "";
@@ -23,11 +28,14 @@ function normalizeMetadataValue(valueNode: SyntaxNode | null | undefined): strin
     return valueNode.text.slice(1, -1);
   }
 
-  const nestedValue = valueNode.namedChildren.find(
-    (child) => child.type === "nl_string" || child.type === "backtick_name",
-  );
-  if (nestedValue) {
-    return normalizeMetadataValue(nestedValue);
+  // Unwrap a wrapper node (value_text) only when its single child spans the
+  // entire value — otherwise unnamed sibling tokens would be silently dropped.
+  const children = valueNode.namedChildren;
+  if (children.length === 1 && children[0]?.text === valueNode.text) {
+    return normalizeMetadataValue(children[0]);
+  }
+  if (children.length > 1) {
+    return valueNode.text;
   }
 
   const text = valueNode.text;

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -71,6 +71,10 @@ export interface NLRefDataItem {
    * describes join conditions and filters — it must not generate NL-derived
    * arrows. Absent means an arrow body or note block. */
   context?: "source_block";
+  /** Width of the opening delimiter stripped from `text` (3 for `"""`, 1 for
+   * `"`, 0 for bare at_refs). `column` points at the delimiter in the source,
+   * so position math must add this back for first-line refs (sl-o3ea). */
+  delimiterWidth?: number;
   line: number;
   column: number;
   file: string;
@@ -152,13 +156,16 @@ const AT_REF_RE = createAtRefRegex();
  * that line. This helper handles both cases and is the single source of truth
  * for diagnostic positions of NL refs (sl-2ji3).
  *
- * @param item   The NL ref source item; only `text`, `line`, `column` are read.
- *               `item.line` and `item.column` are 0-based (CST positions).
+ * @param item   The NL ref source item; only `text`, `line`, `column`, and
+ *               `delimiterWidth` are read. `item.line` and `item.column` are
+ *               0-based (CST positions); `item.column` points at the node's
+ *               opening delimiter, while `item.text` has that delimiter
+ *               stripped — `delimiterWidth` bridges the two (sl-o3ea).
  * @param offset Byte offset of the `@` character within `item.text`.
  * @returns      1-based `{line, column}` suitable for diagnostic reporting.
  */
 export function computeNLRefPosition(
-  item: { text: string; line: number; column: number },
+  item: { text: string; line: number; column: number; delimiterWidth?: number },
   offset: number,
 ): { line: number; column: number } {
   const textBefore = item.text.slice(0, offset);
@@ -172,9 +179,12 @@ export function computeNLRefPosition(
     const lastNl = textBefore.lastIndexOf("\n");
     column = offset - lastNl;
   } else {
-    // No newline crossed — the @ is on the same line as the string opener,
-    // so add the offset to the string's start column (+1 to make 1-based).
-    column = item.column + offset + 1;
+    // No newline crossed — the @ is on the same line as the string opener.
+    // item.column is the opening delimiter, but offset counts from the start
+    // of the delimiter-stripped text, so add the delimiter width back before
+    // converting to 1-based (sl-o3ea: without it, first-line refs pointed at
+    // the character before the @).
+    column = item.column + (item.delimiterWidth ?? 0) + offset + 1;
   }
   return { line, column };
 }
@@ -534,6 +544,14 @@ function nlRefNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
   return [];
 }
 
+// Width of the opening delimiter that the extraction helpers strip from a
+// ref-bearing node's text: `"""` multiline strings (3), `"` NL strings (1),
+// bare at_refs (0). Recorded on every NLRefDataItem so computeNLRefPosition
+// can map text offsets back to source columns on the first line (sl-o3ea).
+function openingDelimiterWidth(node: SyntaxNode): number {
+  return node.type === "multiline_string" ? 3 : node.type === "nl_string" ? 1 : 0;
+}
+
 // The text payload of one ref-bearing node, or null when it cannot contain a
 // ref. Quoted NL strings are unwrapped from their delimiters; a bare at_ref
 // keeps its "@name" text verbatim so the downstream regex scan finds the ref
@@ -565,6 +583,7 @@ function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | n
             mapping: `transform:${transformName}`,
             namespace,
             targetField: null,
+            delimiterWidth: openingDelimiterWidth(nlNode),
             line: nlNode.startPosition.row,
             column: nlNode.startPosition.column,
           });
@@ -591,6 +610,7 @@ function extractStandaloneNoteRefs(
           mapping: parentLabel ? `note:${parentLabel}` : "note:",
           namespace,
           targetField: null,
+          delimiterWidth: openingDelimiterWidth(inner),
           line: inner.startPosition.row,
           column: inner.startPosition.column,
         });
@@ -663,6 +683,7 @@ function walkArrowsForNL(
               mapping: mappingName,
               namespace,
               targetField: null,
+              delimiterWidth: openingDelimiterWidth(inner),
               line: inner.startPosition.row,
               column: inner.startPosition.column,
             });
@@ -692,6 +713,7 @@ function walkArrowsForNL(
             namespace,
             targetField: null,
             context: "source_block",
+            delimiterWidth: openingDelimiterWidth(nlNode),
             line: nlNode.startPosition.row,
             column: nlNode.startPosition.column,
           });
@@ -721,6 +743,7 @@ function walkArrowsForNL(
                   mapping: mappingName,
                   namespace,
                   targetField: tgt,
+                  delimiterWidth: openingDelimiterWidth(nlNode),
                   line: nlNode.startPosition.row,
                   column: nlNode.startPosition.column,
                 });

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -16,7 +16,13 @@ import type { SpreadEntity, EntityRefResolver, SpreadEntityLookup } from "./spre
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface AtRef {
+  /** Flattened display form with backtick quoting removed (e.g. "tax.rate"). */
   ref: string;
+  /** Matched form with backtick quoting preserved (e.g. "`tax.rate`"). Pass
+   * THIS to classifyRef/resolveRef — flattening makes a literal name with an
+   * embedded "." or "::" indistinguishable from a path (sl-g6ga). */
+  raw: string;
+  /** Byte offset of the @ character within the scanned text. */
   offset: number;
 }
 
@@ -200,23 +206,95 @@ export function extractAtRefs(text: string): AtRef[] {
   while ((match = AT_REF_RE.exec(text)) !== null) {
     const rawRef = match[0].slice(1); // remove @
     const ref = rawRef.replace(/`([^`]+)`/g, "$1");
-    refs.push({ ref, offset: match.index });
+    refs.push({ ref, raw: rawRef, offset: match.index });
   }
 
   return refs;
 }
 
-// ── Classification ────────────────────────────────────────────────────────────
+// ── Ref parsing & classification ──────────────────────────────────────────────
+
+/** One segment of an @ref path. `literal` marks backtick-quoted segments,
+ * whose names may contain "." and "::" without those acting as separators. */
+interface RefSegment {
+  name: string;
+  literal: boolean;
+}
+
+/** A ref split into path segments. `separators[i]` sits between
+ * `segments[i]` and `segments[i+1]` and is either "::" or ".". */
+interface ParsedRef {
+  segments: RefSegment[];
+  separators: ("::" | ".")[];
+}
 
 /**
- * Classify an @ref by its syntactic form.
+ * Split a ref into path segments, honouring backtick quoting: "::" and "."
+ * are only separators OUTSIDE backticks (sl-g6ga). Accepts both raw
+ * (backticked) and flattened refs — for refs without backticks the result is
+ * identical to a plain split, so legacy callers keep their behaviour.
+ */
+function parseRef(ref: string): ParsedRef {
+  const segments: RefSegment[] = [];
+  const separators: ("::" | ".")[] = [];
+  let name = "";
+  let literal = false;
+  let i = 0;
+  while (i < ref.length) {
+    const ch = ref[i];
+    if (ch === "`") {
+      // Opaque span: everything to the closing backtick is part of the name.
+      const close = ref.indexOf("`", i + 1);
+      if (close === -1) {
+        name += ref.slice(i + 1);
+        i = ref.length;
+      } else {
+        name += ref.slice(i + 1, close);
+        i = close + 1;
+      }
+      literal = true;
+      continue;
+    }
+    if (ch === ":" && ref[i + 1] === ":") {
+      segments.push({ name, literal });
+      separators.push("::");
+      name = "";
+      literal = false;
+      i += 2;
+      continue;
+    }
+    if (ch === ".") {
+      segments.push({ name, literal });
+      separators.push(".");
+      name = "";
+      literal = false;
+      i += 1;
+      continue;
+    }
+    name += ch;
+    i += 1;
+  }
+  segments.push({ name, literal });
+  return { segments, separators };
+}
+
+/** Derive the classification from the separators found outside backticks. */
+function classificationOf(separators: ParsedRef["separators"]): RefClassification {
+  const hasNs = separators.includes("::");
+  const hasDot = separators.includes(".");
+  if (hasNs) return hasDot ? "namespace-qualified-field" : "namespace-qualified-schema";
+  if (hasDot) return "dotted-field";
+  return "bare";
+}
+
+/**
+ * Classify an @ref by its syntactic form. Backtick-quoted spans are opaque:
+ * @`tax.rate` is a bare ref to a field literally named "tax.rate", not a
+ * dotted path (sl-g6ga). Pass the raw (backtick-preserving) form when
+ * available — see AtRef.raw.
  */
 export function classifyRef(ref: string): RefClassification {
-  if (ref.includes("::")) {
-    return ref.includes(".") ? "namespace-qualified-field" : "namespace-qualified-schema";
-  }
-  if (ref.includes(".")) return "dotted-field";
-  return "bare";
+  return classificationOf(parseRef(ref).separators);
 }
 
 // ── Resolution ────────────────────────────────────────────────────────────────
@@ -258,15 +336,16 @@ function hasField(fields: FieldDecl[], name: string): boolean {
 }
 
 /**
- * Check if a dotted path resolves to a nested field within a field tree.
+ * Check if a path (as pre-split segment names) resolves to a nested field
+ * within a field tree. Segment names are matched verbatim — splitting happens
+ * at parse time so literal (backticked) names keep their embedded dots.
  *
  * Tries two strategies in order:
  *  1. matchPath — treat the path as anchored from the root of the field tree.
  *  2. searchNestedPath — search for the path starting from any nested record
  *     field, to handle refs that omit leading path segments.
  */
-function hasNestedFieldPath(fields: FieldDecl[], path: string): boolean {
-  const segments = path.split(".");
+function hasNestedFieldPath(fields: FieldDecl[], segments: string[]): boolean {
   if (matchPath(fields, segments)) return true;
   return searchNestedPath(fields, segments);
 }
@@ -305,17 +384,26 @@ function searchNestedPath(fields: FieldDecl[], segments: string[]): boolean {
   return false;
 }
 
-function hasFieldWithSpreads(schema: SchemaLike, fieldName: string, lookup: DefinitionLookup): boolean {
-  if (fieldName.includes(".")) {
-    if (hasNestedFieldPath(schema.fields, fieldName)) return true;
+/**
+ * Check if a field path (parsed segments) exists on a schema, consulting
+ * fragment-spread expansion when declared fields alone don't match.
+ *
+ * A single segment is matched as an exact field name — a literal (backticked)
+ * segment may contain "." or "::" but still names ONE field, never a nested
+ * path (sl-g6ga). Multi-segment paths walk the field tree per segment.
+ */
+function hasFieldWithSpreads(schema: SchemaLike, fieldSegs: RefSegment[], lookup: DefinitionLookup): boolean {
+  const names = fieldSegs.map((s) => s.name);
+  if (names.length > 1) {
+    if (hasNestedFieldPath(schema.fields, names)) return true;
     if (!schema.hasSpreads) return false;
     const expanded = getExpandedFields(schema, lookup);
-    return hasNestedFieldPath([...schema.fields, ...expanded], fieldName);
+    return hasNestedFieldPath([...schema.fields, ...expanded], names);
   }
+  const fieldName = names[0]!;
   if (hasField(schema.fields, fieldName)) return true;
   if (!schema.hasSpreads) return false;
-  const expanded = getExpandedFields(schema, lookup);
-  return hasField(expanded, fieldName);
+  return hasField(getExpandedFields(schema, lookup), fieldName);
 }
 
 /**
@@ -362,42 +450,52 @@ function contextSchemaKey(name: string, namespace: string | null, lookup: Defini
 }
 
 export function resolveRef(ref: string, mappingContext: MappingContext, lookup: DefinitionLookup): Resolution {
-  const classification = classifyRef(ref);
+  // Parse once, honouring backtick quoting: separators inside backticks are
+  // part of the name (sl-g6ga). All index lookups and resolvedTo names below
+  // use flattened (backtick-free) segment names.
+  const { segments, separators } = parseRef(ref);
+  const classification = classificationOf(separators);
 
   if (classification === "namespace-qualified-schema") {
-    if (lookup.hasSchema(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(ref) } };
-    if (lookup.hasFragment(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(ref) } };
-    if (lookup.hasTransform(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(ref) } };
+    const key = segments.map((s) => s.name).join("::");
+    if (lookup.hasSchema(key)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(key) } };
+    if (lookup.hasFragment(key)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(key) } };
+    if (lookup.hasTransform(key)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(key) } };
     return { resolved: false, resolvedTo: null };
   }
 
   if (classification === "namespace-qualified-field") {
-    const dotIdx = ref.indexOf(".", ref.indexOf("::") + 2);
-    const schemaRef = ref.slice(0, dotIdx);
-    const fieldName = ref.slice(dotIdx + 1);
+    // Grammar shape: ns::schema.field(.field)* — every "::" precedes the
+    // first ".", so the segments before it form the schema key.
+    const firstDot = separators.indexOf(".");
+    const schemaRef = segments.slice(0, firstDot + 1).map((s) => s.name).join("::");
+    const fieldSegs = segments.slice(firstDot + 1);
+    const fieldName = fieldSegs.map((s) => s.name).join(".");
     const schema = lookup.getSchema(schemaRef);
-    if (schema && hasFieldWithSpreads(schema, fieldName, lookup)) {
+    if (schema && hasFieldWithSpreads(schema, fieldSegs, lookup)) {
       return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldName}` } };
     }
     return { resolved: false, resolvedTo: null };
   }
 
   if (classification === "dotted-field") {
-    const dotIdx = ref.indexOf(".");
-    const schemaName = ref.slice(0, dotIdx);
-    const fieldName = ref.slice(dotIdx + 1);
+    const names = segments.map((s) => s.name);
+    const schemaName = names[0]!;
+    const fieldSegs = segments.slice(1);
+    const fieldName = fieldSegs.map((s) => s.name).join(".");
+    const fullPath = names.join(".");
 
     const allSchemas = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
     for (const s of allSchemas) {
       const key = contextSchemaKey(s, mappingContext.namespace, lookup);
       const schema = lookup.getSchema(key);
-      if (schema && hasNestedFieldPath(schema.fields, ref)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
+      if (schema && hasNestedFieldPath(schema.fields, names)) {
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
       }
       if (schema?.hasSpreads) {
         const expanded = getExpandedFields(schema, lookup);
-        if (hasNestedFieldPath([...schema.fields, ...expanded], ref)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
+        if (hasNestedFieldPath([...schema.fields, ...expanded], names)) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
         }
       }
     }
@@ -408,7 +506,7 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
       if (baseName === schemaName || s === schemaName) {
         const key = contextSchemaKey(s, mappingContext.namespace, lookup);
         const schema = lookup.getSchema(key);
-        if (schema && hasFieldWithSpreads(schema, fieldName, lookup)) {
+        if (schema && hasFieldWithSpreads(schema, fieldSegs, lookup)) {
           return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
         }
       }
@@ -425,26 +523,28 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
         const nsIdx = key.indexOf("::");
         const baseName = nsIdx !== -1 ? key.slice(nsIdx + 2) : key;
         if (baseName === schemaName || key === schemaName) {
-          if (hasFieldWithSpreads(schema, fieldName, lookup)) {
+          if (hasFieldWithSpreads(schema, fieldSegs, lookup)) {
             return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
           }
         }
         // Also try as nested path within this schema
-        if (hasNestedFieldPath(schema.fields, ref)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
+        if (hasNestedFieldPath(schema.fields, names)) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
         }
       }
     }
     return { resolved: false, resolvedTo: null };
   }
 
-  // Bare identifier
+  // Bare identifier — a single segment whose name may legally contain "." or
+  // "::" when backtick-quoted; entity-map lookups use the name verbatim.
+  const bareName = segments[0]!.name;
   const allSchemaNames = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
   for (const s of allSchemaNames) {
     const key = contextSchemaKey(s, mappingContext.namespace, lookup);
     const schema = lookup.getSchema(key);
-    if (schema && hasFieldWithSpreads(schema, ref, lookup)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
+    if (schema && hasFieldWithSpreads(schema, segments, lookup)) {
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${bareName}` } };
     }
   }
 
@@ -452,22 +552,22 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
   // searching all workspace schemas for the bare field name.
   if (allSchemaNames.length === 0 && lookup.iterateSchemas) {
     for (const [key, schema] of lookup.iterateSchemas()) {
-      if (hasFieldWithSpreads(schema, ref, lookup)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${ref}` } };
+      if (hasFieldWithSpreads(schema, segments, lookup)) {
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${bareName}` } };
       }
     }
   }
 
   if (mappingContext.namespace) {
-    const nsRef = `${mappingContext.namespace}::${ref}`;
+    const nsRef = `${mappingContext.namespace}::${bareName}`;
     if (lookup.hasSchema(nsRef)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(nsRef) } };
     if (lookup.hasFragment(nsRef)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(nsRef) } };
     if (lookup.hasTransform(nsRef)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(nsRef) } };
   }
 
-  if (lookup.hasSchema(ref)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(ref) } };
-  if (lookup.hasFragment(ref)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(ref) } };
-  if (lookup.hasTransform(ref)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(ref) } };
+  if (lookup.hasSchema(bareName)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(bareName) } };
+  if (lookup.hasFragment(bareName)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(bareName) } };
+  if (lookup.hasTransform(bareName)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(bareName) } };
 
   return { resolved: false, resolvedTo: null };
 }
@@ -792,9 +892,12 @@ export function resolveAllNLRefs(
       namespace: item.namespace,
     };
 
-    for (const { ref, offset } of atRefs) {
-      const classification = classifyRef(ref);
-      const resolution = resolveRef(ref, mappingContext, lookup);
+    for (const { ref, raw, offset } of atRefs) {
+      // Classify and resolve on the raw form — backticked names with embedded
+      // separators must stay literal (sl-g6ga). The flattened `ref` is what
+      // consumers display and match on.
+      const classification = classifyRef(raw);
+      const resolution = resolveRef(raw, mappingContext, lookup);
 
       // Use the shared helper, then convert back to the 0-based line that
       // ResolvedNLRef has historically returned (consumers add +1 themselves).

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -27,7 +27,7 @@ import { capitalize } from "./string-utils.js";
 import { extractAtRefs, classifyRef, resolveRef, isSchemaInMappingSources, stripNLRefScopePrefix, computeNLRefPosition } from "./nl-ref.js";
 import type { DefinitionLookup } from "./nl-ref.js";
 import { expandSpreads, collectFieldPaths } from "./spread-expand.js";
-import type { SpreadEntity } from "./spread-expand.js";
+import type { SpreadEntity, EntityRefResolver, SpreadEntityLookup } from "./spread-expand.js";
 import { resolveScopedEntityRef } from "./canonical-ref.js";
 import type { FieldDecl, MetaEntry, PipeStep } from "./types.js";
 import { computeImportReachability } from "./import-reachability.js";
@@ -543,34 +543,36 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
 
     const srcSchema = resolvedSrcKeys[0];
 
-    // Build the set of valid source field paths (flat, possibly multi-schema).
+    const { resolveRef, lookupFragment, lookupSchema } = makeSpreadLookups(index, currentNs);
+
+    // Build the set of valid source field paths (flat, possibly multi-schema),
+    // expanding spreads; field checks are suppressed below if any spread is
+    // unresolvable.
     const srcFieldPaths = new Set<string>();
     for (const s of resolvedSrcKeys) {
       collectFieldPaths(index.schemas.get(s)?.fields ?? [], "", srcFieldPaths);
     }
+    const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, resolveRef, lookupFragment, srcFieldPaths, diagnostics as never[], lookupSchema);
+
+    // Multi-source mappings let arrows qualify a path with the authored
+    // source name (s2.created_at). The qualified set must include
+    // spread-inherited fields too (sl-kkao) — expand each source into a
+    // scratch set, then add its paths with the authored prefix. Spread
+    // diagnostics were already emitted by the combined expansion above, so
+    // this pass discards them to avoid duplicates.
     if (resolvedSrcKeys.length > 1) {
       for (let i = 0; i < mapping.sources.length; i++) {
         const key = resolveScopedEntityRef(mapping.sources[i]!, currentNs, index.schemas as Map<string, unknown>);
         if (!key) continue;
-        collectFieldPaths(index.schemas.get(key)?.fields ?? [], mapping.sources[i]! + ".", srcFieldPaths);
+        const perSourcePaths = new Set<string>();
+        collectFieldPaths(index.schemas.get(key)?.fields ?? [], "", perSourcePaths);
+        expandSpreads([key], currentNs, resolveRef, lookupFragment, perSourcePaths, [], lookupSchema);
+        for (const p of perSourcePaths) srcFieldPaths.add(`${mapping.sources[i]}.${p}`);
       }
     }
 
     const tgtFieldPaths = new Set<string>();
     collectFieldPaths(resolvedTgtKey ? (index.schemas.get(resolvedTgtKey)?.fields ?? []) : [], "", tgtFieldPaths);
-
-    // Expand spreads; suppress field checks if any spread is unresolvable.
-    const resolveRef = (ref: string, _ns: string | null) =>
-      resolveScopedEntityRef(ref, currentNs, index.fragments as Map<string, unknown>);
-    const lookupFragment = (key: string): SpreadEntity | undefined => {
-      const f = index.fragments.get(key);
-      return f ? { fields: f.fields, hasSpreads: f.hasSpreads ?? false, spreads: f.spreads, file: f.file, row: f.row } : undefined;
-    };
-    const lookupSchema = (key: string): SpreadEntity | undefined => {
-      const s = index.schemas.get(key);
-      return s ? { fields: s.fields, hasSpreads: s.hasSpreads ?? false, spreads: s.spreads, file: s.file, row: s.row } : undefined;
-    };
-    const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, resolveRef, lookupFragment, srcFieldPaths, diagnostics as never[], lookupSchema);
     const tgtHasUnresolved = resolvedTgtKey
       ? expandSpreads([resolvedTgtKey], currentNs, resolveRef, lookupFragment, tgtFieldPaths, diagnostics as never[], lookupSchema)
       : false;
@@ -608,7 +610,7 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
           diagnostics.push({
             file: arrow.file, line: arrow.line + 1, column: 1, severity: "warning",
             rule: "field-not-in-schema",
-            message: `Arrow source '${source}' not declared in schema '${srcSchema}'`,
+            message: `Arrow source '${source}' not declared in schema '${blamedSourceSchema(source, resolvedSrcKeys, srcSchema)}'`,
           });
         }
       }
@@ -955,33 +957,83 @@ function getConventionFields(schema: SemanticSchema): Set<string> {
 }
 
 /**
+ * Build the resolver/lookup trio that expandSpreads needs from a
+ * SemanticIndex. Fragment refs resolve relative to `currentNs` — the
+ * namespace of whichever entity owns the spread being expanded.
+ */
+function makeSpreadLookups(index: SemanticIndex, currentNs: string | null): {
+  resolveRef: EntityRefResolver;
+  lookupFragment: SpreadEntityLookup;
+  lookupSchema: SpreadEntityLookup;
+} {
+  return {
+    resolveRef: (ref, _ns) => resolveScopedEntityRef(ref, currentNs, index.fragments as Map<string, unknown>),
+    lookupFragment: (key): SpreadEntity | undefined => {
+      const f = index.fragments.get(key);
+      return f ? { fields: f.fields, hasSpreads: f.hasSpreads ?? false, spreads: f.spreads, file: f.file, row: f.row } : undefined;
+    },
+    lookupSchema: (key): SpreadEntity | undefined => {
+      const s = index.schemas.get(key);
+      return s ? { fields: s.fields, hasSpreads: s.hasSpreads ?? false, spreads: s.spreads, file: s.file, row: s.row } : undefined;
+    },
+  };
+}
+
+/**
+ * Find the source schema a qualified arrow path refers to, matching the
+ * qualifier against resolved keys both verbatim and by their post-"::" base
+ * name (paths are authored with bare names even inside namespaces).
+ * Returns null for unqualified paths or unknown qualifiers.
+ */
+function qualifiedSourceSchema(path: string, schemaNames: string[]): string | null {
+  const dotIdx = path.indexOf(".");
+  if (dotIdx <= 0) return null;
+  const qualifier = path.slice(0, dotIdx);
+  return schemaNames.find((s) => {
+    if (s === qualifier) return true;
+    const nsIdx = s.indexOf("::");
+    return nsIdx !== -1 && s.slice(nsIdx + 2) === qualifier;
+  }) ?? null;
+}
+
+/**
+ * Pick the schema to blame in a field-not-in-schema message: a qualified path
+ * (s2.created_at) blames the schema it is qualified with; anything else
+ * blames the first source schema (sl-kkao — the message previously always
+ * named the first source, even for paths qualified with another one).
+ */
+function blamedSourceSchema(path: string, schemaNames: string[], firstSource: string): string {
+  return qualifiedSourceSchema(path, schemaNames) ?? firstSource;
+}
+
+/**
  * Resolve an arrow field path against the known field paths for the mapping's schema.
  * Returns true when the path is valid (no diagnostic needed).
  *
  * Special cases:
  *  - Paths starting with "." are always valid (computed / expression paths).
  *  - The schema name itself is valid (for container arrows targeting the schema root).
- *  - Qualified paths like "source_schema.field" are resolved by stripping the prefix.
+ *  - Qualified paths like "source_schema.field" are resolved by stripping the
+ *    prefix; the qualified schema's spread-inherited fields count too (sl-kkao).
  */
 function resolveFieldPath(path: string, schemaNames: string[], index: SemanticIndex, fieldPaths: Set<string>): boolean {
   if (path.startsWith(".")) return true;
   if (fieldPaths.has(path)) return true;
   if (schemaNames.includes(path)) return true;
 
-  const dotIdx = path.indexOf(".");
-  if (dotIdx > 0) {
-    const qualifier = path.slice(0, dotIdx);
-    const matchedSchema = schemaNames.find((s) => {
-      if (s === qualifier) return true;
-      const nsIdx = s.indexOf("::");
-      return nsIdx !== -1 && s.slice(nsIdx + 2) === qualifier;
-    });
-    if (matchedSchema) {
-      const rest = path.slice(dotIdx + 1);
-      const qualPaths = new Set<string>();
-      collectFieldPaths(index.schemas.get(matchedSchema)?.fields ?? [], "", qualPaths);
-      if (qualPaths.has(rest)) return true;
+  const matchedSchema = qualifiedSourceSchema(path, schemaNames);
+  if (matchedSchema) {
+    const rest = path.slice(path.indexOf(".") + 1);
+    const schema = index.schemas.get(matchedSchema);
+    const qualPaths = new Set<string>();
+    collectFieldPaths(schema?.fields ?? [], "", qualPaths);
+    if (schema?.hasSpreads) {
+      // Spread expansion diagnostics are already emitted when the caller
+      // builds its field path sets — discard them here to avoid duplicates.
+      const { resolveRef, lookupFragment, lookupSchema } = makeSpreadLookups(index, schema.namespace ?? null);
+      expandSpreads([matchedSchema], schema.namespace ?? null, resolveRef, lookupFragment, qualPaths, [], lookupSchema);
     }
+    if (qualPaths.has(rest)) return true;
   }
   return false;
 }

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -423,9 +423,11 @@ function checkNLRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): v
 
     const lookup = makeSemanticLookup(index);
 
-    for (const { ref, offset } of refs) {
-      const classification = classifyRef(ref);
-      const resolution = resolveRef(ref, mappingContext, lookup);
+    for (const { ref, raw, offset } of refs) {
+      // raw keeps backtick quoting so literal names with "." / "::" classify
+      // and resolve correctly (sl-g6ga); ref is the flattened display form.
+      const classification = classifyRef(raw);
+      const resolution = resolveRef(raw, mappingContext, lookup);
       const { line, column } = computeNLRefPosition(item, offset);
 
       if (!resolution.resolved) {

--- a/tooling/satsuma-core/test/meta-extract.test.js
+++ b/tooling/satsuma-core/test/meta-extract.test.js
@@ -54,6 +54,40 @@ describe("extractMetadata()", () => {
     assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "classification", value: "INTERNAL" }]);
   });
 
+  // sl-cvx9: value_text legally mixes quoted strings with surrounding tokens
+  // (e.g. `default "unknown" if null`). The extractor previously discarded
+  // everything except the first nl_string child, silently losing data in all
+  // extraction JSON and hover output. Mixed values must round-trip verbatim.
+
+  it("preserves tokens around a quoted string in a mixed value (sl-cvx9)", () => {
+    // CST shape of `(default "unknown" if null)`: value_text with an nl_string
+    // child followed by two identifier children.
+    const key = n("identifier", [], "default");
+    const val = n(
+      "value_text",
+      [n("nl_string", [], '"unknown"'), n("identifier", [], "if"), n("identifier", [], "null")],
+      '"unknown" if null',
+    );
+    const kv = n("tag_with_value", [key, val]);
+    const meta = metaBlock([kv]);
+    assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "default", value: '"unknown" if null' }]);
+  });
+
+  it("preserves all strings in a multi-string value (sl-cvx9)", () => {
+    // `(default "a" or "b")` — two nl_strings with an identifier between them.
+    // The old code returned just "a"; the outer-quote fallback must also not
+    // fire here (it would mangle the value to `a" or "b`).
+    const key = n("identifier", [], "default");
+    const val = n(
+      "value_text",
+      [n("nl_string", [], '"a"'), n("identifier", [], "or"), n("nl_string", [], '"b"')],
+      '"a" or "b"',
+    );
+    const kv = n("tag_with_value", [key, val]);
+    const meta = metaBlock([kv]);
+    assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "default", value: '"a" or "b"' }]);
+  });
+
   it("extracts enum_body entries", () => {
     const id1 = n("identifier", [], "open");
     const id2 = n("identifier", [], "closed");

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -465,13 +465,76 @@ describe("extractNLRefData — bare pipe-text at_refs (bptar-l6n8)", () => {
   });
 
   it("anchors a bare @ref so position math matches the quoted form", () => {
-    // For quoted items, column points at the opening delimiter and
-    // computeNLRefPosition's +1 lands on the @. A bare item has no delimiter,
-    // so its column is the @ itself and the same +1 yields the 1-based column.
+    // A bare at_ref has no delimiter (delimiterWidth 0): its column is the @
+    // itself, and the +1 in computeNLRefPosition only converts to 1-based.
     const src = "mapping m {\n  a -> b { from @z }\n}";
     const [item] = nlRefItems(src);
     const pos = computeNLRefPosition(item, item.text.indexOf("@"));
     assert.equal(pos.line, 2); // 1-based line of the arrow
     assert.equal(pos.column, src.split("\n")[1].indexOf("@") + 1); // 1-based @ column
+  });
+});
+
+// ── NL ref positions vs string delimiters (sl-o3ea) ──────────────────────────
+//
+// Items extracted from quoted NL strings have the opening delimiter stripped
+// from their text (1 char for ", 3 for """), but item.column still points at
+// the delimiter in the source. computeNLRefPosition previously ignored that
+// gap, so refs on the first line of a string were reported one (or three)
+// columns short — lint output pointed at the space before the @. Each case
+// asserts the reported column is exactly the 1-based source column of the @.
+
+describe("NL ref positions account for string delimiters (sl-o3ea)", () => {
+  before(async () => {
+    await initParser(WASM_PATH);
+  });
+
+  // Extract the single NL ref item from a snippet and return the 1-based
+  // position computeNLRefPosition reports for its first @.
+  function positionOfRef(src) {
+    const items = extractNLRefData(getParser().parse(src).rootNode);
+    assert.equal(items.length, 1, "expected exactly one NL ref item");
+    return computeNLRefPosition(items[0], items[0].text.indexOf("@"));
+  }
+
+  // 1-based position of the first @ in the source itself — ground truth.
+  function atPositionIn(src) {
+    const lines = src.split("\n");
+    const row = lines.findIndex((l) => l.includes("@"));
+    return { line: row + 1, column: lines[row].indexOf("@") + 1 };
+  }
+
+  it("points exactly at the @ in a single-line quoted string", () => {
+    const src = 'mapping m {\n  a -> b { "see @x for ids" }\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
+  });
+
+  it("points exactly at the @ on the opening line of a multiline string", () => {
+    const src = 'mapping m {\n  a -> b { """see @x\nmore text""" }\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
+  });
+
+  it("keeps refs after a newline anchored to their own line", () => {
+    // Continuation-line refs never included the delimiter in their column
+    // math; this guards that the first-line fix does not disturb them.
+    const src = 'mapping m {\n  a -> b { """first\n  see @x""" }\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
+  });
+
+  it("points exactly at the @ in a mapping note block string", () => {
+    // note blocks are a separate extraction site from pipe steps; the
+    // delimiter width must be recorded there too.
+    const src = 'mapping m {\n  note { "uses @x" }\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
+  });
+
+  it("points exactly at the @ in a standalone note string", () => {
+    const src = 'note {\n  "platform docs reference @x"\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
+  });
+
+  it("points exactly at the @ in a transform body string", () => {
+    const src = 'transform t {\n  "lookup against @x"\n}';
+    assert.deepEqual(positionOfRef(src), atPositionIn(src));
   });
 });

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -43,6 +43,15 @@ describe("extractAtRefs()", () => {
     assert.equal(refs[0].ref, "order-id");
   });
 
+  it("preserves backtick quoting in the raw form (sl-g6ga)", () => {
+    // `ref` flattens backticks for display, which makes @`tax.rate`
+    // indistinguishable from the path @tax.rate. `raw` keeps the quoting so
+    // classification and resolution can treat the name as literal.
+    const refs = extractAtRefs("uses @`tax.rate` and @plain.path");
+    assert.deepEqual(refs.map((r) => r.ref), ["tax.rate", "plain.path"]);
+    assert.deepEqual(refs.map((r) => r.raw), ["`tax.rate`", "plain.path"]);
+  });
+
   it("returns empty for text with no refs", () => {
     const refs = extractAtRefs("plain text with no references");
     assert.deepEqual(refs, []);
@@ -205,6 +214,26 @@ describe("classifyRef()", () => {
   it("classifies namespace-qualified field", () => {
     assert.equal(classifyRef("crm::customers.email"), "namespace-qualified-field");
   });
+
+  // sl-g6ga: backtick-quoted names legally contain "." and "::". Classification
+  // previously ran on the backtick-stripped string, so @`tax.rate` was treated
+  // as a schema.field path and @`legacy::thing` as a namespaced schema —
+  // both then failed to resolve. Backticked spans must be opaque.
+
+  it("classifies a backticked name containing a dot as bare (sl-g6ga)", () => {
+    assert.equal(classifyRef("`tax.rate`"), "bare");
+  });
+
+  it("classifies a backticked name containing :: as bare (sl-g6ga)", () => {
+    assert.equal(classifyRef("`legacy::thing`"), "bare");
+  });
+
+  it("only counts separators outside backticks in compound refs (sl-g6ga)", () => {
+    // The dot inside the backticks must not promote the schema ref to a field ref.
+    assert.equal(classifyRef("crm::`my.schema`"), "namespace-qualified-schema");
+    // The separator dot before the literal still makes this a dotted field.
+    assert.equal(classifyRef("customers.`tax.rate`"), "dotted-field");
+  });
 });
 
 // ── resolveRef ────────────────────────────────────────────────────────────────
@@ -301,6 +330,49 @@ describe("resolveRef()", () => {
     assert.equal(r.resolved, true);
     assert.equal(r.resolvedTo.name, "::shared_ref.code");
   });
+
+  // sl-g6ga: refs passed in raw (backticked) form must resolve as literal
+  // names — the embedded "." / "::" are part of the name, not path separators.
+
+  it("resolves a backticked field name containing a dot (sl-g6ga)", () => {
+    const lookup = makeLookup({ "::rates": { fields: [{ name: "tax.rate" }], hasSpreads: false } });
+    const ctx = { sources: ["::rates"], targets: [], namespace: null };
+    const r = resolveRef("`tax.rate`", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.kind, "field");
+    assert.equal(r.resolvedTo.name, "::rates.tax.rate");
+  });
+
+  it("resolves a backticked field name containing :: (sl-g6ga)", () => {
+    const lookup = makeLookup({ "::legacy": { fields: [{ name: "legacy::thing" }], hasSpreads: false } });
+    const ctx = { sources: ["::legacy"], targets: [], namespace: null };
+    const r = resolveRef("`legacy::thing`", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::legacy.legacy::thing");
+  });
+
+  it("does not let a backticked literal match a nested field path (sl-g6ga)", () => {
+    // @`tax.rate` names ONE field literally called "tax.rate". A schema that
+    // only has a record field tax{rate} must not satisfy it — that ref is
+    // written @tax.rate, without backticks.
+    const lookup = makeLookup({
+      "::rates": { fields: [{ name: "tax", children: [{ name: "rate" }] }], hasSpreads: false },
+    });
+    const ctx = { sources: ["::rates"], targets: [], namespace: null };
+    assert.equal(resolveRef("`tax.rate`", ctx, lookup).resolved, false);
+    // Control: the unquoted form still resolves through the field tree.
+    assert.equal(resolveRef("tax.rate", ctx, lookup).resolved, true);
+  });
+
+  it("resolves a schema-qualified backticked field name (sl-g6ga)", () => {
+    // Compound form: the separator dot picks the schema, the backticked
+    // literal names the field exactly.
+    const lookup = makeLookup({ "::customers": { fields: [{ name: "tax.rate" }], hasSpreads: false } });
+    const ctx = { sources: ["::customers"], targets: [], namespace: null };
+    const r = resolveRef("customers.`tax.rate`", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::customers.tax.rate");
+  });
 });
 
 // ── resolveAllNLRefs ──────────────────────────────────────────────────────────
@@ -328,6 +400,32 @@ describe("resolveAllNLRefs()", () => {
   it("returns empty array for empty input", () => {
     const lookup = makeLookup({});
     assert.deepEqual(resolveAllNLRefs([], lookup), []);
+  });
+
+  it("resolves a backticked ref with an embedded dot as a literal field name (sl-g6ga)", () => {
+    // End-to-end through extraction: the item text carries the backticks, the
+    // resolved record reports the flattened ref but classifies and resolves it
+    // as one literal name, not a schema.field path.
+    const lookup = makeLookup(
+      { "::rates": { fields: [{ name: "tax.rate" }], hasSpreads: false } },
+      {}, {},
+      { my_mapping: { sources: ["::rates"], targets: [], namespace: null } },
+    );
+    const items = [{
+      text: "apply @`tax.rate` here",
+      mapping: "my_mapping",
+      namespace: null,
+      targetField: null,
+      line: 5,
+      column: 0,
+      file: "test.stm",
+    }];
+    const results = resolveAllNLRefs(items, lookup);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].ref, "tax.rate");
+    assert.equal(results[0].classification, "bare");
+    assert.equal(results[0].resolved, true);
+    assert.equal(results[0].resolvedTo.name, "::rates.tax.rate");
   });
 });
 

--- a/tooling/satsuma-core/test/validate.test.js
+++ b/tooling/satsuma-core/test/validate.test.js
@@ -335,6 +335,57 @@ describe("arrow field-not-in-schema diagnostics", () => {
     const fieldDiags = diags.filter((d) => d.rule === "field-not-in-schema" && d.message.includes("spread_sourced_field"));
     assert.equal(fieldDiags.length, 0, "must not warn when source has unresolved spreads");
   });
+
+  // sl-kkao: multi-source mappings let arrows qualify a source path with the
+  // schema name (s2.created_at). The qualified path sets were built from
+  // declared fields only — spread-inherited fields validated clean in the
+  // unqualified form but warned in the qualified form.
+
+  it("accepts a schema-qualified spread-inherited field in a multi-source mapping (sl-kkao)", () => {
+    const index = makeIndex({
+      fragments: [{ name: "audit", fields: [{ name: "created_at", type: "TIMESTAMP" }] }],
+      schemas: [
+        { name: "s1", fields: [{ name: "id", type: "INT" }] },
+        { name: "s2", fields: [{ name: "code", type: "STRING" }], spreads: ["audit"] },
+        { name: "z", fields: [{ name: "z_created", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m", sources: ["s1", "s2"], targets: ["z"] }],
+      fieldArrows: [{
+        mapping: "m", namespace: null,
+        sources: ["s2.created_at"],
+        target: "z_created",
+        steps: [], line: 5, file: "test.stm",
+      }],
+    });
+    const diags = collectSemanticDiagnostics(index);
+    const fieldDiags = diags.filter((d) => d.rule === "field-not-in-schema");
+    assert.deepEqual(fieldDiags.map((d) => d.message), [],
+      "qualified spread-inherited field must validate clean");
+  });
+
+  it("blames the schema a qualified path names, not the first source (sl-kkao)", () => {
+    // s2.missing exists nowhere — the warning must point the author at s2,
+    // the schema they qualified the path with, not at s1.
+    const index = makeIndex({
+      schemas: [
+        { name: "s1", fields: [{ name: "id", type: "INT" }] },
+        { name: "s2", fields: [{ name: "code", type: "STRING" }] },
+        { name: "z", fields: [{ name: "z_created", type: "TIMESTAMP" }] },
+      ],
+      mappings: [{ name: "m", sources: ["s1", "s2"], targets: ["z"] }],
+      fieldArrows: [{
+        mapping: "m", namespace: null,
+        sources: ["s2.missing"],
+        target: "z_created",
+        steps: [], line: 5, file: "test.stm",
+      }],
+    });
+    const diags = collectSemanticDiagnostics(index);
+    const diag = diags.find((d) => d.rule === "field-not-in-schema" && d.message.includes("s2.missing"));
+    assert.ok(diag, "should still warn for a genuinely missing qualified field");
+    assert.match(diag.message, /schema 's2'/);
+    assert.ok(!diag.message.includes("'s1'"), "must not blame the first source schema");
+  });
 });
 
 // ---------- Section 7: Transform spread references ----------

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -735,10 +735,12 @@ function resolveTransformAtRefs(
   const lookup = makeVizLookup(wsIndex);
   const ctx = { sources, targets, namespace };
   return extractAtRefs(transform.text).map((br) => {
-    const resolution = resolveRef(br.ref, ctx, lookup);
+    // br.raw keeps backtick quoting so literal names with "." / "::"
+    // classify and resolve correctly (sl-g6ga); br.ref stays for display.
+    const resolution = resolveRef(br.raw, ctx, lookup);
     return {
       ref: br.ref,
-      classification: classifyRef(br.ref),
+      classification: classifyRef(br.raw),
       resolved: resolution.resolved,
       resolvedTo: resolution.resolvedTo ?? null,
     };


### PR DESCRIPTION
## Summary

Fixes the four open P2 `core`-tagged bugs from the June bug hunt, one commit per ticket:

- **sl-cvx9** — `normalizeMetadataValue` truncated mixed metadata values to their first quoted string (`(default "unknown" if null)` → `"unknown"`). Delimiters are now stripped only when a single quoted string spans the whole value; mixed values round-trip verbatim.
- **sl-o3ea** — `computeNLRefPosition` reported first-line @refs one column short (three for multiline strings) because items strip the opening string delimiter from their text. Items now record the delimiter width and the position helper adds it back; lint columns point exactly at the `@`.
- **sl-g6ga** — backtick-quoted @refs containing `.` or `::` (e.g. `` @`tax.rate` ``) were classified as paths and failed to resolve. `AtRef` now carries a raw backtick-preserving form, a backtick-aware tokenizer treats quoted spans as opaque literal names, and all classify/resolve call sites (core validate, CLI lint / schema-graph / graph-builder, viz-model) use it. Flattened refs keep their previous behaviour.
- **sl-kkao** — schema-qualified spread-inherited fields in multi-source mappings (`s2.created_at` where `s2` spreads the field) produced false `field-not-in-schema` warnings, and the message always blamed the first source schema. Spread expansion now feeds the qualified path sets and `resolveFieldPath`'s qualified branch, and the diagnostic names the schema the path is qualified with.

## Testing

- TDD: every fix landed with regression tests verified red before the fix (core suite 396 → 415 tests).
- Full suites green: core (415), CLI (867), LSP (273), viz-backend (163), vscode-satsuma golden runs.
- sl-kkao repro verified end-to-end via `satsuma validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)