### PR TITLE
fix(cli): bug batch — workspace dedup, lineage traversal, context/summary metrics, diff anon mappings

### DIFF
--- a/.tickets/sl-8zyr.md
+++ b/.tickets/sl-8zyr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-8zyr
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:29Z
@@ -17,3 +17,10 @@ satsuma-cli/src/workspace.ts:51-64 followImports keys the visited set on path.re
 
 Imports resolving to the same physical file (case alias or symlink) load once; validate clean; tests for case alias and symlink.
 
+
+## Notes
+
+**2026-06-11T22:30:00Z**
+
+Cause: followImports keyed its visited set on path.resolve output only, so case-aliased or symlinked imports of one physical file loaded it twice, causing false duplicate-definition errors from validate and inflated file counts in summary.
+Fix: canonicalize the entry and every import path with realpathSync.native (follows symlinks, restores on-disk casing) before the visited check; added case-alias and symlink regression tests (commit 774a29e)

--- a/.tickets/sl-h5cx.md
+++ b/.tickets/sl-h5cx.md
@@ -1,6 +1,6 @@
 ---
 id: sl-h5cx
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z
@@ -17,3 +17,10 @@ satsuma-cli/src/commands/lineage.ts:222-265 printUpstreamFlat picks roots as nod
 
 Text mode renders upstream paths in cyclic graphs (cycle-break or SCC handling); cyclic two-file regression test comparing text vs json node coverage.
 
+
+## Notes
+
+**2026-06-11T23:10:00Z**
+
+Cause: printUpstreamFlat found path roots as nodes with no incoming edges and walked forward; in a cyclic upstream graph no node qualifies, so text mode printed only the target while --json reported the full DAG.
+Fix: paths are now discovered by climbing reverse edges from the target, ending at a true source or where a cycle closes onto the current path; regression test pins text output covering every JSON node on the cyclic fixture (commit b79a454)

--- a/.tickets/sl-ndtz.md
+++ b/.tickets/sl-ndtz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ndtz
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z
@@ -17,3 +17,10 @@ satsuma-cli/src/index-builder.ts:294 keys anonymous mappings as <anon>@<absolute
 
 Identical files diff clean including anonymous mappings; user output never shows internal anon keys; help text matches actual import behaviour.
 
+
+## Notes
+
+**2026-06-11T23:55:00Z**
+
+Cause: the index keys anonymous mappings as <anon>@<absolute-path>:<row>, so structurally identical files at different paths always diffed as removed+added and the internal key leaked into output; diff --help also claimed imports are followed while diff.ts passes followImports:false.
+Fix: diffIndex re-keys anonymous mappings to position-independent structural ids (namespace-qualified, stable ordinals for same-signature duplicates) before comparison, rewriting arrow/note attributions; help text corrected; unit + CLI regression tests added (commit f4a73ff)

--- a/.tickets/sl-s2mh.md
+++ b/.tickets/sl-s2mh.md
@@ -1,6 +1,6 @@
 ---
 id: sl-s2mh
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:50Z
@@ -17,3 +17,10 @@ Metric schemas live in both index.schemas and index.metrics. satsuma-cli/src/com
 
 context emits each metric once (as metric); summary schema/metric counts consistent with graph stats; test against metrics-platform example.
 
+
+## Notes
+
+**2026-06-11T23:30:00Z**
+
+Cause: metric schemas live in both index.schemas and index.metrics; context scored both maps (emitting each metric block twice) and summary listed metrics under both sections in JSON, compact, and default modes, so schema counts disagreed with graph stats.
+Fix: context and summary now skip metric ids in their schemas loops via the same partition graph-builder already applied; CLI-level tests added against the metrics-platform example (commit 551c515)

--- a/.tickets/sl-y89y.md
+++ b/.tickets/sl-y89y.md
@@ -1,6 +1,6 @@
 ---
 id: sl-y89y
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:40:29Z
@@ -17,3 +17,10 @@ satsuma-cli/src/commands/lineage.ts:145-164 buildDownstream (and buildUpstream :
 
 Depth-limited traversal expands nodes again when revisited at shallower depth (or tracks min-depth); diamond-graph regression test.
 
+
+## Notes
+
+**2026-06-11T22:55:00Z**
+
+Cause: buildDownstream/buildUpstream used a first-visit-wins visited set, so a node first reached at deep depth was never re-expanded when a shorter path reached it later with depth budget remaining, truncating its subtree.
+Fix: both walks now share a DepthAwareTraversal recording the shallowest visit per node, re-expanding on strictly shallower revisits, and deduplicating rediscovered edges; diamond-graph regression test added (commit e3c8046)

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -186,7 +186,13 @@ function scoreAll(index: ExtractedWorkspace, terms: string[], parsedFiles: Parse
     }
   };
 
-  for (const [name, e] of index.schemas) scoreEntry(name, "schema", e);
+  for (const [name, e] of index.schemas) {
+    // Metric schemas appear in both index.schemas and index.metrics; score
+    // them only once, as metrics, or the same block is emitted twice and
+    // wastes the token budget this command exists to manage (sl-s2mh).
+    if (index.metrics.has(name)) continue;
+    scoreEntry(name, "schema", e);
+  }
   for (const [name, e] of index.metrics) scoreEntry(name, "metric", e);
   for (const [name, e] of index.mappings) scoreEntry(name, "mapping", e);
   for (const [name, e] of index.fragments) scoreEntry(name, "fragment", e);

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -62,8 +62,8 @@ export function register(program: Command): void {
     .option("--names-only", "list changed block names only")
     .option("--stat", "summary counts only")
     .addHelpText("after", `
-Compares two Satsuma files structurally (not text diff). Each file is
-resolved with its imports before comparison.
+Compares two Satsuma files structurally (not text diff). Only the two
+files themselves are compared — imports are not followed.
 
 JSON shape (--json):
   {

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -257,45 +257,45 @@ function buildUpstream(graph: FullGraph, target: string, maxDepth: number): Dag 
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
+/**
+ * Print every upstream path to `target`, one "src -> ... -> target" line each.
+ *
+ * Paths are discovered by climbing reverse edges from the target rather than
+ * by locating in-degree-zero roots and walking forward: in a cyclic graph no
+ * node has zero incoming edges, so a root-based search finds nothing and used
+ * to collapse the output to just the target (sl-h5cx). A path ends where a
+ * node has no parents left to climb — either a true source or a cycle closing
+ * back onto the current path — so every node in the DAG appears in some line.
+ */
 function printUpstreamFlat(dag: Dag, target: string): void {
-  // Build adjacency (upstream direction: parent → child)
-  const adj = new Map<string, string[]>();
+  // Reverse adjacency (child → parents), for climbing away from the target.
+  const parentsOf = new Map<string, string[]>();
   for (const { from, to } of dag.edges) {
-    if (!adj.has(from)) adj.set(from, []);
+    if (!parentsOf.has(to)) parentsOf.set(to, []);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
-    adj.get(from)!.push(to);
+    parentsOf.get(to)!.push(from);
   }
 
-  // Find roots (nodes with no incoming edges in the dag)
-  const hasIncoming = new Set(dag.edges.map((e) => e.to));
-  const roots = dag.nodes.filter((n) => !hasIncoming.has(n.name)).map((n) => n.name);
-  // If no roots found (e.g. target is isolated), just use target
-  if (roots.length === 0) roots.push(target);
-
-  // Print each root-to-target path
   const paths: string[][] = [];
-  function findPaths(node: string, currentPath: string[]): void {
-    currentPath.push(node);
-    const children = adj.get(node) ?? [];
-    if (children.length === 0 || node === target) {
-      if (node === target) paths.push([...currentPath]);
+  // `onPath` mirrors `pathSoFar` as a set, giving O(1) cycle detection while
+  // still allowing a node to appear on *different* paths.
+  function climb(node: string, pathSoFar: string[], onPath: Set<string>): void {
+    pathSoFar.push(node);
+    onPath.add(node);
+    const climbable = (parentsOf.get(node) ?? []).filter((parent) => !onPath.has(parent));
+    if (climbable.length === 0) {
+      // Reached a source (or broke a cycle): emit the path source-first.
+      paths.push([...pathSoFar].reverse());
     } else {
-      for (const child of children) {
-        findPaths(child, currentPath);
+      for (const parent of climbable) {
+        climb(parent, pathSoFar, onPath);
       }
     }
-    currentPath.pop();
+    pathSoFar.pop();
+    onPath.delete(node);
   }
 
-  for (const root of roots) {
-    findPaths(root, []);
-  }
-
-  if (paths.length === 0) {
-    // Fallback: print all nodes
-    console.log(dag.nodes.map((n) => canonicalKey(n.name)).join(" -> "));
-    return;
-  }
+  climb(target, [], new Set());
 
   for (const path of paths) {
     console.log(path.map((n) => canonicalKey(n)).join(" -> "));

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -140,12 +140,10 @@ Examples:
  * Returns {nodes: [...], edges: [{from, to}]}.
  */
 function buildDownstream(graph: FullGraph, start: string, maxDepth: number): Dag {
-  const visitedNodes = new Set<string>();
-  const dagEdges: DagEdge[] = [];
+  const traversal = new DepthAwareTraversal();
 
   function dfs(node: string, depth: number): void {
-    if (depth > maxDepth || visitedNodes.has(node)) return;
-    visitedNodes.add(node);
+    if (depth > maxDepth || !traversal.shouldExpand(node, depth)) return;
     const children = graph.edges.get(node) ?? new Set<string>();
     for (const child of children) {
       const childType = graph.nodes.get(child)?.type;
@@ -156,7 +154,7 @@ function buildDownstream(graph: FullGraph, start: string, maxDepth: number): Dag
       // hop beyond them, so we never emit a mapping with no visible outgoing edge.
       const withinLimit = isSchemaLike ? nextDepth <= maxDepth : depth < maxDepth;
       if (withinLimit) {
-        dagEdges.push({ from: node, to: child });
+        traversal.recordEdge(node, child);
         dfs(child, nextDepth);
       }
     }
@@ -164,10 +162,54 @@ function buildDownstream(graph: FullGraph, start: string, maxDepth: number): Dag
 
   dfs(start, 0);
 
-  return {
-    nodes: [...visitedNodes].map((n) => ({ name: n, ...graph.nodes.get(n) })),
-    edges: dagEdges,
-  };
+  return traversal.toDag(graph);
+}
+
+/**
+ * Shared bookkeeping for depth-limited lineage walks.
+ *
+ * A plain visited-set is wrong under a depth limit: a node first reached at
+ * deep depth would never be re-expanded when a later, shorter path reaches it
+ * with depth budget remaining, silently truncating its subtree (sl-y89y).
+ * Instead we record the shallowest depth each node was expanded at and allow
+ * re-expansion whenever a strictly shallower visit arrives. Cycles still
+ * terminate because depth never decreases along a path, so re-entering a
+ * cycle at equal depth is rejected.
+ *
+ * Re-expansion can rediscover edges, so edges are deduplicated by endpoint pair.
+ */
+class DepthAwareTraversal {
+  /** Shallowest depth at which each node has been expanded so far. */
+  private readonly shallowestVisit = new Map<string, number>();
+  /** Edge endpoint pairs already recorded, to dedupe re-expansions. */
+  private readonly seenEdges = new Set<string>();
+  private readonly dagEdges: DagEdge[] = [];
+
+  /** True (and records the visit) if `node` has not yet been expanded this shallow. */
+  shouldExpand(node: string, depth: number): boolean {
+    const prior = this.shallowestVisit.get(node);
+    if (prior !== undefined && prior <= depth) return false;
+    this.shallowestVisit.set(node, depth);
+    return true;
+  }
+
+  /** Record a traversed edge once, regardless of how many paths rediscover it. */
+  recordEdge(from: string, to: string): void {
+    // NUL separator: node names may contain spaces (e.g. "ns::load hub_store")
+    // but never control characters, so the endpoint-pair key cannot collide.
+    const key = `${from}\u0000${to}`;
+    if (this.seenEdges.has(key)) return;
+    this.seenEdges.add(key);
+    this.dagEdges.push({ from, to });
+  }
+
+  /** Materialize the visited nodes and recorded edges as a Dag. */
+  toDag(graph: FullGraph): Dag {
+    return {
+      nodes: [...this.shallowestVisit.keys()].map((n) => ({ name: n, ...graph.nodes.get(n) })),
+      edges: this.dagEdges,
+    };
+  }
 }
 
 /**
@@ -191,12 +233,10 @@ function buildUpstream(graph: FullGraph, target: string, maxDepth: number): Dag 
     }
   }
 
-  const visitedNodes = new Set<string>();
-  const dagEdges: DagEdge[] = [];
+  const traversal = new DepthAwareTraversal();
 
   function dfs(node: string, depth: number): void {
-    if (depth > maxDepth || visitedNodes.has(node)) return;
-    visitedNodes.add(node);
+    if (depth > maxDepth || !traversal.shouldExpand(node, depth)) return;
     const parents = reverseEdges.get(node) ?? new Set<string>();
     for (const parent of parents) {
       const parentType = graph.nodes.get(parent)?.type;
@@ -204,7 +244,7 @@ function buildUpstream(graph: FullGraph, target: string, maxDepth: number): Dag 
       const nextDepth = isSchemaLike ? depth + 1 : depth;
       const withinLimit = isSchemaLike ? nextDepth <= maxDepth : depth < maxDepth;
       if (withinLimit) {
-        dagEdges.push({ from: parent, to: node });
+        traversal.recordEdge(parent, node);
         dfs(parent, nextDepth);
       }
     }
@@ -212,10 +252,7 @@ function buildUpstream(graph: FullGraph, target: string, maxDepth: number): Dag 
 
   dfs(target, 0);
 
-  return {
-    nodes: [...visitedNodes].map((n) => ({ name: n, ...graph.nodes.get(n) })),
-    edges: dagEdges,
-  };
+  return traversal.toDag(graph);
 }
 
 // ── Formatters ────────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/commands/summary.ts
+++ b/tooling/satsuma-cli/src/commands/summary.ts
@@ -20,7 +20,7 @@ import { canonicalKey } from "../index-builder.js";
 import { expandEntityFields } from "../spread-expand.js";
 import { countNlDerivedEdgesByMapping } from "../nl-ref-extract.js";
 import { canonicalEntityName } from "@satsuma/core";
-import type { FieldDecl, ExtractedWorkspace } from "../types.js";
+import type { FieldDecl, ExtractedWorkspace, SchemaRecord } from "../types.js";
 
 function totalFieldCount(schema: { fields: FieldDecl[]; namespace?: string | null }, index: ExtractedWorkspace): number {
   const expanded = expandEntityFields(schema as Parameters<typeof expandEntityFields>[0], schema.namespace ?? null, index);
@@ -68,12 +68,23 @@ Examples:
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
+/**
+ * Schema entries excluding metric blocks.
+ *
+ * Metric schemas live in both index.schemas and index.metrics; every formatter
+ * must list them only under metrics, or the schema section double-reports them
+ * and its count disagrees with graph stats (sl-s2mh).
+ */
+function nonMetricSchemas(index: ExtractedWorkspace): Map<string, SchemaRecord> {
+  return new Map([...index.schemas].filter(([id]) => !index.metrics.has(id)));
+}
+
 function printJson(index: ExtractedWorkspace, fileCount: number, compact?: boolean): void {
   const displayName = canonicalEntityName;
   const nlDerivedCounts = countNlDerivedEdgesByMapping(index);
 
   const out: Record<string, unknown> = {
-    schemas: [...index.schemas.values()].map((s) => {
+    schemas: [...nonMetricSchemas(index).values()].map((s) => {
       const obj: Record<string, unknown> = { name: displayName(s), fieldCount: totalFieldCount(s, index) };
       if (!compact) { obj.note = s.note; obj.file = s.file; obj.line = s.row + 1; }
       return obj;
@@ -115,7 +126,7 @@ function printCompact(index: ExtractedWorkspace): void {
     for (const name of items) console.log(`  ${name}`);
   };
 
-  section("schemas", [...index.schemas.keys()].map(canonicalKey));
+  section("schemas", [...nonMetricSchemas(index).keys()].map(canonicalKey));
   section("metrics", [...index.metrics.keys()].map(canonicalKey));
   section("mappings", [...index.mappings.keys()].map(canonicalKey));
   section("fragments", [...index.fragments.keys()].map(canonicalKey));
@@ -127,7 +138,7 @@ function plural(n: number, word: string): string {
 }
 
 function printDefault(index: ExtractedWorkspace, fileCount: number): void {
-  const schemas = [...index.schemas.values()];
+  const schemas = [...nonMetricSchemas(index).values()];
   const metrics = [...index.metrics.values()];
   const mappings = [...index.mappings.values()];
   const fragments = [...index.fragments.values()];

--- a/tooling/satsuma-cli/src/diff-engine.ts
+++ b/tooling/satsuma-cli/src/diff-engine.ts
@@ -43,8 +43,16 @@ function noteTextsForParent(index: ExtractedWorkspace, parentName: string): Set<
  * Compares every block type (schemas, mappings, metrics, fragments, transforms)
  * plus standalone note blocks. Block-owned note blocks (those with a non-null
  * parent) are compared within their parent block's diff, not at the top level.
+ *
+ * Anonymous mappings are re-keyed to position-independent structural ids
+ * before comparison (see `normalizeAnonMappingKeys`), so byte-identical files
+ * at different paths diff clean and user-facing output never leaks the
+ * internal `<anon>@file:row` key (sl-ndtz).
  */
 export function diffIndex(indexA: ExtractedWorkspace, indexB: ExtractedWorkspace): Delta {
+  indexA = normalizeAnonMappingKeys(indexA);
+  indexB = normalizeAnonMappingKeys(indexB);
+
   // Collect arrows per mapping for detailed comparison
   const arrowsA = collectArrowsByMapping(indexA);
   const arrowsB = collectArrowsByMapping(indexB);
@@ -68,6 +76,72 @@ export function diffIndex(indexA: ExtractedWorkspace, indexB: ExtractedWorkspace
     fragments: diffBlockMap(indexA.fragments, indexB.fragments, diffFragment),
     transforms: diffBlockMap(indexA.transforms, indexB.transforms, diffTransform),
     notes: diffNotes(indexA.notes ?? [], indexB.notes ?? []),
+  };
+}
+
+// ── Anonymous mapping normalization (sl-ndtz) ────────────────────────────────
+
+/**
+ * The index stores anonymous mappings under synthetic keys of the form
+ * `[ns::]<anon>@<absolute-file-path>:<0-based-row>` (see index-builder.ts).
+ * That key is positional by design — other consumers (arrows, lint fixes)
+ * need to locate the block in its file — but it is wrong for diffing: two
+ * byte-identical files always differ in path, so every anonymous mapping
+ * shows up as removed-and-added, and the internal key leaks into user output.
+ */
+const ANON_KEY = /<anon>@.*:\d+$/;
+
+/**
+ * Re-key anonymous mappings by what they map rather than where they live.
+ *
+ * The structural id is `<anonymous src1,src2 -> tgt1,tgt2>` (namespace prefix
+ * preserved). Several anonymous mappings with the same signature in one
+ * workspace get stable ` #2`, ` #3`… suffixes in file/row order, so they pair
+ * up positionally across the two sides of the diff. Arrow records and note
+ * parents referencing the old keys are rewritten to match.
+ *
+ * Returns a shallow copy; the input index is not mutated.
+ */
+function normalizeAnonMappingKeys(index: ExtractedWorkspace): ExtractedWorkspace {
+  // Map old key → new structural key, assigning ordinals per signature in
+  // deterministic (file, row) order.
+  const rename = new Map<string, string>();
+  const ordinals = new Map<string, number>();
+  const anonEntries = [...index.mappings.entries()]
+    .filter(([key]) => ANON_KEY.test(key))
+    .sort(([, a], [, b]) => (a.file ?? "").localeCompare(b.file ?? "") || a.row - b.row);
+
+  for (const [key, mapping] of anonEntries) {
+    const ns = key.includes("::") ? key.slice(0, key.indexOf("::") + 2) : "";
+    const signature = `${ns}<anonymous ${mapping.sources.join(",")} -> ${mapping.targets.join(",")}>`;
+    const seen = ordinals.get(signature) ?? 0;
+    ordinals.set(signature, seen + 1);
+    rename.set(key, seen === 0 ? signature : `${signature.slice(0, -1)} #${seen + 1}>`);
+  }
+
+  if (rename.size === 0) return index;
+
+  // Arrow records and note parents carry the *bare* (namespace-less) form of
+  // the key, so register those spellings too.
+  for (const [key, newKey] of [...rename]) {
+    const sep = key.indexOf("::");
+    if (sep !== -1) rename.set(key.slice(sep + 2), newKey.slice(newKey.indexOf("::") + 2));
+  }
+
+  return {
+    ...index,
+    mappings: new Map([...index.mappings].map(([key, m]) => [rename.get(key) ?? key, m])),
+    fieldArrows: new Map(
+      [...index.fieldArrows].map(([field, records]) => [
+        field,
+        records.map((r) =>
+          r.mapping && rename.has(r.mapping) ? { ...r, mapping: rename.get(r.mapping) ?? r.mapping } : r,
+        ),
+      ]),
+    ),
+    notes: (index.notes ?? []).map((n) =>
+      n.parent && rename.has(n.parent) ? { ...n, parent: rename.get(n.parent) ?? n.parent } : n,
+    ),
   };
 }
 

--- a/tooling/satsuma-cli/src/workspace.ts
+++ b/tooling/satsuma-cli/src/workspace.ts
@@ -7,10 +7,32 @@
  */
 
 import { stat } from "fs/promises";
-import { readFileSync, statSync } from "fs";
+import { readFileSync, realpathSync, statSync } from "fs";
 import { dirname, resolve } from "path";
 import { extractImports } from "@satsuma/core";
 import { parseSource } from "./parser.js";
+
+/**
+ * Canonicalize a path to its physical identity on disk.
+ *
+ * `path.resolve` alone is not enough to deduplicate files: on the
+ * case-insensitive filesystems that macOS and Windows default to,
+ * "lib.stm" and "LIB.stm" resolve to different strings but the same
+ * physical file, and a symlink resolves to a different string than its
+ * target. `realpathSync.native` collapses both — it follows symlinks and
+ * returns the on-disk casing — so keying visited-sets on its result loads
+ * each physical file exactly once (sl-8zyr).
+ *
+ * Falls back to the input path when realpath fails (e.g. the file
+ * disappeared between stat and canonicalization).
+ */
+function canonicalPath(filePath: string): string {
+  try {
+    return realpathSync.native(filePath);
+  } catch {
+    return filePath;
+  }
+}
 
 /**
  * Error message shown when a directory is passed where a .stm file is expected.
@@ -22,13 +44,15 @@ const DIRECTORY_NOT_SUPPORTED =
 
 /**
  * Follow import declarations from a single .stm file, collecting all
- * transitively imported file paths. Uses a visited set for cycle safety.
+ * transitively imported file paths. Uses a visited set for cycle safety;
+ * paths are canonicalized first so case-aliased or symlinked imports of
+ * the same physical file are visited (and returned) only once.
  *
  * Missing import targets are warned on stderr but do not halt discovery.
  */
 function followImports(entryFile: string): string[] {
   const visited = new Set<string>();
-  const queue = [entryFile];
+  const queue = [canonicalPath(entryFile)];
   while (queue.length > 0) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: queue.length > 0 checked above
     const filePath = queue.pop()!;
@@ -59,8 +83,11 @@ function followImports(entryFile: string): string[] {
         continue;
       }
 
-      if (!visited.has(resolved)) {
-        queue.push(resolved);
+      // Canonicalize before the visited check so two spellings of the same
+      // physical file (case alias, symlink) cannot enqueue it twice.
+      const canonical = canonicalPath(resolved);
+      if (!visited.has(canonical)) {
+        queue.push(canonical);
       }
     }
   }

--- a/tooling/satsuma-cli/test/context.test.ts
+++ b/tooling/satsuma-cli/test/context.test.ts
@@ -144,3 +144,34 @@ describe("estimateTokens", () => {
     assert.equal(estimateTokens("12345"), 2);
   });
 });
+
+// ── CLI-level coverage (spawns the built command) ────────────────────────────
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { run as runCli } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+const METRICS_EXAMPLE = resolve(__dirname, "../../../examples/metrics-platform/metrics.stm");
+
+describe("satsuma context metric deduplication (sl-s2mh)", () => {
+  it("scores each metric block once, as a metric, never additionally as a schema", async () => {
+    // Metric schemas live in both index.schemas and index.metrics; scoring
+    // both rendered the same block twice and wasted the token budget the
+    // command exists to manage.
+    const { stdout, code } = await runCli(CLI, "context", "monthly recurring revenue", "--json", METRICS_EXAMPLE);
+
+    assert.equal(code, 0);
+    const candidates = JSON.parse(stdout) as Array<{ name: string; type: string }>;
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      assert.ok(!seen.has(candidate.name), `'${candidate.name}' emitted more than once`);
+      seen.add(candidate.name);
+    }
+    assert.ok(
+      candidates.some((candidate) => candidate.type === "metric"),
+      "an MRR query against the metrics example should surface metric candidates",
+    );
+  });
+});

--- a/tooling/satsuma-cli/test/diff.test.ts
+++ b/tooling/satsuma-cli/test/diff.test.ts
@@ -423,3 +423,61 @@ describe("diffIndex", () => {
     assert.equal(typeChange.to, "TEXT");
   });
 });
+
+// ── Anonymous mapping normalization (sl-ndtz) ────────────────────────────────
+
+describe("diffIndex anonymous mappings (sl-ndtz)", () => {
+  /** Build a minimal anonymous MappingRecord stored under its internal positional key. */
+  const anonMapping = (file: string, row: number, sources: string[], targets: string[], arrowCount = 1) => ({
+    [`<anon>@${file}:${row}`]: { name: null, sources, targets, arrowCount, file, row },
+  });
+
+  it("treats structurally identical anonymous mappings at different file paths as unchanged", () => {
+    // The internal anon key embeds the absolute path, so byte-identical v1/v2
+    // files used to report every anonymous mapping as removed-and-added.
+    const a = makeIndex({}, anonMapping("/v1/pipe.stm", 2, ["src"], ["tgt"]));
+    const b = makeIndex({}, anonMapping("/v2/pipe.stm", 2, ["src"], ["tgt"]));
+
+    const delta = diffIndex(a, b);
+    assert.equal(delta.mappings.added.length, 0);
+    assert.equal(delta.mappings.removed.length, 0);
+    assert.equal(delta.mappings.changed.length, 0);
+  });
+
+  it("reports a changed anonymous mapping under a structural id, never the internal key", () => {
+    // The synthetic <anon>@path:row key is an implementation detail and must
+    // not leak into the delta consumed by user-facing formatters.
+    const a = makeIndex({}, anonMapping("/v1/pipe.stm", 2, ["src"], ["tgt"], 1));
+    const b = makeIndex({}, anonMapping("/v2/pipe.stm", 7, ["src"], ["tgt"], 3));
+
+    const delta = diffIndex(a, b);
+    assert.equal(delta.mappings.changed.length, 1);
+    assert.equal(delta.mappings.changed[0].name, "<anonymous src -> tgt>");
+    assert.doesNotMatch(delta.mappings.changed[0].name, /<anon>@/);
+  });
+
+  it("pairs multiple same-signature anonymous mappings positionally across versions", () => {
+    // Two anonymous mappings with identical source/target signatures must get
+    // stable ordinals so each pairs with its counterpart instead of colliding.
+    const twoAnon = (file: string) => ({
+      ...anonMapping(file, 2, ["src"], ["tgt"]),
+      ...anonMapping(file, 9, ["src"], ["tgt"]),
+    });
+    const delta = diffIndex(makeIndex({}, twoAnon("/v1/pipe.stm")), makeIndex({}, twoAnon("/v2/pipe.stm")));
+
+    assert.equal(delta.mappings.added.length, 0);
+    assert.equal(delta.mappings.removed.length, 0);
+    assert.equal(delta.mappings.changed.length, 0);
+  });
+
+  it("preserves the namespace prefix on normalized anonymous mapping ids", () => {
+    // Namespaced anon mappings are keyed `ns::<anon>@path:row`; the structural
+    // id must stay namespace-qualified so scoped blocks do not cross-match.
+    const a = makeIndex({}, { "crm::<anon>@/v1/p.stm:4": { name: null, sources: ["s"], targets: ["t"], arrowCount: 1, file: "/v1/p.stm", row: 4 } });
+    const b = makeIndex({}, { "crm::<anon>@/v2/p.stm:4": { name: null, sources: ["s"], targets: ["t"], arrowCount: 2, file: "/v2/p.stm", row: 4 } });
+
+    const delta = diffIndex(a, b);
+    assert.equal(delta.mappings.changed.length, 1);
+    assert.equal(delta.mappings.changed[0].name, "crm::<anonymous s -> t>");
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/lineage-diamond.stm
+++ b/tooling/satsuma-cli/test/fixtures/lineage-diamond.stm
@@ -1,0 +1,39 @@
+schema s0 {
+  id INTEGER
+}
+
+schema s1 {
+  id INTEGER
+}
+
+schema s2 {
+  id INTEGER
+}
+
+schema s3 {
+  id INTEGER
+}
+
+mapping `m_0_to_1` {
+  source { s0 }
+  target { s1 }
+  id -> id
+}
+
+mapping `m_1_to_2` {
+  source { s1 }
+  target { s2 }
+  id -> id
+}
+
+mapping `m_2_to_3` {
+  source { s2 }
+  target { s3 }
+  id -> id
+}
+
+mapping `m_0_to_2` {
+  source { s0 }
+  target { s2 }
+  id -> id
+}

--- a/tooling/satsuma-cli/test/integration.test.ts
+++ b/tooling/satsuma-cli/test/integration.test.ts
@@ -8,7 +8,7 @@
  *   cd tooling/tree-sitter-satsuma && npx node-gyp configure && npx node-gyp build
  */
 
-import { copyFileSync, mkdtempSync, readFileSync, unlinkSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, join } from "node:path";
@@ -2147,6 +2147,31 @@ describe("satsuma diff", () => {
     );
     assert.equal(code, 0);
     assert.ok(stdout.trim().length > 0);
+  });
+
+  it("reports no differences for byte-identical files containing anonymous mappings (sl-ndtz)", async () => {
+    // Anonymous mappings were keyed by absolute path + row internally, so two
+    // identical files at different paths always produced phantom +/- entries.
+    const dir = mkdtempSync(join(tmpdir(), "satsuma-diff-"));
+    const source = "schema s {\n  id INTEGER\n}\n\nschema t {\n  id INTEGER\n}\n\nmapping {\n  source { s }\n  target { t }\n  id -> id\n}\n";
+    const v1 = join(dir, "v1.stm");
+    const v2 = join(dir, "v2.stm");
+    writeFileSync(v1, source);
+    writeFileSync(v2, source);
+
+    const { stdout, code } = await run("diff", v1, v2);
+    assert.equal(code, 0);
+    assert.match(stdout, /no structural differences/i);
+    assert.doesNotMatch(stdout, /<anon>@/, "internal anon keys must never reach user output");
+  });
+
+  it("documents that imports are not followed, matching actual behaviour (sl-ndtz)", async () => {
+    // diff resolves both inputs with followImports:false; the help text used
+    // to claim the opposite.
+    const { stdout, code } = await run("diff", "--help");
+    assert.equal(code, 0);
+    assert.match(stdout, /imports are not followed/i);
+    assert.doesNotMatch(stdout, /resolved with its imports/i);
   });
 
   it("diffs metrics, fragments, and transforms", async () => {

--- a/tooling/satsuma-cli/test/lineage.test.ts
+++ b/tooling/satsuma-cli/test/lineage.test.ts
@@ -15,6 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const LINEAGE_CHAIN = resolve(__dirname, "fixtures/lineage-chain.stm");
 const LINEAGE_CYCLE = resolve(__dirname, "fixtures/lineage-cycle.stm");
+const LINEAGE_DIAMOND = resolve(__dirname, "fixtures/lineage-diamond.stm");
 const NAMESPACES = resolve(__dirname, "fixtures/namespaces.stm");
 
 const run = (...args: string[]) => runCli(CLI, ...args);
@@ -78,6 +79,22 @@ describe("satsuma lineage", () => {
     assert.equal(code, 0);
     assert.match(stdout, /::cycle_a {2}\[schema\] \(cycle\)/);
     assert.ok(stdout.trim().split(/\r?\n/).length <= 5);
+  });
+
+  it("includes nodes reachable within the depth limit via a shorter path found later (sl-y89y)", async () => {
+    // Diamond graph: s0→s1→s2→s3 plus shortcut s0→s2. A first-visit-wins
+    // visited set expands s2 at depth 2 (via s1) and never re-expands it when
+    // the shortcut reaches it at depth 1, wrongly dropping s3 from --depth 2.
+    const { stdout, code } = await run("lineage", "--from", "s0", "--depth", "2", "--json", LINEAGE_DIAMOND);
+
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    const names = data.nodes.map((node: { name: string }) => node.name);
+    assert.ok(names.includes("s3"), `s3 is two schema hops from s0 via the shortcut; got: ${names.join(", ")}`);
+    // Re-expansion must not duplicate nodes or edges in the emitted DAG.
+    assert.equal(new Set(names).size, names.length, "nodes must be unique");
+    const edgeKeys = data.edges.map((edge: { from: string; to: string }) => `${edge.from}->${edge.to}`);
+    assert.equal(new Set(edgeKeys).size, edgeKeys.length, "edges must be unique");
   });
 
   it("emits upstream JSON for --to with edge direction preserved", async () => {

--- a/tooling/satsuma-cli/test/lineage.test.ts
+++ b/tooling/satsuma-cli/test/lineage.test.ts
@@ -111,6 +111,25 @@ describe("satsuma lineage", () => {
     assert.ok(data.edges.some((edge: { from: string; to: string }) => edge.from === "c_to_d" && edge.to === "target_d"));
   });
 
+  it("renders upstream text paths covering every JSON node when upstream contains a cycle (sl-h5cx)", async () => {
+    // In a cyclic graph no node has zero incoming edges, so a root-based path
+    // search finds nothing and used to print only the target, silently losing
+    // all upstream info that --json correctly reported.
+    const text = await run("lineage", "--to", "cycle_a", LINEAGE_CYCLE);
+    const json = await run("lineage", "--to", "cycle_a", "--json", LINEAGE_CYCLE);
+
+    assert.equal(text.code, 0);
+    assert.equal(json.code, 0);
+    // JSON names are bare index keys ("cycle_a"); text prints canonical refs ("::cycle_a").
+    const jsonNames = JSON.parse(json.stdout).nodes.map((node: { name: string }) => node.name);
+    assert.ok(jsonNames.length >= 4, `cycle fixture should yield all 4 nodes in JSON, got: ${jsonNames.join(", ")}`);
+    for (const name of jsonNames) {
+      assert.ok(text.stdout.includes(`::${name}`), `text output must mention '${name}'; got:\n${text.stdout}`);
+    }
+    // The upstream path itself must be visible, not just the target line.
+    assert.match(text.stdout, /::cycle_b -> ::b_to_a -> ::cycle_a/);
+  });
+
   it("resolves namespace-qualified --from names without crossing namespace scope", async () => {
     // Namespaced platform entry points depend on qualified node lookup; this
     // guards the public CLI path rather than only the graph builder.

--- a/tooling/satsuma-cli/test/summary.test.ts
+++ b/tooling/satsuma-cli/test/summary.test.ts
@@ -15,6 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const PLATFORM = resolve(__dirname, "fixtures/platform.stm");
 const IMPORT_ENTRY = resolve(__dirname, "fixtures/import-entry.stm");
+const METRICS_EXAMPLE = resolve(__dirname, "../../../examples/metrics-platform/metrics.stm");
 
 const run = (...args: string[]) => runCli(CLI, ...args);
 
@@ -90,6 +91,21 @@ describe("satsuma summary", () => {
     assert.equal(code, 2);
     assert.match(stderr, /^Error resolving path/);
     assert.doesNotMatch(stderr, /Unhandled error:/);
+  });
+
+  it("lists metric blocks only under metrics, never double-counted as schemas (sl-s2mh)", async () => {
+    // Metric schemas live in both index.schemas and index.metrics; the summary
+    // sections must partition them or the schema count disagrees with graph
+    // stats and every metric is reported twice.
+    const { stdout, code } = await run("summary", "--json", METRICS_EXAMPLE);
+
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.ok(data.metrics.length > 0, "metrics-platform example should yield metric entries");
+    const schemaNames = new Set(data.schemas.map((s: { name: string }) => s.name));
+    for (const metric of data.metrics) {
+      assert.ok(!schemaNames.has(metric.name), `metric '${metric.name}' must not also be listed as a schema`);
+    }
   });
 });
 

--- a/tooling/satsuma-cli/test/workspace.test.ts
+++ b/tooling/satsuma-cli/test/workspace.test.ts
@@ -8,8 +8,10 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { existsSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolveInput } from "#src/workspace.js";
 import { loadWorkspace } from "#src/load-workspace.js";
 
@@ -78,6 +80,63 @@ describe("resolveInput", () => {
     }
 
     assert.match(stderr.join(""), /does-not-exist\.stm/);
+  });
+});
+
+describe("resolveInput physical-file deduplication (sl-8zyr)", () => {
+  // Two import spellings that reach the same physical file must load it once,
+  // otherwise validate reports false duplicate-definition errors for every
+  // schema the file defines. Fixtures are created in a temp dir because the
+  // scenarios depend on filesystem identity (casing, symlinks), not content.
+
+  /** Minimal schema so the imported file parses as a real definition. */
+  const LIB_SOURCE = "schema shared {\n  id: UUID\n}\n";
+
+  /** Build an entry file importing the given paths, in a fresh temp dir. */
+  function makeWorkspace(importPaths: string[]): { dir: string; entry: string } {
+    const dir = mkdtempSync(join(tmpdir(), "satsuma-ws-"));
+    const entry = join(dir, "entry.stm");
+    const imports = importPaths.map((p) => `import { shared } from "${p}"`).join("\n");
+    writeFileSync(join(dir, "lib.stm"), LIB_SOURCE);
+    writeFileSync(entry, `${imports}\n`);
+    return { dir, entry };
+  }
+
+  it("loads a file once when imported under two casings on a case-insensitive filesystem", async (t) => {
+    const { dir, entry } = makeWorkspace(["lib.stm", "LIB.stm"]);
+    try {
+      // Only meaningful where "LIB.stm" actually aliases "lib.stm" (macOS and
+      // Windows defaults); on case-sensitive filesystems it is a missing import.
+      if (!existsSync(join(dir, "LIB.stm"))) {
+        t.skip("filesystem is case-sensitive — no alias to deduplicate");
+        return;
+      }
+      const result = await resolveInput(entry);
+      assert.equal(result.length, 2, `expected entry + one lib, got: ${result.join(", ")}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads a file once when imported both directly and through a symlink", async (t) => {
+    const { dir, entry } = makeWorkspace(["lib.stm", "lib-link.stm"]);
+    try {
+      try {
+        symlinkSync(join(dir, "lib.stm"), join(dir, "lib-link.stm"));
+      } catch {
+        t.skip("symlinks not supported on this platform");
+        return;
+      }
+      const result = await resolveInput(entry);
+      assert.equal(result.length, 2, `expected entry + one lib, got: ${result.join(", ")}`);
+      // The surviving path must be the physical file, not the symlink spelling.
+      assert.ok(
+        result.includes(realpathSync.native(join(dir, "lib.stm"))),
+        "canonical lib.stm path missing from workspace",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the five open `cli`-tagged bug-hunt tickets (bug hunt 2026-06):

- **sl-8zyr** — `followImports` keyed its visited set on `path.resolve` only; case-aliased or symlinked imports of one physical file loaded it twice, causing false duplicate-definition errors. Paths are now canonicalized with `realpathSync.native` (follows symlinks, restores on-disk casing).
- **sl-y89y** — depth-limited lineage traversal marked nodes visited at first touch, truncating subtrees reachable within budget via a later, shorter path (diamond `s0→s1→s2→s3` + `s0→s2` dropped `s3` at `--depth 2`). Both walks now share a `DepthAwareTraversal` that re-expands on strictly shallower revisits and dedupes rediscovered edges.
- **sl-h5cx** — `lineage --to` text output collapsed to just the target when upstream contained a cycle (root search looked for nodes with no incoming edges; cycles have none). Paths are now discovered by climbing reverse edges from the target with per-path cycle breaking; text output covers every JSON node.
- **sl-s2mh** — `context` scored metric blocks in both `index.schemas` and `index.metrics`, emitting each metric twice and wasting the token budget; `summary` listed metrics under both sections in all three output modes. Both now skip metric ids in their schemas loops, matching graph-builder's existing partition.
- **sl-ndtz** — `diff` keyed anonymous mappings as `<anon>@<absolute-path>:<row>`, so byte-identical files always reported phantom changes and leaked the internal key into output. `diffIndex` now re-keys them to position-independent structural ids (`<anonymous src -> tgt>`, namespace-qualified, stable ordinals for duplicates). Also corrects `diff --help`, which claimed imports are followed.

## Test plan

- New regression tests per ticket: case-alias + symlink workspace tests, diamond-graph depth test, cyclic upstream text-vs-JSON coverage test, metrics-platform context/summary dedup tests, anon-mapping unit + CLI diff tests (incl. help text).
- Full satsuma-cli suite: 879 tests passing; repo-wide pre-commit hooks (lint, core, viz-model, LSP, smoke tests) green on every commit.

No ADR: all changes are localized bug fixes with no new architectural decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)