### PR TITLE
fix(security): bump brace-expansion to 1.1.18 / 5.0.9 in all lockfiles (sl-vhyo)

### DIFF
--- a/.tickets/sl-vhyo.md
+++ b/.tickets/sl-vhyo.md
@@ -1,0 +1,18 @@
+---
+id: sl-vhyo
+status: in_progress
+deps: []
+links: []
+created: 2026-07-31T08:29:53Z
+type: chore
+priority: 1
+assignee: Thorben Louw
+---
+# Bump brace-expansion across all lockfiles (1.x -> 1.1.16, 5.x -> 5.0.8) to clear Dependabot alerts 53/55/66
+
+New brace-expansion DoS advisory wave: 1.x line patched in 1.1.16 (dev-scope, site + vscode-satsuma flagged) and 5.x line patched in 5.0.8 (runtime-scope, vscode-satsuma flagged, but every package lockfile carries 5.0.7). Transitive-only deps; fix is lockfile-only npm update in each package dir.
+
+## Acceptance Criteria
+
+brace-expansion >=1.1.16 / >=5.0.8 in all lockfiles; npm audit clean for brace-expansion in every package; Dependabot alerts 53/55/66 close on next default-branch scan
+

--- a/.tickets/sl-vhyo.md
+++ b/.tickets/sl-vhyo.md
@@ -1,6 +1,6 @@
 ---
 id: sl-vhyo
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-07-31T08:29:53Z
@@ -16,3 +16,10 @@ New brace-expansion DoS advisory wave: 1.x line patched in 1.1.16 (dev-scope, si
 
 brace-expansion >=1.1.16 / >=5.0.8 in all lockfiles; npm audit clean for brace-expansion in every package; Dependabot alerts 53/55/66 close on next default-branch scan
 
+
+## Notes
+
+**2026-07-31T08:36:52Z**
+
+Cause: new brace-expansion DoS advisory wave — 1.x line vulnerable <1.1.16 (dev-scope, site + vscode-satsuma) and 5.x line vulnerable <=5.0.7 (runtime-scope via vscode-languageclient in vscode-satsuma; all package lockfiles carried 5.0.7).
+Fix: lockfile-only npm update brace-expansion in every package dir -> 1.1.18 / 5.0.9; all 11 packages pass npm audit --omit=dev --audit-level=high (commit 9e3f555)

--- a/package-lock.json
+++ b/package-lock.json
@@ -599,16 +599,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -366,9 +366,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tooling/satsuma-cli/package-lock.json
+++ b/tooling/satsuma-cli/package-lock.json
@@ -36,8 +36,8 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -589,16 +589,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/satsuma-core/package-lock.json
+++ b/tooling/satsuma-core/package-lock.json
@@ -119,16 +119,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/satsuma-lsp/package-lock.json
+++ b/tooling/satsuma-lsp/package-lock.json
@@ -33,8 +33,8 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -58,8 +58,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -619,16 +619,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -27,8 +27,8 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -37,8 +37,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -152,16 +152,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -28,7 +28,7 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
@@ -53,7 +53,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }

--- a/tooling/satsuma-viz-model/package-lock.json
+++ b/tooling/satsuma-viz-model/package-lock.json
@@ -116,16 +116,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -29,7 +29,7 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
@@ -39,7 +39,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^26.1.1",
+        "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
@@ -617,16 +617,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/c8": {

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -32,8 +32,8 @@
         "web-tree-sitter": "^0.26.11"
       },
       "devDependencies": {
-        "@types/node": "^26.1.1",
-        "c8": "^11.0.0",
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -553,9 +553,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -845,15 +845,15 @@
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {


### PR DESCRIPTION
## Summary

New brace-expansion DoS advisory wave ([GHSA 1.x line](https://github.com/advisories) patched in 1.1.16, 5.x line patched in 5.0.8):

- **Dependabot alerts 53, 55, 66** flagged `site/` (1.1.12, dev) and `tooling/vscode-satsuma/` (1.1.13 dev + 5.0.7 runtime via vscode-languageclient)
- Every other package lockfile also carried 5.0.7 — bumped them all before Dependabot raises further alerts

Lockfile-only `npm update brace-expansion` in each package; no manifest or override changes. This is the same advisory family as the 5.0.7 wave fixed in #384/#386-era commits — the ranges moved again.

## Verification

`npm audit --omit=dev --audit-level=high` (exact CI check) passes in all 11 package directories, so this also clears the `npm audit` CI failure seen on the recent Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)