### PR TITLE
chore(lsp): migrate to vscode-languageserver 10 (sl-w9zz)

### DIFF
--- a/.tickets/sl-w9zz.md
+++ b/.tickets/sl-w9zz.md
@@ -1,0 +1,26 @@
+---
+id: sl-w9zz
+status: closed
+deps: []
+links: []
+created: 2026-06-11T21:46:46Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+external-ref: gh-297
+---
+# Migrate satsuma-lsp to vscode-languageserver 10 (dependabot #297)
+
+Dependabot PR #297 bumps vscode-languageserver 9.0.1 -> 10.0.0 in tooling/satsuma-lsp. v10 (LSP spec 3.18) ships an exports map that the legacy moduleResolution 'node' cannot resolve, so tsc fails with TS2307 across the LSP sources. The VS Code extension already uses vscode-languageclient ^10.0.0, so client/server libs are straddling major versions; aligning on 10 is the intended state.
+
+## Acceptance Criteria
+
+vscode-languageserver bumped to ^10.0.0 in tooling/satsuma-lsp; tsconfig updated to node16 module resolution; LSP test suite passes locally; vscode-satsuma extension compiles and its tests pass; dependabot PR #297 superseded/closed
+
+
+## Notes
+
+**2026-06-11T21:54:50Z**
+
+Cause: vscode-languageserver 10 (LSP 3.18) ships an exports map invisible to the legacy 'node' moduleResolution, so every import failed with TS2307; two real type changes (Diagnostic.message widened to string | MarkupContent, stricter onRequest generics exposing a partial ActionContext fallback) also surfaced.
+Fix: bumped to ^10.0.0, switched tsconfig to nodenext (retiring the @satsuma/* paths workarounds), handled both message forms in ensureNonEmptyMessages, and completed the actionContext fallback object (commit 86abc15).

--- a/tooling/satsuma-cli/package-lock.json
+++ b/tooling/satsuma-cli/package-lock.json
@@ -33,12 +33,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/tooling/satsuma-lsp/package-lock.json
+++ b/tooling/satsuma-lsp/package-lock.json
@@ -11,7 +11,7 @@
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
-        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "web-tree-sitter": "^0.26.7"
       },
@@ -30,12 +30,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "../satsuma-viz-backend": {
@@ -45,7 +45,7 @@
       "dependencies": {
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
-        "vscode-languageserver-types": "^3.17.5"
+        "vscode-languageserver-types": "^3.18.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -58,9 +58,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -1205,34 +1205,34 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.0.0.tgz",
+      "integrity": "sha512-KOdOVuBnNO5EZSejlEDdRPJWpJn/X87vR2TmOXneHsxSYY7mYjgc1SxeZPMoHICcBKTUnM0V19+WP4J92zDd1w==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.0"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
+      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -1242,9 +1242,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/web-tree-sitter": {

--- a/tooling/satsuma-lsp/package.json
+++ b/tooling/satsuma-lsp/package.json
@@ -22,7 +22,7 @@
     "@satsuma/core": "file:../satsuma-core",
     "@satsuma/viz-backend": "file:../satsuma-viz-backend",
     "@satsuma/viz-model": "file:../satsuma-viz-model",
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.0.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "web-tree-sitter": "^0.26.7"
   },

--- a/tooling/satsuma-lsp/src/diagnostics.ts
+++ b/tooling/satsuma-lsp/src/diagnostics.ts
@@ -52,10 +52,20 @@ export function computeDiagnostics(tree: Tree): Diagnostic[] {
  */
 export function ensureNonEmptyMessages(diags: Diagnostic[]): Diagnostic[] {
   return diags.map((d) =>
-    d.message.trim()
+    hasNonEmptyMessage(d)
       ? d
       : { ...d, message: d.code ? `Diagnostic '${d.code}' (no message)` : "Diagnostic (no message)" },
   );
+}
+
+/**
+ * Since LSP 3.18 a diagnostic message may be plain text or MarkupContent
+ * (markdown/plaintext with an explicit kind); the markup form carries its
+ * text in `.value`. Treat whitespace-only text as empty in both forms.
+ */
+function hasNonEmptyMessage(d: Diagnostic): boolean {
+  const text = typeof d.message === "string" ? d.message : d.message.value;
+  return text.trim().length > 0;
 }
 
 /** Collect //! and //? comments as diagnostics. */

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -448,7 +448,7 @@ connection.onRequest(
     };
   }) => {
     const tree = trees.get(params.uri);
-    if (!tree) return { schemaName: null, fieldPath: null };
+    if (!tree) return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
     return computeActionContext(
       tree,
       params.position.line,

--- a/tooling/satsuma-lsp/tsconfig.json
+++ b/tooling/satsuma-lsp/tsconfig.json
@@ -1,18 +1,13 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "baseUrl": ".",
     "ignoreDeprecations": "6.0",
     "target": "es2022",
     "types": ["node"],
     "paths": {
-      "web-tree-sitter": ["./src/web-tree-sitter.d.ts"],
-      "@satsuma/core": ["./node_modules/@satsuma/core/dist/index.d.ts"],
-      "@satsuma/core/format": ["./node_modules/@satsuma/core/dist/format.d.ts"],
-      "@satsuma/viz-backend": ["./node_modules/@satsuma/viz-backend/dist/index.d.ts"],
-      "@satsuma/viz-backend/workspace-index": ["./node_modules/@satsuma/viz-backend/dist/workspace-index.d.ts"],
-      "@satsuma/viz-backend/viz-model": ["./node_modules/@satsuma/viz-backend/dist/viz-model.d.ts"]
+      "web-tree-sitter": ["./src/web-tree-sitter.d.ts"]
     },
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -24,12 +24,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "../satsuma-viz-model": {
@@ -37,9 +37,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -25,12 +25,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "../satsuma-viz-backend": {
@@ -40,7 +40,7 @@
       "dependencies": {
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
-        "vscode-languageserver-types": "^3.17.5"
+        "vscode-languageserver-types": "^3.18.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -53,9 +53,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -26,12 +26,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "../satsuma-viz-model": {
@@ -39,9 +39,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -40,7 +40,7 @@
       "devDependencies": {
         "@types/node": "^25.5.0",
         "c8": "^11.0.0",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.0",
         "typescript": "^6.0.2"
       }
     },


### PR DESCRIPTION
Supersedes dependabot PR #297, which could not merge as-is: `vscode-languageserver` 10 (LSP spec 3.18) ships an `exports` map that the LSP package's legacy `moduleResolution: "node"` could not see, failing compilation with TS2307 on every import.

## Changes

- **Bump `vscode-languageserver` 9.0.1 → ^10.0.0** in `tooling/satsuma-lsp`. This aligns the server library with `vscode-languageclient ^10.0.0` already used by the VS Code extension — the two are released in lockstep upstream.
- **tsconfig: `module`/`moduleResolution` → `nodenext`.** Reads exports maps natively and models Node ≥20.19's `require(esm)` — the runtime behaviour the test build already relied on, since `@satsuma/core` is ESM and the tsc-emitted CJS output `require`s it. Also retires the `paths` workarounds for the `@satsuma/*` packages (their exports maps now resolve directly); only the `web-tree-sitter` typing override remains.
- **Two genuine v10 type fixes:**
  - `Diagnostic.message` is now `string | MarkupContent` — `ensureNonEmptyMessages` reads the text from either form via a new `hasNonEmptyMessage` helper.
  - The `satsuma/actionContext` no-tree fallback returned a partial `ActionContext` (missing `mappingName`/`targetSchema`) — a latent bug that v10's stricter `onRequest` generics caught.
- **Consumer lockfile sync** (separate commit): refreshes the embedded `file:` dependency manifests in five consumer lockfiles after today's dependabot merges.

## Verification

- `tsc --noEmit` clean in `satsuma-lsp`
- LSP test suite: 290/290 pass
- VS Code extension `npm run check`: validate + 21 unit tests + tmgrammar fixtures/golden all pass
- esbuild bundle builds; `npm run smoke` initializes the server OK
- `npm audit`: 0 vulnerabilities

Closes sl-w9zz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)