### PR TITLE
docs(site): refresh test and command counts to verified values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `useful-prompts/`: self-contained system prompts for web LLMs (Excel-to-Satsuma, Satsuma-to-Excel)
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
-- `tooling/tree-sitter-satsuma/`: tree-sitter grammar (482 corpus tests), generated parser artifacts, and queries
-- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (637 tests)
+- `tooling/tree-sitter-satsuma/`: tree-sitter grammar (315 corpus tests), generated parser artifacts, and queries
+- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (879 tests)
 - `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio`
 - `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp`
 

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ Start with Lesson 01 or jump to a [suggested reading path](lessons/README.md#sug
 What exists today:
 
 - the Satsuma v2 language specification
-- a canonical example corpus (20 `.stm` files covering major integration patterns)
-- a tree-sitter parser (245 corpus tests, all examples parse clean)
+- a canonical example corpus (25 `.stm` files covering major integration patterns)
+- a tree-sitter parser (315 corpus tests, all examples parse clean)
 - a TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting) and TextMate grammar

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -1,9 +1,9 @@
 ---
 layout: default.njk
 title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
-description: "The Satsuma CLI gives AI agents 21 deterministic, parser-backed commands to slice, query, and validate Satsuma workspaces. Humans use it for formatting, validation, and linting."
+description: "The Satsuma CLI gives AI agents 22 deterministic, parser-backed commands to slice, query, and validate Satsuma workspaces. Humans use it for formatting, validation, and linting."
 og_title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
-og_description: "Give your AI agent 21 commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
+og_description: "Give your AI agent 22 commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
 nav_id: cli
 permalink: cli.html
 ---
@@ -14,13 +14,13 @@ permalink: cli.html
         <div>
           <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-6">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-            21 commands &middot; 824 tests
+            22 commands &middot; 879 tests
           </div>
           <h1 class="text-4xl sm:text-5xl font-extrabold text-charcoal leading-tight mb-6">
             The agent's <span class="text-orange">toolkit</span> for Satsuma
           </h1>
           <p class="text-lg text-warm-gray leading-relaxed mb-4">
-            The Satsuma CLI is built for AI agents. 21 parser-backed commands let your agent slice workspaces, trace lineage, extract metadata, and pull NL intent &mdash; all from the parse tree, with 100% deterministic results.
+            The Satsuma CLI is built for AI agents. 22 parser-backed commands let your agent slice workspaces, trace lineage, extract metadata, and pull NL intent &mdash; all from the parse tree, with 100% deterministic results.
           </p>
           <p class="text-warm-gray leading-relaxed mb-4">
             Humans use it too &mdash; <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">validate</code>, <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">fmt</code>, and <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">lint</code> are your day-to-day workflow commands. But the CLI's real power is as the structural backbone your agent reasons on top of.
@@ -121,7 +121,7 @@ permalink: cli.html
             </div>
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-              <span class="text-sm text-warm-gray">All 21 CLI commands with usage patterns</span>
+              <span class="text-sm text-warm-gray">All 22 CLI commands with usage patterns</span>
             </div>
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
@@ -606,7 +606,7 @@ permalink: cli.html
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
-<span class="output">21 commands available</span></pre>
+<span class="output">22 commands available</span></pre>
         </div>
         <details class="mt-4 text-sm">
           <summary class="cursor-pointer text-warm-gray hover:text-charcoal transition-colors font-medium">Latest unstable build (from main)</summary>
@@ -636,7 +636,7 @@ permalink: cli.html
   <section id="command-reference" class="py-16 lg:py-24">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12 reveal">
-        <h2 class="text-3xl font-bold text-charcoal mb-3">All 21 commands</h2>
+        <h2 class="text-3xl font-bold text-charcoal mb-3">All 22 commands</h2>
         <p class="text-warm-gray max-w-2xl mx-auto">Complete reference for every command in the CLI. See the <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-CLI.md" target="_blank" class="text-orange hover:underline">full reference on GitHub</a> for detailed usage and examples.</p>
       </div>
 
@@ -675,6 +675,10 @@ permalink: cli.html
             <p class="text-xs text-warm-gray">Schema-level graph traversal, forward or backward.</p>
           </div>
           <div class="bg-white rounded-xl p-4 border border-charcoal/5">
+            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">field-lineage</h4>
+            <p class="text-xs text-warm-gray">Full upstream and downstream lineage of a single field.</p>
+          </div>
+          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">where-used</h4>
             <p class="text-xs text-warm-gray">All references to a schema, fragment, or transform.</p>
           </div>
@@ -706,6 +710,10 @@ permalink: cli.html
           <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">nl</h4>
             <p class="text-xs text-warm-gray">NL content &mdash; notes, transforms, comments &mdash; extracted verbatim.</p>
+          </div>
+          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
+            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">nl-refs</h4>
+            <p class="text-xs text-warm-gray">All <code class="font-mono text-xs">@ref</code> references inside NL transform bodies.</p>
           </div>
           <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">meta</h4>

--- a/site/index.njk
+++ b/site/index.njk
@@ -242,7 +242,7 @@ permalink: index.html
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Machine-Parseable</h3>
-          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with 532 corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with 315 corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
         </div>
         <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
           <div class="w-12 h-12 bg-charcoal rounded-xl flex items-center justify-center mb-4">
@@ -455,7 +455,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">Satsuma CLI</h3>
-              <p class="text-sm text-warm-gray">21 commands &middot; 824 tests</p>
+              <p class="text-sm text-warm-gray">22 commands &middot; 879 tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">
@@ -482,7 +482,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">VS Code Extension</h3>
-              <p class="text-sm text-warm-gray">Full LSP &middot; 179 tests</p>
+              <p class="text-sm text-warm-gray">Full LSP &middot; 293 tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">

--- a/site/index.njk
+++ b/site/index.njk
@@ -267,19 +267,19 @@ permalink: index.html
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-8">
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-orange mb-1">21</div>
+          <div class="text-4xl font-extrabold text-orange mb-1">22</div>
           <div class="text-sm text-warm-gray font-medium">CLI Commands</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-green mb-1">532</div>
+          <div class="text-4xl font-extrabold text-green mb-1">315</div>
           <div class="text-sm text-warm-gray font-medium">Parser Tests</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-orange mb-1">824</div>
+          <div class="text-4xl font-extrabold text-orange mb-1">879</div>
           <div class="text-sm text-warm-gray font-medium">CLI Tests</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-green mb-1">179</div>
+          <div class="text-4xl font-extrabold text-green mb-1">293</div>
           <div class="text-sm text-warm-gray font-medium">LSP Tests</div>
         </div>
       </div>

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -97,7 +97,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
             <pre><code class="font-mono text-charcoal">satsuma validate my-mapping.stm</code></pre>
           </div>
           <p class="text-warm-gray text-sm leading-relaxed mb-3">The parser checks syntax, reference resolution, and structural correctness. Zero errors means you are ready to go. The VS Code extension also shows diagnostics in real time as you type.</p>
-          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all 21 commands &rarr;</a>
+          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all 22 commands &rarr;</a>
         </div>
       </div>
     </div>

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -189,7 +189,7 @@ permalink: vscode.html
   <section class="py-20 lg:py-28 bg-white">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16 reveal">
-        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">7 commands at your fingertips</h2>
+        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">8 commands at your fingertips</h2>
         <p class="text-warm-gray text-lg max-w-2xl mx-auto">Access every command from the Command Palette (<kbd class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded border border-charcoal/10">Ctrl+Shift+P</kbd>). Each one integrates directly with the Satsuma CLI.</p>
       </div>
 
@@ -261,7 +261,7 @@ permalink: vscode.html
             </div>
             <h3 class="font-semibold text-charcoal text-sm">Show Mapping Coverage</h3>
           </div>
-          <p class="text-warm-gray text-xs leading-relaxed">Gutter markers and status bar showing mapped vs. unmapped fields with coverage percentage.</p>
+          <p class="text-warm-gray text-xs leading-relaxed">Gutter markers and status bar showing mapped vs. unmapped fields with coverage percentage. Paired with <em>Clear Mapping Coverage</em> to remove the markers.</p>
         </div>
       </div>
     </div>

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -50,15 +50,15 @@ permalink: vscode.html
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">242</div>
+          <div class="text-2xl font-bold text-green">293</div>
           <div class="text-sm text-warm-gray">LSP Tests</div>
         </div>
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">7</div>
+          <div class="text-2xl font-bold text-green">8</div>
           <div class="text-sm text-warm-gray">Commands</div>
         </div>
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">12</div>
+          <div class="text-2xl font-bold text-green">11</div>
           <div class="text-sm text-warm-gray">LSP Capabilities</div>
         </div>
         <div class="stat-item">

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -29,12 +29,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.7"
+        "web-tree-sitter": "^0.26.9"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.9.3",
         "c8": "^11.0.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "../satsuma-lsp": {
@@ -44,7 +44,7 @@
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
-        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "web-tree-sitter": "^0.26.7"
       },


### PR DESCRIPTION
## Summary

The test and command counts on the website and README had drifted from reality — and the corpus figures were never right: the "532 corpus tests" claim (and the 482 in AGENTS.md) came from counting `===` separator lines without halving them (each corpus case has two). At the commit that wrote 532, the real count was 266.

All numbers in this PR were re-verified by actually running the suites:

| Claim | Was | Now (verified) |
|---|---|---|
| Corpus tests | 245 / 482 / 532 | **315** (all passing, `tree-sitter test --wasm`) |
| CLI tests | 824 / 637 | **879** (all passing) |
| CLI commands | 21 | **22** (`field-lineage` was added since) |
| LSP tests | 179 | **293** (all passing) |
| VS Code palette commands | 7 | **8** |
| Example `.stm` files | 20 | **25** |

## Also in this PR

- The cli.html command grid was missing **`field-lineage`** and **`nl-refs`** entirely — added cards for both (the old "All 21 commands" heading only had 20 distinct commands beneath it).
- The vscode.html coverage card now mentions the companion *Clear Mapping Coverage* command, matching the 8-command count.
- Synced the stale `vscode-satsuma` lockfile snapshot of the linked `satsuma-lsp` package (left behind by the vscode-languageserver 10 migration, sl-w9zz).

Site builds clean with eleventy after the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)