### PR TITLE
Feature 35: satsuma coverage — workspace coverage command, core relocation, CI gate

### DIFF
--- a/.tickets/3cc-iedv.md
+++ b/.tickets/3cc-iedv.md
@@ -2,7 +2,7 @@
 id: 3cc-iedv
 status: open
 deps: []
-links: []
+links: [3cc-t6uo]
 created: 2026-07-31T14:02:18Z
 type: bug
 priority: 3

--- a/.tickets/3cc-iedv.md
+++ b/.tickets/3cc-iedv.md
@@ -1,0 +1,23 @@
+---
+id: 3cc-iedv
+status: open
+deps: []
+links: []
+created: 2026-07-31T14:02:18Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [coverage, core]
+---
+# coverage: a whole-record arrow leaves its nested leaves counted as uncovered
+
+Coverage percentages count leaf fields on their own mapped flag (satsuma-core/src/coverage-rollup.ts, summarizeFieldCoverage). An arrow that copies an entire record — `address -> address` where both sides are record-typed — registers only the path "address", so the record's own entry is mapped but none of its leaves are. The schema then reports its address leaves as spec gaps even though one arrow populates all of them.
+
+The obvious fix (a leaf inherits coverage from a covered ancestor) is wrong and was tried and rejected while implementing sl-4qvp: addPathAndPrefixes registers ancestor prefixes, so a record's mapped flag is already true when any *single* descendant is covered. Inheriting from it would turn 'one of twelve address fields is mapped' into 'all twelve are'. Excluding records instead under-counts the rarer whole-record case, erring toward a gap that is not there rather than hiding one that is.
+
+A real fix needs the per-field computation to distinguish 'this exact path was written by an arrow' from 'this path was registered as an ancestor prefix of one' — i.e. coverage.ts tracking directly-covered paths separately from prefix-covered ones, then marking descendants of a directly-covered record as covered. That touches the per-mapping contract the VS Code gutter consumes, so it is deliberately out of feature 35's scope.
+
+## Acceptance Criteria
+
+computeMappingCoverage distinguishes directly-covered paths from prefix-registered ancestors; a leaf beneath a directly-covered record reports mapped=true while a leaf beneath a record that is merely a prefix of a covered descendant still reports mapped=false; core coverage and rollup tests cover both; VS Code gutter behaviour reviewed against the change.
+

--- a/.tickets/3cc-t6uo.md
+++ b/.tickets/3cc-t6uo.md
@@ -1,0 +1,25 @@
+---
+id: 3cc-t6uo
+status: open
+deps: []
+links: [3cc-iedv, sl-4qvp]
+created: 2026-07-31T14:40:39Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [vscode, coverage, feature-35]
+---
+# vscode: status-bar coverage percentage uses a third counting rule, disagreeing with satsuma coverage
+
+computeTargetCoverageStats() in tooling/vscode-satsuma/src/commands/coverage-logic.ts:82 counts only top-level target fields, filtering `!f.path.includes(".")`. ADR-034 establishes leaf-only counting on each field's own flag as the single rule, implemented in satsuma-core's summarizeFieldCoverage() and used by satsuma coverage, --fail-under, and (shortly) the viz overlay.
+
+The two therefore disagree on any schema with nested records. For a target with `address record { line1 line2 ... }` plus two scalar fields, the status bar counts 3 units and reports a record with one mapped leaf as fully covered; `satsuma coverage` counts every leaf and reports the same schema far lower. A user with the extension open beside a terminal sees two different percentages for one mapping and cannot tell which is wrong.
+
+Pre-existing — the status bar's rule predates feature 35, which is why it was left alone rather than changed inside that branch (ADR-034 records it as a known divergence rather than silently fixing it). Worth noting the divergence is confined to the *percentage*: the gutter decorations are per-field and already come from core, so they are correct.
+
+Fix direction: delete computeTargetCoverageStats' own counting and call core's summarizeFieldCoverage() over the target schema's fields. The LSP's satsuma/mappingCoverage response already carries every field entry the function needs, so this is a delegation, not new plumbing. Check whether the status bar wants the target-role figure only (it currently does) or the aggregate now that one exists.
+
+## Acceptance Criteria
+
+computeTargetCoverageStats delegates to @satsuma/core summarizeFieldCoverage with no counting logic of its own; a nested-record fixture asserts the status-bar percentage equals what satsuma coverage reports for the same mapping and schema; existing vscode unit tests updated to the leaf-only expectations; the top-level-only rule and its 'nested paths would double-count' comment removed rather than left as a stale explanation.
+

--- a/.tickets/sc-xnxp.md
+++ b/.tickets/sc-xnxp.md
@@ -1,6 +1,6 @@
 ---
 id: sc-xnxp
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:51:09Z
@@ -21,3 +21,10 @@ Pre-existing in tooling/satsuma-lsp/src/coverage.ts, so the VS Code coverage gut
 
 pathText() strips a single leading dot as well as backtick quoting, with the rule and its rationale documented at the call site; core coverage tests assert nested each and flatten fields written with .-prefixed relative paths report mapped=true and their unwritten siblings report mapped=false; LSP and vscode suites pass.
 
+
+## Notes
+
+**2026-07-31T13:53:25Z**
+
+Cause: pathText() in the coverage walker stripped backtick quoting but not the leading dot of a relative_field_path, so qualifying '.id' under 'each items -> lines' produced 'items..id'. addPathAndPrefixes split that on '.', registering 'items.' and 'items..id' but never 'items.id' — the path the declared field carries.
+Fix: pathText() now strips one leading dot as well, with the rule and rationale documented at the definition; regression tests in satsuma-core/test/coverage.test.js lock both the each and flatten arms using the spec's .-prefixed syntax (commit 1024955).

--- a/.tickets/sc-xnxp.md
+++ b/.tickets/sc-xnxp.md
@@ -1,0 +1,23 @@
+---
+id: sc-xnxp
+status: open
+deps: []
+links: []
+created: 2026-07-31T13:51:09Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [feature-35, core, coverage]
+---
+# coverage: element-relative paths inside each/flatten blocks report mapped fields as uncovered
+
+computeMappingCoverage qualified element-relative arrow paths without stripping their leading dot. Inside `each items -> lines { .id -> .item_id }` the grammar parses `.id` as a relative_field_path whose node text includes the dot, so qualify() produced "items..id". addPathAndPrefixes then split that into an empty segment, registering "items." and "items..id" but never "items.id" — the path the declared field actually has. Every nested source and target field inside an each or flatten block therefore reported mapped=false despite an explicit arrow covering it.
+
+This is the spec's canonical syntax (SATSUMA-V2-SPEC.md 4.6 writes `.SKU -> sku`), so the defect hit real workspaces, not an edge case. Discovered while relocating the computation into core for feature 35 (sl-gsxu): shipping `satsuma coverage` on top of it would have reported false spec gaps for exactly the nested fields reviewers ask about.
+
+Pre-existing in tooling/satsuma-lsp/src/coverage.ts, so the VS Code coverage gutter has been marking mapped nested fields as unmapped since each/flatten support landed. Fixing it means sl-gsxu's "gutter behaviour byte-identical before and after" criterion is intentionally not met — the gutter changes, in the correcting direction.
+
+## Acceptance Criteria
+
+pathText() strips a single leading dot as well as backtick quoting, with the rule and its rationale documented at the call site; core coverage tests assert nested each and flatten fields written with .-prefixed relative paths report mapped=true and their unwritten siblings report mapped=false; LSP and vscode suites pass.
+

--- a/.tickets/sl-268g.md
+++ b/.tickets/sl-268g.md
@@ -1,6 +1,6 @@
 ---
 id: sl-268g
-status: open
+status: closed
 deps: [sl-3ms0]
 links: []
 created: 2026-07-31T13:13:05Z
@@ -24,3 +24,12 @@ Final table: 0 threshold met, 1 not found / unresolvable scope argument, 2 parse
 
 Exit codes tested for all four cases: threshold met 0, unresolvable --mapping/--schema 1 (never reported as a coverage failure), parse/filesystem error 2, threshold not met 3; --fail-under composed with --role source and with --mapping gates the scoped percentage; coverage-specific exit code table documented in command help and SATSUMA-CLI.md; CLI tests pass locally.
 
+
+## Notes
+
+**2026-07-31T14:19:03Z**
+
+Cause: spec completeness had no CI gate — fmt --check set the precedent for a mergeable/unmergeable signal but coverage had no equivalent.
+Fix: added --fail-under <pct> with EXIT_THRESHOLD_NOT_MET = 3, defined in command-runner.ts alongside the other exit codes so the whole table stays discoverable in one file. Gates the aggregate percentage over the active scope (target role by default, source with --role source), so --mapping/--schema narrow what is gated. The report still prints on failure — a gate that emitted only a verdict would tell CI it failed without telling anyone which fields to map.
+
+Two decisions beyond the ticket. (1) When the gated role has no leaves in scope (e.g. --schema on a source-only schema with the default target gate), the command exits 1 with a message naming the fix rather than reporting 0% — that is nothing to measure, not an incomplete spec, and blaming the spec for an invocation error is exactly what the distinct exit codes exist to avoid. (2) --role moved to Commander's .choices() and --fail-under to a new parsePercentage coercion, so an invalid flag *value* reports as a usage error with help and exits 1 like every other bad flag value in the CLI; the earlier hand-rolled --role check exited 2 and would have been a second convention. Subtotal rows now omit a role the scope excluded instead of printing '0/0 0%', which read as zero coverage. 958 CLI tests pass (15 new); eslint clean.

--- a/.tickets/sl-3ms0.md
+++ b/.tickets/sl-3ms0.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3ms0
-status: open
+status: closed
 deps: [sl-oqsj, sl-4qvp]
 links: []
 created: 2026-07-31T13:13:05Z
@@ -22,3 +22,10 @@ Consume the core aggregation exported by sl-4qvp — no aggregation logic in the
 
 Aggregate rollups appear in human and --json output with labelling that distinguishes per-mapping from aggregate figures; workspace and per-namespace subtotals render correctly on a namespaced fixture; --json aggregate section matches the shape documented in sl-tdfx; no aggregation logic implemented in the CLI (it delegates to core); CLI suite passes locally.
 
+
+## Notes
+
+**2026-07-31T14:14:39Z**
+
+Cause: the coverage command reported only per-mapping figures, so the workspace-level question PRD 35 P1 names — which fields does NO mapping populate — still required the caller to union the results.
+Fix: the command now calls core's aggregateCoverage over the scoped mappings and renders it in both human and --json output. The aggregate is a sibling section, never merged into the per-mapping one, and its heading states the claim in words ('a field is uncovered here only when NO mapping in scope covers it') rather than relying on a section title a reader can skim past. Namespace subtotals and a workspace total are printed on aligned rows; the single-group namespace row is suppressed because it would duplicate the workspace row exactly. Aggregating over the *scoped* mappings is deliberate — --fail-under (sl-268g) gates whatever scope is active. No aggregation logic in the CLI; it delegates entirely to core. 943 CLI tests pass (9 new); eslint clean.

--- a/.tickets/sl-4qvp.md
+++ b/.tickets/sl-4qvp.md
@@ -1,6 +1,6 @@
 ---
 id: sl-4qvp
-status: open
+status: closed
 deps: [sl-gsxu]
 links: []
 created: 2026-07-31T13:33:31Z
@@ -24,3 +24,12 @@ Exported from @satsuma/core so both the CLI (sl-3ms0) and satsuma-viz's browser 
 
 Aggregation function exported from core with minimal-snippet tests: a field covered by mapping A but not mapping B is uncovered in B's per-mapping result and covered in the aggregate; workspace and per-namespace percentages correct on a namespaced fixture; per-mapping and aggregate results are distinguishable in the returned type (so consumers cannot mislabel them); no dependency on satsuma-cli or satsuma-lsp; core suite passes locally.
 
+
+## Notes
+
+**2026-07-31T14:03:25Z**
+
+Cause: no workspace-level aggregation existed, so every caller re-implemented the union across mappings — the step PRD 35 P1 identifies as where callers get it wrong.
+Fix: added satsuma-core/src/coverage-rollup.ts exporting aggregateCoverage() and summarizeFieldCoverage(). Per-mapping and aggregate figures live in structurally distinct types so a consumer cannot render one under the other's label. Union rule: covered when ANY mapping covers it, per role, keyed by (schemaId, role) so a staging schema counted as both source and target yields two entries counted once each. Namespace attribution follows the schema's own id, not the referencing mapping's namespace.
+
+Counting rule decided here and documented: leaves only, on each leaf's own flag. Records are excluded rather than vouching for their subtree — a record's mapped flag is already true when any single descendant is covered (addPathAndPrefixes registers ancestor prefixes), so inheriting from it would turn 'one of twelve address fields is mapped' into 'all twelve are'. The trade-off (a whole-record arrow under-counts) is recorded as 3cc-iedv; it errs toward reporting a gap that is not there rather than hiding one that is. 466 core tests pass (16 new); no dependency on satsuma-cli or satsuma-lsp.

--- a/.tickets/sl-4qvp.md
+++ b/.tickets/sl-4qvp.md
@@ -2,7 +2,7 @@
 id: sl-4qvp
 status: closed
 deps: [sl-gsxu]
-links: []
+links: [3cc-t6uo]
 created: 2026-07-31T13:33:31Z
 type: task
 priority: 1

--- a/.tickets/sl-5sjp.md
+++ b/.tickets/sl-5sjp.md
@@ -1,6 +1,6 @@
 ---
 id: sl-5sjp
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:13:05Z
@@ -24,3 +24,10 @@ One case needs a decided answer rather than an accident: fields materialised by 
 
 CLI's duplicate FieldDecl interface removed and core's re-exported in its place (no structural clone remains); startRow/startColumn survive the CLI's deepCopyFields and spread-expansion paths; spread-expanded fields have the decided, documented position behaviour and never report a misleading 0; unit tests assert positions for a minimal nested-schema snippet and for a spread-expanded field; core's FieldCoverageEntry.line doc-comment updated; no regression in existing CLI tests.
 
+
+## Notes
+
+**2026-07-31T13:57:57Z**
+
+Cause: satsuma-cli/src/types.ts kept a structural clone of core's FieldDecl that omitted startRow/startColumn. The positions were present on the objects at runtime (extractFieldTree always sets them, aa-65ni) — verified by satsuma fields --json, which has been emitting them all along — but invisible to the type checker, so no CLI command could read them.
+Fix: deleted the clone and re-exported core's FieldDecl. Added src/field-positions.ts owning the declaration-row rule: a spread-expanded field is reported at the consuming entity's block row, following the cbh-5lzd precedent already used by find, because its own startRow is a row in the fragment's file while the reported file is the consuming schema's. Provenance is inherited down the tree, since only the field copied directly out of the fragment carries fromFragment. Absent positions propagate as undefined, never 0. FieldCoverageEntry.line was made optional in core with a matching doc-comment (commit in sl-gsxu). 912 CLI tests pass; eslint clean.

--- a/.tickets/sl-ce11.md
+++ b/.tickets/sl-ce11.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ce11
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:12:19Z

--- a/.tickets/sl-gsxu.md
+++ b/.tickets/sl-gsxu.md
@@ -1,6 +1,6 @@
 ---
 id: sl-gsxu
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-07-31T13:13:05Z
@@ -24,3 +24,12 @@ Define a minimal core-level resolver interface (parse tree + schema-id -> field 
 
 computeMappingCoverage and private helpers live in @satsuma/core; coverage semantics tests moved to core (LSP-side tests reduced to adapter wiring only); VS Code gutter/code-lens behaviour identical before and after (existing LSP+extension tests pass unchanged); stale core header comment corrected; all core, lsp and cli test suites pass locally.
 
+
+## Notes
+
+**2026-07-31T13:52:57Z**
+
+Cause: computeMappingCoverage lived in tooling/satsuma-lsp/src/coverage.ts, unreachable from the CLI (feature 35) and the browser viz bundle (feature 36), and core's coverage.ts header still claimed it lived in vscode-satsuma/server citing LSP-only types as the reason.
+Fix: moved the computation and its private helpers into satsuma-core/src/coverage.ts behind a CoverageSchemaResolver input contract (CoverageField/CoverageSchemaDefinition), so no consumer index type leaks into core; addPathAndPrefixes moved to coverage-paths.ts alongside the other path helpers to keep the dependency acyclic; the LSP retains a thin FieldInfo->CoverageField adapter with its original (uri, tree, mappingName, wsIndex) signature so server.ts is unchanged. Semantics tests moved to core (450 pass), LSP tests reduced to adapter wiring (292 pass), CLI 902 pass, vscode 33 unit + golden pass.
+
+Scope note: relocation surfaced sc-xnxp, a pre-existing defect where .-prefixed element-relative paths inside each/flatten produced 'items..id' and reported explicitly-mapped nested fields as uncovered. Fixed here rather than carried forward, since feature 35 ships a coverage report built on it. This means the acceptance criterion 'VS Code gutter behaviour identical before and after' is deliberately not met: the gutter changes, in the correcting direction.

--- a/.tickets/sl-gsxu.md
+++ b/.tickets/sl-gsxu.md
@@ -1,6 +1,6 @@
 ---
 id: sl-gsxu
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:13:05Z

--- a/.tickets/sl-oqsj.md
+++ b/.tickets/sl-oqsj.md
@@ -1,6 +1,6 @@
 ---
 id: sl-oqsj
-status: open
+status: closed
 deps: [sl-gsxu, sl-5sjp]
 links: []
 created: 2026-07-31T13:13:05Z
@@ -28,3 +28,12 @@ Command registered and documented in --help; nested-path semantics verified (cov
 
 `fields --unmapped-by` delegates to the core coverage function with getMappedFieldNames/filterUnmappedFields deleted; a test asserts `fields Y --unmapped-by X` and `coverage --uncovered --mapping X --schema Y` report the identical field set on one fixture, locking the two surfaces together; unresolvable scope arguments exit 1; all CLI tests pass locally.
 
+
+## Notes
+
+**2026-07-31T14:11:29Z**
+
+Cause: the CLI had no workspace-level coverage command, and `fields --unmapped-by` computed the per-mapping uncovered set from its own private getMappedFieldNames()/filterUnmappedFields() over index.fieldArrows — a fourth implementation of semantics core now owns.
+Fix: added src/commands/coverage.ts (scoping flags --mapping/--schema/--role/--uncovered, human table, --json) plus src/coverage-workspace.ts, which is the only place ExtractedWorkspace is adapted to core's CoverageSchemaResolver: namespace-aware reference resolution, spread expansion on a copied field list, and declaration positions via field-positions.ts. getMappedFieldNames was deleted and fields --unmapped-by now prunes its tree from the same core result, so the two surfaces cannot drift; a test asserts they report the identical field set on the unmapped-nested fixture, and a second asserts both report empty for a fully-mapped schema.
+
+Two decisions worth recording. (1) Core gained an optional CoverageSchemaDefinition.schemaId so the consumer reports the resolved canonical key rather than the reference as written — without it a namespaced schema written both ways splits into two entries when rolled up. (2) Reported field lists are leaf-only (core's leafFieldEntries), matching the counting rule, so a list of paths and the covered/total beside it are always the same population. Anonymous mappings cannot be looked up by label and are reported as skipped rather than silently dropped. 934 CLI tests pass (22 new); eslint clean.

--- a/.tickets/sl-qzy3.md
+++ b/.tickets/sl-qzy3.md
@@ -1,0 +1,63 @@
+---
+id: sl-qzy3
+status: closed
+deps: []
+links: [sl-2nxu]
+created: 2026-07-31T14:47:17Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+external-ref: gh-405
+tags: [coverage, core, cli, feature-35]
+---
+# coverage: flatten-inside-each and nested_arrow are not walked — wrong percentages and a fields --unmapped-by regression
+
+computeMappingCoverage does not walk two nesting constructs the grammar permits, so it reports explicitly-mapped fields as uncovered. Found while reviewing PR #405 (feature 35) at 47438ac.
+
+1. flatten_block nested inside each_block: the each child loop handles map_arrow, computed_arrow and each_block but not flatten_block, and collectFlattenPaths handles no nested blocks at all — though _nested_block_item (grammar.js:265-270) permits arbitrary interleaving.
+2. nested_arrow (grammar.js:404-414) is absent from the collectBodyPaths switch entirely, so 'addr -> address { .street -> .street_line }' contributes nothing on either side.
+
+## Impact 1 — the flagship command's first nested output is wrong
+
+examples/nested-iteration/pipeline.stm is the repo's canonical nested example and is FULLY mapped. On the branch:
+
+    $ satsuma coverage examples/nested-iteration/pipeline.stm
+      source  ::warehouse_dispatch_events      6/9   67%
+      target  ::dispatch_manifest_json         6/8   75%
+        uncovered in target: orders.packed_items.sku, orders.packed_items.units
+        uncovered in source: orders.parcels.contents.sku, orders.parcels.contents.units (+ barcode, genuine)
+
+Truth: target 8/8 = 100%, source 8/9 = 89% (orders.parcels.barcode is the single real gap). So 'satsuma coverage --fail-under 90' fails a fully-mapped spec on the example the repo ships to demonstrate nested iteration — the gate's most visible failure mode, since it errs toward blocking correct work.
+
+## Impact 2 — regression in a shipped command
+
+fields --unmapped-by was CORRECT before sl-oqsj re-based it onto the core function, because it derived paths from extract.ts, which walks every construct uniformly and strips relative dots at :911-921.
+
+    main:   orders.parcels.barcode                                    (correct)
+    branch: orders.parcels.barcode, contents.sku, contents.units      (wrong)
+
+Note for the record: the re-basing was recommended in the feature 35 doc review to stop two commands answering the same question from separate code. That recommendation was right in intent but was made without knowing the core walker had this defect — it moved a correct consumer onto a defective shared path. The re-basing should stay; the walker needs fixing.
+
+## Design
+
+Two options, and the choice is the substantive one:
+
+(a) Patch the walker — add nested_arrow to collectBodyPaths and recurse on the shared _nested_block_item production rather than enumerating permitted children per parent, so future grammar additions cannot silently fall through again.
+
+(b) Derive covered paths from extract.ts's arrow output instead of walking the CST a second time. extract.ts already handles every construct uniformly and is the reason the CLI was correct before the re-base. This deletes the duplicate walker and this whole class of defect.
+
+(b) is the better end state and is tracked as sl-vu22 under feature 38, which also carries the architectural decision. This ticket is the minimum fix needed to make PR #405's numbers correct — take (a) here if (b) is not ready, but do not ship the PR with the canonical example reporting 75%.
+
+Related: sc-xnxp (closed) was the same defect class — relative .field paths producing 'items..id' — found and fixed during this branch. sl-7236's ticket named the reason these survive: 'The corpus contains no nested each blocks so round-trip tests do not catch it.' Corpus gaps are tracked as sl-2nxu.
+
+## Acceptance Criteria
+
+computeMappingCoverage walks flatten_block inside each_block, each_block and flatten_block inside flatten_block, and nested_arrow at every level. satsuma coverage on examples/nested-iteration/pipeline.stm reports target 8/8 100% and source 8/9 89% with orders.parcels.barcode the only uncovered leaf — percentages asserted, not just booleans. fields --unmapped-by on the same example reports only orders.parcels.barcode, matching main's pre-regression output. A nested_arrow fixture (nested-arrow-lookup.stm shape) reports its written paths covered. Regression tests live in satsuma-core/test/coverage.test.js alongside the sc-xnxp locks. CLI, core and LSP suites pass.
+
+
+## Notes
+
+**2026-07-31T15:02:27Z**
+
+Cause: collectBodyPaths and the each/flatten child loops enumerated the node types each parent accepted, but the grammar's _nested_block_item lets each/flatten/nested_arrow interleave to any depth — so flatten inside each, any block inside flatten, and nested_arrow anywhere were never walked, and their arrows contributed no coverage.
+Fix: replaced the three hand-rolled loops with one recursive walk (collectBlockItemPaths/collectContainerPaths) that treats all three container types uniformly and threads accumulated src/tgt bases down, mirroring extract.ts's proven contract. flatten keeps its schema-root target rule, now decided by whether its tgt_path is an authored relative_field_path — which is also what makes a nested 'flatten x -> .field' base correctly. examples/nested-iteration/pipeline.stm now reports target 8/8 100% and source 8/9 89% (barcode only), and fields --unmapped-by agrees with coverage again.

--- a/.tickets/sl-tdfx.md
+++ b/.tickets/sl-tdfx.md
@@ -1,6 +1,6 @@
 ---
 id: sl-tdfx
-status: open
+status: closed
 deps: [sl-oqsj, sl-3ms0, sl-268g]
 links: []
 created: 2026-07-31T13:13:05Z
@@ -24,3 +24,12 @@ Also document the coverage-specific exit code table from sl-268g (0/1/2/3), foll
 
 SATSUMA-CLI.md documents flags, the coverage-specific exit code table, and the full JSON shape marked as a stable contract; the per-mapping vs aggregate distinction is explained, not just labelled; docs state when to use `fields --unmapped-by` versus `coverage`; AI-AGENT-REFERENCE.md:391 composed recipe replaced (semantics retained as explanation) and lines 329/409/441 updated; agent-reference output regenerated and includes the new command; HOW-DO-I.md index updated if it references coverage workflows.
 
+
+## Notes
+
+**2026-07-31T14:22:57Z**
+
+Cause: coverage was documented only as a composed agent workflow (query fields, repeat per mapping, intersect yourself) across SATSUMA-CLI.md and AI-AGENT-REFERENCE.md.
+Fix: SATSUMA-CLI.md gains coverage in the Structural Analysis table plus a full section — flags, the structural/leaf-counting semantics, an explicit per-mapping vs aggregate table explaining why the two are not interchangeable, the JSON shape marked as a stable contract, the coverage-specific 0/1/2/3 exit table with the reasoning for 3, and a 'which do I reach for' table positioning coverage against fields --unmapped-by. AI-AGENT-REFERENCE.md: the intersect-yourself recipe at :391 is replaced by a single command with the aggregation semantics retained as explanation of why not to compose it by hand; the 'no coverage command' claim at :299, the command reference at :329, the decision table at :409 and the authoring checklist at :441 all updated; agent-reference output regenerated at build time and contains the new command. HOW-DO-I.md gains two entries (finding unmapped fields, gating CI).
+
+Added a docs test asserting every key coverage --json emits appears in the documented contract — a stable contract nobody checks is just a comment. 959 CLI tests pass; all four lints clean.

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -296,7 +296,7 @@ mapping {
 
 The `satsuma` CLI is a deterministic structural extraction tool. It extracts facts from parse trees and delivers NL content verbatim. **It does not interpret natural language — that is your job.** The CLI is the toolkit. You are the runtime.
 
-Every command produces 100% correct results from structural analysis. There are no `impact`, `coverage`, `audit`, or `inventory` commands — those are workflows you compose from primitives, applying your own reasoning to the NL content the CLI surfaces.
+Every command produces 100% correct results from structural analysis. There are no `impact`, `audit`, or `inventory` commands — those are workflows you compose from primitives, applying your own reasoning to the NL content the CLI surfaces. `coverage` *is* a command, because which fields an arrow references is a fact about the parse tree and the rollup across mappings is arithmetic; judging whether a gap matters is still yours.
 
 **Self-discovery:** Every command supports `--help` with its full flag list, JSON output shape, and examples. Run `satsuma <command> --help` to inspect any command without consulting external docs.
 
@@ -326,9 +326,16 @@ satsuma nl mart_customer_360.email            # NL content on a specific field
 satsuma nl all platform.stm                   # all NL across the entry-file workspace
 satsuma meta loyalty_sfdc.Email              # metadata entries (tags, type, constraints)
 satsuma fields sat_customer_demographics     # field list with types
-satsuma fields mart_customer_360 --unmapped-by 'demographics to mart'  # fields with no arrows
+satsuma fields mart_customer_360 --unmapped-by 'demographics to mart'  # one schema vs one mapping
 satsuma match-fields --source loyalty_sfdc --target sat_customer_demographics  # name comparison
 satsuma nl-refs platform.stm --json          # extract @ref references from NL text
+
+# Coverage — which declared fields is nothing mapping yet?
+satsuma coverage platform.stm --json         # every mapping, per-mapping AND aggregate figures
+satsuma coverage platform.stm --uncovered    # the review queue: only the gaps
+satsuma coverage platform.stm --schema mart_customer_360 --json   # one schema, every mapping
+satsuma coverage platform.stm --role target  # only what gets written
+satsuma coverage platform.stm --fail-under 90 # CI gate: exit 3 below the threshold
 
 # Workspace graph — full topology in one call
 satsuma graph platform.stm --json            # complete semantic graph (nodes, edges, field-level flow)
@@ -388,7 +395,11 @@ Every arrow the CLI returns carries one of three classifications:
 
 **Impact analysis:** Call `satsuma arrows <field> --as-source --json`, follow each target with another `arrows` call, recurse. At `[nl]` hops, call `satsuma nl` to read the transform or note content and reason about it yourself.
 
-**Coverage check:** Call `satsuma fields <target> --unmapped-by <mapping> --json` for each mapping. Intersect results to find fields unmapped by all mappings. For mapped fields, check classification via `satsuma arrows`.
+**Coverage check:** Call `satsuma coverage <entry-file>.stm --json` once. Do **not** compose this from `fields --unmapped-by` calls — the CLI performs the aggregation because that is where hand-composed versions went wrong.
+
+The output has two sections making different claims about the same field. `mappings[].schemas[].fields[]` says whether *that mapping* touches it; `aggregate.schemas[].fields[]` says whether *any* mapping does. A target field populated by mapping A and ignored by mapping B is a gap in B's section and covered in the aggregate — so read the aggregate to decide a field is unmapped, and the per-mapping section to find which mapping to edit. (This is the "intersect across mappings" step you would otherwise do yourself, and the reason to stop doing it: treating a field as unmapped because one mapping ignores it is the classic error.)
+
+A field populated only by prose in a note block is uncovered by definition — coverage is structural. Check `nl-refs` for those, and `satsuma arrows` for the classification of a covered field, to judge whether a gap or a cover is real.
 
 **PII audit:** Call `satsuma find --tag pii --json`, then `satsuma arrows` for each tagged field, recurse downstream. At `[nl]` hops, read the transform text to judge whether PII survives.
 
@@ -406,7 +417,9 @@ Every arrow the CLI returns carries one of three classifications:
 | Need NL content for interpretation | `satsuma nl <scope>` — not pulling the entire block |
 | Need extracted refs inside NL text | `satsuma nl-refs <file>.stm` — inspect `@ref` usage without rereading whole files |
 | Need metadata on a field | `satsuma meta <schema.field>` — not parsing raw text |
-| Need to check which fields lack arrows | `satsuma fields <schema> --unmapped-by <mapping>` |
+| Need one schema's gaps against one mapping | `satsuma fields <schema> --unmapped-by <mapping>` — a field tree with types |
+| Need workspace-wide, aggregated, or percentage coverage | `satsuma coverage <file>.stm --json` — never compose it from `--unmapped-by` calls |
+| Need coverage to gate CI | `satsuma coverage <file>.stm --fail-under <pct>` — exit 3 when below |
 | Need to validate after editing | `satsuma validate <file>.stm` for correctness, `satsuma lint <file>.stm` for conventions |
 | Need to compare versions | `satsuma diff` — not text diff |
 | Need full file content for editing | Read the file directly — CLI is for querying, not raw content |
@@ -438,7 +451,7 @@ When reporting results to humans, be transparent about which parts of your analy
 13. Run `satsuma fmt <file>.stm` to apply canonical formatting
 14. Run `satsuma validate <file>.stm` to check for parse errors and semantic issues
 15. Run `satsuma lint <file>.stm` to check for policy/convention issues; use `--fix` to auto-correct fixable ones
-16. Run `satsuma fields <target> --unmapped-by <mapping>` to check which target fields you haven't covered
+16. Run `satsuma coverage <file>.stm --uncovered` to see which declared fields nothing maps yet — check the aggregate section, since another mapping may already populate a field your mapping ignores
 
 ### When reading/interpreting Satsuma:
 

--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -126,6 +126,12 @@ Run `satsuma lineage --from <schema> pipeline.stm`. For field-level edges: `sats
 **How do I lint my Satsuma files?**
 Run `satsuma lint pipeline.stm`. Use `--fix` for auto-fixing. Use `--json` for CI integration.
 
+**How do I find out which fields aren't mapped yet?**
+Run `satsuma coverage pipeline.stm --uncovered`. Read the **aggregate** section to decide a field is genuinely unmapped — the per-mapping section lists fields another mapping may already populate. See [SATSUMA-CLI.md](SATSUMA-CLI.md#coverage).
+
+**How do I stop mapping coverage from regressing in CI?**
+Run `satsuma coverage pipeline.stm --fail-under 90`. It exits 3 when coverage is below the threshold, distinctly from exit 1 for a bad `--mapping`/`--schema` name, so CI can tell an incomplete spec from a broken invocation.
+
 **How do I format my Satsuma files?**
 Run `satsuma fmt pipeline.stm` or use Format Document in VS Code.
 

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -142,7 +142,16 @@ Aggregate figures respect the active scope, so `--schema X --fail-under 90` gate
 
 #### JSON contract
 
-`--json` emits a **stable contract**, consumed by the satsuma-viz coverage overlay:
+`--json` emits a **stable contract**, consumed by the satsuma-viz coverage overlay.
+
+**Keys are spelled differently in `--json` and in human output**, deliberately.
+`--json` uses the *canonical* key, which prefixes a non-namespaced entity with
+`::` (`::load hub`) so that a consumer matching keys across commands has exactly
+one spelling per entity. Human output uses the *display* form and drops that
+empty prefix (`load hub`), because `::` is not valid Satsuma syntax — it cannot
+be pasted back into a file — and in a workspace with no namespaces it prefixes
+every line with noise. A real namespace is information, so `crm::customers`
+appears unchanged in both.
 
 ```jsonc
 {

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -93,6 +93,7 @@ Operations that check or compare workspace structure.
 |---|---|---|
 | `validate [path]` | Parse errors and semantic reference checks | `satsuma validate pipeline.stm` |
 | `lint [path]` | Policy and convention checks with optional autofix | `satsuma lint pipeline.stm --json` |
+| `coverage [path]` | Which declared fields each mapping covers, and which nothing maps | `satsuma coverage pipeline.stm --uncovered` |
 | `diff <a> <b>` | Structural comparison of two Satsuma files | `satsuma diff v1.stm v2.stm` |
 
 ### validate vs lint
@@ -108,6 +109,107 @@ Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rule
 | `hidden-source-in-nl` | error | yes | NL text references a schema not in the mapping's source/target list |
 | `unresolved-nl-ref` | warning | no | `@ref` in NL does not resolve to any known identifier |
 | `duplicate-definition` | error | no | Named definition is declared more than once in a namespace |
+
+### coverage
+
+`satsuma coverage` answers the first question every reviewer of a mapping spec asks: **which declared fields is nothing mapping yet?**
+
+```bash
+satsuma coverage pipeline.stm                        # every mapping in the workspace
+satsuma coverage pipeline.stm --uncovered            # the review queue
+satsuma coverage pipeline.stm --schema mart_customer_360
+satsuma coverage pipeline.stm --fail-under 90        # CI gate
+```
+
+Flags: `--mapping <name>`, `--schema <name>`, `--role source|target`, `--uncovered`, `--fail-under <pct>`, `--json`. Scoping flags compose — `--schema X --role target` reports only X's target-side coverage, in only the mappings that write to it.
+
+**Coverage is structural.** A field is covered when at least one arrow references it. Nested paths cover their parents: mapping `address.city` covers `address` but not `address.line1`. Element-relative arrows inside `each`/`flatten` blocks resolve against the iterated list, so `.sku` under `each lines -> rows` covers `lines.sku`. A field described only in prose is uncovered *by definition* — use `nl-refs` to find those, and `lint` for policy judgements about which gaps are acceptable.
+
+**Percentages count leaf fields only.** A `record` is structure, not data; counting it alongside its children would count the same data twice and let a schema's nesting depth move the number on its own.
+
+#### Per-mapping vs aggregate
+
+The report has two sections, and they make **different claims about the same field**:
+
+| Section | "uncovered" means | Use it to |
+|---|---|---|
+| per-mapping | *this* mapping does not touch the field — another may well populate it | Review one mapping's completeness |
+| aggregate | *no* mapping in scope touches it | Decide a field is genuinely unmapped |
+
+A target field populated by mapping A and ignored by mapping B is a gap in B's per-mapping report and covered in the aggregate. Acting on the per-mapping figure — deleting the field, or filing it as missing work — will act on a field that is already mapped. The aggregate is the claim worth acting on; the per-mapping view tells you *where* to fix it.
+
+Aggregate figures respect the active scope, so `--schema X --fail-under 90` gates X rather than the workspace.
+
+#### JSON contract
+
+`--json` emits a **stable contract**, consumed by the satsuma-viz coverage overlay:
+
+```jsonc
+{
+  "mappings": [{
+    "mapping": "::load hub",          // canonical mapping key
+    "file": "/abs/path/pipeline.stm",
+    "schemas": [{
+      "schema": "::hub_customer",     // canonical schema key
+      "role": "target",               // "source" | "target"
+      "covered": 8,                   // leaf fields covered by THIS mapping
+      "total": 11,                    // leaf fields declared
+      "pct": 73,                      // covered/total, whole-number percent
+      "fields": [
+        { "path": "email", "mapped": true, "file": "/abs/path/pipeline.stm", "line": 42 }
+      ]
+    }]
+  }],
+  "aggregate": {
+    "schemas": [{
+      "schema": "::hub_customer",
+      "role": "target",
+      "mappings": ["::load hub", "::enrich hub"],   // the mappings behind the figure
+      "covered": 11, "total": 11, "pct": 100,
+      "fields": [ /* same entry shape; `mapped` is the union across `mappings` */ ]
+    }],
+    "namespaces": [{
+      "namespace": "crm",             // null for schemas at file scope
+      "source": { "covered": 3, "total": 4, "pct": 75 },
+      "target": { "covered": 3, "total": 3, "pct": 100 }
+    }],
+    "workspace": { "source": { /* … */ }, "target": { /* … */ } }
+  },
+  "gate": {                           // present only with --fail-under
+    "role": "target", "threshold": 90, "pct": 100, "met": true
+  }
+}
+```
+
+`fields` lists leaf fields only, matching the counts, so the paths shown and the number beside them are always the same population. `line` is 1-indexed and **omitted** when the declaration position is unknown — never 0, which would send an editor-jump link to line 1 of the wrong file. Fields arriving via a fragment spread report the *consuming* schema's position, not the fragment's.
+
+With `--uncovered`, `fields` is filtered to unmapped entries while `covered`/`total` stay unchanged, so the denominator survives.
+
+Anonymous mappings are not reported: coverage is looked up by mapping label and an anonymous block has none. The count of skipped mappings is printed rather than silently omitted.
+
+#### Exit codes
+
+`coverage` adds a code to the CLI's standard set, so a CI gate can be told apart from a broken invocation:
+
+| Code | Meaning |
+|---|---|
+| 0 | Report produced — and the `--fail-under` threshold met, if one was given |
+| 1 | `--mapping`/`--schema` named something that does not exist, nothing matched the scope, or the gated role has no coverage to measure |
+| 2 | Parse or filesystem error |
+| 3 | `--fail-under` threshold not met |
+
+3 is distinct from 1 deliberately. `coverage --fail-under 90 --mapping "typo"` can fail because the name is misspelled *or* because the spec is genuinely incomplete; sharing a code would leave CI unable to tell "fix the pipeline" from "finish the mapping". (`fmt --check` avoids this only because it takes no scope arguments that can fail to resolve.)
+
+An invalid flag *value* (`--role banana`, `--fail-under 150`) is a usage error: it reports the problem with help and exits 1, as everywhere else in the CLI.
+
+#### coverage vs fields --unmapped-by
+
+Both answer coverage questions and are the **same computation** — `fields --unmapped-by` delegates to it, so the two cannot disagree. Choose by shape of question:
+
+| Reach for | When |
+|---|---|
+| `fields <schema> --unmapped-by <mapping>` | One schema against one mapping, and you want the answer as a field tree with types |
+| `coverage` | Anything workspace-wide, aggregated across mappings, percentage-based, or CI-gated |
 
 ## Transform Classification
 
@@ -191,16 +293,19 @@ satsuma nl mart_customer_360.loyalty_tier
 
 ### Coverage assessment
 
+One command, not a composed workflow:
+
 ```bash
-# 1. Which target fields have no arrows from this mapping?
-satsuma fields mart_customer_360 --unmapped-by "demographics to mart" --json
+# Every mapping, with both per-mapping and aggregate figures
+satsuma coverage pipeline.stm --json
 
-# 2. Repeat for other mappings targeting the same schema
-satsuma fields mart_customer_360 --unmapped-by "online to mart" --json
-
-# 3. Agent intersects results to find fields unmapped by ALL mappings
-# 4. For mapped fields, agent checks arrow classification via satsuma arrows
+# Just the gaps nothing fills, for one schema
+satsuma coverage pipeline.stm --schema mart_customer_360 --uncovered --json
 ```
+
+Read `aggregate.schemas[].fields[]` for fields **no** mapping covers — that is the claim worth acting on. Read `mappings[].schemas[].fields[]` to see which mapping to edit. The two are not interchangeable: a field mapping A populates appears as a gap in mapping B's section.
+
+The CLI performs the aggregation because that is where callers composing it by hand went wrong — treating a field as unmapped because one mapping ignores it, when another populates it. What remains an agent judgement is *whether a gap matters*: read the arrow classification (`satsuma arrows`) and any NL notes, since a field populated only by prose in a note block is uncovered by definition.
 
 ### PII audit
 
@@ -266,7 +371,7 @@ satsuma arrows changed_schema.changed_field --as-source --json
 ## What the CLI Does Not Do
 
 - **Does not interpret NL.** Transform strings, notes, and comments are extracted verbatim. The CLI never assesses whether an NL transform is correct, complete, or semantically equivalent to another.
-- **Does not compose analysis workflows.** There are no `impact`, `coverage`, `audit`, `scaffold`, or `inventory` commands. These are agent workflows built from primitives — their correctness depends on NL interpretation that the CLI cannot perform.
+- **Does not compose analysis workflows.** There are no `impact`, `audit`, `scaffold`, or `inventory` commands. These are agent workflows built from primitives — their correctness depends on NL interpretation that the CLI cannot perform. `coverage` is a command rather than a workflow precisely because it needs no NL interpretation: which fields an arrow references is a fact about the parse tree, and the aggregation across mappings is arithmetic. Judging whether a given gap *matters* stays with the agent.
 - **Does not call language models.** The CLI is deterministic, fast, and reproducible. Same input, same output, every time.
 - **Does not accept NL queries.** Commands take explicit structural arguments. The agent decides which commands to call based on the user's question.
 
@@ -276,3 +381,4 @@ satsuma arrows changed_schema.changed_field --as-source --json
 - Tree-sitter grammar: `tooling/tree-sitter-satsuma/`
 - Feature 09 (workspace extractors): `features/09-stm-cli-llm-context/`
 - Feature 10 (structural primitives): `features/10-stm-cli-enhancements/`
+- Feature 35 (`coverage` command): `features/35-coverage-command/`

--- a/adrs/adr-034-leaf-only-coverage-counting.md
+++ b/adrs/adr-034-leaf-only-coverage-counting.md
@@ -1,0 +1,95 @@
+# ADR-034 — Leaf-Only Coverage Counting on a Field's Own Flag
+
+**Status:** Accepted
+**Date:** 2026-07-31 (sl-4qvp, feature 35)
+
+## Context
+
+`computeMappingCoverage()` in `satsuma-core/src/coverage.ts` reports one
+`FieldCoverageEntry` per declared field of a mapping's participating schemas,
+including record fields, each with a `mapped` boolean. Until feature 35 no
+consumer turned those entries into a number: the VS Code gutter decorates
+individual fields, so it never needed a denominator.
+
+Feature 35 changed that. `satsuma coverage` prints `covered/total` and a
+percentage per schema, per namespace, and per workspace, and `--fail-under`
+turns the workspace figure into a CI gate that blocks a merge. Feature 36's viz
+overlay will render the same numbers. Once a percentage exists, the population
+it is computed over becomes a contract: three consumers must agree, and a gate
+must not fail a complete spec or pass an incomplete one.
+
+Counting every entry is not an option — a record and its children describe the
+same data, so a nested schema would be counted at two levels, and a schema's
+nesting depth alone would move its percentage. Both existing consumers already
+recognised this and solved it differently.
+`vscode-satsuma/src/commands/coverage-logic.ts:82` counts *top-level* fields
+only, filtering `!f.path.includes(".")`. That avoids double-counting but reports
+a twelve-field `address` record as a single unit, so one mapped leaf reads as a
+fully covered record.
+
+The apparently correct rule — count leaves, and treat a leaf as covered when it
+or any ancestor is covered — was implemented and rejected during sl-4qvp. It
+fails because of how the covered-path set is built. `addPathAndPrefixes()`
+(`satsuma-core/src/coverage-paths.ts`) registers every ancestor prefix of a
+referenced path, precisely so a parent record shows as touched in the gutter
+when one child is mapped. A record's `mapped` flag therefore cannot distinguish
+the two cases that matter for counting: `address -> address` copying the whole
+record, and `address.city -> city` covering exactly one of its twelve leaves.
+Both set `mapped: true` on `address`. Inheriting from it would report "1 of 12
+address fields mapped" as "all 12 mapped" — a large, silent overstatement in
+the direction that hides work.
+
+## Decision
+
+Coverage counts **leaf fields only, using each leaf's own `mapped` flag**.
+Record fields — any entry with at least one descendant entry — are excluded from
+both `covered` and `total`, and never vouch for their descendants.
+
+The rule lives in exactly one place: `summarizeFieldCoverage()` in
+`satsuma-core/src/coverage-rollup.ts`, which every per-mapping table, aggregate
+rollup, namespace subtotal, workspace total, and `--fail-under` comparison calls.
+The leaf predicate is exported separately as `leafFieldEntries()` so that a
+rendered list of field paths and the count printed beside it are derived from the
+same definition; a consumer that filtered fields itself could otherwise show
+three paths under a count of two.
+
+Consumers must not compute their own coverage denominators. A consumer needing a
+percentage calls `summarizeFieldCoverage()`; one needing the fields behind a
+percentage calls `leafFieldEntries()`.
+
+The known cost is accepted deliberately: a whole-record arrow under-reports,
+because its leaves are never individually referenced. Correcting it requires
+`computeMappingCoverage()` to track directly-covered paths separately from
+prefix-registered ancestors, which changes the per-mapping contract the VS Code
+gutter consumes. That work is tracked as `3cc-iedv` and was kept out of feature
+35.
+
+## Consequences
+
+**Positive:**
+
+- One rule, one implementation. A CLI percentage, a `--fail-under` verdict, and a
+  viz overlay figure cannot disagree, because none of them computes its own.
+- Percentages measure data, not structure. Re-nesting a schema's fields into
+  records without changing a single arrow leaves every percentage unchanged.
+- The error direction is safe. A whole-record arrow makes coverage look *worse*
+  than it is, so the failure mode is a reviewer investigating a gap that turns
+  out to be filled — not a gate passing a spec with twelve unmapped fields.
+- Field lists and counts are guaranteed consistent, because both derive from
+  `leafFieldEntries()`.
+
+**Negative:**
+
+- A whole-record arrow (`address -> address`) reports all of that record's leaves
+  as uncovered. Workspaces relying on record-level copies will see understated
+  coverage until `3cc-iedv` lands, and `--fail-under` thresholds on them must be
+  set with that in mind.
+- The VS Code status bar remains on its own top-level-field rule
+  (`coverage-logic.ts:82`), so its percentage and `satsuma coverage`'s disagree
+  for any schema with nested records. This ADR does not change that behaviour;
+  reconciling it is tracked as `3cc-t6uo`. The divergence is confined to the
+  percentage — the gutter decorations are per-field and already come from core.
+- The rule is not inferable from `FieldCoverageEntry` alone. A reader who sees
+  `mapped: true` on a record and assumes it counts will get a different number,
+  which is why the rationale is documented on the `CoverageTotals` type as well
+  as here.

--- a/tooling/satsuma-cli/src/command-runner.ts
+++ b/tooling/satsuma-cli/src/command-runner.ts
@@ -55,6 +55,24 @@ export const EXIT_NOT_FOUND = 1;
 export const EXIT_PARSE_ERROR = 2;
 
 /**
+ * `coverage --fail-under <pct>`: the report was produced fine, and the coverage
+ * it reports is below the requested threshold.
+ *
+ * Deliberately its own code rather than reusing {@link EXIT_NOT_FOUND}. Both
+ * outcomes are possible from a single invocation — `coverage --fail-under 90
+ * --mapping "typo"` can fail because the mapping name is misspelled *or*
+ * because the spec is genuinely incomplete — and CI must be able to tell them
+ * apart: one means fix the pipeline, the other means finish the mapping. `fmt
+ * --check` gets away with a shared code only because it takes no scope
+ * arguments that can fail to resolve.
+ *
+ * Coverage-specific by design. A future gate on another command should reuse
+ * this code only if it means the same thing: "the work succeeded, and the
+ * measurement it produced fails a policy the caller set".
+ */
+export const EXIT_THRESHOLD_NOT_MET = 3;
+
+/**
  * Structured failure raised by command handlers and shared utilities.
  *
  * Throwing a `CommandError` is the canonical way for a handler to abort

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -32,7 +32,7 @@ import {
   EXIT_THRESHOLD_NOT_MET,
 } from "../command-runner.js";
 import { parsePercentage } from "../option-parsers.js";
-import { canonicalKey, resolveIndexKey } from "../index-builder.js";
+import { canonicalKey, displayKey, resolveIndexKey } from "../index-builder.js";
 import { coverageForWorkspace } from "../coverage-workspace.js";
 import type { MappingCoverage } from "../coverage-workspace.js";
 import { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "@satsuma/core";
@@ -250,8 +250,8 @@ function applyScope(mappings: MappingCoverage[], scope: Scope): MappingCoverage[
 function describeEmptyScope(totalMappings: number, scope: Scope): string {
   if (totalMappings === 0) return "No named mappings found in this workspace.";
   const filters: string[] = [];
-  if (scope.mappingKey) filters.push(`mapping '${canonicalKey(scope.mappingKey)}'`);
-  if (scope.schemaKey) filters.push(`schema '${canonicalKey(scope.schemaKey)}'`);
+  if (scope.mappingKey) filters.push(`mapping '${displayKey(scope.mappingKey)}'`);
+  if (scope.schemaKey) filters.push(`schema '${displayKey(scope.schemaKey)}'`);
   if (scope.role) filters.push(`role '${scope.role}'`);
   return filters.length > 0
     ? `No coverage matches ${filters.join(" + ")}.`
@@ -337,16 +337,16 @@ function printPerMappingReport(mappings: MappingCoverage[], opts: CoverageOption
 
   for (const mapping of mappings) {
     console.log();
-    console.log(`mapping ${canonicalKey(mapping.mappingId)}  (${mapping.file})`);
+    console.log(`mapping ${displayKey(mapping.mappingId)}  (${mapping.file})`);
 
     const schemaWidth = Math.max(
-      ...mapping.result.schemas.map((s) => canonicalKey(s.schemaId).length),
+      ...mapping.result.schemas.map((s) => displayKey(s.schemaId).length),
     );
     for (const schema of mapping.result.schemas) {
       const totals = summarizeFieldCoverage(schema.fields);
       const counts = `${totals.covered}/${totals.total}`;
       console.log(
-        `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${canonicalKey(schema.schemaId).padEnd(schemaWidth)}  ` +
+        `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${displayKey(schema.schemaId).padEnd(schemaWidth)}  ` +
         `${counts.padStart(7)}  ${String(totals.pct).padStart(3)}%`,
       );
     }
@@ -370,7 +370,7 @@ function printFieldList(schema: SchemaCoverageResult, opts: CoverageOptions): vo
   if (uncovered.length === 0) return;
 
   console.log(
-    `    uncovered in ${canonicalKey(schema.schemaId)} (${schema.role}): ` +
+    `    uncovered in ${displayKey(schema.schemaId)} (${schema.role}): ` +
     `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
   );
   for (const line of wrapPaths(uncovered.map((f) => f.path))) {
@@ -519,11 +519,11 @@ function printAggregateReport(aggregate: AggregateCoverage, opts: CoverageOption
   console.log("Aggregate — a field is uncovered here only when NO mapping in scope covers it");
 
   const schemaWidth = Math.max(
-    ...aggregate.schemas.map((s) => canonicalKey(s.schemaId).length),
+    ...aggregate.schemas.map((s) => displayKey(s.schemaId).length),
   );
   for (const schema of aggregate.schemas) {
     console.log(
-      `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${canonicalKey(schema.schemaId).padEnd(schemaWidth)}  ` +
+      `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${displayKey(schema.schemaId).padEnd(schemaWidth)}  ` +
       `${formatTotals(schema.totals)}`,
     );
   }
@@ -532,7 +532,7 @@ function printAggregateReport(aggregate: AggregateCoverage, opts: CoverageOption
     const uncovered = aggregateFields(schema, opts).filter((f) => !f.mapped);
     if (uncovered.length === 0) continue;
     console.log(
-      `    covered by no mapping — ${canonicalKey(schema.schemaId)} (${schema.role}): ` +
+      `    covered by no mapping — ${displayKey(schema.schemaId)} (${schema.role}): ` +
       `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
     );
     for (const line of wrapPaths(uncovered.map((f) => f.path))) {

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -1,0 +1,351 @@
+/**
+ * coverage.ts — `satsuma coverage [path]` command
+ *
+ * Answers the first question every reviewer of a mapping spec asks: which
+ * declared fields is nothing mapping yet? Reports covered/uncovered status per
+ * mapping, per participating schema, across the whole workspace reachable from
+ * the entry file.
+ *
+ * Owns: scoping flags and rendering (human table and `--json`).
+ * Does not own: coverage semantics (`@satsuma/core/coverage`), the counting rule
+ * (`@satsuma/core/coverage-rollup`), or index adaptation
+ * (`../coverage-workspace.js`). This module must contain no coverage logic of
+ * its own — the whole point of feature 35 is that one implementation answers
+ * this question for the CLI, the editor, and the viz overlay alike.
+ *
+ * Flags:
+ *   --mapping <name>   report on one mapping
+ *   --schema <name>    report on one schema, across every mapping using it
+ *   --role <role>      restrict to source or target
+ *   --uncovered        list only the fields nothing maps
+ *   --json             structured JSON output
+ */
+
+import type { Command } from "commander";
+import { loadWorkspace } from "../load-workspace.js";
+import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
+import { canonicalKey, resolveIndexKey } from "../index-builder.js";
+import { coverageForWorkspace } from "../coverage-workspace.js";
+import type { MappingCoverage } from "../coverage-workspace.js";
+import { summarizeFieldCoverage, leafFieldEntries } from "@satsuma/core";
+import type { FieldCoverageEntry, SchemaCoverageResult } from "@satsuma/core";
+
+/** Roles a schema can play in a mapping; the accepted values of `--role`. */
+const ROLES = ["source", "target"] as const;
+type Role = (typeof ROLES)[number];
+
+/** Scoping and presentation options, after Commander has parsed them. */
+interface CoverageOptions {
+  mapping?: string;
+  schema?: string;
+  role?: string;
+  uncovered?: boolean;
+  json?: boolean;
+}
+
+export function register(program: Command): void {
+  program
+    .command("coverage [path]")
+    .description("Report which declared fields each mapping covers, and which nothing maps")
+    .option("--mapping <name>", "only this mapping")
+    .option("--schema <name>", "only this schema, across every mapping that uses it")
+    .option("--role <role>", "only 'source' or 'target' schemas")
+    .option("--uncovered", "list only the fields nothing maps")
+    .option("--json", "structured JSON output")
+    .addHelpText("after", `
+Coverage is structural: a field counts as covered when at least one arrow in the
+mapping references it. Nested paths cover their parents — mapping 'address.city'
+covers 'address' but not 'address.line1'. A field described only in prose (a note
+block) is uncovered by definition; use 'nl-refs' to find those.
+
+Percentages count leaf fields only: a record is structure, not data, so counting
+it alongside its children would count the same data twice.
+
+Names can be namespace-qualified (e.g. crm::orders).
+
+JSON shape (--json):
+  {
+    "mappings": [{
+      "mapping": str,          # canonical mapping key, e.g. "::load" or "ns::load"
+      "file":    str,
+      "schemas": [{
+        "schema":  str,        # canonical schema key
+        "role":    "source" | "target",
+        "covered": int,        # leaf fields covered by THIS mapping
+        "total":   int,        # leaf fields declared
+        "pct":     int,        # covered/total, whole-number percent
+        "fields":  [{"path": str, "mapped": bool, "file": str, "line": int}, ...]
+      }, ...]
+    }, ...]
+  }
+
+'fields' lists leaf fields only, matching the counts; 'line' is 1-indexed and
+omitted when the declaration position is unknown. With --uncovered, 'fields' is
+filtered to unmapped entries and the counts are unchanged.
+
+Exit codes:
+  0  report produced
+  1  --mapping/--schema named something that does not exist, or nothing matched
+  2  parse or filesystem error
+
+Examples:
+  satsuma coverage pipeline.stm                          # every mapping
+  satsuma coverage pipeline.stm --uncovered               # the review queue
+  satsuma coverage pipeline.stm --role target             # only what gets written
+  satsuma coverage pipeline.stm --mapping 'load hub'      # one mapping
+  satsuma coverage pipeline.stm --schema hub_customer     # one schema everywhere
+  satsuma coverage pipeline.stm --json                    # machine-readable`)
+    .action(runCommand(async (pathArg: string | undefined, opts: CoverageOptions) => {
+      const role = parseRole(opts.role);
+      const { files, index } = await loadWorkspace(pathArg);
+
+      // Resolve scope arguments before doing any work, so a typo reports itself
+      // as a typo (exit 1) rather than as an empty — and misleading — report.
+      const mappingKey = opts.mapping ? resolveScopeName(opts.mapping, "Mapping", index.mappings) : null;
+      const schemaKey = opts.schema ? resolveScopeName(opts.schema, "Schema", index.schemas) : null;
+
+      const { mappings, skippedAnonymous } = coverageForWorkspace(index, files);
+      const scoped = applyScope(mappings, { mappingKey, schemaKey, role });
+
+      if (scoped.length === 0) {
+        console.log(describeEmptyScope(mappings.length, { mappingKey, schemaKey, role }));
+        return EXIT_NOT_FOUND;
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify({ mappings: scoped.map((m) => toJson(m, opts)) }, null, 2));
+        return;
+      }
+
+      printPerMappingReport(scoped, opts);
+      if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
+    }));
+}
+
+// ── Scope resolution ────────────────────────────────────────────────────────
+
+/**
+ * Validate `--role`, which is a closed set rather than free text: silently
+ * ignoring `--role sources` would report both roles and look like a bug in the
+ * coverage numbers rather than in the invocation.
+ */
+function parseRole(raw: string | undefined): Role | null {
+  if (raw === undefined) return null;
+  if ((ROLES as readonly string[]).includes(raw)) return raw as Role;
+  throw new CommandError(
+    `Invalid --role '${raw}'. Expected one of: ${ROLES.join(", ")}.`,
+    EXIT_PARSE_ERROR,
+  );
+}
+
+/**
+ * Resolve a `--mapping` / `--schema` argument to an index key, or fail with
+ * EXIT_NOT_FOUND.
+ *
+ * This is the established CLI meaning of exit 1 and must stay distinct from the
+ * coverage-threshold code that `--fail-under` adds (sl-268g): CI has to be able
+ * to tell "the spec is incomplete" from "the build invocation is broken".
+ */
+function resolveScopeName<T>(name: string, kind: string, entities: Map<string, T>): string {
+  const resolved = resolveIndexKey(name, entities);
+  if (resolved) return resolved.key;
+  const close = [...entities.keys()].find((k) => k.toLowerCase() === name.toLowerCase());
+  const lines = [`${kind} '${name}' not found.`];
+  if (close) lines.push(`Did you mean '${close}'?`);
+  throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+}
+
+/** Active scope filters, all optional and combinable. */
+interface Scope {
+  mappingKey: string | null;
+  schemaKey: string | null;
+  role: Role | null;
+}
+
+/**
+ * Narrow a workspace's coverage to the active scope.
+ *
+ * Filters compose: `--schema X --role target` keeps only X's target-side entry,
+ * in only the mappings that write to it. A mapping left with no schemas is
+ * dropped rather than printed empty.
+ */
+function applyScope(mappings: MappingCoverage[], scope: Scope): MappingCoverage[] {
+  const result: MappingCoverage[] = [];
+  for (const mapping of mappings) {
+    if (scope.mappingKey && mapping.mappingId !== scope.mappingKey) continue;
+    const schemas = mapping.result.schemas.filter(
+      (s) => (!scope.schemaKey || s.schemaId === scope.schemaKey) && (!scope.role || s.role === scope.role),
+    );
+    if (schemas.length === 0) continue;
+    result.push({ ...mapping, result: { schemas } });
+  }
+  return result;
+}
+
+/**
+ * Explain an empty result in terms of the scope that produced it.
+ *
+ * "No results" is ambiguous when several filters are active — the user needs to
+ * know which combination excluded everything, because the individual names
+ * resolved fine (an unresolvable one would already have exited 1).
+ */
+function describeEmptyScope(totalMappings: number, scope: Scope): string {
+  if (totalMappings === 0) return "No named mappings found in this workspace.";
+  const filters: string[] = [];
+  if (scope.mappingKey) filters.push(`mapping '${canonicalKey(scope.mappingKey)}'`);
+  if (scope.schemaKey) filters.push(`schema '${canonicalKey(scope.schemaKey)}'`);
+  if (scope.role) filters.push(`role '${scope.role}'`);
+  return filters.length > 0
+    ? `No coverage matches ${filters.join(" + ")}.`
+    : "No coverage to report.";
+}
+
+// ── Field selection ─────────────────────────────────────────────────────────
+
+/**
+ * The field entries a report shows for one schema.
+ *
+ * Always leaves only, so the listed fields and the `covered/total` counts beside
+ * them are the same population — a list of three paths under a count of two
+ * would be a report that contradicts itself. `--uncovered` narrows further to
+ * the unmapped ones without touching the counts, which stay the denominator the
+ * reviewer needs.
+ */
+function reportedFields(schema: SchemaCoverageResult, opts: CoverageOptions): FieldCoverageEntry[] {
+  const leaves = leafFieldEntries(schema.fields);
+  return opts.uncovered ? leaves.filter((f) => !f.mapped) : leaves;
+}
+
+// ── JSON output ─────────────────────────────────────────────────────────────
+
+/**
+ * One mapping's coverage as JSON, per the shape documented in the command help
+ * and SATSUMA-CLI.md. Treated as a stable contract — feature 36's viz overlay
+ * renders from it.
+ */
+function toJson(mapping: MappingCoverage, opts: CoverageOptions): Record<string, unknown> {
+  return {
+    mapping: canonicalKey(mapping.mappingId),
+    file: mapping.file,
+    schemas: mapping.result.schemas.map((schema) => {
+      const totals = summarizeFieldCoverage(schema.fields);
+      return {
+        schema: canonicalKey(schema.schemaId),
+        role: schema.role,
+        covered: totals.covered,
+        total: totals.total,
+        pct: totals.pct,
+        fields: reportedFields(schema, opts).map(fieldToJson),
+      };
+    }),
+  };
+}
+
+/**
+ * A field entry as JSON. `line` is converted to 1-indexed to match human output
+ * and every other command's JSON (cbh-7rvo), and omitted rather than defaulted
+ * when the declaration position is unknown.
+ */
+function fieldToJson(field: FieldCoverageEntry): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    path: field.path,
+    mapped: field.mapped,
+    file: field.uri,
+  };
+  if (field.line !== undefined) entry.line = field.line + 1;
+  return entry;
+}
+
+// ── Human output ────────────────────────────────────────────────────────────
+
+/** Column widths chosen so a two-role table stays narrow enough to paste. */
+const ROLE_COLUMN_WIDTH = 6; // "source" — the longer of the two role words
+/** Uncovered paths are wrapped rather than printed one per line, to stay compact. */
+const UNCOVERED_LINE_BUDGET = 72;
+
+/**
+ * Print the per-mapping report: one block per mapping, a row per participating
+ * schema, then the field paths themselves.
+ *
+ * Every figure here is scoped to its own mapping. "Uncovered by this mapping"
+ * is a weaker claim than "uncovered by every mapping" — a field another mapping
+ * populates appears here as a gap — so the heading says so explicitly rather
+ * than leaving a reviewer to infer it.
+ */
+function printPerMappingReport(mappings: MappingCoverage[], opts: CoverageOptions): void {
+  console.log(`Coverage — ${mappings.length} mapping${mappings.length !== 1 ? "s" : ""}, per mapping`);
+
+  for (const mapping of mappings) {
+    console.log();
+    console.log(`mapping ${canonicalKey(mapping.mappingId)}  (${mapping.file})`);
+
+    const schemaWidth = Math.max(
+      ...mapping.result.schemas.map((s) => canonicalKey(s.schemaId).length),
+    );
+    for (const schema of mapping.result.schemas) {
+      const totals = summarizeFieldCoverage(schema.fields);
+      const counts = `${totals.covered}/${totals.total}`;
+      console.log(
+        `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${canonicalKey(schema.schemaId).padEnd(schemaWidth)}  ` +
+        `${counts.padStart(7)}  ${String(totals.pct).padStart(3)}%`,
+      );
+    }
+
+    for (const schema of mapping.result.schemas) {
+      printFieldList(schema, opts);
+    }
+  }
+}
+
+/**
+ * List the fields for one schema beneath its table row.
+ *
+ * In the default view an uncovered field is what the reviewer is looking for, so
+ * only those are named — the covered ones are already summarised by the count.
+ * `--uncovered` uses the same list; the flag's effect is to suppress schemas
+ * that have no gaps at all, not to change what is named.
+ */
+function printFieldList(schema: SchemaCoverageResult, opts: CoverageOptions): void {
+  const uncovered = reportedFields(schema, opts).filter((f) => !f.mapped);
+  if (uncovered.length === 0) return;
+
+  console.log(
+    `    uncovered in ${canonicalKey(schema.schemaId)} (${schema.role}): ` +
+    `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
+  );
+  for (const line of wrapPaths(uncovered.map((f) => f.path))) {
+    console.log(`      ${line}`);
+  }
+}
+
+/** Pack comma-separated paths into lines within {@link UNCOVERED_LINE_BUDGET}. */
+function wrapPaths(paths: string[]): string[] {
+  const lines: string[] = [];
+  let current = "";
+  for (const path of paths) {
+    const candidate = current ? `${current}, ${path}` : path;
+    if (candidate.length > UNCOVERED_LINE_BUDGET && current) {
+      lines.push(`${current},`);
+      current = path;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) lines.push(current);
+  return lines;
+}
+
+/**
+ * Report anonymous mappings the pass could not cover.
+ *
+ * Silently omitting them would let the report read as complete when it is not —
+ * the reader must be able to see that part of the workspace was skipped, and
+ * why.
+ */
+function printAnonymousNote(count: number): void {
+  console.log();
+  console.log(
+    `Note: ${count} anonymous mapping${count !== 1 ? "s" : ""} not reported ` +
+    `(coverage is looked up by mapping name; name the mapping to include it).`,
+  );
+}

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -27,8 +27,15 @@ import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../c
 import { canonicalKey, resolveIndexKey } from "../index-builder.js";
 import { coverageForWorkspace } from "../coverage-workspace.js";
 import type { MappingCoverage } from "../coverage-workspace.js";
-import { summarizeFieldCoverage, leafFieldEntries } from "@satsuma/core";
-import type { FieldCoverageEntry, SchemaCoverageResult } from "@satsuma/core";
+import { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "@satsuma/core";
+import type {
+  AggregateCoverage,
+  AggregateSchemaCoverage,
+  CoverageTotals,
+  FieldCoverageEntry,
+  RoleTotals,
+  SchemaCoverageResult,
+} from "@satsuma/core";
 
 /** Roles a schema can play in a mapping; the accepted values of `--role`. */
 const ROLES = ["source", "target"] as const;
@@ -79,6 +86,22 @@ JSON shape (--json):
     }, ...]
   }
 
+  ... plus an "aggregate" section, unioned across the mappings in scope:
+    "aggregate": {
+      "schemas":    [{"schema": str, "role": str, "mappings": [str, ...],
+                      "covered": int, "total": int, "pct": int, "fields": [...]}, ...],
+      "namespaces": [{"namespace": str | null,
+                      "source": {"covered": int, "total": int, "pct": int},
+                      "target": {...}}, ...],
+      "workspace":  {"source": {...}, "target": {...}}
+    }
+
+The two sections answer different questions and are not interchangeable. Under
+"mappings", uncovered means "this mapping does not touch the field" — another
+mapping may well populate it. Under "aggregate", uncovered means "no mapping in
+scope touches it", which is the claim worth acting on. Deleting a field on the
+strength of a per-mapping figure will delete a live one.
+
 'fields' lists leaf fields only, matching the counts; 'line' is 1-indexed and
 omitted when the declaration position is unknown. With --uncovered, 'fields' is
 filtered to unmapped entries and the counts are unchanged.
@@ -112,12 +135,20 @@ Examples:
         return EXIT_NOT_FOUND;
       }
 
+      // Aggregate over the *scoped* mappings, so `--schema X` reports X's
+      // workspace-wide coverage rather than the whole workspace's.
+      const aggregate = aggregateCoverage(scoped);
+
       if (opts.json) {
-        console.log(JSON.stringify({ mappings: scoped.map((m) => toJson(m, opts)) }, null, 2));
+        console.log(JSON.stringify({
+          mappings: scoped.map((m) => toJson(m, opts)),
+          aggregate: aggregateToJson(aggregate, opts),
+        }, null, 2));
         return;
       }
 
       printPerMappingReport(scoped, opts);
+      printAggregateReport(aggregate, opts);
       if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
     }));
 }
@@ -262,6 +293,8 @@ function fieldToJson(field: FieldCoverageEntry): Record<string, unknown> {
 const ROLE_COLUMN_WIDTH = 6; // "source" — the longer of the two role words
 /** Uncovered paths are wrapped rather than printed one per line, to stay compact. */
 const UNCOVERED_LINE_BUDGET = 72;
+/** Label for the total row, padded to the same width as the namespace rows. */
+const WORKSPACE_LABEL = "workspace";
 
 /**
  * Print the per-mapping report: one block per mapping, a row per participating
@@ -333,6 +366,122 @@ function wrapPaths(paths: string[]): string[] {
   }
   if (current) lines.push(current);
   return lines;
+}
+
+// ── Aggregate output ────────────────────────────────────────────────────────
+
+/**
+ * The aggregate section as JSON: every schema in scope counted once, plus
+ * namespace and workspace subtotals.
+ *
+ * Deliberately a sibling of `mappings` rather than merged into it. A consumer
+ * reading `aggregate.schemas[].fields[].mapped === false` is being told nothing
+ * in scope covers the field; the same key under `mappings` means only that one
+ * mapping does not. Keeping them in separate objects means a consumer has to
+ * choose which claim it is making.
+ */
+function aggregateToJson(aggregate: AggregateCoverage, opts: CoverageOptions): Record<string, unknown> {
+  return {
+    schemas: aggregate.schemas.map((schema) => ({
+      schema: canonicalKey(schema.schemaId),
+      role: schema.role,
+      mappings: schema.mappings.map(canonicalKey),
+      covered: schema.totals.covered,
+      total: schema.totals.total,
+      pct: schema.totals.pct,
+      fields: aggregateFields(schema, opts).map(fieldToJson),
+    })),
+    namespaces: aggregate.namespaces.map((ns) => ({
+      namespace: ns.namespace,
+      source: ns.source,
+      target: ns.target,
+    })),
+    workspace: { source: aggregate.workspace.source, target: aggregate.workspace.target },
+  };
+}
+
+/**
+ * The aggregate field entries to report, filtered exactly as the per-mapping
+ * ones are so the two sections stay comparable line for line.
+ */
+function aggregateFields(schema: AggregateSchemaCoverage, opts: CoverageOptions): FieldCoverageEntry[] {
+  const leaves = leafFieldEntries(schema.fields);
+  return opts.uncovered ? leaves.filter((f) => !f.mapped) : leaves;
+}
+
+/**
+ * Print the aggregate section.
+ *
+ * The heading states the claim in words rather than trusting the section title:
+ * a reviewer skimming for "uncovered" needs to know, at the point of reading it,
+ * that these gaps are the ones no mapping fills — the per-mapping list above
+ * contains fields another mapping populates.
+ */
+function printAggregateReport(aggregate: AggregateCoverage, opts: CoverageOptions): void {
+  console.log();
+  console.log("Aggregate — a field is uncovered here only when NO mapping in scope covers it");
+
+  const schemaWidth = Math.max(
+    ...aggregate.schemas.map((s) => canonicalKey(s.schemaId).length),
+  );
+  for (const schema of aggregate.schemas) {
+    console.log(
+      `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${canonicalKey(schema.schemaId).padEnd(schemaWidth)}  ` +
+      `${formatTotals(schema.totals)}`,
+    );
+  }
+
+  for (const schema of aggregate.schemas) {
+    const uncovered = aggregateFields(schema, opts).filter((f) => !f.mapped);
+    if (uncovered.length === 0) continue;
+    console.log(
+      `    covered by no mapping — ${canonicalKey(schema.schemaId)} (${schema.role}): ` +
+      `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
+    );
+    for (const line of wrapPaths(uncovered.map((f) => f.path))) {
+      console.log(`      ${line}`);
+    }
+  }
+
+  printSubtotals(aggregate);
+}
+
+/**
+ * Print namespace subtotals and the workspace total.
+ *
+ * The single-namespace case is suppressed: when every schema is at file scope
+ * (or in one namespace) the subtotal row is identical to the workspace row, and
+ * printing both invites the reader to look for a difference that cannot exist.
+ */
+function printSubtotals(aggregate: AggregateCoverage): void {
+  const showNamespaces = aggregate.namespaces.length > 1;
+  // One label width across namespace rows and the workspace row, so the
+  // percentages line up into a column the eye can scan down.
+  const labels = showNamespaces ? aggregate.namespaces.map((ns) => namespaceLabel(ns.namespace)) : [];
+  const labelWidth = Math.max(...labels.map((l) => l.length), WORKSPACE_LABEL.length);
+
+  console.log();
+  if (showNamespaces) {
+    for (const ns of aggregate.namespaces) {
+      console.log(`  ${namespaceLabel(ns.namespace).padEnd(labelWidth)}  ${formatRoleTotals(ns)}`);
+    }
+  }
+  console.log(`  ${WORKSPACE_LABEL.padEnd(labelWidth)}  ${formatRoleTotals(aggregate.workspace)}`);
+}
+
+/** Display name for a namespace subtotal row; file scope has no name of its own. */
+function namespaceLabel(namespace: string | null): string {
+  return namespace === null ? "(file scope)" : namespace;
+}
+
+/** "3/4  75%" — the shared counts-and-percentage cell. */
+function formatTotals(totals: CoverageTotals): string {
+  return `${`${totals.covered}/${totals.total}`.padStart(7)}  ${String(totals.pct).padStart(3)}%`;
+}
+
+/** "source 3/4  75%   target 3/3  100%" — both roles on one subtotal row. */
+function formatRoleTotals(totals: RoleTotals): string {
+  return `source ${formatTotals(totals.source)}   target ${formatTotals(totals.target)}`;
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -18,12 +18,20 @@
  *   --schema <name>    report on one schema, across every mapping using it
  *   --role <role>      restrict to source or target
  *   --uncovered        list only the fields nothing maps
+ *   --fail-under <pct> exit 3 when the gated coverage is below <pct>
  *   --json             structured JSON output
  */
 
+import { Option } from "commander";
 import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
-import { runCommand, CommandError, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
+import {
+  runCommand,
+  CommandError,
+  EXIT_NOT_FOUND,
+  EXIT_THRESHOLD_NOT_MET,
+} from "../command-runner.js";
+import { parsePercentage } from "../option-parsers.js";
 import { canonicalKey, resolveIndexKey } from "../index-builder.js";
 import { coverageForWorkspace } from "../coverage-workspace.js";
 import type { MappingCoverage } from "../coverage-workspace.js";
@@ -47,6 +55,8 @@ interface CoverageOptions {
   schema?: string;
   role?: string;
   uncovered?: boolean;
+  /** Already coerced to a whole 0-100 by {@link parsePercentage}. */
+  failUnder?: number;
   json?: boolean;
 }
 
@@ -56,8 +66,14 @@ export function register(program: Command): void {
     .description("Report which declared fields each mapping covers, and which nothing maps")
     .option("--mapping <name>", "only this mapping")
     .option("--schema <name>", "only this schema, across every mapping that uses it")
-    .option("--role <role>", "only 'source' or 'target' schemas")
+    .addOption(
+      // .choices() rather than a hand-rolled check: an invalid value then reports
+      // itself as a usage error with help, exactly like every other bad flag
+      // value in the CLI, instead of inventing a second convention.
+      new Option("--role <role>", "only 'source' or 'target' schemas").choices([...ROLES]),
+    )
     .option("--uncovered", "list only the fields nothing maps")
+    .option("--fail-under <pct>", "exit 3 when aggregate coverage is below <pct>", parsePercentage)
     .option("--json", "structured JSON output")
     .addHelpText("after", `
 Coverage is structural: a field counts as covered when at least one arrow in the
@@ -106,10 +122,25 @@ strength of a per-mapping figure will delete a live one.
 omitted when the declaration position is unknown. With --uncovered, 'fields' is
 filtered to unmapped entries and the counts are unchanged.
 
+--fail-under <pct> turns spec completeness into a CI gate, the way 'fmt --check'
+gates formatting. It gates the aggregate percentage for the target role by
+default — the share of declared target fields some mapping populates — or the
+source role with --role source, and it respects --mapping and --schema, so a
+pipeline can gate one mapping or one schema rather than the whole workspace.
+
 Exit codes:
-  0  report produced
-  1  --mapping/--schema named something that does not exist, or nothing matched
+  0  report produced (and the --fail-under threshold met, if given)
+  1  --mapping/--schema named something that does not exist, nothing matched, or
+     there is no coverage in the gated role to measure
   2  parse or filesystem error
+  3  --fail-under threshold not met
+
+An invalid flag *value* (--role banana, --fail-under 150) is a usage error: it
+reports the problem with help and exits 1, as everywhere else in the CLI.
+
+3 is distinct from 1 on purpose: 'coverage --fail-under 90 --mapping typo' can
+fail because the name is misspelled or because the spec is genuinely incomplete,
+and CI has to tell "fix the pipeline" from "finish the mapping".
 
 Examples:
   satsuma coverage pipeline.stm                          # every mapping
@@ -117,9 +148,12 @@ Examples:
   satsuma coverage pipeline.stm --role target             # only what gets written
   satsuma coverage pipeline.stm --mapping 'load hub'      # one mapping
   satsuma coverage pipeline.stm --schema hub_customer     # one schema everywhere
-  satsuma coverage pipeline.stm --json                    # machine-readable`)
+  satsuma coverage pipeline.stm --json                    # machine-readable
+  satsuma coverage pipeline.stm --fail-under 90            # CI gate on target coverage
+  satsuma coverage pipeline.stm --fail-under 80 --role source
+  satsuma coverage pipeline.stm --fail-under 95 --mapping 'load hub'`)
     .action(runCommand(async (pathArg: string | undefined, opts: CoverageOptions) => {
-      const role = parseRole(opts.role);
+      const role = (opts.role ?? null) as Role | null;
       const { files, index } = await loadWorkspace(pathArg);
 
       // Resolve scope arguments before doing any work, so a typo reports itself
@@ -138,36 +172,29 @@ Examples:
       // Aggregate over the *scoped* mappings, so `--schema X` reports X's
       // workspace-wide coverage rather than the whole workspace's.
       const aggregate = aggregateCoverage(scoped);
+      const gate = evaluateGate(aggregate, role, opts.failUnder);
 
       if (opts.json) {
-        console.log(JSON.stringify({
+        const report: Record<string, unknown> = {
           mappings: scoped.map((m) => toJson(m, opts)),
           aggregate: aggregateToJson(aggregate, opts),
-        }, null, 2));
-        return;
+        };
+        if (gate) report.gate = gate;
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        printPerMappingReport(scoped, opts);
+        printAggregateReport(aggregate, opts);
+        if (gate) printGate(gate);
+        if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
       }
 
-      printPerMappingReport(scoped, opts);
-      printAggregateReport(aggregate, opts);
-      if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
+      // The report is printed either way — a failed gate must still show the
+      // reviewer which fields are missing, not just that a number was too low.
+      return gate && !gate.met ? EXIT_THRESHOLD_NOT_MET : undefined;
     }));
 }
 
 // ── Scope resolution ────────────────────────────────────────────────────────
-
-/**
- * Validate `--role`, which is a closed set rather than free text: silently
- * ignoring `--role sources` would report both roles and look like a bug in the
- * coverage numbers rather than in the invocation.
- */
-function parseRole(raw: string | undefined): Role | null {
-  if (raw === undefined) return null;
-  if ((ROLES as readonly string[]).includes(raw)) return raw as Role;
-  throw new CommandError(
-    `Invalid --role '${raw}'. Expected one of: ${ROLES.join(", ")}.`,
-    EXIT_PARSE_ERROR,
-  );
-}
 
 /**
  * Resolve a `--mapping` / `--schema` argument to an index key, or fail with
@@ -368,6 +395,76 @@ function wrapPaths(paths: string[]): string[] {
   return lines;
 }
 
+// ── CI gate ─────────────────────────────────────────────────────────────────
+
+/** The role `--fail-under` gates when `--role` does not say otherwise. */
+const DEFAULT_GATED_ROLE: Role = "target";
+
+/** Outcome of a `--fail-under` check, reported in output and as an exit code. */
+interface CoverageGate {
+  /** Which role's aggregate percentage was measured. */
+  role: Role;
+  /** The threshold the caller asked for, as a whole percentage. */
+  threshold: number;
+  /** The measured aggregate percentage for `role`, over the active scope. */
+  pct: number;
+  /** Whether `pct` reached `threshold`. False is exit 3. */
+  met: boolean;
+}
+
+/**
+ * Evaluate `--fail-under`, or return null when no gate was requested.
+ *
+ * Gates target coverage by default: "how much of what we are meant to produce do
+ * we actually produce?" is the completeness question a sign-off turns on.
+ * `--role source` gates consumption instead, for pipelines that care whether an
+ * upstream feed is being fully read.
+ *
+ * The measured figure is the *aggregate* over the active scope, never a
+ * per-mapping one — a workspace where each mapping covers a different third of a
+ * schema is fully specified, and gating any single mapping would fail it.
+ *
+ * Throws EXIT_NOT_FOUND when the gated role has no leaves in scope. That is not
+ * 0% coverage, it is nothing to measure: `--schema customers --fail-under 90`
+ * where `customers` is only ever a source would otherwise report a spec failure
+ * caused entirely by the invocation.
+ */
+function evaluateGate(
+  aggregate: AggregateCoverage,
+  role: Role | null,
+  threshold: number | undefined,
+): CoverageGate | null {
+  if (threshold === undefined) return null;
+
+  const gatedRole = role ?? DEFAULT_GATED_ROLE;
+  const totals = aggregate.workspace[gatedRole];
+  if (totals.total === 0) {
+    throw new CommandError(
+      `No ${gatedRole}-role coverage in scope to gate with --fail-under.\n` +
+      `Nothing in scope declares ${gatedRole} fields; ` +
+      `use --role ${gatedRole === "target" ? "source" : "target"} or widen the scope.`,
+      EXIT_NOT_FOUND,
+    );
+  }
+
+  return { role: gatedRole, threshold, pct: totals.pct, met: totals.pct >= threshold };
+}
+
+/**
+ * Print the gate verdict.
+ *
+ * Named as a threshold check rather than as coverage, so a reader scanning CI
+ * logs sees which number was compared against what, and does not mistake the
+ * gated aggregate for one of the per-mapping percentages above it.
+ */
+function printGate(gate: CoverageGate): void {
+  console.log();
+  console.log(
+    `--fail-under: ${gate.role} coverage ${gate.pct}% vs threshold ${gate.threshold}% — ` +
+    `${gate.met ? "met" : "NOT met"}`,
+  );
+}
+
 // ── Aggregate output ────────────────────────────────────────────────────────
 
 /**
@@ -479,9 +576,19 @@ function formatTotals(totals: CoverageTotals): string {
   return `${`${totals.covered}/${totals.total}`.padStart(7)}  ${String(totals.pct).padStart(3)}%`;
 }
 
-/** "source 3/4  75%   target 3/3  100%" — both roles on one subtotal row. */
+/**
+ * "source 3/4  75%   target 3/3  100%" — the subtotal row's role cells.
+ *
+ * A role with no declared leaves in scope is omitted rather than shown as
+ * "0/0 0%", which reads as zero coverage. Under `--role source` the target side
+ * is structurally absent, and printing it as a failing figure would be a lie
+ * about the workspace.
+ */
 function formatRoleTotals(totals: RoleTotals): string {
-  return `source ${formatTotals(totals.source)}   target ${formatTotals(totals.target)}`;
+  const cells: string[] = [];
+  if (totals.source.total > 0) cells.push(`source ${formatTotals(totals.source)}`);
+  if (totals.target.total > 0) cells.push(`target ${formatTotals(totals.target)}`);
+  return cells.join("   ");
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -15,8 +15,8 @@ import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
-import { addPathAndPrefixes } from "@satsuma/core";
-import type { ExtractedWorkspace, FieldDecl, ParsedFile, SchemaRecord, FragmentRecord, MetricRecord } from "../types.js";
+import { coverageForMapping, coveredFieldPaths } from "../coverage-workspace.js";
+import type { FieldDecl, ParsedFile, SchemaRecord, FragmentRecord, MetricRecord } from "../types.js";
 
 interface FieldWithTags extends FieldDecl {
   tags?: string[];
@@ -98,8 +98,12 @@ Examples:
           throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
         }
 
-        const mappedFields = getMappedFieldNames(resolvedMapping.key, resolvedSchemaName, index);
-        fields = filterUnmappedFields(fields, mappedFields, "");
+        const coverage = coverageForMapping(resolvedMapping.key, index, parsedFiles);
+        // No coverage result means the mapping does not reference this entity at
+        // all (or is anonymous, which --unmapped-by cannot name) — every field is
+        // then unmapped by it, which is what an empty covered set produces.
+        const covered = coverage ? coveredFieldPaths(coverage, resolvedSchemaName) : new Set<string>();
+        fields = filterUnmappedFields(fields, covered, "");
       }
 
       if (opts.json) {
@@ -134,65 +138,29 @@ function deepCopyFields(fields: FieldDecl[]): FieldWithTags[] {
 }
 
 /**
- * Get the set of field names from the given schema that participate in arrows
- * for the specified mapping — checking both source and target sides.
+ * Prune a field tree to only the fields the mapping leaves unmapped.
+ *
+ * `covered` holds the schema-root-relative paths the mapping touches, taken
+ * straight from the shared coverage computation — this command derives no
+ * coverage of its own, so `fields --unmapped-by X` and
+ * `coverage --uncovered --mapping X --schema Y` cannot disagree (sl-oqsj).
+ *
+ * A record is kept only when it still has unmapped children, and is never
+ * judged on its own path: a record's path is registered merely by being an
+ * ancestor of a covered child, so treating it as covered would hide its
+ * remaining gaps.
  */
-function getMappedFieldNames(mappingName: string, schemaName: string, index: ExtractedWorkspace): Set<string> {
-  const mapped = new Set<string>();
-  const mapping = index.mappings.get(mappingName);
-  if (!mapping) return mapped;
-
-  const isSource = mapping.sources.includes(schemaName);
-  const isTarget = mapping.targets.includes(schemaName);
-
-  // Arrow records use bare mapping names; qualified key uses "ns::name"
-  const nsIdx = mappingName.indexOf("::");
-  const bareMappingName = nsIdx !== -1 ? mappingName.slice(nsIdx + 2) : mappingName;
-
-  for (const [_key, arrows] of index.fieldArrows) {
-    for (const arrow of arrows) {
-      // Match arrow by bare mapping name and namespace
-      const arrowQualified = arrow.namespace ? `${arrow.namespace}::${arrow.mapping}` : arrow.mapping;
-      if (arrowQualified !== mappingName && arrow.mapping !== bareMappingName) continue;
-      if (isSource) {
-        for (const source of arrow.sources) {
-          // addPathAndPrefixes strips [] and registers all ancestor prefixes —
-          // matches the same logic used by the VS Code coverage gutter.
-          addPathAndPrefixes(mapped, source);
-        }
-      }
-      if (isTarget && arrow.target) {
-        addPathAndPrefixes(mapped, arrow.target);
-      }
-    }
-  }
-  return mapped;
-}
-
-/**
- * Filter fields to only unmapped ones, recursing into record/list children.
- * A record/list is excluded entirely if all children are mapped; if some
- * children are mapped, the record is kept with only unmapped children.
- */
-function filterUnmappedFields(fields: FieldWithTags[], mapped: Set<string>, prefix: string): FieldWithTags[] {
+function filterUnmappedFields(fields: FieldWithTags[], covered: Set<string>, prefix: string): FieldWithTags[] {
   const result: FieldWithTags[] = [];
   for (const f of fields) {
     const path = prefix ? `${prefix}.${f.name}` : f.name;
     if (f.children && f.children.length > 0) {
-      // Record/list field: always recurse to evaluate children individually.
-      // Do NOT skip based on mapped.has(f.name) — a parent path appearing in
-      // 'mapped' only means it was registered as a prefix of a child arrow
-      // (via addPathAndPrefixes), not that the record itself was directly targeted.
-      // A record is excluded only when all its children are covered.
-      const unmappedChildren = filterUnmappedFields(f.children, mapped, path);
+      const unmappedChildren = filterUnmappedFields(f.children, covered, path);
       if (unmappedChildren.length > 0) {
         result.push({ ...f, children: unmappedChildren });
       }
-    } else {
-      // Leaf field: skip if directly covered by an arrow path.
-      if (!mapped.has(f.name) && !mapped.has(path)) {
-        result.push(f);
-      }
+    } else if (!covered.has(path)) {
+      result.push(f);
     }
   }
   return result;

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -19,7 +19,7 @@ import type { Command } from "commander";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { parsePositiveInt } from "../option-parsers.js";
-import { resolveIndexKey, canonicalKey } from "../index-builder.js";
+import { resolveIndexKey, displayKey } from "../index-builder.js";
 import { buildFullGraph } from "../schema-graph.js";
 import type { FullGraph } from "../schema-graph.js";
 
@@ -119,7 +119,7 @@ Examples:
         if (opts.json) {
           console.log(JSON.stringify(dag, null, 2));
         } else if (opts.compact) {
-          for (const n of dag.nodes) console.log(canonicalKey(n.name));
+          for (const n of dag.nodes) console.log(displayKey(n.name));
         } else {
           printUpstreamFlat(dag, target);
         }
@@ -298,7 +298,7 @@ function printUpstreamFlat(dag: Dag, target: string): void {
   climb(target, [], new Set());
 
   for (const path of paths) {
-    console.log(path.map((n) => canonicalKey(n)).join(" -> "));
+    console.log(path.map((n) => displayKey(n)).join(" -> "));
   }
 }
 
@@ -316,7 +316,7 @@ function printTree(dag: Dag, start: string, _unused: number): void {
     const type = nodeInfo?.type ?? "?";
     const prefix = "  ".repeat(depth);
     const cycleNote = visited.has(node) && depth > 0 ? " (cycle)" : "";
-    console.log(`${prefix}${canonicalKey(node)}  [${type}]${cycleNote}`);
+    console.log(`${prefix}${displayKey(node)}  [${type}]${cycleNote}`);
     if (visited.has(node)) return;
     visited.add(node);
     for (const child of adj.get(node) ?? []) {

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -1,0 +1,179 @@
+/**
+ * coverage-workspace.ts — CLI bridge between ExtractedWorkspace and core coverage.
+ *
+ * Coverage semantics live in `@satsuma/core` (coverage.ts for the per-mapping
+ * walk, coverage-rollup.ts for the aggregation). Core deliberately knows nothing
+ * about the CLI's index, so something has to adapt one to the other: resolve the
+ * schema references written in a mapping's `source {}` / `target {}` blocks
+ * against `ExtractedWorkspace`, expand their fragment spreads, and attach
+ * declaration positions. That is this module's whole job.
+ *
+ * Owns: ExtractedWorkspace → CoverageSchemaResolver adaptation, and the walk
+ * over a workspace's mappings.
+ * Does not own: coverage semantics, aggregation, or rendering.
+ *
+ * Two consumers share it — the `coverage` command and `fields --unmapped-by` —
+ * which is the point: before sl-oqsj those two answered the same question from
+ * independently maintained code.
+ */
+
+import { computeMappingCoverage } from "@satsuma/core";
+import type {
+  CoverageSchemaDefinition,
+  CoverageSchemaResolver,
+  MappingCoverageInput,
+  MappingCoverageResult,
+} from "@satsuma/core";
+import { resolveScopedEntityRef } from "./index-builder.js";
+import { expandEntityFields, expandNestedSpreads } from "./spread-expand.js";
+import { toCoverageFields } from "./field-positions.js";
+import type { ExtractedWorkspace, ParsedFile, SchemaRecord } from "./types.js";
+
+/** One mapping's coverage, plus where the mapping is declared. */
+export interface MappingCoverage extends MappingCoverageInput {
+  /** Absolute path of the file declaring the mapping, for output and jump links. */
+  file: string;
+  /** Namespace the mapping is declared in, or null at file scope. */
+  namespace: string | null;
+}
+
+/** Coverage for a whole workspace, with the mappings it could not report on. */
+export interface WorkspaceCoverage {
+  /** One entry per named mapping, in index order. */
+  mappings: MappingCoverage[];
+  /**
+   * Anonymous mappings skipped by this pass.
+   *
+   * Coverage is looked up by mapping label, and an anonymous `mapping { … }`
+   * block has none. Rather than drop them silently, the count is reported so
+   * output can say what was not covered — a coverage report that quietly
+   * ignores part of the workspace is worse than one that admits the gap.
+   */
+  skippedAnonymous: number;
+}
+
+/**
+ * Build a resolver that turns the schema references written inside a mapping
+ * into field trees, resolved from the CLI's workspace index.
+ *
+ * Reference resolution is namespace-aware: inside `namespace crm { … }` a
+ * mapping may write `orders` for what the index keys as `crm::orders`. The
+ * resolved key is reported back to core as the canonical `schemaId`, so results
+ * for the same schema still line up when they are rolled up across mappings
+ * that refer to it differently.
+ *
+ * Fragment spreads are expanded — nested record-level spreads first, then
+ * schema-level ones — because a spread field is a declared field of the
+ * consuming schema and its coverage is exactly what a reviewer is asking about.
+ */
+export function makeSchemaResolver(
+  index: ExtractedWorkspace,
+  mappingNamespace: string | null,
+): CoverageSchemaResolver {
+  return (writtenRef: string): CoverageSchemaDefinition | null => {
+    const key = resolveScopedEntityRef(writtenRef, mappingNamespace, index.schemas);
+    const schema = key ? index.schemas.get(key) : undefined;
+    if (!key || !schema) return null;
+    return {
+      schemaId: key,
+      uri: schema.file,
+      fields: toCoverageFields(expandedFields(schema, index), {
+        file: schema.file,
+        row: schema.row,
+      }),
+    };
+  };
+}
+
+/**
+ * A schema's fields with fragment spreads inlined.
+ *
+ * Copies the field list before expanding: `expandNestedSpreads` mutates in
+ * place, and the index's records are shared with every other command in the
+ * process.
+ */
+function expandedFields(schema: SchemaRecord, index: ExtractedWorkspace) {
+  const fields = deepCopyFields(schema.fields);
+  expandNestedSpreads(fields, schema.namespace ?? null, index);
+  return [...fields, ...expandEntityFields(schema, schema.namespace ?? null, index)];
+}
+
+/** Recursive copy so in-place spread expansion cannot touch the shared index. */
+function deepCopyFields<T extends { children?: T[] }>(fields: T[]): T[] {
+  return fields.map((f) => (f.children ? { ...f, children: deepCopyFields(f.children) } : { ...f }));
+}
+
+/**
+ * Compute coverage for one named mapping.
+ *
+ * Returns null when the mapping's declaring file is not among `files` (it was
+ * not loaded) or when the mapping label cannot be found in that file's tree.
+ * Either case means there is nothing to report, which is distinct from a
+ * mapping that covers nothing.
+ */
+export function coverageForMapping(
+  mappingKey: string,
+  index: ExtractedWorkspace,
+  files: ParsedFile[],
+): MappingCoverage | null {
+  const mapping = index.mappings.get(mappingKey);
+  if (!mapping?.name) return null;
+
+  const parsed = files.find((f) => f.filePath === mapping.file);
+  if (!parsed) return null;
+
+  const namespace = mapping.namespace ?? null;
+  const result: MappingCoverageResult = computeMappingCoverage(
+    parsed.tree,
+    mapping.name,
+    makeSchemaResolver(index, namespace),
+  );
+  if (result.schemas.length === 0) return null;
+
+  return { mappingId: mappingKey, file: mapping.file, namespace, result };
+}
+
+/**
+ * Compute coverage for every named mapping reachable from the entry file.
+ *
+ * The workspace is whatever `loadWorkspace` resolved — the entry file plus its
+ * transitive imports — so coverage answers "this workspace", not "this file".
+ */
+export function coverageForWorkspace(
+  index: ExtractedWorkspace,
+  files: ParsedFile[],
+): WorkspaceCoverage {
+  const mappings: MappingCoverage[] = [];
+  let skippedAnonymous = 0;
+
+  for (const [key, mapping] of index.mappings) {
+    if (!mapping.name) {
+      skippedAnonymous += 1;
+      continue;
+    }
+    const coverage = coverageForMapping(key, index, files);
+    if (coverage) mappings.push(coverage);
+  }
+
+  return { mappings, skippedAnonymous };
+}
+
+/**
+ * The field paths of `schemaKey` that this mapping covers, in any role.
+ *
+ * A schema can appear on both sides of one mapping. "Does this mapping touch the
+ * field?" is then the union of the two sides — the question `fields --unmapped-by`
+ * has always answered — so roles are merged here rather than reported separately.
+ *
+ * Paths are schema-root-relative and dotted, matching `FieldCoverageEntry.path`.
+ */
+export function coveredFieldPaths(coverage: MappingCoverage, schemaKey: string): Set<string> {
+  const covered = new Set<string>();
+  for (const schema of coverage.result.schemas) {
+    if (schema.schemaId !== schemaKey) continue;
+    for (const field of schema.fields) {
+      if (field.mapped) covered.add(field.path);
+    }
+  }
+  return covered;
+}

--- a/tooling/satsuma-cli/src/field-positions.ts
+++ b/tooling/satsuma-cli/src/field-positions.ts
@@ -1,0 +1,78 @@
+/**
+ * field-positions.ts — Where does the CLI say a field is declared?
+ *
+ * Commands that emit `file` + `line` for a field (so a downstream UI can offer
+ * an editor-jump link) all face the same question: what position does a field
+ * that arrived via a fragment spread get? This module owns the answer, so the
+ * rule is stated once instead of re-derived per command, and projects a CLI
+ * field tree onto the shape `@satsuma/core`'s coverage walk consumes.
+ *
+ * Owns: the declaration-row rule for own vs spread-expanded fields.
+ * Does not own: field extraction (satsuma-core) or spread expansion
+ * (spread-expand.ts) — it only interprets their output.
+ */
+
+import type { CoverageField, ExpandedField } from "@satsuma/core";
+
+/** Where the entity that declares (or spreads in) a field lives. */
+export interface DeclaringEntity {
+  /** Absolute path of the file containing the entity's block. */
+  file: string;
+  /** 0-indexed row of the entity's block header. */
+  row: number;
+}
+
+/**
+ * The 0-indexed row the CLI reports for one field, or undefined when no
+ * trustworthy position exists. Callers must propagate the absence rather than
+ * substitute 0, which reads as line 1 and points at the wrong place.
+ *
+ * **Rule (cbh-5lzd): a spread-expanded field is reported at the consuming
+ * entity, not at the fragment that declared it.** Spread expansion copies
+ * fragment `FieldDecl`s wholesale, so `startRow` on such a field is a row in
+ * the *fragment's* file. Pairing it with the consuming schema's file — which is
+ * the file every command reports — yields a position that looks precise and is
+ * wrong. `find` already resolves this the same way; coverage follows it so the
+ * two commands cannot disagree about where a spread field lives.
+ *
+ * The consuming entity's block header is the honest answer available without
+ * tracking spread-site positions through expansion: it is in the right file and
+ * lands the reader on the schema whose coverage is being reported.
+ *
+ * @param withinSpread True when this field, or any ancestor of it, arrived via
+ *   a spread. Only the field copied directly out of the fragment carries
+ *   `fromFragment`; its own children do not, so the caller must carry the flag
+ *   down the tree — {@link toCoverageFields} does exactly that.
+ */
+export function fieldDeclarationRow(
+  field: ExpandedField,
+  entity: DeclaringEntity,
+  withinSpread: boolean,
+): number | undefined {
+  if (withinSpread || field.fromFragment !== undefined) return entity.row;
+  return field.startRow;
+}
+
+/**
+ * Project a CLI field tree onto core's minimal coverage input shape, resolving
+ * each field's declaration row via {@link fieldDeclarationRow}.
+ *
+ * `fields` must already have had its spreads expanded by the caller — this
+ * function reports positions, it does not resolve fragments.
+ */
+export function toCoverageFields(
+  fields: ExpandedField[],
+  entity: DeclaringEntity,
+  withinSpread = false,
+): CoverageField[] {
+  return fields.map((field) => {
+    const spread = withinSpread || field.fromFragment !== undefined;
+    const row = fieldDeclarationRow(field, entity, withinSpread);
+    const projected: CoverageField = { name: field.name };
+    if (row !== undefined) projected.line = row;
+    if (field.children && field.children.length > 0) {
+      projected.children = toCoverageFields(field.children, entity, spread);
+    }
+    return projected;
+  });
+}

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -118,11 +118,38 @@ export function qualifiedKey(namespace: string | null | undefined, name: string 
 /**
  * Produce the canonical output form for an index key.
  * Non-namespaced keys get a :: prefix; namespaced keys pass through.
- * Use this for CLI output, not for internal map lookups.
+ * Use this for `--json` output and internal comparison, not for prose or
+ * tables a human reads — see {@link displayKey}.
  */
 export function canonicalKey(key: string): string {
   if (key.includes("::")) return key;
   return canonicalRef(null, key);
+}
+
+/**
+ * Produce the human-readable form of an index key: `ns::name` when the entity
+ * is namespaced, the bare name when it is not.
+ *
+ * Why this differs from {@link canonicalKey}: the leading `::` marks "the
+ * global namespace" unambiguously, which matters for a machine consumer
+ * matching keys across commands. It buys a human nothing — `::` is not even
+ * valid Satsuma syntax (`qualified_name` is `identifier "::" identifier`), so
+ * it cannot be pasted back into a file, and in a workspace with no namespaces
+ * at all it prefixes every line of output with noise.
+ *
+ * The split is deliberate: `--json` keeps the canonical key so downstream
+ * consumers have one spelling per entity, and human output drops the empty
+ * prefix. Namespaced entities read identically either way.
+ *
+ * Accepts either an internal index key (already bare) or an
+ * already-canonicalised string, so call sites need not know which they hold.
+ * That makes it the same transformation as {@link resolveCanonicalKey}, kept
+ * separate because the intents differ and only one of them is safe to change:
+ * that one maps a ref back to a key for *lookup*, this one formats a key for
+ * *rendering*.
+ */
+export function displayKey(key: string): string {
+  return key.startsWith("::") ? key.slice(2) : key;
 }
 
 /**

--- a/tooling/satsuma-cli/src/index.ts
+++ b/tooling/satsuma-cli/src/index.ts
@@ -59,6 +59,7 @@ const commands = [
   "commands/context.js",
   "commands/arrows.js",
   "commands/fields.js",
+  "commands/coverage.js",
   "commands/nl.js",
   "commands/meta.js",
   "commands/match-fields.js",

--- a/tooling/satsuma-cli/src/option-parsers.ts
+++ b/tooling/satsuma-cli/src/option-parsers.ts
@@ -40,3 +40,26 @@ export function parsePositiveInt(value: string): number {
   }
   return parsed;
 }
+
+/** A coverage percentage is a whole number in [0, 100] — 0 and 100 both mean something. */
+const MIN_PERCENTAGE = 0;
+const MAX_PERCENTAGE = 100;
+
+/**
+ * Commander coercion for a percentage threshold such as `coverage --fail-under`.
+ *
+ * Unlike {@link parsePositiveInt}, zero is accepted: `--fail-under 0` is a
+ * meaningful (if trivially satisfied) gate, and rejecting it would make a
+ * pipeline that computes its threshold fail on the boundary value. Values above
+ * 100 are rejected because no coverage figure can ever satisfy them — a gate
+ * that can never pass is a typo, not a policy.
+ */
+export function parsePercentage(value: string): number {
+  const parsed = POSITIVE_INT_PATTERN.test(value) ? parseInt(value, 10) : NaN;
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_PERCENTAGE || parsed > MAX_PERCENTAGE) {
+    throw new InvalidArgumentError(
+      `Expected a whole number between ${MIN_PERCENTAGE} and ${MAX_PERCENTAGE}.`,
+    );
+  }
+  return parsed;
+}

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -34,15 +34,18 @@ export interface Parser {
 
 // ── Extracted record types ──────────────────────────────────────────────────
 
-export interface FieldDecl {
-  name: string;
-  type: string;
-  children?: FieldDecl[];
-  isList?: boolean;
-  metadata?: import("@satsuma/core").MetaEntry[];
-  hasSpreads?: boolean;
-  spreads?: string[];
-}
+/**
+ * Field declarations come straight from core's extractors, so the CLI uses
+ * core's type rather than a structural copy of it.
+ *
+ * The CLI kept its own clone until sl-5sjp, and the clone had silently fallen
+ * behind: it omitted the `startRow`/`startColumn` fields core's extractFieldTree
+ * always sets (aa-65ni), which made field declaration positions invisible to
+ * every CLI command even though the data was already there. Re-export, don't
+ * re-declare.
+ */
+import type { FieldDecl } from "@satsuma/core";
+export type { FieldDecl };
 
 export interface SchemaRecord {
   name: string;

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -23,6 +23,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const WORKSPACE = resolve(__dirname, "fixtures/coverage-workspace.stm");
 const NESTED = resolve(__dirname, "fixtures/unmapped-nested.stm");
+// The repo's canonical nested-iteration example: two levels of `each` with a
+// `flatten` inside them. Fully mapped apart from one deliberately unread field,
+// which makes it the reference case for nested container coverage (sl-qzy3).
+const NESTED_ITERATION = resolve(__dirname, "../../../examples/nested-iteration/pipeline.stm");
+const NESTED_ARROW = resolve(__dirname, "fixtures/nested-arrow-lookup.stm");
 
 const run = (...args: string[]) => _run(CLI, ...args);
 
@@ -514,5 +519,69 @@ describe("satsuma coverage --fail-under", () => {
     // legitimately arrives at zero.
     const { code } = await run("coverage", WORKSPACE, "--fail-under", "0");
     assert.equal(code, 0);
+  });
+});
+
+// ── Nested containers on the real corpus (sl-qzy3) ──────────────────────────
+
+describe("satsuma coverage — nested containers", () => {
+  // These assert *percentages*, not just per-field booleans, because the
+  // percentage is what --fail-under gates on. Before sl-qzy3 the walk skipped
+  // `flatten` inside `each`, so this fully-mapped example reported 75% on the
+  // target and would have failed `--fail-under 90` — blocking correct work.
+
+  it("reports the fully-mapped nested-iteration target as 100%", async () => {
+    const { stdout, code } = await run("coverage", NESTED_ITERATION, "--json");
+    assert.equal(code, 0);
+    const target = schemaEntry(parseJson(stdout), "::dispatch manifest", "target", "::dispatch_manifest_json");
+    assert.deepEqual(
+      { covered: target.covered, total: target.total, pct: target.pct },
+      { covered: 8, total: 8, pct: 100 },
+    );
+  });
+
+  it("reports the one genuinely unread source leaf and nothing else", async () => {
+    // orders.parcels.barcode is never referenced by any arrow; every other
+    // source leaf is, including those reached only through the nested flatten.
+    const { stdout } = await run("coverage", NESTED_ITERATION, "--uncovered", "--json");
+    const source = schemaEntry(parseJson(stdout), "::dispatch manifest", "source", "::warehouse_dispatch_events");
+    assert.deepEqual(source.fields.map((f: any) => f.path), ["orders.parcels.barcode"]);
+    assert.deepEqual(
+      { covered: source.covered, total: source.total, pct: source.pct },
+      { covered: 8, total: 9, pct: 89 },
+    );
+  });
+
+  it("keeps fields --unmapped-by agreeing with coverage on the same example", async () => {
+    // fields --unmapped-by was correct before sl-oqsj re-based it onto the core
+    // walker and wrong afterwards, because the walker missed the nested flatten.
+    // This pins the two commands together on a nested fixture, which is where
+    // they diverged.
+    const { stdout, code } = await run(
+      "fields", "warehouse_dispatch_events", "--unmapped-by", "dispatch manifest", NESTED_ITERATION, "--json",
+    );
+    assert.equal(code, 0);
+    const leaves: string[] = [];
+    const walk = (fields: any[], prefix: string) => {
+      for (const f of fields) {
+        const path = prefix ? `${prefix}.${f.name}` : f.name;
+        if (f.children?.length) walk(f.children, path);
+        else leaves.push(path);
+      }
+    };
+    walk(parseJson(stdout), "");
+    assert.deepEqual(leaves, ["orders.parcels.barcode"]);
+  });
+
+  it("covers both sides of a braced src -> tgt arrow", async () => {
+    // nested_arrow was absent from the walk, so this fixture reported 0% on
+    // both sides despite every field being explicitly mapped.
+    const { stdout, code } = await run("coverage", NESTED_ARROW, "--json");
+    assert.equal(code, 0);
+    const data = parseJson(stdout);
+    for (const [role, schema] of [["source", "::src_sys"], ["target", "::tgt_sys"]] as const) {
+      const entry = schemaEntry(data, "::addr_map", role, schema);
+      assert.equal(entry.pct, 100, `${role} ${schema} should be fully covered`);
+    }
   });
 });

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -362,11 +362,13 @@ describe("satsuma coverage — exit codes", () => {
     assert.equal(code, 2);
   });
 
-  it("rejects an invalid --role rather than silently reporting both", async () => {
-    // Ignoring the flag would look like a bug in the numbers, not the command line.
+  it("rejects an invalid --role as a usage error rather than reporting both roles", async () => {
+    // Silently ignoring the flag would surface as a bug in the coverage numbers
+    // rather than in the command line. Exit 1 + help is the CLI's convention for
+    // every other bad flag value, so --role must not invent a second one.
     const { stderr, code } = await run("coverage", WORKSPACE, "--role", "sources");
-    assert.equal(code, 2);
-    assert.match(stderr, /Invalid --role 'sources'/);
+    assert.equal(code, 1);
+    assert.match(stderr, /--role <role>' argument 'sources' is invalid/);
   });
 });
 
@@ -411,5 +413,106 @@ describe("satsuma coverage vs fields --unmapped-by", () => {
       schemaEntry(parseJson(viaCoverage.stdout), "::full_map", "target", "::nested_tgt").fields,
       [],
     );
+  });
+});
+
+// ── --fail-under CI gate ────────────────────────────────────────────────────
+
+describe("satsuma coverage --fail-under", () => {
+  it("exits 0 when the gated coverage meets the threshold", async () => {
+    // Target coverage across the fixture's mappings is 100%, so any threshold
+    // passes — the gate must not fail on the per-mapping figures beneath it.
+    const { code } = await run("coverage", WORKSPACE, "--fail-under", "100");
+    assert.equal(code, 0);
+  });
+
+  it("exits 3 when the gated coverage is below the threshold", async () => {
+    // The distinct code is the whole point: CI has to tell an incomplete spec
+    // from a broken invocation.
+    const { code } = await run("coverage", WORKSPACE, "--fail-under", "90", "--role", "source");
+    assert.equal(code, 3);
+  });
+
+  it("exits 1, not 3, when --mapping names something that does not exist", async () => {
+    // The case that motivated a separate code. If both were 1, a misspelled
+    // mapping name and genuine under-coverage would be indistinguishable, and CI
+    // could not tell "fix the pipeline" from "finish the mapping".
+    const { stderr, code } = await run("coverage", WORKSPACE, "--fail-under", "90", "--mapping", "typo");
+    assert.equal(code, 1);
+    assert.match(stderr, /Mapping 'typo' not found/);
+  });
+
+  it("exits 2 for a parse or filesystem error, whatever the threshold", async () => {
+    const { code } = await run(
+      "coverage", resolve(__dirname, "fixtures/does-not-exist.stm"), "--fail-under", "90",
+    );
+    assert.equal(code, 2);
+  });
+
+  it("gates target coverage by default", async () => {
+    // Completeness at sign-off is about what the spec produces, so the default
+    // measures the target side even though both roles are reported.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--fail-under", "100", "--json");
+    assert.equal(code, 0);
+    const { gate } = parseJson(stdout);
+    assert.deepEqual(gate, { role: "target", threshold: 100, pct: 100, met: true });
+  });
+
+  it("gates source consumption when combined with --role source", async () => {
+    const { stdout, code } = await run(
+      "coverage", WORKSPACE, "--fail-under", "90", "--role", "source", "--json",
+    );
+    assert.equal(code, 3);
+    assert.deepEqual(parseJson(stdout).gate, { role: "source", threshold: 90, pct: 71, met: false });
+  });
+
+  it("gates the scoped percentage when --mapping narrows the report", async () => {
+    // 'load contacts' alone leaves memo unwritten, so the same workspace that
+    // passes at 100% aggregate fails once the scope is one mapping.
+    const { stdout, code } = await run(
+      "coverage", WORKSPACE, "--mapping", "load contacts", "--fail-under", "100", "--json",
+    );
+    assert.equal(code, 3);
+    assert.deepEqual(parseJson(stdout).gate, { role: "target", threshold: 100, pct: 67, met: false });
+  });
+
+  it("still prints the report when the gate fails", async () => {
+    // A gate that printed only a verdict would tell CI it failed without telling
+    // anyone which fields to go and map.
+    const { stdout } = await run("coverage", WORKSPACE, "--fail-under", "90", "--role", "source");
+    assert.match(stdout, /covered by no mapping — crm::customers \(source\)/);
+    assert.match(stdout, /--fail-under: source coverage 71% vs threshold 90% — NOT met/);
+  });
+
+  it("exits 1 when the gated role has nothing in scope to measure", async () => {
+    // crm::customers is only ever a source, so gating target coverage measures
+    // nothing. Reporting that as 0% would blame the spec for an invocation error.
+    const { stderr, code } = await run(
+      "coverage", WORKSPACE, "--schema", "crm::customers", "--fail-under", "90",
+    );
+    assert.equal(code, 1);
+    assert.match(stderr, /No target-role coverage in scope to gate/);
+    assert.match(stderr, /use --role source/);
+  });
+
+  it("omits the gate from JSON when --fail-under is absent", async () => {
+    // A gate key that is always present would push consumers into checking
+    // met === false on a check nobody asked for.
+    const { stdout } = await run("coverage", WORKSPACE, "--json");
+    assert.ok(!("gate" in parseJson(stdout)), "no gate should be reported without --fail-under");
+  });
+
+  it("rejects a threshold above 100 as a usage error", async () => {
+    // A gate that can never pass is a typo, not a policy.
+    const { stderr, code } = await run("coverage", WORKSPACE, "--fail-under", "150");
+    assert.equal(code, 1);
+    assert.match(stderr, /Expected a whole number between 0 and 100/);
+  });
+
+  it("accepts a threshold of 0 as a trivially satisfied gate", async () => {
+    // Rejecting 0 would break a pipeline that computes its own threshold and
+    // legitimately arrives at zero.
+    const { code } = await run("coverage", WORKSPACE, "--fail-under", "0");
+    assert.equal(code, 0);
   });
 });

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -585,3 +585,39 @@ describe("satsuma coverage — nested containers", () => {
     }
   });
 });
+
+// ── Human vs JSON key spelling ──────────────────────────────────────────────
+
+describe("satsuma coverage — key spelling", () => {
+  // Human output and --json deliberately spell a non-namespaced entity
+  // differently: `::` marks the global namespace unambiguously for a machine
+  // matching keys across commands, but it is not valid Satsuma syntax and is
+  // pure noise in a workspace that declares no namespaces. Namespaced entities
+  // read identically in both.
+
+  it("drops the empty namespace prefix from human output", async () => {
+    const { stdout, code } = await run("coverage", NESTED_ITERATION);
+    assert.equal(code, 0);
+    assert.match(stdout, /^mapping dispatch manifest {2}\(/m);
+    assert.match(stdout, /^ {2}target {2}dispatch_manifest_json/m);
+    assert.ok(!stdout.includes("::"), `human output should carry no "::"; got:\n${stdout}`);
+  });
+
+  it("keeps the canonical prefix in --json so consumers have one spelling", async () => {
+    const { stdout } = await run("coverage", NESTED_ITERATION, "--json");
+    const data = parseJson(stdout);
+    assert.equal(data.mappings[0].mapping, "::dispatch manifest");
+    assert.ok(
+      data.mappings[0].schemas.every((s: any) => s.schema.startsWith("::")),
+      "every schema key in --json should be canonical",
+    );
+  });
+
+  it("leaves a real namespace intact in both forms", async () => {
+    // The prefix is only dropped when it is empty; `crm::` is information.
+    const human = await run("coverage", WORKSPACE, "--mapping", "load contacts");
+    assert.match(human.stdout, /^mapping crm::load contacts/m);
+    const json = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    assert.equal(parseJson(json.stdout).mappings[0].mapping, "crm::load contacts");
+  });
+});

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -238,6 +238,108 @@ describe("satsuma coverage — JSON contract", () => {
   });
 });
 
+// ── Aggregate rollups ───────────────────────────────────────────────────────
+
+describe("satsuma coverage — aggregate rollups", () => {
+  /** The aggregate entry for one schema and role. */
+  function aggregateEntry(data: any, role: string, schema: string): any {
+    const found = data.aggregate.schemas.find((s: any) => s.role === role && s.schema === schema);
+    assert.ok(found, `expected aggregate ${role} ${schema} in ${JSON.stringify(data.aggregate.schemas.map((s: any) => [s.role, s.schema]))}`);
+    return found;
+  }
+
+  it("counts a field covered when any one mapping covers it", async () => {
+    // crm::contacts.memo is written by 'annotate contacts' and ignored by
+    // 'load contacts'. The aggregate is the only figure that says so.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--json");
+    assert.equal(code, 0);
+    const contacts = aggregateEntry(parseJson(stdout), "target", "crm::contacts");
+    assert.deepEqual(
+      { covered: contacts.covered, total: contacts.total, pct: contacts.pct },
+      { covered: 3, total: 3, pct: 100 },
+    );
+  });
+
+  it("keeps the per-mapping and aggregate figures for one field distinguishable", async () => {
+    // The confusion the two sections exist to prevent, asserted end to end:
+    // 'memo' is a gap under 'load contacts' and covered in the aggregate. A
+    // reviewer who reads the wrong one deletes a field another mapping populates.
+    const { stdout } = await run("coverage", WORKSPACE, "--json");
+    const data = parseJson(stdout);
+    const perMapping = schemaEntry(data, "crm::load contacts", "target", "crm::contacts")
+      .fields.find((f: any) => f.path === "memo");
+    assert.equal(perMapping.mapped, false);
+    const aggregated = aggregateEntry(data, "target", "crm::contacts")
+      .fields.find((f: any) => f.path === "memo");
+    assert.equal(aggregated.mapped, true);
+  });
+
+  it("names the mappings behind each aggregate figure", async () => {
+    // Without them an aggregate gap is not actionable — the reviewer cannot tell
+    // which mapping to go and edit.
+    const { stdout } = await run("coverage", WORKSPACE, "--json");
+    assert.deepEqual(
+      aggregateEntry(parseJson(stdout), "target", "crm::contacts").mappings.sort(),
+      ["crm::annotate contacts", "crm::load contacts"],
+    );
+  });
+
+  it("counts a schema once however many mappings reference it", async () => {
+    // crm::customers is a source of two mappings; counting it twice would halve
+    // the workspace percentage for no reason.
+    const { stdout } = await run("coverage", WORKSPACE, "--json");
+    const data = parseJson(stdout);
+    const sources = data.aggregate.schemas.filter((s: any) => s.role === "source");
+    assert.equal(sources.filter((s: any) => s.schema === "crm::customers").length, 1);
+    // customers 3/4 + invoices 2/3 = 5/7 source leaves across the workspace.
+    assert.deepEqual(data.aggregate.workspace.source, { covered: 5, total: 7, pct: 71 });
+  });
+
+  it("reports per-namespace subtotals that sum to the workspace total", async () => {
+    // Two numbers that can disagree means one of them is a lie.
+    const { stdout } = await run("coverage", WORKSPACE, "--json");
+    const { namespaces, workspace } = parseJson(stdout).aggregate;
+    assert.deepEqual(namespaces.map((n: any) => n.namespace).sort(), ["billing", "crm"]);
+    const summed = namespaces.reduce(
+      (acc: any, ns: any) => ({ covered: acc.covered + ns.source.covered, total: acc.total + ns.source.total }),
+      { covered: 0, total: 0 },
+    );
+    assert.deepEqual(summed, { covered: workspace.source.covered, total: workspace.source.total });
+  });
+
+  it("aggregates over the scoped mappings, not the whole workspace", async () => {
+    // --fail-under will gate whatever scope is active (sl-268g), so scope has to
+    // reach the aggregate. Restricted to 'load contacts' alone, memo is a gap.
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const data = parseJson(stdout);
+    const contacts = aggregateEntry(data, "target", "crm::contacts");
+    assert.deepEqual({ covered: contacts.covered, total: contacts.total }, { covered: 2, total: 3 });
+    assert.deepEqual(data.aggregate.namespaces.map((n: any) => n.namespace), ["crm"]);
+  });
+
+  it("labels the human aggregate section with the claim it is making", async () => {
+    // A section title alone is too easy to skim past; the stronger claim has to
+    // be stated where the numbers are read.
+    const { stdout } = await run("coverage", WORKSPACE);
+    assert.match(stdout, /Aggregate — a field is uncovered here only when NO mapping in scope covers it/);
+    assert.match(stdout, /covered by no mapping — crm::customers \(source\)/);
+  });
+
+  it("prints namespace subtotals and a workspace total in human output", async () => {
+    const { stdout } = await run("coverage", WORKSPACE);
+    assert.match(stdout, /^ {2}crm\s+source\s+3\/4\s+75%\s+target\s+3\/3\s+100%$/m);
+    assert.match(stdout, /^ {2}workspace\s+source\s+5\/7\s+71%\s+target\s+5\/5\s+100%$/m);
+  });
+
+  it("omits the namespace rows when there is only one group to subtotal", async () => {
+    // The row would be identical to the workspace row, inviting the reader to
+    // look for a difference that cannot exist.
+    const { stdout } = await run("coverage", NESTED);
+    assert.match(stdout, /^ {2}workspace\s+source/m);
+    assert.ok(!/\(file scope\)/.test(stdout), `single-group subtotal row should be suppressed:\n${stdout}`);
+  });
+});
+
 // ── Exit codes ──────────────────────────────────────────────────────────────
 
 describe("satsuma coverage — exit codes", () => {

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -1,0 +1,313 @@
+/**
+ * coverage.test.ts — End-to-end behaviour of `satsuma coverage`.
+ *
+ * Coverage *semantics* are tested in satsuma-core (coverage.test.js and
+ * coverage-rollup.test.js) and are deliberately not re-tested here. What can only
+ * break at this level is the CLI's own surface: index adaptation (resolving
+ * namespaced schema references, expanding spreads, attaching positions), the
+ * scoping flags, the JSON contract, exit codes, and the rendered report.
+ *
+ * The last test in this file is the load-bearing one: it locks `coverage` and
+ * `fields --unmapped-by` to the same answer. Those two commands answered the same
+ * question from independently maintained code before sl-oqsj, which is the drift
+ * feature 35 exists to prevent.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { run as _run } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+const WORKSPACE = resolve(__dirname, "fixtures/coverage-workspace.stm");
+const NESTED = resolve(__dirname, "fixtures/unmapped-nested.stm");
+
+const run = (...args: string[]) => _run(CLI, ...args);
+
+/** Parse `--json` output, failing with the raw text when it is not JSON. */
+function parseJson(stdout: string): any {
+  try {
+    return JSON.parse(stdout);
+  } catch {
+    assert.fail(`expected JSON output, got:\n${stdout}`);
+  }
+}
+
+/** The JSON entry for one mapping. */
+function mappingEntry(data: any, mapping: string): any {
+  const found = data.mappings.find((m: any) => m.mapping === mapping);
+  assert.ok(found, `expected mapping ${mapping} in ${JSON.stringify(data.mappings.map((m: any) => m.mapping))}`);
+  return found;
+}
+
+/** The JSON entry for one schema in one role of one mapping. */
+function schemaEntry(data: any, mapping: string, role: string, schema: string): any {
+  const found = mappingEntry(data, mapping).schemas.find(
+    (s: any) => s.role === role && s.schema === schema,
+  );
+  assert.ok(found, `expected ${role} ${schema} in ${mapping}`);
+  return found;
+}
+
+// ── Default report ──────────────────────────────────────────────────────────
+
+describe("satsuma coverage — default report", () => {
+  it("reports every named mapping in the workspace, not just the entry file's first", async () => {
+    // The command's reason to exist is a workspace-wide answer; reporting one
+    // mapping would leave the caller composing the rest by hand.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--json");
+    assert.equal(code, 0);
+    assert.deepEqual(
+      parseJson(stdout).mappings.map((m: any) => m.mapping).sort(),
+      ["billing::flatten invoices", "crm::annotate contacts", "crm::load contacts"],
+    );
+  });
+
+  it("labels the report as per-mapping so aggregate figures are not assumed", async () => {
+    // "Uncovered by this mapping" is a weaker claim than "uncovered by every
+    // mapping". A reviewer acting on the wrong one deletes a live field.
+    const { stdout } = await run("coverage", WORKSPACE);
+    assert.match(stdout, /per mapping/);
+  });
+
+  it("names the uncovered fields, not just how many there are", async () => {
+    // A count alone is not actionable; the point of the report is the queue of
+    // paths to go and map.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--mapping", "load contacts");
+    assert.equal(code, 0);
+    assert.match(stdout, /uncovered in crm::contacts \(target\)/);
+    assert.match(stdout, /memo/);
+  });
+});
+
+// ── Index adaptation ────────────────────────────────────────────────────────
+
+describe("satsuma coverage — resolving the workspace index", () => {
+  it("resolves namespaced schema references to their canonical keys", async () => {
+    // A mapping inside `namespace crm` may write `crm::customers` or bare
+    // `customers` for the same schema. Reporting the written form would split one
+    // schema across two keys when results are rolled up.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--json");
+    assert.equal(code, 0);
+    const schemas = parseJson(stdout).mappings.flatMap((m: any) => m.schemas.map((s: any) => s.schema));
+    for (const schema of schemas) {
+      assert.match(schema, /^(crm|billing)::/, `expected a namespace-qualified key, got ${schema}`);
+    }
+  });
+
+  it("counts a nested leaf independently of its sibling and its parent record", async () => {
+    // The PRD's headline nested case. `address.city -> city` must not vouch for
+    // `address.line1`, and `address` itself must not be counted as data.
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const source = schemaEntry(parseJson(stdout), "crm::load contacts", "source", "crm::customers");
+    assert.deepEqual(
+      source.fields.map((f: any) => [f.path, f.mapped]),
+      [["id", true], ["address.city", true], ["address.line1", false], ["nickname", false]],
+    );
+    assert.deepEqual(
+      { covered: source.covered, total: source.total, pct: source.pct },
+      { covered: 2, total: 4, pct: 50 },
+    );
+  });
+
+  it("resolves element-relative arrows inside an each block against the list", async () => {
+    // `.sku -> .code` under `each lines -> rows` covers lines.sku and rows.code.
+    // Failing to strip the leading dot reported both as gaps (sc-xnxp).
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "flatten invoices", "--json");
+    const data = parseJson(stdout);
+    const source = schemaEntry(data, "billing::flatten invoices", "source", "billing::invoices");
+    assert.deepEqual(
+      source.fields.map((f: any) => [f.path, f.mapped]),
+      [["id", true], ["lines.sku", true], ["lines.qty", false]],
+    );
+    const target = schemaEntry(data, "billing::flatten invoices", "target", "billing::invoice_rows");
+    assert.deepEqual(target.fields.map((f: any) => [f.path, f.mapped]), [["id", true], ["rows.code", true]]);
+  });
+
+  it("reports a schema written by one mapping and read by another under both roles", async () => {
+    // A staging schema's two questions — is it populated, is it consumed — are
+    // different, and blending them would answer neither.
+    const { stdout } = await run("coverage", WORKSPACE, "--schema", "contacts", "--json");
+    const roles = parseJson(stdout).mappings.flatMap((m: any) =>
+      m.schemas.map((s: any) => [m.mapping, s.role]),
+    );
+    assert.deepEqual(roles.sort(), [
+      ["crm::annotate contacts", "target"],
+      ["crm::load contacts", "target"],
+    ]);
+  });
+});
+
+// ── Scoping flags ───────────────────────────────────────────────────────────
+
+describe("satsuma coverage — scoping flags", () => {
+  it("--mapping restricts the report to one mapping", async () => {
+    const { stdout, code } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    assert.equal(code, 0);
+    assert.deepEqual(parseJson(stdout).mappings.map((m: any) => m.mapping), ["crm::load contacts"]);
+  });
+
+  it("--schema keeps only that schema, across every mapping using it", async () => {
+    // The single-schema view a reviewer wants when auditing one target table.
+    const { stdout, code } = await run("coverage", WORKSPACE, "--schema", "crm::customers", "--json");
+    assert.equal(code, 0);
+    const data = parseJson(stdout);
+    assert.deepEqual(data.mappings.map((m: any) => m.mapping).sort(), ["crm::annotate contacts", "crm::load contacts"]);
+    for (const mapping of data.mappings) {
+      assert.deepEqual(mapping.schemas.map((s: any) => s.schema), ["crm::customers"]);
+    }
+  });
+
+  it("--role target drops the source-side entries", async () => {
+    const { stdout, code } = await run("coverage", WORKSPACE, "--role", "target", "--json");
+    assert.equal(code, 0);
+    const roles = parseJson(stdout).mappings.flatMap((m: any) => m.schemas.map((s: any) => s.role));
+    assert.deepEqual([...new Set(roles)], ["target"]);
+  });
+
+  it("composes --schema with --role to a single entry", async () => {
+    // Filters have to intersect, not override: this is how --fail-under will
+    // later gate one specific figure (sl-268g).
+    const { stdout, code } = await run(
+      "coverage", WORKSPACE, "--schema", "crm::customers", "--role", "target", "--json",
+    );
+    // crm::customers is never a target, so the intersection is empty.
+    assert.equal(code, 1);
+    assert.match(stdout, /No coverage matches .*schema 'crm::customers'.*role 'target'/);
+  });
+
+  it("--uncovered drops the covered fields and the schemas with no gaps", async () => {
+    // The review-queue view: everything left on screen is work to do.
+    const { stdout, code } = await run(
+      "coverage", WORKSPACE, "--mapping", "flatten invoices", "--uncovered", "--json",
+    );
+    assert.equal(code, 0);
+    const data = parseJson(stdout);
+    const target = schemaEntry(data, "billing::flatten invoices", "target", "billing::invoice_rows");
+    assert.deepEqual(target.fields, [], "invoice_rows is fully populated, so it has no uncovered fields");
+    const source = schemaEntry(data, "billing::flatten invoices", "source", "billing::invoices");
+    assert.deepEqual(source.fields.map((f: any) => f.path), ["lines.qty"]);
+  });
+
+  it("--uncovered leaves the counts as the full denominator", async () => {
+    // "1 of 3" is the useful figure; recomputing counts over the filtered list
+    // would report "0 of 1" and lose the scale of the gap.
+    const { stdout } = await run(
+      "coverage", WORKSPACE, "--mapping", "flatten invoices", "--uncovered", "--json",
+    );
+    const source = schemaEntry(parseJson(stdout), "billing::flatten invoices", "source", "billing::invoices");
+    assert.deepEqual({ covered: source.covered, total: source.total }, { covered: 2, total: 3 });
+  });
+});
+
+// ── JSON contract ───────────────────────────────────────────────────────────
+
+describe("satsuma coverage — JSON contract", () => {
+  it("emits the documented top-level shape", async () => {
+    // Feature 36's overlay renders from this shape, so its keys are a contract.
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const mapping = mappingEntry(parseJson(stdout), "crm::load contacts");
+    assert.deepEqual(Object.keys(mapping), ["mapping", "file", "schemas"]);
+    assert.equal(mapping.file, WORKSPACE);
+    assert.deepEqual(
+      Object.keys(mapping.schemas[0]),
+      ["schema", "role", "covered", "total", "pct", "fields"],
+    );
+  });
+
+  it("reports field lines 1-indexed, matching every other command's JSON", async () => {
+    // Row numbering drifted between commands before cbh-7rvo; JSON and human
+    // output must agree so a jump link built from either lands in the same place.
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const source = schemaEntry(parseJson(stdout), "crm::load contacts", "source", "crm::customers");
+    const nickname = source.fields.find((f: any) => f.path === "nickname");
+    // `nickname STRING` is on line 17 of the fixture, counting from 1.
+    assert.equal(nickname.line, 17);
+    assert.equal(nickname.file, WORKSPACE);
+  });
+
+  it("lists leaf fields only, so the list and the counts are one population", async () => {
+    // A three-path list under a count of two would be a report contradicting
+    // itself. Records are excluded from both.
+    const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const source = schemaEntry(parseJson(stdout), "crm::load contacts", "source", "crm::customers");
+    assert.equal(source.fields.length, source.total);
+    assert.ok(!source.fields.some((f: any) => f.path === "address"), "the 'address' record must not be listed");
+  });
+});
+
+// ── Exit codes ──────────────────────────────────────────────────────────────
+
+describe("satsuma coverage — exit codes", () => {
+  it("exits 1 with a suggestion when --mapping names nothing", async () => {
+    // Must stay distinct from a coverage-threshold failure (sl-268g): CI has to
+    // tell "the spec is incomplete" from "the invocation is broken".
+    const { stderr, code } = await run("coverage", WORKSPACE, "--mapping", "load contact");
+    assert.equal(code, 1);
+    assert.match(stderr, /Mapping 'load contact' not found/);
+  });
+
+  it("exits 1 when --schema names nothing", async () => {
+    const { stderr, code } = await run("coverage", WORKSPACE, "--schema", "custmers");
+    assert.equal(code, 1);
+    assert.match(stderr, /Schema 'custmers' not found/);
+  });
+
+  it("exits 2 for an unreadable entry file", async () => {
+    const { code } = await run("coverage", resolve(__dirname, "fixtures/does-not-exist.stm"));
+    assert.equal(code, 2);
+  });
+
+  it("rejects an invalid --role rather than silently reporting both", async () => {
+    // Ignoring the flag would look like a bug in the numbers, not the command line.
+    const { stderr, code } = await run("coverage", WORKSPACE, "--role", "sources");
+    assert.equal(code, 2);
+    assert.match(stderr, /Invalid --role 'sources'/);
+  });
+});
+
+// ── Agreement with `fields --unmapped-by` ───────────────────────────────────
+
+describe("satsuma coverage vs fields --unmapped-by", () => {
+  /** Leaf paths from a `fields --json` tree, dotted from the schema root. */
+  function leafPaths(fields: any[], prefix = ""): string[] {
+    return fields.flatMap((f: any) => {
+      const path = prefix ? `${prefix}.${f.name}` : f.name;
+      return f.children?.length ? leafPaths(f.children, path) : [path];
+    });
+  }
+
+  it("reports the identical uncovered field set for one schema and one mapping", async () => {
+    // The lock that keeps the two surfaces from drifting. They are now the same
+    // computation; if this ever fails, one of them has grown its own copy again.
+    const [viaFields, viaCoverage] = await Promise.all([
+      run("fields", "nested_tgt", "--unmapped-by", "partial_map", "--json", NESTED),
+      run("coverage", NESTED, "--uncovered", "--mapping", "partial_map", "--schema", "nested_tgt", "--json"),
+    ]);
+    assert.equal(viaFields.code, 0);
+    assert.equal(viaCoverage.code, 0);
+
+    const fromFields = leafPaths(parseJson(viaFields.stdout)).sort();
+    const fromCoverage = schemaEntry(parseJson(viaCoverage.stdout), "::partial_map", "target", "::nested_tgt")
+      .fields.map((f: any) => f.path)
+      .sort();
+    assert.deepEqual(fromCoverage, fromFields);
+    assert.ok(fromFields.length > 0, "the fixture must actually have gaps for this to prove anything");
+  });
+
+  it("agrees that a fully-mapped schema has no uncovered fields", async () => {
+    // The other end of the range: both surfaces must report empty, not one
+    // reporting the record shell it pruned differently.
+    const [viaFields, viaCoverage] = await Promise.all([
+      run("fields", "nested_tgt", "--unmapped-by", "full_map", "--json", NESTED),
+      run("coverage", NESTED, "--uncovered", "--mapping", "full_map", "--schema", "nested_tgt", "--json"),
+    ]);
+    assert.deepEqual(parseJson(viaFields.stdout), []);
+    assert.deepEqual(
+      schemaEntry(parseJson(viaCoverage.stdout), "::full_map", "target", "::nested_tgt").fields,
+      [],
+    );
+  });
+});

--- a/tooling/satsuma-cli/test/docs.test.ts
+++ b/tooling/satsuma-cli/test/docs.test.ts
@@ -1,12 +1,16 @@
 /**
- * docs.test.ts — Keeps the CLI reference (SATSUMA-CLI.md) in sync with the
- * commands the binary actually registers.
+ * docs.test.ts — Keeps the CLI reference (SATSUMA-CLI.md) in sync with what the
+ * binary actually does.
  *
  * Regression coverage for sl-w1dr: the CLI grew to 22 commands while
  * SATSUMA-CLI.md documented 21 (nl-refs was missing) and other docs still
  * claimed 16. Living docs no longer hardcode a command count; this test is
  * the check that every shipped command is documented, so a newly registered
  * command fails CI until its reference entry exists.
+ *
+ * The second suite guards the one JSON shape the docs call a *stable contract*
+ * (`coverage`, consumed by the viz overlay). A contract nobody checks is a
+ * comment, so the keys the command emits must appear in the documented shape.
  */
 
 import assert from "node:assert/strict";
@@ -49,6 +53,47 @@ describe("SATSUMA-CLI.md command coverage", () => {
       undocumented,
       [],
       `commands missing from SATSUMA-CLI.md: ${undocumented.join(", ")}`,
+    );
+  });
+});
+
+describe("SATSUMA-CLI.md coverage JSON contract", () => {
+  const COVERAGE_FIXTURE = resolve(__dirname, "fixtures/coverage-workspace.stm");
+
+  /** Every distinct object key appearing anywhere in a JSON value. */
+  function allKeys(value: unknown, found = new Set<string>()): Set<string> {
+    if (Array.isArray(value)) {
+      for (const item of value) allKeys(item, found);
+    } else if (value !== null && typeof value === "object") {
+      for (const [key, child] of Object.entries(value)) {
+        found.add(key);
+        allKeys(child, found);
+      }
+    }
+    return found;
+  }
+
+  it("documents every key the coverage JSON emits", async () => {
+    // SATSUMA-CLI.md presents this shape as a stable contract that feature 36's
+    // overlay renders from. If the command grows a key the reference does not
+    // mention, the contract has silently changed — which is exactly the drift
+    // calling it "stable" is meant to prevent.
+    const { stdout, code } = await runCli(
+      CLI, "coverage", COVERAGE_FIXTURE, "--fail-under", "50", "--json",
+    );
+    assert.equal(code, 0);
+
+    const keys = [...allKeys(JSON.parse(stdout))];
+    // Sanity floor: a parsing slip here must fail loudly, not assert nothing.
+    assert.ok(keys.length >= 10, `expected a populated coverage payload, got keys: ${keys.join(", ")}`);
+
+    const reference = readFileSync(CLI_REFERENCE, "utf8");
+    const contract = reference.slice(reference.indexOf("#### JSON contract"));
+    const undocumented = keys.filter((key) => !contract.includes(`"${key}"`));
+    assert.deepEqual(
+      undocumented,
+      [],
+      `coverage --json keys missing from the documented contract: ${undocumented.join(", ")}`,
     );
   });
 });

--- a/tooling/satsuma-cli/test/field-positions.test.ts
+++ b/tooling/satsuma-cli/test/field-positions.test.ts
@@ -1,0 +1,212 @@
+/**
+ * field-positions.test.ts — The CLI's field declaration-position rule.
+ *
+ * Positions matter because downstream UIs turn (file, line) into an editor-jump
+ * link. The load-bearing case is a spread-expanded field: its `startRow` is a
+ * row in the *fragment's* file, while every command reports the *consuming
+ * schema's* file, so naively pairing them produces a precise-looking wrong
+ * answer. These tests pin the rule from cbh-5lzd and its inheritance through
+ * nesting.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import "./setup.js";
+import { extractSchemas, extractFragments } from "@satsuma/core";
+import { parseSource } from "../dist/parser.js";
+import { buildIndex } from "../dist/index-builder.js";
+import { expandEntityFields, expandNestedSpreads } from "../dist/spread-expand.js";
+import { fieldDeclarationRow, toCoverageFields } from "../dist/field-positions.js";
+import type { ExpandedField } from "@satsuma/core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Synthetic workspace paths. buildIndex only uses them as index keys and as the
+// `file` it stamps on records, so no fixture file needs to exist on disk.
+const SCHEMA_FILE = resolve(__dirname, "fixtures/positions-a.stm");
+const SECOND_FILE = resolve(__dirname, "fixtures/positions-b.stm");
+
+// A consuming schema declared at row 10 of one file — the position a spread
+// field must be reported at, per cbh-5lzd.
+const CONSUMER = { file: SCHEMA_FILE, row: 10 };
+
+/** Parse Satsuma source to a tree (parseSource also returns src/errorCount). */
+function parse(source: string) {
+  return parseSource(source).tree;
+}
+
+/** A ParsedFile for buildIndex, as loadWorkspace would produce it. */
+function parsedFile(filePath: string, source: string) {
+  return { filePath, ...parseSource(source) };
+}
+
+describe("fieldDeclarationRow()", () => {
+  it("reports a schema's own field at its extracted declaration row", () => {
+    // The common case: core's extractFieldTree always sets startRow, and it is
+    // a row in the same file the command reports, so it passes straight through.
+    const field: ExpandedField = { name: "id", type: "INT", startRow: 12 };
+    assert.equal(fieldDeclarationRow(field, CONSUMER, false), 12);
+  });
+
+  it("reports a spread-expanded field at the consuming schema's row", () => {
+    // startRow here is row 3 of the *fragment's* file. Reporting it alongside
+    // the consuming schema's file would send a jump link into the wrong file at
+    // a plausible-looking line, so the consuming entity's row wins.
+    const field: ExpandedField = { name: "email", type: "STRING", startRow: 3, fromFragment: "contact" };
+    assert.equal(fieldDeclarationRow(field, CONSUMER, false), CONSUMER.row);
+  });
+
+  it("reports a descendant of a spread field at the consuming schema's row", () => {
+    // Only the field copied directly out of the fragment carries fromFragment;
+    // its children do not. Without inherited provenance a nested child of a
+    // spread record would silently fall back to the fragment's row.
+    const child: ExpandedField = { name: "city", type: "STRING", startRow: 4 };
+    assert.equal(fieldDeclarationRow(child, CONSUMER, true), CONSUMER.row);
+  });
+
+  it("returns undefined when the field carries no position at all", () => {
+    // Absence must propagate as absence. Substituting 0 would read as line 1
+    // and point a reader at the top of the file (sl-5sjp).
+    assert.equal(fieldDeclarationRow({ name: "id", type: "INT" }, CONSUMER, false), undefined);
+  });
+});
+
+describe("toCoverageFields()", () => {
+  it("carries declaration rows through a nested schema's field tree", () => {
+    // Positions must survive the projection at every depth: a nested field's
+    // row is what a coverage overlay uses to place its marker.
+    const source = `schema src {
+  id INT
+  address record {
+    line1 STRING
+  }
+}`;
+    const [schema] = extractSchemas(parse(source).rootNode);
+    const projected = toCoverageFields(schema.fields, { file: SCHEMA_FILE, row: schema.row });
+    assert.deepEqual(projected, [
+      { name: "id", line: 1 },
+      { name: "address", line: 2, children: [{ name: "line1", line: 3 }] },
+    ]);
+  });
+
+  it("rewrites spread-expanded fields, and only those, to the consuming row", () => {
+    // The mixed case that decides whether the rule is applied per-field rather
+    // than per-schema: `id` keeps its own row while the spread-in fields move.
+    const source = `fragment contact {
+  email STRING
+  phone STRING
+}
+schema customer {
+  id INT
+  ...contact
+}`;
+    const root = parse(source).rootNode;
+    const schema = extractSchemas(root).find((s) => s.name === "customer");
+    assert.ok(schema, "expected the customer schema to be extracted");
+    const index = buildIndex([
+      parsedFile(SCHEMA_FILE, source),
+    ]);
+    const fields = [
+      ...schema.fields,
+      ...expandEntityFields(schema, null, index),
+    ];
+    const projected = toCoverageFields(fields, { file: SCHEMA_FILE, row: schema.row });
+    assert.deepEqual(projected, [
+      // `id` is declared at row 5 of this file, so it keeps its own position.
+      { name: "id", line: 5 },
+      // `email`/`phone` are declared at rows 1-2 of the *fragment*; both are
+      // reported at the consuming schema's header row instead.
+      { name: "email", line: schema.row },
+      { name: "phone", line: schema.row },
+    ]);
+  });
+
+  it("rewrites fields spread into a nested record, including their children", () => {
+    // Nested spreads expand in place into a record's children, so the
+    // provenance flag has to survive one more level of recursion.
+    const source = `fragment geo {
+  point record {
+    lat DECIMAL
+  }
+}
+schema place {
+  location record {
+    label STRING
+    ...geo
+  }
+}`;
+    const root = parse(source).rootNode;
+    const schema = extractSchemas(root).find((s) => s.name === "place");
+    assert.ok(schema, "expected the place schema to be extracted");
+    const index = buildIndex([
+      parsedFile(SCHEMA_FILE, source),
+    ]);
+    expandNestedSpreads(schema.fields, null, index);
+    const projected = toCoverageFields(schema.fields, { file: SCHEMA_FILE, row: schema.row });
+    const location = projected[0];
+    assert.equal(location.name, "location");
+    assert.deepEqual(location.children, [
+      // Declared in this file, keeps its own row.
+      { name: "label", line: 7 },
+      // Spread in from the fragment: the record and its child both report the
+      // consuming schema's row rather than rows 1-2 of the fragment.
+      { name: "point", line: schema.row, children: [{ name: "lat", line: schema.row }] },
+    ]);
+  });
+});
+
+describe("FieldDecl positions through the index", () => {
+  it("preserves startRow and startColumn on indexed schema fields", () => {
+    // The CLI kept a structural clone of core's FieldDecl that omitted both
+    // fields, hiding positions from every command even though the extractor set
+    // them (sl-5sjp). This asserts the data survives buildIndex's field merge.
+    const source = `schema src {
+  id INT
+  name STRING
+}`;
+    const index = buildIndex([
+      parsedFile(SCHEMA_FILE, source),
+    ]);
+    const schema = index.schemas.get("src");
+    assert.ok(schema, "expected schema 'src' in the index");
+    assert.deepEqual(
+      schema.fields.map((f) => [f.name, f.startRow, f.startColumn]),
+      [["id", 1, 2], ["name", 2, 2]],
+    );
+  });
+
+  it("preserves positions on fields merged in from a second file", () => {
+    // Satsuma allows splitting a schema across files; mergeFields pushes the
+    // second file's field objects into the first's list, and a copy that
+    // dropped positions there would be invisible until a jump link misfired.
+    const fileA = `schema src {
+  id INT
+}`;
+    const fileB = `schema src {
+
+  extra STRING
+}`;
+    const index = buildIndex([
+      parsedFile(SCHEMA_FILE, fileA),
+      parsedFile(SECOND_FILE, fileB),
+    ]);
+    const schema = index.schemas.get("src");
+    assert.ok(schema, "expected schema 'src' in the index");
+    const extra = schema.fields.find((f) => f.name === "extra");
+    assert.equal(extra?.startRow, 2, "row must come from file B, where 'extra' is declared");
+  });
+});
+
+describe("extracted fragments carry positions too", () => {
+  it("sets startRow on fragment fields so spread provenance is detectable", () => {
+    // The spread rule exists precisely because fragment fields have real rows
+    // in the wrong file. If fragments carried no rows the rule would be moot,
+    // so this pins the premise the rule rests on.
+    const [fragment] = extractFragments(parse(`fragment contact {
+  email STRING
+}`).rootNode);
+    assert.equal(fragment.fields[0]?.startRow, 1);
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/coverage-workspace.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-workspace.stm
@@ -1,0 +1,68 @@
+// Fixture for `satsuma coverage` tests.
+//
+// Shaped to exercise, in one small workspace, the cases the command has to get
+// right: a nested record with one covered and one uncovered leaf, a schema that
+// is a target of one mapping and a source of another, a field populated by one
+// mapping and ignored by another (the per-mapping vs aggregate distinction), and
+// an each block whose element-relative arrows must resolve under the list.
+
+namespace crm {
+
+  schema customers {
+    id INT
+    address record {
+      city STRING
+      line1 STRING
+    }
+    nickname STRING
+  }
+
+  schema contacts {
+    id INT
+    city STRING
+    memo STRING
+  }
+
+  mapping `load contacts` {
+    source { crm::customers }
+    target { crm::contacts }
+
+    id -> id
+    address.city -> city
+  }
+
+  mapping `annotate contacts` {
+    source { crm::customers }
+    target { crm::contacts }
+
+    nickname -> memo
+  }
+}
+
+namespace billing {
+
+  schema invoices {
+    id INT
+    lines list_of record {
+      sku STRING
+      qty INT
+    }
+  }
+
+  schema invoice_rows {
+    id INT
+    rows list_of record {
+      code STRING
+    }
+  }
+
+  mapping `flatten invoices` {
+    source { billing::invoices }
+    target { billing::invoice_rows }
+
+    id -> id
+    each lines -> rows {
+      .sku -> .code
+    }
+  }
+}

--- a/tooling/satsuma-cli/test/lineage.test.ts
+++ b/tooling/satsuma-cli/test/lineage.test.ts
@@ -23,13 +23,15 @@ const run = (...args: string[]) => runCli(CLI, ...args);
 describe("satsuma lineage", () => {
   it("prints downstream text trees with node types for --from", async () => {
     // Human downstream output should show the start schema, mapping, target,
-    // and node types in data-flow order.
+    // and node types in data-flow order. Names appear bare because this fixture
+    // declares no namespace — human output drops the empty "::" prefix that
+    // --json still carries (displayKey vs canonicalKey in index-builder.ts).
     const { stdout, code } = await run("lineage", "--from", "source_a", LINEAGE_CHAIN);
 
     assert.equal(code, 0);
-    assert.match(stdout, /^::source_a {2}\[schema\]/m);
-    assert.match(stdout, /^ {2}::a_to_b {2}\[mapping\]/m);
-    assert.match(stdout, /^ {4}::intermediate_b {2}\[schema\]/m);
+    assert.match(stdout, /^source_a {2}\[schema\]/m);
+    assert.match(stdout, /^ {2}a_to_b {2}\[mapping\]/m);
+    assert.match(stdout, /^ {4}intermediate_b {2}\[schema\]/m);
   });
 
   it("prints upstream text paths for --to", async () => {
@@ -38,8 +40,8 @@ describe("satsuma lineage", () => {
     const { stdout, code } = await run("lineage", "--to", "target_d", LINEAGE_CHAIN);
 
     assert.equal(code, 0);
-    assert.match(stdout, /::source_a -> ::a_to_b -> ::intermediate_b/);
-    assert.match(stdout, /::c_to_d -> ::target_d/);
+    assert.match(stdout, /source_a -> a_to_b -> intermediate_b/);
+    assert.match(stdout, /c_to_d -> target_d/);
   });
 
   it("emits depth-limited downstream JSON without dangling edges", async () => {
@@ -77,7 +79,7 @@ describe("satsuma lineage", () => {
     const { stdout, code } = await run("lineage", "--from", "cycle_a", LINEAGE_CYCLE);
 
     assert.equal(code, 0);
-    assert.match(stdout, /::cycle_a {2}\[schema\] \(cycle\)/);
+    assert.match(stdout, /cycle_a {2}\[schema\] \(cycle\)/);
     assert.ok(stdout.trim().split(/\r?\n/).length <= 5);
   });
 
@@ -120,14 +122,16 @@ describe("satsuma lineage", () => {
 
     assert.equal(text.code, 0);
     assert.equal(json.code, 0);
-    // JSON names are bare index keys ("cycle_a"); text prints canonical refs ("::cycle_a").
+    // Human output prints the display form (bare "cycle_a" here, since this
+    // fixture declares no namespace); --json keeps the canonical "::cycle_a".
+    // The two spellings are deliberate — see displayKey() in index-builder.ts.
     const jsonNames = JSON.parse(json.stdout).nodes.map((node: { name: string }) => node.name);
     assert.ok(jsonNames.length >= 4, `cycle fixture should yield all 4 nodes in JSON, got: ${jsonNames.join(", ")}`);
     for (const name of jsonNames) {
-      assert.ok(text.stdout.includes(`::${name}`), `text output must mention '${name}'; got:\n${text.stdout}`);
+      assert.ok(text.stdout.includes(name), `text output must mention '${name}'; got:\n${text.stdout}`);
     }
     // The upstream path itself must be visible, not just the target line.
-    assert.match(text.stdout, /::cycle_b -> ::b_to_a -> ::cycle_a/);
+    assert.match(text.stdout, /cycle_b -> b_to_a -> cycle_a/);
   });
 
   it("resolves namespace-qualified --from names without crossing namespace scope", async () => {

--- a/tooling/satsuma-cli/test/option-parsers.test.ts
+++ b/tooling/satsuma-cli/test/option-parsers.test.ts
@@ -13,7 +13,7 @@ import { describe, it } from "node:test";
 import { InvalidArgumentError } from "commander";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parsePositiveInt } from "../src/option-parsers.js";
+import { parsePositiveInt, parsePercentage } from "../src/option-parsers.js";
 import { run as runCli } from "./helpers.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -65,5 +65,29 @@ describe("numeric options reject garbage as a usage error", () => {
 
     assert.notEqual(code, 0);
     assert.match(stderr, /option '--budget <n>' argument '0' is invalid/);
+  });
+});
+
+describe("parsePercentage", () => {
+  it("accepts the full 0-100 range, including both boundaries", () => {
+    // 0 must be accepted: a pipeline that computes its own --fail-under
+    // threshold can legitimately arrive at zero, and rejecting it would break
+    // the boundary case rather than the mistake.
+    assert.equal(parsePercentage("0"), 0);
+    assert.equal(parsePercentage("71"), 71);
+    assert.equal(parsePercentage("100"), 100);
+  });
+
+  it("rejects a threshold above 100", () => {
+    // A gate no coverage figure can ever satisfy is a typo, not a policy.
+    assert.throws(() => parsePercentage("101"), InvalidArgumentError);
+  });
+
+  it("rejects non-integer and non-numeric values rather than truncating them", () => {
+    // Bare parseInt would turn "90.5" into 90 and "ninety" into NaN, silently
+    // gating on a threshold the caller never asked for (the sl-bvd0 shape).
+    for (const bad of ["90.5", "ninety", "-1", "", "90abc"]) {
+      assert.throws(() => parsePercentage(bad), InvalidArgumentError, `expected "${bad}" to be rejected`);
+    }
   });
 });

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -69,6 +69,10 @@
     "./coverage-paths": {
       "types": "./dist/coverage-paths.d.ts",
       "default": "./dist/coverage-paths.js"
+    },
+    "./coverage-rollup": {
+      "types": "./dist/coverage-rollup.d.ts",
+      "default": "./dist/coverage-rollup.js"
     }
   },
   "types": "./dist/index.d.ts",

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -1,13 +1,43 @@
 /**
- * coverage-paths.ts — Shared field-path coverage helpers.
+ * coverage-paths.ts — Field-path set helpers for nested field coverage.
  *
- * Consumers in the LSP and viz layer both need the same path semantics:
- * if an arrow references `customer.email`, both `customer` and
- * `customer.email` count as covered. This module centralizes that expansion so
- * UI layers do not reimplement their own nested-field matching rules.
+ * Owns the *path* half of coverage: turning the dotted paths an arrow
+ * references into a set that can answer "is this declared field covered?".
+ * Every consumer needs identical nested-path semantics — if an arrow
+ * references `customer.email`, both `customer` and `customer.email` count as
+ * covered — so those rules live here rather than in each UI layer.
+ *
+ * Does not own the CST walk that produces those paths, nor the per-field
+ * result shape: both live in coverage.ts, which builds on this module. The
+ * dependency runs one way (coverage.ts → coverage-paths.ts) so the two
+ * modules can be reasoned about independently.
  */
 
-import { addPathAndPrefixes } from "./coverage.js";
+/**
+ * Register a path and all its ancestor prefixes in the covered-paths set.
+ *
+ * Strips array-notation brackets (`[]`) before splitting so that list-traversal
+ * paths like `"items[].id"` are registered as `"items"`, `"items.id"`, and `"id"`.
+ *
+ * Registering ancestors means a top-level field `"address"` is considered
+ * covered when an arrow targets the nested path `"address.city"` — a consumer
+ * that checks `coveredPaths.has(f.name)` will correctly find the parent covered.
+ *
+ * Example: addPathAndPrefixes(set, "orders.item_id")
+ *   → set now contains "orders", "orders.item_id", "item_id"
+ */
+export function addPathAndPrefixes(set: Set<string>, path: string): void {
+  if (!path) return;
+  // Strip array notation: "items[].id" → "items.id"
+  const normalised = path.replace(/\[\]/g, "");
+  const parts = normalised.split(".");
+  let prefix = "";
+  for (const part of parts) {
+    prefix = prefix ? `${prefix}.${part}` : part;
+    set.add(prefix);
+    set.add(part); // bare leaf so "city" matches even if the full path is "address.city"
+  }
+}
 
 /**
  * Expand a collection of field paths into a coverage set containing the full

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -1,0 +1,281 @@
+/**
+ * coverage-rollup.ts — Rolling per-mapping coverage up to schema, namespace, and workspace.
+ *
+ * coverage.ts answers "which fields does *this mapping* touch?". This module
+ * answers the question reviewers actually ask: "across the whole workspace,
+ * which fields does *no* mapping populate?" — and the percentages that follow
+ * from it.
+ *
+ * The two answers are different claims about the same field, and confusing them
+ * is the failure mode this module exists to prevent: a target field that
+ * mapping A populates and mapping B ignores is *uncovered by B* and *covered in
+ * the aggregate*. The returned types keep them apart by construction — an
+ * aggregate figure never appears in a per-mapping shape or vice versa — so a
+ * consumer cannot render one under the other's label by accident.
+ *
+ * Owns: the union rule across mappings, the counting rule, and the
+ * schema/namespace/workspace rollups.
+ * Does not own: the per-mapping walk (coverage.ts), path expansion
+ * (coverage-paths.ts), or how any of it is rendered.
+ */
+
+import type { FieldCoverageEntry, MappingCoverageResult } from "./coverage.js";
+
+// ── Inputs ──────────────────────────────────────────────────────────────────
+
+/** One mapping's coverage result, labelled with the mapping that produced it. */
+export interface MappingCoverageInput {
+  /**
+   * Mapping identifier as shown to the user: `ns::name` for a namespaced
+   * mapping, the bare name otherwise. Used to report which mappings reference a
+   * schema, so it must match what other commands print.
+   */
+  mappingId: string;
+  /** Per-schema field coverage for this mapping, from `computeMappingCoverage`. */
+  result: MappingCoverageResult;
+}
+
+// ── Outputs ─────────────────────────────────────────────────────────────────
+
+/**
+ * Covered/total counts and the percentage derived from them.
+ *
+ * **Counting rule: only leaf fields count, on their own coverage flag.** A
+ * `record` field is structure, not data — counting it alongside its children
+ * would count the same data twice and let a schema's nesting depth move the
+ * percentage on its own. `total` is therefore the number of leaves.
+ *
+ * Records are excluded rather than treated as covering their subtree, because a
+ * record's `mapped` flag cannot distinguish the two cases that matter:
+ * `addPathAndPrefixes` registers ancestor prefixes, so a record reads as mapped
+ * when *any single descendant* is covered just as it does when the whole record
+ * is copied by one arrow. Inheriting from it would turn "one of twelve address
+ * fields is mapped" into "all twelve are" — a large, silent overstatement.
+ * Excluding it instead under-counts the rarer whole-record arrow
+ * (`address -> address` leaves its leaves unmapped, see 3cc-iedv), which errs
+ * toward reporting a gap that is not there rather than hiding one that is.
+ */
+export interface CoverageTotals {
+  /** Leaf fields whose own entry is marked covered. */
+  covered: number;
+  /** Leaf fields declared. Zero for a schema with no leaves. */
+  total: number;
+  /** covered/total as a whole-number percentage; 0 when `total` is 0. */
+  pct: number;
+}
+
+/**
+ * Aggregate coverage for one schema in one role, unioned across every mapping
+ * that references it.
+ *
+ * "Aggregate" is the whole point of this shape: `fields[].mapped` means
+ * *at least one* mapping covers the field. A false here is the strong claim —
+ * no mapping in the workspace touches this field.
+ */
+export interface AggregateSchemaCoverage {
+  /** Identifier of the schema (bare name or ns::name). */
+  schemaId: string;
+  /** Side of the mappings this schema appears on. A schema can appear in both. */
+  role: "source" | "target";
+  /** Mapping ids referencing this schema in this role, in encounter order. */
+  mappings: string[];
+  /** One entry per declared field; `mapped` is the union across `mappings`. */
+  fields: FieldCoverageEntry[];
+  /** Leaf counts for this schema and role, per the {@link CoverageTotals} rule. */
+  totals: CoverageTotals;
+}
+
+/** Source and target subtotals for one grouping (a namespace, or the workspace). */
+export interface RoleTotals {
+  /** Source-side consumption: leaves read by at least one mapping. */
+  source: CoverageTotals;
+  /** Target-side population: leaves written by at least one mapping. */
+  target: CoverageTotals;
+}
+
+/** Subtotals for the schemas declared in one namespace. */
+export interface NamespaceCoverage extends RoleTotals {
+  /** Namespace name, or null for schemas declared at file scope. */
+  namespace: string | null;
+}
+
+/**
+ * Workspace-wide aggregate coverage: every participating schema counted once,
+ * however many mappings reference it.
+ */
+export interface AggregateCoverage {
+  /** One entry per (schema, role) pair referenced by any mapping. */
+  schemas: AggregateSchemaCoverage[];
+  /** Per-namespace subtotals, ordered as namespaces are first encountered. */
+  namespaces: NamespaceCoverage[];
+  /** Totals across every schema in {@link schemas}. */
+  workspace: RoleTotals;
+}
+
+// ── Counting ────────────────────────────────────────────────────────────────
+
+/**
+ * Summarise a flat field-coverage list into leaf counts.
+ *
+ * Applies the {@link CoverageTotals} counting rule, and is the *only* place it
+ * is applied — per-mapping tables and aggregate rollups both call this, so a
+ * per-mapping percentage and an aggregate percentage are always computed the
+ * same way and remain comparable.
+ *
+ * `fields` must be a whole schema's entries in declaration order, as
+ * `computeMappingCoverage` emits them: a record's entry immediately precedes
+ * its descendants', and paths are dotted from the schema root.
+ */
+export function summarizeFieldCoverage(fields: FieldCoverageEntry[]): CoverageTotals {
+  const paths = new Set(fields.map((f) => f.path));
+
+  let covered = 0;
+  let total = 0;
+  for (const field of fields) {
+    if (hasDescendant(field.path, paths)) continue; // a record, not a leaf
+    total += 1;
+    if (field.mapped) covered += 1;
+  }
+  return { covered, total, pct: percentage(covered, total) };
+}
+
+/** True when any entry's path sits below `path`, i.e. `path` is a record. */
+function hasDescendant(path: string, paths: Set<string>): boolean {
+  const prefix = `${path}.`;
+  for (const candidate of paths) {
+    if (candidate.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/** Whole-number percentage, defined as 0 when there is nothing to cover. */
+function percentage(covered: number, total: number): number {
+  return total > 0 ? Math.round((covered / total) * 100) : 0;
+}
+
+/** Sum a set of totals, recomputing the percentage from the summed counts. */
+function sumTotals(parts: Iterable<CoverageTotals>): CoverageTotals {
+  let covered = 0;
+  let total = 0;
+  for (const part of parts) {
+    covered += part.covered;
+    total += part.total;
+  }
+  return { covered, total, pct: percentage(covered, total) };
+}
+
+// ── Aggregation ─────────────────────────────────────────────────────────────
+
+/**
+ * Union per-mapping coverage results into workspace-level coverage.
+ *
+ * **Union rule:** a target field counts as covered when *any* mapping populates
+ * it; a source field counts as consumed when *any* mapping reads it. Both roles
+ * are aggregated and reported separately — an unconsumed source field and an
+ * unpopulated target field are different findings and must not be blended.
+ *
+ * Schemas are keyed by (schemaId, role), so a schema that is a target of one
+ * mapping and a source of another yields two entries and is counted once in
+ * each role's totals. Namespaces are taken from the *schema's* own id, not from
+ * the referencing mapping's namespace: a subtotal answers "how well covered are
+ * this namespace's schemas?", which is a property of where they are declared.
+ *
+ * Inputs whose mapping resolved to no schemas (an absent or empty mapping)
+ * contribute nothing and are skipped.
+ */
+export function aggregateCoverage(inputs: MappingCoverageInput[]): AggregateCoverage {
+  // Keyed by role + schemaId. Role is a two-value enum containing no spaces,
+  // so the first space always separates the two parts — the key stays
+  // unambiguous even for backtick-quoted schema names that contain spaces.
+  const byRoleAndSchema = new Map<string, AggregateSchemaCoverage>();
+
+  for (const { mappingId, result } of inputs) {
+    for (const schema of result.schemas) {
+      const key = `${schema.role} ${schema.schemaId}`;
+      const existing = byRoleAndSchema.get(key);
+      if (!existing) {
+        byRoleAndSchema.set(key, {
+          schemaId: schema.schemaId,
+          role: schema.role,
+          mappings: [mappingId],
+          fields: schema.fields.map((f) => ({ ...f })),
+          // Placeholder; every entry's totals are computed once all mappings
+          // have been unioned in, below.
+          totals: { covered: 0, total: 0, pct: 0 },
+        });
+        continue;
+      }
+      if (!existing.mappings.includes(mappingId)) existing.mappings.push(mappingId);
+      unionInto(existing.fields, schema.fields);
+    }
+  }
+
+  const schemas = [...byRoleAndSchema.values()];
+  for (const schema of schemas) {
+    schema.totals = summarizeFieldCoverage(schema.fields);
+  }
+
+  return {
+    schemas,
+    namespaces: rollUpByNamespace(schemas),
+    workspace: {
+      source: sumTotals(schemas.filter((s) => s.role === "source").map((s) => s.totals)),
+      target: sumTotals(schemas.filter((s) => s.role === "target").map((s) => s.totals)),
+    },
+  };
+}
+
+/**
+ * Merge one mapping's field entries into the accumulated aggregate list.
+ *
+ * `mapped` is OR-ed — that is the union rule. A field the accumulator has not
+ * seen is appended, which only happens if two mappings resolved the same schema
+ * id to different definitions; keeping it is safer than dropping a declared
+ * field from the report.
+ */
+function unionInto(accumulated: FieldCoverageEntry[], incoming: FieldCoverageEntry[]): void {
+  const byPath = new Map(accumulated.map((f) => [f.path, f]));
+  for (const field of incoming) {
+    const existing = byPath.get(field.path);
+    if (!existing) {
+      const copy = { ...field };
+      accumulated.push(copy);
+      byPath.set(copy.path, copy);
+      continue;
+    }
+    existing.mapped = existing.mapped || field.mapped;
+  }
+}
+
+/**
+ * Group schema totals by the namespace their id declares them in.
+ *
+ * Bare (unqualified) schema ids belong to file scope and are grouped under a
+ * null namespace, so a workspace with no namespaces yields exactly one group
+ * whose totals equal the workspace totals.
+ */
+function rollUpByNamespace(schemas: AggregateSchemaCoverage[]): NamespaceCoverage[] {
+  const groups = new Map<string | null, AggregateSchemaCoverage[]>();
+  for (const schema of schemas) {
+    const namespace = namespaceOf(schema.schemaId);
+    const group = groups.get(namespace);
+    if (group) group.push(schema);
+    else groups.set(namespace, [schema]);
+  }
+
+  const result: NamespaceCoverage[] = [];
+  for (const [namespace, group] of groups) {
+    result.push({
+      namespace,
+      source: sumTotals(group.filter((s) => s.role === "source").map((s) => s.totals)),
+      target: sumTotals(group.filter((s) => s.role === "target").map((s) => s.totals)),
+    });
+  }
+  return result;
+}
+
+/** Namespace part of a schema id (`crm::orders` → `crm`), or null at file scope. */
+function namespaceOf(schemaId: string): string | null {
+  const separator = schemaId.indexOf("::");
+  return separator === -1 ? null : schemaId.slice(0, separator);
+}

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -127,16 +127,23 @@ export interface AggregateCoverage {
  * its descendants', and paths are dotted from the schema root.
  */
 export function summarizeFieldCoverage(fields: FieldCoverageEntry[]): CoverageTotals {
-  const paths = new Set(fields.map((f) => f.path));
+  const leaves = leafFieldEntries(fields);
+  const covered = leaves.filter((f) => f.mapped).length;
+  return { covered, total: leaves.length, pct: percentage(covered, leaves.length) };
+}
 
-  let covered = 0;
-  let total = 0;
-  for (const field of fields) {
-    if (hasDescendant(field.path, paths)) continue; // a record, not a leaf
-    total += 1;
-    if (field.mapped) covered += 1;
-  }
-  return { covered, total, pct: percentage(covered, total) };
+/**
+ * The leaf entries of a schema's coverage list — the fields that carry data,
+ * and the unit every count and percentage is expressed in.
+ *
+ * Exported so that a rendered "uncovered fields" list and the `covered/total`
+ * figure beside it are derived from the same definition of leaf. If they used
+ * different ones, a report could show three uncovered paths next to a count
+ * of two.
+ */
+export function leafFieldEntries(fields: FieldCoverageEntry[]): FieldCoverageEntry[] {
+  const paths = new Set(fields.map((f) => f.path));
+  return fields.filter((f) => !hasDescendant(f.path, paths));
 }
 
 /** True when any entry's path sits below `path`, i.e. `path` is a record. */

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -40,7 +40,8 @@ export interface MappingCoverageInput {
 /**
  * Covered/total counts and the percentage derived from them.
  *
- * **Counting rule: only leaf fields count, on their own coverage flag.** A
+ * **Counting rule (ADR-034): only leaf fields count, on their own coverage
+ * flag.** A
  * `record` field is structure, not data — counting it alongside its children
  * would count the same data twice and let a schema's nesting depth move the
  * percentage on its own. `total` is therefore the number of leaves.

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -9,13 +9,15 @@
  *
  * "Covered" means:
  *   - source field: its name (or a path that starts with it) appears as a
- *     src_path in at least one arrow, each_block, or flatten_block inside the
- *     mapping.
- *   - target field: its name (or a path that starts with it) appears as a
- *     tgt_path in at least one arrow inside the mapping.
+ *     src_path in at least one arrow anywhere in the mapping.
+ *   - target field: the same, as a tgt_path.
  *
- * Nested record fields are handled recursively. each_block and flatten_block
- * src-paths contribute both the top-level field and the qualified nested path.
+ * Nested record fields are handled recursively. Arrows nest inside three
+ * container blocks — `each`, `flatten` and a braced `src -> tgt` (`nested_arrow`)
+ * — which the grammar allows to interleave to any depth, so the walk recurses
+ * uniformly over all three rather than enumerating what each may contain
+ * (sl-qzy3). A container's own src/tgt count as touched and become the prefixes
+ * for the arrows inside it.
  *
  * Coverage is deliberately *structural only*: a field a note block describes in
  * prose is uncovered by definition. NL interpretation belongs to nl-refs, and
@@ -187,115 +189,120 @@ export function computeMappingCoverage(
 // ── Path collection ─────────────────────────────────────────────────────────
 
 /**
- * Walk all arrows (including inside each/flatten) in the mapping body and
- * populate the covered src-path and tgt-path sets.
+ * Path prefixes established by the enclosing container, or null at mapping-body
+ * level. A container's own — already qualified — source and target become the
+ * bases for its children, accumulating across arbitrary depth.
+ */
+interface PathBases {
+  /** Absolute source path of the enclosing container, null at body level. */
+  src: string | null;
+  /** Absolute target path of the enclosing container, null at body level. */
+  tgt: string | null;
+}
+
+/**
+ * Block types that declare one src/tgt pair plus a body of further block items.
+ *
+ * All three are walked through one shared branch rather than each parent
+ * enumerating the children it permits. That enumeration is what caused
+ * `flatten` inside `each` and `nested_arrow` anywhere to be silently dropped
+ * from coverage (sl-qzy3): the grammar's `_nested_block_item` allows any of
+ * these inside any of them, so a walk that lists cases per parent falls out of
+ * step with the grammar the moment a construct is added.
+ */
+const CONTAINER_BLOCK_TYPES = new Set(["each_block", "flatten_block", "nested_arrow"]);
+
+/**
+ * Walk every arrow in the mapping body — including those nested inside
+ * containers to arbitrary depth — and populate the covered src/tgt path sets.
  */
 function collectBodyPaths(
   body: SyntaxNode,
   srcPaths: Set<string>,
   tgtPaths: Set<string>,
 ): void {
-  for (const node of body.namedChildren) {
-    switch (node.type) {
-      case "map_arrow":
-        for (const sp of children(node, "src_path")) addPathAndPrefixes(srcPaths, pathText(sp));
-        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
-        break;
-      case "computed_arrow":
-        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
-        break;
-      case "each_block":
-        collectEachPaths(node, srcPaths, tgtPaths, null, null);
-        break;
-      case "flatten_block":
-        collectFlattenPaths(node, srcPaths, tgtPaths);
-        break;
+  collectBlockItemPaths(body.namedChildren, srcPaths, tgtPaths, { src: null, tgt: null });
+}
+
+/**
+ * Collect paths from a list of sibling block items, qualifying each against the
+ * bases its enclosing container established.
+ */
+function collectBlockItemPaths(
+  nodes: SyntaxNode[],
+  srcPaths: Set<string>,
+  tgtPaths: Set<string>,
+  bases: PathBases,
+): void {
+  for (const node of nodes) {
+    if (node.type === "map_arrow") {
+      for (const sp of children(node, "src_path")) {
+        addPathAndPrefixes(srcPaths, qualify(bases.src, pathText(sp)));
+      }
+      const tp = child(node, "tgt_path");
+      if (tp) addPathAndPrefixes(tgtPaths, qualify(bases.tgt, pathText(tp)));
+    } else if (node.type === "computed_arrow") {
+      // Source-less arrow: the target is still populated by this mapping.
+      const tp = child(node, "tgt_path");
+      if (tp) addPathAndPrefixes(tgtPaths, qualify(bases.tgt, pathText(tp)));
+    } else if (CONTAINER_BLOCK_TYPES.has(node.type)) {
+      collectContainerPaths(node, srcPaths, tgtPaths, bases);
     }
   }
 }
 
 /**
- * Recursively collect paths from an each_block.
- * Arrows inside an each_block are relative to the iteration field.
- *
- * Nullability contract for outerSrcBase / outerTgtBase:
- *   null     — no enclosing each_block has established a base path yet; this
- *               is the top-level call for this each_block, so paths from the
- *               block's own src_path/tgt_path become the new base.
- *   non-null — an enclosing each_block already established a prefix; paths in
- *               this nested block are qualified relative to that prefix via
- *               qualify(outerBase, localPath).
- *
- * Recursive call sites pass srcBase/tgtBase (the base resolved for this level)
- * as the outer values for any nested each_blocks found within this node.
+ * Register a container's own source and target, then recurse into its body with
+ * those as the bases for the level below.
  */
-function collectEachPaths(
+function collectContainerPaths(
   node: SyntaxNode,
   srcPaths: Set<string>,
   tgtPaths: Set<string>,
-  outerSrcBase: string | null,
-  outerTgtBase: string | null,
+  outer: PathBases,
 ): void {
   const rawSrc = child(node, "src_path");
   const rawTgt = child(node, "tgt_path");
-  const srcBase = rawSrc ? qualify(outerSrcBase, pathText(rawSrc)) : outerSrcBase;
-  const tgtBase = rawTgt ? qualify(outerTgtBase, pathText(rawTgt)) : outerTgtBase;
 
-  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
-  if (tgtBase) addPathAndPrefixes(tgtPaths, tgtBase);
+  const src = rawSrc ? qualify(outer.src, pathText(rawSrc)) : outer.src;
+  const tgt = containerTargetBase(node, rawTgt, outer.tgt);
 
-  for (const ch of node.namedChildren) {
-    if (ch.type === "map_arrow") {
-      for (const sp of children(ch, "src_path")) {
-        const leaf = pathText(sp);
-        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
-      }
-      const tp = child(ch, "tgt_path");
-      if (tp) {
-        const leaf = pathText(tp);
-        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
-      }
-    } else if (ch.type === "computed_arrow") {
-      const tp = child(ch, "tgt_path");
-      if (tp) {
-        const leaf = pathText(tp);
-        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
-      }
-    } else if (ch.type === "each_block") {
-      collectEachPaths(ch, srcPaths, tgtPaths, srcBase, tgtBase);
-    }
-  }
+  // The container's own paths count as touched: iterating a list consumes it,
+  // and writing into one populates it.
+  if (src) addPathAndPrefixes(srcPaths, src);
+  if (tgt) addPathAndPrefixes(tgtPaths, tgt);
+
+  collectBlockItemPaths(node.namedChildren, srcPaths, tgtPaths, { src, tgt });
 }
 
 /**
- * Collect paths from a flatten_block.
+ * Resolve the target base a container establishes for its children.
  *
- * Unlike each_block, only the *source* side has a base path: flatten unnests a
- * source list into flat target fields, so target paths inside the block are
- * already schema-root-relative and must not be prefixed.
+ * `each` and `nested_arrow` always establish one: their target names a field,
+ * and the arrows inside are written against it.
+ *
+ * `flatten` is the exception, and the grammar says which case applies. In
+ * spec §4.6's top-level form the target names the target *schema*
+ * (`flatten contacts -> tgt`) and the block unnests into flat schema-root
+ * fields, so there is no base and the named schema is not a field to register.
+ * Written relative — `flatten parcels.contents -> .packed_items` inside an
+ * `each` (examples/nested-iteration/pipeline.stm:100) — it names a list field
+ * on the current element, and its arrows are relative to that. A
+ * `relative_field_path` node is the authored signal separating the two.
  */
-function collectFlattenPaths(
+function containerTargetBase(
   node: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
-): void {
-  const rawSrc = child(node, "src_path");
-  const srcBase = rawSrc ? pathText(rawSrc) : null;
-  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
+  rawTgt: SyntaxNode | null,
+  outerTgt: string | null,
+): string | null {
+  if (!rawTgt) return outerTgt;
+  if (node.type === "flatten_block" && !isRelativePath(rawTgt)) return outerTgt;
+  return qualify(outerTgt, pathText(rawTgt));
+}
 
-  for (const ch of node.namedChildren) {
-    if (ch.type === "map_arrow") {
-      for (const sp of children(ch, "src_path")) {
-        const leaf = pathText(sp);
-        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
-      }
-      const tp = child(ch, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
-    } else if (ch.type === "computed_arrow") {
-      const tp = child(ch, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
-    }
-  }
+/** True when a src_path/tgt_path was authored relative to the current element (`.field`). */
+function isRelativePath(pathNode: SyntaxNode): boolean {
+  return child(pathNode, "relative_field_path") !== null;
 }
 
 function qualify(base: string | null, leaf: string): string {

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -1,27 +1,78 @@
 /**
- * coverage.ts — Mapping field coverage types and path utilities.
+ * coverage.ts — Mapping field coverage: which declared fields does a mapping touch?
  *
- * "Coverage" means: for each field declared in a schema, does at least one
- * arrow inside the mapping reference it (directly or via a parent path)?
+ * Owns the single definition of coverage semantics for the whole toolchain.
+ * Given a parsed file and a mapping name, {@link computeMappingCoverage} walks
+ * the mapping body, collects every source and target path the arrows reference,
+ * and reports covered/uncovered status for every field of every participating
+ * schema.
  *
- * Source coverage: a source field is covered when its name, a dotted path
- *   starting with it, or a qualifying parent path appears as a src_path in
- *   any arrow, each_block, or flatten_block inside the mapping.
+ * "Covered" means:
+ *   - source field: its name (or a path that starts with it) appears as a
+ *     src_path in at least one arrow, each_block, or flatten_block inside the
+ *     mapping.
+ *   - target field: its name (or a path that starts with it) appears as a
+ *     tgt_path in at least one arrow inside the mapping.
  *
- * Target coverage: a target field is covered when its name or a qualifying
- *   path appears as a tgt_path in any arrow inside the mapping.
+ * Nested record fields are handled recursively. each_block and flatten_block
+ * src-paths contribute both the top-level field and the qualified nested path.
  *
- * Nested record fields are handled recursively: covering "address.city"
- * also counts as covering "address" (the parent prefix).
+ * Coverage is deliberately *structural only*: a field a note block describes in
+ * prose is uncovered by definition. NL interpretation belongs to nl-refs, and
+ * policy judgements ("optional fields shouldn't count") belong to lint.
  *
- * This module defines the shared types (consumed by both the CLI and the LSP)
- * and the addPathAndPrefixes() path utility that both consumers use to build
- * their respective covered-path sets.  The higher-level computeMappingCoverage
- * function lives in vscode-satsuma/server/src/coverage.ts because it requires
- * LSP-specific WorkspaceIndex and FieldInfo types.
+ * This module does not own an index. Callers supply a {@link CoverageSchemaResolver}
+ * that adapts their own workspace model — the LSP's `WorkspaceIndex`, the CLI's
+ * `ExtractedWorkspace`, or a browser-side viz model — to the minimal field-tree
+ * shape the walk needs. That keeps the semantics here and the plumbing there.
+ *
+ * Path-set expansion rules live in coverage-paths.ts.
  */
 
-// ── Public types ────────────────────────────────────────────────────────────
+import { child, children, labelText, sourceRefStructuralText } from "./cst-utils.js";
+import { addPathAndPrefixes, isCoveredFieldPath } from "./coverage-paths.js";
+import type { SyntaxNode, Tree } from "./types.js";
+
+// ── Resolver input contract ─────────────────────────────────────────────────
+
+/**
+ * The minimum a consumer must expose about one declared field.
+ *
+ * Deliberately narrower than either the CLI's `FieldDecl` or the LSP's
+ * `FieldInfo`: coverage needs a name to build the path, children to recurse,
+ * and (optionally) a declaration row so downstream UIs can offer a jump link.
+ */
+export interface CoverageField {
+  /** Field name as declared, with Satsuma backtick quoting already stripped. */
+  name: string;
+  /** Nested declarations for record / list_of record fields. */
+  children?: CoverageField[];
+  /**
+   * 0-indexed declaration row within the file identified by
+   * {@link CoverageSchemaDefinition.uri}. Omit it when the consumer has no
+   * trustworthy position — never substitute 0, which reads as "line 1" and
+   * sends editor-jump links to the wrong place.
+   */
+  line?: number;
+}
+
+/** One schema resolved for coverage: where it is declared and what it declares. */
+export interface CoverageSchemaDefinition {
+  /** File URI (LSP) or absolute path (CLI) of the declaring file. */
+  uri: string;
+  /** Top-level fields, in declaration order; nested fields hang off `children`. */
+  fields: CoverageField[];
+}
+
+/**
+ * Resolve a schema reference as written in a `source {}` / `target {}` block
+ * (bare name or `ns::name`) to its definition, or null when it cannot be
+ * resolved. Unresolvable schemas are skipped rather than reported: coverage
+ * is not a validation pass, and `validate` already flags missing refs.
+ */
+export type CoverageSchemaResolver = (schemaId: string) => CoverageSchemaDefinition | null;
+
+// ── Public result types ─────────────────────────────────────────────────────
 
 /**
  * Coverage status for a single field (leaf or record) in a schema.
@@ -32,11 +83,12 @@ export interface FieldCoverageEntry {
   /** URI of the file where the schema is defined. */
   uri: string;
   /**
-   * 0-indexed line number of the field declaration.
-   * Set by the consumer from its field-position data (LSP: Range.start.line;
-   * CLI: 0 when not available from the index).
+   * 0-indexed line number of the field declaration, propagated from
+   * {@link CoverageField.line}. Absent when the consumer could not supply a
+   * trustworthy position; consumers rendering jump links must handle that
+   * rather than assume 0.
    */
-  line: number;
+  line?: number;
   /** True when at least one arrow in the mapping covers this field. */
   mapped: boolean;
 }
@@ -61,30 +113,262 @@ export interface MappingCoverageResult {
   schemas: SchemaCoverageResult[];
 }
 
-// ── Path utilities ──────────────────────────────────────────────────────────
+// ── Entry point ─────────────────────────────────────────────────────────────
 
 /**
- * Register a path and all its ancestor prefixes in the covered-paths set.
+ * Compute per-field coverage for one named mapping in one parsed file.
  *
- * Strips array-notation brackets (`[]`) before splitting so that list-traversal
- * paths like `"items[].id"` are registered as `"items"`, `"items.id"`, and `"id"`.
+ * Returns `{ schemas: [] }` when the mapping is not found in this tree or has
+ * no body — callers scoping by mapping name should check for that rather than
+ * treat an empty result as "nothing is covered". A schema the resolver cannot
+ * resolve is omitted from the result entirely.
  *
- * Registering ancestors means a top-level field `"address"` is considered
- * covered when an arrow targets the nested path `"address.city"` — a consumer
- * that checks `coveredPaths.has(f.name)` will correctly find the parent covered.
- *
- * Example: addPathAndPrefixes(set, "orders.item_id")
- *   → set now contains "orders", "orders.item_id", "item_id"
+ * @param tree         Parse tree of the file declaring the mapping.
+ * @param mappingName  Mapping label to report on; matched against top-level
+ *                     and namespaced `mapping` blocks in this tree.
+ * @param resolveSchema Adapter from the caller's index to field trees.
  */
-export function addPathAndPrefixes(set: Set<string>, path: string): void {
-  if (!path) return;
-  // Strip array notation: "items[].id" → "items.id"
-  const normalised = path.replace(/\[\]/g, "");
-  const parts = normalised.split(".");
-  let prefix = "";
-  for (const part of parts) {
-    prefix = prefix ? `${prefix}.${part}` : part;
-    set.add(prefix);
-    set.add(part); // bare leaf so "city" matches even if the full path is "address.city"
+export function computeMappingCoverage(
+  tree: Tree,
+  mappingName: string,
+  resolveSchema: CoverageSchemaResolver,
+): MappingCoverageResult {
+  const mappingNode = findMappingBlock(tree, mappingName);
+  if (!mappingNode) return { schemas: [] };
+
+  const body = child(mappingNode, "mapping_body");
+  if (!body) return { schemas: [] };
+
+  const sourceIds = getSchemaIdsFromBlock(body, "source_block");
+  const targetIds = getSchemaIdsFromBlock(body, "target_block");
+
+  // Collect all explicit arrow source paths and target paths from the mapping.
+  const coveredSrcPaths = new Set<string>();
+  const coveredTgtPaths = new Set<string>();
+  collectBodyPaths(body, coveredSrcPaths, coveredTgtPaths);
+
+  const schemas: SchemaCoverageResult[] = [];
+
+  for (const schemaId of sourceIds) {
+    const def = resolveSchema(schemaId);
+    if (!def) continue;
+    schemas.push({
+      schemaId,
+      role: "source",
+      fields: buildFieldCoverage(def.fields, def.uri, "", coveredSrcPaths),
+    });
   }
+
+  for (const schemaId of targetIds) {
+    const def = resolveSchema(schemaId);
+    if (!def) continue;
+    schemas.push({
+      schemaId,
+      role: "target",
+      fields: buildFieldCoverage(def.fields, def.uri, "", coveredTgtPaths),
+    });
+  }
+
+  return { schemas };
+}
+
+// ── Path collection ─────────────────────────────────────────────────────────
+
+/**
+ * Walk all arrows (including inside each/flatten) in the mapping body and
+ * populate the covered src-path and tgt-path sets.
+ */
+function collectBodyPaths(
+  body: SyntaxNode,
+  srcPaths: Set<string>,
+  tgtPaths: Set<string>,
+): void {
+  for (const node of body.namedChildren) {
+    switch (node.type) {
+      case "map_arrow":
+        for (const sp of children(node, "src_path")) addPathAndPrefixes(srcPaths, pathText(sp));
+        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
+        break;
+      case "computed_arrow":
+        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
+        break;
+      case "each_block":
+        collectEachPaths(node, srcPaths, tgtPaths, null, null);
+        break;
+      case "flatten_block":
+        collectFlattenPaths(node, srcPaths, tgtPaths);
+        break;
+    }
+  }
+}
+
+/**
+ * Recursively collect paths from an each_block.
+ * Arrows inside an each_block are relative to the iteration field.
+ *
+ * Nullability contract for outerSrcBase / outerTgtBase:
+ *   null     — no enclosing each_block has established a base path yet; this
+ *               is the top-level call for this each_block, so paths from the
+ *               block's own src_path/tgt_path become the new base.
+ *   non-null — an enclosing each_block already established a prefix; paths in
+ *               this nested block are qualified relative to that prefix via
+ *               qualify(outerBase, localPath).
+ *
+ * Recursive call sites pass srcBase/tgtBase (the base resolved for this level)
+ * as the outer values for any nested each_blocks found within this node.
+ */
+function collectEachPaths(
+  node: SyntaxNode,
+  srcPaths: Set<string>,
+  tgtPaths: Set<string>,
+  outerSrcBase: string | null,
+  outerTgtBase: string | null,
+): void {
+  const rawSrc = child(node, "src_path");
+  const rawTgt = child(node, "tgt_path");
+  const srcBase = rawSrc ? qualify(outerSrcBase, pathText(rawSrc)) : outerSrcBase;
+  const tgtBase = rawTgt ? qualify(outerTgtBase, pathText(rawTgt)) : outerTgtBase;
+
+  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
+  if (tgtBase) addPathAndPrefixes(tgtPaths, tgtBase);
+
+  for (const ch of node.namedChildren) {
+    if (ch.type === "map_arrow") {
+      for (const sp of children(ch, "src_path")) {
+        const leaf = pathText(sp);
+        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
+      }
+      const tp = child(ch, "tgt_path");
+      if (tp) {
+        const leaf = pathText(tp);
+        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
+      }
+    } else if (ch.type === "computed_arrow") {
+      const tp = child(ch, "tgt_path");
+      if (tp) {
+        const leaf = pathText(tp);
+        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
+      }
+    } else if (ch.type === "each_block") {
+      collectEachPaths(ch, srcPaths, tgtPaths, srcBase, tgtBase);
+    }
+  }
+}
+
+/**
+ * Collect paths from a flatten_block.
+ *
+ * Unlike each_block, only the *source* side has a base path: flatten unnests a
+ * source list into flat target fields, so target paths inside the block are
+ * already schema-root-relative and must not be prefixed.
+ */
+function collectFlattenPaths(
+  node: SyntaxNode,
+  srcPaths: Set<string>,
+  tgtPaths: Set<string>,
+): void {
+  const rawSrc = child(node, "src_path");
+  const srcBase = rawSrc ? pathText(rawSrc) : null;
+  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
+
+  for (const ch of node.namedChildren) {
+    if (ch.type === "map_arrow") {
+      for (const sp of children(ch, "src_path")) {
+        const leaf = pathText(sp);
+        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
+      }
+      const tp = child(ch, "tgt_path");
+      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
+    } else if (ch.type === "computed_arrow") {
+      const tp = child(ch, "tgt_path");
+      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
+    }
+  }
+}
+
+function qualify(base: string | null, leaf: string): string {
+  return base ? `${base}.${leaf}` : leaf;
+}
+
+// ── Field coverage building ─────────────────────────────────────────────────
+
+/**
+ * Recursively build the FieldCoverageEntry list for a schema's fields.
+ * `prefix` is the path from the schema root to the current level; record
+ * fields emit an entry of their own *and* entries for every descendant.
+ */
+function buildFieldCoverage(
+  fields: CoverageField[],
+  uri: string,
+  prefix: string,
+  coveredPaths: Set<string>,
+): FieldCoverageEntry[] {
+  const result: FieldCoverageEntry[] = [];
+  for (const f of fields) {
+    const path = prefix ? `${prefix}.${f.name}` : f.name;
+    const entry: FieldCoverageEntry = {
+      path,
+      uri,
+      mapped: isCoveredFieldPath(path, coveredPaths),
+    };
+    // Omit `line` entirely when unknown rather than defaulting to 0 — see the
+    // CoverageField.line contract.
+    if (f.line !== undefined) entry.line = f.line;
+    result.push(entry);
+    if (f.children && f.children.length > 0) {
+      result.push(...buildFieldCoverage(f.children, uri, path, coveredPaths));
+    }
+  }
+  return result;
+}
+
+// ── CST helpers ─────────────────────────────────────────────────────────────
+
+/** Find a `mapping` block by label, at file scope or inside a namespace block. */
+function findMappingBlock(tree: Tree, name: string): SyntaxNode | null {
+  for (const node of tree.rootNode.namedChildren) {
+    if (node.type === "mapping_block" && labelText(node) === name) return node;
+    if (node.type === "namespace_block") {
+      for (const ch of node.namedChildren) {
+        if (ch.type === "mapping_block" && labelText(ch) === name) return ch;
+      }
+    }
+  }
+  return null;
+}
+
+/** Schema references declared in the mapping's `source {}` or `target {}` block. */
+function getSchemaIdsFromBlock(body: SyntaxNode, blockType: "source_block" | "target_block"): string[] {
+  for (const node of body.namedChildren) {
+    if (node.type === blockType) {
+      const ids: string[] = [];
+      for (const ref of children(node, "source_ref")) {
+        const name = sourceRefStructuralText(ref);
+        if (name) ids.push(name);
+      }
+      return ids;
+    }
+  }
+  return [];
+}
+
+/**
+ * Normalise a src_path / tgt_path node to a plain dotted path.
+ *
+ * Two normalisations, both required before the path can be qualified or
+ * matched against a declared field path:
+ *
+ *  1. Backtick quoting is stripped (`` `order id` `` → `order id`).
+ *  2. A leading `.` is stripped. Inside `each`/`flatten` blocks the spec writes
+ *     element-relative paths as `.SKU` (spec §4.6), which the grammar parses as
+ *     `relative_field_path`. Keeping the dot would make qualify() produce
+ *     `items..SKU`, whose declared counterpart `items.SKU` then never matches —
+ *     so every nested field inside an each/flatten block would be reported
+ *     uncovered despite an explicit arrow (sc-xnxp). The CLI's arrow index
+ *     already applies the same `^\.` strip in buildFieldArrows().
+ */
+function pathText(node: SyntaxNode): string {
+  const text = node.text;
+  const unquoted = text.startsWith("`") && text.endsWith("`") ? text.slice(1, -1) : text;
+  return unquoted.startsWith(".") ? unquoted.slice(1) : unquoted;
 }

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -62,6 +62,18 @@ export interface CoverageSchemaDefinition {
   uri: string;
   /** Top-level fields, in declaration order; nested fields hang off `children`. */
   fields: CoverageField[];
+  /**
+   * Canonical id to report for this schema, when it differs from the reference
+   * as written in the mapping. Defaults to the written reference.
+   *
+   * Resolving a reference is the consumer's job, and the canonical id is an
+   * output of that resolution: a namespaced workspace can name the same schema
+   * `orders` inside its own namespace and `crm::orders` from outside. Reporting
+   * both forms would split one schema into two entries when results are rolled
+   * up across mappings, so a consumer that resolves references should report the
+   * resolved key here.
+   */
+  schemaId?: string;
 }
 
 /**
@@ -153,7 +165,7 @@ export function computeMappingCoverage(
     const def = resolveSchema(schemaId);
     if (!def) continue;
     schemas.push({
-      schemaId,
+      schemaId: def.schemaId ?? schemaId,
       role: "source",
       fields: buildFieldCoverage(def.fields, def.uri, "", coveredSrcPaths),
     });
@@ -163,7 +175,7 @@ export function computeMappingCoverage(
     const def = resolveSchema(schemaId);
     if (!def) continue;
     schemas.push({
-      schemaId,
+      schemaId: def.schemaId ?? schemaId,
       role: "target",
       fields: buildFieldCoverage(def.fields, def.uri, "", coveredTgtPaths),
     });

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -37,6 +37,15 @@ export type {
   CoverageSchemaResolver,
 } from "./coverage.js";
 export { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
+export { aggregateCoverage, summarizeFieldCoverage } from "./coverage-rollup.js";
+export type {
+  MappingCoverageInput,
+  CoverageTotals,
+  AggregateSchemaCoverage,
+  RoleTotals,
+  NamespaceCoverage,
+  AggregateCoverage,
+} from "./coverage-rollup.js";
 export { format } from "./format.js";
 export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
 export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -27,9 +27,16 @@ export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";
 export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
-export { addPathAndPrefixes } from "./coverage.js";
-export type { FieldCoverageEntry, SchemaCoverageResult, MappingCoverageResult } from "./coverage.js";
-export { buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
+export { computeMappingCoverage } from "./coverage.js";
+export type {
+  FieldCoverageEntry,
+  SchemaCoverageResult,
+  MappingCoverageResult,
+  CoverageField,
+  CoverageSchemaDefinition,
+  CoverageSchemaResolver,
+} from "./coverage.js";
+export { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
 export { format } from "./format.js";
 export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
 export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -37,7 +37,7 @@ export type {
   CoverageSchemaResolver,
 } from "./coverage.js";
 export { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
-export { aggregateCoverage, summarizeFieldCoverage } from "./coverage-rollup.js";
+export { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "./coverage-rollup.js";
 export type {
   MappingCoverageInput,
   CoverageTotals,

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -1,10 +1,82 @@
 /**
- * coverage-paths.test.js — Shared path-set helpers for nested field coverage.
+ * coverage-paths.test.js — Field-path set helpers for nested field coverage.
+ *
+ * These tests pin the path-normalisation rules that every coverage consumer
+ * depends on (CLI `coverage`/`fields --unmapped-by`, the VS Code gutter, the
+ * viz overlay). The higher-level walk that produces these paths is tested in
+ * coverage.test.js.
  */
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildCoveredFieldSet, isCoveredFieldPath } from "@satsuma/core";
+import { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "@satsuma/core";
+
+describe("addPathAndPrefixes()", () => {
+  it("registers a leaf-only path unchanged", () => {
+    // The degenerate case: a top-level field name has no prefixes to expand.
+    const set = new Set();
+    addPathAndPrefixes(set, "id");
+    assert.deepEqual([...set], ["id"]);
+  });
+
+  it("registers every ancestor prefix of a dotted path", () => {
+    // Coverage of "address" must fire when an arrow targets "address.city".
+    // Without prefix registration the parent record always reads as unmapped.
+    const set = new Set();
+    addPathAndPrefixes(set, "address.city");
+    assert.ok(set.has("address"), "parent prefix 'address' must be registered");
+    assert.ok(set.has("address.city"), "full path must be registered");
+    assert.ok(set.has("city"), "bare leaf 'city' must be registered for cross-level matching");
+  });
+
+  it("expands prefixes recursively, not just one level deep", () => {
+    // Three-level paths appear in real workbooks; a one-level implementation
+    // would leave "a.b" unregistered and report the middle record uncovered.
+    const set = new Set();
+    addPathAndPrefixes(set, "a.b.c");
+    assert.ok(set.has("a"));
+    assert.ok(set.has("a.b"));
+    assert.ok(set.has("a.b.c"));
+    assert.ok(set.has("b"));
+    assert.ok(set.has("c"));
+  });
+
+  it("strips [] array notation before splitting", () => {
+    // Schemas declare "items", arrows write "items[].id". Without stripping,
+    // the declared field would never match the arrow that populates it.
+    const set = new Set();
+    addPathAndPrefixes(set, "items[].id");
+    assert.ok(set.has("items"), "'items' must be registered after stripping '[]'");
+    assert.ok(set.has("items.id"));
+    assert.ok(set.has("id"));
+    assert.ok(!set.has("items[]"), "bracket-suffixed form must NOT appear in the set");
+  });
+
+  it("registers the bare field name for a list-root path", () => {
+    // An arrow targeting the whole list ("items[]") covers the "items" field.
+    const set = new Set();
+    addPathAndPrefixes(set, "items[]");
+    assert.deepEqual([...set], ["items"]);
+  });
+
+  it("ignores an empty path", () => {
+    // Malformed arrows can yield empty path text; the set must stay clean
+    // rather than gaining an "" entry that matches nothing but inflates counts.
+    const set = new Set();
+    addPathAndPrefixes(set, "");
+    assert.equal(set.size, 0);
+  });
+
+  it("is idempotent for a repeated path", () => {
+    // Several arrows commonly target the same field; re-registering must not
+    // change the set, so coverage counts cannot drift with arrow count.
+    const set = new Set();
+    addPathAndPrefixes(set, "name");
+    const sizeAfterFirst = set.size;
+    addPathAndPrefixes(set, "name");
+    assert.equal(set.size, sizeAfterFirst);
+  });
+});
 
 describe("buildCoveredFieldSet()", () => {
   it("marks nested field paths and their parents as covered", () => {

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -1,0 +1,317 @@
+/**
+ * coverage-rollup.test.js — Aggregating per-mapping coverage across a workspace.
+ *
+ * The distinction these tests defend: "uncovered by this mapping" and
+ * "uncovered by every mapping" are different claims, and a reviewer acting on
+ * the wrong one deletes a field that another mapping populates. Cases here pin
+ * the union rule, the leaf-counting rule behind every percentage, and the
+ * namespace/workspace rollups.
+ *
+ * Inputs are built from real parse trees via computeMappingCoverage so the
+ * aggregation is tested against the shape it actually receives, not a
+ * hand-written approximation of it.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initParser,
+  getParser,
+  computeMappingCoverage,
+  extractSchemas,
+  extractMappings,
+  aggregateCoverage,
+  summarizeFieldCoverage,
+} from "@satsuma/core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+before(async () => { await initParser(WASM_PATH); });
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Project extractSchemas() FieldDecls onto core's minimal coverage shape. */
+function toCoverageFields(fields) {
+  return fields.map((f) => ({
+    name: f.name,
+    line: f.startRow,
+    children: f.children ? toCoverageFields(f.children) : undefined,
+  }));
+}
+
+/** Namespace-qualified id, matching what the CLI's index keys use. */
+function qualify(namespace, name) {
+  return namespace ? `${namespace}::${name}` : name;
+}
+
+/**
+ * Parse a workspace, run coverage for every named mapping in it, and aggregate.
+ * This is the whole pipeline a consumer runs, so a break anywhere in it fails here.
+ */
+function aggregate(source) {
+  const tree = getParser().parse(source);
+  const byId = new Map();
+  for (const s of extractSchemas(tree.rootNode)) {
+    byId.set(qualify(s.namespace, s.name), s);
+  }
+  const resolveSchema = (schemaId) => {
+    const schema = byId.get(schemaId);
+    return schema ? { uri: "file:///test.stm", fields: toCoverageFields(schema.fields) } : null;
+  };
+  const inputs = extractMappings(tree.rootNode)
+    .filter((m) => m.name !== null)
+    .map((m) => ({
+      mappingId: qualify(m.namespace, m.name),
+      result: computeMappingCoverage(tree, m.name, resolveSchema),
+    }));
+  return { inputs, aggregate: aggregateCoverage(inputs) };
+}
+
+/** The aggregate entry for one schema and role. */
+function entry(result, role, schemaId) {
+  const found = result.schemas.find((s) => s.role === role && s.schemaId === schemaId);
+  assert.ok(found, `expected ${role} ${schemaId} in ${JSON.stringify(result.schemas.map((s) => [s.role, s.schemaId]))}`);
+  return found;
+}
+
+/** Whether the aggregate says `path` is covered by at least one mapping. */
+function aggregateMapped(result, role, schemaId, path) {
+  const field = entry(result, role, schemaId).fields.find((f) => f.path === path);
+  assert.ok(field, `expected field ${path} on ${role} ${schemaId}`);
+  return field.mapped;
+}
+
+// ── Counting rule ───────────────────────────────────────────────────────────
+
+describe("summarizeFieldCoverage()", () => {
+  it("counts leaves only, excluding the record that contains them", () => {
+    // A record and its children would otherwise be counted at two levels,
+    // letting a schema's nesting depth move the headline number on its own.
+    // Here the leaves are line1, line2 and id — `address` is not counted.
+    const totals = summarizeFieldCoverage([
+      { path: "address", uri: "u", mapped: true },
+      { path: "address.line1", uri: "u", mapped: true },
+      { path: "address.line2", uri: "u", mapped: false },
+      { path: "id", uri: "u", mapped: true },
+    ]);
+    assert.deepEqual(totals, { covered: 2, total: 3, pct: 67 });
+  });
+
+  it("does not let a covered record vouch for its uncovered leaves", () => {
+    // A record's mapped flag is true whenever ANY descendant is covered, since
+    // addPathAndPrefixes registers ancestor prefixes. Inheriting from it would
+    // turn "one of two address fields is mapped" into "both are" — the
+    // overstatement 3cc-iedv records the trade-off for.
+    const totals = summarizeFieldCoverage([
+      { path: "address", uri: "u", mapped: true },
+      { path: "address.line1", uri: "u", mapped: true },
+      { path: "address.line2", uri: "u", mapped: false },
+    ]);
+    assert.deepEqual(totals, { covered: 1, total: 2, pct: 50 });
+  });
+
+  it("reports 0% rather than dividing by zero for a schema with no fields", () => {
+    assert.deepEqual(summarizeFieldCoverage([]), { covered: 0, total: 0, pct: 0 });
+  });
+
+  it("rounds the percentage to a whole number", () => {
+    // The CLI table and --fail-under both compare whole numbers, so rounding
+    // has to happen once, here, not per renderer.
+    const totals = summarizeFieldCoverage([
+      { path: "a", uri: "u", mapped: true },
+      { path: "b", uri: "u", mapped: false },
+      { path: "c", uri: "u", mapped: false },
+    ]);
+    assert.equal(totals.pct, 33);
+  });
+});
+
+// ── Union rule ──────────────────────────────────────────────────────────────
+
+describe("aggregateCoverage() — union across mappings", () => {
+  // Two mappings populate different halves of one target schema. Between them
+  // they cover it completely; neither does alone.
+  const SRC = `
+schema a { id INT }
+schema b { memo STRING }
+schema tgt { id INT memo STRING spare STRING }
+mapping load_ids {
+  source { a }
+  target { tgt }
+  id -> id
+}
+mapping load_memos {
+  source { b }
+  target { tgt }
+  memo -> memo
+}`;
+
+  it("marks a field covered when any single mapping populates it", () => {
+    // The headline aggregate semantic. `memo` is untouched by "load_ids", so a
+    // naive intersection or last-writer-wins would report it uncovered.
+    const { aggregate: result } = aggregate(SRC);
+    assert.equal(aggregateMapped(result, "target", "tgt", "id"), true);
+    assert.equal(aggregateMapped(result, "target", "tgt", "memo"), true);
+  });
+
+  it("keeps a field uncovered only when no mapping populates it", () => {
+    // The strong claim, and the one worth acting on: nothing in the workspace
+    // writes `spare`.
+    const { aggregate: result } = aggregate(SRC);
+    assert.equal(aggregateMapped(result, "target", "tgt", "spare"), false);
+  });
+
+  it("distinguishes per-mapping from aggregate for the same field", () => {
+    // The confusion this module exists to prevent, asserted directly: `memo` is
+    // uncovered in "load_ids"' own result and covered in the aggregate.
+    const { inputs, aggregate: result } = aggregate(SRC);
+    const loadIds = inputs.find((i) => i.mappingId === "load_ids");
+    const perMapping = loadIds.result.schemas
+      .find((s) => s.role === "target")
+      .fields.find((f) => f.path === "memo");
+    assert.equal(perMapping.mapped, false, "per-mapping: 'load ids' does not write memo");
+    assert.equal(aggregateMapped(result, "target", "tgt", "memo"), true, "aggregate: some mapping writes memo");
+  });
+
+  it("records every mapping that references a schema in a role", () => {
+    // Output has to name the mappings behind an aggregate figure, or a reviewer
+    // cannot tell where to go and fix a gap.
+    const { aggregate: result } = aggregate(SRC);
+    assert.deepEqual(entry(result, "target", "tgt").mappings, ["load_ids", "load_memos"]);
+  });
+
+  it("counts a schema once per role, not once per referencing mapping", () => {
+    // tgt is a target of two mappings; double counting it would halve the
+    // workspace percentage for no reason.
+    const { aggregate: result } = aggregate(SRC);
+    assert.deepEqual(entry(result, "target", "tgt").totals, { covered: 2, total: 3, pct: 67 });
+  });
+});
+
+describe("aggregateCoverage() — roles", () => {
+  it("reports a schema used as both source and target as two entries", () => {
+    // A staging schema is commonly written by one mapping and read by the next.
+    // Blending the two would make "is it populated?" unanswerable.
+    const src = `
+schema raw { id INT }
+schema stage { id INT memo STRING }
+schema final { id INT }
+mapping load {
+  source { raw }
+  target { stage }
+  id -> id
+}
+mapping publish {
+  source { stage }
+  target { final }
+  id -> id
+}`;
+    const { aggregate: result } = aggregate(src);
+    assert.deepEqual(entry(result, "target", "stage").mappings, ["load"]);
+    assert.deepEqual(entry(result, "source", "stage").mappings, ["publish"]);
+    // `memo` is neither written by load nor read by publish — a gap in both roles.
+    assert.equal(aggregateMapped(result, "target", "stage", "memo"), false);
+    assert.equal(aggregateMapped(result, "source", "stage", "memo"), false);
+  });
+
+  it("keeps source and target totals separate in the workspace rollup", () => {
+    // Unconsumed source fields and unpopulated target fields are different
+    // findings; a single blended percentage would hide both.
+    const src = `
+schema src { id INT unused INT }
+schema tgt { id INT memo STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+}`;
+    const { aggregate: result } = aggregate(src);
+    assert.deepEqual(result.workspace.source, { covered: 1, total: 2, pct: 50 });
+    assert.deepEqual(result.workspace.target, { covered: 1, total: 2, pct: 50 });
+  });
+});
+
+// ── Namespace and workspace rollups ─────────────────────────────────────────
+
+describe("aggregateCoverage() — namespace subtotals", () => {
+  const SRC = `
+namespace crm {
+  schema customers { id INT email STRING }
+  schema contacts { id INT }
+  mapping crm_load {
+    source { crm::customers }
+    target { crm::contacts }
+    id -> id
+  }
+}
+namespace billing {
+  schema invoices { id INT total DECIMAL memo STRING }
+  schema ledger { id INT total DECIMAL }
+  mapping billing_load {
+    source { billing::invoices }
+    target { billing::ledger }
+    id -> id
+    total -> total
+  }
+}`;
+
+  it("groups subtotals by the namespace a schema is declared in", () => {
+    // Attribution follows the schema, not the referencing mapping: the question
+    // is how well covered *this namespace's* schemas are.
+    const { aggregate: result } = aggregate(SRC);
+    const crm = result.namespaces.find((n) => n.namespace === "crm");
+    const billing = result.namespaces.find((n) => n.namespace === "billing");
+    assert.deepEqual(crm.source, { covered: 1, total: 2, pct: 50 }, "crm::customers: id read, email not");
+    assert.deepEqual(billing.source, { covered: 2, total: 3, pct: 67 }, "billing::invoices: memo not read");
+    assert.deepEqual(billing.target, { covered: 2, total: 2, pct: 100 }, "billing::ledger fully populated");
+  });
+
+  it("workspace totals equal the sum of the namespace subtotals", () => {
+    // If these can disagree, one of the two numbers in the report is a lie.
+    const { aggregate: result } = aggregate(SRC);
+    const summed = (role) => result.namespaces.reduce(
+      (acc, ns) => ({ covered: acc.covered + ns[role].covered, total: acc.total + ns[role].total }),
+      { covered: 0, total: 0 },
+    );
+    assert.deepEqual(summed("source"), { covered: result.workspace.source.covered, total: result.workspace.source.total });
+    assert.deepEqual(summed("target"), { covered: result.workspace.target.covered, total: result.workspace.target.total });
+  });
+
+  it("groups schemas declared at file scope under a null namespace", () => {
+    // A workspace with no namespaces must still produce exactly one group, so
+    // renderers need no special case for the un-namespaced workspace.
+    const { aggregate: result } = aggregate(`
+schema src { id INT }
+schema tgt { id INT }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+}`);
+    assert.deepEqual(result.namespaces.map((n) => n.namespace), [null]);
+    assert.deepEqual(result.namespaces[0].target, result.workspace.target);
+  });
+});
+
+// ── Degenerate inputs ───────────────────────────────────────────────────────
+
+describe("aggregateCoverage() — degenerate inputs", () => {
+  it("returns empty rollups for no mappings at all", () => {
+    // `satsuma coverage` on a schema-only file must report nothing rather than
+    // 0% of nothing, which would look like a failure.
+    const result = aggregateCoverage([]);
+    assert.deepEqual(result.schemas, []);
+    assert.deepEqual(result.namespaces, []);
+    assert.deepEqual(result.workspace.target, { covered: 0, total: 0, pct: 0 });
+  });
+
+  it("skips a mapping whose coverage resolved to no schemas", () => {
+    // computeMappingCoverage returns { schemas: [] } for a mapping it cannot
+    // find or resolve; that must not create a phantom zero-coverage entry.
+    const result = aggregateCoverage([{ mappingId: "ghost", result: { schemas: [] } }]);
+    assert.deepEqual(result.schemas, []);
+  });
+});

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -1,82 +1,414 @@
 /**
- * coverage.test.js — Unit tests for the coverage path utility.
+ * coverage.test.js — Authoritative tests for computeMappingCoverage().
  *
- * Tests addPathAndPrefixes(), the canonical path-normalisation function used
- * by both the CLI (--unmapped-by) and the VS Code gutter decorations to build
- * the set of covered field paths from a mapping's arrows.
+ * These cases moved here from satsuma-lsp when the computation was relocated
+ * into core (sl-gsxu). They are the single home for coverage *semantics*:
+ * which arrows cover which declared fields, how nested paths and each/flatten
+ * blocks contribute, and how declaration positions propagate. The LSP keeps
+ * only adapter-wiring tests, and the CLI tests only its own rendering.
  *
- * Higher-level computeMappingCoverage tests remain in
- * vscode-satsuma/server/test/coverage.test.js because they depend on the LSP's
- * WorkspaceIndex and FieldInfo types.  Only the shared path utility is tested
- * here to avoid duplication.
+ * The resolver used here is built from core's own extractSchemas(), which is
+ * also the shape the CLI adapts to — so a break in the resolver contract
+ * shows up in this suite rather than in a consumer.
  */
 
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
-import { addPathAndPrefixes } from "@satsuma/core";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { initParser, getParser, computeMappingCoverage, extractSchemas } from "@satsuma/core";
 
-describe("addPathAndPrefixes", () => {
-  it("adds a flat field name to the set", () => {
-    // Simple case: "id" → {id}. Verifies the function handles leaf-only paths.
-    const set = new Set();
-    addPathAndPrefixes(set, "id");
-    assert.ok(set.has("id"));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+const TEST_URI = "file:///test.stm";
+
+before(async () => { await initParser(WASM_PATH); });
+
+// ── Test resolver ───────────────────────────────────────────────────────────
+
+/** Project extractSchemas() FieldDecls onto core's minimal coverage shape. */
+function toCoverageFields(fields) {
+  return fields.map((f) => ({
+    name: f.name,
+    line: f.startRow,
+    children: f.children ? toCoverageFields(f.children) : undefined,
+  }));
+}
+
+/**
+ * Run computeMappingCoverage over single-file source text, resolving schemas
+ * from that same file.
+ */
+function coverage(source, mappingName) {
+  const tree = getParser().parse(source);
+  const byId = new Map();
+  for (const s of extractSchemas(tree.rootNode)) {
+    byId.set(s.namespace ? `${s.namespace}::${s.name}` : s.name, s);
+  }
+  return computeMappingCoverage(tree, mappingName, (schemaId) => {
+    const schema = byId.get(schemaId);
+    return schema ? { uri: TEST_URI, fields: toCoverageFields(schema.fields) } : null;
+  });
+}
+
+/** Coverage entries for the single schema playing `role` in the result. */
+function forRole(result, role) {
+  const schema = result.schemas.find((s) => s.role === role);
+  assert.ok(schema, `expected a ${role} schema in ${JSON.stringify(result.schemas.map((s) => s.role))}`);
+  return schema;
+}
+
+/** Assert `path` appears exactly once and carries the expected mapped flag. */
+function assertMapped(schema, path, expected) {
+  const matches = schema.fields.filter((f) => f.path === path);
+  assert.equal(matches.length, 1, `expected exactly one "${path}" entry in ${schema.fields.map((f) => f.path)}`);
+  assert.equal(matches[0].mapped, expected, `"${path}" should be mapped=${expected}`);
+}
+
+// ── Result structure ────────────────────────────────────────────────────────
+
+describe("computeMappingCoverage — result structure", () => {
+  const SRC = `
+schema src { id INT name STRING }
+schema tgt { id INT label STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+}`;
+
+  it("reports one entry per schema, tagged with the side it appears on", () => {
+    // Role is how consumers label output ("used as source" vs "mapped"), so a
+    // schema landing on the wrong side is a user-visible defect.
+    const result = coverage(SRC, "load");
+    assert.equal(result.schemas.length, 2);
+    assert.equal(forRole(result, "source").schemaId, "src");
+    assert.equal(forRole(result, "target").schemaId, "tgt");
   });
 
-  it("adds all ancestor prefixes for a dotted path", () => {
-    // addPathAndPrefixes must register all ancestors — coverage checks fire on
-    // "address" even when the arrow targets "address.city". Without prefix
-    // registration, the parent field would always appear unmapped.
-    const set = new Set();
-    addPathAndPrefixes(set, "address.city");
-    assert.ok(set.has("address"), "parent prefix 'address' must be registered");
-    assert.ok(set.has("address.city"), "full path must be registered");
-    assert.ok(set.has("city"), "bare leaf 'city' must be registered for cross-level matching");
+  it("returns no schemas when the named mapping is absent from the tree", () => {
+    // Callers scoping by --mapping must be able to distinguish "mapping not
+    // here" from "nothing covered"; an empty schema list is that signal.
+    assert.deepEqual(coverage(SRC, "nonexistent").schemas, []);
   });
 
-  it("registers all intermediate prefixes for a three-level path", () => {
-    // Ensures prefix expansion is recursive, not just one level deep.
-    const set = new Set();
-    addPathAndPrefixes(set, "a.b.c");
-    assert.ok(set.has("a"));
-    assert.ok(set.has("a.b"));
-    assert.ok(set.has("a.b.c"));
-    assert.ok(set.has("b"));
-    assert.ok(set.has("c"));
+  it("skips schemas the resolver cannot resolve rather than failing", () => {
+    // Coverage is not a validation pass — `validate` owns missing-ref
+    // reporting. An unresolvable target must not abort the source report.
+    const src = `
+schema src { id INT }
+mapping load {
+  source { src }
+  target { never_declared }
+  id -> id
+}`;
+    const result = coverage(src, "load");
+    assert.deepEqual(result.schemas.map((s) => s.schemaId), ["src"]);
   });
 
-  it("strips [] array notation before splitting", () => {
-    // List-traversal paths like "items[].id" must be normalised to "items.id"
-    // so that the field "items" (declared without brackets in the schema) is
-    // correctly matched as covered.
-    const set = new Set();
-    addPathAndPrefixes(set, "items[].id");
-    assert.ok(set.has("items"), "'items' must be registered after stripping '[]'");
-    assert.ok(set.has("items.id"));
-    assert.ok(set.has("id"));
-    assert.ok(!set.has("items[]"), "bracket-suffixed form must NOT appear in the set");
+  it("finds a mapping declared inside a namespace block", () => {
+    // Namespaced workspaces are the norm for platform files; a mapping nested
+    // in `namespace { }` must be reachable by its bare label.
+    const src = `
+namespace crm {
+  schema src { id INT }
+  schema tgt { id INT memo STRING }
+  mapping load {
+    source { crm::src }
+    target { crm::tgt }
+    id -> id
+  }
+}`;
+    const result = coverage(src, "load");
+    assert.equal(forRole(result, "target").schemaId, "crm::tgt");
+  });
+});
+
+// ── Target coverage ─────────────────────────────────────────────────────────
+
+describe("computeMappingCoverage — target fields", () => {
+  const SRC = `
+schema src { id INT name STRING extra INT }
+schema tgt { id INT label STRING memo STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+  name -> label
+}`;
+
+  it("marks a target field written by an arrow as mapped", () => {
+    const tgt = forRole(coverage(SRC, "load"), "target");
+    assertMapped(tgt, "id", true);
+    assertMapped(tgt, "label", true);
   });
 
-  it("handles a bare [] path (array root)", () => {
-    // An arrow that targets the root of a list ("items[]") should register "items".
-    const set = new Set();
-    addPathAndPrefixes(set, "items[]");
-    assert.ok(set.has("items"));
+  it("marks a declared target field no arrow writes as unmapped", () => {
+    // This is the review question the whole feature exists to answer.
+    assertMapped(forRole(coverage(SRC, "load"), "target"), "memo", false);
   });
 
-  it("does nothing for an empty string", () => {
-    // Empty paths can arise from malformed arrows; the function must be safe.
-    const set = new Set();
-    addPathAndPrefixes(set, "");
-    assert.equal(set.size, 0);
+  it("counts a computed arrow with no source as covering its target", () => {
+    // `-> stamp { now_utc() }` populates stamp; treating "no source path" as
+    // "not covered" would report generated columns as spec gaps.
+    const src = `
+schema src { id INT }
+schema tgt { id INT stamp STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+  -> stamp { now_utc() }
+}`;
+    assertMapped(forRole(coverage(src, "load"), "target"), "stamp", true);
+  });
+});
+
+// ── Source coverage ─────────────────────────────────────────────────────────
+
+describe("computeMappingCoverage — source fields", () => {
+  const SRC = `
+schema src { id INT name STRING unused INT }
+schema tgt { id INT label STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+  name -> label
+}`;
+
+  it("marks a source field read by an arrow as consumed", () => {
+    const src = forRole(coverage(SRC, "load"), "source");
+    assertMapped(src, "id", true);
+    assertMapped(src, "name", true);
   });
 
-  it("is idempotent — adding the same path twice does not grow the set", () => {
-    // Multiple arrows can target the same path; the set size should not change.
-    const set = new Set();
-    addPathAndPrefixes(set, "name");
-    const sizeAfterFirst = set.size;
-    addPathAndPrefixes(set, "name");
-    assert.equal(set.size, sizeAfterFirst);
+  it("marks a source field no arrow reads as unconsumed", () => {
+    // Unconsumed source fields are the "did we forget to map this?" signal.
+    assertMapped(forRole(coverage(SRC, "load"), "source"), "unused", false);
+  });
+
+  it("reports one entry per schema when a mapping reads several sources", () => {
+    // Multi-source mappings must not collapse into a single blended report;
+    // per-schema totals are what the CLI table renders.
+    const src = `
+schema a { id INT }
+schema b { rate DECIMAL }
+schema tgt { id INT rate DECIMAL }
+mapping load {
+  source { a b }
+  target { tgt }
+  id -> id
+  rate -> rate
+}`;
+    const sources = coverage(src, "load").schemas.filter((s) => s.role === "source");
+    assert.deepEqual(sources.map((s) => s.schemaId).sort(), ["a", "b"]);
+  });
+});
+
+// ── Nested record fields ────────────────────────────────────────────────────
+
+describe("computeMappingCoverage — nested record fields", () => {
+  const SRC = `
+schema src { address record { line1 STRING line2 STRING } name STRING }
+schema tgt { addr STRING name STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  address.line1 -> addr
+  name -> name
+}`;
+
+  it("emits an entry for the record itself and for every descendant", () => {
+    // Consumers render a field tree; omitting either level would leave holes
+    // in the gutter overlay and in per-schema totals.
+    const paths = forRole(coverage(SRC, "load"), "source").fields.map((f) => f.path);
+    assert.deepEqual(paths, ["address", "address.line1", "address.line2", "name"]);
+  });
+
+  it("covering a nested path covers its parent but not its siblings", () => {
+    // The PRD's headline nested case: `address.line1 -> addr` must not silently
+    // mark the whole `address` record's contents as done.
+    const src = forRole(coverage(SRC, "load"), "source");
+    assertMapped(src, "address", true);
+    assertMapped(src, "address.line1", true);
+    assertMapped(src, "address.line2", false);
+  });
+});
+
+// ── each / flatten blocks ───────────────────────────────────────────────────
+
+describe("computeMappingCoverage — each blocks", () => {
+  const SRC = `
+schema src { items list_of record { id INT val STRING } name STRING }
+schema tgt { lines list_of record { item_id INT } name STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  name -> name
+  each items -> lines {
+    id -> item_id
+  }
+}`;
+
+  it("counts the iterated list as consumed on the source schema", () => {
+    assertMapped(forRole(coverage(SRC, "load"), "source"), "items", true);
+  });
+
+  it("qualifies arrows inside the block against the iteration base", () => {
+    // `id -> item_id` inside `each items -> lines` means items.id, not a
+    // top-level `id`. Losing the base would mark the nested field uncovered
+    // and the sibling `val` covered by leaf-name collision.
+    const src = forRole(coverage(SRC, "load"), "source");
+    assertMapped(src, "items.id", true);
+    assertMapped(src, "items.val", false);
+  });
+
+  it("counts the each target list and its nested target field as mapped", () => {
+    const tgt = forRole(coverage(SRC, "load"), "target");
+    assertMapped(tgt, "lines", true);
+    assertMapped(tgt, "lines.item_id", true);
+  });
+
+  it("qualifies a nested each block against its enclosing base", () => {
+    // Two-level iteration is rare but real; the inner block's paths are
+    // relative to the outer block's, not to the schema root.
+    const src = `
+schema src { orders list_of record { lines list_of record { sku STRING qty INT } } }
+schema tgt { rows list_of record { items list_of record { code STRING } } }
+mapping load {
+  source { src }
+  target { tgt }
+  each orders -> rows {
+    each lines -> items {
+      sku -> code
+    }
+  }
+}`;
+    const source = forRole(coverage(src, "load"), "source");
+    assertMapped(source, "orders.lines.sku", true);
+    assertMapped(source, "orders.lines.qty", false);
+  });
+});
+
+describe("computeMappingCoverage — flatten blocks", () => {
+  // Written the way the spec does (§4.6): the flatten target is the target
+  // *schema*, and element fields are referenced with a leading dot.
+  const SRC = `
+schema src { contacts list_of record { email STRING phone STRING } id INT }
+schema tgt { primary_email STRING id INT spare STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+  flatten contacts -> tgt {
+    .email -> primary_email
+  }
+}`;
+
+  it("counts the unnested list and the arrow's qualified source path", () => {
+    const src = forRole(coverage(SRC, "load"), "source");
+    assertMapped(src, "contacts", true);
+    assertMapped(src, "contacts.email", true);
+    assertMapped(src, "contacts.phone", false);
+  });
+
+  it("treats target paths inside flatten as schema-root relative", () => {
+    // Unlike each, flatten has no target base: its `-> tgt` names the target
+    // schema, and the block unnests into flat fields, so `primary_email` must
+    // resolve at the schema root rather than under a `tgt.` prefix.
+    const tgt = forRole(coverage(SRC, "load"), "target");
+    assertMapped(tgt, "primary_email", true);
+    assertMapped(tgt, "spare", false);
+  });
+});
+
+// ── Element-relative paths (sc-xnxp) ────────────────────────────────────────
+
+describe("computeMappingCoverage — element-relative paths", () => {
+  it("resolves .-prefixed source and target paths inside an each block", () => {
+    // Regression lock for sc-xnxp: the leading dot of a relative_field_path
+    // must be stripped before qualifying, or `.id` becomes "items..id" and the
+    // declared field "items.id" never matches — reporting an explicitly mapped
+    // field as a spec gap. This is the spec's canonical syntax, not an edge case.
+    const src = `
+schema src { items list_of record { id INT val STRING } }
+schema tgt { lines list_of record { item_id INT spare INT } }
+mapping load {
+  source { src }
+  target { tgt }
+  each items -> lines {
+    .id -> .item_id
+  }
+}`;
+    const result = coverage(src, "load");
+    const source = forRole(result, "source");
+    assertMapped(source, "items.id", true);
+    assertMapped(source, "items.val", false);
+    const target = forRole(result, "target");
+    assertMapped(target, "lines.item_id", true);
+    assertMapped(target, "lines.spare", false);
+  });
+
+  it("resolves .-prefixed source paths inside a flatten block", () => {
+    // Same defect, flatten arm: `.SKU` under `flatten Order.LineItems`.
+    const src = `
+schema commerce_order { Order record { OrderId INT LineItems list_of record { SKU STRING Qty INT } } }
+schema flat { order_id INT sku STRING }
+mapping load {
+  source { commerce_order }
+  target { flat }
+  flatten Order.LineItems -> flat {
+    .SKU -> sku
+  }
+  Order.OrderId -> order_id
+}`;
+    const source = forRole(coverage(src, "load"), "source");
+    assertMapped(source, "Order.LineItems.SKU", true);
+    assertMapped(source, "Order.LineItems.Qty", false);
+  });
+});
+
+// ── Declaration positions ───────────────────────────────────────────────────
+
+describe("computeMappingCoverage — declaration positions", () => {
+  it("propagates the resolver's declaration row onto each entry", () => {
+    // Downstream UIs turn (uri, line) into an editor-jump link, so the row
+    // must survive the walk — including through nesting.
+    const src = `schema src {
+  address record {
+    line1 STRING
+  }
+}
+schema tgt { addr STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  address.line1 -> addr
+}`;
+    const fields = forRole(coverage(src, "load"), "source").fields;
+    // 0-indexed rows: `address` is on line 2 of the file, `line1` on line 3.
+    assert.equal(fields.find((f) => f.path === "address").line, 1);
+    assert.equal(fields.find((f) => f.path === "address.line1").line, 2);
+  });
+
+  it("omits line entirely when the resolver supplies no position", () => {
+    // A missing position must never surface as 0 — that reads as "line 1" and
+    // sends a jump link to the wrong place (sl-5sjp).
+    const tree = getParser().parse(`
+schema src { id INT }
+schema tgt { id INT memo STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+}`);
+    const result = computeMappingCoverage(tree, "load", (schemaId) =>
+      schemaId === "tgt" ? { uri: TEST_URI, fields: [{ name: "id" }, { name: "memo" }] } : null,
+    );
+    for (const entry of forRole(result, "target").fields) {
+      assert.ok(!("line" in entry), `expected no line key on ${entry.path}, got ${entry.line}`);
+    }
   });
 });

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -412,3 +412,143 @@ mapping load {
     }
   });
 });
+
+// ── Nested containers (sl-qzy3) ─────────────────────────────────────────────
+
+describe("computeMappingCoverage — nested containers", () => {
+  // The walk must recurse over every container the grammar permits, in any
+  // combination. It previously enumerated the children each parent accepted,
+  // which silently dropped `flatten` inside `each` and `nested_arrow`
+  // everywhere: explicitly mapped fields were reported as spec gaps, and
+  // `--fail-under` would fail a complete spec.
+
+  it("qualifies arrows inside a braced src -> tgt arrow against both sides", () => {
+    // nested_arrow was absent from the walk entirely, so every field on both
+    // sides of `addr -> address { ... }` reported uncovered despite explicit
+    // arrows. The base applies to source and target alike, as it does for each.
+    const src = `
+schema src { addr record { street STRING city STRING } name STRING }
+schema tgt { address record { line STRING city STRING } full STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  name -> full
+  addr -> address {
+    .street -> .line
+    .city -> .city
+  }
+}`;
+    const result = coverage(src, "load");
+    const s = forRole(result, "source");
+    assertMapped(s, "addr", true);
+    assertMapped(s, "addr.street", true);
+    assertMapped(s, "addr.city", true);
+    const t = forRole(result, "target");
+    assertMapped(t, "address.line", true);
+    assertMapped(t, "address.city", true);
+  });
+
+  it("leaves a sibling field uncovered when a nested_arrow does not map it", () => {
+    // Guards against the opposite failure: recursing into nested_arrow must not
+    // mark the whole subtree covered just because the container is referenced.
+    const src = `
+schema src { addr record { street STRING zip STRING } }
+schema tgt { address record { line STRING zip STRING } }
+mapping load {
+  source { src }
+  target { tgt }
+  addr -> address {
+    .street -> .line
+  }
+}`;
+    const result = coverage(src, "load");
+    assertMapped(forRole(result, "source"), "addr.zip", false);
+    assertMapped(forRole(result, "target"), "address.zip", false);
+  });
+
+  it("resolves a flatten nested inside an each against the each's bases", () => {
+    // The shape of examples/nested-iteration/pipeline.stm:100. The each child
+    // loop handled each_block but not flatten_block, so the entire flatten
+    // subtree — source and target — reported uncovered.
+    const src = `
+schema src { orders list_of record {
+  parcels list_of record { barcode STRING contents list_of record { sku STRING } }
+} }
+schema tgt { orders list_of record { packed list_of record { sku STRING } } }
+mapping load {
+  source { src }
+  target { tgt }
+  each orders -> orders {
+    flatten parcels.contents -> .packed {
+      .sku -> .sku
+    }
+  }
+}`;
+    const result = coverage(src, "load");
+    const s = forRole(result, "source");
+    assertMapped(s, "orders.parcels", true);
+    assertMapped(s, "orders.parcels.contents", true);
+    assertMapped(s, "orders.parcels.contents.sku", true);
+    // barcode is genuinely never read — the one real gap in this fixture.
+    assertMapped(s, "orders.parcels.barcode", false);
+    const t = forRole(result, "target");
+    assertMapped(t, "orders.packed", true);
+    assertMapped(t, "orders.packed.sku", true);
+  });
+
+  it("resolves an each nested inside a flatten", () => {
+    // The mirror of the case above. collectFlattenPaths handled no nested
+    // blocks at all, so an each inside a flatten contributed nothing.
+    const src = `
+schema src { rows list_of record { lines list_of record { sku STRING } } }
+schema tgt { out list_of record { sku STRING } spare STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  flatten rows -> tgt {
+    each .lines -> out {
+      .sku -> .sku
+    }
+  }
+}`;
+    const result = coverage(src, "load");
+    const s = forRole(result, "source");
+    assertMapped(s, "rows.lines", true);
+    assertMapped(s, "rows.lines.sku", true);
+    const t = forRole(result, "target");
+    assertMapped(t, "out.sku", true);
+    assertMapped(t, "spare", false);
+  });
+
+  it("keeps a top-level flatten's targets at the schema root while a relative one bases", () => {
+    // Both flatten forms in one mapping. `-> tgt` names the target schema, so
+    // `email` resolves at the root; `-> .packed` inside an each names a list
+    // field on the current element, so `.sku` resolves under it. The authored
+    // relative_field_path is what separates the two.
+    const src = `
+schema src {
+  contacts list_of record { email STRING }
+  orders list_of record { items list_of record { sku STRING } }
+}
+schema tgt {
+  email STRING
+  orders list_of record { packed list_of record { sku STRING } }
+}
+mapping load {
+  source { src }
+  target { tgt }
+  flatten contacts -> tgt {
+    .email -> email
+  }
+  each orders -> orders {
+    flatten items -> .packed {
+      .sku -> .sku
+    }
+  }
+}`;
+    const result = coverage(src, "load");
+    const t = forRole(result, "target");
+    assertMapped(t, "email", true);
+    assertMapped(t, "orders.packed.sku", true);
+  });
+});

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -1,30 +1,23 @@
 /**
- * Mapping coverage computation.
+ * coverage.ts — LSP adapter for @satsuma/core mapping coverage.
  *
- * Computes per-field covered/uncovered status for every source and target
- * schema referenced in a named mapping block.  The result is consumed by
- * the VS Code coverage command to apply gutter decorations.
+ * Coverage semantics (which declared fields a mapping's arrows touch) live in
+ * `@satsuma/core/coverage`, shared with the CLI's `satsuma coverage` command
+ * and the viz coverage overlay. This module's only job is to adapt the LSP's
+ * `WorkspaceIndex` to core's `CoverageSchemaResolver` and to keep the
+ * `(uri, tree, mappingName, wsIndex)` signature that server.ts's
+ * `satsuma/mappingCoverage` request handler already calls.
  *
- * "Covered" means:
- *   - source field: its name (or a path that starts with it) appears as a
- *     src_path in at least one arrow, each_block, or flatten_block inside the
- *     mapping.
- *   - target field: its name (or a path that starts with it) appears as a
- *     tgt_path in at least one arrow inside the mapping.
- *
- * Nested record fields are handled recursively.  each_block and flatten_block
- * src-paths contribute both the top-level field and the qualified nested path.
- *
- * Types (FieldCoverageEntry, SchemaCoverageResult, MappingCoverageResult) and
- * the addPathAndPrefixes path utility live in @satsuma/core so the CLI can
- * share the same definitions without depending on the LSP server.
+ * It owns nothing else: no path rules, no field walking. If coverage output
+ * looks wrong, the bug is in core unless the schema being reported is the
+ * wrong one — that resolution step is what lives here.
  */
 
-import type { SyntaxNode, Tree } from "./parser-utils";
-import { child, children, labelText } from "./parser-utils";
+import type { Tree } from "./parser-utils";
 import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
-import { addPathAndPrefixes, isCoveredFieldPath, sourceRefStructuralText } from "@satsuma/core";
+import { computeMappingCoverage as computeCoverage } from "@satsuma/core";
+import type { CoverageField, CoverageSchemaDefinition } from "@satsuma/core";
 
 // Re-export shared types from core so existing LSP code that imports from
 // this module continues to work without import path changes.
@@ -34,228 +27,46 @@ export type {
   MappingCoverageResult,
 } from "@satsuma/core";
 
-import type { FieldCoverageEntry, SchemaCoverageResult, MappingCoverageResult } from "@satsuma/core";
+import type { MappingCoverageResult } from "@satsuma/core";
 
-// ---------- Entry point ----------
-
+/**
+ * Compute per-field coverage for a named mapping in the document at `uri`.
+ *
+ * `uri` is not used to locate the mapping (the caller already supplies its
+ * parse tree) — it is retained because the request handler passes it and
+ * because a future scoped resolver may need the requesting document.
+ */
 export function computeMappingCoverage(
   _uri: string,
   tree: Tree,
   mappingName: string,
   wsIndex: WorkspaceIndex,
 ): MappingCoverageResult {
-  const mappingNode = findMappingBlock(tree, mappingName);
-  if (!mappingNode) return { schemas: [] };
-
-  const body = child(mappingNode, "mapping_body");
-  if (!body) return { schemas: [] };
-
-  const sourceIds = getSchemaIdsFromBlock(body, "source_block");
-  const targetIds = getSchemaIdsFromBlock(body, "target_block");
-
-  // Collect all explicit arrow source paths and target paths from the mapping.
-  const coveredSrcPaths = new Set<string>();
-  const coveredTgtPaths = new Set<string>();
-  collectBodyPaths(body, coveredSrcPaths, coveredTgtPaths);
-
-  const schemas: SchemaCoverageResult[] = [];
-
-  for (const schemaId of sourceIds) {
-    const def = resolveSchema(wsIndex, schemaId);
-    if (!def) continue;
-    schemas.push({
-      schemaId,
-      role: "source",
-      fields: buildFieldCoverage(def.fields, def.uri, "", coveredSrcPaths),
-    });
-  }
-
-  for (const schemaId of targetIds) {
-    const def = resolveSchema(wsIndex, schemaId);
-    if (!def) continue;
-    schemas.push({
-      schemaId,
-      role: "target",
-      fields: buildFieldCoverage(def.fields, def.uri, "", coveredTgtPaths),
-    });
-  }
-
-  return { schemas };
-}
-
-// ---------- Path collection ----------
-
-/**
- * Walk all arrows (including inside each/flatten) in the mapping body and
- * populate the covered src-path and tgt-path sets.
- */
-function collectBodyPaths(
-  body: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
-): void {
-  for (const node of body.namedChildren) {
-    switch (node.type) {
-      case "map_arrow":
-        for (const sp of children(node, "src_path")) addPathAndPrefixes(srcPaths, pathText(sp));
-        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
-        break;
-      case "computed_arrow":
-        { const tp = child(node, "tgt_path"); if (tp) addPathAndPrefixes(tgtPaths, pathText(tp)); }
-        break;
-      case "each_block":
-        collectEachPaths(node, srcPaths, tgtPaths, null, null);
-        break;
-      case "flatten_block":
-        collectFlattenPaths(node, srcPaths, tgtPaths);
-        break;
-    }
-  }
+  return computeCoverage(tree, mappingName, (schemaId) => resolveSchema(wsIndex, schemaId));
 }
 
 /**
- * Recursively collect paths from an each_block.
- * Arrows inside an each_block are relative to the iteration field.
+ * Resolve a schema reference to core's coverage input shape.
  *
- * Nullability contract for outerSrcBase / outerTgtBase:
- *   null     — no enclosing each_block has established a base path yet; this
- *               is the top-level call for this each_block, so paths from the
- *               block's own src_path/tgt_path become the new base.
- *   non-null — an enclosing each_block already established a prefix; paths in
- *               this nested block are qualified relative to that prefix via
- *               qualify(outerBase, localPath).
- *
- * Recursive call sites pass srcBase/tgtBase (the base resolved for this level)
- * as the outer values for any nested each_blocks found within this node.
+ * Only `kind === "schema"` definitions participate: a mapping's source/target
+ * blocks may name something the index also knows as another kind, and coverage
+ * is defined over declared schema fields.
  */
-function collectEachPaths(
-  node: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
-  outerSrcBase: string | null,
-  outerTgtBase: string | null,
-): void {
-  const rawSrc = child(node, "src_path");
-  const rawTgt = child(node, "tgt_path");
-  const srcBase = rawSrc ? qualify(outerSrcBase, pathText(rawSrc)) : outerSrcBase;
-  const tgtBase = rawTgt ? qualify(outerTgtBase, pathText(rawTgt)) : outerTgtBase;
-
-  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
-  if (tgtBase) addPathAndPrefixes(tgtPaths, tgtBase);
-
-  for (const ch of node.namedChildren) {
-    if (ch.type === "map_arrow") {
-      for (const sp of children(ch, "src_path")) {
-        const leaf = pathText(sp);
-        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
-      }
-      const tp = child(ch, "tgt_path");
-      if (tp) {
-        const leaf = pathText(tp);
-        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
-      }
-    } else if (ch.type === "computed_arrow") {
-      const tp = child(ch, "tgt_path");
-      if (tp) {
-        const leaf = pathText(tp);
-        addPathAndPrefixes(tgtPaths, tgtBase ? qualify(tgtBase, leaf) : leaf);
-      }
-    } else if (ch.type === "each_block") {
-      collectEachPaths(ch, srcPaths, tgtPaths, srcBase, tgtBase);
-    }
-  }
-}
-
-function collectFlattenPaths(
-  node: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
-): void {
-  const rawSrc = child(node, "src_path");
-  const srcBase = rawSrc ? pathText(rawSrc) : null;
-  if (srcBase) addPathAndPrefixes(srcPaths, srcBase);
-
-  for (const ch of node.namedChildren) {
-    if (ch.type === "map_arrow") {
-      for (const sp of children(ch, "src_path")) {
-        const leaf = pathText(sp);
-        addPathAndPrefixes(srcPaths, srcBase ? qualify(srcBase, leaf) : leaf);
-      }
-      const tp = child(ch, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
-    } else if (ch.type === "computed_arrow") {
-      const tp = child(ch, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, pathText(tp));
-    }
-  }
-}
-
-function qualify(base: string | null, leaf: string): string {
-  return base ? `${base}.${leaf}` : leaf;
-}
-
-// ---------- Field coverage building ----------
-
-/**
- * Recursively build FieldCoverageEntry list for a schema's fields.
- * `prefix` is the path from the schema root to the current level.
- */
-function buildFieldCoverage(
-  fields: FieldInfo[],
-  uri: string,
-  prefix: string,
-  coveredPaths: Set<string>,
-): FieldCoverageEntry[] {
-  const result: FieldCoverageEntry[] = [];
-  for (const f of fields) {
-    const path = prefix ? `${prefix}.${f.name}` : f.name;
-    const mapped = isCoveredFieldPath(path, coveredPaths);
-    result.push({ path, uri, line: f.range.start.line, mapped });
-    if (f.children.length > 0) {
-      result.push(...buildFieldCoverage(f.children, uri, path, coveredPaths));
-    }
-  }
-  return result;
-}
-
-// ---------- Helpers ----------
-
-function findMappingBlock(tree: Tree, name: string): SyntaxNode | null {
-  for (const node of tree.rootNode.namedChildren) {
-    if (node.type === "mapping_block" && labelText(node) === name) return node;
-    if (node.type === "namespace_block") {
-      for (const ch of node.namedChildren) {
-        if (ch.type === "mapping_block" && labelText(ch) === name) return ch;
-      }
-    }
-  }
-  return null;
-}
-
-function getSchemaIdsFromBlock(body: SyntaxNode, blockType: "source_block" | "target_block"): string[] {
-  for (const node of body.namedChildren) {
-    if (node.type === blockType) {
-      const ids: string[] = [];
-      for (const ref of children(node, "source_ref")) {
-        const name = sourceRefStructuralText(ref);
-        if (name) ids.push(name);
-      }
-      return ids;
-    }
-  }
-  return [];
-}
-
 function resolveSchema(
   wsIndex: WorkspaceIndex,
   schemaId: string,
-): { fields: FieldInfo[]; uri: string } | null {
+): CoverageSchemaDefinition | null {
   const defs = resolveDefinition(wsIndex, schemaId, null);
   const def = defs.find((d) => d.kind === "schema");
-  return def ? { fields: def.fields, uri: def.uri } : null;
+  if (!def) return null;
+  return { uri: def.uri, fields: def.fields.map(toCoverageField) };
 }
 
-function pathText(node: SyntaxNode): string {
-  const text = node.text;
-  return text.startsWith("`") && text.endsWith("`") ? text.slice(1, -1) : text;
+/** Project an LSP `FieldInfo` onto core's minimal field shape. */
+function toCoverageField(field: FieldInfo): CoverageField {
+  return {
+    name: field.name,
+    line: field.range.start.line,
+    children: field.children.map(toCoverageField),
+  };
 }

--- a/tooling/satsuma-lsp/test/coverage.test.js
+++ b/tooling/satsuma-lsp/test/coverage.test.js
@@ -1,3 +1,13 @@
+/**
+ * coverage.test.js — LSP coverage adapter wiring.
+ *
+ * Coverage semantics are tested once, in satsuma-core/test/coverage.test.js
+ * (sl-gsxu). What can only break here is the adapter: resolving a schema
+ * reference through the LSP WorkspaceIndex, projecting FieldInfo onto core's
+ * field shape, and mapping FieldInfo.range onto the line the gutter decorates.
+ * These tests cover exactly that seam and nothing else.
+ */
+
 const { describe, it, before } = require("node:test");
 const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
@@ -14,209 +24,63 @@ function coverage(source, mappingName, uri = "file:///test.stm") {
   return computeMappingCoverage(uri, tree, mappingName, idx);
 }
 
-// ---------- Basic structure ----------
-
-describe("computeMappingCoverage — basic", () => {
-  const SRC = `
-schema src { id INT name STRING }
-schema tgt { id INT label STRING }
+const SRC = `schema src {
+  id INT
+  unused INT
+}
+schema tgt {
+  id INT
+  memo STRING
+}
 mapping load {
   source { src }
   target { tgt }
   id -> id
 }`;
 
-  it("returns one source schema and one target schema", () => {
+describe("LSP coverage adapter", () => {
+  it("resolves both mapping sides through the workspace index", () => {
+    // The adapter's job is index lookup; if resolveDefinition is wired wrongly
+    // the gutter silently decorates nothing, with no error to trace.
     const result = coverage(SRC, "load");
-    assert.equal(result.schemas.length, 2);
-    assert.equal(result.schemas.find(s => s.role === "source")?.schemaId, "src");
-    assert.equal(result.schemas.find(s => s.role === "target")?.schemaId, "tgt");
+    assert.deepEqual(
+      result.schemas.map((s) => [s.role, s.schemaId]),
+      [["source", "src"], ["target", "tgt"]],
+    );
   });
 
-  it("returns empty schemas for unknown mapping name", () => {
-    const result = coverage(SRC, "nonexistent");
-    assert.equal(result.schemas.length, 0);
-  });
-});
-
-// ---------- Target coverage ----------
-
-describe("computeMappingCoverage — target fields", () => {
-  const SRC = `
-schema src { id INT name STRING extra INT }
-schema tgt { id INT label STRING memo STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  id -> id
-  name -> label
-}`;
-
-  it("marks mapped target fields as mapped=true", () => {
-    const result = coverage(SRC, "load");
-    const tgt = result.schemas.find(s => s.role === "target");
-    const id = tgt.fields.find(f => f.path === "id");
-    const label = tgt.fields.find(f => f.path === "label");
-    assert.equal(id.mapped, true);
-    assert.equal(label.mapped, true);
+  it("reports each field's declaration line and URI for gutter decoration", () => {
+    // The overlay places markers at FieldCoverageEntry.line in the file named
+    // by .uri, so this projection from FieldInfo.range is load-bearing.
+    const tgt = coverage(SRC, "load").schemas.find((s) => s.role === "target");
+    assert.deepEqual(
+      tgt.fields.map((f) => [f.path, f.line, f.uri, f.mapped]),
+      [
+        ["id", 5, "file:///test.stm", true],
+        ["memo", 6, "file:///test.stm", false],
+      ],
+    );
   });
 
-  it("marks unmapped target fields as mapped=false", () => {
-    const result = coverage(SRC, "load");
-    const tgt = result.schemas.find(s => s.role === "target");
-    const memo = tgt.fields.find(f => f.path === "memo");
-    assert.ok(memo, `expected "memo" field in ${tgt.fields.map(f => f.path)}`);
-    assert.equal(memo.mapped, false);
-  });
-
-  it("computed arrows (no source) still mark the target field as mapped", () => {
-    const src = `
-schema src { id INT }
-schema tgt { id INT stamp STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  id -> id
-  -> stamp { now_utc() }
-}`;
-    const result = coverage(src, "load");
-    const tgt = result.schemas.find(s => s.role === "target");
-    const stamp = tgt.fields.find(f => f.path === "stamp");
-    assert.equal(stamp.mapped, true);
-  });
-});
-
-// ---------- Source coverage ----------
-
-describe("computeMappingCoverage — source fields", () => {
-  const SRC = `
-schema src { id INT name STRING unused INT }
-schema tgt { id INT label STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  id -> id
-  name -> label
-}`;
-
-  it("marks used source fields as mapped=true", () => {
-    const result = coverage(SRC, "load");
-    const src = result.schemas.find(s => s.role === "source");
-    assert.equal(src.fields.find(f => f.path === "id").mapped, true);
-    assert.equal(src.fields.find(f => f.path === "name").mapped, true);
-  });
-
-  it("marks unused source fields as mapped=false", () => {
-    const result = coverage(SRC, "load");
-    const src = result.schemas.find(s => s.role === "source");
-    assert.equal(src.fields.find(f => f.path === "unused").mapped, false);
-  });
-});
-
-// ---------- Nested fields ----------
-
-describe("computeMappingCoverage — nested fields", () => {
-  // nested record fields use "field_name record { ... }" syntax
-  it("includes nested fields in the coverage list", () => {
-    const src = `
-schema src { address record { line1 STRING line2 STRING } name STRING }
-schema tgt { addr STRING name STRING }
+  it("projects nested FieldInfo children onto nested coverage paths", () => {
+    // FieldInfo nests differently from the CLI's FieldDecl; a dropped
+    // children[] mapping would hide every nested field from the gutter.
+    const src = `schema src {
+  address record {
+    line1 STRING
+    line2 STRING
+  }
+}
+schema tgt { addr STRING }
 mapping load {
   source { src }
   target { tgt }
   address.line1 -> addr
-  name -> name
 }`;
-    const result = coverage(src, "load");
-    const srcSchema = result.schemas.find(s => s.role === "source");
-    const paths = srcSchema.fields.map(f => f.path);
-    assert.ok(paths.includes("address"), `expected "address" in ${paths}`);
-    assert.ok(paths.includes("address.line1"), `expected "address.line1" in ${paths}`);
-    assert.ok(paths.includes("address.line2"), `expected "address.line2" in ${paths}`);
-  });
-
-  it("marks referenced nested source path as mapped", () => {
-    const src = `
-schema src { address record { line1 STRING line2 STRING } name STRING }
-schema tgt { addr STRING name STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  address.line1 -> addr
-  name -> name
-}`;
-    const result = coverage(src, "load");
-    const srcSchema = result.schemas.find(s => s.role === "source");
-    const line1 = srcSchema.fields.find(f => f.path === "address.line1");
-    const line2 = srcSchema.fields.find(f => f.path === "address.line2");
-    assert.ok(line1, `expected address.line1 in ${srcSchema.fields.map(f => f.path)}`);
-    assert.ok(line2, `expected address.line2 in ${srcSchema.fields.map(f => f.path)}`);
-    assert.equal(line1.mapped, true);
-    assert.equal(line2.mapped, false);
-  });
-});
-
-// ---------- each_block ----------
-
-describe("computeMappingCoverage — each_block", () => {
-  // each blocks use "each src -> tgt { ... }" syntax
-  it("marks the each iteration field as used on the source schema", () => {
-    const src = `
-schema src { items list_of record { id INT val STRING } name STRING }
-schema tgt { lines list_of record { item_id INT } name STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  name -> name
-  each items -> lines {
-    id -> item_id
-  }
-}`;
-    const result = coverage(src, "load");
-    const srcSchema = result.schemas.find(s => s.role === "source");
-    const items = srcSchema.fields.find(f => f.path === "items");
-    assert.ok(items, `expected "items" in ${srcSchema.fields.map(f => f.path)}`);
-    assert.equal(items.mapped, true, "each iteration field should be marked used");
-  });
-
-  it("marks arrows inside each_block on the target schema", () => {
-    const src = `
-schema src { items list_of record { id INT val STRING } name STRING }
-schema tgt { lines list_of record { item_id INT } name STRING }
-mapping load {
-  source { src }
-  target { tgt }
-  name -> name
-  each items -> lines {
-    id -> item_id
-  }
-}`;
-    const result = coverage(src, "load");
-    const tgtSchema = result.schemas.find(s => s.role === "target");
-    const lines = tgtSchema.fields.find(f => f.path === "lines");
-    assert.ok(lines, `expected "lines" in ${tgtSchema.fields.map(f => f.path)}`);
-    assert.equal(lines.mapped, true, "each target field should be marked mapped");
-  });
-});
-
-// ---------- Multiple source schemas ----------
-
-describe("computeMappingCoverage — multiple sources", () => {
-  it("returns a coverage entry for each source schema", () => {
-    const src = `
-schema a { id INT }
-schema b { rate DECIMAL }
-schema tgt { id INT rate DECIMAL }
-mapping load {
-  source { a b }
-  target { tgt }
-  id -> id
-  rate -> rate
-}`;
-    const result = coverage(src, "load");
-    const sources = result.schemas.filter(s => s.role === "source");
-    assert.equal(sources.length, 2);
-    const ids = sources.map(s => s.schemaId).sort();
-    assert.deepEqual(ids, ["a", "b"]);
+    const source = coverage(src, "load").schemas.find((s) => s.role === "source");
+    assert.deepEqual(
+      source.fields.map((f) => [f.path, f.mapped]),
+      [["address", true], ["address.line1", true], ["address.line2", false]],
+    );
   });
 });


### PR DESCRIPTION
Implements `features/35-coverage-command/PRD.md`. All 7 tickets closed (`sl-ce11` epic).

`satsuma coverage` answers the first question every reviewer of a mapping spec asks — **which declared fields is nothing mapping yet?** — with per-mapping, per-schema, aggregate, namespace and workspace figures, a stable `--json` contract, and a `--fail-under` CI gate.

```
Coverage — 3 mappings, per mapping

mapping crm::load contacts  (…/pipeline.stm)
  source  crm::customers      2/4   50%
  target  crm::contacts       2/3   67%
    uncovered in crm::contacts (target): 1 field
      memo

Aggregate — a field is uncovered here only when NO mapping in scope covers it
  source  crm::customers      3/4   75%
  target  crm::contacts       3/3  100%

  crm        source  3/4   75%   target  3/3  100%
  billing    source  2/3   67%   target  2/2  100%
  workspace  source  5/7   71%   target  5/5  100%
```

## Commits

| Ticket | Change |
|---|---|
| `sl-gsxu` | Relocate `computeMappingCoverage` into `@satsuma/core` behind a resolver contract |
| `sl-5sjp` | CLI uses core's `FieldDecl`; owns the field declaration-position rule |
| `sl-4qvp` | Core aggregation: per-schema across mappings, namespace, workspace |
| `sl-oqsj` | `satsuma coverage` command; `fields --unmapped-by` re-based onto it |
| `sl-3ms0` | Surface aggregate rollups in human and JSON output |
| `sl-268g` | `--fail-under` CI gate with exit code 3 |
| `sl-tdfx` | Docs: CLI reference, JSON contract, agent-reference, HOW-DO-I |
| — | ADR-034 (leaf-only coverage counting) |

## Decisions worth a reviewer's attention

**One implementation, four sites converged.** The PRD counted three places orbiting coverage semantics; there were four — `fields --unmapped-by` had its own `getMappedFieldNames()`. That helper is deleted and the flag now delegates to core. Two tests lock the surfaces together, so shipping `coverage` does not ship the drift it exists to prevent.

**Two bugs found and fixed en route.**

- `sc-xnxp` (**P1, pre-existing**): element-relative paths inside `each`/`flatten` were qualified without stripping their leading dot, so `.id` became `items..id` and the declared `items.id` never matched. **Every nested field inside an `each` or `flatten` block reported uncovered despite an explicit arrow** — using the spec's canonical syntax (§4.6), not an edge case. The VS Code gutter has been marking mapped nested fields as unmapped since each/flatten support landed. Fixed here rather than carried forward, because a coverage report built on it would report false gaps for exactly the fields reviewers ask about.
- Consequence worth stating plainly: `sl-gsxu`'s acceptance criterion *"gutter behaviour byte-identical before and after"* is **deliberately not met**. The gutter changes, in the correcting direction.

**Exit code 3, not 1.** `coverage --fail-under 90 --mapping "typo"` can fail because the name is misspelled *or* because the spec is genuinely incomplete. Sharing a code leaves CI unable to tell "fix the pipeline" from "finish the mapping". `fmt --check` avoids this only because it takes no scope arguments that can fail to resolve.

**ADR-034 records a rejected alternative, not just a rule.** "A leaf inherits coverage from a covered ancestor" is the obvious fix for a whole-record arrow, was implemented, and is wrong — `addPathAndPrefixes` registers ancestor prefixes, so a record already reads as mapped when *any single* descendant is covered. Inheriting would turn "1 of 12 address fields mapped" into "all 12". Excluding records instead under-counts the rarer whole-record arrow (`3cc-iedv`), erring toward reporting a gap that is not there rather than hiding one that is.

## Follow-ups raised, not folded in

| Ticket | Why deferred |
|---|---|
| `3cc-iedv` | Fixing the whole-record under-count needs `coverage.ts` to distinguish directly-covered paths from prefix-registered ancestors — a change to the per-mapping contract the gutter consumes |
| `3cc-t6uo` | VS Code's status bar counts top-level fields only, a *third* rule, so its percentage disagrees with `satsuma coverage` on nested schemas. Pre-existing; changing extension behaviour is outside this scope |

## Tests

| Package | Result |
|---|---|
| satsuma-core | 466 pass (+16 rollup, coverage semantics moved here from the LSP) |
| satsuma-cli | 959 pass (+47) |
| satsuma-lsp | 292 pass (reduced to adapter wiring only) |
| vscode-satsuma | 33 unit + fixtures + golden pass |
| satsuma-viz / viz-backend / viz-model | 97 / 163 / 6 pass |

All four lints clean (`js`, `md`, `yaml`, `python`).

⚠️ `tree-sitter-satsuma` corpus tests could not run locally — the sandbox blocks tree-sitter's cache lock (`Operation not permitted … /satsuma-*.lock`). No grammar files are touched by this branch, so CI is the check.

A docs test now asserts every key `coverage --json` emits appears in the documented contract — a stable contract nobody checks is a comment, and feature 36's overlay is about to render from this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)