### PR TITLE
fix(viz): render field notes only as the note row, not as a meta pill (sl-1gqw)

### DIFF
--- a/.tickets/sl-1gqw.md
+++ b/.tickets/sl-1gqw.md
@@ -1,0 +1,28 @@
+---
+id: sl-1gqw
+status: closed
+deps: []
+links: []
+created: 2026-06-12T09:14:43Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz]
+---
+# viz: field note renders twice in detail view (meta pill + note row)
+
+In the mapping detail view, a field with a (note "...") tag renders the note twice: once as a 'note ...' meta pill next to the field name, and once as the shaded italic field-note row below the field. The schema-level metadata pills already exclude note entries (sz-schema-card.ts renderSchema), but _fieldMetaPills does not.
+
+## Acceptance Criteria
+
+Field-level note metadata renders only as the shaded field-note row; no 'note' pill appears in the badges. Other field metadata pills (sensitivity, classification, etc.) and constraint badges are unaffected. Unit test covers the exclusion.
+
+
+## Notes
+
+**2026-06-12T09:17:09Z**
+
+**2026-06-12T00:00:00Z**
+
+Cause: A field's (note "...") tag reaches the viz model twice — as a NoteBlock in FieldEntry.notes and as a MetadataEntry in FieldEntry.metadata. The schema-level pill renderer excluded note entries but _fieldMetaPills did not, so the detail view showed both a "note ..." pill and the shaded field-note row.
+Fix: _fieldMetaPills now filters out note entries, matching the schema-level dedupe; the note renders only as the field-note row. Unit test added in automation.test.js.

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -721,17 +721,20 @@ export class SzSchemaCard extends LitElement {
 
   /**
    * Metadata entries to render as pills on a field row: everything the author
-   * wrote except bare tags already shown as constraint badges (sl-6x1o).
+   * wrote except entries already rendered elsewhere on the row (sl-6x1o).
    * Key-value entries always render — `sensitivity internal` and
    * `access_group property_facilities` must be visible, and a kv whose key is
    * also a constraint tag (e.g. `encrypt aes`) carries a value the badge
-   * alone would hide.
+   * alone would hide. Excluded:
+   *   - bare tags already shown as constraint badges
+   *   - `note` entries, which render as the shaded field-note row below the
+   *     field (sl-1gqw) — same dedupe the schema-level pills apply
    */
   private _fieldMetaPills(f: FieldEntry) {
     // Tolerate models serialized before FieldEntry carried metadata (older
     // LSP servers, cached webview payloads) — render no pills, don't crash.
     return (f.metadata ?? []).filter(
-      (m) => !(m.value === "" && f.constraints.includes(m.key)),
+      (m) => m.key !== "note" && !(m.value === "" && f.constraints.includes(m.key)),
     );
   }
 

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -101,6 +101,46 @@ describe("viz automation helpers", () => {
     assert.match(serialized, /src-legacy-field-amount/);
   });
 
+  it("renders a field note only as the field-note row, never as a meta pill (sl-1gqw)", async () => {
+    // A field's (note "...") tag reaches the model twice: as a NoteBlock in
+    // f.notes and as a MetadataEntry in f.metadata. Only the shaded field-note
+    // row should render it — a duplicate "note ..." pill is visual noise.
+    // Other kv metadata on the same field must still render as pills.
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-orders";
+    card.mappedFields = new Set();
+    const field = {
+      name: "order_key",
+      type: "VARCHAR",
+      constraints: [],
+      metadata: [
+        { key: "note", value: "Unique key across ORDERS tables" },
+        { key: "sensitivity", value: "internal" },
+      ],
+      notes: [{ text: "Unique key across ORDERS tables", isMultiline: false,
+        location: { uri: "file:///t.stm", line: 1, character: 0 } }],
+      comments: [],
+      children: [],
+      location: { uri: "file:///t.stm", line: 1, character: 0 },
+    };
+    const pills = card._fieldMetaPills(field);
+    assert.deepEqual(pills.map((p) => p.key), ["sensitivity"]);
+
+    // The note text must still reach the rendered output via the field-note row.
+    const serialize = (t) => {
+      if (t == null || typeof t !== "object") return String(t ?? "");
+      if (Array.isArray(t)) return t.map(serialize).join(" ");
+      if (t.strings && t.values) {
+        return [...t.strings, ...t.values.map(serialize)].join(" ");
+      }
+      return "";
+    };
+    const serialized = serialize(card._renderField(field, 0));
+    assert.match(serialized, /field-note/);
+    assert.match(serialized, /Unique key across ORDERS tables/);
+  });
+
   it("gives mapping-detail source and target schema cards distinct testIdPrefix values", async () => {
     // Source and target schema cards in the mapping detail must be addressable
     // separately even when the same schema id appears on both sides (sl-eikr).


### PR DESCRIPTION
## Summary

In the mapping detail view, a field with a `(note "...")` tag rendered the note twice: as a `note ...` meta pill next to the field name **and** as the shaded italic field-note row beneath it.

The note tag reaches the viz model in two places — `FieldEntry.notes` (NoteBlock) and `FieldEntry.metadata` (MetadataEntry). The schema-level metadata pills already exclude `note` entries, but the field-level `_fieldMetaPills` did not.

## Fix

`_fieldMetaPills` in `sz-schema-card.ts` now filters out `note` entries, so the note renders only as the field-note row. Other key-value pills (`sensitivity`, `classification`, …) and constraint badges are unaffected.

## Testing

- New unit test in `tooling/satsuma-viz/test/automation.test.js` asserting note metadata produces no pill while the field-note row still carries the text, and that sibling kv metadata still renders as a pill.
- Full satsuma-viz suite: 97 tests passing.

Closes sl-1gqw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)