### PR TITLE
Feature 38: hierarchical field coverage — PRD, tickets, and two P1 coverage bugs

### DIFF
--- a/.tickets/sl-0pun.md
+++ b/.tickets/sl-0pun.md
@@ -1,0 +1,28 @@
+---
+id: sl-0pun
+status: open
+deps: [sl-fmx0]
+links: []
+created: 2026-07-31T14:43:38Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, core, lsp, cli]
+---
+# core: container coverage tri-state (covered / partial / uncovered)
+
+PRD 38 R2. Replace the two contradictory boolean definitions of a covered record with one three-valued state: covered when every descendant leaf is covered, partial when at least one but not all are, uncovered when none are. Leaves stay binary.
+
+Today the LSP treats a record as mapped when ANY descendant is covered (buildFieldCoverage, asserted by its own test: items.mapped === true when only items.id is mapped), while the CLI's filterUnmappedFields excludes a record only when ALL children are covered, deliberately and with a comment explaining why. Both are right for their consumer; one boolean cannot carry both claims. Feature 35's sl-oqsj already commits to an acceptance criterion requiring the two to agree.
+
+## Design
+
+The tri-state subsumes both consumers without either changing what it shows: the LSP gutter paints on covered||partial (today's behaviour exactly), the CLI review queue lists anything not covered (today's behaviour exactly). Feature 36 R2 gains the signal it currently lacks — a record with 1 of 12 leaves mapped can render differently from a fully mapped one.
+
+FieldCoverageEntry.mapped is an existing contract, so ADD the state rather than repurposing mapped, and define mapped = state !== 'uncovered' for containers so LSP output stays byte-identical.
+
+## Acceptance Criteria
+
+Tri-state on record and list_of record entries, doc-commented; leaves never report partial; mapped === (state !== 'uncovered') for containers so the VS Code gutter is unchanged; one of three leaves mapped yields partial, three of three covered, zero of three uncovered; partial propagates upward while covered does not (a record { b record { x, y } } with only a.b.x mapped leaves both a.b and a partial); a container referenced with an empty each body (each parcels -> .packed { }) is uncovered, not partial — a container reference must not manufacture leaf coverage; core, LSP and CLI suites pass.
+

--- a/.tickets/sl-2nxu.md
+++ b/.tickets/sl-2nxu.md
@@ -1,0 +1,25 @@
+---
+id: sl-2nxu
+status: open
+deps: []
+links: [sl-vu22, sl-qzy3]
+created: 2026-07-31T14:44:15Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, tree-sitter, testing]
+---
+# tree-sitter: corpus fixtures for fragment-spread-into-record and each-inside-flatten
+
+PRD 38 acceptance case 30. Two gaps in the corpus let nesting defects survive:
+
+1. No corpus fixture spreads a fragment into a record or list_of record body, though the grammar permits it (_schema_body_item includes fragment_spread) and examples/lib/sfdc_fragments.stm does it. Every '...' in the corpus is at schema or fragment top level.
+2. The corpus has 'Nested flatten inside each' (each_flatten.txt:331-374) but not the mirror case, each nested inside flatten.
+
+sl-7236's ticket identified missing corpus coverage as the reason a nesting defect survived in format.ts: 'The corpus contains no nested each blocks so round-trip tests do not catch it.' The same gap is why the coverage walker's missing flatten-inside-each went unnoticed.
+
+## Acceptance Criteria
+
+Corpus fixture covering a fragment spread inside a record body and inside a list_of record body; corpus fixture covering each nested inside flatten; both parse to the expected CST and the corpus suite passes with --wasm.
+

--- a/.tickets/sl-5nsv.md
+++ b/.tickets/sl-5nsv.md
@@ -1,0 +1,22 @@
+---
+id: sl-5nsv
+status: open
+deps: [sl-0pun, sl-hcan, sl-vu22]
+links: []
+created: 2026-07-31T14:44:00Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, testing, viz, cli]
+---
+# test: cross-consumer coverage parity, including fragment-spread expansion
+
+PRD 38 R6. Feature 36 requires the viz overlay's numbers to equal satsuma coverage --json. That guarantee currently has no test that would fail if it broke. Add one: a single nested fixture computed through the CLI path and the viz-backend path, asserting identical leaf verdicts, identical container states and identical percentages.
+
+This is also the test that catches spread-expansion divergence. The three consumers expand fragment spreads at three different points: the CLI before filtering (expandNestedSpreads/expandEntityFields in fields.ts:74-82), viz at model-build time (viz-model.ts:266-298), and the LSP/core coverage path NOT AT ALL — so fields a schema acquires via ...fragment are currently invisible to the gutter and status bar while the CLI lists them, appearing in neither numerator nor denominator.
+
+## Acceptance Criteria
+
+Parity test over one nested fixture asserts identical leaf verdicts, container states and percentages across the CLI and viz-backend paths. Spread-materialised nested fields are counted in every consumer, using tooling/satsuma-cli/test/fixtures/nested-record-spread.stm where a record body contains only '...address_fields' — address.street and address.city appear as coverage entries with correct states in all paths. A new fixture covers a spread into a list_of record body, which exists nowhere in the repo today. A test covers one fragment spread into two sibling record bodies (examples/lib/sfdc_fragments.stm shape) asserting that mapping BillingAddress.Street leaves ShippingAddress.Street uncovered.
+

--- a/.tickets/sl-8o1n.md
+++ b/.tickets/sl-8o1n.md
@@ -1,0 +1,20 @@
+---
+id: sl-8o1n
+status: open
+deps: []
+links: []
+created: 2026-07-31T14:44:15Z
+type: chore
+priority: 3
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, core]
+---
+# core: make [] path normalization symmetric or delete it
+
+PRD 38 R7, hygiene. addPathAndPrefixes strips [] when BUILDING the covered set but isCoveredFieldPath does not strip it when PROBING, so a probe containing [] never matches. Note this is dead code for current syntax: [] was removed from all paths in v2 (grammar.js:429-431, 'iteration is expressed via each/flatten') and bracket paths cannot parse. Either make the normalization symmetric via one shared named helper used by both sides, or delete it and keep a test asserting bracket paths do not parse. Do not leave it asymmetric and undocumented.
+
+## Acceptance Criteria
+
+Either one shared normalization helper used on both the build and probe sides with a test asserting both directions match, or the normalization removed with a test asserting bracket paths are a parse error; the existing core tests that assert [] stripping (coverage.test.js, coverage-paths.test.js) updated to match whichever is chosen, with a comment citing the v2 syntax decision.
+

--- a/.tickets/sl-fmx0.md
+++ b/.tickets/sl-fmx0.md
@@ -1,0 +1,24 @@
+---
+id: sl-fmx0
+status: open
+deps: [sl-joeq]
+links: []
+created: 2026-07-31T14:43:17Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, core]
+---
+# core: separate directly-covered paths from prefix-derived coverage
+
+PRD 38 R1. Replace the flat Set<string> covered-path model with one that records WHY a path is covered: a set of directly-covered paths (an arrow wrote exactly this) kept separate from the ancestor relation, which is recomputable from it. This is the structural change the rest of the feature rests on — it is what makes the container tri-state (R2) and whole-subtree arrows (R5) expressible at all, and it is the fix 3cc-iedv independently identified as necessary.
+
+## Design
+
+Derive rather than store the answers consumers need: a leaf is covered iff its qualified path is directly covered OR it descends from a directly-covered container (R5); a container's state is computed from its descendant leaves (R2). Keep isCoveredFieldPath(path, set) working for consumers that only need the boolean so the change is additive at call sites that do not care. Note ticket 3cc-iedv (on branch feat/35-coverage-command, arrives on main when feature 35 merges) records the same requirement from the whole-record-arrow angle; close it under R5.
+
+## Acceptance Criteria
+
+Covered-path model distinguishes direct from derived coverage, with the distinction doc-commented as the public contract; isCoveredFieldPath retains its current signature and behaviour for direct+ancestor queries; a leaf beneath a directly-covered record reports covered while a leaf beneath a record that is merely an ancestor of a covered descendant does not; core coverage tests cover both; no consumer needs to change to keep working.
+

--- a/.tickets/sl-hcan.md
+++ b/.tickets/sl-hcan.md
@@ -1,0 +1,27 @@
+---
+id: sl-hcan
+status: open
+deps: [sl-0pun]
+links: []
+created: 2026-07-31T14:44:00Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, vscode, viz, core]
+---
+# viz: schema card counts containers in its coverage ratio, disagreeing with satsuma coverage
+
+PRD 38 R3, viz half. ADR-034 (Accepted) settles the rule — coverage counts leaf fields only, on each leaf's own flag — and states plainly that "consumers must not compute their own coverage denominators". Two consumers still do. The VS Code status bar half is already raised as 3cc-t6uo (on branch feat/35-coverage-command); this ticket is the viz half, which that ticket does not cover.
+
+The three conventions shipping today:
+1. VS Code status bar (vscode-satsuma/src/commands/coverage-logic.ts:78-86) counts TOP-LEVEL fields only via filter(f => !f.path.includes('.')), so a record is in the denominator and its leaves are not — 'address record {line1,line2,line3}' with only line1 mapped reports 100%.
+2. viz schema card (satsuma-viz/src/components/sz-schema-card.ts:748-766) counts EVERY node including containers in both numerator and denominator, so one covered leaf inflates the numerator once per ancestor level.
+3. The core rollup added by sl-4qvp counts LEAVES ONLY, with the correct rationale documented at coverage-rollup.ts:43-56 — a record is structure, not data, and counting it alongside its children would let nesting depth move the percentage.
+
+(3) is right, is now ADR-034, and stays. (1) is 3cc-t6uo. (2) is this ticket: the viz card must delegate to core, or feature 36's requirement that overlay numbers equal coverage --json fails on the first nested schema — and a reviewer with the extension, a terminal and the viz panel open sees three different figures for one mapping.
+
+## Acceptance Criteria
+
+The viz card's _countFields/_countMapped stop computing their own figures and delegate to core summarizeFieldCoverage/leafFieldEntries per ADR-034; container states reported alongside as counts (records: {covered, partial, uncovered}) — useful review information but not a percentage; the depth-invariance invariant documented: a schema's percentage is unchanged by re-nesting, same leaves and same arrows give the same number; test asserting two schemas with the same four leaves, one flat and one nested three deep, report identical percentages; test asserting the same fixture reports the same number from the core rollup and the viz card (today 25% and 40%); once 3cc-t6uo also lands, all three surfaces agree; containers excluded from the denominator — 'amount' plus 'address record {city,line1,postcode}' with only address.city mapped reports 25%, not 40%; vscode and viz suites pass.
+

--- a/.tickets/sl-j6g9.md
+++ b/.tickets/sl-j6g9.md
@@ -1,0 +1,29 @@
+---
+id: sl-j6g9
+status: open
+deps: [sl-joeq]
+links: [sl-joeq]
+created: 2026-07-31T14:42:52Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-38, coverage, core]
+---
+# Feature 38 epic: hierarchical field coverage
+
+Implement features/38-hierarchical-coverage/PRD.md. Make field coverage correct and single-definition for nested records, lists of records, and schemas that reuse field names across depths, so a coverage percentage can be trusted as a merge gate.
+
+Six defects verified against branch feat/35-coverage-command (HEAD fc3d5a5), not main — feature 35 is substantially implemented there:
+1. Bare-segment registration makes coverage name-based, reporting unmapped fields as mapped (raised separately as sl-joeq, this epic depends on it).
+2. nested_arrow contributes no coverage at all.
+3. flatten nested inside each — and any block inside flatten — is not walked. Running the branch's computeMappingCoverage on examples/nested-iteration/pipeline.stm reports the target schema at 75% when it is 100% mapped, so --fail-under 90 would fail a fully-mapped spec on the repo's own canonical nested example.
+4. Three percentage conventions ship, all different: VS Code status bar counts top-level fields only (a record with 1 of 3 leaves mapped reports 100%), the viz card counts every node including containers, the new core rollup counts leaves only.
+5. Two independent walkers diverge on nesting — the CLI derives paths from extract.ts and is correct; computeMappingCoverage does its own CST walk and is not. Feature 35's sl-oqsj requires the two to agree, which they cannot on any nested fixture.
+6. Container semantics are contradictory by construction: LSP treats a record as covered when ANY descendant is, the CLI only when ALL descendants are. One boolean cannot carry both claims.
+
+Root cause of most of it: the covered set is a flat bag of strings mixing 'an arrow wrote exactly this', 'this is an ancestor of that', and 'this is a segment of that', with no way to tell them apart.
+
+## Acceptance Criteria
+
+All PRD requirements R1-R7 delivered; the 31 acceptance tests in the PRD pass, including the nine that must fail before the work starts; coverage figures reported by the CLI, the VS Code status bar and the viz card are identical for the same workspace; features/38 PRD open questions resolved and recorded.
+

--- a/.tickets/sl-joeq.md
+++ b/.tickets/sl-joeq.md
@@ -1,0 +1,80 @@
+---
+id: sl-joeq
+status: open
+deps: []
+links: [sl-j6g9]
+created: 2026-07-31T14:42:19Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [coverage, core, cli, lsp, viz]
+---
+# coverage: bare-segment registration makes coverage name-based, silently reporting unmapped fields as mapped
+
+addPathAndPrefixes registers every segment of a covered path as a standalone bare name, so field coverage resolves by NAME rather than by PATH. Any field whose local name matches a segment of some other covered path anywhere in the same schema is silently reported as mapped. This is a false positive in the dangerous direction: a silent over-count that makes an incomplete spec look complete.
+
+Live on main and on feat/35-coverage-command. Affects shipped `satsuma fields --unmapped-by` and the VS Code coverage gutter/status bar today, and would corrupt the percentages introduced by feature 35 (satsuma coverage --fail-under) and feature 36 (viz overlay badges).
+
+## Root cause
+
+satsuma-core/src/coverage.ts (main) / coverage-paths.ts:29-40 (branch):
+
+    for (const part of parts) {
+      prefix = prefix ? `${prefix}.${part}` : part;
+      set.add(prefix);
+      set.add(part); // bare leaf so "city" matches even if the full path is "address.city"
+    }
+
+Covering `address.city` yields the set {"address", "address.city", "city"}. The bare entry is deliberate — it exists so a consumer can probe by local field name (see the comment at coverage.ts:72-74) — but it makes the covered set unable to distinguish 'an arrow wrote this path' from 'some path with this segment was written'. Leaf-name reuse across depths (id, sku, code, amount, city, BIC) is normal in nested schemas, so the collision rate rises with exactly the schemas coverage analysis is for.
+
+satsuma-cli/src/commands/fields.ts:193 makes it worse by ORing the bare check explicitly: `if (!mapped.has(f.name) && !mapped.has(path))`.
+
+## Reproduction 1 — committed fixture, ISO-20022
+
+tooling/satsuma-cli/test/fixtures/deep-nested-bugs.stm declares four BIC leaves (GrpHdr.InstgAgt, GrpHdr.InstdAgt, CdtTrfTxInf.DbtrAgt, CdtTrfTxInf.CdtrAgt); the mapping covers three, leaving GrpHdr.InstdAgt.BIC unmapped.
+
+    $ satsuma fields pacs008 --unmapped-by 'pacs008 to iso_target' deep-nested-bugs.stm
+      GrpHdr  record
+        MsgId  STRING
+
+GrpHdr.InstdAgt.BIC and its parent record are omitted entirely — reported as mapped because the instructing-agent BIC is mapped. Confusing instructing with instructed agent is precisely the error coverage should catch in payment messaging.
+
+## Reproduction 2 — an untouched container reads as half-mapped
+
+Source orders.lines{sku,qty} fully mapped inside nested each blocks; orders.packed{sku,units} given no arrows at all:
+
+    $ satsuma fields tgt_ev --unmapped-by 'partial each' eachleak.stm
+      orders  list_of record
+        packed  list_of record
+          units  INT
+
+orders.packed.sku is reported mapped solely because orders.lines.sku exists in a sibling container.
+
+Also reproducible against examples/lib/sfdc_fragments.stm, which spreads one fragment into both BillingAddress and ShippingAddress record bodies, so every leaf name exists at two paths.
+
+## Design
+
+Fix: stop registering bare segments. A path's coverage is decided by its qualified path only. Then fix the consumers that depend on the bare form:
+
+- satsuma-cli/src/commands/fields.ts:193 — drop the mapped.has(f.name) clause from the leaf test.
+- satsuma-lsp / satsuma-core buildFieldCoverage already probes qualified paths (coverage.ts:212 on main, :300-323 on branch) — confirm no other call site probes by local name.
+- satsuma-viz/src/components/sz-schema-card.ts:656-658,722 and sz-mapping-detail.ts:526,546 — audit membership probes.
+
+This makes coverage STRICTER: fields previously reported mapped become correctly reported unmapped, so existing coverage figures will drop. That is the correction, not a regression — call it out in CHANGELOG.md because anyone who has recorded a coverage number will see it change.
+
+Scope note: this ticket is the leak only. The related structural work — separating directly-covered from prefix-derived coverage, container tri-state, whole-subtree arrows (3cc-iedv), and the unwalked nesting constructs — is specified in features/38-hierarchical-coverage/PRD.md, which depends on this fix. Deliberately kept separate so a silent over-count in a shipped command can be fixed without waiting for a feature.
+
+## Acceptance Criteria
+
+Bare-segment registration removed from addPathAndPrefixes; covered set contains only full paths and ancestor prefixes.
+
+Regression tests (each must fail before the fix):
+- top-level field shadowed by a nested leaf: top-level 'city' uncovered when only home_address.city is mapped;
+- sibling records sharing a leaf name: work_address.city uncovered when only home_address.city is mapped;
+- sibling list containers: orders.packed.sku uncovered when only orders.lines.sku is mapped;
+- deep segments: with only a.b.c.d mapped, top-level fields named b, c and d are all uncovered;
+- committed-fixture case: fields pacs008 --unmapped-by on deep-nested-bugs.stm reports GrpHdr.InstdAgt.BIC as unmapped;
+- one fragment spread into two sibling records (sfdc_fragments.stm shape): mapping BillingAddress.Street leaves ShippingAddress.Street uncovered.
+
+Existing core test at satsuma-core/test/coverage.test.js asserting set.has("city") for the bare leaf is updated, with a comment citing this ticket rather than silently deleted. CLI, core, LSP, viz and vscode suites pass. Coverage-figure change noted in CHANGELOG.md.
+

--- a/.tickets/sl-r6b0.md
+++ b/.tickets/sl-r6b0.md
@@ -1,0 +1,26 @@
+---
+id: sl-r6b0
+status: open
+deps: [sl-fmx0]
+links: []
+created: 2026-07-31T14:43:38Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, core]
+---
+# core: whole-subtree arrow coverage (a record-targeted arrow covers its subtree)
+
+PRD 38 R5. An arrow whose path resolves to a record or list_of record node covers that node's entire subtree. 'addr -> address' between two records asserts the structure maps across; reporting its leaves as gaps reports a gap the author explicitly closed. Closes 3cc-iedv (raised on branch feat/35-coverage-command; arrives on main when feature 35 merges).
+
+## Design
+
+R1's direct/derived split is what makes this safe. The record is DIRECTLY covered so its descendants inherit; a record that is merely an ancestor of a covered leaf confers nothing downward. 3cc-iedv records that the naive fix — a leaf inherits from any covered ancestor — was tried and rejected during sl-4qvp precisely because ancestor prefixes make a record read as covered when any single descendant is, which would turn 'one of twelve address fields is mapped' into 'all twelve are'.
+
+Implement as subtree expansion at set-build time, not a probe-time wildcard, so the covered set stays a plain set and consumers do not change. Expansion needs the schema's field tree at build time; reuse the core resolver interface feature 35 introduced (CoverageSchemaResolver).
+
+## Acceptance Criteria
+
+addr -> address between records with three leaves reports all three leaves covered, the record covered, 3/3. Direct and derived are not confused: in one schema where address is covered by a whole-record arrow and billing only by an arrow to billing.city, address's leaves are all covered while billing.line1 is uncovered and billing is partial — the case 3cc-iedv says a naive ancestor-inheritance fix would break. Whole-subtree arrow plus a more specific sibling arrow does not double count and the percentage stays <= 100%. Whole-subtree arrow onto a list_of record expands the same way. 3cc-iedv closed with a note referencing this work.
+

--- a/.tickets/sl-vu22.md
+++ b/.tickets/sl-vu22.md
@@ -1,0 +1,30 @@
+---
+id: sl-vu22
+status: open
+deps: [sl-qzy3]
+links: [sl-2nxu]
+created: 2026-07-31T14:43:17Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, core]
+---
+# core: derive covered paths from extraction instead of maintaining a second CST walker
+
+PRD 38 R4, architectural half. The immediate defects — flatten inside each, and nested_arrow, both unwalked — are raised separately as sl-qzy3 (P1, blocking PR #405) because they are a live regression that should not wait for a feature. This ticket is the structural fix that makes that class of defect impossible rather than fixed case by case.
+
+Coverage paths are derived twice from different sources: computeMappingCoverage walks the CST itself, while extract.ts walks it for arrows and handles every nesting construct uniformly (accumulating-prefix contract documented at :844-852, relative-dot stripping at :911-921). The duplicate walker is why the two disagree, and it is why fields --unmapped-by was correct until sl-oqsj re-based it onto the core path. Three defects of this class have now been found in the CST walker — sc-xnxp (relative dots, fixed), and the two in sl-qzy3 — each caught by inspection rather than by tests.
+
+## Design
+
+SETTLE PRD 38 OPEN QUESTION 1 FIRST — it is the feature's main design decision, and it decides whether this ticket exists at all. Two options: (a) keep the CST walker and patch it per construct (what sl-qzy3 does as the immediate fix), recursing on the shared _nested_block_item production rather than enumerating permitted children per parent so future grammar additions cannot silently fall through; (b) delete the walker and derive covered paths from extract.ts's arrow output. PRD proposes (b), keeping a CST walk only if a consumer needs per-node positions extraction cannot supply — check what the VS Code gutter needs before committing, since it consumes per-field entries with declaration lines.
+
+If (a) is chosen, close this ticket as won't-do once sl-qzy3 lands and record the decision in the PRD; the value here is entirely in removing the duplication.
+
+Also correct viz-model regardless of the choice: EachBlock has nestedEach but no nestedFlatten, FlattenBlock has no target field, and the comment at viz-backend/src/viz-model.ts:1040-1043 justifies this by asserting the grammar forbids nested flatten — it does not (grammar.js:265-270, corpus fixture each_flatten.txt:331-374, and examples/nested-iteration/pipeline.stm:100 all contradict it). Same defect class as sl-7236, whose ticket named the cause: the corpus contains no nested each blocks so round-trip tests do not catch it.
+
+## Acceptance Criteria
+
+Open question 1 resolved and the decision recorded in the PRD. If (b): one derivation path for covered paths, the CST walker in coverage.ts deleted, and every sl-qzy3 regression test still passing against the new derivation — plus each with a dotted multi-segment target (cobol-to-avro:148) qualifying under the full path, and two each blocks writing the same target list (edi-to-json:106-171) unioning without double counting. Either way: viz-model carries nested flatten blocks and a flatten target, the incorrect comment is removed, and viz coverage reflects nested flatten arrows.
+

--- a/features/38-hierarchical-coverage/PRD.md
+++ b/features/38-hierarchical-coverage/PRD.md
@@ -1,0 +1,635 @@
+# Feature 38 — Hierarchical Field Coverage
+
+> **Status: PROPOSED** (2026-07-31) — blocks publication of Feature 35's
+> `--json` contract. Raised after reading the coverage implementation and
+> reproducing its behaviour: nested-field coverage has three live defects
+> (one producing false positives, two producing false negatives), three
+> different percentage conventions ship today, and the container semantics the
+> CLI and LSP each rely on are mutually contradictory.
+>
+> **State this PRD is written against:** branch `feat/35-coverage-command`
+> at **`47438ac`** — Feature 35, open as **PR #405**, not `main`. Feature 35 is
+> now fully implemented there (`sl-gsxu`, `sl-5sjp`, `sl-4qvp`, `sl-oqsj`,
+> `sl-3ms0`, `sl-268g`, `sl-tdfx`) plus **ADR-034**, so `main` is well behind.
+> Every claim below was re-verified against `47438ac`.
+>
+> **Relationship to ADR-034 (Accepted).** This feature is not in tension with
+> it — ADR-034 reaches the same conclusion from the same evidence and names the
+> deferred work. It establishes leaf-only counting on each leaf's own flag
+> (this feature's R3, already implemented), identifies the same root cause
+> ("a record's `mapped` flag cannot distinguish the two cases that matter"),
+> and defers the fix as requiring `computeMappingCoverage()` "to track
+> directly-covered paths separately from prefix-registered ancestors" — which
+> is precisely R1. ADR-034 also rules that "consumers must not compute their own
+> coverage denominators", which makes the two surviving local denominators
+> (R3) ADR violations rather than mere inconsistencies.
+>
+> R5 does modify ADR-034's letter — records "never vouch for their
+> descendants" becomes "*directly-covered* records vouch for their subtree" —
+> so this feature needs an ADR that supersedes or amends ADR-034. Per project
+> convention the ADR-034 body stays immutable and only its Status line changes.
+
+## Goal
+
+Make field coverage correct and single-definition for hierarchical schemas —
+nested records, lists of records, and fields whose names repeat at different
+depths — so a coverage *number* can be trusted as a merge gate:
+
+1. **No false positives.** A field with no arrow pointing at it is never
+   reported covered, whatever else in the schema shares its name.
+2. **No false negatives from unwalked syntax.** Every nesting construct the
+   grammar permits contributes coverage.
+3. **One definition of a covered container**, replacing the two contradictory
+   ones in use, and **one percentage convention**, replacing three.
+4. **Whole-subtree arrows have defined semantics** (folds in `3cc-iedv`).
+
+## Background — verified behaviour
+
+Confirmed by reading the implementation and running it, with reproductions on
+files that pass `satsuma validate`. Corrects an earlier assessment of mine that
+claimed no coverage percentage existed — three do.
+
+### The data model, and why it is the root cause
+
+`addPathAndPrefixes` (`satsuma-core/src/coverage-paths.ts:29-40` on the branch)
+is the whole of the nested-path logic:
+
+```ts
+export function addPathAndPrefixes(set: Set<string>, path: string): void {
+  if (!path) return;
+  const normalised = path.replace(/\[\]/g, "");
+  const parts = normalised.split(".");
+  let prefix = "";
+  for (const part of parts) {
+    prefix = prefix ? `${prefix}.${part}` : part;
+    set.add(prefix);
+    set.add(part); // bare leaf so "city" matches even if the full path is "address.city"
+  }
+}
+```
+
+`isCoveredFieldPath` is then exact membership: `coveredPaths.has(path)`.
+
+The covered set is therefore a **flat bag of strings that mixes three different
+claims** — "an arrow wrote exactly this path", "this is an ancestor of a path an
+arrow wrote", and "this is a bare segment of some path an arrow wrote" — with no
+way to tell them apart afterwards. Almost everything below follows from that.
+
+Empirically, one arrow covering `address.city` produces
+`{"address", "address.city", "city"}`:
+
+- **Upward propagation: yes**, by ancestor prefix. Intended and documented.
+- **Downward propagation: no.** An arrow covering the record `address` yields
+  `{"address"}` — its leaves stay uncovered.
+- **Every path segment is also registered bare.** `a.b.c.d` adds standalone
+  `a`, `b`, `c`, `d`.
+
+### Defect 1 — coverage is name-based, so unrelated fields share it (false positives)
+
+The bare-segment registration makes coverage match on *names*, not paths.
+Field-name reuse across depths is normal in the schemas that most need coverage
+analysis — XML/XSD, JSON, COBOL copybooks.
+
+Reproduced. Fixture: top-level `city`, plus `home_address` and `work_address`
+records each containing `city` and `line1`; one arrow mapping only
+`home_address.city`.
+
+```
+$ satsuma fields tgt_decl --unmapped-by 'leak repro' leak.stm
+  amount        STRING
+  home_address  record
+    line1  STRING
+  work_address  record
+    line1  STRING
+```
+
+Five fields are unmapped; three are reported. Top-level **`city`** and
+**`work_address.city`** are silently treated as mapped because bare `"city"`
+entered the set.
+
+Worse with the shape real nested data takes — sibling list containers reusing
+leaf names. `orders.lines{sku,qty}` fully mapped inside nested `each` blocks;
+`orders.packed{sku,units}` given **no arrows at all**:
+
+```
+$ satsuma fields tgt_ev --unmapped-by 'partial each' eachleak.stm
+  orders  list_of record
+    packed  list_of record
+      units  INT
+```
+
+`orders.packed.sku` is reported mapped. An untouched container reads as
+half-mapped. For `--fail-under` this is the dangerous direction: a silent
+**over**-count that passes an incomplete spec.
+
+The repo already contains fixtures that would trip this — `examples/lib/
+sfdc_fragments.stm:49-62` spreads one fragment into both `BillingAddress` and
+`ShippingAddress` record bodies, so every leaf name exists at two paths; and
+`satsuma-cli/test/fixtures/deep-nested-bugs.stm` declares four sibling `BIC`
+leaves at different depths.
+
+### Defect 2 — `nested_arrow` contributes no coverage (false negatives)
+
+`collectBodyPaths` (branch `satsuma-core/src/coverage.ts:200-210`) switches on
+`map_arrow`, `computed_arrow`, `each_block`, `flatten_block`. The grammar's
+fourth nesting construct, `nested_arrow` — `src -> tgt { arrow* }`
+(`grammar.js:404-414`) — is not handled and falls through.
+
+So for `addr -> address { .street -> .street_line  .city -> .city }`, the shape
+in `satsuma-cli/test/fixtures/nested-arrow-lookup.stm`, **every field on both
+sides reports uncovered**, including the ones with explicit arrows.
+
+### Defect 3 — nested blocks inside `each`/`flatten` are skipped (false negatives)
+
+The `each` child loop (branch `coverage.ts:248-264`) handles `map_arrow`,
+`computed_arrow` and `each_block` — **not `flatten_block`**.
+`collectFlattenPaths` (`:287-294`) handles only `map_arrow` and
+`computed_arrow` — no nested blocks at all.
+
+The grammar permits both (`_nested_block_item`, `grammar.js:265-270`), the
+corpus has a fixture (`test/corpus/each_flatten.txt:331-374`), and the repo's
+canonical nested example uses it: `examples/nested-iteration/pipeline.stm:100`
+is a `flatten parcels.contents -> .packed_items` inside `each orders`.
+
+Reproduced by running the branch's `computeMappingCoverage` on that example.
+The whole flatten subtree reports uncovered on both sides:
+
+```
+=== source  warehouse_dispatch_events        === target  dispatch_manifest_json
+   COVERED    orders.lines.sku                  COVERED    orders.lines.sku
+   COVERED    orders.lines.quantity             COVERED    orders.lines.qty
+   uncovered  orders.parcels                    uncovered  orders.packed_items
+   uncovered  orders.parcels.barcode            uncovered  orders.packed_items.sku
+   uncovered  orders.parcels.contents           uncovered  orders.packed_items.units
+   uncovered  orders.parcels.contents.sku
+   uncovered  orders.parcels.contents.units
+```
+
+In leaf percentages: the target schema is **100% mapped** and reports
+**75%** (6 of 8 leaves). The source is 89% read — `orders.parcels.barcode` is
+the one genuine gap — and reports **67%** (6 of 9).
+
+This is not theoretical: it is what the finished command on PR #405 prints.
+
+```
+$ satsuma coverage examples/nested-iteration/pipeline.stm
+  source  ::warehouse_dispatch_events      6/9   67%
+  target  ::dispatch_manifest_json         6/8   75%
+```
+
+So `--fail-under 90` fails a fully-mapped spec, on the example the repo ships
+to demonstrate nested iteration — the gate's worst failure mode, since it errs
+toward blocking correct work.
+
+**It also regressed a shipped command.** `sl-oqsj` re-based
+`fields --unmapped-by` onto the core function, which was the right call in
+intent — two commands answering one question from separate code is the drift
+Feature 35 exists to prevent — but the shared path it moved onto has this
+defect, and the CLI's own path did not:
+
+```
+main:   orders.parcels.barcode                                 (correct)
+#405:   orders.parcels.barcode, contents.sku, contents.units    (wrong)
+```
+
+Raised as **`sl-qzy3`** (P1, `gh-405`) so the immediate fix is not gated on this
+feature.
+
+This is the same defect class `sl-7236` fixed in `format.ts`, whose ticket noted
+the cause: *"The corpus contains no nested each blocks so round-trip tests do
+not catch it."*
+
+**Note the CLI is not affected**, and that is itself the problem — see Defect 5.
+
+### Defect 4 — three percentage conventions ship, all different
+
+1. **VS Code status bar** — `vscode-satsuma/src/commands/coverage-logic.ts:78-86`
+   counts **top-level fields only** (`filter(f => !f.path.includes("."))`), so a
+   record is in the denominator and its leaves are not. `address record {line1,
+   line2, line3}` with only `line1` mapped reports **100%**.
+2. **viz schema card** — `satsuma-viz/src/components/sz-schema-card.ts:748-766`
+   counts **every node including containers** in both numerator and
+   denominator, so one covered leaf inflates the numerator once per ancestor
+   level.
+3. **New core rollup** (branch `coverage-rollup.ts:132`) counts **leaves only**,
+   with the right rationale documented at `:43-56`: a record "is structure, not
+   data — counting it alongside its children would count the same data twice
+   and let a schema's nesting depth move the percentage".
+
+(3) is correct, is now **ADR-034 (Accepted)**, and this feature keeps it.
+ADR-034 further rules that consumers must not compute their own denominators, so
+(1) and (2) are ADR violations. (1) is already raised on the branch as
+**`3cc-t6uo`**; (2) — the viz card — is this feature's `sl-hcan`. Until both
+land, a reviewer with the extension, a terminal and the viz panel open sees
+three different figures for one mapping, and Feature 36's requirement that
+overlay numbers equal `coverage --json` fails on the first nested schema.
+
+### Defect 5 — two independent walkers, diverging on nesting
+
+Coverage paths are derived twice from different sources:
+
+- **`computeMappingCoverage`** walks the CST itself (the code above, now in
+  core), with Defects 2 and 3.
+- **`fields --unmapped-by`** builds its set from `index.fieldArrows`, produced
+  by `satsuma-core/src/extract.ts`, which handles all nesting constructs
+  uniformly and strips relative-path dots at `:911-921`.
+
+So the CLI reports `examples/nested-iteration/pipeline.stm` correctly — one
+unread source leaf, `orders.parcels.barcode` — while the promoted walker does
+not. Feature 35's `sl-oqsj` requires `fields --unmapped-by` and
+`coverage --uncovered --mapping` to report the identical field set; **on any
+nested fixture they currently cannot**.
+
+A third walker exists in viz (`field-coverage.ts:85-101`) with its own blind
+spot: `viz-model`'s `EachBlock` has `nestedEach` but no `nestedFlatten`, and
+`FlattenBlock` has no target field, justified by a comment
+(`viz-backend/src/viz-model.ts:1040-1043`) asserting "the grammar does not
+permit them" — which is incorrect.
+
+### Defect 6 — container semantics are contradictory by construction
+
+- **LSP/core** `buildFieldCoverage` (branch `coverage.ts:300-323`) sets
+  `mapped = isCoveredFieldPath(path, ...)` for every field including records.
+  Via ancestor prefixes, a record with **any** covered descendant is
+  `mapped: true`. Its test asserts this (`items.mapped === true` when only
+  `items.id` is mapped).
+- **CLI** `filterUnmappedFields` (`commands/fields.ts:177-199`) does the
+  opposite for records, deliberately and with a comment explaining why: a
+  record is excluded only when **all** children are covered.
+
+Both are right for their consumer — the gutter wants "something in here is
+mapped", the review queue wants "is this record finished?" — and both are
+called coverage. One boolean cannot carry both claims.
+
+### Already-known and already-ticketed
+
+`3cc-iedv` (open, on the branch) records that a whole-record arrow
+`address -> address` leaves its leaves counted uncovered, and correctly
+identifies the fix as *distinguishing directly-covered paths from
+prefix-registered ancestors*. That is the same model change R1 makes, so this
+feature subsumes the ticket rather than duplicating it.
+
+`sc-xnxp` (closed on the branch) fixed a fourth defect of this class: relative
+`.field` paths inside `each`/`flatten` produced `items..id` and matched nothing,
+so the VS Code gutter had been mis-reporting every nested field since
+`each`/`flatten` landed. Regression-lock it here; it is the precedent that this
+walker's nesting handling needs systematic tests, not spot fixes.
+
+## Problems
+
+### P1 — Coverage claims to be path-based but resolves by name
+
+Defect 1. Two unrelated fields that share a leaf name share coverage. The
+collision rate rises with nesting depth and with name reuse — i.e. with exactly
+the schemas coverage analysis is for.
+
+### P2 — Coverage silently ignores syntax the grammar permits
+
+Defects 2 and 3. `nested_arrow` and blocks nested inside `each`/`flatten` are
+invisible, so explicitly mapped fields report as spec gaps. Reviewers chase
+gaps that do not exist, and — worse for trust — the repo's own canonical
+nested example is one of the affected cases.
+
+### P3 — One workspace, three completeness figures
+
+Defect 4. A number that differs between the status bar, the viz card and the
+CLI cannot gate anything, and discredits the others when a reviewer notices.
+
+### P4 — The consumers cannot be reconciled while "covered record" is one boolean
+
+Defects 5 and 6. Feature 35 has already committed to an acceptance criterion
+requiring two of these consumers to agree, and it cannot hold for records or
+for nested fixtures as things stand.
+
+### P5 — A whole-subtree arrow reports gaps the author has closed
+
+`3cc-iedv`. Mapping a record wholesale is legal and meaningful; today it covers
+the record node and none of its leaves.
+
+## Requirements
+
+### R1 — Distinguish direct coverage from derived coverage (fixes P1, P5)
+
+Replace the flat `Set<string>` with a model that records *why* a path is
+covered. Minimally: a set of **directly covered** paths (an arrow wrote exactly
+this) separate from the derived-ancestor relation, which is recomputable from
+it.
+
+- Delete the bare-segment registration. A path's coverage is decided by its
+  qualified path, never by a name match at another depth.
+- Derive, rather than store, the answers consumers need:
+  - leaf covered ⇔ its qualified path is directly covered, **or** it descends
+    from a directly-covered container (R5).
+  - container state ⇔ computed from its descendant leaves (R2).
+- Keep `isCoveredFieldPath(path, set)` working for consumers that only need the
+  boolean, so the change is additive at the call sites that do not care.
+- Audit every consumer for name-based probes and fix them:
+  - `satsuma-cli/src/commands/fields.ts:193` — drop the `mapped.has(f.name)`
+    clause from the leaf test.
+  - `satsuma-viz/src/components/sz-schema-card.ts:656-658,722` and
+    `sz-mapping-detail.ts:526,546` — confirm qualified-path probes.
+- **This makes coverage stricter and existing figures will drop.** That is the
+  correction, and it must be called out in `CHANGELOG.md`.
+
+### R2 — One tri-state definition of container coverage (fixes P4)
+
+| State | Meaning |
+|---|---|
+| `covered` | every descendant leaf is covered |
+| `partial` | at least one, but not all, descendant leaves are covered |
+| `uncovered` | no descendant leaf is covered |
+
+Leaves stay binary. This subsumes both existing consumers without either
+changing what it shows:
+
+- LSP gutter paints on `covered || partial` — today's behaviour exactly.
+- CLI review queue lists anything not `covered` — today's behaviour exactly.
+- Feature 36 R2 gains the signal it lacks: a record with 1 of 12 leaves mapped
+  can render differently from a fully mapped one.
+
+`FieldCoverageEntry.mapped` is an existing contract, so **add** the state rather
+than repurposing `mapped`, and define `mapped = state !== "uncovered"` for
+containers so LSP output is byte-identical.
+
+### R3 — One percentage convention (fixes P3)
+
+- Leaves only, as the branch's `coverage-rollup.ts` already implements. Keep it.
+- Reconcile the two shipped counters to it: `computeTargetCoverageStats`
+  (vscode) and `_countFields`/`_countMapped` (viz card) both stop counting
+  containers and delegate to the core rollup instead of computing their own.
+- Report container states as counts alongside
+  (`records: {covered, partial, uncovered}`) — useful review information, but
+  not a percentage.
+- Document the invariant: **a schema's percentage is unchanged by re-nesting.**
+  Same leaves, same arrows, same number.
+
+### R4 — Walk every nesting construct the grammar permits (fixes P2)
+
+The **immediate** fix is `sl-qzy3`, outside this feature because it is a
+regression in PR #405's own work and should not wait: handle `nested_arrow` in
+`collectBodyPaths` with the same parent-prefix qualification as `each`, and
+handle `flatten_block` inside `each_block` plus both block types inside
+`flatten_block`. Recurse on the shared `_nested_block_item` production rather
+than enumerating permitted children per parent, so a future grammar addition
+cannot silently fall through a third time.
+
+What remains here:
+
+- **Stop maintaining a second walker.** `extract.ts` already handles every
+  construct uniformly and is why `fields --unmapped-by` was correct before it
+  was re-based. Deriving covered paths from extraction removes Defects 2, 3 and
+  5 as a class instead of patching each — three have now been found by
+  inspection (`sc-xnxp`, plus the two in `sl-qzy3`) and none by a test. See
+  Open Question 1; if the answer is "keep the walker", `sl-vu22` closes as
+  won't-do and `sl-qzy3` is the whole of R4.
+- Correct `viz-model`'s `EachBlock`/`FlattenBlock` to carry nested flatten
+  blocks and a flatten target, and remove the comment at
+  `viz-backend/src/viz-model.ts:1040-1043` asserting the grammar forbids nested
+  flatten — `grammar.js:265-270`, `each_flatten.txt:331-374` and
+  `examples/nested-iteration/pipeline.stm:100` each contradict it.
+
+### R5 — Whole-subtree arrow semantics (fixes P5, closes `3cc-iedv`)
+
+An arrow whose path resolves to a record or list-of-record node covers that
+node's **entire subtree**. `addr -> address` between two records asserts the
+structure maps across; reporting its leaves as gaps reports a gap the author
+closed. R1's direct/derived split is what makes this expressible — the record
+is *directly* covered, so its descendants inherit; a record that is merely an
+ancestor of a covered leaf does not confer anything downward.
+
+Close `3cc-iedv` as part of this requirement.
+
+### R6 — Cross-consumer parity is tested (fixes P3, P4)
+
+Feature 36 requires overlay numbers to equal `coverage --json`. That needs a
+test that fails when it breaks: one nested fixture, computed through the CLI
+path and the viz-backend path, asserting **identical leaf verdicts, identical
+container states, identical percentages**.
+
+This is also the test that catches spread-expansion divergence. The three
+consumers expand fragment spreads at three different points: the CLI before
+filtering (`expandNestedSpreads` / `expandEntityFields` in `fields.ts:74-82`),
+viz at model-build time (`viz-model.ts:266-298`), and **the LSP/core coverage
+path not at all** — so fields a schema acquires via `...fragment` are currently
+invisible to the gutter and status bar while the CLI lists them.
+
+### R7 — `[]` normalization hygiene (low priority)
+
+`addPathAndPrefixes` strips `[]` on write; `isCoveredFieldPath` does not on
+read, so a probe containing `[]` never matches. Note this is **dead code for
+current syntax** — `[]` was removed from paths in v2 (`grammar.js:429-431`) and
+cannot parse. Either make the normalization symmetric via one shared helper, or
+delete it and keep a test asserting bracket paths do not parse. Do not leave it
+asymmetric and undocumented.
+
+## Acceptance Tests
+
+Minimal snippets per the test quality standards, except where a named repo
+fixture is the point. Cases 1–9 must **fail** against `fc3d5a5`.
+
+### Path-based, not name-based (R1)
+
+1. **Top-level field shadowed by a nested leaf.** Top-level `city` plus
+   `home_address record { city, line1 }`; only `home_address.city` mapped. →
+   top-level `city` **uncovered**. *(Today: covered.)*
+2. **Sibling records sharing a leaf name.** Same fixture. →
+   `work_address.city` **uncovered**. *(Today: covered.)*
+3. **Sibling list containers sharing a leaf name.** `orders.lines{sku,qty}`
+   fully mapped in nested `each`; `orders.packed{sku,units}` unmapped. → both
+   `packed` leaves **uncovered** and `orders.packed` is `uncovered`, not
+   `partial`. *(Today: `packed.sku` covered.)*
+4. **Deep-segment leak.** Only `a.b.c.d` mapped, schema also declares top-level
+   `b`, `c`, `d`. → all three **uncovered**. *(Today: all covered.)*
+5. **One fragment spread into two sibling records.** Use
+   `examples/lib/sfdc_fragments.stm`'s shape: `...sfdc address` spread into both
+   `BillingAddress` and `ShippingAddress`. Map only `BillingAddress.Street`. →
+   `ShippingAddress.Street` **uncovered**. *(Today: covered — and this is a
+   shipped example, not a contrived case.)*
+6. **Repeated leaf names at four depths — as already committed.**
+   `satsuma-cli/test/fixtures/deep-nested-bugs.stm` (ISO-20022 pacs.008)
+   declares four `BIC` leaves — `GrpHdr.InstgAgt`, `GrpHdr.InstdAgt`,
+   `CdtTrfTxInf.DbtrAgt`, `CdtTrfTxInf.CdtrAgt` — and its mapping covers three
+   of them, leaving `GrpHdr.InstdAgt.BIC` unmapped.
+   → `GrpHdr.InstdAgt.BIC` **uncovered** and `GrpHdr.InstdAgt` `uncovered`.
+
+   Today both are omitted entirely:
+
+   ```
+   $ satsuma fields pacs008 --unmapped-by 'pacs008 to iso_target' deep-nested-bugs.stm
+     GrpHdr  record
+       MsgId  STRING
+   ```
+
+   The instructed-agent BIC is silently reported as mapped because the
+   instructing-agent BIC is. Confusing those two is precisely the error
+   coverage analysis exists to catch in payment messaging, and the fixture is
+   already in the repo — no contrived input needed to demonstrate the defect.
+
+### Unwalked syntax (R4)
+
+7. **`nested_arrow`.** `addr -> address { .street -> .street_line  .city ->
+   .city }` (the `nested-arrow-lookup.stm` shape). → the four written paths
+   `covered`, unwritten siblings `uncovered`. *(Today: all uncovered.)*
+8. **`flatten` nested inside `each`.** `examples/nested-iteration/pipeline.stm`
+   verbatim. → `orders.parcels.contents.sku`, `.units` and
+   `orders.packed_items.sku`, `.units` `covered`; `orders.parcels.barcode` the
+   **single** uncovered source leaf; target percentage **100%** and source
+   **89%**. *(Today: whole flatten subtree uncovered, 75% and 67%.)* Assert the
+   percentages, not just the booleans — the percentage is what gates CI.
+9. **`each` nested inside `flatten`.** The corpus already has the inverse
+   fixture (`each_flatten.txt:331-374`); add the mirror. → inner arrows
+   contribute coverage.
+10. **Relative-dot regression lock** (`sc-xnxp`). `each items -> lines { .id ->
+    .item_id }` → `items.id` and `lines.item_id` `covered`. Locks a fix that had
+    no test before the branch.
+11. **`each` with a dotted multi-segment target.** From
+    `examples/cobol-to-avro/pipeline.stm:148`, `each PHONE_NUMBERS ->
+    contact_info.phones` → inner arrows qualify under the full target path.
+12. **Two `each` blocks writing the same target list.** From
+    `examples/edi-to-json/pipeline.stm:106-171`, where `LineItems` and
+    `Quantities` both target `ShipmentHeader.asnDetails.items` → union, no
+    double counting, percentage ≤ 100%.
+
+### Container tri-state (R2)
+
+13. One of three leaves mapped → `partial`, with `mapped === true` so the
+    gutter is unchanged.
+14. Three of three → `covered`. Zero of three → `uncovered`,
+    `mapped === false`.
+15. **`partial` propagates upward; `covered` does not.** `a record { b record {
+    x, y } }`, only `a.b.x` mapped → `a.b` **and** `a` are `partial`, neither
+    `covered`.
+16. **Container referenced but no leaf.** `each parcels -> .packed { }` — empty
+    body. → `packed` is `uncovered`. A container reference must not manufacture
+    leaf coverage.
+17. **Computed arrow into a container.** From `edi-to-json`,
+    `-> ShipmentHeader.asnDetails.containers { "…no source data…" }` where the
+    container's four leaves have no arrows → decided-and-documented state;
+    proposed `uncovered` with the container's own `mapped` true, because the
+    example's own `//!` markers assert those leaves are a known data gap.
+
+### Percentage (R3)
+
+18. **Containers excluded.** `amount` + `address record { city, line1,
+    postcode }`, only `address.city` mapped → **25%** (1/4), not 40% (2/5).
+19. **Depth invariance.** Two schemas, same four leaves, one flat and one
+    nested three deep, same arrows → **identical** percentages.
+20. **All three surfaces agree.** The 25% fixture reports 25% from the core
+    rollup, the VS Code status bar, and the viz card. *(Today: 25%, 100% and
+    40% respectively.)*
+21. Container counts reported separately: `records: {covered: 0, partial: 1,
+    uncovered: 0}`.
+
+### Whole-subtree arrows (R5)
+
+22. `addr -> address`, both records with three leaves → all three leaves
+    `covered`, `address` `covered`, 3/3.
+23. **Direct vs derived is not confused.** In one schema: `address` covered by a
+    whole-record arrow, `billing` covered only by an arrow to `billing.city`. →
+    `address`'s leaves all `covered`; `billing.line1` **uncovered**,
+    `billing` `partial`. This is the case `3cc-iedv` says a naive
+    ancestor-inheritance fix would break.
+24. Whole-subtree arrow plus a more specific sibling arrow → no double count.
+25. Whole-subtree arrow onto a `list_of record` → same expansion.
+
+### Parity and spreads (R6)
+
+26. One nested fixture through the CLI path and the viz-backend path →
+    identical leaf verdicts, container states and percentage.
+27. **Spread-materialised nested fields are counted in every consumer.** Use
+    `satsuma-cli/test/fixtures/nested-record-spread.stm`, where a record body
+    contains only `...address_fields`. → `address.street`/`.city` appear as
+    coverage entries with correct states in the CLI, core and viz paths.
+    *(Today the core/LSP path does not expand spreads at all, so they are
+    absent from both numerator and denominator.)*
+28. Spread into a `list_of record` body — no fixture exists anywhere; add one.
+
+### Regression
+
+29. `satsuma coverage` over `examples/nested-iteration/pipeline.stm` reports
+    exactly one uncovered source leaf: `orders.parcels.barcode`.
+30. Corpus gap: no tree-sitter fixture spreads a fragment into a record body,
+    and none nests `each` inside `flatten`. Add both.
+31. The LSP coverage suite passes; tests encoding a defect above are updated
+    with a comment citing this feature.
+
+## Out of Scope
+
+- Coverage *policy* — whether a gap is acceptable. Unchanged from Feature 35:
+  the count is deterministic, policy is lint (Feature 37).
+- Whether the two ends of a whole-subtree arrow have *compatible* record
+  shapes. R5 defines the coverage consequence only; structural comparison is a
+  plausible future lint rule.
+- Revising `each`/`flatten` path *relativity* rules. `extract.ts`'s
+  accumulating-prefix contract is correct and is only regression-locked here.
+- NL-derived coverage. A field populated only by prose stays uncovered.
+- Coverage history or trends.
+
+## Open Questions
+
+1. **One walker or two?** (`sl-vu22`) R4 can be satisfied by patching the CST
+   walker (`nested_arrow` + nested-block recursion) or by deriving covered
+   paths from `extract.ts`'s arrow output, which already handles every construct
+   and is why the CLI is correct today. Patching is smaller; deriving deletes
+   Defects 2, 3 and 5 as a class and removes a whole duplicate walker.
+   Proposed: **derive from extraction**, keeping the CST walk only if a consumer
+   needs per-node CST positions extraction cannot supply. This is the feature's
+   main design decision and `sl-vu22` carries it as its first acceptance
+   criterion — settle it before implementing.
+2. **Should the leak fix ship ahead of this feature?** **Resolved** — raised as
+   `sl-joeq` (P1 bug), fixable now against `main` independently of Features
+   35/36, with this epic depending on it. A silent over-count in a shipped
+   command should not wait for a feature. `sl-joeq` is scoped to the leak
+   only; the structural work stays here.
+3. **Ordering against Feature 35 — overtaken by events.** An earlier draft
+   proposed landing this feature before `sl-tdfx` published the `--json`
+   contract. `sl-tdfx` has landed on PR #405; `SATSUMA-CLI.md:145` already
+   describes `--json` as "a **stable contract**, consumed by the satsuma-viz
+   coverage overlay". So the question is now how to change a published contract:
+
+   - R2's tri-state is **additive** — a new field alongside `mapped`, which
+     keeps its meaning. Safe.
+   - R1, R5 and `sl-qzy3` change **values, not shape**: the same fields report
+     different coverage, and percentages move in both directions (up where
+     false negatives are fixed, down where false positives are). Every one of
+     those movements is a correction, but a consumer that has recorded a number
+     will see it change.
+
+   Proposed: land `sl-qzy3` inside PR #405 if that PR is still open, since it is
+   a regression in that PR's own work; treat the rest as a documented contract
+   revision with a `CHANGELOG.md` entry, and land it before Feature 36's
+   overlay ships so the two do not disagree in public. `sl-joeq` need not wait
+   for anything.
+4. **Is `partial` the right shape?** (`sl-0pun`) Proposed: three named states,
+   leaves never `partial`. The alternative — `coveredLeaves`/`totalLeaves`
+   counts on every node and no named states — is more data but pushes the "is
+   this done?" judgement onto every consumer, which is how the current
+   disagreement arose.
+5. **Case 17: computed arrow into a container.** Proposed `uncovered` for the
+   leaves with the container's own `mapped` true, but this is a judgement call
+   about whether "I have declared this a data gap" should read as coverage.
+
+## Ticket Map
+
+| Requirement | Ticket | Depends on |
+|---|---|---|
+| **Prerequisite bug** — bare-segment leak (false positives) | `sl-joeq` (P1) | — |
+| **Prerequisite bug** — unwalked nesting + `--unmapped-by` regression | `sl-qzy3` (P1, `gh-405`) | — |
+| Epic | `sl-j6g9` | `sl-joeq` |
+| R1 direct vs derived coverage | `sl-fmx0` | `sl-joeq` |
+| R2 container tri-state | `sl-0pun` | `sl-fmx0` |
+| R3 percentage — viz card | `sl-hcan` | `sl-0pun` |
+| R3 percentage — VS Code status bar | `3cc-t6uo` *(raised on PR #405)* | — |
+| R4 remove the duplicate walker | `sl-vu22` | `sl-qzy3` (settles OQ1) |
+| R5 whole-subtree arrows (closes `3cc-iedv`) | `sl-r6b0` | `sl-fmx0` |
+| R6 cross-consumer parity + spreads | `sl-5nsv` | `sl-0pun`, `sl-hcan`, `sl-vu22` |
+| R7 `[]` hygiene | `sl-8o1n` | — |
+| Corpus fixture gaps (case 30) | `sl-2nxu` | — |
+
+Two tickets pre-exist on PR #405 and are **not** duplicated here: `3cc-iedv`
+(whole-record arrows — closed by `sl-r6b0`) and `3cc-t6uo` (the status-bar
+denominator — the other half of R3). Both arrive on `main` when #405 merges.
+
+`sl-joeq`, `sl-qzy3`, `sl-8o1n` and `sl-2nxu` are ready immediately. Schedule
+`sl-qzy3` first: it is a regression in an open PR's own work, and fixing it
+settles what `sl-vu22` still has to do.

--- a/features/38-hierarchical-coverage/PRD.md
+++ b/features/38-hierarchical-coverage/PRD.md
@@ -1,17 +1,30 @@
 # Feature 38 — Hierarchical Field Coverage
 
-> **Status: PROPOSED** (2026-07-31) — blocks publication of Feature 35's
-> `--json` contract. Raised after reading the coverage implementation and
-> reproducing its behaviour: nested-field coverage has three live defects
-> (one producing false positives, two producing false negatives), three
-> different percentage conventions ship today, and the container semantics the
-> CLI and LSP each rely on are mutually contradictory.
+> **Status: PROPOSED** (2026-07-31) — raised after reading the coverage
+> implementation and reproducing its behaviour. Six defects were found: coverage
+> resolves field names rather than paths and so reports unmapped fields as
+> mapped, two nesting constructs were not walked at all, three different
+> percentage conventions ship, two independent walkers derive the same paths, and
+> the container semantics the CLI and LSP each rely on are mutually
+> contradictory. The two unwalked constructs are fixed (`sl-qzy3`); the rest are
+> open, and share one root cause.
 >
-> **State this PRD is written against:** branch `feat/35-coverage-command`
-> at **`47438ac`** — Feature 35, open as **PR #405**, not `main`. Feature 35 is
-> now fully implemented there (`sl-gsxu`, `sl-5sjp`, `sl-4qvp`, `sl-oqsj`,
-> `sl-3ms0`, `sl-268g`, `sl-tdfx`) plus **ADR-034**, so `main` is well behind.
-> Every claim below was re-verified against `47438ac`.
+> **State this PRD was written against:** branch `feat/35-coverage-command` at
+> `47438ac`, since merged to `main` as **PR #405** (Feature 35 complete —
+> `sl-gsxu`, `sl-5sjp`, `sl-4qvp`, `sl-oqsj`, `sl-3ms0`, `sl-268g`, `sl-tdfx`,
+> plus **ADR-034**). Every claim below was verified against that commit.
+>
+> **Defects 2 and 3 have since been fixed** by `sl-qzy3`, which landed in
+> PR #405 before it merged: the walk now recurses uniformly over all three
+> container blocks, so `nested_arrow` and `flatten`-inside-`each` contribute
+> coverage. They are kept below, with their pre-fix figures, because they are
+> the evidence for R4 — three defects of that class were found by inspection
+> and none by a test, which is the case for removing the duplicate walker
+> rather than patching it a fourth time.
+>
+> **Defects 1, 4, 5 and 6 remain open.** Defect 5's *symptom* is gone — the two
+> walkers agree again on the nested corpus — but the duplication that caused it
+> is still there, which is what `sl-vu22` addresses. R1–R7 are unchanged.
 >
 > **Relationship to ADR-034 (Accepted).** This feature is not in tension with
 > it — ADR-034 reaches the same conclusion from the same evidence and names the
@@ -365,13 +378,11 @@ containers so LSP output is byte-identical.
 
 ### R4 — Walk every nesting construct the grammar permits (fixes P2)
 
-The **immediate** fix is `sl-qzy3`, outside this feature because it is a
-regression in PR #405's own work and should not wait: handle `nested_arrow` in
-`collectBodyPaths` with the same parent-prefix qualification as `each`, and
-handle `flatten_block` inside `each_block` plus both block types inside
-`flatten_block`. Recurse on the shared `_nested_block_item` production rather
-than enumerating permitted children per parent, so a future grammar addition
-cannot silently fall through a third time.
+The immediate fix **has landed** — `sl-qzy3`, in PR #405 before it merged. It
+handles `nested_arrow` in the body walk and recurses on the shared
+`_nested_block_item` production rather than enumerating permitted children per
+parent, so a future grammar addition cannot silently fall through a fourth
+time. Defects 2 and 3 are closed.
 
 What remains here:
 
@@ -589,17 +600,18 @@ fixture is the point. Cases 1–9 must **fail** against `fc3d5a5`.
 
    - R2's tri-state is **additive** — a new field alongside `mapped`, which
      keeps its meaning. Safe.
-   - R1, R5 and `sl-qzy3` change **values, not shape**: the same fields report
+   - R1 and R5 change **values, not shape**: the same fields report
      different coverage, and percentages move in both directions (up where
      false negatives are fixed, down where false positives are). Every one of
      those movements is a correction, but a consumer that has recorded a number
      will see it change.
 
-   Proposed: land `sl-qzy3` inside PR #405 if that PR is still open, since it is
-   a regression in that PR's own work; treat the rest as a documented contract
-   revision with a `CHANGELOG.md` entry, and land it before Feature 36's
-   overlay ships so the two do not disagree in public. `sl-joeq` need not wait
-   for anything.
+   `sl-qzy3` took this route already: it landed inside PR #405, since it was a
+   regression in that PR's own work, and its value changes shipped with the
+   contract rather than after it. Proposed for the rest: treat it as a
+   documented contract revision with a `CHANGELOG.md` entry, and land it before
+   Feature 36's overlay ships so the two do not disagree in public. `sl-joeq`
+   need not wait for anything.
 4. **Is `partial` the right shape?** (`sl-0pun`) Proposed: three named states,
    leaves never `partial`. The alternative — `coveredLeaves`/`totalLeaves`
    counts on every node and no named states — is more data but pushes the "is
@@ -614,22 +626,23 @@ fixture is the point. Cases 1–9 must **fail** against `fc3d5a5`.
 | Requirement | Ticket | Depends on |
 |---|---|---|
 | **Prerequisite bug** — bare-segment leak (false positives) | `sl-joeq` (P1) | — |
-| **Prerequisite bug** — unwalked nesting + `--unmapped-by` regression | `sl-qzy3` (P1, `gh-405`) | — |
+| ~~Prerequisite bug — unwalked nesting + `--unmapped-by` regression~~ | `sl-qzy3` — **done**, merged in #405 | — |
 | Epic | `sl-j6g9` | `sl-joeq` |
 | R1 direct vs derived coverage | `sl-fmx0` | `sl-joeq` |
 | R2 container tri-state | `sl-0pun` | `sl-fmx0` |
 | R3 percentage — viz card | `sl-hcan` | `sl-0pun` |
-| R3 percentage — VS Code status bar | `3cc-t6uo` *(raised on PR #405)* | — |
-| R4 remove the duplicate walker | `sl-vu22` | `sl-qzy3` (settles OQ1) |
+| R3 percentage — VS Code status bar | `3cc-t6uo` *(from #405, now on `main`)* | — |
+| R4 remove the duplicate walker | `sl-vu22` | `sl-qzy3` ✓ (settles OQ1) |
 | R5 whole-subtree arrows (closes `3cc-iedv`) | `sl-r6b0` | `sl-fmx0` |
 | R6 cross-consumer parity + spreads | `sl-5nsv` | `sl-0pun`, `sl-hcan`, `sl-vu22` |
 | R7 `[]` hygiene | `sl-8o1n` | — |
 | Corpus fixture gaps (case 30) | `sl-2nxu` | — |
 
-Two tickets pre-exist on PR #405 and are **not** duplicated here: `3cc-iedv`
+Two tickets came from PR #405 and are **not** duplicated here: `3cc-iedv`
 (whole-record arrows — closed by `sl-r6b0`) and `3cc-t6uo` (the status-bar
-denominator — the other half of R3). Both arrive on `main` when #405 merges.
+denominator — the other half of R3). Both are now on `main`.
 
-`sl-joeq`, `sl-qzy3`, `sl-8o1n` and `sl-2nxu` are ready immediately. Schedule
-`sl-qzy3` first: it is a regression in an open PR's own work, and fixing it
-settles what `sl-vu22` still has to do.
+`sl-joeq`, `sl-8o1n`, `sl-2nxu` and `sl-vu22` are ready immediately.
+`sl-joeq` is the one to schedule first — a silent over-count in shipped
+commands — and `sl-vu22`'s open question should be answered before R1 starts,
+since it decides whether there is one derivation path or two.


### PR DESCRIPTION
Adds `features/38-hierarchical-coverage/PRD.md` and its 11 tickets. No implementation.

I went back over nested-field coverage by reading the implementation and running it rather than trusting its comments, after being asked to verify before making confident claims. That turned up more than expected — including a regression caused by one of my own earlier review recommendations.

**Verified against PR #405 at `47438ac`, not `main`.** Feature 35 is fully implemented there plus ADR-034, so `main` is well behind and several of these defects are only observable on that branch.

## Two P1 bugs, raised standalone rather than as feature work

Both are live in shipped commands and shouldn't wait for a feature.

### `sl-joeq` — coverage resolves by name, not by path

`addPathAndPrefixes` registers every path segment as a standalone bare name, so any field whose local name matches a segment of some other covered path in the same schema is reported mapped. Reproduced on a **committed fixture**:

`deep-nested-bugs.stm` (ISO-20022 pacs.008) declares four `BIC` leaves and maps three. The unmapped `GrpHdr.InstdAgt.BIC` is silently reported as mapped, because the instructing-agent BIC is. Confusing instructed with instructing agent is precisely what coverage analysis exists to catch in payment messaging.

The same defect makes an entirely untouched list container read as half-mapped when a sibling container reuses a leaf name — which is the norm in nested data (`id`, `sku`, `code`, `city`).

This is a silent **over**-count: it makes an incomplete spec look complete.

### `sl-qzy3` — unwalked nesting, and a regression in a shipped command

`computeMappingCoverage` doesn't walk `flatten` inside `each`, nor `nested_arrow` at all, though the grammar permits both. On #405 the finished command prints:

```
$ satsuma coverage examples/nested-iteration/pipeline.stm
  source  ::warehouse_dispatch_events      6/9   67%
  target  ::dispatch_manifest_json         6/8   75%
```

That example is **fully mapped** (target 8/8; source 8/9, `orders.parcels.barcode` the one real gap). So `--fail-under 90` fails a correct spec on the example the repo ships to demonstrate nested iteration — the gate's worst failure mode, since it errs toward blocking correct work.

**It also regressed `fields --unmapped-by`**, which was correct on `main` and is wrong on #405:

```
main:   orders.parcels.barcode                                 (correct)
#405:   orders.parcels.barcode, contents.sku, contents.units    (wrong)
```

`sl-oqsj` re-based that command onto the core function. That was right in intent — two commands answering one question from separate code is the drift Feature 35 exists to prevent — but the shared path has this defect and the CLI's own path did not. **I recommended that re-basing in the Feature 35 doc review without knowing the walker was defective**, so this one is mine. The re-basing should stay; the walker needs fixing.

Tagged `gh-405` — worth fixing inside that PR, since it's a regression in its own work.

## The feature

Six verified defects behind one root cause: the covered set is a flat bag of strings mixing "an arrow wrote exactly this", "this is an ancestor of that" and "this is a segment of that", with no way to tell them apart afterwards.

R1 separates direct from derived coverage. That single change fixes the false positives, makes a container tri-state expressible, and resolves `3cc-iedv` — whose own analysis independently identified the same change as the prerequisite.

The rest: a `covered`/`partial`/`uncovered` tri-state reconciling the CLI's "all descendants" and the LSP's "any descendant" definitions without either consumer changing what it displays; one percentage convention replacing three; removing the duplicate CST walker; whole-subtree arrow semantics; and a cross-consumer parity test that would actually fail if the three surfaces diverged again.

## Relationship to ADR-034

Not in tension. ADR-034 reaches the same conclusion from the same evidence, already implements leaf-only counting (this feature's R3), identifies the same root cause — *"a record's `mapped` flag cannot distinguish the two cases that matter"* — and defers the fix as requiring the tracking of *"directly-covered paths separately from prefix-registered ancestors"*, which is R1 exactly. It also rules that consumers must not compute their own denominators, which makes the two surviving local denominators ADR violations rather than mere inconsistencies.

R5 does modify its letter — records "never vouch for their descendants" becomes "*directly-covered* records vouch for their subtree" — so this feature will need an ADR superseding it. Flagged in the PRD rather than assumed.

## Not duplicated

`3cc-iedv` and `3cc-t6uo` already exist on #405, covering whole-record arrows and the status-bar denominator. `sl-r6b0` closes the first; `sl-hcan` is scoped to the viz half of the second so the two don't collide.

## Test cases

31 acceptance tests, nine of which must fail before the work starts. They lean on fixtures already in the repo rather than contrived snippets — `sfdc_fragments.stm` spreads one fragment into both `BillingAddress` and `ShippingAddress`, so every leaf name exists at two paths; `edi-to-json` has two `each` blocks writing one target list; `deep-nested-bugs.stm` has the four `BIC` leaves. Percentages are asserted, not just booleans, because the percentage is what gates CI.

Also flagged: no corpus fixture spreads a fragment into a record body, and none nests `each` inside `flatten` (`sl-2nxu`). `sl-7236`'s ticket already named that gap as the reason a nesting defect survived in `format.ts`; it's why these survived too. Three walker defects have now been found by inspection and none by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)