### PR TITLE
fix: LSP validate JSON envelope, namespaced where-used refs, structural diff vs fmt (sl-rngq, sl-l3m8, sl-dxjh)

### DIFF
--- a/.tickets/sl-dxjh.md
+++ b/.tickets/sl-dxjh.md
@@ -1,6 +1,6 @@
 ---
 id: sl-dxjh
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-12T09:31:12Z
@@ -21,3 +21,10 @@ Note: NL strings are delivered verbatim by design, so verbatim comparison of quo
 
 satsuma diff old new reports no changes when new is exactly satsuma-fmt(old); pipe chains and map entries compare on parsed structure, not raw body text; quoted NL strings still compare verbatim; tests cover fmt-roundtrip diff emptiness for the example corpus
 
+
+## Notes
+
+**2026-06-12T12:05:30Z**
+
+Cause: diffTransform compared raw pipe-chain text and arrows compared transform_raw built from raw step text, so fmt's layout changes (steps one-per-line, map entries newline-separated) registered as structural changes.
+Fix: Added canonicalPipeChainText to core extract (steps joined ' | ', map entries rebuilt single-line, leaf tokens verbatim); ExtractedTransform gains canonicalBody, transform_raw is now canonical, diff compares canonical forms. Corpus-wide fmt-roundtrip test asserts diff(file, fmt(file)) is empty for all 25 examples (commit e9e35b2)

--- a/.tickets/sl-l3m8.md
+++ b/.tickets/sl-l3m8.md
@@ -1,6 +1,6 @@
 ---
 id: sl-l3m8
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-12T09:31:06Z
@@ -32,3 +32,10 @@ Fragment case: a fragment in a namespace spread via ...audit_fields into two sch
 
 where-used <transform> finds bare invocations and ...spreads of a transform defined in a namespace, both from inside and outside that namespace; where-used <fragment> finds ...spreads of a namespaced fragment; tests cover bare/spread x namespaced/unnamespaced; assess whether the resolution lives in satsuma-core and fix it there so the LSP find-references gets the same fix
 
+
+## Notes
+
+**2026-06-12T11:54:25Z**
+
+Cause: where-used resolved the queried definition through the namespace-aware index (key e.g. crm::tidy) but compared CST reference text raw, so bare invocations/spreads authored inside the namespace never matched the qualified key.
+Fix: Threaded the enclosing namespace through findTransformRefs/findFragmentSpreads and resolved each reference via core's resolveScopedEntityRef (same binding rule as the LSP's sl-p256 fix); LSP unaffected since viz-backend already re-resolves refs by authoring namespace. Subprocess tests now cover bare/spread x namespaced/unnamespaced plus shadowing (commit 86db538)

--- a/.tickets/sl-rngq.md
+++ b/.tickets/sl-rngq.md
@@ -1,6 +1,6 @@
 ---
 id: sl-rngq
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-06-12T09:24:18Z
@@ -17,3 +17,10 @@ The LSP's on-save validate fallback (tooling/satsuma-lsp/src/validate-diagnostic
 
 1. runValidate parses the {findings, summary} envelope (tolerating the legacy bare-array shape is optional but document the choice). 2. Saving examples/namespaces/namespaces.stm surfaces the four field-not-in-schema warnings as editor diagnostics with source 'satsuma-validate'. 3. LSP tests cover the envelope shape; a regression test fails if the CLI JSON shape and LSP parser drift again (e.g. shared fixture or contract test against actual CLI output).
 
+
+## Notes
+
+**2026-06-12T11:46:47Z**
+
+Cause: The LSP's runValidate parsed `satsuma validate --json` expecting a bare array, but commit 8758118 (2026-03-25) wrapped the output in a {findings, summary} envelope; the Array.isArray guard rejected it and silently resolved an empty diagnostics map.
+Fix: Extracted parseValidateFindings handling both the envelope and the still-live bare-array resolve-failure shape; added a contract test running the locally built CLI against examples/namespaces/namespaces.stm that hard-asserts the four field-not-in-schema warnings (commit 35b3a86)

--- a/adrs/adr-033-canonical-pipe-chain-serialization.md
+++ b/adrs/adr-033-canonical-pipe-chain-serialization.md
@@ -1,0 +1,64 @@
+# ADR-033 — Canonical Pipe-Chain Serialization Defines Structural Identity
+
+**Status:** Accepted
+**Date:** 2026-06-12 (sl-dxjh)
+
+## Context
+
+`satsuma fmt` guarantees that formatting does not change a file's meaning, and
+`satsuma diff` claims to report *structural* differences. The two disagreed
+about what structural identity means for pipe content: fmt freely re-lays a
+pipe chain (steps split one-per-line beyond the column cap) and a `map`
+literal (entries newline-separated instead of comma-separated), while the diff
+engine compared transform bodies as raw source text and arrow transforms via
+`transform_raw`, which embedded each step's raw text — including the internal
+layout of map literals. Running diff between a file and its own fmt output
+reported transform bodies and map-carrying arrows as `~` changed.
+
+Since ADR-023, everything inside a pipe step is NL — human-interpreted text
+that tooling must deliver verbatim. So the fix could not be "normalize the
+text": collapsing whitespace inside NL strings would change what a human
+reads. Nor could it be "compare formatted output": the formatter's layout is
+line-length-dependent (a map literal renders single-line or multi-line based
+on entry count and column position), so formatting is not a canonical form.
+
+The alternative of making diff re-parse and walk CSTs was rejected: the diff
+engine deliberately operates on extracted records, not trees (two workspaces'
+trees cannot be alive simultaneously under the single parser buffer), and
+every other consumer of pipe content already works from extraction output.
+
+## Decision
+
+Structural identity for pipe content is defined by a **canonical
+serialization** computed at extraction time in `satsuma-core`
+(`canonicalPipeChainText` in `extract.ts`): pipe steps joined with `" | "`,
+`map` literals rebuilt as a single-line entry list (`map { k: v, k: v }`),
+and every leaf token — pipe text, map keys, map values, spread names —
+passed through verbatim. The canonical form normalizes exactly the layout
+the formatter owns (separators between steps and between map entries) and
+nothing else.
+
+`ExtractedTransform` carries both `body` (raw source text, preserving the
+author's layout for display) and `canonicalBody`; arrows' `transform_raw` is
+now built from canonical step text. The diff engine compares canonical forms
+only. The contract is pinned corpus-wide by a property test in the CLI suite:
+for every file in `examples/`, `diff(file, fmt(file))` must be empty.
+
+## Consequences
+
+**Positive:**
+- fmt and diff agree on meaning: formatting-only changes can never appear in
+  a structural diff, verified for the whole example corpus.
+- NL content remains verbatim end-to-end — quoted strings, casing, and inner
+  whitespace are never normalized, consistent with ADR-023.
+- Any future formatter layout rule that the canonical serialization does not
+  normalize fails the corpus roundtrip test immediately rather than silently
+  reintroducing false diffs.
+
+**Negative:**
+- `transform_raw` is no longer literally raw: map literals in `arrows --json`
+  output and diff messages render in canonical single-line form regardless of
+  authored layout. Consumers needing the authored text must use the raw body.
+- The canonical serializer must be extended in step with any new pipe-step
+  node type the grammar grows; an unhandled type falls back to raw node text
+  and may reintroduce layout sensitivity for that construct.

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -5,7 +5,12 @@
  *
  * Schema references:   via referenceGraph.usedByMappings + metricsReferences
  * Fragment references: via CST fragment_spread nodes across all files
- * Transform refs:      not currently cross-referenced in CST (reported as such)
+ * Transform refs:      via CST pipe_step nodes (bare invocations and spreads)
+ *
+ * Reference text is resolved against the namespace it is authored in
+ * (core's resolveScopedEntityRef), matching the binding rule the LSP uses:
+ * a bare name inside a namespace binds to the namespace-local definition
+ * when one exists, else to the global one (sl-l3m8).
  *
  * Output is grouped by usage type (mapping, metric, schema).
  *
@@ -18,7 +23,7 @@ import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey, canonicalKey } from "../index-builder.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
-import { stripNLRefScopePrefix } from "@satsuma/core";
+import { stripNLRefScopePrefix, resolveScopedEntityRef } from "@satsuma/core";
 import type { SyntaxNode, ExtractedWorkspace, ParsedFile } from "../types.js";
 
 interface Ref {
@@ -126,7 +131,7 @@ function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: Parsed
   if (isFragment) {
     // Find fragment_spread nodes across all files
     for (const { filePath, tree } of parsedFiles) {
-      const spreads = findFragmentSpreads(tree.rootNode, name);
+      const spreads = findFragmentSpreads(tree.rootNode, name, index.fragments);
       for (const { block, row } of spreads) {
         refs.push({ kind: "fragment_spread", name: block, file: filePath, line: row + 1 });
       }
@@ -136,7 +141,7 @@ function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: Parsed
   if (isTransform) {
     // Find transform invocations in arrow pipe chains
     for (const { filePath, tree } of parsedFiles) {
-      const transformRefs = findTransformRefs(tree.rootNode, name);
+      const transformRefs = findTransformRefs(tree.rootNode, name, index.transforms);
       for (const { mapping, row } of transformRefs) {
         refs.push({ kind: "transform_call", name: mapping, file: filePath, line: row + 1 });
       }
@@ -201,10 +206,22 @@ function matchesEntityOrField(resolvedName: string, internalName: string, canoni
 }
 
 /**
- * Find all fragment_spread usages of `fragmentName` in the CST.
+ * Find all fragment_spread usages binding to the fragment keyed by
+ * `fragmentKey` (a resolved index key, e.g. "audit_fields" or
+ * "crm::audit_fields") in the CST.
+ *
+ * Each spread's authored text is resolved against the namespace it appears
+ * in — a bare `...audit_fields` inside `namespace crm` binds to
+ * crm::audit_fields when that exists — so raw-text comparison against the
+ * qualified key no longer drops namespace-local spreads (sl-l3m8).
+ *
  * Returns [{block, row}] where block is the containing schema/fragment name.
  */
-function findFragmentSpreads(rootNode: SyntaxNode, fragmentName: string): Array<{ block: string; row: number }> {
+function findFragmentSpreads(
+  rootNode: SyntaxNode,
+  fragmentKey: string,
+  fragments: Map<string, unknown>,
+): Array<{ block: string; row: number }> {
   const results: Array<{ block: string; row: number }> = [];
   function checkBlock(topLevel: SyntaxNode, namespace: string | null): void {
     if (topLevel.type !== "schema_block" && topLevel.type !== "fragment_block") return;
@@ -216,7 +233,7 @@ function findFragmentSpreads(rootNode: SyntaxNode, fragmentName: string): Array<
 
     const body = topLevel.namedChildren.find((c) => c.type === "schema_body");
     if (body) {
-      walkForSpreads(body, fragmentName, blockName, results);
+      walkForSpreads(body, fragmentKey, fragments, namespace, blockName, results);
     }
   }
   for (const topLevel of rootNode.namedChildren) {
@@ -232,7 +249,14 @@ function findFragmentSpreads(rootNode: SyntaxNode, fragmentName: string): Array<
   return results;
 }
 
-function walkForSpreads(bodyNode: SyntaxNode, fragmentName: string, blockName: string, results: Array<{ block: string; row: number }>): void {
+function walkForSpreads(
+  bodyNode: SyntaxNode,
+  fragmentKey: string,
+  fragments: Map<string, unknown>,
+  namespace: string | null,
+  blockName: string,
+  results: Array<{ block: string; row: number }>,
+): void {
   for (const c of bodyNode.namedChildren) {
     if (c.type === "fragment_spread") {
       // fragment_spread children use spread_label, not block_label
@@ -249,22 +273,34 @@ function walkForSpreads(bodyNode: SyntaxNode, fragmentName: string, blockName: s
             .join(" ");
         }
       }
-      if (sname === fragmentName) {
+      if (sname && resolveScopedEntityRef(sname, namespace, fragments) === fragmentKey) {
         results.push({ block: blockName, row: c.startPosition.row });
       }
     } else if (c.type === "field_decl") {
       // Recurse into nested record/list_of fields for spreads
       const nested = c.namedChildren.find((x) => x.type === "schema_body");
-      if (nested) walkForSpreads(nested, fragmentName, blockName, results);
+      if (nested) walkForSpreads(nested, fragmentKey, fragments, namespace, blockName, results);
     }
   }
 }
 
 /**
- * Find all transform invocations (token_call) matching `transformName` in mapping arrows.
+ * Find all transform invocations binding to the transform keyed by
+ * `transformKey` (a resolved index key, e.g. "tidy" or "crm::tidy") in
+ * mapping arrow pipe chains.
+ *
+ * As with fragment spreads, each invocation's authored text is resolved
+ * against its enclosing namespace before comparing, so a bare `tidy` (pipe
+ * step or `...tidy` spread) inside `namespace crm` binds to crm::tidy when
+ * that exists (sl-l3m8).
+ *
  * Returns [{mapping, row}] where mapping is the qualified mapping name.
  */
-function findTransformRefs(rootNode: SyntaxNode, transformName: string): Array<{ mapping: string; row: number }> {
+function findTransformRefs(
+  rootNode: SyntaxNode,
+  transformKey: string,
+  transforms: Map<string, unknown>,
+): Array<{ mapping: string; row: number }> {
   const results: Array<{ mapping: string; row: number }> = [];
 
   function scanMappings(node: SyntaxNode, namespace: string | null): void {
@@ -283,7 +319,7 @@ function findTransformRefs(rootNode: SyntaxNode, transformName: string): Array<{
       if (namespace) mappingName = `${namespace}::${mappingName}`;
 
       // Walk all pipe_step/token_call descendants
-      walkForTransformCalls(c, transformName, mappingName, results);
+      walkForTransformCalls(c, transformKey, transforms, namespace, mappingName, results);
     }
   }
 
@@ -291,25 +327,34 @@ function findTransformRefs(rootNode: SyntaxNode, transformName: string): Array<{
   return results;
 }
 
-function walkForTransformCalls(node: SyntaxNode, transformName: string, mappingName: string, results: Array<{ mapping: string; row: number }>): void {
+function walkForTransformCalls(
+  node: SyntaxNode,
+  transformKey: string,
+  transforms: Map<string, unknown>,
+  namespace: string | null,
+  mappingName: string,
+  results: Array<{ mapping: string; row: number }>,
+): void {
+  const bindsToTarget = (refText: string): boolean =>
+    refText !== "" && resolveScopedEntityRef(refText, namespace, transforms) === transformKey;
+
   for (const c of node.namedChildren) {
     if (c.type === "pipe_step") {
       const inner = c.namedChildren[0];
-      if (inner?.type === "pipe_text" && inner.text === transformName) {
+      if (inner?.type === "pipe_text" && bindsToTarget(inner.text)) {
         results.push({ mapping: mappingName, row: c.startPosition.row });
       }
       // Check for fragment_spread inside pipe_step (transform spread: ...name)
       if (inner?.type === "fragment_spread") {
         const lbl = inner.namedChildren.find((x) => x.type === "spread_label");
-        const spreadName = getSpreadName(lbl);
-        if (spreadName === transformName) {
+        if (bindsToTarget(getSpreadName(lbl))) {
           results.push({ mapping: mappingName, row: c.startPosition.row });
         }
       }
       // Don't recurse into pipe_step — already checked its children above
       continue;
     }
-    walkForTransformCalls(c, transformName, mappingName, results);
+    walkForTransformCalls(c, transformKey, transforms, namespace, mappingName, results);
   }
 }
 

--- a/tooling/satsuma-cli/src/diff-engine.ts
+++ b/tooling/satsuma-cli/src/diff-engine.ts
@@ -292,15 +292,20 @@ function diffFragment(a: FragmentRecord, b: FragmentRecord): SchemaChange[] {
 /**
  * Compute the change set for a named transform.
  *
- * Transform bodies are NL strings (Feature 28 made everything inside a pipe
- * step human-interpreted), so we cannot meaningfully diff them structurally.
- * We compare body text verbatim and emit a single `body-changed` event with
- * the before/after text — the reviewer reads the diff themselves.
+ * Step content is NL (Feature 28 made everything inside a pipe step
+ * human-interpreted), so each step's text is compared verbatim — but the
+ * chain's *layout* belongs to the formatter, so we compare the canonical
+ * serialization (steps joined " | ", map entries joined ", ") rather than
+ * raw body text. fmt re-laying a chain one-step-per-line is not a
+ * structural change (sl-dxjh). A single `body-changed` event carries the
+ * canonical before/after — the reviewer reads the NL diff themselves.
  */
 function diffTransform(a: TransformRecord, b: TransformRecord): TransformChange[] {
   const changes: TransformChange[] = [];
-  if ((a.body ?? "") !== (b.body ?? "")) {
-    changes.push({ kind: "body-changed", from: a.body || "(empty)", to: b.body || "(empty)" });
+  const aBody = a.canonicalBody ?? a.body ?? "";
+  const bBody = b.canonicalBody ?? b.body ?? "";
+  if (aBody !== bBody) {
+    changes.push({ kind: "body-changed", from: aBody || "(empty)", to: bBody || "(empty)" });
   }
   return changes;
 }

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -90,7 +90,10 @@ export interface FragmentRecord {
 
 export interface TransformRecord {
   name: string;
+  /** Raw pipe-chain source text, preserving the author's layout. */
   body: string | null;
+  /** Layout-independent chain serialization — what diff compares (sl-dxjh). */
+  canonicalBody: string | null;
   file: string;
   row: number;
   namespace?: string;

--- a/tooling/satsuma-cli/test/diff.test.ts
+++ b/tooling/satsuma-cli/test/diff.test.ts
@@ -8,6 +8,9 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { diffIndex } from "#src/diff-engine.js";
 
 function makeIndex(schemas: any = {}, mappings: any = {}, { metrics = {}, fragments = {}, transforms = {}, notes = [] as any[], fieldArrows = {} }: any = {}) {
@@ -480,4 +483,65 @@ describe("diffIndex anonymous mappings (sl-ndtz)", () => {
     assert.equal(delta.mappings.changed.length, 1);
     assert.equal(delta.mappings.changed[0].name, "crm::<anonymous s -> t>");
   });
+});
+
+// ── fmt-roundtrip structural identity (sl-dxjh) ──────────────────────────────
+
+describe("fmt-roundtrip structural identity (sl-dxjh)", () => {
+  // fmt guarantees it does not change meaning, and diff claims to be
+  // structural — so diffing any file against its own formatted output must
+  // be empty. fmt re-lays pipe chains (steps one-per-line) and map literals
+  // (entries newline-separated), which a raw-text body comparison reports
+  // as changes; these cases pin that pipe chains and map entries compare on
+  // parsed structure while everything else still diffs as before. The whole
+  // example corpus is swept so any future formatter layout rule that the
+  // canonical serialization does not normalize fails here immediately.
+
+  /** Recursively collect every .stm file under a directory. */
+  function collectStmFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...collectStmFiles(full));
+      else if (entry.name.endsWith(".stm")) out.push(full);
+    }
+    return out.sort();
+  }
+
+  /** Flatten a Delta into human-readable "section: detail" strings. */
+  function describeDelta(delta: any): string[] {
+    const lines: string[] = [];
+    for (const section of ["schemas", "mappings", "metrics", "fragments", "transforms"]) {
+      const s = delta[section];
+      for (const name of s.added) lines.push(`${section} added: ${name}`);
+      for (const name of s.removed) lines.push(`${section} removed: ${name}`);
+      for (const c of s.changed) lines.push(`${section} changed: ${c.name} (${c.changes.map((ch: any) => ch.kind).join(", ")})`);
+    }
+    for (const t of delta.notes.added) lines.push(`note added: ${t.slice(0, 40)}`);
+    for (const t of delta.notes.removed) lines.push(`note removed: ${t.slice(0, 40)}`);
+    return lines;
+  }
+
+  const EXAMPLES_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../../../examples");
+
+  for (const file of collectStmFiles(EXAMPLES_DIR)) {
+    const rel = relative(EXAMPLES_DIR, file);
+    it(`reports no structural differences between ${rel} and its fmt output`, async () => {
+      const { parseSource } = await import("#src/parser.js");
+      const { buildIndex } = await import("#src/index-builder.js");
+      const { format } = await import("@satsuma/core");
+
+      const src = readFileSync(file, "utf8");
+      const parsedOriginal = parseSource(src);
+      const formatted = format(parsedOriginal.tree, src);
+      // Trees are invalidated by subsequent parses (single parser buffer),
+      // so index the original before parsing the formatted text.
+      const indexA = buildIndex([{ filePath: file, ...parseSource(src) } as any]);
+      const indexB = buildIndex([{ filePath: file, ...parseSource(formatted) } as any]);
+
+      const delta = diffIndex(indexA, indexB);
+      const differences = describeDelta(delta);
+      assert.deepEqual(differences, [], `fmt-only changes reported as structural:\n  ${differences.join("\n  ")}`);
+    });
+  }
 });

--- a/tooling/satsuma-cli/test/fixtures/namespace-where-used.stm
+++ b/tooling/satsuma-cli/test/fixtures/namespace-where-used.stm
@@ -1,0 +1,68 @@
+// Fixture for sl-l3m8: where-used must find references to transforms and
+// fragments defined inside a namespace, whether referenced bare (from inside
+// the namespace) or qualified (from outside it).
+
+namespace crm {
+  fragment audit_fields {
+    created_at TIMESTAMP
+  }
+
+  schema customers {
+    id STRING
+    ...audit_fields            // bare spread inside the namespace
+  }
+
+  schema customers_clean {
+    id STRING
+  }
+
+  transform tidy {
+    trim | lowercase
+  }
+
+  mapping clean_customers {
+    source { customers }
+    target { customers_clean }
+    id -> id { ...tidy }       // bare spread invocation inside the namespace
+  }
+
+  mapping clean_customers_again {
+    source { customers }
+    target { customers_clean }
+    id -> id { tidy }          // bare pipe invocation inside the namespace
+  }
+}
+
+// A global transform with the same bare name as the namespaced one: bare
+// references inside crm must bind to crm::tidy, not to this.
+transform tidy {
+  uppercase
+}
+
+// Multi-word backticked fragment name — regression coverage for spread-label
+// text extraction alongside the namespace resolution.
+fragment `common keys` {
+  tenant_id STRING
+}
+
+schema global_users {
+  id STRING
+  ...crm::audit_fields         // qualified spread from outside the namespace
+  ...`common keys`             // unnamespaced multi-word spread
+}
+
+schema global_users_clean {
+  id STRING
+}
+
+mapping clean_global_users {
+  source { global_users }
+  target { global_users_clean }
+  id -> id { ...crm::tidy }    // qualified spread invocation from outside
+}
+
+mapping shout_global_users {
+  source { global_users }
+  target { global_users_clean }
+  id -> id { tidy }            // bare invocation outside crm binds to global tidy
+}

--- a/tooling/satsuma-cli/test/where-used.test.ts
+++ b/tooling/satsuma-cli/test/where-used.test.ts
@@ -1,148 +1,90 @@
 /**
- * where-used.test.js — Unit tests for where-used command helpers.
+ * where-used.test.ts — End-to-end tests for `satsuma where-used`.
+ *
+ * Runs the built CLI as a subprocess against fixtures (the same pattern as
+ * namespace-bugs.test.ts). The previous version of this file tested an
+ * inline *copy* of the walker implementation, which kept passing while the
+ * real command silently found nothing for namespaced transforms and
+ * fragments (sl-l3m8) — these tests exercise the actual command.
  */
 
-import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { run as _run } from "./helpers.js";
 
-// ── Mock CST helpers ──────────────────────────────────────────────────────────
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+// Fixture defining crm::tidy / crm::audit_fields plus a global `tidy` that
+// shares the bare name, exercising every bare/qualified × inside/outside
+// namespace combination (sl-l3m8).
+const FIXTURE = resolve(__dirname, "fixtures/namespace-where-used.stm");
+// Canonical example: a GLOBAL fragment spread bare into namespaced schemas.
+const NS_PLATFORM = resolve(__dirname, "../../../examples/namespaces/ns-platform.stm");
 
-function n(type: string, namedChildren: any[] = [], text = "", row = 0): any {
-  return { type, text, startPosition: { row, column: 0 }, namedChildren };
-}
-function ident(t: string) { return n("identifier", [], t); }
-function quoted(t: string) { return n("backtick_name", [], `'${t}'`); }
-function blockLabel(name: string) {
-  const inner = name.startsWith("'") ? quoted(name.slice(1, -1)) : ident(name);
-  return n("block_label", [inner]);
-}
-function spreadLabel(name: string) {
-  if (name.startsWith("'")) return n("spread_label", [quoted(name.slice(1, -1))]);
-  return n("spread_label", name.split(" ").map(ident));
-}
+const run = (...args: string[]) => _run(CLI, ...args);
 
-// ── Inline findFragmentSpreads + walkForSpreads ───────────────────────────────
-
-function walkForSpreads(bodyNode: any, fragmentName: string, blockName: string, results: any[]) {
-  for (const c of bodyNode.namedChildren) {
-    if (c.type === "fragment_spread") {
-      const lbl = c.namedChildren.find((x: any) => x.type === "spread_label" || x.type === "block_label");
-      let sname = "";
-      if (lbl) {
-        const q = lbl.namedChildren.find((x: any) => x.type === "backtick_name");
-        if (q) {
-          sname = q.text.slice(1, -1);
-        } else {
-          sname = lbl.namedChildren
-            .filter((x: any) => x.type === "identifier" || x.type === "qualified_name")
-            .map((x: any) => x.text)
-            .join(" ");
-        }
-      }
-      if (sname === fragmentName) results.push({ block: blockName, row: c.startPosition.row });
-    } else if (c.type === "record_block" || c.type === "list_block") {
-      const nested = c.namedChildren.find((x: any) => x.type === "schema_body");
-      if (nested) walkForSpreads(nested, fragmentName, blockName, results);
-    }
-  }
+/** Parse `--json` stdout and return the refs of the given kind. */
+function refsOfKind(stdout: string, kind: string): Array<{ name: string; line: number }> {
+  return JSON.parse(stdout).refs.filter((r: { kind: string }) => r.kind === kind);
 }
 
-function findFragmentSpreads(rootNode: any, fragmentName: string) {
-  const results: any[] = [];
-  for (const topLevel of rootNode.namedChildren) {
-    if (topLevel.type !== "schema_block" && topLevel.type !== "fragment_block") continue;
-    const lbl = topLevel.namedChildren.find((c: any) => c.type === "block_label");
-    const inner = lbl?.namedChildren[0];
-    let blockName = inner?.text ?? "";
-    if (inner?.type === "backtick_name") blockName = blockName.slice(1, -1);
-
-    const body = topLevel.namedChildren.find((c: any) => c.type === "schema_body");
-    if (body) walkForSpreads(body, fragmentName, blockName, results);
-  }
-  return results;
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
-describe("findFragmentSpreads", () => {
-  it("finds a quoted fragment spread in a schema", () => {
-    const spread = n("fragment_spread", [spreadLabel("'address fields'")], "", 5);
-    const body = n("schema_body", [spread]);
-    const schemaBlock = n("schema_block", [blockLabel("orders"), body]);
-    const root = n("source_file", [schemaBlock]);
-
-    const results = findFragmentSpreads(root, "address fields");
-    assert.equal(results.length, 1);
-    assert.equal(results[0].block, "orders");
-    assert.equal(results[0].row, 5);
+describe("where-used: transforms defined inside a namespace (sl-l3m8)", () => {
+  it("finds bare invocations, bare spreads, and qualified spreads of a namespaced transform", async () => {
+    const { stdout, code } = await run("where-used", "crm::tidy", FIXTURE, "--json");
+    assert.equal(code, 0);
+    const calls = refsOfKind(stdout, "transform_call");
+    const byMapping = new Map(calls.map((r) => [r.name, r.line]));
+    // `...tidy` spread inside the namespace binds to crm::tidy
+    assert.ok(byMapping.has("crm::clean_customers"), "bare ...spread inside namespace must be found");
+    // bare `tidy` pipe step inside the namespace binds to crm::tidy
+    assert.ok(byMapping.has("crm::clean_customers_again"), "bare pipe invocation inside namespace must be found");
+    // `...crm::tidy` from outside the namespace binds to crm::tidy
+    assert.ok(byMapping.has("clean_global_users"), "qualified ...spread from outside namespace must be found");
+    assert.equal(calls.length, 3, "exactly the three crm::tidy call sites — no fan-out to the global tidy");
   });
 
-  it("returns empty when fragment not spread anywhere", () => {
-    const body = n("schema_body", []);
-    const schemaBlock = n("schema_block", [blockLabel("orders"), body]);
-    const root = n("source_file", [schemaBlock]);
-
-    assert.deepEqual(findFragmentSpreads(root, "address fields"), []);
-  });
-
-  it("finds fragment spread in multiple schemas", () => {
-    const spread1 = n("fragment_spread", [spreadLabel("'audit columns'")]);
-    const spread2 = n("fragment_spread", [spreadLabel("'audit columns'")]);
-    const body1 = n("schema_body", [spread1]);
-    const body2 = n("schema_body", [spread2]);
-    const s1 = n("schema_block", [blockLabel("orders"), body1]);
-    const s2 = n("schema_block", [blockLabel("customers"), body2]);
-    const root = n("source_file", [s1, s2]);
-
-    const results = findFragmentSpreads(root, "audit columns");
-    assert.equal(results.length, 2);
-    assert.ok(results.some((r) => r.block === "orders"));
-    assert.ok(results.some((r) => r.block === "customers"));
-  });
-
-  it("does not match different fragment names", () => {
-    const spread = n("fragment_spread", [spreadLabel("'other frag'")]);
-    const body = n("schema_body", [spread]);
-    const block = n("schema_block", [blockLabel("t"), body]);
-    const root = n("source_file", [block]);
-
-    assert.deepEqual(findFragmentSpreads(root, "address fields"), []);
-  });
-
-  it("finds spreads in record_block nested bodies", () => {
-    const spread = n("fragment_spread", [spreadLabel("'audit columns'")], "", 10);
-    const innerBody = n("schema_body", [spread]);
-    const recBlock = n("record_block", [blockLabel("audit"), innerBody]);
-    const outerBody = n("schema_body", [recBlock]);
-    const schemaBlock = n("schema_block", [blockLabel("orders"), outerBody]);
-    const root = n("source_file", [schemaBlock]);
-
-    const results = findFragmentSpreads(root, "audit columns");
-    assert.equal(results.length, 1);
-    assert.equal(results[0].block, "orders");
-  });
-
-  it("finds unquoted multi-word fragment spreads", () => {
-    const spread = n("fragment_spread", [spreadLabel("audit columns")], "", 3);
-    const body = n("schema_body", [spread]);
-    const schemaBlock = n("schema_block", [blockLabel("orders"), body]);
-    const root = n("source_file", [schemaBlock]);
-
-    const results = findFragmentSpreads(root, "audit columns");
-    assert.equal(results.length, 1);
-    assert.equal(results[0].block, "orders");
+  it("does not attribute bare references inside the namespace to a same-named global transform", async () => {
+    // The fixture's global `tidy` shadows nothing inside crm: a bare `tidy`
+    // authored in crm binds to crm::tidy, so the global transform's
+    // references are only those authored outside the namespace.
+    const { stdout, code } = await run("where-used", "tidy", FIXTURE, "--json");
+    assert.equal(code, 0);
+    const data = JSON.parse(stdout);
+    assert.equal(data.name, "::tidy", "bare query resolves to the global transform");
+    const calls = refsOfKind(stdout, "transform_call");
+    assert.deepEqual(calls.map((r) => r.name), ["shout_global_users"]);
   });
 });
 
-describe("referenceGraph usedByMappings", () => {
-  it("collects schemas referenced by mappings", () => {
-    const usedByMappings = new Map([
-      ["legacy_sqlserver", ["customer migration"]],
-      ["postgres_db", ["customer migration"]],
-    ]);
+describe("where-used: fragments defined inside a namespace (sl-l3m8)", () => {
+  it("finds bare spreads from inside and qualified spreads from outside the namespace", async () => {
+    const { stdout, code } = await run("where-used", "crm::audit_fields", FIXTURE, "--json");
+    assert.equal(code, 0);
+    const spreads = refsOfKind(stdout, "fragment_spread");
+    const blocks = spreads.map((r) => r.name).sort();
+    assert.deepEqual(blocks, ["crm::customers", "global_users"]);
+  });
 
-    const refs = usedByMappings.get("legacy_sqlserver") ?? [];
-    assert.deepEqual(refs, ["customer migration"]);
-    assert.equal((usedByMappings.get("postgres_db") ?? []).length, 1);
+  it("still finds bare spreads of a GLOBAL fragment authored inside namespaces (corpus)", async () => {
+    // ns-platform.stm spreads the global standard_metadata fragment into
+    // schemas across several namespace blocks — the pre-fix raw-text match
+    // happened to work here, so this pins against regression in the other
+    // direction (bare ref in a namespace falling back to the global def).
+    const { stdout, code } = await run("where-used", "standard_metadata", NS_PLATFORM, "--json");
+    assert.equal(code, 0);
+    const spreads = refsOfKind(stdout, "fragment_spread");
+    assert.ok(spreads.length >= 5, `expected the corpus's many spreads, got ${spreads.length}`);
+    assert.ok(spreads.some((r) => r.name.includes("::")), "spread targets include namespaced schemas");
+  });
+
+  it("finds spreads of multi-word backticked fragment names", async () => {
+    // Spread-label text extraction joins identifier parts with spaces and
+    // strips backticks; this guards that path alongside namespace resolution.
+    const { stdout, code } = await run("where-used", "common keys", FIXTURE, "--json");
+    assert.equal(code, 0);
+    const spreads = refsOfKind(stdout, "fragment_spread");
+    assert.deepEqual(spreads.map((r) => r.name), ["global_users"]);
   });
 });

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -469,7 +469,15 @@ export function extractFragments(rootNode: SyntaxNode): ExtractedFragment[] {
 
 export interface ExtractedTransform {
   name: string | null;
+  /** Raw pipe-chain source text, preserving the author's layout. */
   body: string | null;
+  /**
+   * Layout-independent serialization of the pipe chain (see
+   * canonicalPipeChainText). Two transforms with the same canonicalBody are
+   * structurally identical even if the author or formatter laid the steps
+   * out differently — diff compares this, not `body` (sl-dxjh).
+   */
+  canonicalBody: string | null;
   namespace: string | null;
   /** 0-indexed row from CST startPosition. */
   row: number;
@@ -483,9 +491,11 @@ export interface ExtractedTransform {
 export function extractTransforms(rootNode: SyntaxNode): ExtractedTransform[] {
   return collectFromNamespaces(rootNode, "transform_block").map(({ node, namespace }) => {
     const pipeChain = child(node, "pipe_chain");
+    const pipeSteps = pipeChain ? children(pipeChain, "pipe_step") : [];
     return {
       name: labelText(node),
       body: pipeChain ? pipeChain.text : null,
+      canonicalBody: pipeChain ? canonicalPipeChainText(pipeSteps) : null,
       namespace,
       row: node.startPosition.row,
       startColumn: node.startPosition.column,
@@ -747,6 +757,51 @@ function decomposePipeSteps(steps: SyntaxNode[]): PipeStep[] {
   });
 }
 
+// ── Canonical pipe-chain serialization ──────────────────────────────────────
+//
+// The formatter is free to re-lay a pipe chain (steps one-per-line, map
+// entries newline-separated) without changing meaning, so structural
+// comparisons must not use raw chain text. The canonical form normalizes
+// exactly the layout the formatter owns — separators between steps and
+// between map entries — while every leaf token (pipe text, map keys, map
+// values, spread names) is the verbatim source text: NL strings are
+// human-interpreted and must never be normalized (sl-dxjh).
+
+/**
+ * Serialize one pipe step's inner node into its canonical text.
+ *
+ * `map { ... }` literals are rebuilt as a single-line entry list; all other
+ * step kinds (pipe_text, fragment_spread) are single tokens whose text is
+ * already layout-free, so they pass through verbatim.
+ */
+function canonicalPipeStepText(inner: SyntaxNode | undefined, fallback: string): string {
+  if (!inner) return fallback;
+  if (inner.type !== "map_literal") return inner.text;
+
+  const entries = children(inner, "map_entry");
+  if (entries.length === 0) return "map { }";
+  const entryTexts = entries.map((e) => {
+    const key = child(e, "map_key");
+    const value = child(e, "map_value");
+    // Key and value text stay verbatim — quoted strings are NL content.
+    return key && value ? `${key.text}: ${value.text}` : e.text;
+  });
+  return `map { ${entryTexts.join(", ")} }`;
+}
+
+/**
+ * Serialize a pipe chain (list of pipe_step nodes) into a single
+ * layout-independent line: canonical step texts joined with " | ".
+ *
+ * Invariant: a chain and its formatter output produce the same canonical
+ * text, so fmt-only changes never register as structural differences.
+ */
+export function canonicalPipeChainText(pipeSteps: SyntaxNode[]): string {
+  return pipeSteps
+    .map((s) => canonicalPipeStepText(s.namedChildren[0], s.text))
+    .join(" | ");
+}
+
 export interface ExtractedArrow {
   mapping: string | null;
   namespace: string | null;
@@ -865,9 +920,10 @@ function extractSingleArrow(
     target = `${parentTgt}.${cleanTgt}`;
   }
 
-  const transformRaw = pipeSteps.length > 0
-    ? pipeSteps.map((s) => s.namedChildren[0]?.text ?? s.text).join(" | ")
-    : "";
+  // Canonical (layout-independent) so two arrows that differ only in how
+  // the formatter laid out the chain or a map literal compare equal — diff
+  // matches arrows on this text (sl-dxjh).
+  const transformRaw = pipeSteps.length > 0 ? canonicalPipeChainText(pipeSteps) : "";
 
   const metaNode = child(arrow, "metadata_block");
   const metadata = metaNode ? extractMetadata(metaNode) : undefined;

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -50,6 +50,7 @@ export {
   extractQuestions,
   extractImports,
   extractArrowRecords,
+  canonicalPipeChainText,
 } from "./extract.js";
 export {
   collectFieldPaths,

--- a/tooling/satsuma-core/test/extract.test.js
+++ b/tooling/satsuma-core/test/extract.test.js
@@ -424,13 +424,47 @@ describe("extractMetrics()", () => {
 
 describe("extractTransforms()", () => {
   it("extracts a transform block with its name", () => {
-    const pipeChain = n("pipe_chain", [], "lookup(dim)");
+    const step = n("pipe_step", [n("pipe_text", [], "lookup(dim)")], "lookup(dim)");
+    const pipeChain = n("pipe_chain", [step], "lookup(dim)");
     const transformBlock = n("transform_block", [blockLabel("enrich"), pipeChain]);
     const root = n("program", [transformBlock]);
 
     assert.deepStrictEqual(extractTransforms(root), [
-      { name: "enrich", body: "lookup(dim)", namespace: null, row: 0, startColumn: 0 },
+      { name: "enrich", body: "lookup(dim)", canonicalBody: "lookup(dim)", namespace: null, row: 0, startColumn: 0 },
     ]);
+  });
+
+  it("canonicalBody normalizes step layout while body preserves it (sl-dxjh)", () => {
+    // A formatter is free to put each pipe step on its own line; the raw
+    // body keeps that layout but canonicalBody must be identical to the
+    // single-line spelling so diff sees no structural change.
+    const steps = [
+      n("pipe_step", [n("pipe_text", [], "trim")], "trim"),
+      n("pipe_step", [n("pipe_text", [], "uppercase")], "uppercase"),
+    ];
+    const pipeChain = n("pipe_chain", steps, "trim\n  | uppercase");
+    const transformBlock = n("transform_block", [blockLabel("tidy"), pipeChain]);
+    const root = n("program", [transformBlock]);
+
+    const [t] = extractTransforms(root);
+    assert.equal(t.body, "trim\n  | uppercase");
+    assert.equal(t.canonicalBody, "trim | uppercase");
+  });
+
+  it("canonicalBody rebuilds map literals as a single-line entry list with verbatim keys/values (sl-dxjh)", () => {
+    // Map entries may be authored comma-separated on one line or
+    // newline-separated by the formatter — both canonicalize to the same
+    // text. The quoted key and the value are NL content and must pass
+    // through verbatim, including casing and inner whitespace.
+    const entry = (k, v) => n("map_entry", [n("map_key", [], k), n("map_value", [], v)]);
+    const mapLit = n("map_literal", [entry('"A B"', "first class"), entry("_", "other")],
+      'map {\n  "A B": first class\n  _: other\n}');
+    const pipeChain = n("pipe_chain", [n("pipe_step", [mapLit], mapLit.text)], mapLit.text);
+    const transformBlock = n("transform_block", [blockLabel("classify"), pipeChain]);
+    const root = n("program", [transformBlock]);
+
+    const [t] = extractTransforms(root);
+    assert.equal(t.canonicalBody, 'map { "A B": first class, _: other }');
   });
 
   it("extracts transform inside namespace", () => {

--- a/tooling/satsuma-lsp/src/validate-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/validate-diagnostics.ts
@@ -26,6 +26,40 @@ const SEVERITY_MAP: Record<string, DiagnosticSeverity> = {
 };
 
 /**
+ * Extract the findings array from raw `satsuma validate --json` stdout.
+ *
+ * The CLI emits two shapes (sl-rngq):
+ *  - `{findings: [...], summary: {...}}` — the normal envelope, matching
+ *    `lint --json`, for every run that gets as far as validating files.
+ *  - a bare array — still live (not just legacy) for path-resolve failures,
+ *    where the CLI emits `[{severity, message}]` with no file/line so jq
+ *    pipelines keep parsing (see satsuma-cli validate.ts).
+ *
+ * Returns an empty array for unparseable or unrecognised input. Entries
+ * without a `file` (the resolve-failure shape) are kept here and filtered
+ * by the caller, which needs a file to attach a diagnostic to.
+ */
+export function parseValidateFindings(raw: string): ValidateEntry[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (Array.isArray(parsed)) {
+    return parsed as ValidateEntry[];
+  }
+  if (
+    parsed !== null &&
+    typeof parsed === "object" &&
+    Array.isArray((parsed as { findings?: unknown }).findings)
+  ) {
+    return (parsed as { findings: ValidateEntry[] }).findings;
+  }
+  return [];
+}
+
+/**
  * Run `satsuma validate --json` on the directory containing the given file
  * and return LSP diagnostics grouped by file URI.
  *
@@ -53,20 +87,14 @@ export async function runValidate(
             return;
           }
 
-          let entries: ValidateEntry[];
-          try {
-            entries = JSON.parse(raw);
-          } catch {
-            resolve(result);
-            return;
-          }
-
-          if (!Array.isArray(entries)) {
-            resolve(result);
-            return;
-          }
+          const entries = parseValidateFindings(raw);
 
           for (const entry of entries) {
+            // Resolve-failure entries carry no file/position — there is no
+            // document to attach them to, so they cannot become diagnostics.
+            if (!entry.file) {
+              continue;
+            }
             // Canonical so result keys line up with the workspace index and
             // the server's canonical-keyed caches (sl-ku3c).
             const uri = canonicalizeFileUri(pathToFileUri(entry.file));

--- a/tooling/satsuma-lsp/test/validate-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/validate-diagnostics.test.js
@@ -1,11 +1,19 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const path = require("node:path");
 const { fileURLToPath, pathToFileURL } = require("node:url");
 const {
   runValidate,
+  parseValidateFindings,
   pathToFileUri,
   reconcileValidateCache,
 } = require("../dist/validate-diagnostics");
+
+// The locally built CLI, invoked directly (it has a `#!/usr/bin/env node`
+// shebang). Tests must NOT use a bare "satsuma" from PATH: a missing global
+// install silently yields zero diagnostics, which is exactly how the
+// sl-rngq regression passed the old soft-guarded tests unnoticed.
+const CLI_PATH = path.resolve(__dirname, "../../satsuma-cli/dist/index.js");
 
 describe("reconcileValidateCache", () => {
   // sl-th5k: on save, only the saved file's cache entry was deleted. A
@@ -74,6 +82,42 @@ describe("pathToFileUri", () => {
   });
 });
 
+describe("parseValidateFindings", () => {
+  // sl-rngq: the CLI switched `validate --json` from a bare array to a
+  // `{findings, summary}` envelope (commit 8758118) and the LSP's
+  // Array.isArray guard silently rejected it — every validate diagnostic
+  // vanished from the editor for months. These cases pin both accepted
+  // shapes and the rejection behaviour.
+
+  it("extracts findings from the {findings, summary} envelope the CLI emits today", () => {
+    const raw = JSON.stringify({
+      findings: [{ file: "/a.stm", line: 3, column: 1, severity: "warning", rule: "r", message: "m", fixable: false }],
+      summary: { files: 1, errors: 0, warnings: 1 },
+    });
+    const entries = parseValidateFindings(raw);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].rule, "r");
+  });
+
+  it("accepts the bare-array shape still emitted for path-resolve failures", () => {
+    // Not legacy tolerance: satsuma-cli validate.ts emits
+    // `[{severity, message}]` (no file) when input resolution fails.
+    const entries = parseValidateFindings(
+      JSON.stringify([{ severity: "error", message: "Error resolving path: nope" }]),
+    );
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].file, undefined);
+  });
+
+  it("returns no findings for unparseable or unrecognised JSON", () => {
+    assert.deepEqual(parseValidateFindings("not json"), []);
+    // An object without a findings array (e.g. a future shape change) must
+    // degrade to empty, not throw inside the execFile callback.
+    assert.deepEqual(parseValidateFindings(JSON.stringify({ summary: {} })), []);
+    assert.deepEqual(parseValidateFindings(JSON.stringify({ findings: "oops" })), []);
+  });
+});
+
 describe("runValidate", () => {
   it("returns empty map when CLI produces no output", async () => {
     // Use a non-existent CLI to exercise the error/empty path
@@ -95,100 +139,40 @@ describe("runValidate", () => {
     assert.equal(result.size, 0);
   });
 
-  it("parses valid satsuma validate --json output", async () => {
-    // Use the real satsuma CLI against a fixture with known warnings
-    const fixtureDir = require("path").resolve(
+  // Contract test against the real built CLI (sl-rngq acceptance criterion 3):
+  // if the CLI's --json shape and the LSP parser ever drift again, this fails
+  // loudly instead of degrading to zero diagnostics. The namespaces example
+  // ships four known field-not-in-schema warnings (bogus source fields on
+  // warehouse::conformed_store in the 'daily sales pipeline' mapping), so a
+  // non-empty result is a hard requirement, not an if-guarded hope.
+  it("surfaces the namespaces example's four field-not-in-schema warnings from the real CLI", async () => {
+    const fixturePath = path.resolve(
       __dirname,
-      "../../../examples/db-to-db/pipeline.stm",
+      "../../../examples/namespaces/namespaces.stm",
     );
-    const fixtureUri = "file://" + encodeURI(fixtureDir);
+    const fixtureUri = pathToFileURL(fixturePath).toString();
 
-    const result = await runValidate(fixtureUri, "satsuma");
+    const result = await runValidate(fixtureUri, CLI_PATH);
 
-    // db-to-db.stm should have warnings (missing-import, undefined-ref, etc.)
-    // If satsuma CLI is not available, this effectively tests graceful fallback
-    if (result.size > 0) {
-      for (const [uri, diags] of result) {
-        assert.ok(uri.startsWith("file://"), `URI should be file:// got ${uri}`);
-        assert.ok(diags.length > 0, "Should have diagnostics");
-        for (const d of diags) {
-          assert.equal(d.source, "satsuma-validate");
-          assert.ok(d.message, "Diagnostic should have a message");
-          assert.ok(d.code, "Diagnostic should have a rule code");
-          assert.ok(d.range, "Diagnostic should have a range");
-          // Lines should be 0-based (converted from 1-based)
-          assert.ok(
-            d.range.start.line >= 0,
-            "Line should be non-negative",
-          );
-        }
-      }
+    assert.ok(result.size > 0, "real CLI output must produce diagnostics — empty means the JSON shapes have drifted (sl-rngq)");
+
+    const all = [...result.values()].flat();
+    const fieldWarnings = all.filter((d) => d.code === "field-not-in-schema");
+    assert.equal(fieldWarnings.length, 4, "the four bogus source fields must each surface as a diagnostic");
+    for (const d of fieldWarnings) {
+      assert.equal(d.source, "satsuma-validate");
+      // DiagnosticSeverity.Warning === 2
+      assert.equal(d.severity, 2, "field-not-in-schema is warning severity");
+      assert.match(d.message, /not declared in schema 'warehouse::conformed_store'/);
+      // CLI reports lines 105-108 (1-based); LSP must convert to 0-based.
+      assert.ok(d.range.start.line >= 104 && d.range.start.line <= 107,
+        `expected 0-based line in [104,107], got ${d.range.start.line}`);
     }
-  });
 
-  it("returns diagnostics with correct severity mapping", async () => {
-    const fixtureDir = require("path").resolve(
-      __dirname,
-      "../../../examples/db-to-db/pipeline.stm",
-    );
-    const fixtureUri = "file://" + encodeURI(fixtureDir);
-
-    const result = await runValidate(fixtureUri, "satsuma");
-
-    if (result.size > 0) {
-      for (const [, diags] of result) {
-        for (const d of diags) {
-          // DiagnosticSeverity: Error=1, Warning=2, Information=3, Hint=4
-          assert.ok(
-            [1, 2, 3, 4].includes(d.severity),
-            `Severity should be a valid LSP value, got ${d.severity}`,
-          );
-        }
-      }
-    }
-  });
-
-  it("groups diagnostics by file URI", async () => {
-    // Validate the examples directory — should have multiple files
-    const examplesDir = require("path").resolve(
-      __dirname,
-      "../../../examples",
-    );
-    // Pick a file that imports from another file
-    const fixtureUri = "file://" + encodeURI(
-      require("path").join(examplesDir, "db-to-db/pipeline.stm"),
-    );
-
-    const result = await runValidate(fixtureUri, "satsuma");
-
-    if (result.size > 0) {
-      // All URIs should be properly formatted
-      for (const [uri] of result) {
-        assert.ok(
-          uri.startsWith("file://"),
-          `URI should start with file://, got: ${uri}`,
-        );
-      }
-    }
-  });
-
-  it("converts 1-based line/column to 0-based", async () => {
-    const fixtureDir = require("path").resolve(
-      __dirname,
-      "../../../examples/db-to-db/pipeline.stm",
-    );
-    const fixtureUri = "file://" + encodeURI(fixtureDir);
-
-    const result = await runValidate(fixtureUri, "satsuma");
-
-    if (result.size > 0) {
-      for (const [, diags] of result) {
-        for (const d of diags) {
-          // 0-based lines: line 3 in CLI output → line 2 in LSP
-          assert.ok(d.range.start.line >= 0, "Line must be 0-based");
-          assert.ok(d.range.start.character >= 0, "Character must be 0-based");
-        }
-      }
+    // Diagnostics must be keyed by canonical file:// URIs so they attach to
+    // the open editor document.
+    for (const [uri] of result) {
+      assert.ok(uri.startsWith("file://"), `URI should start with file://, got: ${uri}`);
     }
   });
 });

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -39,7 +39,7 @@
     },
     "../satsuma-lsp": {
       "name": "@satsuma/lsp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",


### PR DESCRIPTION
Fixes three bugs from the 2026-06-12 smoke checks: the P1 LSP diagnostics regression plus two CLI namespace/structural-identity bugs.

## sl-rngq (P1) — LSP validate fallback silently dropped all CLI diagnostics

`runValidate` parsed `satsuma validate --json` expecting a bare array, but the CLI has emitted a `{findings, summary}` envelope since commit 8758118 (2026-03-25). The `Array.isArray` guard rejected the envelope and resolved an empty map — no `satsuma-validate` diagnostics ever reached the editor.

- Extracted `parseValidateFindings`, accepting both the envelope and the bare-array shape (still live for path-resolve failures, not just legacy); file-less entries are skipped.
- Replaced the old `if (result.size > 0)`-guarded tests — which silently passed throughout the regression — with a contract test that runs the locally built CLI against `examples/namespaces/namespaces.stm` and hard-asserts its four field-not-in-schema warnings. Shape drift now fails loudly.

## sl-l3m8 — where-used found no references to namespaced transforms/fragments

where-used resolved the *definition* through the namespace-aware index (echoing `crm::tidy`) but compared CST reference text raw, so bare invocations/spreads authored inside the namespace never matched. Fixed by threading the authoring namespace through both walkers and resolving each reference with core's existing `resolveScopedEntityRef` — the same binding rule as the LSP's sl-p256 fix (bare name binds namespace-local first, then global). The LSP is unaffected: viz-backend already re-resolves references by authoring namespace, and the binding rule already lived in core.

Old tests exercised an inline copy of the walker; replaced with subprocess tests covering bare/spread × namespaced/unnamespaced plus shadowing in both directions.

## sl-dxjh — diff reported fmt-only layout changes as structural

Transform bodies compared as raw text and arrows' `transform_raw` embedded raw map-literal layout, so `diff(file, fmt(file))` was non-empty. Added `canonicalPipeChainText` to core extraction: steps joined `" | "`, map entries rebuilt single-line, every leaf token (NL content) verbatim. `ExtractedTransform` gains `canonicalBody` alongside the raw `body`; diff compares canonical forms. A corpus-wide property test asserts `diff(file, fmt(file))` is empty for all 25 example files.

**ADR-033** (canonical pipe-chain serialization defines structural identity) is included — please review; it documents the `transform_raw` contract change (map literals now render canonical single-line in `arrows --json` and diff output).

## Tests

- core: 428 pass (canonicalBody layout/verbatim cases added)
- cli: 902 pass (where-used matrix + 25 corpus fmt-roundtrip cases added)
- lsp: 301 pass (envelope parsing + real-CLI contract test added)
- viz-backend: 163 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)