### PR TITLE
docs: features 35-37 plans and tickets, plus stale spec-link repair

### DIFF
--- a/.tickets/sl-1ml2.md
+++ b/.tickets/sl-1ml2.md
@@ -1,0 +1,20 @@
+---
+id: sl-1ml2
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:13:41Z
+type: chore
+priority: 3
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, docs]
+---
+# docs: roadmap note for future playground coverage exposure
+
+PRD 36 open question 1, resolved in user review: exposing coverage mode in the public site playground is a separate future feature. Record it in docs/product-owner/ROADMAP.md so the decision is not lost, referencing feature 36 and the Feature 34 playground UX bar.
+
+## Acceptance Criteria
+
+ROADMAP.md entry added describing the deferred playground exposure and its dependency on feature 36 shipping in harness and VS Code first.
+

--- a/.tickets/sl-1u6r.md
+++ b/.tickets/sl-1u6r.md
@@ -1,0 +1,31 @@
+---
+id: sl-1u6r
+status: open
+deps: [sl-npi6]
+links: []
+created: 2026-07-31T13:14:15Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-iffm
+tags: [feature-37, cli]
+---
+# cli: lint exit-code escalation (strict mode)
+
+PRD 37 open question 3, resolved YES (exit code) in user review: warnings remain advisory by default, but CI users can make lint exit non-zero on warnings via the strict flag in satsuma.config.yaml or a --strict CLI flag (flag wins over config).
+
+## Design
+
+Lint gets its own documented exit-code table (user decision, doc review 2026-07-31). lint already contradicts the CLI-wide table: commands/lint.ts:114 returns EXIT_PARSE_ERROR (2) when there are error-severity findings, where 2 is documented as "parse error or filesystem error" (SATSUMA-CLI.md:164-169). Adding strict mode on top would make 1 — documented as "not found / no results" — mean "warnings present", giving all three codes a third meaning. So pin the table down before strict mode ships, following the fmt precedent at SATSUMA-CLI.md:86:
+
+  0  no findings, or warnings only without --strict
+  1  warnings present and --strict active
+  2  error-severity findings present
+  3  parse or filesystem error (lint could not run)
+
+This moves lint's "could not run" case off 2 and leaves 2 meaning "the workspace has lint errors" — the meaning it already has in practice. It is a breaking change for any CI job keying off lint's current codes, so it must be called out in CHANGELOG.md.
+
+## Acceptance Criteria
+
+Full exit-code matrix tested: clean 0; warnings without --strict 0; warnings with --strict 1; error findings 2; unparseable workspace 3; --strict flag overrides config strict false; suppressed rules do not trigger strict failure; lint exit-code table documented in command help and SATSUMA-CLI.md; the code change for error findings (2) and parse failures (3) called out in CHANGELOG.md as breaking for CI consumers; CLI tests pass locally.
+

--- a/.tickets/sl-268g.md
+++ b/.tickets/sl-268g.md
@@ -1,0 +1,26 @@
+---
+id: sl-268g
+status: open
+deps: [sl-3ms0]
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, cli]
+---
+# cli: coverage --fail-under CI gate and exit codes
+
+PRD 35 R4. satsuma coverage entry.stm --fail-under 90 exits non-zero when coverage is below threshold, making spec completeness CI-gateable like fmt --check. Applies to target-role aggregate by default; respects active scope flags (--role, --mapping) per user-accepted proposal.
+
+## Design
+
+Threshold-not-met uses a distinct exit code 3, decided in doc review 2026-07-31 (the PRD originally proposed reusing 1). 1 keeps its established CLI meaning of not-found / no-results — EXIT_NOT_FOUND is already thrown for an unresolvable --mapping name at commands/fields.ts:98. If threshold-not-met also returned 1, then `coverage --fail-under 90 --mapping "typo"` would exit 1 for a misspelled mapping name and 1 for genuine under-coverage, so CI could not distinguish "the spec is incomplete" from "the build invocation is broken" — defeating the gate. fmt --check avoids this only because it takes no scope arguments that can fail to resolve.
+
+Final table: 0 threshold met, 1 not found / unresolvable scope argument, 2 parse or filesystem error, 3 threshold not met. Document it as a coverage-specific table in SATSUMA-CLI.md, following the precedent already set for fmt (SATSUMA-CLI.md:86).
+
+## Acceptance Criteria
+
+Exit codes tested for all four cases: threshold met 0, unresolvable --mapping/--schema 1 (never reported as a coverage failure), parse/filesystem error 2, threshold not met 3; --fail-under composed with --role source and with --mapping gates the scoped percentage; coverage-specific exit code table documented in command help and SATSUMA-CLI.md; CLI tests pass locally.
+

--- a/.tickets/sl-3de8.md
+++ b/.tickets/sl-3de8.md
@@ -1,0 +1,15 @@
+---
+id: sl-3de8
+status: open
+deps: [sl-ce11]
+links: []
+created: 2026-07-31T13:13:41Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-36, viz]
+---
+# Feature 36 epic: viz coverage overlay and field chain view
+
+Implement features/36-viz-coverage-and-chain-view/PRD.md: a paint-only coverage overlay on the viz overview, uncovered-field treatment in cards and detail views, and a chain view rendering one field's full upstream/downstream lineage. Depends on feature 35 for the core coverage function (sl-gsxu) and the core aggregate rollup (sl-4qvp) — not on the whole of feature 35. Doc review 2026-07-31 split the aggregation so this feature's overlay work runs in parallel with feature 35's CLI command rather than behind it; the per-ticket deps carry that, so treat the epic-level dep as informational. Open questions resolved by user review 2026-07-31: playground exposure deferred to a separate future feature (roadmap note); wide fans collapse by namespace with expand-on-click; the component accepts host-supplied models so VS Code reuses the LSP computation instead of shipping a second one in the webview bundle.
+

--- a/.tickets/sl-3ms0.md
+++ b/.tickets/sl-3ms0.md
@@ -1,0 +1,24 @@
+---
+id: sl-3ms0
+status: open
+deps: [sl-oqsj, sl-4qvp]
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, core, cli]
+---
+# cli: surface aggregate coverage rollups in coverage output
+
+PRD 35 R3, CLI half. Split after doc review 2026-07-31: the core aggregation function moved to sl-4qvp so it is not blocked behind the CLI command, because feature 36's browser-only overlay (sl-5m9x) consumes the core function directly and would otherwise be serialised behind CLI plumbing it never uses. This ticket is the CLI's rendering of that function.
+
+## Design
+
+Consume the core aggregation exported by sl-4qvp — no aggregation logic in the CLI. Surface it in both human and --json output, labelled distinctly from per-mapping numbers: "a field is uncovered by this mapping" and "a field is uncovered by every mapping" are different claims and a reviewer must not be able to confuse them. Include workspace totals and per-namespace subtotals.
+
+## Acceptance Criteria
+
+Aggregate rollups appear in human and --json output with labelling that distinguishes per-mapping from aggregate figures; workspace and per-namespace subtotals render correctly on a namespaced fixture; --json aggregate section matches the shape documented in sl-tdfx; no aggregation logic implemented in the CLI (it delegates to core); CLI suite passes locally.
+

--- a/.tickets/sl-4czz.md
+++ b/.tickets/sl-4czz.md
@@ -1,0 +1,24 @@
+---
+id: sl-4czz
+status: open
+deps: [sl-jcs6]
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, viz]
+---
+# viz: chain view rendering (left-to-right field lineage rail)
+
+PRD 36 R4. Render a selected field's chain model as a single left-to-right rail: upstream sources, visually anchored focus field, downstream consumers; one card per hop (schema + field) with edges labelled by mapping name and classification badge; nl-derived hops visibly differentiated.
+
+## Design
+
+Entry points: field action in expanded cards and detail view (trace this field) plus programmatic component API for hosts, accepting a host-supplied chain model. The component API is host-agnostic and the harness drives the same API, but wiring it to playground URL state is out of scope — public-playground exposure is deferred to its own feature (see sl-1ml2). The PRD's earlier mention of playground URL state as an entry point was corrected in doc review 2026-07-31. Branching renders as a fan, collapsed by namespace with expand-on-click (user decision). Depth limit shows an explicit affordance, never silent truncation. Hop click refocuses the chain on that field; mapping label click opens that mapping detail. Back navigation preserves the Feature 34 R1 guarantee: an edit while in chain view re-traces the same field if it still exists, falls back to overview only when it does not.
+
+## Acceptance Criteria
+
+Three-mapping chain fixture renders all hops in order with correct labels and classifications; nl-derived hop distinct; namespace fan collapse and expand works; depth-limit affordance shown; hop refocus and mapping-label navigation work; edit-while-in-chain-view preserves state; unit tests pass locally.
+

--- a/.tickets/sl-4qvp.md
+++ b/.tickets/sl-4qvp.md
@@ -1,0 +1,26 @@
+---
+id: sl-4qvp
+status: open
+deps: [sl-gsxu]
+links: []
+created: 2026-07-31T13:33:31Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, core]
+---
+# core: aggregate coverage rollup function (per-schema across mappings, workspace, per-namespace)
+
+PRD 35 R3, core half. Split out of sl-3ms0 after doc review 2026-07-31: sl-3ms0 depended on the CLI command (sl-oqsj), which serialised feature 36's browser-only coverage overlay behind CLI plumbing it never uses. The aggregation is a core concern and depends only on the relocation (sl-gsxu).
+
+Aggregate semantics: a target field counts covered when ANY mapping populates it; a source field counts consumed when ANY mapping reads it. Both roles aggregated and clearly labelled (user-accepted proposal). Produces workspace totals plus per-namespace subtotals.
+
+## Design
+
+Exported from @satsuma/core so both the CLI (sl-3ms0) and satsuma-viz's browser bundle (sl-5m9x) call one function — feature 36 requires overlay numbers identical to CLI output, which only holds if there is a single implementation. The function must take core-level inputs only; no CLI index or LSP WorkspaceIndex types.
+
+## Acceptance Criteria
+
+Aggregation function exported from core with minimal-snippet tests: a field covered by mapping A but not mapping B is uncovered in B's per-mapping result and covered in the aggregate; workspace and per-namespace percentages correct on a namespaced fixture; per-mapping and aggregate results are distinguishable in the returned type (so consumers cannot mislabel them); no dependency on satsuma-cli or satsuma-lsp; core suite passes locally.
+

--- a/.tickets/sl-5m9x.md
+++ b/.tickets/sl-5m9x.md
@@ -1,0 +1,24 @@
+---
+id: sl-5m9x
+status: open
+deps: [sl-gsxu, sl-4qvp]
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, viz]
+---
+# viz: coverage overlay toggle on the overview
+
+PRD 36 R1. User-facing toggle (default off) switching the overview into coverage mode: each schema card shows mapped/total count and percentage from the core aggregate coverage function (same semantics as the satsuma coverage schema-level rollup), with a percentage badge and proportional header fill.
+
+## Design
+
+Overlay is paint-only: card sizes and ELK layout identical between modes so toggling never reshuffles the diagram. Use the existing token/theming system; respect light and dark themes; not colour-alone (dataviz accessibility conventions already used by the component). Component also accepts a host-supplied coverage model (user decision: VS Code reuses LSP computation).
+
+## Acceptance Criteria
+
+Toggle renders correct percentages on a fixture with one fully-mapped and one half-mapped schema, matching satsuma coverage --json values; layout geometry unchanged between modes (snapshot comparison); works from both self-computed (core in browser) and host-supplied models; light+dark rendering verified; unit tests pass locally.
+

--- a/.tickets/sl-5sjp.md
+++ b/.tickets/sl-5sjp.md
@@ -1,0 +1,26 @@
+---
+id: sl-5sjp
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, cli]
+---
+# cli: replace the CLI's duplicate FieldDecl with core's, exposing field declaration positions
+
+PRD 35 open question 1, resolved YES in user review: per-field coverage entries in CLI output must carry the declaration line number, enabling editor-jump links in downstream UIs.
+
+## Design
+
+Reframed after doc review 2026-07-31 — the work is smaller and differently shaped than originally written. The positions already exist: core FieldDecl carries startRow/startColumn, "always set by extractFieldTree" (satsuma-core/src/types.ts:113-127, added by aa-65ni). The CLI cannot see them because satsuma-cli/src/types.ts:37-45 keeps a divergent structural copy of FieldDecl that omits both fields. So this is not "add position tracking to the index-builder" — it is delete the CLI's clone and re-export core's type. That duplicate is itself a Core vs Consumer violation.
+
+One case needs a decided answer rather than an accident: fields materialised by fragment-spread expansion (spread-expand.ts, deepCopyFields) have no declaration row of their own. Decide explicitly whether they carry the spread site's position or report line as absent. They must never report a silently-wrong 0 — an editor-jump link would land on line 1 of the wrong file. Note core's FieldCoverageEntry.line doc-comment currently says "CLI: 0 when not available from the index"; update it to match whatever is decided here.
+
+## Acceptance Criteria
+
+CLI's duplicate FieldDecl interface removed and core's re-exported in its place (no structural clone remains); startRow/startColumn survive the CLI's deepCopyFields and spread-expansion paths; spread-expanded fields have the decided, documented position behaviour and never report a misleading 0; unit tests assert positions for a minimal nested-schema snippet and for a spread-expanded field; core's FieldCoverageEntry.line doc-comment updated; no regression in existing CLI tests.
+

--- a/.tickets/sl-ay8a.md
+++ b/.tickets/sl-ay8a.md
@@ -1,0 +1,24 @@
+---
+id: sl-ay8a
+status: open
+deps: [sl-j30s, sl-hysg, sl-1u6r]
+links: []
+created: 2026-07-31T13:14:15Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-iffm
+tags: [feature-37, docs]
+---
+# docs: lint rules table, config file reference, agent-reference update
+
+PRD 37 R6 (renumbered from R4 in doc review 2026-07-31, when the config file and lint exit-code table became R4 and R5). Add both rules to the SATSUMA-CLI.md lint rules table with severity and fixability, document the exemptions prominently (transform-bearing arrows never type-checked, with the design-principle rationale; self-mappings never cycles, with the roadmap citation), and document the satsuma.config.yaml schema (suppression, type aliases, strict). Update AI-AGENT-REFERENCE.md so agents drafting mappings know a bare arrow asserts type-preserving identity and a transform body suppresses the check.
+
+## Design
+
+Also document, added in doc review 2026-07-31: the lint exit-code table from sl-1u6r (0/1/2/3) as a lint-specific table following the fmt precedent at SATSUMA-CLI.md:86; that value maps are never type-checked because they classify as nl; the suppression precedence rule from sl-npi6 (flags win over config, --ignore and lint.suppress union, --select still runs a suppressed rule); and that lineage-cycle reports one finding per strongly-connected component rather than per elementary cycle, so a reviewer reading one finding knows it may cover several cycles.
+
+## Acceptance Criteria
+
+SATSUMA-CLI.md rules table, config-file section and lint exit-code table added; exemptions (transform bodies, value maps, self-mappings) documented with their rationale and citations; suppression precedence documented; SCC-per-finding behaviour explained; AI-AGENT-REFERENCE.md updated and regenerated into the CLI agent-reference output; HOW-DO-I.md updated if it indexes lint guidance.
+

--- a/.tickets/sl-ce11.md
+++ b/.tickets/sl-ce11.md
@@ -1,0 +1,17 @@
+---
+id: sl-ce11
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:12:19Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-35, cli, core]
+---
+# Feature 35 epic: workspace coverage command (satsuma coverage)
+
+Implement features/35-coverage-command/PRD.md: relocate computeMappingCoverage from satsuma-lsp into @satsuma/core, add a satsuma coverage CLI command with per-mapping/per-schema/workspace rollups, a stable --json contract, and a --fail-under CI gate. Open questions resolved by user review 2026-07-31: per-field entries carry declaration line numbers; aggregate covers both roles clearly labelled; --fail-under respects active scope flags.
+
+Doc review 2026-07-31 changed three things. (1) `fields --unmapped-by` is an existing fourth implementation of these semantics; it is kept as a convenience alias but re-based on the relocated core function (sl-oqsj), else the feature ships the drift it exists to prevent. (2) --fail-under uses a distinct exit code 3, because reusing 1 would make a misspelled --mapping indistinguishable from genuine under-coverage in CI (sl-268g). (3) The aggregation was split into a core half (sl-4qvp) and a CLI half (sl-3ms0) so feature 36's browser-only overlay is not serialised behind CLI plumbing it never uses.
+

--- a/.tickets/sl-gsxu.md
+++ b/.tickets/sl-gsxu.md
@@ -1,0 +1,26 @@
+---
+id: sl-gsxu
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, core, lsp]
+---
+# core: relocate computeMappingCoverage from satsuma-lsp into @satsuma/core
+
+PRD 35 R1. The full coverage computation lives in tooling/satsuma-lsp/src/coverage.ts:41 but is needed by the CLI (feature 35) and the browser-bundled viz (feature 36). Per the Core vs Consumer rule it must move to core with its tests.
+
+Note there are four sites orbiting these semantics, not three (doc review 2026-07-31): core's types + addPathAndPrefixes, the LSP function being moved, satsuma-viz/src/field-coverage.ts, and — easily missed — the CLI's own private getMappedFieldNames()/filterUnmappedFields() behind `fields --unmapped-by` (commands/fields.ts:89-103). The relocated function is what all four converge on; sl-oqsj re-bases the CLI pair onto it.
+
+## Design
+
+Define a minimal core-level resolver interface (parse tree + schema-id -> field list) so the function depends on neither the LSP WorkspaceIndex nor the CLI index; each consumer adapts its own index. LSP keeps a thin adapter and re-exports so existing imports compile unchanged. Fix the stale header comment in satsuma-core/src/coverage.ts (still points at vscode-satsuma/server and cites LSP-only types as the reason). Note aa-65ni already added optional source locations to core FieldDecl.
+
+## Acceptance Criteria
+
+computeMappingCoverage and private helpers live in @satsuma/core; coverage semantics tests moved to core (LSP-side tests reduced to adapter wiring only); VS Code gutter/code-lens behaviour identical before and after (existing LSP+extension tests pass unchanged); stale core header comment corrected; all core, lsp and cli test suites pass locally.
+

--- a/.tickets/sl-hysg.md
+++ b/.tickets/sl-hysg.md
@@ -1,0 +1,28 @@
+---
+id: sl-hysg
+status: open
+deps: [sl-npi6]
+links: []
+created: 2026-07-31T13:14:15Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-iffm
+tags: [feature-37, core, cli]
+---
+# core+cli: lineage-cycle lint rule
+
+PRD 37 R2. Warn when the schema-level mapping graph (source schemas -> target schemas per mapping, same edge semantics as satsuma lineage / graph --compact) contains a cycle. Self-mapping edges (source schema equals target schema) are excluded before detection — recorded product decision in docs/product-owner/ROADMAP.md, cited in the rule doc comment.
+
+## Design
+
+Detector in @satsuma/core; thin lint-engine wrapper. Severity warning, not fixable.
+
+One finding per strongly-connected component, not per elementary cycle (user decision, doc review 2026-07-31 — the PRD originally specified elementary-cycle enumeration with a truncation cap). Compute SCCs with Tarjan; each SCC with more than one node is one finding, reported as one representative cycle through it. Enumerating elementary cycles (Johnson) is output-exponential: a densely cross-linked platform graph can hold combinatorially many cycles that all describe the same tangle of mappings, which is exactly why the original spec needed a cap. SCC-per-finding removes the need for the cap — the count is bounded by the number of schemas — and matches what the reviewer must actually do, which is untangle the component rather than audit each rotation through it.
+
+Canonicalise the representative: enter the SCC at its lexicographically smallest schema id and walk a deterministic shortest cycle from there, so output does not vary with run order or file order. Message shows that path plus the mapping responsible for each edge, and when the component holds more schemas than the representative path shows, names them ("component also includes: ...") so nothing in the tangle is hidden.
+
+## Acceptance Criteria
+
+Minimal-snippet tests in core: two mappings forming a-b-a yield exactly one warning with canonical path and both mapping names; self-mapping yields no warning (regression-locks the roadmap decision); three-schema cycle reported once regardless of declaration order; a densely connected component containing several elementary cycles yields exactly one finding and names the component's other schemas; representative path is identical across shuffled file/mapping orderings; no truncation cap is needed or present; CLI-level tests cover registration and --json shape; all suites pass locally.
+

--- a/.tickets/sl-iffm.md
+++ b/.tickets/sl-iffm.md
@@ -1,0 +1,17 @@
+---
+id: sl-iffm
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:14:15Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-37, cli, core]
+---
+# Feature 37 epic: structural lint rules (type mismatch, lineage cycles) and lint config
+
+Implement features/37-lint-structural-rules/PRD.md: two new warning-severity lint rules — type-mismatch-direct-arrow (bare arrows between fields of different declared types) and lineage-cycle (schema-level cycles, self-mappings exempt per the recorded roadmap decision) — with detection logic in @satsuma/core. Open questions resolved by user review 2026-07-31: add a YAML config file (default ./satsuma.config.yaml) with a type-alias mapping section and global lint rule suppression; warnings stay advisory but can be escalated to a failing exit code.
+
+Doc review 2026-07-31 settled four further points. (1) Config file is satsuma.config.yaml, not .satsumacfg — .satsuma is a first-class source extension. (2) Config suppression is the persistent form of the existing --ignore flag, not a parallel mechanism; flags win over config. (3) lineage-cycle reports one finding per strongly-connected component rather than per elementary cycle, which removes the need for a truncation cap. (4) Strict mode forced lint's exit codes to be pinned down: lint currently returns 2 for error findings where 2 is documented as "parse error", so lint gets its own documented table (0/1/2/3) — a breaking change for CI consumers.
+

--- a/.tickets/sl-iwlv.md
+++ b/.tickets/sl-iwlv.md
@@ -1,0 +1,20 @@
+---
+id: sl-iwlv
+status: open
+deps: [sl-5m9x, sl-4czz]
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, vscode, lsp]
+---
+# vscode: feed host-computed coverage and chain models to the viz webview
+
+PRD 36 open question 3, resolved REUSE in user review: the VS Code extension supplies coverage and chain models computed via the LSP/core path to the webview component, instead of bundling a second computation in the webview. Add commands/entry points to open coverage mode and trace a field from the editor.
+
+## Acceptance Criteria
+
+Webview panels show coverage overlay and chain view using host-supplied models; values match CLI output for the same workspace; extension commands exposed and tested; vscode-satsuma test suite passes locally.
+

--- a/.tickets/sl-j30s.md
+++ b/.tickets/sl-j30s.md
@@ -1,0 +1,26 @@
+---
+id: sl-j30s
+status: open
+deps: [sl-npi6]
+links: []
+created: 2026-07-31T13:14:15Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-iffm
+tags: [feature-37, core, cli]
+---
+# core+cli: type-mismatch-direct-arrow lint rule
+
+PRD 37 R1. Warn when an arrow classified none (bare src -> tgt, no transform body) connects two fields whose declared types differ. Arrows classified nl or nl-derived are exempt: a transform body may legitimately change type, and judging that is NL interpretation which the CLI leaves to agents.
+
+## Design
+
+Detector in @satsuma/core operating on core extraction types; lint-engine.ts registers a thin wrapper (Core vs Consumer rule — the LSP will mirror this diagnostic later). Normalization: case-insensitive base-token equality (parameterized lengths/precision ignored), extended by alias groups from the satsuma.config.yaml type mapping section (C1). Skip silently when either side lacks a declared type or is unresolvable (validate territory). Severity warning, not fixable. Message names both qualified field paths and both declared types so lint --json consumers can group by type-pair.
+
+Value-map arrows need no special case, and this is decidable today (doc review 2026-07-31 — the PRD previously hedged). map_literal is a pipe_step (grammar.js:483-488) and classifyTransform returns "nl" for any non-empty pipe chain (satsuma-core/src/classify.ts:26-28), so an arrow bearing `map { ... }` always classifies nl and is already excluded by the none-only criterion. Do not add a map-literal branch to the rule. A regression test must lock this: a future refactor that classifies map literals separately would silently start type-checking value maps, which convert values and so may legitimately change type.
+
+## Acceptance Criteria
+
+Minimal-snippet tests in core: STRING to DATE bare arrow warns naming both fields and types; same arrow with any transform body does not warn; an arrow bearing a `map { ... }` value map between differently-typed fields does not warn (locks the classification reasoning above); String vs STRING and parameterized vs bare base token do not warn; missing declared type does not warn; alias group in config suppresses an otherwise-mismatching pair; the rule contains no map-literal special case; CLI-level tests cover registration, severity and --json shape only; all suites pass locally.
+

--- a/.tickets/sl-jcs6.md
+++ b/.tickets/sl-jcs6.md
@@ -1,0 +1,26 @@
+---
+id: sl-jcs6
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, viz, core]
+---
+# viz-model+backend: chain traversal model type and builder
+
+PRD 36 R3. Add a chain/traversal model type to @satsuma/viz-model: ordered upstream hops -> focus field -> ordered downstream hops; each hop carries field ref, owning schema, via_mapping, and classification (none / nl / nl-derived). @satsuma/viz-backend gains a builder producing it from the in-memory workspace.
+
+## Design
+
+Keep the shape deliberately compatible with the field-lineage --json output of the CLI so either source can feed the component. Depth-limited and cycle-guarded like the CLI traversal.
+
+Parity test uses a checked-in golden, not a live CLI call (doc review 2026-07-31, user-confirmed). Commit the expected field-lineage --json output as a fixture and regenerate it with a script under scripts/. viz-backend must not gain a dependency on satsuma-cli to shell out for the comparison: the dependency direction is backend -> core, and inverting it for a test would couple the browser bundle's package graph to the CLI. Committing the golden is also what makes a divergence appear as a reviewable diff instead of a red test with no history.
+
+## Acceptance Criteria
+
+Model type exported with doc-commented fields; backend builder unit-tested against minimal .stm snippets including an nl-derived hop; golden parity test asserts builder output matches the committed field-lineage --json fixture, with a documented regeneration script under scripts/; viz-backend has no dependency on satsuma-cli; viz-model and viz-backend suites pass locally.
+

--- a/.tickets/sl-npi6.md
+++ b/.tickets/sl-npi6.md
@@ -1,0 +1,30 @@
+---
+id: sl-npi6
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:14:15Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-iffm
+tags: [feature-37, core, cli]
+---
+# core+cli: satsuma.config.yaml YAML config loader (lint suppression, type aliases, strict mode)
+
+User decision from PRD 37 review: introduce a workspace config file, default path ./satsuma.config.yaml (YAML), with a lint section supporting: global rule suppression (list of rule ids), type alias groups consumed by the type-mismatch rule (e.g. a group declaring STRING/TEXT/VARCHAR equivalent), and a strict flag escalating warnings to a failing exit code. CLI gains a --config <path> override.
+
+## Design
+
+Loader and config types live in @satsuma/core (the LSP will need the same config when it mirrors these diagnostics). Missing file is not an error (all defaults); malformed YAML or unknown structure fails loudly with a clear message. Document the schema with commented examples. Run npm audit after adding any YAML dependency per the security policy.
+
+File name settled in doc review 2026-07-31: satsuma.config.yaml, not the originally proposed .satsumacfg. `.satsuma` is a first-class Satsuma source extension (SATSUMA_FILE_EXTENSIONS = [".stm", ".satsuma"], core/source-files.ts:18), so a dotfile named .satsumacfg sits one character from a source-file glob and gets no editor YAML association or schema support.
+
+Suppression precedence — deliberately simple (user: "go for simplicity"). lint.suppress is the persistent form of the existing --ignore <rules> flag (SATSUMA-CLI.md:104), not a parallel mechanism. One rule: flags win over config, and the union of --ignore and lint.suppress is suppressed. --select keeps meaning "run exactly these", so an explicitly selected rule runs even when the config suppresses it — naming a rule is an unambiguous instruction to run it. Reuse the existing rule-id validation so a typo in lint.suppress is reported the way a typo in --ignore is.
+
+Malformed-config exit code is 3, not 2, per the lint exit-code table established in sl-1u6r (2 now means "lint errors found"; 3 means "lint could not run").
+
+## Acceptance Criteria
+
+Config loads from default path ./satsuma.config.yaml and from a --config override; lint.suppress removes a rule from output; --select on a config-suppressed rule still runs it; --ignore and lint.suppress union correctly; alias groups and strict flag parse into typed config; an invalid rule id in lint.suppress is reported like an invalid --ignore id; missing file yields defaults silently; malformed file exits 3 with an actionable message; unknown top-level keys warn; core and CLI tests pass locally; npm audit clean.
+

--- a/.tickets/sl-nswc.md
+++ b/.tickets/sl-nswc.md
@@ -1,0 +1,24 @@
+---
+id: sl-nswc
+status: open
+deps: [sl-5m9x, sl-twe8, sl-4czz, sl-iwlv]
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, viz, testing]
+---
+# harness: Playwright spec suite for coverage overlay and chain view
+
+PRD 36 R5. New Playwright specs in tooling/satsuma-viz-harness covering: coverage toggle on/off, badge values against a known-coverage fixture, uncovered-field treatment, chain view for a field with at least 2 upstream and 2 downstream hops including one nl-derived hop, hop-click refocus, and edit-while-in-chain-view state preservation.
+
+## Design
+
+Runs only via the sentinel-file watcher protocol (agent sandbox cannot launch browsers): human starts watch-and-test.sh, agent touches .run-tests and reads .playwright-results.txt. Include the layout-snapshot comparison proving coverage-mode toggling does not change card geometry.
+
+## Acceptance Criteria
+
+All new specs pass and the full existing harness suite remains green via the watcher protocol; layout snapshot test in place; results confirmed from .playwright-results.txt.
+

--- a/.tickets/sl-oqsj.md
+++ b/.tickets/sl-oqsj.md
@@ -1,0 +1,30 @@
+---
+id: sl-oqsj
+status: open
+deps: [sl-gsxu, sl-5sjp]
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, cli]
+---
+# cli: add satsuma coverage command (per-mapping report, scoping flags, --json)
+
+PRD 35 R2. New command in tooling/satsuma-cli/src/commands/coverage.ts using the relocated core function. Default scope: every mapping reachable from the entry file (imports followed). Flags: --mapping <name>, --schema <name>, --role source|target, --uncovered, --json.
+
+## Design
+
+Follow existing command-loader conventions. Human output: per-mapping table (schema, role, covered/total, percent) then uncovered field paths — compact enough to paste in a review comment. JSON entries carry path, role, mapped, file, line (from sl-5sjp).
+
+Re-base `fields --unmapped-by`, keep it as an alias (added after doc review 2026-07-31). The CLI already has a fourth coverage implementation: `fields <schema> --unmapped-by <mapping>` (commands/fields.ts:89-103) computes the per-mapping uncovered set via its own private getMappedFieldNames() + filterUnmappedFields() helpers over core's addPathAndPrefixes. User decision: keep the flag — it is documented, agent-facing, and the natural single-schema shorthand — but delete those two private helpers and delegate to the core function relocated in sl-gsxu. Without this, shipping `coverage` leaves two CLI commands answering the same question from independently maintained code, which is the drift this feature exists to prevent.
+
+Scope-argument exit codes: an unresolvable --mapping/--schema exits 1 (EXIT_NOT_FOUND), as `fields` already does at fields.ts:98. Keep this distinct from the coverage-threshold code introduced in sl-268g.
+
+## Acceptance Criteria
+
+Command registered and documented in --help; nested-path semantics verified (covering address.city covers address; sibling address.line1 uncovered); each/flatten source paths contribute coverage identically to pre-move LSP behaviour; scoping flags and --uncovered work and are tested; --json validates against the shape that will be documented in SATSUMA-CLI.md; golden fixture test from an examples/ workspace.
+
+`fields --unmapped-by` delegates to the core coverage function with getMappedFieldNames/filterUnmappedFields deleted; a test asserts `fields Y --unmapped-by X` and `coverage --uncovered --mapping X --schema Y` report the identical field set on one fixture, locking the two surfaces together; unresolvable scope arguments exit 1; all CLI tests pass locally.
+

--- a/.tickets/sl-tdfx.md
+++ b/.tickets/sl-tdfx.md
@@ -1,0 +1,26 @@
+---
+id: sl-tdfx
+status: open
+deps: [sl-oqsj, sl-3ms0, sl-268g]
+links: []
+created: 2026-07-31T13:13:05Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-ce11
+tags: [feature-35, docs]
+---
+# docs: coverage command reference, JSON contract, agent-reference update
+
+PRD 35 R5. Add coverage to the SATSUMA-CLI.md extractors table plus a section documenting the JSON contract as stable (consumed by feature 36) and the per-mapping vs aggregate distinction. Update AI-AGENT-REFERENCE.md: the composed coverage-assessment workflow is replaced by the single command, retained only to explain semantics.
+
+## Design
+
+Added in doc review 2026-07-31: `fields --unmapped-by` is retained as a convenience alias (user decision), so the docs must position the two commands rather than silently leave both. Say plainly which to reach for: `fields --unmapped-by` for one schema against one mapping, `coverage` for anything workspace-wide or aggregated. The specific places that currently teach the composed workflow are AI-AGENT-REFERENCE.md:391 (the intersect-yourself recipe, now replaced by `coverage`), plus :329, :409 and :441, and SATSUMA-CLI.md:196.
+
+Also document the coverage-specific exit code table from sl-268g (0/1/2/3), following the fmt precedent at SATSUMA-CLI.md:86.
+
+## Acceptance Criteria
+
+SATSUMA-CLI.md documents flags, the coverage-specific exit code table, and the full JSON shape marked as a stable contract; the per-mapping vs aggregate distinction is explained, not just labelled; docs state when to use `fields --unmapped-by` versus `coverage`; AI-AGENT-REFERENCE.md:391 composed recipe replaced (semantics retained as explanation) and lines 329/409/441 updated; agent-reference output regenerated and includes the new command; HOW-DO-I.md index updated if it references coverage workflows.
+

--- a/.tickets/sl-twe8.md
+++ b/.tickets/sl-twe8.md
@@ -1,0 +1,24 @@
+---
+id: sl-twe8
+status: open
+deps: [sl-5m9x]
+links: []
+created: 2026-07-31T13:13:41Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-3de8
+tags: [feature-36, viz]
+---
+# viz: uncovered-field treatment in expanded cards and mapping detail view
+
+PRD 36 R2. In coverage mode, uncovered fields render with a distinct theme-safe treatment (muted plus iconography, not colour alone) in expanded schema cards and the mapping detail view.
+
+## Design
+
+Presentation only — reuse the existing field-coverage.ts covered-set computation; no new semantics.
+
+## Acceptance Criteria
+
+Uncovered fields visually distinct in both views in light and dark themes; covered-set values unchanged from existing field-coverage.ts behaviour (no semantic drift); unit tests pass locally.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,16 +8,16 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 
 ## Repository Layout
 
-- `SATSUMA-V2-SPEC.md`: authoritative language specification (v2)
-- `PROJECT-OVERVIEW.md`: product vision, motivation, and roadmap
+- `docs/developer/SATSUMA-V2-SPEC.md`: authoritative language specification (v2)
+- `docs/product-owner/PROJECT-OVERVIEW.md`: product vision, motivation, and roadmap
 - `SATSUMA-CLI.md`: CLI command reference
 - `AI-AGENT-REFERENCE.md`: compact grammar and agent-oriented Satsuma guidance (v2) — also available via `satsuma agent-reference`
 - `HOW-DO-I.md`: question-based index to all guides and conventions
-- `ROADMAP.md`: deferred work items, ideas, and convention docs still to write
+- `docs/product-owner/ROADMAP.md`: deferred work items, ideas, and convention docs still to write
 - `examples/`: canonical `.stm` examples and fixtures (v2 syntax)
 - `archive/v1/`: archived v1 specification and examples — for historical reference only, not for new work
-- `archive/features/`: completed feature specs (29 feature directories) — for historical reference only
-- `features/`: active feature plans (1 feature with open work)
+- `archive/features/`: completed feature specs (30 feature directories) — for historical reference only
+- `features/`: active feature plans (features 30–37; 35–37 are proposed and not yet started)
 - `useful-prompts/`: self-contained system prompts for web LLMs (Excel-to-Satsuma, Satsuma-to-Excel)
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
@@ -37,13 +37,13 @@ import { billing::invoices } from "billing/pipeline.stm"
 import { warehouse::inventory } from "warehouse/ingest.stm"
 ```
 
-Use `satsuma lineage --from <schema> platform.stm` to trace data flow through the platform. See `features/15-namespaces/PRD.md` for the full namespace specification.
+Use `satsuma lineage --from <schema> platform.stm` to trace data flow through the platform. See `archive/features/15-namespaces/PRD.md` for the full namespace specification.
 
 ## Source of Truth
 
 When making changes or answering questions about syntax, semantics, or supported constructs:
 
-1. Treat `SATSUMA-V2-SPEC.md` as the primary authority. The v1 spec is archived at `archive/v1/STM-SPEC.md` — do not use it for new work.
+1. Treat `docs/developer/SATSUMA-V2-SPEC.md` as the primary authority. The v1 spec is archived at `archive/v1/STM-SPEC.md` — do not use it for new work.
 2. Use `examples/` as the executable corpus of valid language patterns (v2 syntax).
 3. Use feature docs in `features/` to guide tooling order and architecture.
 4. If docs conflict, prefer the spec and call out the mismatch explicitly.
@@ -289,7 +289,7 @@ Expected workflow:
    criteria, and acceptance tests before writing any code.
 2. Write failing tests first (TDD) where practical.
 3. Implement the smallest change that makes the tests pass. Always do the RIGHT thing, not the FAST thing, so never hack tests or add lint ignore rules because that's easier than fixing the underlying issue.
-6. Update `PROJECT_OVERVIEW.md` if the architecture changes.
+6. Update `docs/product-owner/PROJECT-OVERVIEW.md` if the architecture changes.
 
 ## Ralph Loops
 When you are implementing a whole feature in a Ralph Loop, and have finished all related tk (ticket) tasks such that there are no remaining ready tasks, emit <PROMISE>DONE</PROMISE> to signal completion of the feature.

--- a/features/35-coverage-command/PRD.md
+++ b/features/35-coverage-command/PRD.md
@@ -1,0 +1,264 @@
+# Feature 35 — Workspace Coverage Command (`satsuma coverage`)
+
+> **Status: PROPOSED** (2026-07-31) — not yet started. Motivated by recurring
+> engagements where mapping specs are reverse-engineered from spreadsheet
+> workbooks and the first question every reviewer asks is "which fields are
+> not mapped yet?". Today that question is answerable only inside VS Code
+> (coverage gutter decorations) or by hand-composing multiple CLI calls.
+
+## Goal
+
+Give the CLI a first-class, deterministic coverage report: for every schema
+participating in a mapping, which declared fields are referenced by at least
+one arrow — per mapping, per schema, and rolled up across the workspace —
+with a stable JSON contract that downstream consumers (dashboards,
+satsuma-viz, CI pipelines, agents) can render without re-deriving the
+semantics.
+
+The primary success criteria are:
+
+1. **One command answers the coverage question.** `satsuma coverage
+   pipeline.stm` reports covered/uncovered fields for every mapping in the
+   workspace without the caller composing `fields` + `arrows` + `mapping`
+   round-trips.
+2. **The computation lives in core, once.** `computeMappingCoverage` moves
+   from the LSP into `@satsuma/core`; the LSP, the CLI, and satsuma-viz all
+   consume the same function. No consumer re-implements coverage semantics.
+3. **The JSON output is a documented, stable contract.** A dashboard or viz
+   overlay can be built against `satsuma coverage --json` alone.
+4. **Coverage can gate CI.** `--fail-under <pct>` turns spec completeness
+   into a mergeable/unmergeable signal, the same way `fmt --check` gates
+   formatting.
+
+## Background
+
+Coverage semantics are already implemented and tested — but split across the
+wrong packages:
+
+- `tooling/satsuma-core/src/coverage.ts` holds the shared types
+  (`FieldCoverageEntry`, `SchemaCoverageResult`, `MappingCoverageResult`) and
+  the `addPathAndPrefixes()` path utility. Its header comment states the
+  higher-level function "lives in vscode-satsuma/server/src/coverage.ts" —
+  this is stale twice over: the code has since moved to
+  `tooling/satsuma-lsp/src/coverage.ts`, and the stated reason (LSP-specific
+  `WorkspaceIndex`/`FieldInfo` types) is an argument for defining a core-level
+  input contract, not for leaving the logic in a consumer.
+- `tooling/satsuma-lsp/src/coverage.ts:41` — `computeMappingCoverage(uri,
+  tree, mappingName, wsIndex)` walks a mapping body, collects covered
+  source/target paths (arrows, `each` blocks, `flatten` blocks), and builds
+  per-schema field coverage. Consumed only by the VS Code coverage command
+  for gutter decorations.
+- `tooling/satsuma-viz/src/field-coverage.ts` independently consumes
+  `@satsuma/core/coverage-paths` (`buildCoveredFieldSet`) for mapping-detail
+  rendering — a third consumer already orbiting the same semantics.
+- `tooling/satsuma-cli/src/commands/fields.ts:89-103` — **the CLI already has a
+  fourth implementation**. `satsuma fields <schema> --unmapped-by <mapping>`
+  computes the per-mapping uncovered set via its own private
+  `getMappedFieldNames()` + `filterUnmappedFields()` helpers, built on core's
+  `addPathAndPrefixes`. It is documented at `SATSUMA-CLI.md:196` and
+  `AI-AGENT-REFERENCE.md:329,391,409,441`. This is the single most important
+  fact for this feature: unless `--unmapped-by` is re-based on the relocated
+  core function (R2), shipping `coverage` creates two CLI commands answering
+  the same question from independently maintained code — exactly the drift
+  this feature exists to prevent.
+- `SATSUMA-CLI.md` documents "coverage assessment" as a *composed agent
+  workflow* (query target fields, query arrows per mapping, intersect results
+  yourself). This is exactly the kind of deterministic, structure-only
+  operation the CLI's design principle says belongs in the CLI.
+
+Per the Core vs Consumer rule in `CLAUDE.md`, logic needed by a second
+consumer must move to core — including its tests — as part of the ticket
+work. This feature is that move, plus the thin command on top.
+
+## Problems
+
+### P1 — The coverage question has no *workspace-level* CLI answer
+
+The CLI answers coverage for **one schema against one mapping**
+(`fields <schema> --unmapped-by <mapping>`), and it gets the path-prefix
+semantics right. What it cannot answer is the question reviewers actually
+ask: *"across this whole workspace, which fields does no mapping populate?"*
+
+An agent or script must therefore enumerate every mapping, call `fields
+--unmapped-by` once per (schema, mapping) pair, and intersect the results
+itself — the composed workflow documented at `AI-AGENT-REFERENCE.md:391`.
+The per-call normalization is safe; the *aggregation* is what every caller
+re-implements, and where they get it wrong (e.g. treating a field as
+uncovered because mapping B ignores it, when mapping A populates it).
+
+### P2 — The computation sits in a consumer package
+
+`computeMappingCoverage` lives in `satsuma-lsp` and is exercised only through
+the editor. The CLI cannot reach it (the LSP is not a CLI dependency), and
+the browser-bundled viz component cannot either. The core module's own header
+comment anticipates CLI sharing and is now factually wrong about where the
+function lives.
+
+### P3 — No machine-readable coverage contract exists
+
+There is no JSON shape a dashboard, viz overlay, or report generator can
+consume. Feature 36 (viz coverage overlay) is blocked on this: the overlay
+must render the same numbers the CLI reports, or the two will drift.
+
+### P4 — Spec completeness cannot gate CI
+
+Teams converting large mapping workbooks iteratively have no way to enforce
+"coverage must not regress" or "the target schema must be ≥ N% mapped before
+sign-off" in a pipeline. `fmt --check` set the precedent for CI-gating exit
+codes; coverage has no equivalent.
+
+## Requirements
+
+### R1 — Relocate `computeMappingCoverage` into `@satsuma/core` (fixes P2)
+
+- Move the function and its private helpers from
+  `tooling/satsuma-lsp/src/coverage.ts` into core, alongside the types it
+  already returns.
+- Define the input contract in core terms: the function needs a parse tree
+  and a way to resolve schema definitions to field lists. Introduce a minimal
+  core-level resolver interface (or reuse core's existing extraction types)
+  so the function depends on neither the LSP's `WorkspaceIndex` nor the CLI's
+  index — each consumer adapts its own index to the interface.
+- The LSP keeps a thin adapter and re-exports so existing imports compile
+  unchanged; the VS Code gutter behaviour must be byte-identical before and
+  after.
+- Move the coverage tests to core with the logic (per the test-consolidation
+  standard: test each invariant once, at the right level). LSP-side tests
+  shrink to adapter wiring only.
+- Fix the stale header comment in `satsuma-core/src/coverage.ts`.
+
+### R2 — `satsuma coverage [path]` command (fixes P1)
+
+New command in `tooling/satsuma-cli/src/commands/coverage.ts`, following the
+existing command-loader conventions:
+
+- Default scope: every mapping in the workspace reachable from the entry
+  file (imports followed, like other commands).
+- Scoping flags: `--mapping <name>` (one mapping), `--schema <name>` (one
+  schema across all mappings that reference it), `--role source|target`.
+- `--uncovered` lists only unmapped fields — the review-queue view.
+- Human output: a per-mapping table (schema, role, covered/total, %) followed
+  by uncovered field paths; compact enough to paste into a review comment.
+- `--json`: the full structure — per-mapping, per-schema, per-field entries
+  (path, role, mapped, file, line where available from the CLI index).
+
+**`fields --unmapped-by` is re-based, not removed.** The existing flag stays
+as a convenience alias — it is documented, agent-facing, and the natural
+single-schema shorthand — but its private `getMappedFieldNames()` /
+`filterUnmappedFields()` helpers are deleted and it delegates to the
+relocated core function. A test must assert that `fields Y --unmapped-by X`
+and `coverage --uncovered --mapping X --schema Y` report the same field set
+on one fixture, so the two surfaces cannot drift.
+
+### R3 — Aggregation and rollups (fixes P1, P3)
+
+- **Per-mapping**: covered/total per participating schema (this is R1's
+  function, unchanged).
+- **Per-schema across mappings**: a target field counts as covered when *any*
+  mapping populates it; a source field counts as consumed when *any* mapping
+  reads it. This matches the documented composed workflow ("intersect results
+  to find fields unmapped by ALL mappings") and must be labelled as the
+  aggregate view in output so it is not confused with per-mapping numbers.
+- **Workspace totals**: overall percentage, plus per-namespace subtotals when
+  namespaces are present.
+- The JSON shape for all three levels is documented in `SATSUMA-CLI.md` and
+  treated as a stable contract (consumed by Feature 36).
+
+**Build order: the core aggregation function must not depend on the CLI
+command.** Feature 36's browser-only coverage overlay consumes the aggregation
+directly from `@satsuma/core`; if the core function is built behind the CLI
+surface, the viz overlay is serialised behind CLI plumbing it never uses. The
+core aggregation depends only on R1; the CLI's rendering of it depends on R2.
+
+### R4 — CI gate via `--fail-under <pct>` (fixes P4)
+
+- `satsuma coverage pipeline.stm --fail-under 90` exits non-zero when the
+  workspace target-coverage percentage is below the threshold.
+- Exit codes: `0` success/threshold met, `2` parse or filesystem error,
+  `3` **threshold not met**. `1` keeps its established meaning (not found /
+  no results) — `EXIT_NOT_FOUND` is already thrown for an unresolvable
+  `--mapping` name (`fields.ts:98`).
+
+  A distinct code is required, not cosmetic: if "threshold not met" also
+  returned `1`, then `coverage --fail-under 90 --mapping "typo"` would exit
+  `1` for a misspelled mapping name *and* `1` for genuine under-coverage. CI
+  could not distinguish "the spec is incomplete" from "the build invocation
+  is broken" — which defeats the purpose of the gate. `fmt --check` does not
+  have this problem because it takes no scope arguments that can fail to
+  resolve.
+- Unresolvable scope arguments (`--mapping`, `--schema` naming something that
+  does not exist) exit `1` as elsewhere in the CLI, and must never be
+  reported as a coverage failure.
+- `--fail-under` applies to target-role aggregate coverage by default;
+  combined with `--role source` it gates source consumption instead.
+- The coverage-specific exit codes are documented as their own table in
+  `SATSUMA-CLI.md`, following the precedent already set for `fmt`
+  (`SATSUMA-CLI.md:86`).
+
+### R5 — Documentation and agent surface (fixes P3)
+
+- Add the command to `SATSUMA-CLI.md` (extractors table + a coverage section
+  with the JSON contract and the per-mapping vs aggregate distinction).
+- Update `AI-AGENT-REFERENCE.md` / `agent-reference` output: the documented
+  "coverage assessment" composed workflow is replaced by the single command,
+  with the composed form retained only as an explanation of the semantics.
+
+## Acceptance Tests
+
+Minimal-snippet tests (per test quality standards), covering at least:
+
+- A mapping covering a nested path (`address.city`) reports the parent
+  (`address`) covered and a sibling (`address.line1`) uncovered.
+- `each`/`flatten` block source paths contribute coverage exactly as the LSP
+  behaviour does today (regression-locked by the relocated core tests).
+- A target field populated by mapping A but not mapping B is uncovered in
+  B's per-mapping report and covered in the schema-level aggregate.
+- `fields Y --unmapped-by X` and `coverage --uncovered --mapping X --schema Y`
+  report the identical field set (locks the two surfaces together).
+- `--fail-under` exit codes: met → 0, not met → 3, parse error → 2,
+  unresolvable `--mapping` → 1 (not mistaken for a coverage failure).
+- `--json` output validates against the documented shape (golden fixture from
+  an `examples/` workspace).
+- LSP regression: existing coverage code-lens/gutter tests pass unchanged
+  against the adapter.
+
+## Out of Scope
+
+- Any dashboard or visual rendering of coverage (Feature 36).
+- Policy judgements about *acceptable* gaps — e.g. "fields tagged
+  `(optional)` don't count against coverage". That is lint/policy territory
+  (see Feature 37 and the lint framework) and must not be baked into the
+  deterministic count. The JSON includes field metadata so policy layers can
+  filter.
+- NL interpretation: a field populated "implicitly" by prose in a note block
+  is uncovered by definition. Surfacing candidate NL mentions stays with
+  `nl-refs`/`hidden-source-in-nl`.
+
+## Open Questions
+
+1. Should per-field entries carry declaration line numbers in CLI output?
+   The core type has a `line` field set by the consumer; the CLI's index may
+   need to start recording field positions to populate it (useful for
+   editor-jump links in downstream UIs). YES
+
+   **Resolved, and the work is smaller than stated.** The positions already
+   exist: core's `FieldDecl` carries `startRow`/`startColumn`, "always set by
+   `extractFieldTree`" (`satsuma-core/src/types.ts:113-127`, added by
+   aa-65ni). The reason the CLI cannot see them is that
+   `satsuma-cli/src/types.ts:37-45` keeps a *divergent structural copy* of
+   `FieldDecl` that omits both fields. The task is therefore to delete the
+   CLI's clone and re-export core's type — a Core vs Consumer violation in
+   its own right — not to add position tracking.
+
+   One case needs a decided answer rather than an accident: fields
+   materialised by fragment-spread expansion (`spread-expand.ts`,
+   `deepCopyFields`) have no declaration row of their own. They must either
+   carry the spread site's position or report `line` as absent — never a
+   silently-wrong `0`, which would send an editor-jump link to line 1 of the
+   wrong file.
+2. Aggregate source coverage: is "read by any mapping" the right default, or
+   should unreferenced source fields be reported per-mapping only? Default
+   proposed: aggregate both roles, clearly labelled. ACCEPT PROPOSAL
+3. Does `--fail-under` belong on aggregate workspace coverage only, or also
+   per-mapping (`--fail-under 90 --mapping "orders to warehouse"`)? Proposed:
+   respect whatever scope flags are active. ACCEPT PROPOSAL

--- a/features/36-viz-coverage-and-chain-view/PRD.md
+++ b/features/36-viz-coverage-and-chain-view/PRD.md
@@ -1,0 +1,202 @@
+# Feature 36 — Viz Coverage Overlay & Field Chain View
+
+> **Status: PROPOSED** (2026-07-31) — depends on Feature 35 (workspace
+> coverage command / core relocation) for the coverage data contract.
+> Motivated by review workflows on large converted mapping specs: reviewers
+> need to *see* where a spec is incomplete, and to follow a single field's
+> journey end-to-end, without reading mapping detail views hop by hop.
+
+## Goal
+
+Extend satsuma-viz with two review-oriented views built entirely on data the
+toolchain already computes:
+
+1. **Coverage overlay** — the overview answers "how complete is this spec?"
+   at a glance: each schema card shows its mapped-field percentage and
+   uncovered count, and uncovered fields are visually distinct in card and
+   detail views.
+2. **Field chain view** — selecting a field renders its full upstream and
+   downstream lineage as a single left-to-right chain — the "biography of one
+   field" — with each hop's transform classification visible.
+
+The primary success criteria are:
+
+1. A reviewer opening the viz on a half-converted workspace can identify the
+   least-complete schemas without opening a single mapping detail view.
+2. The numbers shown by the overlay are **identical** to `satsuma coverage`
+   output for the same workspace — same core function, no viz-side
+   re-derivation.
+3. A user can go from any field (overview card, detail view, or chain view
+   hop) to that field's chain view in one interaction, and walk the chain in
+   either direction.
+4. Both views work in the client-only live editor: no CLI process, no
+   backend — computation comes from `@satsuma/core` in the browser bundle.
+5. The Playwright harness suite covers both views via the watcher protocol.
+
+## Background
+
+- satsuma-viz (`tooling/satsuma-viz/`) is a Lit web component with an
+  ELK-laid-out overview (schema/metric cards, mapping edges) and a
+  per-mapping detail view. It is embedded in the VS Code webview panels and
+  in the site's client-only "Try it Live!" playground (Features 33/34).
+- `tooling/satsuma-viz/src/field-coverage.ts` already consumes
+  `@satsuma/core/coverage-paths` (`buildCoveredFieldSet`) so the detail view
+  shares the LSP's nested-field coverage semantics. The component is one step
+  short of *showing* coverage as a first-class signal — the semantics are
+  wired in, the presentation is not.
+- Feature 35 relocates `computeMappingCoverage` into `@satsuma/core`. Because
+  the playground is client-only, this relocation is what makes a coverage
+  overlay *possible* there at all: viz can call the core function directly on
+  its in-browser workspace model. The CLI's `coverage --json` contract and
+  the overlay must be two renderings of one function.
+- Field-level lineage traversal exists in the CLI:
+  `satsuma field-lineage <schema.field> --json`
+  (`tooling/satsuma-cli/src/commands/field-lineage.ts`) returns upstream and
+  downstream chains with per-hop `via_mapping` and `classification`
+  (`none` / `nl` / `nl-derived`), depth-limited, cycle-guarded. Nothing
+  renders this: users reconstruct a field's journey by opening successive
+  mapping detail views and finding the field in each.
+
+## Problems
+
+### P1 — Coverage is invisible outside the VS Code editor
+
+Coverage exists as editor gutter decorations (LSP consumer) and as covered/
+uncovered logic inside the detail view's rendering helpers. A stakeholder
+looking at the viz — the audience the playground and webview panels exist
+for — gets no completeness signal. The overview presents a half-mapped
+workspace and a fully-mapped one identically.
+
+### P2 — No way to see one field's end-to-end journey
+
+The question users ask most in review sessions is "where does this field
+come from, and where does it go?". `field-lineage` answers it as JSON, but in
+the viz the user must: open mapping detail A, find the field, note its
+source, close, open mapping detail B, repeat. For chains crossing three or
+more mappings this is slow and error-prone, and NL-derived hops (implicit
+dependencies referenced in prose) are easy to miss entirely.
+
+### P3 — Chain data has no viz-model representation
+
+The viz-model (`@satsuma/viz-model`) describes cards, fields, and mapping
+edges — there is no model type for a traversal result (an ordered chain of
+field hops with classifications). Without one, any chain rendering would
+couple the component directly to CLI JSON shapes, violating the existing
+backend/model separation (`@satsuma/viz-backend` builds models; the
+component renders them).
+
+## Requirements
+
+### R1 — Coverage overlay on the overview (fixes P1)
+
+- A user-facing toggle (default off) switches the overview into coverage
+  mode.
+- In coverage mode each schema card shows: mapped/total field count and
+  percentage, computed by the core coverage function aggregated across all
+  mappings referencing the schema (the same aggregate semantics as
+  `satsuma coverage`'s schema-level rollup — Feature 35 R3).
+- Cards are visually ranked by completeness (e.g. a percentage badge and a
+  proportional fill on the card header) using the existing token/theming
+  system — must respect both light and dark themes and meet the dataviz
+  accessibility conventions already used by the component.
+- Percentage badges must not perturb layout: card sizes and ELK layout are
+  unchanged between modes (overlay is paint-only), so toggling doesn't
+  reshuffle the diagram the user is looking at.
+
+### R2 — Uncovered fields are distinct in card and detail views (fixes P1)
+
+- In coverage mode, expanded schema cards and the mapping detail view render
+  uncovered fields with a distinct, theme-safe treatment (muted +
+  iconography, not colour alone).
+- The detail view's treatment must reuse the existing
+  `field-coverage.ts` covered-set computation — this requirement is
+  presentation only; no new semantics.
+
+### R3 — Chain view model type in `@satsuma/viz-model` (fixes P3)
+
+- Add a chain/traversal model type: ordered upstream hops → focus field →
+  ordered downstream hops; each hop carries field ref, owning schema,
+  `via_mapping`, and classification (`none` / `nl` / `nl-derived`).
+- `@satsuma/viz-backend` gains a builder that produces this model from the
+  in-memory workspace (browser path), with the shape kept deliberately
+  compatible with `field-lineage --json` (CLI path) so either source can
+  feed the component.
+
+### R4 — Chain view rendering (fixes P2)
+
+- Entry points: a field action in expanded cards and in the mapping detail
+  view ("trace this field"), plus programmatic API on the component for
+  hosts (VS Code commands; the harness drives the same API). The component
+  API is host-agnostic, but *wiring it to playground URL state is out of
+  scope* — public-playground exposure is deferred to its own feature per
+  Open Question 1.
+- Rendering: a single left-to-right rail — upstream sources, focus field
+  (visually anchored), downstream consumers — one card per hop showing
+  schema + field, connected by edges labelled with the mapping name and a
+  classification badge. NL-derived hops are visibly differentiated (they are
+  inferred from prose, not declared — reviewers must be able to tell).
+- Branching chains (a field feeding multiple targets) render as a fan; depth
+  is limited with an explicit "depth limit reached" affordance rather than
+  silent truncation (no-silent-caps rule).
+- Every hop is clickable: clicking a hop re-focuses the chain view on that
+  field; clicking the mapping label opens that mapping's detail view.
+- Back navigation returns to the view the user came from, preserving the
+  Feature 34 R1 guarantee (view state survives model updates in the live
+  editor — an edit while in chain view re-traces the same field if it still
+  exists, and falls back to overview only when it doesn't).
+
+### R5 — Test coverage via the harness (all)
+
+- New Playwright specs in `tooling/satsuma-viz-harness/` exercised through
+  the sentinel-file watcher protocol (agent sandbox cannot run browsers):
+  coverage toggle on/off, badge values against a fixture with known
+  coverage, uncovered-field treatment, chain view for a fixture field with
+  ≥2 upstream and ≥2 downstream hops including one `nl-derived` hop,
+  hop-click refocus, and edit-while-in-chain-view state preservation.
+- Unit tests for the viz-backend chain builder against minimal `.stm`
+  snippets, asserting parity with `field-lineage --json` for the same
+  fixture (golden comparison keeps the two paths honest).
+
+  Parity is asserted against a **checked-in golden file**, regenerated by a
+  script under `scripts/`. viz-backend must not gain a dependency on
+  `satsuma-cli` to shell out for the comparison: the dependency direction is
+  backend → core, and inverting it for a test would couple the browser bundle's
+  package graph to the CLI. The regeneration script's output being committed is
+  what makes a divergence show up as a reviewable diff.
+
+## Acceptance Tests
+
+- Fixture workspace with one fully-mapped and one half-mapped schema:
+  coverage mode shows 100% and the exact expected percentage; numbers match
+  `satsuma coverage --json` for the same fixture byte-for-value.
+- Chain view on a field with a three-mapping chain shows all hops in order
+  with correct mapping labels and classifications.
+- A field referenced only via an NL `@ref` appears in the chain as an
+  `nl-derived` hop with distinct rendering.
+- Toggling coverage mode does not change card geometry (layout snapshot
+  comparison).
+- All existing harness suites remain green.
+
+## Out of Scope
+
+- A standalone deployed lineage web application (hosting, routing, auth) —
+  satsuma-viz remains an embeddable component; app shells are consumer
+  projects.
+- Coverage *policy* (which gaps are acceptable) — the overlay renders
+  deterministic counts only; policy belongs to lint (Feature 37).
+- Historical/trend coverage (comparing coverage across git revisions).
+- Rendering CLI `coverage --json` files loaded from disk into the component
+  (the shapes are kept compatible, but a file-loading UI is not part of this
+  feature).
+
+## Open Questions
+
+1. Should coverage mode be exposed in the site playground immediately, or
+   land in the harness + VS Code panels first? (Playground chrome is a
+   product surface with its own UX bar per Feature 34.) Separate feature (future) -> add to roadmap.
+2. Chain view for very wide fans (a hub field feeding dozens of targets):
+   collapse groups by namespace, or paginate the fan? Proposed: collapse by
+   namespace with expand-on-click. ACCEPT PROPOSAL
+3. Should the component accept an externally supplied coverage/chain model
+   (host-computed) in addition to computing its own? VS Code could reuse the
+   LSP's computation instead of shipping a second one in the webview bundle. REUSE

--- a/features/37-lint-structural-rules/PRD.md
+++ b/features/37-lint-structural-rules/PRD.md
@@ -1,0 +1,300 @@
+# Feature 37 — Structural Lint Rules: Type Mismatch & Lineage Cycles
+
+> **Status: PROPOSED** (2026-07-31) — independent of Features 35/36; shares
+> their motivation. Large multi-layer mapping specs — especially ones
+> reverse-engineered from spreadsheet workbooks — accumulate two classes of
+> silent structural defect that the current toolchain accepts without
+> comment: bare arrows connecting fields of different declared types, and
+> unintended cycles in the schema-level lineage graph.
+
+## Goal
+
+Add two deterministic, parser-backed rules to `satsuma lint`:
+
+1. `type-mismatch-direct-arrow` — a bare arrow (no transform body) connects
+   two fields whose declared types differ.
+2. `lineage-cycle` — the schema-level mapping graph contains a cycle that is
+   not an intentional self-mapping.
+
+The primary success criteria are:
+
+1. **Copy-paste and drift errors surface at lint time.** A `STRING → DATE`
+   bare arrow — almost always a wrong field reference, a stale type after a
+   schema edit, or a missing transform — is flagged with both declared types
+   in the message.
+2. **No false pressure on legitimate specs.** Arrows with transform bodies
+   are exempt (a transform may legitimately change type), self-mappings are
+   exempt (an explicit, documented design decision), and both rules are
+   warnings, not errors — `validate` semantics are unchanged.
+3. **Each cycle is reported exactly once**, as a readable path
+   (`a → b → c → a`), not once per participating mapping.
+4. **The rules are documented and machine-consumable** via the existing
+   `lint --json` output and the rules table in `SATSUMA-CLI.md`.
+
+## Background
+
+- The lint framework exists: `tooling/satsuma-cli/src/lint-engine.ts` +
+  `commands/lint.ts`, currently shipping three rules
+  (`hidden-source-in-nl` error/fixable, `unresolved-nl-ref` warning,
+  `duplicate-definition` error). `validate` owns structural correctness;
+  `lint` owns policy and convention — both new rules are policy (a type
+  mismatch or cycle can be intentional), so they belong in lint at warning
+  severity.
+- Arrow transform classification is already deterministic and simple
+  (`SATSUMA-CLI.md` § Transform Classification): `none` (bare
+  `src -> tgt`), `nl` (any transform body — all pipe content is natural
+  language by design), `nl-derived` (synthetic arrow inferred from an NL
+  `@ref`). This gives the type-mismatch rule a crisp applicability
+  criterion: **only `none` arrows**. Any transform body means the spec
+  author has said "something happens here", and judging whether that
+  something preserves type is NL interpretation — which the CLI's design
+  principle explicitly leaves to agents.
+- Field types are declared in schemas and already extracted (`satsuma
+  fields <schema>` returns them), so both sides of a bare arrow have
+  resolvable declared types whenever the author provided them.
+- Cycle policy is already decided in `docs/product-owner/ROADMAP.md`:
+  *"self-mappings (same source and target schema) are OK — we can use that
+  to represent things like increments, and DON'T cause graph cycles."* The
+  carve-out is a recorded product decision, not an implementation
+  convenience, and the rule must cite it.
+- Traversal code already defends against cycles — `field-lineage` is
+  documented as cycle-guarded (`tooling/satsuma-cli/src/commands/
+  field-lineage.ts`) — but guarding is not reporting: a traversal that
+  quietly stops at a visited node hides the cycle from the one audience
+  (spec reviewers) who need to know it exists.
+
+## Problems
+
+### P1 — Bare arrows between incompatible types are silent
+
+In a spec spanning several representation layers, the same logical field is
+declared repeatedly with per-layer types. A bare arrow asserting "these are
+the same value, unchanged" between fields declared as different types is
+almost always one of: a mis-picked field (adjacent-row copy-paste in the
+source workbook), a schema edit that outran its mappings, or a transform
+that was never written down. Today nothing flags it — `validate` checks
+references resolve, not that the assertion is coherent — so the error
+survives until a human happens to read that arrow.
+
+### P2 — Unintended lineage cycles are invisible
+
+A cycle across distinct schemas (`a → b` in one mapping, `b → a` in
+another) is occasionally intentional (bidirectional sync specs) but more
+often a mistake: a reversed arrow, or two mappings authored independently
+that disagree about direction. Because traversal is cycle-guarded, the
+symptom is subtle — lineage output that silently omits expected upstream
+hops — and users have no diagnostic pointing at the cause. The self-mapping
+decision in the roadmap explicitly anticipated distinguishing benign
+self-loops from real cycles; the "real cycles" half was never built.
+
+### P3 — Rule logic risks landing in the wrong package
+
+Per the Core vs Consumer rule and the established precedent of
+duplicate-definition detection being surfaced by both the CLI and the LSP,
+any rule the LSP will eventually mirror as an editor diagnostic must have
+its detection logic in `@satsuma/core`, not in `satsuma-cli/src/lint-engine.ts`.
+Both of these rules are natural editor diagnostics.
+
+## Requirements
+
+### R1 — `type-mismatch-direct-arrow` rule (fixes P1)
+
+- **Applies to**: arrows classified `none` only. Arrows classified `nl` are
+  skipped entirely; `nl-derived` synthetic arrows are skipped (they carry no
+  authored type assertion).
+- **Check**: resolve the declared type of the source field and target
+  field. If both are present and their normalized forms differ, report a
+  warning naming both fields and both types.
+- **Normalization (initial)**: case-insensitive exact match on the declared
+  type token, with parameterized forms compared on the base token (e.g.
+  declared lengths/precision do not count as mismatches in v1). No
+  cross-type compatibility table in v1 — see Open Questions.
+- **Skips silently**: either side lacking a declared type; either field
+  unresolvable (that's `validate`'s territory).
+- **Value-map arrows are always exempt, and this is decidable today** — no
+  hedging needed. `map_literal` is a `pipe_step` (`grammar.js:483-488`), and
+  `classifyTransform` returns `nl` for any non-empty pipe chain
+  (`satsuma-core/src/classify.ts:26-28`). An arrow bearing a `map { … }`
+  therefore always classifies `nl` and is skipped by the `none`-only
+  criterion, with no special case in the rule. A regression test must lock
+  this: a future refactor that classifies map literals separately would
+  silently start type-checking value maps, which convert values and so may
+  legitimately change type.
+- **Severity**: warning. **Fixable**: no (the fix is a human judgement:
+  correct the field, correct the type, or add the missing transform).
+- Message format includes both qualified field paths and both declared
+  types, so `lint --json` consumers can group by type-pair.
+
+### R2 — `lineage-cycle` rule (fixes P2)
+
+- **Graph**: schema-level directed edges from each mapping's source schemas
+  to its target schemas (the same edge semantics as `satsuma lineage` /
+  `graph --compact`).
+- **Exemption**: edges where source schema == target schema (self-mappings)
+  are excluded before cycle detection, citing the roadmap decision in the
+  rule's doc comment.
+- **Detection: one cycle per strongly-connected component**, not every
+  elementary cycle. Compute the SCCs of the schema graph (Tarjan); each SCC
+  with more than one node — or a single node with a retained self-edge — is
+  one finding, reported as one representative cycle through it.
+
+  Enumerating elementary cycles (Johnson) is output-exponential: a densely
+  cross-linked platform graph can contain combinatorially many cycles that
+  all describe *the same* tangle of mappings, which is why R2 originally
+  needed a truncation cap. SCC-per-finding removes the need for the cap
+  entirely, and matches what the reviewer must actually do — untangle the
+  component, not audit each rotation through it. The count is bounded by the
+  number of schemas, so there is no scale guard and nothing is truncated.
+- **Stability**: the representative cycle is canonicalised — enter the SCC at
+  its lexicographically smallest schema id and walk a deterministic shortest
+  cycle from there — so output does not vary with run order or file order.
+- **Message**: the representative cycle path (`crm::a → billing::b → crm::a`)
+  plus the mapping name responsible for each edge — the reviewer's next
+  question is always "which mapping do I look at?". When the component holds
+  more schemas than the representative path shows, name them ("component also
+  includes: …") so nothing in the tangle is hidden.
+- **Severity**: warning. **Fixable**: no.
+
+### R3 — Detection logic in core, surfaced by the CLI (fixes P3)
+
+- Both detectors are implemented in `@satsuma/core` operating on core
+  extraction types, with `lint-engine.ts` registering thin rule wrappers.
+- Tests for detection semantics live in core; CLI-level tests cover rule
+  registration, severity, message formatting, and `--json` shape only (test
+  each invariant once).
+- LSP mirroring of the two diagnostics is explicitly deferred (see Out of
+  Scope) but must require no re-implementation when picked up.
+
+### R4 — Workspace config file: `satsuma.config.yaml`
+
+Resolves Open Questions 1–3. A YAML config, default path
+`./satsuma.config.yaml`, overridable with `--config <path>`:
+
+- `lint.suppress`: list of rule ids excluded from all runs.
+- `lint.typeAliases`: alias groups consumed by R1 (a group declaring
+  `STRING`/`TEXT`/`VARCHAR` equivalent).
+- `lint.strict`: escalate warnings to a failing exit code.
+
+Loader and config types live in `@satsuma/core` — the LSP needs the same
+config when it mirrors these diagnostics. A missing file is not an error (all
+defaults); malformed YAML fails loudly.
+
+**Naming**: `satsuma.config.yaml`, not a dotfile. `.satsuma` is a first-class
+Satsuma *source* extension (`SATSUMA_FILE_EXTENSIONS = [".stm", ".satsuma"]`,
+`core/source-files.ts:18`), so a config named `.satsumacfg` sits one character
+from a source-file glob and gets no editor YAML association or schema support.
+
+**Precedence — keep it simple**: `lint.suppress` is the persistent form of the
+existing `--ignore <rules>` flag (`SATSUMA-CLI.md:104`), not a new mechanism.
+One rule, stated once: **flags win over config, and the union of
+`--ignore` + `lint.suppress` is suppressed.** `--select` continues to mean
+"run exactly these", so an explicitly selected rule runs even if the config
+suppresses it — selecting a rule by name is an unambiguous instruction to run
+it. Config suppression reuses the existing rule-id validation, so a typo in
+`lint.suppress` is reported the same way as a typo in `--ignore`.
+
+### R5 — Lint exit codes get their own documented table (fixes P1, P2)
+
+`lint` already contradicts the CLI-wide exit-code table: `commands/lint.ts:114`
+returns `EXIT_PARSE_ERROR` (`2`) when there are **error-severity findings**,
+where `2` is documented as "parse error or filesystem error"
+(`SATSUMA-CLI.md:164-169`). Adding strict mode would make `1` — documented as
+"not found / no results" — mean "warnings present", giving all three codes a
+third meaning.
+
+Before strict mode ships, `lint` publishes its own exit-code table, following
+the `fmt` precedent (`SATSUMA-CLI.md:86`):
+
+| Code | Meaning |
+|---|---|
+| 0 | No findings, or warnings only without `--strict` |
+| 1 | Warnings present and `--strict` active |
+| 2 | Error-severity findings present |
+| 3 | Parse or filesystem error (lint could not run) |
+
+This moves lint's "could not run" case off `2` and leaves `2` meaning "the
+workspace has lint errors" — the meaning it already has in practice. It is a
+breaking change for any CI job keying off lint's current codes, so it must be
+called out in `CHANGELOG.md`. Suppressed rules never trigger a strict failure.
+
+### R6 — Documentation (fixes P1, P2)
+
+- Add both rules to the `SATSUMA-CLI.md` lint rules table with severity and
+  fixability.
+- Document the `satsuma.config.yaml` schema with commented examples, and the
+  lint exit-code table from R5.
+- Document the exemptions prominently: transform-bearing arrows are never
+  type-checked (with the design-principle rationale), and self-mappings are
+  never cycles (with the roadmap citation).
+- Update `AI-AGENT-REFERENCE.md` so agents drafting mappings know a bare
+  arrow asserts type-preserving identity and a transform body suppresses
+  the check — this makes the rule a forcing function for honest specs.
+
+## Acceptance Tests
+
+Minimal-snippet cases (per test quality standards):
+
+- Bare arrow `STRING → DATE` → one `type-mismatch-direct-arrow` warning
+  naming both fields and types.
+- Same fields with any transform body → no warning.
+- Bare arrow between same-type fields with different case/parameters
+  (`String` vs `STRING`; parameterized vs bare base token) → no warning.
+- Arrow where one side has no declared type → no warning.
+- An arrow bearing a `map { … }` value map between differently-typed fields →
+  no warning (locks the classification reasoning in R1).
+- Two mappings forming `a → b → a` → exactly one `lineage-cycle` warning
+  with the canonical path and both mapping names.
+- Self-mapping (`a → a`) → no warning (regression-locks the roadmap
+  decision).
+- Three-schema cycle reported once regardless of file/mapping declaration
+  order.
+- A densely connected component containing several elementary cycles → one
+  finding, naming the other schemas in the component (locks SCC-per-finding
+  rather than per-rotation reporting).
+- `lint --json` includes both rules with stable ids, severities, and
+  locations.
+- Config: `lint.suppress` removes a rule; `--select` on a config-suppressed
+  rule still runs it; an alias group makes an otherwise-mismatching type pair
+  pass; a missing config file yields defaults silently; a malformed one exits
+  `3` with an actionable message.
+- Lint exit codes: clean → 0; warnings without `--strict` → 0; warnings with
+  `--strict` → 1; error findings → 2; unparseable workspace → 3.
+
+## Out of Scope
+
+- LSP diagnostics for these rules (follow-up once core detectors exist).
+- A **built-in** type-compatibility matrix (widening conversions, a shipped
+  `TEXT`/`STRING` equivalence table). Deciding those equivalences on users'
+  behalf requires a convention decision this feature does not make. Users
+  declare their own equivalences via `lint.typeAliases` (R4); nothing is
+  presumed equivalent by default beyond base-token equality.
+- Field-level cycle detection (the schema-level graph is the reviewable
+  unit; field-level traversal already guards itself).
+- Autofixes for either rule.
+- Any change to `validate` — both findings remain policy warnings.
+
+## Open Questions
+
+1. **Type alias table**: should `TEXT`/`STRING`/`VARCHAR`-style equivalences
+   be recognized in v1, and if so where does the table live (a documented
+   convention in `docs/conventions-for-schema-formats/`, consumed by core)?
+   Proposed: ship v1 with base-token equality only, gather false-positive
+   data from real workspaces, then decide. **RESOLVED** — ship a YAML config
+   (default `./satsuma.config.yaml`, `--config` override) with a type-alias
+   section and lint rule suppression. Specified in R4. Config file name
+   changed from the originally proposed `.satsumacfg` to avoid collision with
+   the `.satsuma` source extension (see R4).
+2. **Suppression mechanism**: lint has no *per-line* suppression (it does
+   already have run-scoped `--select` / `--ignore` flags —
+   `SATSUMA-CLI.md:104`). Is an intentional cross-schema cycle common enough
+   to need per-line suppression (e.g. a metadata token on the mapping), or is
+   "warnings are advisory" sufficient for v1? **RESOLVED** — advisory is
+   sufficient; no per-line suppression in v1. Workspace-wide suppression via
+   `lint.suppress` in the config, defined in R4 as the persistent form of the
+   existing `--ignore` flag rather than a parallel mechanism.
+3. **Severity escalation**: should CI users be able to promote these
+   warnings to errors (`lint --strict` or per-rule severity config)? That's
+   a lint-framework feature, not specific to these rules, but these two may
+   be what first creates the demand. **RESOLVED** — yes, via exit code:
+   `--strict` (or `lint.strict`) makes warnings exit non-zero. This forced
+   lint's exit codes to be pinned down properly; see R5.

--- a/site/_includes/footer.njk
+++ b/site/_includes/footer.njk
@@ -24,7 +24,7 @@
           <li><a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/tutorials/ba-tutorial.md" target="_blank" class="hover:text-orange transition-colors">PO / BA Tutorial</a></li>
           <li><a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/tutorials/data-engineer-tutorial.md" target="_blank" class="hover:text-orange transition-colors">Data / ML Tutorial</a></li>
           <li><a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/tutorials/integration-engineer-tutorial.md" target="_blank" class="hover:text-orange transition-colors">IE Tutorial</a></li>
-          <li><a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-V2-SPEC.md" target="_blank" class="hover:text-orange transition-colors">Language Spec</a></li>
+          <li><a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/developer/SATSUMA-V2-SPEC.md" target="_blank" class="hover:text-orange transition-colors">Language Spec</a></li>
         </ul>
       </div>
       <div>

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -466,7 +466,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
           <h3 class="text-xl font-bold text-charcoal mb-4">Language &amp; Specification</h3>
           <ul class="space-y-3">
             <li>
-              <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-V2-SPEC.md" target="_blank" rel="noopener"
+              <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/developer/SATSUMA-V2-SPEC.md" target="_blank" rel="noopener"
                  class="flex items-center gap-2 text-sm text-warm-gray hover:text-orange transition-colors group">
                 <svg class="w-4 h-4 text-orange/60 group-hover:text-orange flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 Language Specification (v2)

--- a/testing-prompts/test-arrows.md
+++ b/testing-prompts/test-arrows.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma arrows --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for mappings with various arrow types.

--- a/testing-prompts/test-context.md
+++ b/testing-prompts/test-context.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma context --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for test material.

--- a/testing-prompts/test-cross-command.md
+++ b/testing-prompts/test-cross-command.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to test **multi
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 3. Explore the `examples/` folder for realistic workspaces.
 

--- a/testing-prompts/test-diff.md
+++ b/testing-prompts/test-diff.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma diff --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for test material.

--- a/testing-prompts/test-field-lineage.md
+++ b/testing-prompts/test-field-lineage.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma field-lineage --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore `tooling/satsuma-cli/src/commands/field-lineage.ts` to understand the implementation surface.
@@ -152,5 +152,5 @@ When you find a bug:
 
 - **Do not fix bugs.** Only log them.
 - **Do not modify any existing files** in the repo. Only create files in `/tmp/`.
-- Base expected behavior on `SATSUMA-V2-SPEC.md` and `SATSUMA-CLI.md`, not on what the code currently does.
+- Base expected behavior on `docs/developer/SATSUMA-V2-SPEC.md` and `SATSUMA-CLI.md`, not on what the code currently does.
 - Be systematic — paste actual CLI output in tickets, include exact commands and fixture paths.

--- a/testing-prompts/test-fields.md
+++ b/testing-prompts/test-fields.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma fields --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for schemas with varied field structures.

--- a/testing-prompts/test-find.md
+++ b/testing-prompts/test-find.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma find --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for existing test material.

--- a/testing-prompts/test-graph.md
+++ b/testing-prompts/test-graph.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma graph --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for workspaces with schemas, mappings, and metrics.

--- a/testing-prompts/test-lineage.md
+++ b/testing-prompts/test-lineage.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma lineage --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder — especially `multi-source-hub.stm` and `multi-source-join.stm` for lineage chains.

--- a/testing-prompts/test-lint.md
+++ b/testing-prompts/test-lint.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma lint --help` output and `satsuma lint --rules` to see available lint rules.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues. Note especially `sl-04pv` about `hidden-source-in-nl`.
 4. Explore the `examples/` folder for test material.

--- a/testing-prompts/test-mapping.md
+++ b/testing-prompts/test-mapping.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma mapping --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for existing test material.

--- a/testing-prompts/test-match-fields.md
+++ b/testing-prompts/test-match-fields.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma match-fields --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for schemas that could be matched.

--- a/testing-prompts/test-meta.md
+++ b/testing-prompts/test-meta.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma meta --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for schemas with varied metadata.

--- a/testing-prompts/test-metric.md
+++ b/testing-prompts/test-metric.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma metric --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore `examples/metrics.stm` and `examples/metrics-platform/metric_sources.stm` for existing metric definitions.

--- a/testing-prompts/test-nl-refs.md
+++ b/testing-prompts/test-nl-refs.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma nl-refs --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for files with NL content containing `@ref` references.

--- a/testing-prompts/test-nl.md
+++ b/testing-prompts/test-nl.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma nl --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for files with NL content (notes, NL transforms, comments).

--- a/testing-prompts/test-schema.md
+++ b/testing-prompts/test-schema.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma schema --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for existing test material.

--- a/testing-prompts/test-summary.md
+++ b/testing-prompts/test-summary.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma summary --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for existing test material.

--- a/testing-prompts/test-validate.md
+++ b/testing-prompts/test-validate.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma validate --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder — all examples should validate cleanly.

--- a/testing-prompts/test-warnings.md
+++ b/testing-prompts/test-warnings.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma warnings --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for files containing `//!` and `//?` comments.

--- a/testing-prompts/test-where-used.md
+++ b/testing-prompts/test-where-used.md
@@ -9,7 +9,7 @@ You are an exploratory QA agent for the Satsuma CLI. Your job is to thoroughly t
 1. Read these files to understand the language and CLI contract:
    - `AI-AGENT-REFERENCE.md` — compact grammar and conventions reference
    - `SATSUMA-CLI.md` — full CLI command reference
-   - `SATSUMA-V2-SPEC.md` — authoritative language specification
+   - `docs/developer/SATSUMA-V2-SPEC.md` — authoritative language specification
 2. Read the `satsuma where-used --help` output.
 3. Review existing open bug tickets with `tk list` to avoid duplicating known issues.
 4. Explore the `examples/` folder for schemas, fragments, and transforms that reference each other.

--- a/tooling/tree-sitter-satsuma/README.md
+++ b/tooling/tree-sitter-satsuma/README.md
@@ -13,7 +13,7 @@ Downstream tooling that depends on this CST:
 
 ## Source of Truth
 
-- Language spec: `docs/developer/SATSUMA-V2-SPEC.md` (repo root)
+- Language spec: `docs/developer/SATSUMA-V2-SPEC.md`
 - Grammar PRD: `features/08-treesitter-parser-v2/PRD.md`
 - CST node reference: `docs/cst-reference.md`
 - Example files: `examples/`


### PR DESCRIPTION
Adds the plans for features 35 (`satsuma coverage`), 36 (viz coverage overlay + field chain view) and 37 (structural lint rules) — three PRDs and 22 tickets — and repairs a set of stale documentation links found while verifying them.

Nothing here is implementation. The point of the PR is that the plans have been checked against the code they rest on, so the tickets can be picked up without re-deriving their premises.

## Review changes to the plans

Each of these prevents a defect rather than polishing prose.

**Feature 35 was written as if coverage semantics lived in three places — there are four.** `fields <schema> --unmapped-by <mapping>` already computes the per-mapping uncovered set from its own private helpers (`commands/fields.ts:89-103`). The flag is kept as a convenience alias but re-based on the relocated core function; otherwise shipping `coverage` creates two CLI commands answering one question from independently maintained code, which is the drift the feature exists to prevent. A test locks the two surfaces together. P1 is corrected accordingly: the CLI gets *per-mapping* coverage right, and it is the *workspace-level aggregation* that callers re-implement and get wrong.

**`coverage --fail-under` gets exit code 3** rather than reusing `1`. Reusing `1` would make `--mapping "typo"` and genuine under-coverage indistinguishable, so CI could not tell "the spec is incomplete" from "the invocation is broken". `fmt --check` avoids this only because it takes no scope arguments that can fail to resolve.

**The coverage aggregation is split** into a core half (new `sl-4qvp`) and a CLI half (`sl-3ms0`). Feature 36's browser-only overlay consumes the core function directly, so building it behind the CLI surface would serialise viz work behind plumbing it never uses. Feature 36's overlay now unblocks in parallel with Feature 35's command.

**Feature 37's value-map exemption is decidable today**, not an open risk. `map_literal` is a `pipe_step` (`grammar.js:483-488`) and `classifyTransform` returns `nl` for any non-empty pipe chain (`classify.ts:26-28`), so value maps are already excluded by the `none`-only criterion. Locked with a regression test rather than a special case in the rule.

**`lineage-cycle` reports one finding per strongly-connected component** rather than per elementary cycle. Johnson enumeration is output-exponential, and a dense platform graph yields combinatorially many cycles all describing the same tangle — which is why the first draft needed a truncation cap. SCC-per-finding removes the cap entirely and matches what a reviewer must actually do: untangle the component, not audit each rotation through it.

**Config file is `satsuma.config.yaml`, not `.satsumacfg`.** `.satsuma` is a first-class source extension (`core/source-files.ts:18`), so the dotfile name sat one character from a source-file glob and would get no editor YAML association. Suppression is defined as the persistent form of the existing `--ignore` flag rather than a parallel mechanism: flags win over config, `--select` still runs a suppressed rule.

**`sl-5sjp` is reframed.** The field positions already exist on core's `FieldDecl` (`startRow`/`startColumn`, from aa-65ni); the CLI cannot see them because `satsuma-cli/src/types.ts:37-45` keeps a divergent copy that drops them. The work is deleting the clone, not adding position tracking.

## Two things needing a decision later

**The lint exit-code change is breaking.** Pinning down lint's codes means "could not run" moves from `2` to `3`, and `2` becomes "lint errors found" — the meaning it already has in practice at `lint.ts:114`. Any CI job keying off current codes changes behaviour. Flagged for `CHANGELOG.md` in `sl-1u6r`'s acceptance criteria; it may deserve release-note prominence rather than a ticket line.

**One decision made on the author's behalf**, since it blocked the `sl-5sjp` reframing: spread-expanded fields have no declaration row of their own. The ticket now requires them to carry the spread site's position *or* report `line` as absent — never `0`, which is what core's `FieldCoverageEntry.line` doc-comment currently sanctions and which would send editor-jump links to line 1 of the wrong file. The ticket asks for an explicit choice between the two options.

## Link repair (second commit)

The spec moved to `docs/developer/` but 26 references still pointed at the repo root. **Two were live 404s for site visitors** — the footer "Language Spec" link and the learn-page spec link. Also fixed in `AGENTS.md` (`CLAUDE.md` symlinks to it, so agents read these paths every session): `PROJECT-OVERVIEW.md` and `ROADMAP.md` are under `docs/`, the namespaces PRD is in `archive/features/`, and two drifted counts in Repository Layout.

Left alone deliberately: `CHANGELOG.md` and `.tickets/` entries (historical records), ADR bodies (immutable by convention), and `docs/developer/ARCHITECTURE.md` where the bare filename is already correct relative to its own directory.

## Not included

No ADR. The decisions above are recorded in the PRDs, and the two with architectural weight — the lint exit-code contract and the core/consumer coverage split — are better drafted as ADRs when the implementation lands and the shape is proven, rather than from a plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)