### PR TITLE
chore(ci): extend npm audit and Dependabot to all package directories (sl-qpbx)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,9 @@
 version: 2
+
+# One npm entry per directory with its own package-lock.json. When adding a
+# new package, add a matching entry here — the CI audit loop in
+# .github/workflows/security.yml discovers lockfiles automatically, but
+# Dependabot requires an explicit entry per directory (sl-qpbx).
 updates:
   # Root package (devDependencies: eslint, typescript, etc.)
   - package-ecosystem: "npm"
@@ -8,9 +13,65 @@ updates:
     open-pull-requests-limit: 10
     labels: ["dependencies"]
 
+  # Project website
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
   # satsuma-cli
   - package-ecosystem: "npm"
     directory: "/tooling/satsuma-cli"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-core (shared language utilities)
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-lsp (standalone language server)
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-lsp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-viz (visualization components)
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-viz"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-viz-backend
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-viz-backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-viz-harness (Playwright test harness)
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-viz-harness"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels: ["dependencies"]
+
+  # satsuma-viz-model
+  - package-ecosystem: "npm"
+    directory: "/tooling/satsuma-viz-model"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -30,14 +91,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    labels: ["dependencies"]
-
-  # vscode-satsuma LSP server (nested package)
-  - package-ecosystem: "npm"
-    directory: "/tooling/vscode-satsuma/server"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
     labels: ["dependencies"]
 
   # GitHub Actions versions

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install dependencies
-        run: npm run ci:all
-
       - name: Parse allowlist
         id: allowlist
         run: |
@@ -32,10 +29,15 @@ jobs:
           echo "ids=$(cat /tmp/npm-allowlist.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Audit all packages
+        # npm audit reads package-lock.json directly (no install needed), so the
+        # loop discovers every tracked lockfile instead of maintaining a
+        # hardcoded directory list — new packages are covered automatically
+        # without anyone remembering to edit this workflow (sl-qpbx).
         run: |
           set +e
           failed=0
-          for dir in . tooling/satsuma-cli tooling/tree-sitter-satsuma tooling/satsuma-lsp tooling/vscode-satsuma; do
+          for lockfile in $(git ls-files '*package-lock.json'); do
+            dir=$(dirname "$lockfile")
             echo "::group::npm audit — $dir"
             cd "$GITHUB_WORKSPACE/$dir"
             npm audit --omit=dev --audit-level=high 2>&1

--- a/.tickets/sl-qpbx.md
+++ b/.tickets/sl-qpbx.md
@@ -1,6 +1,6 @@
 ---
 id: sl-qpbx
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-10T23:18:25Z
@@ -17,3 +17,10 @@ The CI security workflow runs npm audit (--omit=dev --audit-level=high) over onl
 
 security.yml npm-audit job covers every package directory that has a package-lock.json (core, viz, viz-backend, viz-model, viz-harness, site) — or documents an explicit exclusion reason inline. .github/dependabot.yml has an npm entry for each of those directories. CI passes with the expanded matrix. SECURITY-REPORT.md 'Known Gaps' item 2 and the CI controls table updated to reflect the closed gap.
 
+
+## Notes
+
+**2026-06-11T21:16:52Z**
+
+Cause: The security.yml npm-audit loop hardcoded 5 directories and dependabot.yml only listed 5 npm dirs, leaving satsuma-core, the four viz packages, and site without continuous dependency monitoring.
+Fix: Audit loop now discovers every tracked package-lock.json via git ls-files (covers all 11 dirs, future-proof); dependabot.yml gained entries for the six missing dirs (and dropped the stale vscode-satsuma/server entry); SECURITY-REPORT.md gap 2 closed (commit 461552b)

--- a/SECURITY-REPORT.md
+++ b/SECURITY-REPORT.md
@@ -130,9 +130,9 @@ listed in earlier revisions has been **removed** — nothing compiles C on your
 machine at install time.
 
 **Mitigations:**
-- `npm audit --omit=dev --audit-level=high` runs in CI and blocks high/critical findings — but currently only over 5 of the package directories (see [Known Gaps](#known-gaps-and-honest-caveats))
+- `npm audit --omit=dev --audit-level=high` runs in CI and blocks high/critical findings — since 2026-06-11 over **every** directory with a tracked `package-lock.json` (the loop discovers lockfiles automatically, so new packages are covered without workflow edits)
 - A local audit on 2026-06-11 across **all 9 package directories** (production *and* dev dependencies) found **0 vulnerabilities**
-- Dependabot opens weekly update PRs (coverage gaps noted below)
+- Dependabot opens weekly update PRs for every package directory plus GitHub Actions
 - Pre-built release tarballs bundle dependencies so end users skip `npm install` entirely
 - `package-lock.json` pins exact versions
 - All packages are marked `"private": true` — they cannot be accidentally published to npm
@@ -406,13 +406,13 @@ reading the workflows, not the previous report):
 
 | Control | Tool | Status |
 |---|---|---|
-| **Dependency vulnerabilities** | `npm audit --omit=dev --audit-level=high` | ✅ Active — root, CLI, tree-sitter, LSP, VS Code extension. ⚠️ Does **not** yet cover satsuma-core, the four viz packages, or the site |
+| **Dependency vulnerabilities** | `npm audit --omit=dev --audit-level=high` | ✅ Active — every directory with a tracked `package-lock.json` (10 as of 2026-06-11); the CI loop discovers lockfiles automatically, so new packages are covered without workflow edits |
 | **Static analysis (SAST)** | Semgrep (`--config auto`, ERROR+WARNING) | ✅ Active on every push/PR to main; results uploaded as SARIF |
 | **Secret scanning** | Gitleaks | ⚠️ **Disabled since 2026-06-04** pending org licence; re-enables automatically when `GITLEAKS_LICENSE` is provisioned |
 | **Semantic analysis (CodeQL)** | — | ❌ Not running. The previous report listed CodeQL as a control; only the SARIF *upload action* (which is published under `github/codeql-action`) is used. No CodeQL analysis job exists |
 | **Parser integrity** | `tree-sitter generate` + diff | ✅ Active — CI fails if committed parser sources differ from regenerated output |
 | **Grammar conflict budget** | `CONFLICTS.expected` check | ✅ Active — grammar conflict count must match the documented expectation |
-| **Dependency updates** | Dependabot (weekly) | ✅ Active for root, CLI, tree-sitter, VS Code extension (+nested server), GitHub Actions. ⚠️ Missing: satsuma-core, viz packages, site |
+| **Dependency updates** | Dependabot (weekly) | ✅ Active for all 11 package directories plus GitHub Actions. ⚠️ Unlike the audit loop, Dependabot needs a manual entry per directory — add one when creating a new package |
 | **Release gate** | `release.yml` calls `security.yml` | ✅ Active — releases require the security workflow to pass (with the caveat that the gate is only as strong as the checks enabled within it) |
 | **Release smoke tests** | Global-install + LSP handshake checks | ✅ Active — tarballs are installed and exercised before publishing |
 | **Pre-commit hooks** | `scripts/run-repo-checks.sh` | ✅ Lint + full local test suite across packages before every commit |
@@ -437,11 +437,12 @@ discovered. None is a known vulnerability; all reduce *assurance*.
 1. **Secret scanning is currently off.** Gitleaks has been skipped in CI
    since 2026-06-04 pending an organization licence. It re-enables
    automatically once the licence secret is provisioned.
-2. **CI dependency auditing covers 5 of 10 package directories.**
-   `satsuma-core`, the four viz packages, and the website are not in the
-   `npm audit` loop or Dependabot config. (A full local audit of all
-   directories on 2026-06-11 found 0 vulnerabilities, but that is a
-   point-in-time check, not a continuous control.)
+2. **~~CI dependency auditing covers 5 of 10 package directories.~~
+   Closed 2026-06-11 (sl-qpbx).** The `npm audit` CI loop now discovers
+   every tracked `package-lock.json` automatically, and Dependabot has an
+   entry for every package directory. The residual risk is Dependabot
+   coverage drifting when a new package is added without a matching
+   `dependabot.yml` entry (the audit loop has no such drift).
 3. **Allowlist expiry is not enforced.** Expired allowlist entries do not
    fail CI; re-review depends on humans noticing.
 4. **No CodeQL.** SAST coverage is Semgrep `--config auto` only.
@@ -584,9 +585,9 @@ tracing, workflow YAML review) plus direct local `npm audit` runs.
    since 2026-06-04 awaiting an org licence. If procurement stalls, switch to
    a licence-free alternative (e.g. `gitleaks` CLI pinned in CI, or
    `trufflehog`) rather than running without scanning.
-2. **Extend `npm audit` and Dependabot to all package directories.** Six
-   directories with real production dependencies (`satsuma-core`, four viz
-   packages, `site`) have no continuous dependency monitoring.
+2. **~~Extend `npm audit` and Dependabot to all package directories.~~
+   Done 2026-06-11 (sl-qpbx).** The CI audit loop now discovers every
+   tracked lockfile, and `dependabot.yml` covers every package directory.
 3. **Implement allowlist expiry enforcement.** The `expires` field exists in
    `.security-allowlist.yml` but nothing checks it. A few lines in the
    existing parse script would make expired findings fail CI.


### PR DESCRIPTION
## Summary

Closes the dependency-monitoring gap from the 2026-06-11 security review (SECURITY-REPORT.md Known Gaps item 2): six directories with their own lockfiles (`satsuma-core`, `satsuma-viz`, `satsuma-viz-backend`, `satsuma-viz-model`, `satsuma-viz-harness`, `site`) had no continuous npm audit or Dependabot coverage.

- **security.yml**: the npm-audit job now discovers every tracked `package-lock.json` via `git ls-files` instead of a hardcoded 5-directory list — all 11 package directories are audited, and future packages are covered automatically. The `ci:all` install step is dropped from this job: `npm audit` reads the lockfile directly and needs no `node_modules`, so the job is also much faster.
- **dependabot.yml**: npm entries added for the six missing directories. Also removed the stale `/tooling/vscode-satsuma/server` entry — that directory no longer exists (the LSP server moved to `tooling/satsuma-lsp`, which now has its own entry).
- **SECURITY-REPORT.md**: Known Gaps item 2 and recommendation 2 marked closed; CI controls table updated. The noted residual risk is that Dependabot (unlike the audit loop) still needs a manual entry per new package.

## Verification

- Ran the new audit loop locally over all 11 lockfile directories: every one exits 0 with 0 vulnerabilities.
- `yamllint` clean on both files; full pre-commit suite passed on both commits.
- The Security workflow runs on this PR itself, exercising the expanded matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)