### PR TITLE
fix(vscode): VS Code bug batch — coverage staleness, viz refresh races, .satsuma support (sl-89id, sl-jar4, sl-v215)

### DIFF
--- a/.tickets/sl-89id.md
+++ b/.tickets/sl-89id.md
@@ -1,6 +1,6 @@
 ---
 id: sl-89id
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z
@@ -17,3 +17,10 @@ vscode-satsuma/src/commands/coverage.ts applies mapped/unmapped gutter decoratio
 
 Decorations cleared on each run (and a way to dismiss them); files from a previous run show no stale icons; editor focus not yanked per file.
 
+
+## Notes
+
+**2026-06-11T21:45:25Z**
+
+Cause: showCoverage applied gutter decorations per file but nothing ever removed them (only the status bar hid on editor switch), and one showTextDocument call per affected file churned the visible editor.
+Fix: Decoration types are created per run and disposed on replace/clear (disposal removes icons from non-visible tabs, which per-editor clearing cannot); markers apply to editors as they become visible instead of force-opening files; added satsuma.clearCoverage command, also bound to the status-bar item. Pure shaping extracted to coverage-logic.ts with unit tests. (commit fcf2bb4)

--- a/.tickets/sl-jar4.md
+++ b/.tickets/sl-jar4.md
@@ -1,6 +1,6 @@
 ---
 id: sl-jar4
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z
@@ -17,3 +17,10 @@ vscode-satsuma/src/webview/viz/panel.ts — onDidSaveTextDocument and onDidChang
 
 Refresh requests are serialized or stamped with a generation id; stale responses discarded; unit test for out-of-order completion.
 
+
+## Notes
+
+**2026-06-11T21:40:25Z**
+
+Cause: onDidSaveTextDocument/onDidChangeActiveTextEditor watchers and manual refresh could trigger overlapping loadFullLineageModel calls with no generation counter or cancellation, so a slow earlier response could postMessage after a newer one.
+Fix: Added RefreshGate (pure latest-wins generation counter, unit-tested for out-of-order completion); refresh() stamps each load and drops superseded results and errors; expandLineage() drops expansions whose base model was replaced mid-flight. (commit dd63394)

--- a/.tickets/sl-v215.md
+++ b/.tickets/sl-v215.md
@@ -1,6 +1,6 @@
 ---
 id: sl-v215
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-11T02:43:30Z
@@ -17,3 +17,10 @@ package.json registers .stm AND .satsuma and the client watches **/*.satsuma, bu
 
 Single decision applied consistently: either .satsuma works in index/watcher/entry-file/menus (tests) or the extension registration and watcher are removed.
 
+
+## Notes
+
+**2026-06-11T21:36:18Z**
+
+Cause: The extension registered .satsuma alongside .stm (f2v-hp48), but the LSP watched-file gate, LSP workspace scan, entry-file resolution, and explorer context menu each hard-coded .endsWith(".stm"), so .satsuma workspaces got highlighting but no cross-file features.
+Fix: Decision: support .satsuma everywhere. Extension policy centralised in @satsuma/core source-files (SATSUMA_FILE_EXTENSIONS, SATSUMA_FILE_GLOB, isSatsumaFilePath); LSP watcher gate and workspace scan (extracted to testable source-scan.ts), entry-file glob, explorer menu, and client watcher all use it. CLI was already extension-agnostic. (commit 6c21fc4)

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -50,6 +50,10 @@
       "types": "./dist/string-utils.d.ts",
       "default": "./dist/string-utils.js"
     },
+    "./source-files": {
+      "types": "./dist/source-files.d.ts",
+      "default": "./dist/source-files.js"
+    },
     "./parser": {
       "types": "./dist/parser.d.ts",
       "default": "./dist/parser.js"

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -1,4 +1,9 @@
 export { capitalize, normalizeName } from "./string-utils.js";
+export {
+  SATSUMA_FILE_EXTENSIONS,
+  SATSUMA_FILE_GLOB,
+  isSatsumaFilePath,
+} from "./source-files.js";
 export { findFieldByPath, collectFieldNames } from "./field-utils.js";
 export type { FieldTreeNode } from "./field-utils.js";
 export { collectSemanticDiagnostics, validateSemanticWorkspace } from "./validate.js";

--- a/tooling/satsuma-core/src/source-files.ts
+++ b/tooling/satsuma-core/src/source-files.ts
@@ -1,0 +1,32 @@
+/**
+ * source-files.ts — the single definition of what counts as a Satsuma source file.
+ *
+ * The VS Code extension registers both `.stm` and `.satsuma` (f2v-hp48), but
+ * each consumer historically hard-coded its own `.endsWith(".stm")` check, so
+ * `.satsuma` files got syntax highlighting yet were invisible to the workspace
+ * index, file watchers, and entry-file resolution (sl-v215). Every consumer
+ * (CLI, LSP, VS Code extension) must use these exports instead of spelling
+ * extensions inline. This module owns only the extension policy — file
+ * discovery and parsing live with each consumer.
+ */
+
+/**
+ * Recognised Satsuma source-file extensions. `.stm` is the canonical
+ * extension used throughout docs and examples; `.satsuma` is the explicit
+ * long-form alternative registered alongside it by the VS Code extension.
+ */
+export const SATSUMA_FILE_EXTENSIONS = [".stm", ".satsuma"] as const;
+
+/**
+ * Glob matching all Satsuma source files, for file watchers and workspace
+ * searches (VS Code `findFiles`/`createFileSystemWatcher` brace syntax).
+ */
+export const SATSUMA_FILE_GLOB = "**/*.{stm,satsuma}";
+
+/**
+ * True when a filesystem path, bare file name, or URI string names a Satsuma
+ * source file. Matching is by extension suffix only — the file need not exist.
+ */
+export function isSatsumaFilePath(pathOrUri: string): boolean {
+  return SATSUMA_FILE_EXTENSIONS.some((ext) => pathOrUri.endsWith(ext));
+}

--- a/tooling/satsuma-core/test/source-files.test.js
+++ b/tooling/satsuma-core/test/source-files.test.js
@@ -1,0 +1,54 @@
+/**
+ * source-files.test.js — Unit tests for src/source-files.ts
+ *
+ * Pins the extension policy fixed by sl-v215: `.satsuma` is a first-class
+ * source extension alongside `.stm`, and every consumer recognises files via
+ * this shared predicate rather than inline `.endsWith(".stm")` checks.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  SATSUMA_FILE_EXTENSIONS,
+  SATSUMA_FILE_GLOB,
+  isSatsumaFilePath,
+} from "@satsuma/core";
+
+describe("isSatsumaFilePath", () => {
+  it("recognises both registered extensions, on paths and on URIs (sl-v215)", () => {
+    // Consumers pass both fs paths (LSP workspace scan) and URI strings
+    // (LSP watched-file events) — the predicate must accept either form.
+    assert.equal(isSatsumaFilePath("/ws/pipeline.stm"), true);
+    assert.equal(isSatsumaFilePath("/ws/pipeline.satsuma"), true);
+    assert.equal(isSatsumaFilePath("file:///ws/pipeline.stm"), true);
+    assert.equal(isSatsumaFilePath("file:///ws/pipeline.satsuma"), true);
+  });
+
+  it("rejects unrelated extensions, including ones containing 'stm'", () => {
+    // ".stm" must match as a suffix segment, not a substring — a .stmx or
+    // .json file must never be indexed as Satsuma source.
+    assert.equal(isSatsumaFilePath("/ws/pipeline.stmx"), false);
+    assert.equal(isSatsumaFilePath("/ws/notes.md"), false);
+    assert.equal(isSatsumaFilePath("/ws/pipeline.stm.bak"), false);
+  });
+
+  it("matches every extension listed in SATSUMA_FILE_EXTENSIONS", () => {
+    // The predicate and the constant must never drift apart: a new extension
+    // added to the list is automatically recognised by the predicate.
+    for (const ext of SATSUMA_FILE_EXTENSIONS) {
+      assert.equal(isSatsumaFilePath(`/ws/file${ext}`), true);
+    }
+  });
+});
+
+describe("SATSUMA_FILE_GLOB", () => {
+  it("covers exactly the registered extensions", () => {
+    // Watchers built from the glob and indexers built from the predicate must
+    // agree on the file set, or watched .satsuma edits would be dropped again.
+    const globExts = /\{(.+)\}/.exec(SATSUMA_FILE_GLOB)?.[1].split(",") ?? [];
+    assert.deepEqual(
+      globExts.map((e) => `.${e}`).sort(),
+      [...SATSUMA_FILE_EXTENSIONS].sort(),
+    );
+  });
+});

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -42,6 +42,8 @@ import { computeFormatting, initFormatting } from "./formatting";
 import { computeFullLineage } from "./full-lineage";
 import { buildVizModel } from "@satsuma/viz-backend";
 import { computeMappingCoverage } from "./coverage";
+import { isSatsumaFilePath } from "@satsuma/core";
+import { findSatsumaSourceFiles } from "./source-scan";
 
 // ---------- Connection setup ----------
 
@@ -222,11 +224,13 @@ documents.onDidSave(async (event) => {
   }
 });
 
-// Watch for .stm file changes outside the editor
+// Watch for Satsuma source file changes outside the editor. The client
+// watches both registered extensions, so the gate must accept both — a
+// bare .endsWith(".stm") check silently dropped .satsuma events (sl-v215).
 connection.onDidChangeWatchedFiles((params) => {
   const parser = getParser();
   for (const change of params.changes) {
-    if (!change.uri.endsWith(".stm")) continue;
+    if (!isSatsumaFilePath(change.uri)) continue;
 
     if (change.type === FileChangeType.Deleted) {
       removeFile(wsIndex, change.uri);
@@ -509,12 +513,12 @@ function sendMergedDiagnostics(uri: string, tree: Tree): void {
   });
 }
 
-/** Recursively find all .stm files in a directory and index them. */
+/** Recursively find all Satsuma source files in a directory and index them. */
 function indexWorkspaceFolder(folderPath: string): void {
   const parser = getParser();
-  const stmFiles = findStmFiles(folderPath);
+  const sourceFiles = findSatsumaSourceFiles(folderPath);
 
-  for (const filePath of stmFiles) {
+  for (const filePath of sourceFiles) {
     try {
       const content = fs.readFileSync(filePath, "utf-8");
       const tree = parser.parse(content);
@@ -525,26 +529,6 @@ function indexWorkspaceFolder(folderPath: string): void {
       // Unreadable file — skip
     }
   }
-}
-
-/** Recursively find .stm files, skipping hidden dirs and node_modules. */
-function findStmFiles(dir: string): string[] {
-  const results: string[] = [];
-  try {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        results.push(...findStmFiles(full));
-      } else if (entry.name.endsWith(".stm")) {
-        results.push(full);
-      }
-    }
-  } catch {
-    // Unreadable directory — skip
-  }
-  return results;
 }
 
 // ---------- Start ----------

--- a/tooling/satsuma-lsp/src/source-scan.ts
+++ b/tooling/satsuma-lsp/src/source-scan.ts
@@ -1,0 +1,45 @@
+/**
+ * source-scan.ts — recursive filesystem scan for Satsuma source files.
+ *
+ * Owns the directory walk the server runs at startup to seed the workspace
+ * index. Which extensions count as Satsuma source is owned by @satsuma/core
+ * (sl-v215) — this module only owns the traversal rules: which directories
+ * are skipped and the recursion itself. Parsing and indexing stay in server.ts.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { isSatsumaFilePath } from "@satsuma/core";
+
+/**
+ * Directory names excluded from the scan: hidden directories (VCS metadata,
+ * editor state) and installed dependencies are never Satsuma workspace source.
+ */
+function isSkippedDirectory(name: string): boolean {
+  return name.startsWith(".") || name === "node_modules";
+}
+
+/**
+ * Recursively collect absolute paths of all Satsuma source files (.stm and
+ * .satsuma) under `dir`, skipping hidden directories and node_modules.
+ * Unreadable directories are silently skipped — a permission error in one
+ * subtree must not abort workspace indexing.
+ */
+export function findSatsumaSourceFiles(dir: string): string[] {
+  const results: string[] = [];
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (isSkippedDirectory(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...findSatsumaSourceFiles(full));
+      } else if (isSatsumaFilePath(entry.name)) {
+        results.push(full);
+      }
+    }
+  } catch {
+    // Unreadable directory — skip
+  }
+  return results;
+}

--- a/tooling/satsuma-lsp/test/source-scan.test.js
+++ b/tooling/satsuma-lsp/test/source-scan.test.js
@@ -1,0 +1,55 @@
+/**
+ * source-scan.test.js — workspace scan discovers all Satsuma source files.
+ *
+ * sl-v215: the startup scan indexed only .stm, so a workspace of .satsuma
+ * files got syntax highlighting but no cross-file features. These cases pin
+ * the invariant that the scan and the registered extensions agree, and that
+ * the traversal skip rules (hidden dirs, node_modules) still hold.
+ */
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const { findSatsumaSourceFiles } = require("../dist/source-scan");
+
+describe("findSatsumaSourceFiles", () => {
+  let root;
+
+  before(() => {
+    // Minimal on-disk workspace: both extensions at mixed depths, plus
+    // locations the scan must ignore.
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "satsuma-scan-"));
+    fs.writeFileSync(path.join(root, "pipeline.stm"), "");
+    fs.writeFileSync(path.join(root, "ingest.satsuma"), "");
+    fs.writeFileSync(path.join(root, "README.md"), "");
+    fs.mkdirSync(path.join(root, "crm"));
+    fs.writeFileSync(path.join(root, "crm", "orders.satsuma"), "");
+    fs.mkdirSync(path.join(root, "node_modules", "dep"), { recursive: true });
+    fs.writeFileSync(path.join(root, "node_modules", "dep", "x.stm"), "");
+    fs.mkdirSync(path.join(root, ".git"));
+    fs.writeFileSync(path.join(root, ".git", "y.stm"), "");
+  });
+
+  after(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("finds .stm and .satsuma files at any depth (sl-v215)", () => {
+    const found = findSatsumaSourceFiles(root).map((p) => path.relative(root, p)).sort();
+    assert.deepEqual(found, ["crm/orders.satsuma", "ingest.satsuma", "pipeline.stm"]);
+  });
+
+  it("never descends into hidden directories or node_modules", () => {
+    // Dependency and VCS trees can contain .stm fixtures; indexing them would
+    // pollute cross-file navigation with definitions outside the workspace.
+    const found = findSatsumaSourceFiles(root);
+    assert.equal(found.some((p) => p.includes("node_modules") || p.includes(".git")), false);
+  });
+
+  it("returns an empty list for an unreadable or missing directory", () => {
+    // A permission error must degrade to "no files", not crash server startup.
+    assert.deepEqual(findSatsumaSourceFiles(path.join(root, "does-not-exist")), []);
+  });
+});

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
+        "@satsuma/core": "file:../satsuma-core",
         "@satsuma/lsp": "file:../satsuma-lsp",
         "vscode-languageclient": "^10.0.0"
       },
@@ -21,6 +22,19 @@
       },
       "engines": {
         "vscode": "^1.91.0"
+      }
+    },
+    "../satsuma-core": {
+      "name": "@satsuma/core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "web-tree-sitter": "^0.26.7"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
+        "typescript": "^6.0.2"
       }
     },
     "../satsuma-lsp": {
@@ -485,6 +499,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@satsuma/core": {
+      "resolved": "../satsuma-core",
+      "link": true
     },
     "node_modules/@satsuma/lsp": {
       "resolved": "../satsuma-lsp",

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -79,6 +79,10 @@
         "title": "Satsuma: Show Mapping Coverage"
       },
       {
+        "command": "satsuma.clearCoverage",
+        "title": "Satsuma: Clear Mapping Coverage"
+      },
+      {
         "command": "satsuma.showViz",
         "title": "Satsuma: Overview Visualization",
         "icon": "$(eye)"

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -126,7 +126,7 @@
       "explorer/context": [
         {
           "command": "satsuma.showViz",
-          "when": "resourceExtname == .stm",
+          "when": "resourceExtname == .stm || resourceExtname == .satsuma",
           "group": "satsuma"
         }
       ]
@@ -175,6 +175,7 @@
     "package": "npm run build && npx @vscode/vsce package --no-dependencies -o vscode-satsuma.vsix"
   },
   "dependencies": {
+    "@satsuma/core": "file:../satsuma-core",
     "@satsuma/lsp": "file:../satsuma-lsp",
     "vscode-languageclient": "^10.0.0"
   },

--- a/tooling/vscode-satsuma/src/commands/coverage-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage-logic.ts
@@ -1,0 +1,86 @@
+/**
+ * coverage-logic.ts — pure shaping of mapping-coverage results (no vscode).
+ *
+ * The LSP's satsuma/mappingCoverage response is a flat list of fields per
+ * schema; the editor overlay needs them grouped per file with hover text, and
+ * the status bar needs a target-coverage percentage. This module owns those
+ * two transformations so they stay unit-testable in plain Node; decoration
+ * types, editors, and the status bar live in coverage.ts (sl-89id).
+ */
+
+/** One schema's fields from the LSP satsuma/mappingCoverage response. */
+export interface CoverageSchema {
+  /** Identifier of the schema, as reported by the LSP. */
+  schemaId: string;
+  /** Whether the mapping reads from (source) or writes to (target) this schema. */
+  role: "source" | "target";
+  /** Every declared field with its location and whether the mapping touches it. */
+  fields: Array<{ path: string; uri: string; line: number; mapped: boolean }>;
+}
+
+/** A single gutter marker: where it goes and what its hover says. */
+export interface CoverageMarker {
+  /** Zero-based line of the field declaration. */
+  line: number;
+  /** Markdown hover text, e.g. `**customer.id** — used as source`. */
+  hoverMessage: string;
+}
+
+/** All gutter markers for one file, split by the icon they get. */
+export interface FileCoverageMarkers {
+  mapped: CoverageMarker[];
+  unmapped: CoverageMarker[];
+}
+
+/**
+ * Group coverage fields by the file they live in, with role-appropriate
+ * hover labels (source fields are "used / not used as source"; target
+ * fields are "mapped / unmapped"). Keys are the URIs reported by the LSP.
+ */
+export function groupCoverageByUri(
+  schemas: CoverageSchema[],
+): Map<string, FileCoverageMarkers> {
+  const byUri = new Map<string, FileCoverageMarkers>();
+  for (const schema of schemas) {
+    const mappedLabel = schema.role === "source" ? "used as source" : "mapped";
+    const unmappedLabel =
+      schema.role === "source" ? "not used as source" : "unmapped";
+    for (const f of schema.fields) {
+      let bucket = byUri.get(f.uri);
+      if (!bucket) {
+        bucket = { mapped: [], unmapped: [] };
+        byUri.set(f.uri, bucket);
+      }
+      const label = f.mapped ? mappedLabel : unmappedLabel;
+      const marker = { line: f.line, hoverMessage: `**${f.path}** — ${label}` };
+      (f.mapped ? bucket.mapped : bucket.unmapped).push(marker);
+    }
+  }
+  return byUri;
+}
+
+/** Status-bar summary of how much of the target schema the mapping fills. */
+export interface TargetCoverageStats {
+  /** Count of top-level target fields the mapping writes. */
+  mapped: number;
+  /** Count of all top-level target fields. */
+  total: number;
+  /** Whole-number percentage (mapped/total), 0 when the schema has no fields. */
+  pct: number;
+}
+
+/**
+ * Compute the target-coverage percentage shown in the status bar, counting
+ * only top-level fields (nested paths contain "." and would double-count
+ * their parent). Returns undefined when the result has no target schema.
+ */
+export function computeTargetCoverageStats(
+  schemas: CoverageSchema[],
+): TargetCoverageStats | undefined {
+  const target = schemas.find((s) => s.role === "target");
+  if (!target) return undefined;
+  const topLevel = target.fields.filter((f) => !f.path.includes("."));
+  const mapped = topLevel.filter((f) => f.mapped).length;
+  const total = topLevel.length;
+  return { mapped, total, pct: total > 0 ? Math.round((mapped / total) * 100) : 0 };
+}

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -1,36 +1,115 @@
+/**
+ * coverage.ts — vscode wiring for the mapping-coverage gutter overlay.
+ *
+ * Owns the decoration types, status-bar item, and editor lifecycle around the
+ * pure result shaping in coverage-logic.ts. One coverage overlay is active at
+ * a time: running the command replaces the previous overlay entirely, and the
+ * satsuma.clearCoverage command (also bound to the status-bar item) dismisses
+ * it. Decorations are applied to editors as they become visible — never by
+ * opening files, which used to yank editor focus once per schema (sl-89id).
+ */
+
 import * as vscode from "vscode";
 import { join } from "path";
 import { LanguageClient } from "vscode-languageclient/node";
 import { getEditorActionContext } from "./action-context";
+import {
+  CoverageSchema,
+  FileCoverageMarkers,
+  computeTargetCoverageStats,
+  groupCoverageByUri,
+} from "./coverage-logic";
 
+// ---------- Overlay state (one active coverage run at a time) ----------
+
+/**
+ * Decoration types for the current run. Created fresh per run and disposed on
+ * clear: disposing a TextEditorDecorationType is the only operation that
+ * removes its decorations from every editor, including tabs that are not
+ * currently visible — per-editor setDecorations(…, []) cannot reach those,
+ * which is exactly how stale icons survived earlier runs (sl-89id).
+ */
 let mappedDecoration: vscode.TextEditorDecorationType | undefined;
 let unmappedDecoration: vscode.TextEditorDecorationType | undefined;
+
+/** Status bar item showing target coverage %; clicking it clears the overlay. */
 let coverageBar: vscode.StatusBarItem | undefined;
+
+/**
+ * Markers of the active run, keyed by normalised document URI. Consulted when
+ * an affected file becomes visible so its icons appear without the command
+ * having to open (and focus) every file up front.
+ */
+let activeMarkers: Map<string, FileCoverageMarkers> | undefined;
+
+/** Normalise an LSP-reported URI for comparison with editor document URIs. */
+function normalizeUri(uri: string): string {
+  return vscode.Uri.parse(uri).toString();
+}
+
+/** Dispose the current overlay: all gutter icons everywhere, plus the bar. */
+function clearCoverageOverlay(): void {
+  mappedDecoration?.dispose();
+  unmappedDecoration?.dispose();
+  mappedDecoration = undefined;
+  unmappedDecoration = undefined;
+  activeMarkers = undefined;
+  coverageBar?.hide();
+}
+
+// ---------- Decoration application ----------
+
+/** Gutter icon size relative to the line height, shared by both icons. */
+const GUTTER_ICON_SIZE = "80%";
+
+function createDecorationTypes(extensionPath: string): void {
+  mappedDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: join(extensionPath, "icons", "mapped.svg"),
+    gutterIconSize: GUTTER_ICON_SIZE,
+    overviewRulerColor: "#4caf50",
+    overviewRulerLane: vscode.OverviewRulerLane.Left,
+  });
+  unmappedDecoration = vscode.window.createTextEditorDecorationType({
+    gutterIconPath: join(extensionPath, "icons", "unmapped.svg"),
+    gutterIconSize: GUTTER_ICON_SIZE,
+    overviewRulerColor: "#f44336",
+    overviewRulerLane: vscode.OverviewRulerLane.Left,
+  });
+}
+
+function toDecorationOptions(
+  markers: { line: number; hoverMessage: string }[],
+): vscode.DecorationOptions[] {
+  return markers.map((m) => ({
+    range: new vscode.Range(m.line, 0, m.line, 0),
+    hoverMessage: m.hoverMessage,
+  }));
+}
+
+/** Apply the active run's markers to one editor, if its file is affected. */
+function decorateEditor(editor: vscode.TextEditor): void {
+  if (!activeMarkers || !mappedDecoration || !unmappedDecoration) return;
+  const markers = activeMarkers.get(editor.document.uri.toString());
+  if (!markers) return;
+  editor.setDecorations(mappedDecoration, toDecorationOptions(markers.mapped));
+  editor.setDecorations(unmappedDecoration, toDecorationOptions(markers.unmapped));
+}
+
+// ---------- Command registration ----------
 
 export function registerCoverageCommand(
   context: vscode.ExtensionContext,
   _cliPath: string,
   client: LanguageClient,
 ): void {
-  mappedDecoration = vscode.window.createTextEditorDecorationType({
-    gutterIconPath: join(context.extensionPath, "icons", "mapped.svg"),
-    gutterIconSize: "80%",
-    overviewRulerColor: "#4caf50",
-    overviewRulerLane: vscode.OverviewRulerLane.Left,
-  });
-
-  unmappedDecoration = vscode.window.createTextEditorDecorationType({
-    gutterIconPath: join(context.extensionPath, "icons", "unmapped.svg"),
-    gutterIconSize: "80%",
-    overviewRulerColor: "#f44336",
-    overviewRulerLane: vscode.OverviewRulerLane.Left,
-  });
-
   coverageBar = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,
     100,
   );
-  context.subscriptions.push(mappedDecoration, unmappedDecoration, coverageBar);
+  // The bar doubles as the overlay's dismiss affordance.
+  coverageBar.command = "satsuma.clearCoverage";
+  context.subscriptions.push(coverageBar);
+  context.subscriptions.push({ dispose: clearCoverageOverlay });
 
   context.subscriptions.push(
     vscode.commands.registerCommand("satsuma.showCoverage", async () => {
@@ -47,14 +126,7 @@ export function registerCoverageCommand(
         return;
       }
 
-      let coverageResult: {
-        schemas: Array<{
-          schemaId: string;
-          role: "source" | "target";
-          fields: Array<{ path: string; uri: string; line: number; mapped: boolean }>;
-        }>;
-      };
-
+      let coverageResult: { schemas: CoverageSchema[] };
       try {
         coverageResult = await client.sendRequest("satsuma/mappingCoverage", {
           uri: editor.document.uri.toString(),
@@ -72,52 +144,46 @@ export function registerCoverageCommand(
         return;
       }
 
-      // Group fields by file URI so we make one showTextDocument call per file.
-      const byUri = new Map<string, {
-        mapped: vscode.DecorationOptions[];
-        unmapped: vscode.DecorationOptions[];
-      }>();
+      // Each run fully replaces the previous overlay — disposing the old
+      // decoration types removes stale icons from every file (sl-89id).
+      clearCoverageOverlay();
+      createDecorationTypes(context.extensionPath);
 
-      for (const schema of coverageResult.schemas) {
-        const srcLabel = schema.role === "source" ? "used as source" : "mapped";
-        const tgtLabel = schema.role === "source" ? "not used as source" : "unmapped";
-        for (const f of schema.fields) {
-          if (!byUri.has(f.uri)) byUri.set(f.uri, { mapped: [], unmapped: [] });
-          const bucket = byUri.get(f.uri)!;
-          const range = new vscode.Range(f.line, 0, f.line, 0);
-          if (f.mapped) {
-            bucket.mapped.push({ range, hoverMessage: `**${f.path}** — ${srcLabel}` });
-          } else {
-            bucket.unmapped.push({ range, hoverMessage: `**${f.path}** — ${tgtLabel}` });
-          }
-        }
+      const grouped = groupCoverageByUri(coverageResult.schemas);
+      activeMarkers = new Map(
+        [...grouped].map(([uri, markers]) => [normalizeUri(uri), markers]),
+      );
+
+      // Decorate only what is already on screen; other affected files get
+      // their icons when they become visible. Never open files here — one
+      // showTextDocument per schema used to churn the visible editor.
+      for (const visible of vscode.window.visibleTextEditors) {
+        decorateEditor(visible);
       }
 
-      // Apply decorations to each affected file.
-      for (const [uri, { mapped, unmapped }] of byUri) {
-        const doc = await vscode.workspace.openTextDocument(vscode.Uri.parse(uri));
-        const schemaEditor = await vscode.window.showTextDocument(doc, { preserveFocus: true });
-        schemaEditor.setDecorations(mappedDecoration!, mapped);
-        schemaEditor.setDecorations(unmappedDecoration!, unmapped);
-      }
-
-      // Status bar: show target coverage %.
-      const targetSchema = coverageResult.schemas.find((s) => s.role === "target");
-      if (targetSchema) {
-        const total = targetSchema.fields.filter((f) => !f.path.includes(".")).length;
-        const mapped = targetSchema.fields.filter((f) => !f.path.includes(".") && f.mapped).length;
-        const pct = total > 0 ? Math.round((mapped / total) * 100) : 0;
-        coverageBar!.text = `$(check) Coverage: ${pct}%`;
-        coverageBar!.tooltip = `${mapped}/${total} target fields mapped by '${mappingName}'`;
-        coverageBar!.show();
+      const stats = computeTargetCoverageStats(coverageResult.schemas);
+      if (stats && coverageBar) {
+        coverageBar.text = `$(check) Coverage: ${stats.pct}%`;
+        coverageBar.tooltip =
+          `${stats.mapped}/${stats.total} target fields mapped by ` +
+          `'${mappingName}' — click to clear coverage icons`;
+        coverageBar.show();
       }
     }),
   );
 
-  // Clear decorations when switching editors.
+  // Explicit dismissal for the whole overlay (also reachable via the bar).
   context.subscriptions.push(
-    vscode.window.onDidChangeActiveTextEditor(() => {
-      if (coverageBar) coverageBar.hide();
+    vscode.commands.registerCommand("satsuma.clearCoverage", () => {
+      clearCoverageOverlay();
+    }),
+  );
+
+  // Late decoration: an affected file opened or revealed after the run still
+  // gets its icons, replacing the old behaviour of force-opening every file.
+  context.subscriptions.push(
+    vscode.window.onDidChangeVisibleTextEditors((editors) => {
+      for (const e of editors) decorateEditor(e);
     }),
   );
 }

--- a/tooling/vscode-satsuma/src/commands/entry-file-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/entry-file-logic.ts
@@ -2,48 +2,48 @@
  * entry-file-logic.ts — pure entry-file selection rules (no vscode imports).
  *
  * Since ADR-022 the Satsuma CLI rejects directory arguments: a workspace is
- * defined by a .stm entry file plus its transitive imports. Every extension
- * feature that shells out to the CLI must therefore name a concrete .stm
- * file. This module owns the *decision rules* for which file that should be;
- * the vscode wiring (active editor, file search, quick pick) lives in
- * entry-file.ts so these rules stay unit-testable in plain Node (sl-1ycv).
+ * defined by a Satsuma entry file plus its transitive imports. Every extension
+ * feature that shells out to the CLI must therefore name a concrete source
+ * file (.stm or .satsuma — see @satsuma/core source-files, sl-v215). This
+ * module owns the *decision rules* for which file that should be; the vscode
+ * wiring (active editor, file search, quick pick) lives in entry-file.ts so
+ * these rules stay unit-testable in plain Node (sl-1ycv).
  */
 
-/** File extension that marks a Satsuma source file. */
-const STM_EXTENSION = ".stm";
+import { isSatsumaFilePath } from "@satsuma/core/source-files";
 
 /** Outcome of classifying the available entry-file candidates. */
 export type EntryFileResolution =
-  /** The active editor is a .stm file — use it without prompting. */
+  /** The active editor is a Satsuma file — use it without prompting. */
   | { kind: "active"; fsPath: string }
-  /** Exactly one .stm file exists in the workspace — use it without prompting. */
+  /** Exactly one Satsuma file exists in the workspace — use it without prompting. */
   | { kind: "single"; fsPath: string }
-  /** Several .stm files and no active one — the caller must ask the user. */
+  /** Several Satsuma files and no active one — the caller must ask the user. */
   | { kind: "ambiguous"; candidates: string[] }
-  /** No .stm files in the workspace at all. */
+  /** No Satsuma files in the workspace at all. */
   | { kind: "none" };
 
 /**
- * Decide which .stm file should anchor a CLI invocation.
+ * Decide which Satsuma file should anchor a CLI invocation.
  *
- * Priority: the active editor's file when it is a .stm file (the user is
+ * Priority: the active editor's file when it is a Satsuma file (the user is
  * looking at it — it is the least surprising workspace root), else the only
- * .stm file when there is exactly one, else an ambiguous result carrying the
- * candidates ordered for a quick pick. Returns `none` when the workspace has
- * no .stm files.
+ * Satsuma file when there is exactly one, else an ambiguous result carrying
+ * the candidates ordered for a quick pick. Returns `none` when the workspace
+ * has no Satsuma files.
  */
 export function classifyEntryFileCandidates(
   activeEditorFsPath: string | undefined,
-  workspaceStmFiles: string[],
+  workspaceSourceFiles: string[],
 ): EntryFileResolution {
-  if (activeEditorFsPath && activeEditorFsPath.endsWith(STM_EXTENSION)) {
+  if (activeEditorFsPath && isSatsumaFilePath(activeEditorFsPath)) {
     return { kind: "active", fsPath: activeEditorFsPath };
   }
-  if (workspaceStmFiles.length === 1) {
-    return { kind: "single", fsPath: workspaceStmFiles[0] };
+  if (workspaceSourceFiles.length === 1) {
+    return { kind: "single", fsPath: workspaceSourceFiles[0] };
   }
-  if (workspaceStmFiles.length > 1) {
-    return { kind: "ambiguous", candidates: orderCandidatesForPick(workspaceStmFiles) };
+  if (workspaceSourceFiles.length > 1) {
+    return { kind: "ambiguous", candidates: orderCandidatesForPick(workspaceSourceFiles) };
   }
   return { kind: "none" };
 }

--- a/tooling/vscode-satsuma/src/commands/entry-file.ts
+++ b/tooling/vscode-satsuma/src/commands/entry-file.ts
@@ -8,14 +8,15 @@
  */
 
 import * as vscode from "vscode";
+import { SATSUMA_FILE_GLOB } from "@satsuma/core/source-files";
 import { classifyEntryFileCandidates } from "./entry-file-logic";
 
 /**
- * Cap on the workspace .stm search. Far above any realistic workspace size —
- * it only guards against pathological folders (e.g. a home directory opened
- * by accident).
+ * Cap on the workspace source-file search. Far above any realistic workspace
+ * size — it only guards against pathological folders (e.g. a home directory
+ * opened by accident).
  */
-const MAX_STM_SEARCH_RESULTS = 200;
+const MAX_SOURCE_SEARCH_RESULTS = 200;
 
 /**
  * The user's last quick-pick choice, offered as the top item next time.
@@ -25,11 +26,11 @@ const MAX_STM_SEARCH_RESULTS = 200;
 let lastPickedEntryFile: string | undefined;
 
 /**
- * Resolve the .stm file that anchors a CLI invocation, prompting only when
- * the workspace is genuinely ambiguous (several .stm files and none active).
- * Returns undefined when the user dismisses the prompt or the workspace has
- * no .stm files — callers must abort their CLI call in that case, never
- * substitute a directory.
+ * Resolve the Satsuma file (.stm or .satsuma) that anchors a CLI invocation,
+ * prompting only when the workspace is genuinely ambiguous (several source
+ * files and none active). Returns undefined when the user dismisses the
+ * prompt or the workspace has no Satsuma files — callers must abort their
+ * CLI call in that case, never substitute a directory.
  */
 export async function resolveEntryFile(): Promise<string | undefined> {
   const activeDoc = vscode.window.activeTextEditor?.document;
@@ -37,9 +38,9 @@ export async function resolveEntryFile(): Promise<string | undefined> {
     activeDoc && !activeDoc.isUntitled ? activeDoc.uri.fsPath : undefined;
 
   const found = await vscode.workspace.findFiles(
-    "**/*.stm",
+    SATSUMA_FILE_GLOB,
     "**/node_modules/**",
-    MAX_STM_SEARCH_RESULTS,
+    MAX_SOURCE_SEARCH_RESULTS,
   );
 
   const resolution = classifyEntryFileCandidates(
@@ -79,7 +80,7 @@ export async function resolveEntryFile(): Promise<string | undefined> {
 
     case "none":
       vscode.window.showInformationMessage(
-        "No .stm files found in this workspace.",
+        "No Satsuma files (.stm or .satsuma) found in this workspace.",
       );
       return undefined;
   }

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import * as vscode from "vscode";
 import { ExtensionContext, window, workspace } from "vscode";
+import { SATSUMA_FILE_GLOB } from "@satsuma/core/source-files";
 import {
   LanguageClient,
   LanguageClientOptions,
@@ -42,10 +43,9 @@ export function activate(context: ExtensionContext): void {
       cliPath,
     },
     synchronize: {
-      fileEvents: [
-        workspace.createFileSystemWatcher("**/*.stm"),
-        workspace.createFileSystemWatcher("**/*.satsuma"),
-      ],
+      // One watcher covering every registered Satsuma extension — the server
+      // gates incoming events with the same shared predicate (sl-v215).
+      fileEvents: [workspace.createFileSystemWatcher(SATSUMA_FILE_GLOB)],
     },
   };
 

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -9,6 +9,7 @@ import {
   loadFullLineageModel,
   vizThemeForKind,
 } from "./integration";
+import { RefreshGate } from "./refresh-gate";
 
 export class VizPanel {
   static currentPanel: VizPanel | undefined;
@@ -19,6 +20,12 @@ export class VizPanel {
   private disposables: vscode.Disposable[] = [];
   /** URI of the last successfully loaded .stm file — used by Refresh to reload without requiring focus. */
   private _lastUri: string | undefined;
+  /**
+   * Latest-wins ordering for overlapping loads: save/editor watchers and
+   * manual refresh can race, and a slow earlier LSP response must not
+   * overwrite a newer model in the webview (sl-jar4).
+   */
+  private readonly refreshGate = new RefreshGate();
 
   static createOrShow(
     extensionUri: vscode.Uri,
@@ -121,12 +128,18 @@ export class VizPanel {
       return;
     }
 
+    // Stamp this load; any result (success or error) arriving after a newer
+    // load has started is stale and must be dropped, not rendered (sl-jar4).
+    const generation = this.refreshGate.begin();
+
     try {
       const modelEnvelope = await loadFullLineageModel(
         this.client,
         uri,
         vscode.window.activeColorTheme.kind,
       );
+      if (!this.refreshGate.isCurrent(generation)) return;
+
       if (!modelEnvelope) {
         this.panel.webview.postMessage({
           type: "error",
@@ -144,6 +157,7 @@ export class VizPanel {
         theme: modelEnvelope.theme,
       });
     } catch (err) {
+      if (!this.refreshGate.isCurrent(generation)) return;
       this.panel.webview.postMessage({
         type: "error",
         message: `Failed to load VizModel: ${err instanceof Error ? err.message : String(err)}`,
@@ -213,6 +227,11 @@ export class VizPanel {
         ? editor.document.uri.toString()
         : undefined) ?? this._lastUri ?? "";
 
+    // An expansion is computed against the model currently in the webview.
+    // If a refresh starts while the request is in flight, the expansion
+    // belongs to the replaced model and must be dropped (sl-jar4).
+    const baseGeneration = this.refreshGate.latest();
+
     try {
       const expandedEnvelope = await loadExpandedModels(
         this.client,
@@ -220,6 +239,7 @@ export class VizPanel {
         currentUri,
         vscode.window.activeColorTheme.kind,
       );
+      if (!this.refreshGate.isCurrent(baseGeneration)) return;
 
       if (expandedEnvelope.models.length === 0) {
         return;
@@ -233,6 +253,7 @@ export class VizPanel {
         theme: expandedEnvelope.theme,
       });
     } catch (err) {
+      if (!this.refreshGate.isCurrent(baseGeneration)) return;
       this.panel.webview.postMessage({
         type: "error",
         message: `Failed to expand lineage: ${err instanceof Error ? err.message : String(err)}`,

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { join } from "path";
+import { isSatsumaFilePath } from "@satsuma/core/source-files";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { FieldLineagePanel } from "../field-lineage/panel";
 import { resolveEntryFile } from "../../commands/entry-file";
@@ -68,7 +69,7 @@ export class VizPanel {
 
     // Refresh on save
     const saveWatcher = vscode.workspace.onDidSaveTextDocument((doc) => {
-      if (doc.fileName.endsWith(".stm") || doc.fileName.endsWith(".satsuma")) {
+      if (isSatsumaFilePath(doc.fileName)) {
         this.refresh();
       }
     });

--- a/tooling/vscode-satsuma/src/webview/viz/refresh-gate.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/refresh-gate.ts
@@ -1,0 +1,40 @@
+/**
+ * refresh-gate.ts — latest-wins guard for overlapping async loads (sl-jar4).
+ *
+ * The viz panel refreshes on save, on active-editor change, and on manual
+ * request; nothing serialises the LSP round-trips those trigger, so a slow
+ * earlier response could land after a newer one and overwrite fresh webview
+ * state with stale data. This module owns only the ordering rule: each load
+ * takes a token, and only the holder of the newest token may publish its
+ * result. It knows nothing about VS Code or the LSP, so the rule stays
+ * unit-testable in plain Node.
+ */
+
+/**
+ * Monotonic generation counter shared by all loads that publish to one
+ * consumer (one webview). Begin a load with {@link begin}; before publishing
+ * its result, check {@link isCurrent} and drop the result if it fails.
+ */
+export class RefreshGate {
+  /** Generation of the most recently started load. */
+  private generation = 0;
+
+  /** Start a new load, superseding every load started earlier. */
+  begin(): number {
+    return ++this.generation;
+  }
+
+  /**
+   * Token of the most recently started load, without superseding it. Lets a
+   * dependent request (e.g. lineage expansion) detect that the model it was
+   * computed against has since been replaced.
+   */
+  latest(): number {
+    return this.generation;
+  }
+
+  /** True while no newer load has started since `token` was issued. */
+  isCurrent(token: number): boolean {
+    return token === this.generation;
+  }
+}

--- a/tooling/vscode-satsuma/test/coverage-logic.test.js
+++ b/tooling/vscode-satsuma/test/coverage-logic.test.js
@@ -1,0 +1,95 @@
+/**
+ * coverage-logic.test.js — shaping of mapping-coverage results (sl-89id).
+ *
+ * The gutter overlay and status bar are driven entirely by these two pure
+ * transformations; regressions here mean wrong hover labels, icons on the
+ * wrong files, or a wrong coverage percentage in the status bar.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  groupCoverageByUri,
+  computeTargetCoverageStats,
+} = require("../dist/client/commands/coverage-logic.js");
+
+/** Minimal two-schema coverage result spanning two files. */
+function sampleSchemas() {
+  return [
+    {
+      schemaId: "customers",
+      role: "source",
+      fields: [
+        { path: "id", uri: "file:///ws/src.stm", line: 2, mapped: true },
+        { path: "internal_note", uri: "file:///ws/src.stm", line: 3, mapped: false },
+      ],
+    },
+    {
+      schemaId: "dim_customer",
+      role: "target",
+      fields: [
+        { path: "customer_id", uri: "file:///ws/tgt.stm", line: 5, mapped: true },
+        { path: "segment", uri: "file:///ws/tgt.stm", line: 6, mapped: false },
+        // Nested path: must appear as a marker but not count toward the
+        // status-bar percentage (its parent already counts).
+        { path: "address.city", uri: "file:///ws/tgt.stm", line: 7, mapped: true },
+      ],
+    },
+  ];
+}
+
+describe("groupCoverageByUri", () => {
+  it("groups markers under the file each field lives in", () => {
+    // Fields from different schemas land in different files; an icon in the
+    // wrong file would mislabel a different schema's field entirely.
+    const byUri = groupCoverageByUri(sampleSchemas());
+    assert.deepEqual([...byUri.keys()].sort(), [
+      "file:///ws/src.stm",
+      "file:///ws/tgt.stm",
+    ]);
+    assert.equal(byUri.get("file:///ws/src.stm").mapped.length, 1);
+    assert.equal(byUri.get("file:///ws/src.stm").unmapped.length, 1);
+    assert.equal(byUri.get("file:///ws/tgt.stm").mapped.length, 2);
+  });
+
+  it("labels hovers by schema role: source usage vs target mapping", () => {
+    // A source field is "used", a target field is "mapped" — swapping the
+    // vocabulary makes the hover claim the opposite data-flow direction.
+    const byUri = groupCoverageByUri(sampleSchemas());
+    assert.equal(
+      byUri.get("file:///ws/src.stm").mapped[0].hoverMessage,
+      "**id** — used as source",
+    );
+    assert.equal(
+      byUri.get("file:///ws/src.stm").unmapped[0].hoverMessage,
+      "**internal_note** — not used as source",
+    );
+    assert.equal(
+      byUri.get("file:///ws/tgt.stm").unmapped[0].hoverMessage,
+      "**segment** — unmapped",
+    );
+  });
+});
+
+describe("computeTargetCoverageStats", () => {
+  it("counts only top-level target fields toward the percentage", () => {
+    // address.city is nested: counting it would report 2/3 mapped instead of
+    // the 1/2 the user sees at the schema's top level.
+    const stats = computeTargetCoverageStats(sampleSchemas());
+    assert.deepEqual(stats, { mapped: 1, total: 2, pct: 50 });
+  });
+
+  it("returns undefined when the result has no target schema", () => {
+    // Without a target there is no meaningful percentage — the status bar
+    // must stay hidden rather than show a fabricated 0%.
+    const sourceOnly = sampleSchemas().filter((s) => s.role === "source");
+    assert.equal(computeTargetCoverageStats(sourceOnly), undefined);
+  });
+
+  it("reports 0% for an empty target schema instead of dividing by zero", () => {
+    const stats = computeTargetCoverageStats([
+      { schemaId: "empty", role: "target", fields: [] },
+    ]);
+    assert.deepEqual(stats, { mapped: 0, total: 0, pct: 0 });
+  });
+});

--- a/tooling/vscode-satsuma/test/entry-file-logic.test.js
+++ b/tooling/vscode-satsuma/test/entry-file-logic.test.js
@@ -2,9 +2,9 @@
  * Tests for the pure entry-file selection rules (sl-1ycv).
  *
  * Since ADR-022 the CLI rejects directory arguments, so every extension CLI
- * invocation must name a .stm file. These rules decide which file that is;
- * regressions here mean the extension either prompts when it shouldn't or
- * silently picks a surprising workspace root.
+ * invocation must name a Satsuma source file (.stm or .satsuma, sl-v215).
+ * These rules decide which file that is; regressions here mean the extension
+ * either prompts when it shouldn't or silently picks a surprising root.
  */
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
@@ -24,11 +24,22 @@ describe("classifyEntryFileCandidates", () => {
     assert.deepEqual(res, { kind: "active", fsPath: "/ws/crm/pipeline.stm" });
   });
 
-  // A non-.stm active editor (e.g. README.md) must not be passed to the CLI —
-  // that is exactly the class of bad argument ADR-022 rejects.
-  it("ignores a non-.stm active editor and falls through to the workspace files", () => {
+  // A non-Satsuma active editor (e.g. README.md) must not be passed to the
+  // CLI — that is exactly the class of bad argument ADR-022 rejects.
+  it("ignores a non-Satsuma active editor and falls through to the workspace files", () => {
     const res = classifyEntryFileCandidates("/ws/README.md", ["/ws/pipeline.stm"]);
     assert.deepEqual(res, { kind: "single", fsPath: "/ws/pipeline.stm" });
+  });
+
+  // .satsuma is registered alongside .stm; an active .satsuma editor was
+  // previously skipped here, leaving the user with "No .stm files found"
+  // in an all-.satsuma workspace (sl-v215).
+  it("uses the active editor's file when it is a .satsuma file (sl-v215)", () => {
+    const res = classifyEntryFileCandidates("/ws/pipeline.satsuma", [
+      "/ws/pipeline.satsuma",
+      "/ws/other.stm",
+    ]);
+    assert.deepEqual(res, { kind: "active", fsPath: "/ws/pipeline.satsuma" });
   });
 
   it("uses the only .stm file in the workspace without prompting", () => {

--- a/tooling/vscode-satsuma/test/refresh-gate.test.js
+++ b/tooling/vscode-satsuma/test/refresh-gate.test.js
@@ -1,0 +1,76 @@
+/**
+ * refresh-gate.test.js — latest-wins ordering for overlapping viz loads.
+ *
+ * sl-jar4: save/editor watchers plus manual refresh can trigger overlapping
+ * LSP loads with no cancellation, so a slow earlier response could render
+ * after a newer one and leave the webview showing stale data. These cases
+ * pin the ordering rule the panel relies on: only the newest load (or a
+ * dependent request whose base model is still current) may publish.
+ */
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { RefreshGate } = require("../dist/client/webview/viz/refresh-gate.js");
+
+/** A manually-resolvable promise, to script completion order in tests. */
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+describe("RefreshGate", () => {
+  it("discards an earlier load that completes after a newer one (sl-jar4)", async () => {
+    // The exact bug scenario: load A starts (slow), load B starts (fast),
+    // B completes and renders, then A completes — A's result must be dropped
+    // so the webview keeps B's newer model.
+    const gate = new RefreshGate();
+    const rendered = [];
+
+    const slowResponse = deferred();
+    const fastResponse = deferred();
+
+    const loadA = (async () => {
+      const token = gate.begin();
+      const model = await slowResponse.promise;
+      if (gate.isCurrent(token)) rendered.push(model);
+    })();
+    const loadB = (async () => {
+      const token = gate.begin();
+      const model = await fastResponse.promise;
+      if (gate.isCurrent(token)) rendered.push(model);
+    })();
+
+    fastResponse.resolve("newer-model");
+    await loadB;
+    slowResponse.resolve("stale-model");
+    await loadA;
+
+    assert.deepEqual(rendered, ["newer-model"]);
+  });
+
+  it("lets sequential loads each publish in turn", () => {
+    // Non-overlapping refreshes are the common case and must all render —
+    // the gate only suppresses results that have been superseded.
+    const gate = new RefreshGate();
+    const first = gate.begin();
+    assert.equal(gate.isCurrent(first), true);
+    const second = gate.begin();
+    assert.equal(gate.isCurrent(second), true);
+    assert.equal(gate.isCurrent(first), false);
+  });
+
+  it("invalidates a dependent request when its base model is superseded", () => {
+    // Lineage expansion reads the latest token without superseding it: an
+    // expansion started against model N must be dropped once a refresh has
+    // replaced the model, but must not itself block that refresh.
+    const gate = new RefreshGate();
+    gate.begin();
+
+    const expansionBase = gate.latest();
+    assert.equal(gate.isCurrent(expansionBase), true, "no refresh yet — expansion may publish");
+
+    gate.begin();
+    assert.equal(gate.isCurrent(expansionBase), false, "model replaced — expansion is stale");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the three open VS Code bug-hunt tickets as a batch.

### sl-v215 — `.satsuma` was half-supported across the toolchain
The extension registered `.satsuma` alongside `.stm` (f2v-hp48), but the LSP watched-file gate, the LSP workspace scan, entry-file resolution, and the explorer context menu all hard-coded `.endsWith(".stm")` — a `.satsuma` workspace got highlighting but no cross-file features and "No .stm files found". **Decision: support `.satsuma` everywhere.** The extension policy now lives in one place, `@satsuma/core` `source-files` (`SATSUMA_FILE_EXTENSIONS`, `SATSUMA_FILE_GLOB`, `isSatsumaFilePath`, with a subpath export so the client bundle doesn't pull in the parser). The LSP workspace scan moved to a testable `source-scan` module; the client builds its single file watcher from the shared glob. The CLI was already extension-agnostic.

### sl-jar4 — VizPanel stale refreshes could overwrite newer models
Save/editor watchers plus manual refresh could trigger overlapping `loadFullLineageModel` calls with no cancellation, so a slow earlier LSP response could `postMessage` after a newer one. Loads now take a token from a `RefreshGate` (pure latest-wins counter, unit-tested for out-of-order completion); superseded results **and errors** are dropped, and lineage expansions are discarded when the base model they were computed against has been replaced mid-flight.

### sl-89id — coverage gutter icons never cleared, focus churn
Coverage decorations were never removed, so stale icons survived across runs indefinitely, and one `showTextDocument` call per affected file churned the visible editor. Decoration types are now created per run and disposed when replaced (disposal is the only operation that clears non-visible tabs); markers apply to editors as they become visible instead of force-opening files; new **Satsuma: Clear Mapping Coverage** command, also bound to the status-bar item, dismisses the overlay. Result shaping extracted to a pure `coverage-logic` module.

## Tests

- `@satsuma/core`: 419 pass (4 new: source-files policy)
- `satsuma-lsp`: 293 pass (3 new: source scan incl. `.satsuma`, skip rules)
- `vscode-satsuma`: 30 unit + fixtures/golden pass (8 new: refresh-gate out-of-order race, coverage grouping/stats, `.satsuma` entry-file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)