### PR TITLE
fix(vscode): restore webviews broken by message guard (sl-b90g)

### DIFF
--- a/.tickets/sl-b90g.md
+++ b/.tickets/sl-b90g.md
@@ -1,6 +1,6 @@
 ---
 id: sl-b90g
-status: in_progress
+status: closed
 deps: []
 links: [sl-mrn3]
 created: 2026-07-22T15:18:15Z
@@ -26,3 +26,9 @@ The security fix in e8c638c (sl-mrn3) added a webview message guard that checks 
 
 Cause: The webview message guard added in e8c638c (sl-mrn3) checked event.source === window.parent. That invariant does not hold in the VS Code webview runtime — host messages posted via webview.postMessage() do not arrive with source === window.parent — so the guard dropped every host message and all four webviews (viz, lineage, schema-lineage, field-lineage) stopped receiving data; viz showed a permanent 'No mapping file loaded'.
 Fix: Switched the guard to the VS Code-sanctioned check event.origin === window.origin (isExtensionHostMessage now takes selfOrigin), updated all four call sites to pass window.origin, and rewrote message-guard.test.js for origin semantics. Guard still rejects foreign-origin messages, preserving the sl-mrn3 Semgrep fix.
+
+**2026-07-22T15:25:59Z**
+
+**2026-07-22T15:25:59Z**
+
+Verified: user installed the locally-built vsix (0.10.0) and confirmed the viz preview renders again (fix commit d5245d7).

--- a/.tickets/sl-b90g.md
+++ b/.tickets/sl-b90g.md
@@ -1,0 +1,28 @@
+---
+id: sl-b90g
+status: in_progress
+deps: []
+links: [sl-mrn3]
+created: 2026-07-22T15:18:15Z
+type: bug
+priority: 0
+assignee: Thorben Louw
+tags: [vscode, webview, regression]
+---
+# Webview message guard breaks all webviews: 'No mapping file loaded'
+
+The security fix in e8c638c (sl-mrn3) added a webview message guard that checks event.source === window.parent. This is the wrong invariant for VS Code webviews: messages posted by the extension host via webview.postMessage() do not arrive with source === window.parent, so the guard silently drops every host message. All four webviews (viz, lineage, schema-lineage, field-lineage) are affected; the viz panel shows a permanent 'No mapping file loaded' because the vizModel message never reaches the component. The regression shipped untested against the real VS Code runtime — message-guard.test.js only unit-tests the pure identity function, and the viz-harness Playwright suite does not exercise the VS Code webview.
+
+## Acceptance Criteria
+
+1. Viz panel renders the mapping model again (no permanent 'No mapping file loaded'). 2. All four webviews receive host messages. 3. Provenance guard still rejects foreign-origin messages, satisfying the Semgrep concern from sl-mrn3. 4. Guard uses the VS Code-sanctioned check (event.origin === window.origin). 5. message-guard.test.js updated to reflect origin semantics; unit tests pass. 6. dist rebuilt.
+
+
+## Notes
+
+**2026-07-22T15:21:26Z**
+
+**2026-07-22T15:21:26Z**
+
+Cause: The webview message guard added in e8c638c (sl-mrn3) checked event.source === window.parent. That invariant does not hold in the VS Code webview runtime — host messages posted via webview.postMessage() do not arrive with source === window.parent — so the guard dropped every host message and all four webviews (viz, lineage, schema-lineage, field-lineage) stopped receiving data; viz showed a permanent 'No mapping file loaded'.
+Fix: Switched the guard to the VS Code-sanctioned check event.origin === window.origin (isExtensionHostMessage now takes selfOrigin), updated all four call sites to pass window.origin, and rewrote message-guard.test.js for origin semantics. Guard still rejects foreign-origin messages, preserving the sl-mrn3 Semgrep fix.

--- a/.tickets/sl-mrn3.md
+++ b/.tickets/sl-mrn3.md
@@ -2,7 +2,7 @@
 id: sl-mrn3
 status: closed
 deps: []
-links: []
+links: [sl-b90g]
 created: 2026-07-14T08:09:03Z
 type: task
 priority: 2

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -29,10 +29,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.10"
+        "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "c8": "^11.0.0",
         "typescript": "^6.0.3"
       }
@@ -845,9 +845,9 @@
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
@@ -58,7 +58,7 @@ let lastPayload: Payload | null = null;
 // ── Entry point ────────────────────────────────────────────────────────────
 
 window.addEventListener("message", (event: MessageEvent) => {
-  if (!isExtensionHostMessage(event, window.parent)) return;
+  if (!isExtensionHostMessage(event, window.origin)) return;
   const msg = event.data as { type: string; payload?: Payload; message?: string };
   if (msg.type === "fieldLineageData" && msg.payload) {
     lastPayload = msg.payload;

--- a/tooling/vscode-satsuma/src/webview/lineage/lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/lineage/lineage.ts
@@ -19,7 +19,7 @@ interface ArrowEntry {
 }
 
 window.addEventListener("message", (event) => {
-  if (!isExtensionHostMessage(event, window.parent)) return;
+  if (!isExtensionHostMessage(event, window.origin)) return;
   const msg = event.data;
   if (msg.type === "lineageData") {
     render(msg.payload);

--- a/tooling/vscode-satsuma/src/webview/message-guard.ts
+++ b/tooling/vscode-satsuma/src/webview/message-guard.ts
@@ -2,27 +2,34 @@
  * message-guard.ts — provenance check for messages arriving in webview scripts.
  *
  * Every webview entry point listens for window `message` events to receive
- * data from the extension host. The host relays those messages through the
- * enclosing webview frame, so a legitimate message's `source` is always the
- * webview's parent window. Messages from any other window — for example
- * content embedded inside the webview in the future — must be ignored
- * (Semgrep: insufficient-postmessage-origin-validation).
+ * data from the extension host. VS Code delivers those messages into the
+ * webview's own frame, so a legitimate message's `origin` equals the webview
+ * window's own origin. Messages from any other window — for example content
+ * embedded inside the webview in the future — carry a different origin and
+ * must be ignored (Semgrep: insufficient-postmessage-origin-validation).
  *
- * The check matches on `event.source` rather than pinning `event.origin`:
- * the origin string differs across VS Code desktop, web, and remote hosts,
- * while the parent-frame relay is an invariant of the webview architecture.
+ * The check compares `event.origin` against the webview's own `window.origin`
+ * rather than pinning a hardcoded string: the concrete origin differs across
+ * VS Code desktop, web, and remote hosts (and embeds a per-webview UUID), but
+ * a host message always shares the webview's own origin. This is the check the
+ * VS Code team recommends for extension-to-webview messaging (see sl-b90g).
+ *
+ * Note: an earlier revision (sl-mrn3) compared `event.source` to
+ * `window.parent`. That invariant does not hold in the VS Code runtime — host
+ * messages do not arrive with `source === window.parent` — so the guard
+ * silently dropped every host message and broke all four webviews.
  */
 
 /**
- * True when a `message` event was posted by the extension host (relayed via
- * the webview's parent frame) rather than by embedded or foreign content.
+ * True when a `message` event was posted by the extension host (and so carries
+ * the webview's own origin) rather than by embedded or foreign content.
  *
- * `parentWindow` is injected — call sites pass `window.parent` — so the rule
+ * `selfOrigin` is injected — call sites pass `window.origin` — so the rule
  * stays testable outside a browser environment.
  */
 export function isExtensionHostMessage(
-  event: Pick<MessageEvent, "source">,
-  parentWindow: unknown,
+  event: Pick<MessageEvent, "origin">,
+  selfOrigin: string,
 ): boolean {
-  return event.source === parentWindow;
+  return event.origin === selfOrigin;
 }

--- a/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
@@ -53,7 +53,7 @@ interface NodePos {
 // ── Entry point ────────────────────────────────────────────────────────────
 
 window.addEventListener("message", (event: MessageEvent) => {
-  if (!isExtensionHostMessage(event, window.parent)) return;
+  if (!isExtensionHostMessage(event, window.origin)) return;
   const msg = event.data as { type: string; payload?: Payload; message?: string };
   if (msg.type === "schemaLineageData" && msg.payload) {
     render(msg.payload);

--- a/tooling/vscode-satsuma/src/webview/viz/viz.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/viz.ts
@@ -59,7 +59,7 @@ vizEl.addEventListener("field-lineage", (ev: CustomEvent) => {
 
 // Receive messages from the extension host
 window.addEventListener("message", (event) => {
-  if (!isExtensionHostMessage(event, window.parent)) return;
+  if (!isExtensionHostMessage(event, window.origin)) return;
   const msg = event.data;
 
   if (msg.type === "vizModel") {

--- a/tooling/vscode-satsuma/test/message-guard.test.js
+++ b/tooling/vscode-satsuma/test/message-guard.test.js
@@ -1,36 +1,40 @@
 /**
  * message-guard.test.js — provenance rule for webview `message` events.
  *
- * sl-mrn3: the webview entry points must only act on messages relayed by the
- * extension host (the webview's parent frame) and ignore messages posted by
- * any other window, e.g. content embedded in the webview. These cases pin
- * the source-matching rule all four webview scripts rely on.
+ * sl-mrn3 introduced the guard; sl-b90g corrected its invariant. The webview
+ * entry points must only act on messages posted by the extension host — which
+ * arrive carrying the webview's own origin — and ignore messages posted by any
+ * other window (e.g. content embedded in the webview), which carry a different
+ * origin. These cases pin the origin-matching rule all four webview scripts
+ * rely on.
  */
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
 const { isExtensionHostMessage } = require("../dist/client/webview/message-guard.js");
 
+// The webview's own origin. VS Code assigns each webview a unique
+// `vscode-webview://<uuid>` origin; the concrete value is opaque here, so we
+// use a representative stand-in and assert only on the equality contract.
+const SELF_ORIGIN = "vscode-webview://11111111-2222-3333-4444-555555555555";
+
 describe("isExtensionHostMessage", () => {
-  // The legitimate path: the extension host's messages arrive with the
-  // webview's parent frame as their source.
-  it("accepts a message whose source is the webview's parent frame", () => {
-    const parent = { name: "parent-frame" };
-    assert.equal(isExtensionHostMessage({ source: parent }, parent), true);
+  // The legitimate path: the extension host's messages are delivered into the
+  // webview's own frame, so they share the webview's own origin.
+  it("accepts a message whose origin matches the webview's own origin", () => {
+    assert.equal(isExtensionHostMessage({ origin: SELF_ORIGIN }, SELF_ORIGIN), true);
   });
 
-  // The attack path the guard exists for: an embedded iframe (or any other
-  // window) posts into the webview — its source is not the parent frame.
-  it("rejects a message posted by a different window", () => {
-    const parent = { name: "parent-frame" };
-    const foreign = { name: "embedded-iframe" };
-    assert.equal(isExtensionHostMessage({ source: foreign }, parent), false);
+  // The attack path the guard exists for: another window (an embedded iframe,
+  // or foreign content) posts into the webview — its origin differs.
+  it("rejects a message posted from a different origin", () => {
+    const foreignOrigin = "https://evil.example.com";
+    assert.equal(isExtensionHostMessage({ origin: foreignOrigin }, SELF_ORIGIN), false);
   });
 
-  // MessageEvents constructed without a source (e.g. synthetic dispatch)
-  // carry source: null — identity comparison must not treat null as trusted.
-  it("rejects a synthetic message with a null source", () => {
-    const parent = { name: "parent-frame" };
-    assert.equal(isExtensionHostMessage({ source: null }, parent), false);
+  // An empty-string origin (some synthetic or sandboxed dispatches) must not be
+  // treated as trusted when the webview has a concrete origin of its own.
+  it("rejects a message with an empty origin", () => {
+    assert.equal(isExtensionHostMessage({ origin: "" }, SELF_ORIGIN), false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes **sl-b90g** — the VS Code viz preview (and the lineage, schema-lineage, and field-lineage panels) stopped displaying anything, showing a permanent **"No mapping file loaded"**.

## Root cause

The webview message guard added in `e8c638c` (sl-mrn3) checks:

```js
event.source === window.parent
```

That invariant does **not** hold in the VS Code webview runtime. Messages posted by the extension host via `webview.postMessage()` do not arrive with `source === window.parent`, so the guard silently dropped **every** host message. All four webviews stopped receiving data; the viz panel never got its `vizModel` envelope and stayed in its empty state.

The regression shipped untested against the real runtime: `message-guard.test.js` only exercises the pure identity function, and the viz-harness Playwright suite drives a standalone web server, not the VS Code webview.

## Fix

Switch to the [VS Code-sanctioned](https://github.com/microsoft/vscode-discussions/discussions/1061) provenance check — `event.origin === window.origin`:

- `isExtensionHostMessage` now takes `selfOrigin` and compares origins.
- All four webview call sites pass `window.origin`.
- `message-guard.test.js` rewritten for origin semantics.

The guard still rejects foreign-origin messages, so the original sl-mrn3 Semgrep concern (`insufficient-postmessage-origin-validation`) remains addressed.

## Testing

- `npm test` in `tooling/vscode-satsuma` — 33 unit tests + TextMate fixture/golden suites all pass.
- ⚠️ **Manual verification still needed in a running VS Code instance**: the webview runtime cannot be exercised in the agent sandbox. Please open a `.stm` file and confirm the viz preview renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)