### PR TITLE
fix(tree-sitter): run corpus tests through WASM, document the cache redirect (sl-cysb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,10 @@ jobs:
           fi
 
       - name: Run corpus tests
-        run: node_modules/.bin/tree-sitter test
+        # --wasm is the repo-wide convention (AGENTS.md): there is no native
+        # build here, so the corpus must be exercised through the same WASM
+        # parser every consumer loads (sl-cysb).
+        run: node_modules/.bin/tree-sitter test --wasm
 
       - name: Install pytest
         run: pip install pytest

--- a/.tickets/sl-cysb.md
+++ b/.tickets/sl-cysb.md
@@ -1,0 +1,37 @@
+---
+id: sl-cysb
+status: closed
+deps: []
+links: []
+created: 2026-07-31T14:49:04Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [tree-sitter, ci, docs]
+---
+# tree-sitter: corpus test path is native, contradicting the WASM-only convention
+
+AGENTS.md:197, docs/developer/AGENT-CONTRIBUTIONS.md:162 and README.md:396 all state the convention: always use --wasm, there is no native build in this repository. Two invocations ignore it:
+
+- tooling/tree-sitter-satsuma/package.json 'test': `tree-sitter generate && tree-sitter test` (no flag)
+- .github/workflows/ci.yml:250: `node_modules/.bin/tree-sitter test` (no flag)
+
+A test:wasm script exists with the correct flag and nothing invokes it — dead since it was added. scripts/run-repo-checks.sh already uses --wasm, so the repo is inconsistent with itself.
+
+Consequence: `npm test` in that package requires a C toolchain, which is the portability the convention exists to protect. Verified in the agent sandbox — the native path fails with 'clang: unable to execute command: posix_spawn failed' even with a writable cache, while --wasm passes all 315 parses.
+
+Second, separate gap in the guidance: --wasm is necessary but NOT sufficient. Both the native and the --wasm path write compiled artifacts into ~/.cache/tree-sitter, which a sandboxed agent cannot write, producing an opaque 'Operation not permitted (os error 1)' on a lock-file path. The working invocation needs XDG_CACHE_HOME redirected to a writable directory. Without that documented, an agent hits the lock error and reasonably concludes the corpus tests cannot be run locally at all — which is what happened during feature 35 (PR #405) and led to the grammar suite being reported as unverifiable.
+
+## Acceptance Criteria
+
+package.json 'test' uses --wasm and the redundant test:wasm script is removed; ci.yml runs the corpus tests with --wasm; AGENTS.md and AGENT-CONTRIBUTIONS.md document the XDG_CACHE_HOME redirect with a copy-pasteable command and state that npm test in that package is the WASM path; corpus tests verified passing locally via the documented command; CI green.
+
+
+## Notes
+
+**2026-07-31T14:51:00Z**
+
+Cause: tooling/tree-sitter-satsuma/package.json's 'test' script and .github/workflows/ci.yml:250 both ran bare `tree-sitter test`, compiling the grammar natively, while AGENTS.md:197, AGENT-CONTRIBUTIONS.md:162, README.md:396 and scripts/run-repo-checks.sh all specify --wasm. A test:wasm script with the correct flag existed and nothing invoked it.
+Fix: 'test' now runs `tree-sitter generate && tree-sitter test --wasm` and the redundant test:wasm script is deleted; ci.yml runs the corpus tests with --wasm and a comment citing the convention. Verified: `npm --prefix tooling/tree-sitter-satsuma test` passes 315/315.
+
+Second gap fixed in the same change — the guidance was incomplete, not just unenforced. --wasm is necessary but not sufficient in the agent sandbox: both paths compile into ~/.cache/tree-sitter, which is unwritable there, and the failure surfaces as 'Operation not permitted (os error 1)' on a lock-file path that looks nothing like a permissions problem. AGENTS.md and AGENT-CONTRIBUTIONS.md now document the XDG_CACHE_HOME redirect with a copy-pasteable command and state explicitly not to conclude the corpus tests are unrunnable locally. That wrong conclusion is what happened during feature 35 (PR #405), where the grammar suite was reported as unverifiable when it was in fact runnable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,32 @@ HOMEBREW_NO_AUTO_UPDATE=1 brew ...
 Prefer these forms over prompt-prone variants such as plain `cp`, `mv`, or `rm`.
 
 ## Running tree-sitter CLI
-Always use --wasm flag to avoid the need for a C compiler and because we want to keep things platform portable.
+
+**Always pass `--wasm`.** There is no native build in this repository: the
+`tree-sitter-satsuma` package's `install` script deliberately skips node-gyp, and
+every consumer loads `tree-sitter-satsuma.wasm`. The native path needs a C
+toolchain, which is exactly the portability the WASM migration removed (ADR-002).
+`npm test` in that package is already the `--wasm` path (sl-cysb) — you do not
+need to add the flag yourself when using the npm scripts.
+
+**In the agent sandbox, also redirect the tree-sitter cache.** `--wasm` alone is
+not sufficient. Both the native and the WASM path compile the grammar into
+`~/.cache/tree-sitter/`, which the sandbox cannot write, and the failure is an
+opaque lock-file error that looks nothing like a permissions problem:
+
+```
+Error: Operation not permitted (os error 1) (~/.cache/tree-sitter/lock/satsuma-<hash>.lock)
+```
+
+Point `XDG_CACHE_HOME` at your scratchpad and the corpus tests run normally:
+
+```bash
+XDG_CACHE_HOME="$SCRATCHPAD/ts-cache" npm --prefix tooling/tree-sitter-satsuma test
+```
+
+Do **not** conclude from the lock error that the corpus tests cannot be run
+locally — they can, and they must be before any grammar change is pushed. All 315
+parses should pass.
 
 ## Code Search with ast-grep
 

--- a/docs/developer/AGENT-CONTRIBUTIONS.md
+++ b/docs/developer/AGENT-CONTRIBUTIONS.md
@@ -159,4 +159,18 @@ After PR is merged:
 - [ ] Delete the local branch: `git branch -d <branch>`
 
 ## Running tree-sitter CLI
-Always use --wasm flag to avoid the need for a C compiler and because we want to keep things platform portable.
+
+Always pass `--wasm` — there is no native build in this repository, and the native
+path needs a C toolchain the WASM migration removed (ADR-002). The npm scripts
+already do this, so `npm --prefix tooling/tree-sitter-satsuma test` is correct as-is.
+
+In the agent sandbox you must also redirect the tree-sitter cache, because both
+the native and WASM paths compile into `~/.cache/tree-sitter/` and fail there with
+an opaque `Operation not permitted` lock-file error:
+
+```bash
+XDG_CACHE_HOME="$SCRATCHPAD/ts-cache" npm --prefix tooling/tree-sitter-satsuma test
+```
+
+See the "Running tree-sitter CLI" section of [AGENTS.md](../../AGENTS.md) for the
+full explanation.

--- a/tooling/tree-sitter-satsuma/package.json
+++ b/tooling/tree-sitter-satsuma/package.json
@@ -8,8 +8,7 @@
     "install": "echo 'Skipping native build — WASM only'",
     "generate": "tree-sitter generate",
     "build": "tree-sitter generate && tree-sitter build --wasm . -o tree-sitter-satsuma.wasm",
-    "test": "tree-sitter generate && tree-sitter test",
-    "test:wasm": "tree-sitter generate && tree-sitter test --wasm",
+    "test": "tree-sitter generate && tree-sitter test --wasm",
     "smoke": "node scripts/smoke-check.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Found while investigating why the grammar suite appeared unrunnable during feature 35 (#405). Two separate problems, both in the same area.

## 1. The corpus test path was native, contradicting the repo's own convention

Four places state that `--wasm` is mandatory because there is no native build here — `AGENTS.md`, `docs/developer/AGENT-CONTRIBUTIONS.md`, `README.md:396`, and `scripts/run-repo-checks.sh`. Two invocations ignored it:

| Invocation | Before | After |
|---|---|---|
| `tooling/tree-sitter-satsuma` `npm test` | `tree-sitter generate && tree-sitter test` | `… && tree-sitter test --wasm` |
| `.github/workflows/ci.yml:250` | `tree-sitter test` | `tree-sitter test --wasm` |

A `test:wasm` script with the correct flag already existed and **nothing invoked it** — dead since it was added. It's now deleted rather than left as a second way to do the same thing, so there is one corpus command instead of a correct script nobody calls and a default that contradicts the docs.

The consequence was real: `npm test` in that package required a C toolchain, which is exactly the portability ADR-002 removed.

## 2. The guidance was incomplete in the way that actually cost time

`--wasm` is necessary but **not sufficient** in the agent sandbox. Both the native and the WASM path compile the grammar into `~/.cache/tree-sitter/`, which the sandbox cannot write, and it surfaces as:

```
Error: Operation not permitted (os error 1) (~/.cache/tree-sitter/lock/satsuma-<hash>.lock)
```

That reads like a stuck lock, not a permissions problem. On #405 I drew the wrong conclusion from it and reported the grammar suite as unverifiable locally. It was runnable the whole time — the fix is one environment variable:

```bash
XDG_CACHE_HOME="$SCRATCHPAD/ts-cache" npm --prefix tooling/tree-sitter-satsuma test
```

`AGENTS.md` and `AGENT-CONTRIBUTIONS.md` now carry that command and say plainly *not* to conclude the corpus tests can't run locally. Wrong guidance that produces a confident wrong conclusion is worse than missing guidance, which is why this is part of the fix and not a follow-up.

## Verification

- `npm --prefix tooling/tree-sitter-satsuma test` → **315/315 parses, 0 failed**, via the documented command with no extra flags.
- The native path genuinely cannot work in the sandbox *even with a writable cache* — `clang: unable to execute command: posix_spawn failed`. So WASM-only is the only path that serves both agents and contributors without a toolchain; this isn't a preference, it's the only one that runs.
- `lint:md` and `lint:yaml` clean. No dangling `test:wasm` references outside `archive/`.

No grammar, parser, or `.stm` files are touched — this is build/CI/docs only.

## Note on scope

Raised and fixed separately from #405 deliberately: that PR is green and under review, and this touches CI config and agent guidance a reviewer would want to see isolated.

One thing I did **not** change, and want to flag rather than decide unilaterally: `scripts/run-repo-checks.sh:85-95` treats a tree-sitter CLI built without the wasm feature as a loud `SKIP` rather than a failure. That was presumably a pragmatic hedge, but now that WASM is the only path it means the pre-commit corpus check can pass while running nothing. Happy to tighten it to a hard failure if you want the guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)