### PR TITLE
fix(lsp): false diagnostics for namespaces — reopened blocks and metric targets (sl-padl, lnd-qqo7)

### DIFF
--- a/.tickets/lnd-qqo7.md
+++ b/.tickets/lnd-qqo7.md
@@ -1,6 +1,6 @@
 ---
 id: lnd-qqo7
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-12T08:58:24Z
@@ -23,3 +23,10 @@ Acceptance criteria:
 - A mapping targeting a qualified metric name defined in the same closure resolves in the LSP semantic diagnostics path.
 - Regression test in tooling/satsuma-lsp/test/semantic-diagnostics.test.js.
 
+
+## Notes
+
+**2026-06-12T12:40:00+01:00**
+
+Cause: The LSP semantic-index adapter routed metric-kind definition entries only into the metrics map, but core resolves mapping source/target refs against schemas+fragments; the CLI index-builder records metric-decorated schemas in both maps, so the false undefined-ref was LSP-only.
+Fix: buildSemanticIndex now adds metric entries to both the metrics and schemas maps, matching CLI semantics; regression test covers a mapping targeting a qualified metric in the same namespace (commit 7512785)

--- a/.tickets/lnd-qqo7.md
+++ b/.tickets/lnd-qqo7.md
@@ -1,0 +1,25 @@
+---
+id: lnd-qqo7
+status: open
+deps: []
+links: []
+created: 2026-06-12T08:58:24Z
+type: task
+priority: 2
+assignee: Thorben Louw
+---
+# LSP: false undefined-ref for namespace-qualified metric target in same namespace
+
+Opening examples/namespaces/namespaces.stm in the editor produces:
+
+  undefined-ref: Mapping 'analytics::daily sales pipeline' references undefined target 'analytics::daily_sales'
+
+analytics::daily_sales is defined directly above the mapping (a metric-decorated schema in the same namespace block), and `satsuma validate` on the same file reports no such error — this is an LSP live-path-only false positive, likely in how buildSemanticIndex / defEntryToMapping (tooling/satsuma-lsp/src/semantic-diagnostics.ts) resolves namespace-qualified targets against metric-kind definitions.
+
+Found while fixing sl-padl (false duplicate-definition for reopened namespaces).
+
+Acceptance criteria:
+- Opening examples/namespaces/namespaces.stm produces no undefined-ref diagnostic for analytics::daily_sales.
+- A mapping targeting a qualified metric name defined in the same closure resolves in the LSP semantic diagnostics path.
+- Regression test in tooling/satsuma-lsp/test/semantic-diagnostics.test.js.
+

--- a/.tickets/sl-padl.md
+++ b/.tickets/sl-padl.md
@@ -1,6 +1,6 @@
 ---
 id: sl-padl
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-12T08:53:17Z
@@ -23,3 +23,10 @@ Acceptance criteria:
 - Duplicate detection for schemas/fragments/mappings/metrics/transforms is unchanged (existing tests stay green).
 - Regression test added in tooling/satsuma-lsp/test/semantic-diagnostics.test.js covering a reopened namespace across two files in the same closure.
 
+
+## Notes
+
+**2026-06-12T12:00:00+01:00**
+
+Cause: The LSP semantic-index adapter (buildSemanticIndex in tooling/satsuma-lsp/src/semantic-diagnostics.ts) derived duplicate-definition records from any definition name with multiple workspace-index entries, but namespace blocks are registered as definition entries per block and reopening a namespace is legal merging (Feature 15), never a collision.
+Fix: Excluded namespace-kind entries from the duplicate derivation while keeping collisions for definitions inside merged namespaces; added three regression tests covering cross-file reopening, same-file reopening, and a genuine intra-namespace schema collision (commit 1730228)

--- a/.tickets/sl-padl.md
+++ b/.tickets/sl-padl.md
@@ -1,0 +1,25 @@
+---
+id: sl-padl
+status: open
+deps: []
+links: []
+created: 2026-06-12T08:53:17Z
+type: task
+priority: 2
+assignee: Thorben Louw
+---
+# LSP: false duplicate-definition for reopened namespace blocks
+
+Opening examples/namespaces/ns-platform.stm in VS Code shows:
+
+  Namespace 'analytics' is already defined in .../examples/namespaces/namespaces.stm:93  satsuma(duplicate-definition)
+
+ns-platform.stm imports from namespaces.stm, so both files are in the open file's import closure (scoping per sl-rw3e is working correctly). The false positive comes from the LSP semantic-index adapter: the workspace index registers each namespace_block as a definition entry (kind "namespace", needed for go-to-definition), and buildSemanticIndex in tooling/satsuma-lsp/src/semantic-diagnostics.ts derives duplicate records from ANY name with multiple definition entries.
+
+But reopening a namespace is legal Satsuma (features/15-namespaces): the CLI index-builder merges reopened namespace blocks across files and never calls checkDuplicate for namespace names — it only emits namespace-metadata conflicts for disagreeing notes. The LSP adapter must match: namespace-kind definition entries must be excluded from duplicate derivation.
+
+Acceptance criteria:
+- Opening a file whose import closure contains the same namespace reopened in multiple files/blocks produces NO duplicate-definition diagnostic for the namespace name.
+- Duplicate detection for schemas/fragments/mappings/metrics/transforms is unchanged (existing tests stay green).
+- Regression test added in tooling/satsuma-lsp/test/semantic-diagnostics.test.js covering a reopened namespace across two files in the same closure.
+

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -228,37 +228,46 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
   }> = [];
 
   for (const [name, entries] of wsIndex.definitions) {
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i]!;
-      // Track duplicates: if same name has multiple definitions. Each
-      // conflict is recorded in BOTH directions, attributing a diagnostic to
-      // each definition site: published diagnostics are filtered to the open
-      // file, and under import-closure scoping (sl-rw3e) either site may be
-      // the open one — e.g. when the open file's definition was indexed first
-      // and a file it imports redefines the name, the one-directional record
-      // pointed at the imported file and the conflict never surfaced.
-      if (i > 0) {
-        const prev = entries[0]!;
-        duplicates.push({
-          kind: entry.kind,
-          name,
-          file: entry.uri,
-          row: entry.range.start.line,
-          previousKind: prev.kind,
-          previousFile: prev.uri,
-          previousRow: prev.range.start.line,
-        });
-        duplicates.push({
-          kind: prev.kind,
-          name,
-          file: prev.uri,
-          row: prev.range.start.line,
-          previousKind: entry.kind,
-          previousFile: entry.uri,
-          previousRow: entry.range.start.line,
-        });
-      }
+    // Track duplicates: if same name has multiple definitions. Each
+    // conflict is recorded in BOTH directions, attributing a diagnostic to
+    // each definition site: published diagnostics are filtered to the open
+    // file, and under import-closure scoping (sl-rw3e) either site may be
+    // the open one — e.g. when the open file's definition was indexed first
+    // and a file it imports redefines the name, the one-directional record
+    // pointed at the imported file and the conflict never surfaced.
+    //
+    // Namespace blocks are exempt: reopening a namespace — the same name in
+    // multiple blocks or files — is the language's mechanism for spreading a
+    // namespace across files (Feature 15), never a collision. The index
+    // registers every block as a definition entry so navigation works, but
+    // only non-namespace entries can collide (sl-padl). Conflicting
+    // namespace METADATA is a separate rule (namespace-metadata-conflict)
+    // surfaced by the CLI on-save validate fallback.
+    const collidable = entries.filter((e) => e.kind !== "namespace");
+    for (let i = 1; i < collidable.length; i++) {
+      const entry = collidable[i]!;
+      const prev = collidable[0]!;
+      duplicates.push({
+        kind: entry.kind,
+        name,
+        file: entry.uri,
+        row: entry.range.start.line,
+        previousKind: prev.kind,
+        previousFile: prev.uri,
+        previousRow: prev.range.start.line,
+      });
+      duplicates.push({
+        kind: prev.kind,
+        name,
+        file: prev.uri,
+        row: prev.range.start.line,
+        previousKind: entry.kind,
+        previousFile: entry.uri,
+        previousRow: entry.range.start.line,
+      });
+    }
 
+    for (const entry of entries) {
       switch (entry.kind) {
         case "schema":
           if (!schemas.has(name)) {

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -285,8 +285,17 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
           }
           break;
         case "metric":
+          // A v2 metric is a schema_block decorated with the (metric) tag,
+          // so it is BOTH a metric and a schema: mappings may target it like
+          // any other schema, and core resolves mapping refs against the
+          // schemas map. The CLI index-builder records metric schemas in
+          // both maps; the adapter must match or qualified metric targets
+          // report false undefined-refs (lnd-qqo7).
           if (!metrics.has(name)) {
             metrics.set(name, defEntryToMetric(name, entry, wsIndex));
+          }
+          if (!schemas.has(name)) {
+            schemas.set(name, defEntryToSchema(name, entry));
           }
           break;
         case "transform":

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -234,6 +234,33 @@ schema bad_metric (metric, source missing_fact) {
     assert.equal(undef[0].range.start.line, 4);
   });
 
+  // Regression for lnd-qqo7: a v2 metric is a schema_block decorated with
+  // the (metric) tag, so a mapping may target it like any other schema —
+  // the CLI index-builder records it in both the schemas and metrics maps.
+  // The LSP adapter routed metric entries only into the metrics map, so
+  // core's target resolution (schemas + fragments) missed them and reported
+  // a false undefined-ref for e.g. examples/namespaces/namespaces.stm.
+  it("does not report undefined-ref for a mapping targeting a metric in the same namespace", () => {
+    const src = `namespace analytics (note "Business metrics layer") {
+  schema staging_sales { order_date DATE }
+  schema daily_sales (metric, grain daily) {
+    sale_date DATE
+  }
+  mapping pipeline {
+    source { staging_sales }
+    target { analytics::daily_sales }
+    order_date -> sale_date
+  }
+}`;
+    const idx = buildIndex({ "file:///a.stm": src });
+    const diags = computeCoreSemanticDiagnostics("file:///a.stm", idx);
+    assert.equal(
+      diags.filter((d) => d.code === "undefined-ref").length,
+      0,
+      "a qualified metric target in the same namespace must resolve",
+    );
+  });
+
   it("does not report quoted join descriptions as undefined mapping sources", () => {
     const src = `schema a { id INT }
 schema b { id INT }

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -396,6 +396,71 @@ schema fact_orders { id UUID }`,
     );
   });
 
+  // Regression for sl-padl: duplicate namespace blocks are NOT an error —
+  // they are the mechanism for spreading a namespace across files (Feature
+  // 15). Here the open file imports from a file that reopens the same
+  // namespace, so both blocks are genuinely in scope at once, and the
+  // duplicate-definition rule must still stay silent about the namespace.
+  it("does not report a duplicate when an imported file reopens the open file's namespace", () => {
+    const idx = buildIndex({
+      "file:///entry.stm": `import { analytics::pipeline_value } from "lib.stm"
+namespace analytics (note "Business metrics layer") {
+  schema fact_revenue { id UUID }
+}`,
+      "file:///lib.stm": `namespace analytics (note "Business metrics layer") {
+  schema pipeline_value { id UUID }
+}`,
+    });
+    const diags = computeScopedSemanticDiagnostics("file:///entry.stm", idx);
+    assert.equal(
+      diags.find((d) => d.code === "duplicate-definition"),
+      undefined,
+      "reopening a namespace across files merges it — it is not a duplicate",
+    );
+  });
+
+  // Same invariant within a single file: a namespace block may be reopened
+  // to group related definitions, and each block adds to the shared
+  // namespace rather than colliding with the earlier one (sl-padl).
+  it("does not report a duplicate when one file reopens its own namespace", () => {
+    const idx = buildIndex({
+      "file:///a.stm": `namespace crm (note "CRM layer") {
+  schema customers { id UUID }
+}
+namespace crm (note "CRM layer") {
+  schema orders { id UUID }
+}`,
+    });
+    const diags = computeScopedSemanticDiagnostics("file:///a.stm", idx);
+    assert.equal(
+      diags.find((d) => d.code === "duplicate-definition"),
+      undefined,
+      "reopening a namespace in the same file is legal merging, not a duplicate",
+    );
+  });
+
+  // Reopened namespace blocks merge, but the names INSIDE the merged
+  // namespace still share one scope: two schemas with the same qualified
+  // name across the reopened blocks remain a genuine conflict (sl-padl).
+  it("still reports a duplicate for the same schema name defined in two blocks of one namespace", () => {
+    const idx = buildIndex({
+      "file:///entry.stm": `import { analytics::pipeline_value } from "lib.stm"
+namespace analytics (note "Business metrics layer") {
+  schema pipeline_value { id UUID }
+}`,
+      "file:///lib.stm": `namespace analytics (note "Business metrics layer") {
+  schema pipeline_value { id UUID }
+}`,
+    });
+    const diags = computeScopedSemanticDiagnostics("file:///entry.stm", idx);
+    const dup = diags.find((d) => d.code === "duplicate-definition");
+    assert.ok(dup, "same qualified schema name in one merged namespace is a real conflict");
+    assert.ok(
+      dup.message.includes("pipeline_value"),
+      "diagnostic should name the conflicting schema, not the namespace",
+    );
+  });
+
   // The missing-import rule must keep its folder-wide view: a symbol defined
   // only OUTSIDE the closure should still produce the actionable "Add:
   // import ..." suggestion, not silently disappear with the scoping change.


### PR DESCRIPTION
Two LSP-only false positives in the semantic-index adapter (`tooling/satsuma-lsp/src/semantic-diagnostics.ts`), both found via `examples/namespaces/`. CLI validate was clean for both — the bugs were in how the adapter builds core's `SemanticIndex` from the LSP workspace index.

## 1. Reopened namespace blocks flagged as duplicate definitions (sl-padl)

Opening `examples/namespaces/ns-platform.stm` in VS Code showed:

> Namespace 'analytics' is already defined in .../examples/namespaces/namespaces.stm:93 — satsuma(duplicate-definition)

`ns-platform.stm` imports from `namespaces.stm`, so both files are correctly in the open file's import closure (the sl-rw3e / PR #316 scoping is working as designed). The bug is upstream of scoping: the workspace index registers every `namespace_block` as a definition entry (needed for go-to-definition), and the adapter turned *any* name with multiple definition entries into a duplicate record. But duplicate namespace blocks are **not** an error — they are the mechanism for spreading a namespace across files (Feature 15), and the CLI index-builder has never flagged them. Even reopening a namespace within a single file falsely fired.

**Fix:** namespace-kind entries are excluded from the duplicate derivation. Definitions *inside* a merged namespace still share one scope and still collide (covered by a new test).

## 2. False undefined-ref for mapping targets that are metrics (lnd-qqo7)

`examples/namespaces/namespaces.stm` showed:

> undefined-ref: Mapping 'analytics::daily sales pipeline' references undefined target 'analytics::daily_sales'

even though `analytics::daily_sales` is defined directly above the mapping. A v2 metric is a `schema_block` decorated with the `(metric)` tag, so it is both a metric and a schema — the CLI index-builder records it in **both** maps, and core resolves mapping source/target refs against schemas+fragments. The adapter routed metric-kind entries only into the metrics map, so qualified metric targets never resolved.

**Fix:** metric entries now populate both the metrics and schemas maps, matching CLI semantics.

## Verification

- 4 new regression tests in `tooling/satsuma-lsp/test/semantic-diagnostics.test.js`: cross-file namespace reopening within a closure, same-file reopening, a genuine intra-namespace schema collision that must still be reported, and a mapping targeting a qualified metric in the same namespace. All failed before their fixes.
- Full LSP suite: 301/301 passing.
- Replayed the LSP publish path against the real example corpus: all three `examples/namespaces/*.stm` files now produce zero diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)