### PR TITLE
fix(lsp): LSP bug batch — rename safety, diagnostic attribution, URI canonicalization, full lineage

### DIFF
--- a/.tickets/sl-ei1e.md
+++ b/.tickets/sl-ei1e.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ei1e
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ satsuma-lsp/src/semantic-diagnostics.ts:293-301 defEntryToMapping gathers source
 
 Sources/targets attributed per mapping (range-scoped), not per file; multi-mapping file emits exactly one diagnostic at the offending mapping.
 
+
+## Notes
+
+**2026-06-11T13:07:36Z**
+
+Cause: defEntryToMapping/defEntryToMetric gathered source/target/metric_source refs from every reference in the same file (uri-only filter), so each mapping/metric inherited every other block's refs — undefined-ref diagnostics duplicated once per block and misattributed.
+Fix: refs are matched by the container identity recorded at index time (metric_source refs now also carry container, mirroring mappings); a multi-mapping file emits exactly one diagnostic at the offending block. Regression tests for both mapping and metric attribution.

--- a/.tickets/sl-kilo.md
+++ b/.tickets/sl-kilo.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kilo
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ satsuma-lsp/src/rename.ts:45-48 — for a block inside a namespace the placehold
 
 Placeholder matches the exact text the edit range covers (bare label), or the range covers the qualified form; rename-in-namespace test.
 
+
+## Notes
+
+**2026-06-11T13:03:33Z**
+
+Cause: prepareRename returned ctx.name as the placeholder, which findNodeContext qualifies with the namespace for block labels, while the edit range covers only the bare label node — accepting the prefilled name wrote the qualified form into the label.
+Fix: prepareRename strips the namespace prefix so the placeholder is exactly the text the range covers; rename-in-namespace regression test asserts placeholder === covered text.

--- a/.tickets/sl-ku3c.md
+++ b/.tickets/sl-ku3c.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ku3c
-status: open
+status: closed
 deps: []
 links: [sl-vmqv]
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ The sl-akz6/gh-274 fix canonicalized the workspace index but not the tree cache.
 
 trees keyed by canonical URI everywhere; unit test with percent-encoded drive-letter URI; linked Windows CI ticket covers e2e.
 
+
+## Notes
+
+**2026-06-11T13:14:50Z**
+
+Cause: server.ts trees and validateDiagCache were keyed by the raw client URI while the workspace index canonicalizes keys (sl-akz6) — on Windows the didOpen spelling (file:///c%3A/...) and the canonical spelling (file:///c:/...) addressed different entries, so canonical lookups missed open files.
+Fix: new CanonicalUriMap (src/canonical-uri-map.ts) canonicalizes every key on get/set/has/delete; trees and validateDiagCache use it, and runValidate canonicalizes its result URIs. Unit tests cover percent-encoded drive-letter spellings; e2e Windows coverage tracked by linked sl-vmqv.

--- a/.tickets/sl-mg63.md
+++ b/.tickets/sl-mg63.md
@@ -1,6 +1,6 @@
 ---
 id: sl-mg63
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ satsuma-lsp/src/server.ts:348-364 — the handler resolves each import-reachable
 
 vizFullLineage parses unopened import-reachable files (from disk or retained trees); integration test with a closed imported file appearing in lineage.
 
+
+## Notes
+
+**2026-06-11T13:19:38Z**
+
+Cause: the satsuma/vizFullLineage handler resolved each import-reachable URI through the trees map, which only holds open-editor documents — the workspace scan and watched-file handler discard their trees — so 'full transitive lineage' contained only open files.
+Fix: traversal extracted to computeFullLineage (src/full-lineage.ts) with tree acquisition as a loader callback; the server backs it with trees.get plus a new parseTreeFromDisk fallback so closed imports are parsed from disk. The unit test now exercises the real module (the old test faked a fully-populated trees map) and pins that every reachable file is requested from the loader.

--- a/.tickets/sl-p256.md
+++ b/.tickets/sl-p256.md
@@ -1,6 +1,6 @@
 ---
 id: sl-p256
-status: open
+status: closed
 deps: []
 links: [sl-xf3f]
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ satsuma-viz-backend/src/workspace-index.ts:433-439 — findReferences for a bare
 
 Rename of a::foo touches only refs resolving to a::foo; find-references is namespace-accurate; tests with same-named schemas in two namespaces.
 
+
+## Notes
+
+**2026-06-11T13:27:00Z**
+
+Cause: findReferences fanned out by spelling — a qualified query also returned every bare ref of that name anywhere, and a bare query returned every *::name ref. rename.ts consumed these unfiltered, so renaming a::foo rewrote source { foo } inside namespace b (which binds to b::foo).
+Fix: ReferenceEntry records the namespace it was authored in (threaded through every indexing site; NL refs recover it from the ancestor chain); new resolveReferenceKey() mirrors resolveDefinition's binding order; findReferences re-resolves each candidate against its own scope and returns only refs binding to the requested key. references.ts/rename.ts canonicalize their query through resolveReferenceKey, and rename's qualified-ref sub-range now also applies when the renamed symbol is itself namespaced.

--- a/.tickets/sl-th5k.md
+++ b/.tickets/sl-th5k.md
@@ -1,6 +1,6 @@
 ---
 id: sl-th5k
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:41:29Z
@@ -17,3 +17,10 @@ satsuma-lsp/src/server.ts:163-176 — on save only validateDiagCache.delete(even
 
 After a save, files no longer reporting diagnostics get them cleared (publish empty); cross-file fix test.
 
+
+## Notes
+
+**2026-06-11T13:11:30Z**
+
+Cause: onDidSave deleted only the saved file's validateDiagCache entry; cross-file diagnostics cached for other files in the validated closure were never removed when a new run stopped reporting them, freezing them client-side until that file was saved.
+Fix: new pure reconcileValidateCache() in validate-diagnostics.ts clears cached entries for in-scope (import-reachable) files absent from the new run and returns them; the save handler republishes every touched file, with an explicit empty publish for cleared files that are not open. Entries outside the closure stay.

--- a/tooling/satsuma-lsp/src/canonical-uri-map.ts
+++ b/tooling/satsuma-lsp/src/canonical-uri-map.ts
@@ -1,0 +1,35 @@
+/**
+ * canonical-uri-map.ts — a Map that keys entries by canonical file URIs.
+ *
+ * LSP clients may spell the same file's URI differently between requests:
+ * VS Code on Windows sends `file:///c%3A/proj/x.stm` while Node's
+ * `pathToFileURL` produces `file:///C:/proj/x.stm`. The workspace index
+ * canonicalizes its keys (sl-akz6), but server caches keyed by the raw
+ * client URI missed lookups whenever the spelling differed: vizFullLineage
+ * skipped open files, on-save diagnostics for sibling files never published,
+ * and the watched-file "is it open?" skip never matched (sl-ku3c).
+ *
+ * Every key is canonicalized on the way in, so all spellings of one file
+ * address the same entry. Iteration yields canonical keys. Non-file URIs
+ * pass through canonicalizeFileUri unchanged.
+ */
+
+import { canonicalizeFileUri } from "./workspace-index";
+
+export class CanonicalUriMap<V> extends Map<string, V> {
+  override get(uri: string): V | undefined {
+    return super.get(canonicalizeFileUri(uri));
+  }
+
+  override set(uri: string, value: V): this {
+    return super.set(canonicalizeFileUri(uri), value);
+  }
+
+  override has(uri: string): boolean {
+    return super.has(canonicalizeFileUri(uri));
+  }
+
+  override delete(uri: string): boolean {
+    return super.delete(canonicalizeFileUri(uri));
+  }
+}

--- a/tooling/satsuma-lsp/src/full-lineage.ts
+++ b/tooling/satsuma-lsp/src/full-lineage.ts
@@ -1,0 +1,54 @@
+/**
+ * full-lineage.ts — merged VizModel across a file's transitive import graph.
+ *
+ * Owns the satsuma/vizFullLineage traversal: walk every import-reachable file
+ * from the requested entry, build a per-file VizModel, and merge them so stub
+ * schemas are superseded by their full upstream definitions.
+ *
+ * Tree acquisition is delegated to the caller. The server supplies open-editor
+ * trees with an on-disk parse fallback, so files that are merely imported —
+ * not open in any editor — still contribute their definitions. The previous
+ * inline handler read only the open-editor tree cache, so "full transitive
+ * lineage" silently contained just the files the user happened to have open
+ * (sl-mg63). This module never touches the filesystem itself.
+ */
+
+import type { Tree } from "./parser-utils";
+import {
+  WorkspaceIndex,
+  getImportReachableUris,
+  createScopedIndex,
+} from "./workspace-index";
+import { buildVizModel, mergeVizModels } from "@satsuma/viz-backend";
+import type { VizModel } from "@satsuma/viz-backend";
+
+/**
+ * Build the merged lineage model for `primaryUri`.
+ *
+ * @param primaryUri The entry file the client requested lineage for.
+ * @param wsIndex    Full workspace index (used for import-graph traversal and
+ *                   per-file scoped indexing).
+ * @param loadTree   Returns a parse tree for a URI, from any source the caller
+ *                   has (open editors, disk, …), or null when unavailable.
+ * @returns The merged model anchored to `primaryUri`, or null when the primary
+ *          file itself cannot be loaded. Unloadable imported files are skipped.
+ */
+export function computeFullLineage(
+  primaryUri: string,
+  wsIndex: WorkspaceIndex,
+  loadTree: (uri: string) => Tree | null | undefined,
+): VizModel | null {
+  // No tree for the requested file means there is nothing to anchor the
+  // model to — preserve the original handler's null contract.
+  if (!loadTree(primaryUri)) return null;
+
+  const models: VizModel[] = [];
+  for (const fileUri of getImportReachableUris(primaryUri, wsIndex)) {
+    const fileTree = loadTree(fileUri);
+    if (!fileTree) continue;
+    const scoped = createScopedIndex(wsIndex, getImportReachableUris(fileUri, wsIndex));
+    models.push(buildVizModel(fileUri, fileTree, scoped));
+  }
+
+  return mergeVizModels(primaryUri, models);
+}

--- a/tooling/satsuma-lsp/src/references.ts
+++ b/tooling/satsuma-lsp/src/references.ts
@@ -6,6 +6,7 @@ import {
   WorkspaceIndex,
   resolveDefinition,
   findReferences as indexFindReferences,
+  resolveReferenceKey,
 } from "./workspace-index";
 
 /**
@@ -26,9 +27,12 @@ export function computeReferences(
   const ctx = findNodeContext(node);
   if (!ctx) return [];
 
-  // Determine the canonical name to search for
+  // Determine the canonical name to search for. A bare name authored inside
+  // a namespace binds to the namespace-local definition when one exists, so
+  // the reference query must use that qualified key (sl-p256).
   const name = ctx.name;
   if (!name) return [];
+  const refKey = resolveReferenceKey(index, name, ctx.namespace ?? null);
 
   // Use a seen set so qualified + bare lookups never duplicate the same location.
   const seen = new Set<string>();
@@ -41,8 +45,8 @@ export function computeReferences(
     results.push(Location.create(uri, range));
   }
 
-  // Add bare-name references (always)
-  for (const ref of indexFindReferences(index, name)) {
+  // Add references binding to the canonical key (always)
+  for (const ref of indexFindReferences(index, refKey)) {
     addRef(ref.uri, ref.range);
   }
 

--- a/tooling/satsuma-lsp/src/rename.ts
+++ b/tooling/satsuma-lsp/src/rename.ts
@@ -10,6 +10,7 @@ import {
   WorkspaceIndex,
   resolveDefinition,
   findReferences,
+  resolveReferenceKey,
 } from "./workspace-index";
 
 /**
@@ -91,17 +92,19 @@ export function computeRename(
     addEdit(changes, def.uri, def.selectionRange, newName);
   }
 
-  // 2. Rename all reference sites
-  const refs = findReferences(index, oldName);
+  // 2. Rename all reference sites. Query by the canonical key the symbol
+  // binds to — a bare name inside a namespace binds to the namespace-local
+  // definition, and findReferences returns only refs resolving to that key,
+  // so same-named symbols in other namespaces are never touched (sl-p256).
+  const refs = findReferences(index, resolveReferenceKey(index, oldName, ctx.namespace ?? null));
+  const oldBare = oldName.includes("::") ? oldName.split("::").pop()! : oldName;
   for (const ref of refs) {
-    // For qualified references like "ns::oldName", only replace the name part
-    if (ref.name.includes("::") && !oldName.includes("::")) {
-      // The reference is qualified but the old name is bare — this ref
-      // might match via namespace fallback. Compute the sub-range for just
-      // the name part after "::"
+    // For references authored qualified ("ns::oldName"), only replace the
+    // name part — rewriting the whole range would delete the "ns::" prefix.
+    if (ref.name.includes("::")) {
       const colonIdx = ref.name.indexOf("::");
       const bareInRef = ref.name.slice(colonIdx + 2);
-      if (bareInRef === oldName) {
+      if (bareInRef === oldBare) {
         // Adjust range to only cover the part after "::"
         const prefixLen = colonIdx + 2;
         const adjusted: Range = {

--- a/tooling/satsuma-lsp/src/rename.ts
+++ b/tooling/satsuma-lsp/src/rename.ts
@@ -39,9 +39,19 @@ export function prepareRename(
 
   if (!renameable.has(ctx.kind)) return null;
 
+  // The placeholder must be exactly the text the range covers: clients
+  // prefill it and replace the range verbatim with whatever the user accepts.
+  // For block labels inside a namespace ctx.name is qualified ("a::foo") but
+  // ctx.node covers only the bare label — returning the qualified form wrote
+  // "a::foo2" INTO the label, yielding a doubly-qualified name (sl-kilo).
+  const placeholder =
+    ctx.namespace && ctx.name.startsWith(`${ctx.namespace}::`)
+      ? ctx.name.slice(ctx.namespace.length + 2)
+      : ctx.name;
+
   return {
     range: nodeRange(ctx.node),
-    placeholder: ctx.name,
+    placeholder,
   };
 }
 

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -223,7 +223,7 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
           break;
         case "metric":
           if (!metrics.has(name)) {
-            metrics.set(name, defEntryToMetric(entry, wsIndex));
+            metrics.set(name, defEntryToMetric(name, entry, wsIndex));
           }
           break;
         case "transform":
@@ -287,12 +287,15 @@ function defEntryToMapping(
   entry: DefinitionEntry,
   wsIndex: WorkspaceIndex,
 ): SemanticMapping {
-  // Gather source/target refs for this mapping from the reference index
+  // Gather source/target refs belonging to THIS mapping, matched by the
+  // container identity recorded at index time. Filtering by file alone made
+  // every mapping inherit every other mapping's refs, duplicating and
+  // misattributing undefined-ref diagnostics in multi-mapping files (sl-ei1e).
   const sources: string[] = [];
   const targets: string[] = [];
   for (const [refName, refs] of wsIndex.references) {
     for (const ref of refs) {
-      if (ref.uri !== entry.uri) continue;
+      if (ref.uri !== entry.uri || ref.container !== name) continue;
       if (ref.context === "source") {
         if (!sources.includes(refName)) sources.push(refName);
       } else if (ref.context === "target") {
@@ -313,13 +316,17 @@ function defEntryToMapping(
 
 /** Convert a DefinitionEntry with kind "metric" to a SemanticMetric. */
 function defEntryToMetric(
+  name: string,
   entry: DefinitionEntry,
   wsIndex: WorkspaceIndex,
 ): SemanticMetric {
+  // Matched by container identity, not just file — see defEntryToMapping
+  // (sl-ei1e applies equally to metric_source refs).
   const sources: string[] = [];
   for (const [refName, refs] of wsIndex.references) {
     for (const ref of refs) {
-      if (ref.uri === entry.uri && ref.context === "metric_source" && !sources.includes(refName)) {
+      if (ref.uri !== entry.uri || ref.container !== name) continue;
+      if (ref.context === "metric_source" && !sources.includes(refName)) {
         sources.push(refName);
       }
     }

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -19,6 +19,7 @@ import { computeFoldingRanges } from "./folding";
 import { computeSemanticTokens, semanticTokensLegend } from "./semantic-tokens";
 import { computeHover } from "./hover";
 import { runValidate, reconcileValidateCache } from "./validate-diagnostics";
+import { CanonicalUriMap } from "./canonical-uri-map";
 import {
   WorkspaceIndex,
   createWorkspaceIndex,
@@ -46,11 +47,13 @@ import { computeMappingCoverage } from "./coverage";
 const connection = createConnection(ProposedFeatures.all);
 const documents = new TextDocuments(TextDocument);
 
-// Per-document parse tree cache
-const trees = new Map<string, Tree>();
+// Per-document parse tree cache. Keyed by CANONICAL URI: the workspace index
+// canonicalizes its keys, and a raw-keyed cache missed open files whenever
+// the client's URI spelling differed (Windows drive letters, sl-ku3c).
+const trees = new CanonicalUriMap<Tree>();
 
-// Per-document validate diagnostics cache (keyed by URI)
-const validateDiagCache = new Map<string, import("vscode-languageserver").Diagnostic[]>();
+// Per-document validate diagnostics cache, canonical-keyed for the same reason.
+const validateDiagCache = new CanonicalUriMap<import("vscode-languageserver").Diagnostic[]>();
 
 // Workspace index for cross-file navigation
 const wsIndex: WorkspaceIndex = createWorkspaceIndex();

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -18,7 +18,7 @@ import { computeDocumentSymbols } from "./symbols";
 import { computeFoldingRanges } from "./folding";
 import { computeSemanticTokens, semanticTokensLegend } from "./semantic-tokens";
 import { computeHover } from "./hover";
-import { runValidate } from "./validate-diagnostics";
+import { runValidate, reconcileValidateCache } from "./validate-diagnostics";
 import {
   WorkspaceIndex,
   createWorkspaceIndex,
@@ -187,23 +187,25 @@ documents.onDidSave(async (event) => {
   try {
     const diagsByUri = await runValidate(event.document.uri, cliPath);
 
-    // Update cache: clear stale entries for files no longer reporting
-    validateDiagCache.delete(event.document.uri);
+    // The run covers the saved file's whole import closure, so any file in
+    // that closure with cached diagnostics the run no longer reports is
+    // stale and must be cleared — fixing in file A an error attributed to
+    // file B previously left B's diagnostic frozen until B itself was saved
+    // (sl-th5k). Files outside the closure keep their cache entries.
+    const scopeUris = getImportReachableUris(event.document.uri, wsIndex);
+    const clearedUris = reconcileValidateCache(validateDiagCache, scopeUris, diagsByUri);
 
-    for (const [uri, diags] of diagsByUri) {
-      validateDiagCache.set(uri, diags);
-
-      // For the currently open document, merge with parse diagnostics
+    // Republish every file the run touched: fresh results merged with parse
+    // diagnostics for open documents, an explicit empty publish for cleared
+    // files that are not open (nothing else would reach the client).
+    const toRefresh = new Set([...diagsByUri.keys(), ...clearedUris, event.document.uri]);
+    for (const uri of toRefresh) {
       const openTree = trees.get(uri);
       if (openTree) {
         sendMergedDiagnostics(uri, openTree);
+      } else if (clearedUris.includes(uri)) {
+        connection.sendDiagnostics({ uri, diagnostics: [] });
       }
-    }
-
-    // If saved file had validate diagnostics before but now has none, refresh
-    const savedTree = trees.get(event.document.uri);
-    if (savedTree && !diagsByUri.has(event.document.uri)) {
-      sendMergedDiagnostics(event.document.uri, savedTree);
     }
   } catch {
     // CLI not available or errored — parse diagnostics still work

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -39,7 +39,8 @@ import { computeCodeLenses } from "./codelens";
 import { computeActionContext } from "./action-context";
 import { prepareRename, computeRename } from "./rename";
 import { computeFormatting, initFormatting } from "./formatting";
-import { buildVizModel, mergeVizModels } from "@satsuma/viz-backend";
+import { computeFullLineage } from "./full-lineage";
+import { buildVizModel } from "@satsuma/viz-backend";
 import { computeMappingCoverage } from "./coverage";
 
 // ---------- Connection setup ----------
@@ -163,19 +164,25 @@ documents.onDidClose((event) => {
  * corresponds to anything the user can navigate to.
  */
 function reindexFromDisk(uri: string): void {
-  let fsPath: string;
-  try {
-    fsPath = fileURLToPath(uri);
-  } catch {
+  const tree = parseTreeFromDisk(uri);
+  if (tree) {
+    indexFile(wsIndex, uri, tree);
+  } else {
     removeFile(wsIndex, uri);
-    return;
   }
+}
+
+/**
+ * Parse a file straight from disk; null for non-file URIs, unreadable files,
+ * or parser failures. Backs the loaders that must see files no editor has
+ * open — e.g. full-lineage traversal over closed imports (sl-mg63).
+ */
+function parseTreeFromDisk(uri: string): Tree | null {
   try {
-    const content = fs.readFileSync(fsPath, "utf-8");
-    const tree = getParser().parse(content);
-    if (tree) indexFile(wsIndex, uri, tree);
+    const content = fs.readFileSync(fileURLToPath(uri), "utf-8");
+    return getParser().parse(content) ?? null;
   } catch {
-    removeFile(wsIndex, uri);
+    return null;
   }
 }
 
@@ -373,23 +380,14 @@ connection.onRequest(
  * Return a merged VizModel spanning the full transitive lineage reachable from
  * the given file via import declarations. Each import-reachable file contributes
  * its schemas, mappings, metrics, and fragments — deduplicated so that stub
- * schemas are superseded by their full upstream definitions.
+ * schemas are superseded by their full upstream definitions. Files that are not
+ * open in any editor are parsed straight from disk, so the lineage really is
+ * the full import closure, not just the open tabs (sl-mg63).
  */
 connection.onRequest(
   "satsuma/vizFullLineage",
   (params: { uri: string }) => {
-    const primaryTree = trees.get(params.uri);
-    if (!primaryTree) return null;
-
-    const reachableUris = getImportReachableUris(params.uri, wsIndex);
-    const models = [];
-    for (const fileUri of reachableUris) {
-      const fileTree = trees.get(fileUri);
-      if (!fileTree) continue;
-      models.push(buildVizModel(fileUri, fileTree, scopeIndex(fileUri)));
-    }
-
-    return mergeVizModels(params.uri, models);
+    return computeFullLineage(params.uri, wsIndex, (uri) => trees.get(uri) ?? parseTreeFromDisk(uri));
   },
 );
 

--- a/tooling/satsuma-lsp/src/validate-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/validate-diagnostics.ts
@@ -115,3 +115,35 @@ export async function runValidate(
 export function pathToFileUri(fsPath: string): string {
   return pathToFileURL(fsPath).toString();
 }
+
+/**
+ * Reconcile the validate-diagnostics cache after a save.
+ *
+ * `runValidate` reports diagnostics for every file in the saved file's import
+ * closure. A cached entry for an in-scope file the new run no longer reports
+ * is stale — the save fixed the underlying issue — and must be removed so the
+ * client stops showing it. Cached entries for files OUTSIDE the closure came
+ * from validating a different entry file; this run says nothing about them,
+ * so they are left alone (sl-th5k).
+ *
+ * Mutates `cache`: fresh results overwrite, stale in-scope entries are
+ * deleted. Returns the URIs whose entries were cleared so the caller can
+ * publish the now-empty diagnostics.
+ */
+export function reconcileValidateCache(
+  cache: Map<string, Diagnostic[]>,
+  scopeUris: Iterable<string>,
+  results: Map<string, Diagnostic[]>,
+): string[] {
+  const cleared: string[] = [];
+  for (const uri of scopeUris) {
+    if (!results.has(uri) && cache.has(uri)) {
+      cache.delete(uri);
+      cleared.push(uri);
+    }
+  }
+  for (const [uri, diags] of results) {
+    cache.set(uri, diags);
+  }
+  return cleared;
+}

--- a/tooling/satsuma-lsp/src/validate-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/validate-diagnostics.ts
@@ -6,6 +6,7 @@ import {
 } from "vscode-languageserver";
 import { execFile } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { canonicalizeFileUri } from "./workspace-index";
 
 /** Shape of a single entry from `satsuma validate --json`. */
 interface ValidateEntry {
@@ -66,7 +67,9 @@ export async function runValidate(
           }
 
           for (const entry of entries) {
-            const uri = pathToFileUri(entry.file);
+            // Canonical so result keys line up with the workspace index and
+            // the server's canonical-keyed caches (sl-ku3c).
+            const uri = canonicalizeFileUri(pathToFileUri(entry.file));
             // validate lines are 1-based; LSP is 0-based
             const line = Math.max(0, entry.line - 1);
             const col = Math.max(0, entry.column - 1);

--- a/tooling/satsuma-lsp/test/canonical-uri-map.test.js
+++ b/tooling/satsuma-lsp/test/canonical-uri-map.test.js
@@ -1,0 +1,42 @@
+/**
+ * canonical-uri-map.test.js — Map keyed by canonical file URIs.
+ *
+ * sl-ku3c: the server's parse-tree and validate-diagnostics caches were keyed
+ * by the raw client URI while the workspace index keys are canonical. On
+ * Windows the same file arrives as file:///c%3A/... (didOpen) and
+ * file:///c:/... (canonical / workspace scan), so canonical lookups missed
+ * open files: vizFullLineage skipped them, on-save sibling diagnostics never
+ * published, and the watched-file "is it open?" skip never matched. These
+ * cases pin the invariant that every URI spelling addresses one entry.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { CanonicalUriMap } = require("../dist/canonical-uri-map");
+
+describe("CanonicalUriMap", () => {
+  it("treats percent-encoded and plain drive-letter spellings as one key (sl-ku3c)", () => {
+    const map = new CanonicalUriMap();
+    map.set("file:///c%3A/proj/x.stm", "tree"); // VS Code didOpen spelling
+    assert.equal(map.get("file:///c:/proj/x.stm"), "tree"); // canonical spelling
+    assert.equal(map.has("file:///C:/proj/x.stm"), true); // pathToFileURL spelling
+    assert.equal(map.size, 1, "all spellings must share one entry");
+  });
+
+  it("deletes through any spelling of the key", () => {
+    // The watched-file handler deletes by the watcher's spelling while
+    // didOpen stored under the client's — both must address the same entry.
+    const map = new CanonicalUriMap();
+    map.set("file:///C:/proj/x.stm", "tree");
+    assert.equal(map.delete("file:///c%3A/proj/x.stm"), true);
+    assert.equal(map.size, 0);
+  });
+
+  it("leaves non-file URIs untouched", () => {
+    // untitled: documents have no canonical file form; raw-string keying
+    // must keep working for them.
+    const map = new CanonicalUriMap();
+    map.set("untitled:Untitled-1", 42);
+    assert.equal(map.get("untitled:Untitled-1"), 42);
+  });
+});

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -49,6 +49,25 @@ describe("prepareRename", () => {
     assert.equal(result.placeholder, "customers");
   });
 
+  it("placeholder matches exactly the text the edit range covers for a namespaced block (sl-kilo)", () => {
+    // For a block inside a namespace the context name is qualified ("a::foo")
+    // but the rename range covers only the bare label. A qualified placeholder
+    // makes the client prefill "a::foo"; accepting it writes the qualified
+    // name INTO the label, producing namespace a { schema a::foo2 }.
+    const source = "namespace a {\n  schema foo {\n    id UUID\n  }\n}";
+    const { index, trees } = buildIndex({ "file:///a.stm": source });
+    // Cursor on "foo" (line 1, col 10)
+    const result = prepareRename(trees["file:///a.stm"], 1, 10, "file:///a.stm", index);
+    assert.ok(result);
+    const lines = source.split("\n");
+    const covered = lines[result.range.start.line].slice(
+      result.range.start.character,
+      result.range.end.character,
+    );
+    assert.equal(result.placeholder, covered);
+    assert.equal(result.placeholder, "foo");
+  });
+
   it("returns null for non-renameable positions", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -108,6 +108,42 @@ function applyEdits(source, edits) {
 }
 
 describe("computeRename", () => {
+  it("renaming a::foo leaves same-named refs in namespace b untouched (sl-p256)", () => {
+    // Two namespaces each declare a schema foo; namespace b's mapping refs
+    // bind to b::foo. The namespace-blind findReferences fan-out previously
+    // pulled those bare refs into a rename of a::foo, rewriting another
+    // namespace's mapping.
+    const source = [
+      "namespace a {",
+      "  schema foo { id UUID }",
+      "  mapping m1 {",
+      "    source { foo }",
+      "    target { foo }",
+      "    id -> id",
+      "  }",
+      "}",
+      "namespace b {",
+      "  schema foo { id UUID }",
+      "  mapping m2 {",
+      "    source { foo }",
+      "    target { foo }",
+      "    id -> id",
+      "  }",
+      "}",
+    ].join("\n");
+    const { index, trees } = buildIndex({ "file:///a.stm": source });
+    // Cursor on namespace a's "foo" label (line 1, col 10)
+    const edit = computeRename(trees["file:///a.stm"], 1, 10, "file:///a.stm", index, "bar");
+    assert.ok(edit);
+    const result = applyEdits(source, edit.changes["file:///a.stm"]);
+    const aBlock = result.slice(0, result.indexOf("namespace b"));
+    const bBlock = result.slice(result.indexOf("namespace b"));
+    assert.ok(aBlock.includes("schema bar"), "a's definition is renamed");
+    assert.ok(aBlock.includes("source { bar }"), "a's own mapping refs are renamed");
+    assert.ok(!bBlock.includes("bar"), "namespace b must be untouched");
+    assert.ok(bBlock.includes("source { foo }"), "b's refs keep binding to b::foo");
+  });
+
   it("renames schema definition and all references", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -182,6 +182,54 @@ mapping m {
 });
 
 describe("computeCoreSemanticDiagnostics", () => {
+  // sl-ei1e: the index-to-semantic adapter gathered source/target refs for a
+  // mapping from EVERY reference in the same file, so each mapping inherited
+  // every other mapping's refs — an undefined source in one mapping produced
+  // one diagnostic per mapping in the file, most of them misattributed.
+
+  it("attributes an undefined mapping source only to the mapping that references it (sl-ei1e)", () => {
+    const src = `schema s { id INT }
+schema t { id INT }
+mapping good {
+  source { s }
+  target { t }
+  id -> id
+}
+mapping bad {
+  source { does_not_exist }
+  target { t }
+  id -> id
+}`;
+    const idx = buildIndex({ "file:///a.stm": src });
+    const diags = computeCoreSemanticDiagnostics("file:///a.stm", idx);
+    const undef = diags.filter(
+      (d) => d.code === "undefined-ref" && d.message.includes("does_not_exist"),
+    );
+    assert.equal(undef.length, 1, "exactly one diagnostic for the single bad ref");
+    // The diagnostic must sit on mapping `bad` (line 7), not on `good`.
+    assert.equal(undef[0].range.start.line, 7);
+    assert.ok(undef[0].message.includes("bad"), "message should name the offending mapping");
+  });
+
+  it("attributes an undefined metric source only to the metric that references it (sl-ei1e)", () => {
+    // Metrics share the same per-file ref-gathering shape as mappings, so the
+    // same union bug applied to metric_source refs.
+    const src = `schema fact_orders { amount DECIMAL }
+schema good_metric (metric, source fact_orders) {
+  value DECIMAL (measure additive)
+}
+schema bad_metric (metric, source missing_fact) {
+  value DECIMAL (measure additive)
+}`;
+    const idx = buildIndex({ "file:///a.stm": src });
+    const diags = computeCoreSemanticDiagnostics("file:///a.stm", idx);
+    const undef = diags.filter(
+      (d) => d.code === "undefined-ref" && d.message.includes("missing_fact"),
+    );
+    assert.equal(undef.length, 1, "exactly one diagnostic for the single bad metric source");
+    assert.equal(undef[0].range.start.line, 4);
+  });
+
   it("does not report quoted join descriptions as undefined mapping sources", () => {
     const src = `schema a { id INT }
 schema b { id INT }

--- a/tooling/satsuma-lsp/test/validate-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/validate-diagnostics.test.js
@@ -1,7 +1,55 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { fileURLToPath, pathToFileURL } = require("node:url");
-const { runValidate, pathToFileUri } = require("../dist/validate-diagnostics");
+const {
+  runValidate,
+  pathToFileUri,
+  reconcileValidateCache,
+} = require("../dist/validate-diagnostics");
+
+describe("reconcileValidateCache", () => {
+  // sl-th5k: on save, only the saved file's cache entry was deleted. A
+  // cross-file diagnostic (error in A attributed to B) stayed cached for B
+  // even after the fixing save removed it from the validate output — the
+  // client showed B's stale diagnostic until B itself was saved.
+
+  const diag = (msg) => [{ message: msg, range: {}, severity: 1 }];
+
+  it("clears cached entries for in-scope files the new run no longer reports (sl-th5k)", () => {
+    const cache = new Map([
+      ["file:///a.stm", diag("old A")],
+      ["file:///b.stm", diag("cross-file error in B")],
+    ]);
+    // The fixing save: the new run reports nothing for B any more.
+    const results = new Map([["file:///a.stm", diag("new A")]]);
+    const cleared = reconcileValidateCache(
+      cache,
+      ["file:///a.stm", "file:///b.stm"],
+      results,
+    );
+    assert.deepEqual(cleared, ["file:///b.stm"]);
+    assert.equal(cache.has("file:///b.stm"), false, "stale entry must be removed");
+    assert.deepEqual(cache.get("file:///a.stm"), diag("new A"), "fresh results replace old");
+  });
+
+  it("leaves cached entries outside the run's scope untouched", () => {
+    // C's diagnostics came from validating a different entry file; this run
+    // says nothing about C and must not wipe legitimate results.
+    const cache = new Map([["file:///c.stm", diag("error in other closure")]]);
+    const cleared = reconcileValidateCache(cache, ["file:///a.stm"], new Map());
+    assert.deepEqual(cleared, []);
+    assert.ok(cache.has("file:///c.stm"));
+  });
+
+  it("clears the saved file itself when it stops reporting", () => {
+    // The saved file is part of its own closure: fixing the last error in A
+    // must clear A without special-casing.
+    const cache = new Map([["file:///a.stm", diag("old A")]]);
+    const cleared = reconcileValidateCache(cache, ["file:///a.stm"], new Map());
+    assert.deepEqual(cleared, ["file:///a.stm"]);
+    assert.equal(cache.size, 0);
+  });
+});
 
 describe("pathToFileUri", () => {
   // The Windows symptom (a `C:\…` path becoming a malformed `file://C:\…`

--- a/tooling/satsuma-lsp/test/viz-full-lineage.test.js
+++ b/tooling/satsuma-lsp/test/viz-full-lineage.test.js
@@ -1,40 +1,46 @@
 /**
  * viz-full-lineage.test.js — Unit tests for satsuma/vizFullLineage.
  *
- * The handler walks the import graph from the requested file and merges per-
- * file VizModels into one. These tests verify the *merge* contract: schemas
- * from imported files appear, the result is anchored to the primary URI, and
- * stub schemas are deduplicated against full upstream definitions.
+ * Exercises the real computeFullLineage module the server handler delegates
+ * to. The handler walks the import graph from the requested file, asks the
+ * caller-provided loader for each file's tree, and merges per-file VizModels
+ * into one. Tree acquisition is a callback precisely so files that are NOT
+ * open in any editor can be parsed from disk (sl-mg63) — these tests pin
+ * both the merge contract and that loader contract.
  */
 
 const { describe, it, before } = require("node:test");
 const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
+const { computeFullLineage } = require("../dist/full-lineage");
 const {
   createWorkspaceIndex,
   indexFile,
-  getImportReachableUris,
-  buildVizModel,
-  mergeVizModels,
 } = require("@satsuma/viz-backend");
 
 before(async () => { await initTestParser(); });
 
-/** Mirror the satsuma/vizFullLineage handler: walk imports, build & merge models. */
+/**
+ * Run computeFullLineage over an in-memory workspace. Every file's tree is
+ * served through the loader callback — exactly how the server supplies
+ * open-editor trees with a disk-parse fallback. Returns the merged model
+ * plus the URIs the loader was asked for.
+ */
 function fullLineage(files, primaryUri) {
   const index = createWorkspaceIndex();
-  const trees = {};
+  const allTrees = {};
   for (const [uri, source] of Object.entries(files)) {
     const tree = parse(source);
-    trees[uri] = tree;
+    allTrees[uri] = tree;
     indexFile(index, uri, tree);
   }
-  const reachable = getImportReachableUris(primaryUri, index);
-  const models = [];
-  for (const uri of reachable) {
-    if (trees[uri]) models.push(buildVizModel(uri, trees[uri], index));
-  }
-  return mergeVizModels(primaryUri, models);
+  const requested = [];
+  const loadTree = (uri) => {
+    requested.push(uri);
+    return allTrees[uri] ?? null;
+  };
+  const model = computeFullLineage(primaryUri, index, loadTree);
+  return { model, requested };
 }
 
 describe("satsuma/vizFullLineage — import graph traversal", () => {
@@ -47,15 +53,51 @@ describe("satsuma/vizFullLineage — import graph traversal", () => {
   };
 
   it("anchors the merged model to the primary uri", () => {
-    const model = fullLineage(FILES, "file:///entry.stm");
+    const { model } = fullLineage(FILES, "file:///entry.stm");
     assert.equal(model.uri, "file:///entry.stm");
   });
 
   it("includes schemas from import-reachable files", () => {
-    const model = fullLineage(FILES, "file:///entry.stm");
+    const { model } = fullLineage(FILES, "file:///entry.stm");
     const ids = model.namespaces.flatMap((g) => g.schemas.map((s) => s.id));
     assert.ok(ids.includes("customers"), "imported schema 'customers' should appear in merged model");
     assert.ok(ids.includes("orders"), "local schema 'orders' should still appear");
+  });
+
+  // sl-mg63: the old handler resolved each reachable URI only through the
+  // open-editor trees map, so "full transitive lineage" silently contained
+  // just the files the user happened to have open. The loader callback must
+  // be asked for EVERY reachable file — the server backs it with a disk
+  // parse for files no editor has open.
+  it("requests every import-reachable file from the loader, not only open ones (sl-mg63)", () => {
+    const { model, requested } = fullLineage(FILES, "file:///entry.stm");
+    assert.ok(
+      requested.includes("file:///defs.stm"),
+      "the imported (potentially closed) file must be requested from the loader",
+    );
+    const ids = model.namespaces.flatMap((g) => g.schemas.map((s) => s.id));
+    assert.ok(ids.includes("customers"), "closed imported file's schema must appear in lineage");
+  });
+
+  it("returns null when the primary file cannot be loaded", () => {
+    // Mirrors the old contract: no tree for the requested file → no model.
+    const index = createWorkspaceIndex();
+    const model = computeFullLineage("file:///missing.stm", index, () => null);
+    assert.equal(model, null);
+  });
+
+  it("skips unreadable imported files but still returns the rest", () => {
+    // A deleted or unreadable import must not take down the whole lineage.
+    const index = createWorkspaceIndex();
+    const entrySrc = 'import { customers } from "gone.stm"\nschema orders { id UUID }';
+    const entryTree = parse(entrySrc);
+    indexFile(index, "file:///entry.stm", entryTree);
+    const model = computeFullLineage("file:///entry.stm", index, (uri) =>
+      uri === "file:///entry.stm" ? entryTree : null,
+    );
+    assert.ok(model, "model should still be produced");
+    const ids = model.namespaces.flatMap((g) => g.schemas.map((s) => s.id));
+    assert.ok(ids.includes("orders"));
   });
 });
 
@@ -64,7 +106,7 @@ describe("satsuma/vizFullLineage — stub deduplication", () => {
   // bare name, the merged model must not contain two copies of `customers` —
   // the upstream definition supersedes any stub.
   it("deduplicates schemas by qualified id across files", () => {
-    const model = fullLineage(
+    const { model } = fullLineage(
       {
         "file:///defs.stm": "schema customers { id UUID email VARCHAR }",
         "file:///entry.stm":

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -362,6 +362,63 @@ describe("findReferences", () => {
     const refs = findReferences(idx, "customers");
     assert.equal(refs.length, 0);
   });
+
+  // sl-p256: findReferences fanned out namespace-blind — a qualified query
+  // also returned every bare ref of that name anywhere, and a bare query
+  // returned every *::name ref. Renames consumed these unfiltered, so
+  // renaming a::foo rewrote source { foo } inside namespace b. Each bare
+  // ref must bind to the namespace-local definition when one exists.
+
+  const TWO_NAMESPACES =
+    "namespace a {\n  schema foo { id UUID }\n}\n" +
+    "namespace b {\n  schema foo { id UUID }\n  mapping m {\n    source { foo }\n    target { foo }\n    id -> id\n  }\n}";
+
+  it("does not return bare refs that resolve in a different namespace (sl-p256)", () => {
+    const idx = buildIndex({ "file:///a.stm": TWO_NAMESPACES });
+    // b's source { foo } binds to b::foo, so a::foo has no references.
+    const aRefs = findReferences(idx, "a::foo").filter((r) => r.context === "source" || r.context === "target");
+    assert.equal(aRefs.length, 0, "a::foo must not inherit namespace b's refs");
+    const bRefs = findReferences(idx, "b::foo").filter((r) => r.context === "source");
+    assert.equal(bRefs.length, 1, "b::foo keeps its own bare source ref");
+  });
+
+  it("excludes bare refs shadowed by a namespace-local definition from the global query (sl-p256)", () => {
+    const idx = buildIndex({
+      "file:///a.stm":
+        "schema foo { id UUID }\n" +
+        "namespace b {\n  schema foo { id UUID }\n  mapping m {\n    source { foo }\n    target { foo }\n    id -> id\n  }\n}",
+    });
+    // namespace b declares its own foo, so b's refs bind there — the global
+    // schema foo is unreferenced.
+    const refs = findReferences(idx, "foo").filter((r) => r.context === "source" || r.context === "target");
+    assert.equal(refs.length, 0, "shadowed bare refs must not count against the global name");
+  });
+
+  it("binds bare refs inside a namespace to the global definition when nothing local shadows it (sl-p256)", () => {
+    const idx = buildIndex({
+      "file:///a.stm":
+        "schema shared { id UUID }\n" +
+        "namespace b {\n  schema tgt { id UUID }\n  mapping m {\n    source { shared }\n    target { tgt }\n    id -> id\n  }\n}",
+    });
+    const refs = findReferences(idx, "shared").filter((r) => r.context === "source");
+    assert.equal(refs.length, 1, "unshadowed bare ref falls through to the global definition");
+  });
+
+  it("excludes refs authored with an explicit namespace from the bare-name query (sl-p256)", () => {
+    const idx = buildIndex({
+      "file:///a.stm":
+        "schema foo { id UUID }\n" +
+        "namespace x {\n  schema foo { id UUID }\n}\n" +
+        "mapping m {\n  source { x::foo }\n  target { foo }\n  id -> id\n}",
+    });
+    // source { x::foo } binds to x::foo; only the bare target ref binds to
+    // the global foo.
+    const refs = findReferences(idx, "foo").filter((r) => r.context === "source" || r.context === "target");
+    assert.equal(refs.length, 1);
+    assert.equal(refs[0].context, "target");
+    const qualified = findReferences(idx, "x::foo").filter((r) => r.context === "source");
+    assert.equal(qualified.length, 1, "the qualified query owns the authored-qualified ref");
+  });
 });
 
 describe("allBlockNames", () => {

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -81,6 +81,12 @@ export interface ReferenceEntry {
    *  and attribute refs to the right block instead of unioning per file
    *  (sl-ei1e). */
   container?: string;
+  /** Namespace block the reference is authored inside, or null at the top
+   *  level. Bare names resolve against a namespace-local definition before
+   *  the global one, so reference queries must know the authoring scope —
+   *  without it, renaming a::foo also rewrote bare refs that bind to b::foo
+   *  (sl-p256). */
+  namespace?: string | null;
 }
 
 export interface ImportEntry {
@@ -418,38 +424,64 @@ export function resolveDefinition(
   return index.definitions.get(name) ?? [];
 }
 
-/** Find all references to a name. */
+/**
+ * The canonical definition key a name binds to when authored inside
+ * `namespace`, mirroring resolveDefinition's order: a name written with "::"
+ * binds to that key directly; a bare name binds to the namespace-local
+ * definition when the enclosing namespace declares one, else to the global
+ * key. Consumers querying references for a bare name they found in source
+ * should canonicalize through this first (sl-p256).
+ */
+export function resolveReferenceKey(
+  index: WorkspaceIndex,
+  name: string,
+  namespace: string | null | undefined,
+): string {
+  if (name.includes("::")) return name;
+  if (namespace && index.definitions.has(`${namespace}::${name}`)) {
+    return `${namespace}::${name}`;
+  }
+  return name;
+}
+
+/**
+ * Find all references that bind to the definition keyed by `name`.
+ *
+ * Each candidate reference is re-resolved against its own authoring
+ * namespace rather than fanned out by spelling: the old behaviour returned
+ * every bare ref for a qualified query (and every `*::name` ref for a bare
+ * query), so renaming a::foo also rewrote `source { foo }` inside namespace
+ * b — a reference that binds to b::foo (sl-p256).
+ */
 export function findReferences(
   index: WorkspaceIndex,
   name: string,
 ): ReferenceEntry[] {
   const results: ReferenceEntry[] = [];
 
-  // Direct match
-  const direct = index.references.get(name);
-  if (direct) results.push(...direct);
-
-  // If the name is qualified (ns::foo), also check for bare references
-  // that could resolve to this qualified name
   if (name.includes("::")) {
-    const bare = name.split("::").pop()!;
-    const bareRefs = index.references.get(bare);
-    if (bareRefs) {
-      // Only include bare refs that are in files where the namespace context matches
-      // For simplicity, include all bare refs — the caller can filter by context
-      results.push(...bareRefs);
-    }
-  }
+    // References authored with the explicit qualifier bind here directly.
+    results.push(...(index.references.get(name) ?? []));
 
-  // If the name is bare, also check for qualified forms
-  if (!name.includes("::")) {
-    for (const [key, entries] of index.references) {
-      if (key.endsWith(`::${name}`) && key !== name) {
-        results.push(...entries);
+    // Bare references bind here when authored inside this namespace
+    // (namespace-local resolution wins over global).
+    const bare = name.split("::").pop()!;
+    for (const ref of index.references.get(bare) ?? []) {
+      if (resolveReferenceKey(index, bare, ref.namespace) === name) {
+        results.push(ref);
       }
     }
+    return results;
   }
 
+  // Bare key: a bare reference binds to the global definition only when no
+  // namespace-local definition shadows it. References authored with an
+  // explicit qualifier bind to their own qualified key, never the bare one.
+  for (const ref of index.references.get(name) ?? []) {
+    if (resolveReferenceKey(index, name, ref.namespace) === name) {
+      results.push(ref);
+    }
+  }
   return results;
 }
 
@@ -607,7 +639,7 @@ function indexTopLevel(
   if (effectiveKind === "schema" || effectiveKind === "fragment") {
     const body = child(node, "schema_body");
     if (body) {
-      indexSpreadRefs(index, uri, body);
+      indexSpreadRefs(index, uri, body, namespace);
     }
   }
 }
@@ -649,6 +681,7 @@ function indexImport(index: WorkspaceIndex, uri: string, node: SyntaxNode): void
         range: nodeRange(nameNode),
         name: text,
         context: "import",
+        namespace: null, // import declarations are top-level only
       });
     }
   }
@@ -683,6 +716,7 @@ function indexMappingRefs(
             name,
             context: "source",
             container,
+            namespace,
           });
         }
       }
@@ -696,6 +730,7 @@ function indexMappingRefs(
             name,
             context: "target",
             container,
+            namespace,
           });
         }
       }
@@ -703,12 +738,12 @@ function indexMappingRefs(
 
     // Index spread refs inside mapping body
     if (ch.type === "source_block" || ch.type === "target_block") continue;
-    indexArrowSpreadRefs(index, uri, ch);
+    indexArrowSpreadRefs(index, uri, ch, namespace);
   }
 
   // Index field-level references from arrow src_path / tgt_path nodes.
   // (@refs in NL strings are indexed file-wide by indexFile, not here.)
-  indexArrowFieldRefs(index, uri, body);
+  indexArrowFieldRefs(index, uri, body, namespace);
 }
 
 /**
@@ -733,6 +768,7 @@ function indexArrowSpreadRefs(
   index: WorkspaceIndex,
   uri: string,
   node: SyntaxNode,
+  namespace: string | null,
 ): void {
   // Walk all descendants looking for fragment_spread nodes
   walkDescendants(node, (n) => {
@@ -748,6 +784,7 @@ function indexArrowSpreadRefs(
           range: nodeRange(sl),
           name,
           context: "spread",
+          namespace,
         });
       }
     }
@@ -758,6 +795,7 @@ function indexArrowFieldRefs(
   index: WorkspaceIndex,
   uri: string,
   body: SyntaxNode,
+  namespace: string | null,
 ): void {
   const sourceSchemas = getMappingBodySchemas(body, "source_block");
   const targetSchemas = getMappingBodySchemas(body, "target_block");
@@ -787,6 +825,7 @@ function indexArrowFieldRefs(
       range: firstSegmentRange,
       name: fieldName,
       context: "arrow",
+      namespace,
     });
 
     // schema.fullPath — canonical qualified keys, matching CLI index-builder
@@ -798,6 +837,7 @@ function indexArrowFieldRefs(
           range: fullPathRange,
           name: qualKey,
           context: "arrow",
+          namespace,
         });
       }
       // Also index the full path without a schema prefix when it differs from
@@ -808,6 +848,7 @@ function indexArrowFieldRefs(
           range: fullPathRange,
           name: fullPath,
           context: "arrow",
+          namespace,
         });
       }
     }
@@ -928,6 +969,20 @@ function extractArrowFieldName(pathNode: SyntaxNode): string | null {
 const NL_AT_REF_RE = createAtRefRegex();
 
 /**
+ * Namespace block enclosing a node, or null at the top level. NL refs are
+ * indexed in one file-wide walk (sl-ellp), so their authoring scope has to be
+ * recovered from the ancestor chain rather than threaded down (sl-p256).
+ */
+function enclosingNamespace(node: SyntaxNode): string | null {
+  for (let p = node.parent; p; p = p.parent) {
+    if (p.type === "namespace_block") {
+      return p.childForFieldName?.("name")?.text ?? null;
+    }
+  }
+  return null;
+}
+
+/**
  * Index every @ref inside NL prose under `node` as an "nl" reference.
  *
  * Called once per file with the root node (sl-ellp): NL prose carrying refs
@@ -963,6 +1018,7 @@ function indexNlRefs(
         ),
         name: refName,
         context: "nl",
+        namespace: enclosingNamespace(n),
       });
       return;
     }
@@ -991,6 +1047,7 @@ function indexNlRefs(
         range,
         name: refName,
         context: "nl",
+        namespace: enclosingNamespace(n),
       });
     }
 
@@ -1040,6 +1097,7 @@ function indexSpreadRefs(
   index: WorkspaceIndex,
   uri: string,
   body: SyntaxNode,
+  namespace: string | null,
 ): void {
   for (const spread of children(body, "fragment_spread")) {
     const sl = child(spread, "spread_label");
@@ -1051,6 +1109,7 @@ function indexSpreadRefs(
         range: nodeRange(sl),
         name,
         context: "spread",
+        namespace,
       });
     }
   }
@@ -1088,6 +1147,7 @@ function indexMetricRefs(
             name,
             context: "metric_source",
             container,
+            namespace,
           });
         }
       }

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -75,9 +75,11 @@ export interface ReferenceEntry {
    *  src/tgt path references; "nl" marks @refs found inside NL prose strings
    *  (arrow bodies, note tags/blocks, metadata values — sl-ellp). */
   context: "source" | "target" | "spread" | "import" | "arrow" | "nl" | "metric_source";
-  /** Qualified name of the mapping whose source/target block contains this
-   *  reference. Set only for "source"/"target" contexts; lets consumers count
-   *  distinct mappings rather than reference sites (sl-0tgo). */
+  /** Qualified name of the mapping (or metric) whose body contains this
+   *  reference. Set for "source"/"target"/"metric_source" contexts; lets
+   *  consumers count distinct mappings rather than reference sites (sl-0tgo)
+   *  and attribute refs to the right block instead of unioning per file
+   *  (sl-ei1e). */
   container?: string;
 }
 
@@ -1058,11 +1060,19 @@ function indexMetricRefs(
   index: WorkspaceIndex,
   uri: string,
   metricNode: SyntaxNode,
-  _namespace: string | null,
+  namespace: string | null,
 ): void {
   // Metric sources are in the metadata block as "source <name>" key-value pairs
   const meta = child(metricNode, "metadata_block");
   if (!meta) return;
+
+  // Identity of the containing metric, mirroring the mapping container — so
+  // consumers can attribute each source to its own metric instead of unioning
+  // every metric_source ref in the file (sl-ei1e).
+  const metricName = labelText(metricNode);
+  const container = metricName
+    ? (namespace ? `${namespace}::${metricName}` : metricName)
+    : `<anon>@${uri}:${metricNode.startPosition.row}`;
 
   walkDescendants(meta, (n) => {
     if (n.type === "tag_with_value") {
@@ -1077,6 +1087,7 @@ function indexMetricRefs(
             range: nodeRange(valNode),
             name,
             context: "metric_source",
+            container,
           });
         }
       }


### PR DESCRIPTION
## Summary

Fixes all six open LSP-cluster bugs from the June bug hunt (two P1s, four P2s), one commit per ticket:

- **sl-kilo** — `prepareRename` returned the namespace-qualified name as the placeholder while the edit range covered only the bare label, so accepting the prefill wrote `a::foo2` into the label. The placeholder now matches exactly the text the range covers.
- **sl-ei1e** — the index-to-semantic adapter unioned every source/target ref in a file onto every mapping (and every `metric_source` onto every metric), duplicating and misattributing undefined-ref diagnostics. Refs are now matched by the container identity recorded at index time; metric refs gained the same `container` field mappings already had.
- **sl-th5k** — saving only evicted the saved file's validate-diagnostics cache entry, freezing cross-file diagnostics until the other file was saved. New pure `reconcileValidateCache()` clears in-scope entries the new run no longer reports and the handler publishes the now-empty diagnostics; entries from other validate closures are untouched.
- **sl-ku3c** — the parse-tree and validate caches were keyed by the raw client URI while the index keys are canonical, breaking lookups on Windows drive-letter spellings. A new `CanonicalUriMap` canonicalizes keys on every operation, and `runValidate` emits canonical result URIs. E2E Windows coverage tracked by linked sl-vmqv.
- **sl-mg63 (P1)** — `satsuma/vizFullLineage` resolved files only through the open-editor tree cache, so "full transitive lineage" contained just the open tabs. The traversal now lives in `computeFullLineage` with tree acquisition as a loader callback; the server backs it with an on-disk parse fallback. The unit test now exercises the real module instead of a hand-rolled mirror.
- **sl-p256 (P1)** — `findReferences` fanned out namespace-blind, so renaming `a::foo` also rewrote `source { foo }` inside namespace `b`. References now record their authoring namespace, each candidate is re-resolved against its own scope via new `resolveReferenceKey()`, and find-references/rename canonicalize their query key.

## Testing

- TDD: regression tests verified red before each fix (LSP suite 273 → 290 tests).
- Full suites green: LSP (290) + smoke initialize, viz-backend (163), CLI (867), core (415), vscode-satsuma golden runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)