### PR TITLE
fix(security): patch js-yaml DoS in site/ (Dependabot #42/#43)

### DIFF
--- a/.tickets/sl-4wo3.md
+++ b/.tickets/sl-4wo3.md
@@ -1,0 +1,28 @@
+---
+id: sl-4wo3
+status: closed
+deps: []
+links: []
+created: 2026-07-22T16:26:40Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+external-ref: gh-alert-42,gh-alert-43
+---
+# Fix js-yaml quadratic-complexity DoS in site/ (Dependabot #42/#43)
+
+Dependabot alerts #42/#43 (medium): js-yaml quadratic-complexity DoS via merge-key repeated aliases. site/ resolves js-yaml 3.14.2 (via gray-matter) and 4.1.1 (via @11ty/eleventy), both dev-only/build-time transitive deps. Fix: npm update js-yaml in site/ bumps to patched 3.15.0 and 4.3.0 within existing ^ ranges (no package.json or override changes; site builds clean).
+
+## Acceptance Criteria
+
+site/package-lock.json resolves js-yaml >=3.15.0 and >=4.2.0; eleventy build passes; Dependabot alerts #42/#43 auto-close after merge.
+
+
+## Notes
+
+**2026-07-22T16:27:52Z**
+
+2026-07-22T16:27:52Z
+
+Cause: site/ resolved js-yaml 3.14.2 (via gray-matter) and 4.1.1 (via @11ty/eleventy), both matching the js-yaml quadratic-complexity DoS advisory (Dependabot #42/#43, medium); dev-only build-time transitive deps, not audited by CI (--omit=dev).
+Fix: 'npm update js-yaml' in site/ bumped both to patched 3.15.0 and 4.3.0 within existing ^ ranges (lockfile-only, no package.json/override changes). Eleventy build verified clean.

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -995,10 +995,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## What

Bumps the two `js-yaml` instances in `site/` into their patched versions, resolving Dependabot alerts **#42** and **#43** (medium — js-yaml quadratic-complexity DoS via merge-key repeated aliases).

| Dependent | Range | Before | After |
|---|---|---|---|
| `gray-matter@4.0.3` | `js-yaml ^3.13.1` | 3.14.2 ⚠️ | **3.15.0** ✅ |
| `@11ty/eleventy` | `js-yaml ^4.1.1` | 4.1.1 ⚠️ | **4.3.0** ✅ |

## How

`npm update js-yaml` inside `site/`. Both are **transitive, dev-only, build-time** dependencies, so:
- No `package.json` or `overrides` changes are needed — the patched versions already satisfy the existing `^` ranges.
- The change is **lockfile-only** (`site/package-lock.json`).
- These deps are omitted from CI's `npm audit --omit=dev`, so they never blocked CI — this is proactive cleanup of the reported Dependabot alerts.

## Verification

- `npm ci` + `eleventy` build in `site/` passes (frontmatter parsing via gray-matter/js-yaml works with the patched versions).
- Post-update lockfile resolves `js-yaml` to `3.15.0` and `4.3.0` only.

Closes ticket sl-4wo3. Dependabot alerts #42/#43 will auto-close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)