### PR TITLE
chore(vscode): raise minimum VS Code to 1.125 to match @types/vscode

### DIFF
--- a/.tickets/sl-xcqm.md
+++ b/.tickets/sl-xcqm.md
@@ -1,0 +1,14 @@
+---
+id: sl-xcqm
+status: open
+deps: []
+links: []
+created: 2026-07-13T16:24:35Z
+type: task
+priority: 2
+assignee: Thorben Louw
+---
+# Pin GitHub Actions to commit SHAs to satisfy Semgrep mutable-tag rule
+
+Semgrep SAST now blocks on yaml.github-actions.security.github-actions-mutable-action-tag (61 findings). All workflow 'uses:' references use mutable tags like actions/checkout@v7. Every PR since ~2026-07-07 shows a failing (non-required) Semgrep SAST check. Fix: pin each action to a full 40-char commit SHA with a version comment, e.g. 'uses: actions/checkout@<sha> # v7'. Acceptance: Semgrep SAST check green on a fresh PR; all workflows under .github/workflows/ pinned; dependabot github-actions ecosystem still able to update pinned SHAs.
+

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -21,7 +21,7 @@
         "vscode-tmgrammar-test": "^0.1.3"
       },
       "engines": {
-        "vscode": "^1.91.0"
+        "vscode": "^1.125.0"
       }
     },
     "../satsuma-core": {
@@ -29,10 +29,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.9"
+        "web-tree-sitter": "^0.26.10"
       },
       "devDependencies": {
-        "@types/node": "^25.9.3",
+        "@types/node": "^26.1.0",
         "c8": "^11.0.0",
         "typescript": "^6.0.3"
       }
@@ -44,7 +44,7 @@
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",
         "@satsuma/viz-model": "file:../satsuma-viz-model",
-        "vscode-languageserver": "^10.0.0",
+        "vscode-languageserver": "^10.1.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "web-tree-sitter": "^0.26.7"
       },

--- a/tooling/vscode-satsuma/package.json
+++ b/tooling/vscode-satsuma/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/EqualExperts/satsuma-lang"
   },
   "engines": {
-    "vscode": "^1.91.0"
+    "vscode": "^1.125.0"
   },
   "categories": [
     "Programming Languages"


### PR DESCRIPTION
## Why

Dependabot PR #332 bumped `@types/vscode` to 1.125.0. `vsce package` (run by the release workflow) refuses to build when the `@types/vscode` version exceeds the `engines.vscode` minimum, so without this change the next release would fail.

## What

- Raise `engines.vscode` from `^1.91.0` to `^1.125.0` in `tooling/vscode-satsuma`. This raises the minimum supported VS Code version (agreed with @thorbenlouw over closing/pinning the types).
- Sync `package-lock.json`, including the linked `satsuma-core` snapshot picking up the web-tree-sitter 0.26.10 bump from #345.
- Add ticket `sl-xcqm`: pin GitHub Actions to commit SHAs — the Semgrep SAST `github-actions-mutable-action-tag` rule became blocking (~Jul 7) and now fails (non-required) on every fresh PR, including all recent Dependabot ones.

## Verification

`npm run package` in `tooling/vscode-satsuma` completes: `DONE Packaged: vscode-satsuma.vsix (72 files, 4.84 MB)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)