### PR TITLE
chore(tickets): sl-9p2t — decide whether --json drops the :: prefix too

### DIFF
--- a/.tickets/sl-3de8.md
+++ b/.tickets/sl-3de8.md
@@ -2,7 +2,7 @@
 id: sl-3de8
 status: open
 deps: [sl-ce11]
-links: []
+links: [sl-9p2t]
 created: 2026-07-31T13:13:41Z
 type: epic
 priority: 1

--- a/.tickets/sl-9p2t.md
+++ b/.tickets/sl-9p2t.md
@@ -1,0 +1,41 @@
+---
+id: sl-9p2t
+status: open
+deps: []
+links: [sl-3de8]
+created: 2026-07-31T15:30:59Z
+type: task
+priority: 3
+assignee: Thorben Louw
+tags: [cli, docs, breaking]
+---
+# cli: extend the display key form to --json output across all commands
+
+Human output stopped printing the empty '::' namespace prefix in 755ef6e (displayKey in index-builder.ts); --json still emits the canonical key. That split was deliberate and is documented, but it leaves one entity with two spellings depending on which output you ask for. This ticket is the decision to finish the job by dropping the prefix from --json too, or to keep the split permanently.
+
+The case for finishing it: '::name' is not valid Satsuma syntax (qualified_name is identifier '::' identifier), so a consumer cannot paste a canonical key back into a file, into a --mapping/--schema flag, or into an @ref. Its only value is signalling 'global namespace' unambiguously, which a bare name already does given namespaced entities keep their 'ns::' prefix — there is no collision to disambiguate.
+
+The case against: it is a breaking change to output shapes documented as stable, and at least one is consumed by the satsuma-viz coverage overlay.
+
+## Design
+
+Scope — every canonicalKey() call site that feeds JSON or is compared against JSON:
+
+- commands/coverage.ts (toJson, aggregate JSON)
+- commands/field-lineage.ts (field, via_mapping, upstream/downstream entries)
+- commands/graph-builder.ts (node ids, edge endpoints)
+- commands/mapping.ts (sources, targets)
+- commands/arrows.ts (mapping, source, target) — NOTE :151/:185-187 COMPARE canonical forms when resolving NL refs; those comparisons must move together or matching silently breaks
+- commands/where-used.ts (:94 JSON name; :179 cName is comparison, same caveat)
+- nl-ref-extract.ts (:121, :126, :145)
+
+Docs to update: SATSUMA-CLI.md:150,153,167,241-243 (coverage and field-lineage JSON examples), AI-AGENT-REFERENCE.md:376, and the coverage command's --help JSON shape block which currently reads 'canonical mapping key, e.g. "::load" or "ns::load"'. Remove the human-vs-JSON spelling note added to the coverage JSON contract section, since the distinction would no longer exist.
+
+If the split is kept instead, close this as won't-do and keep that note as the explanation.
+
+Sequencing: worth doing before feature 36's viz overlay consumes coverage --json, so the overlay is written against one spelling rather than migrated later.
+
+## Acceptance Criteria
+
+Decision recorded (finish it, or keep the split and close won't-do). If finishing: no canonicalKey() call remains on a JSON output path; canonicalKey and displayKey are reconciled to one function if the distinction no longer earns its place; the NL-ref comparison sites in arrows.ts and where-used.ts are migrated in the same change with tests proving @ref resolution still matches; every documented JSON example updated; a CHANGELOG.md entry names the affected commands and shows before/after, since agents and the viz overlay consume these shapes; full CLI suite passes.
+


### PR DESCRIPTION
One ticket file. Records a decision that #405 left open rather than letting it sit as an accident of scope.

## Why

`755ef6e` (in #405) dropped the empty `::` namespace prefix from **human** output via `displayKey()`, but left `--json` on `canonicalKey()`. So one entity now has two spellings depending on which output you ask for:

```
human:  mapping dispatch manifest
--json: "mapping": "::dispatch manifest"
```

That split is deliberate and documented in `SATSUMA-CLI.md`, and it was the right call for that PR — dropping it from `--json` too would have been a breaking change to a contract the same PR was publishing as stable. But it's a fork in the road, not a resting place, so it deserves an explicit decision.

## Both directions, recorded

**For finishing it:** `::name` isn't valid Satsuma syntax (`qualified_name` is `identifier "::" identifier`), so a consumer can't paste a canonical key back into a file, a `--mapping` flag, or an `@ref`. Its only value is signalling "global namespace" unambiguously — and a bare name already does that, since namespaced entities keep their `ns::` prefix. There's no collision a bare name fails to disambiguate.

**Against:** it breaks output shapes documented as stable, one of which the satsuma-viz coverage overlay consumes.

## The trap for whoever takes it

`arrows.ts:151,185-187` and `where-used.ts:179` **compare** canonical forms when resolving NL `@ref`s. Those sites have to migrate in the same change or `@ref` matching breaks silently — a test-passing, wrong-answer failure. Called out in the ticket's design notes with the specific lines.

Also scoped: the seven JSON-producing call sites, the documented examples at `SATSUMA-CLI.md:150,153,167,241-243` and `AI-AGENT-REFERENCE.md:376`, and the `coverage --help` JSON shape block which currently says `"canonical mapping key, e.g. \"::load\""`.

## Sequencing

Linked to the Feature 36 epic (`sl-3de8`). Worth deciding before the viz overlay consumes `coverage --json`, so the overlay is written against one spelling rather than migrated later.

P3 — nothing is broken today, and either answer is defensible. Closing it as won't-do and keeping the documented split is a perfectly good outcome; the point is that it be chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)