### PR TITLE
fix(core): NL @ref lineage phantom paths + ADR-036 (coverage must follow @refs)

### DIFF
--- a/.tickets/sl-0zgi.md
+++ b/.tickets/sl-0zgi.md
@@ -1,0 +1,55 @@
+---
+id: sl-0zgi
+status: open
+deps: []
+links: [sl-ez36]
+created: 2026-07-31T15:54:58Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [lint, nl-refs]
+---
+# lint: bare @ref matching a field in more than one source schema binds silently to the first
+
+`resolveRef` walks `[...sources, ...targets]` in declaration order and returns
+the first schema carrying the field name. When two sources declare the same field
+name, the ref binds to whichever schema was listed first, with no diagnostic.
+
+    schema left  { id, amount }
+    schema right { id, amount }
+    mapping join_them {
+      source { left, right }
+      target { tgt }
+      -> total { "Sum @amount across both sides" }
+    }
+
+    $ satsuma nl-refs
+    @amount  ->  ::left.amount          # ::right.amount gets no edge
+
+    $ satsuma validate   # no issues found
+    $ satsuma lint       # no findings
+
+The reader's intent here is plainly both sides, and joins across schemas that
+share column names are the normal case for the idiom
+(`examples/multi-source/multi-source-join.stm`). Reordering the `source {}` block
+silently changes the lineage graph.
+
+Picking the first match is a defensible resolution rule — the gap is that
+nothing tells the author the ref was ambiguous, so the wrong binding is
+invisible. This is lint's job, alongside `unresolved-nl-ref` (which fires when a
+ref matches nothing; nothing fires when it matches too much).
+
+Lower priority than the two path bugs: the resolved path here is real, just
+possibly not the intended one.
+
+## Acceptance Criteria
+
+- A new lint rule (e.g. `ambiguous-nl-ref`, severity warning) fires when a bare
+  @ref matches a field name on more than one schema in the mapping context.
+- The message names every candidate schema and states which one resolution
+  picked, so the author can disambiguate by writing `@left.amount`.
+- The rule does not fire when the ref is already qualified (`@left.amount`,
+  `@ns::s.f`), nor when only one schema in context carries the name.
+- Registered in `lint --rules` with a one-line description.
+- Not auto-fixable: choosing the intended schema is an authoring decision.
+

--- a/.tickets/sl-ez36.md
+++ b/.tickets/sl-ez36.md
@@ -1,0 +1,78 @@
+---
+id: sl-ez36
+status: open
+deps: []
+links: [sl-hrql, sl-0zgi]
+created: 2026-07-31T15:54:12Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [core, lineage, nl-refs]
+---
+# core: @ref to a nested source field resolves to a phantom top-level path
+
+`resolveRef` in `tooling/satsuma-core/src/nl-ref.ts` finds nested fields but
+throws away the path it found them at, so it reports a field that does not
+exist.
+
+Two branches are affected:
+
+1. Bare ref (nl-ref.ts:546-548). `hasFieldWithSpreads` -> `hasField` recurses
+   into `children`, but the result is built as `${schemaKey}.${bareName}`.
+   `@city` against `schema src { address record { city ... } }` resolves to
+   `::src.city`; the real field is `::src.address.city`.
+
+2. Dotted ref (nl-ref.ts:531-533). `hasNestedFieldPath` falls back to
+   `searchNestedPath`, which deliberately matches a path starting at any nested
+   record, but the result is built as `${schemaKey}.${fullPath}` as written.
+   `@contents.sku` against `parcels list_of record { contents list_of record {
+   sku ... } }` resolves to `::src.contents.sku`; the real field is
+   `::src.parcels.contents.sku`.
+
+Both cases report `resolved: true`, so `unresolved-nl-ref` stays silent and the
+bad path flows straight into lineage. The consequence is worse than a missing
+edge: `field-lineage` on the real nested field reports no connection, while a
+fabricated node carries the edge instead.
+
+Reproduced across every container shape in a scratch probe — for
+`schema src { hdr record { amount, vat }, contacts record { email, phone },
+parcels list_of record { contents list_of record { sku, qty } } }`, all six
+refs (`@amount @vat @email @phone @sku @qty`) resolved to `::src.<leaf>` and
+none to their real nested path.
+
+Confirmed in the shipped corpus: `examples/sap-po-to-mfcs/pipeline.stm:159`,
+where `@MEINS` (declared at `sap_purchase_order.Items.MEINS`) resolves to
+`::sap_purchase_order.MEINS`.
+
+Note the semantic question this raises for bare refs inside `each`: a bare
+`@MEINS` inside `each Items -> items` means the current element's field. The fix
+should decide whether resolution becomes container-aware (prefer the enclosing
+source base) or simply reports the full path of whatever field it matched.
+Reporting the full path of the match is the minimum needed to stop fabricating
+nodes; container-awareness additionally disambiguates a leaf name that occurs at
+more than one nesting level.
+
+Affected consumers: `nl-refs`, `field-lineage`, `graph --json`, `arrows`,
+`summary --json` nl-derived counts, and `satsuma-viz-backend`'s
+`resolveTransformAtRefs`.
+
+Sibling of the target-side defect in this same walk.
+
+## Acceptance Criteria
+
+- `resolveRef` returns the full path from the schema root to the field it
+  actually matched, for both the bare branch and the `searchNestedPath`
+  fallback in the dotted branch.
+- `@city` against `src { address record { city } }` resolves to
+  `::src.address.city`.
+- `@contents.sku` against `src { parcels list_of record { contents list_of
+  record { sku } } }` resolves to `::src.parcels.contents.sku`.
+- A ref that matches no field still reports `resolved: false` — the change must
+  not widen the match surface.
+- The chosen behaviour for a leaf name occurring at two nesting levels is
+  documented at the resolution site, with a test pinning it.
+- `field-lineage src.address.city --downstream` lists the target populated by
+  the `@city` ref.
+- Corpus regression test for `examples/sap-po-to-mfcs/pipeline.stm`
+  (`@MEINS` -> `::sap_purchase_order.Items.MEINS`).
+

--- a/.tickets/sl-ez36.md
+++ b/.tickets/sl-ez36.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ez36
-status: open
+status: closed
 deps: []
 links: [sl-hrql, sl-0zgi]
 created: 2026-07-31T15:54:12Z
@@ -76,3 +76,24 @@ Sibling of the target-side defect in this same walk.
 - Corpus regression test for `examples/sap-po-to-mfcs/pipeline.stm`
   (`@MEINS` -> `::sap_purchase_order.Items.MEINS`).
 
+
+## Notes
+
+**2026-07-31T16:11:42Z**
+
+**2026-07-31T16:11:42Z**
+
+Cause: resolveRef in satsuma-core/src/nl-ref.ts located nested fields but built
+the result from the ref as written — the bare branch returned
+`${schemaKey}.${bareName}` and the dotted branch's searchNestedPath fallback
+returned the path without the ancestor prefix that reached the match. Both
+reported resolved:true, so unresolved-nl-ref stayed silent and the fabricated
+path flowed into lineage: field-lineage on the real nested field showed nothing
+while a phantom node carried the edge.
+Fix: replaced the boolean helpers (hasField, hasNestedFieldPath,
+hasFieldWithSpreads) with path-returning equivalents (findFieldPath,
+findNestedFieldPath, findFieldPathWithSpreads) and used their result to build
+resolvedTo.name in all four resolution branches. Search is breadth-first so the
+match is the shallowest — a top-level 'city' wins over 'address.city' — which
+makes the answer independent of field declaration order; pinned by test. 6 core
+tests plus the shared corpus regression tests with sl-hrql.

--- a/.tickets/sl-hrql.md
+++ b/.tickets/sl-hrql.md
@@ -1,0 +1,67 @@
+---
+id: sl-hrql
+status: open
+deps: []
+links: [sl-ez36]
+created: 2026-07-31T15:53:53Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [core, lineage, nl-refs]
+---
+# core: NL @ref target field is not qualified with its container base, producing phantom nl-derived edges
+
+`walkArrowsForNL` in `tooling/satsuma-core/src/nl-ref.ts` records `targetField`
+as the arrow's own `tgt_path` text verbatim. It never accumulates the target
+base established by the enclosing `each` / `flatten` / `nested_arrow` container,
+so a computed arrow written inside a container reports a relative target.
+
+For:
+
+    each items -> lines {
+      -> .line_total { "Multiply @qty by @price" }
+    }
+
+`nl-refs --json` reports `targetField: ".line_total"`. Downstream,
+`qualifyField(".line_total", ["tgt"])` strips the dot and attaches the leaf to
+the schema root, yielding `::tgt.line_total` — a field that does not exist.
+The real field is `::tgt.lines.line_total`.
+
+The declared-arrow index gets this right, so `satsuma graph --json` emits two
+contradictory target nodes for the same source line:
+
+    { "to": "::tgt.lines.line_total", "classification": "nl",        "line": 32 }
+    { "to": "::tgt.line_total",       "classification": "nl-derived", "line": 32 }
+
+Confirmed in the shipped corpus: `examples/sap-po-to-mfcs/pipeline.stm:159`
+(`each Items -> items { .MENGE -> .orderedQty { "... @MEINS ..." } }`) produces
+an nl-derived edge to `::mfcs_purchase_order.orderedQty` instead of
+`::mfcs_purchase_order.items.orderedQty`.
+
+Affected consumers: `field-lineage` (both directions), `graph --json` edges,
+`arrows`, and the nl-derived edge counts in `summary --json` /
+`countNlDerivedEdgesByMapping`.
+
+`coverage.ts:collectBlockItemPaths` already solves exactly this problem by
+threading a `PathBases {src, tgt}` through the walk (see the sl-qzy3 and
+sc-xnxp doc-comments). `walkArrowsForNL` needs the same treatment for its
+target side — and see the sibling ticket for the source side.
+
+## Acceptance Criteria
+
+- `walkArrowsForNL` threads the enclosing container's target base through the
+  recursion, mirroring `collectBlockItemPaths` in coverage.ts, and records a
+  `targetField` that is fully qualified relative to the target schema root.
+- `flatten` at mapping-body level keeps establishing no target base (its target
+  names the target schema, per spec 4.6), matching `containerTargetBase`.
+- `nl-refs --json` on an `each`-nested computed arrow reports
+  `targetField: "lines.line_total"`, not `".line_total"`.
+- `field-lineage tgt.lines.line_total` lists the @ref'd source fields upstream;
+  `field-lineage tgt.line_total` no longer resolves to a phantom node.
+- `graph --json` emits one target node per arrow: the `nl` and `nl-derived`
+  edges for a given source line agree on `to`.
+- Core tests cover targets nested in `each`, `flatten` (relative form),
+  `nested_arrow`, and a container nested two levels deep.
+- A corpus regression test asserts the corrected edge for
+  `examples/sap-po-to-mfcs/pipeline.stm`.
+

--- a/.tickets/sl-hrql.md
+++ b/.tickets/sl-hrql.md
@@ -1,6 +1,6 @@
 ---
 id: sl-hrql
-status: open
+status: closed
 deps: []
 links: [sl-ez36]
 created: 2026-07-31T15:53:53Z
@@ -65,3 +65,23 @@ target side — and see the sibling ticket for the source side.
 - A corpus regression test asserts the corrected edge for
   `examples/sap-po-to-mfcs/pipeline.stm`.
 
+
+## Notes
+
+**2026-07-31T16:11:42Z**
+
+**2026-07-31T16:11:42Z**
+
+Cause: walkArrowsForNL in satsuma-core/src/nl-ref.ts recorded targetField as the
+arrow's own tgt_path text verbatim, never accumulating the target base its
+enclosing each/flatten/nested_arrow container established. Downstream
+qualifyField() strips the leading dot and prepends the target schema, so
+'.line_total' became 'tgt.line_total' instead of 'tgt.lines.line_total' —
+a field that does not exist.
+Fix: added qualifyTarget() and containerTargetBase() and threaded the base
+through the walk, mirroring collectBlockItemPaths/containerTargetBase in
+coverage.ts. flatten keeps its two cases: a relative target (.contents ->
+.packed_items) stacks a base, a top-level one (flatten contacts -> tgt) names
+the schema and establishes none. 5 core tests cover each/nested_arrow/two-level
+nesting/top-level flatten/the no-container control; 3 CLI tests guard the
+shipped corpus and assert graph's nl and nl-derived edges now name one target.

--- a/.tickets/sl-qxyl.md
+++ b/.tickets/sl-qxyl.md
@@ -1,0 +1,74 @@
+---
+id: sl-qxyl
+status: open
+deps: [sl-hrql, sl-ez36]
+links: []
+created: 2026-07-31T15:54:44Z
+type: task
+priority: 3
+assignee: Thorben Louw
+tags: [coverage, product-decision]
+---
+# decide: source-role coverage reads 0% for specs that name their sources only in NL
+
+Not a bug — a decision to confirm or revisit.
+
+`coverage` is structural by design: "a field described only in prose (a note
+block) is uncovered by definition; use 'nl-refs' to find those"
+(coverage.ts module comment, features/35-coverage-command/PRD.md:233,
+features/38-hierarchical-coverage/PRD.md:576).
+
+The consequence is sharper than the wording suggests, because the
+`-> target { "... @a and @b" }` idiom is a *first-class* way to declare a
+mapping, not an aside in a note block. For:
+
+    mapping load {
+      source { src_a, src_b }
+      target { tgt }
+      -> gross_total { "Add @net_amount and @tax_amount" }
+      -> final_total { "@gross_total minus @discount" }
+    }
+
+    $ satsuma coverage
+      source  src_a   0/3   0%
+      source  src_b   0/2   0%
+      target  tgt     2/3  67%
+
+Every source field is reported uncovered, and `--uncovered` lists all five as
+the review queue, even though `field-lineage` resolves them and labels the edges
+`nl-derived`. `coverage --fail-under <n> --role source` is therefore unusable on
+any spec that leans on the idiom, and the "covered by no mapping" aggregate —
+the one the help text says is "the claim worth acting on" — will send a reader
+to delete live fields.
+
+The toolchain is already inconsistent about this: `field-lineage`, `arrows` and
+`graph` all follow NL @refs and mark them `nl-derived`; only `coverage` does
+not. `nl-refs` finds them but has no coverage view.
+
+Options:
+  1. Keep structural-only, and make the source-role report say so — e.g. flag
+     schemas whose fields are reached only via NL refs, so 0% is legible rather
+     than alarming.
+  2. Count NL-ref coverage as a distinct tier, reported separately from
+     declared coverage (`covered` / `nl-covered` / `uncovered`), leaving the
+     structural percentage untouched. Matches how `arrows` and `graph` already
+     separate `none` / `nl` / `nl-derived`.
+  3. Add an opt-in flag (`--include-nl`) that folds NL-ref coverage into the
+     percentage for teams that treat prose refs as declarations.
+
+Option 2 preserves the existing contract while making the report actionable, and
+reuses classification vocabulary the CLI already ships.
+
+Blocked on the two nl-ref path bugs: NL-ref coverage computed today would
+attribute coverage to fabricated field paths for anything nested.
+
+## Acceptance Criteria
+
+- A decision is recorded (spec, PRD, or ADR) on whether coverage stays
+  structural-only, gains a separate NL tier, or gains an opt-in flag.
+- If the answer is "stays structural-only", `coverage --role source` output and
+  the `--fail-under` help text call out that NL-only sources read as 0%, and
+  point at `nl-refs`.
+- The decision names how `--fail-under --role source` should behave for a
+  prose-heavy spec.
+

--- a/.tickets/sl-qxyl.md
+++ b/.tickets/sl-qxyl.md
@@ -105,3 +105,28 @@ the code:
   ADR-036.
 - `3cc-t6uo` is either fixed or explicitly re-scoped: the VS Code status bar's
   own rule now disagrees on two axes, not one.
+
+## Notes
+
+**2026-07-31T16:15:18Z**
+
+**2026-07-31T16:15:18Z**
+
+Unblocked: sl-hrql and sl-ez36 are both fixed and closed, so resolved @refs now
+carry real field paths on both ends and coverage can credit them safely.
+
+Two changes on main since this ticket was written make the work smaller than the
+description implies:
+
+1. sl-joeq replaced name-based matching with path-based matching, and left the
+   seam collectBodyPaths -> schemaLocalFieldPath in place. A resolved @ref
+   already yields a canonical absolute path, which is exactly the shape that
+   seam consumes — so the interaction noted in the description resolves in this
+   ticket's favour rather than needing separate work.
+2. PRD 38 Open Question 1 resolved (sl-vu22): coverage will derive covered paths
+   from extract.ts's arrow output and delete its own CST walker. Sequence this
+   ticket AFTER that swap if both are in flight, so the NL tier is added to one
+   producer rather than to a walker that is about to be deleted.
+
+ADR-036 is on the branch for PR #409 (adrs/adr-036-nl-ref-coverage-tier.md).
+Numbered 036 because another session took 035 for coverage path identity.

--- a/.tickets/sl-qxyl.md
+++ b/.tickets/sl-qxyl.md
@@ -4,29 +4,31 @@ status: open
 deps: [sl-hrql, sl-ez36]
 links: []
 created: 2026-07-31T15:54:44Z
-type: task
-priority: 3
+type: bug
+priority: 1
 assignee: Thorben Louw
-tags: [coverage, product-decision]
+tags: [coverage, core, nl-refs]
 ---
-# decide: source-role coverage reads 0% for specs that name their sources only in NL
+# coverage: resolved @refs do not count toward coverage, contradicting ADR-013
 
-Not a bug — a decision to confirm or revisit.
+`satsuma coverage` treats a field referenced only by a resolved NL `@ref` as
+uncovered. ADR-013 ("NL @ref Mentions as Implicit Field Lineage", Accepted,
+unsuperseded) says the opposite: a resolved `@ref` "carries the same lineage
+weight as a declared source field to the left of an arrow" and such refs "are
+not second-class". `arrows`, `graph`, `lineage`, `field-lineage` and `lint` all
+honour that. `coverage` is the sole dissenter.
 
-`coverage` is structural by design: "a field described only in prose (a note
-block) is uncovered by definition; use 'nl-refs' to find those"
-(coverage.ts module comment, features/35-coverage-command/PRD.md:233,
-features/38-hierarchical-coverage/PRD.md:576).
+The exclusion was introduced as a Feature 35 non-goal and was never recorded as
+an amendment to ADR-013. ADR-036 reverses it and defines the replacement
+contract; this ticket implements ADR-036.
 
-The consequence is sharper than the wording suggests, because the
-`-> target { "... @a and @b" }` idiom is a *first-class* way to declare a
-mapping, not an aside in a note block. For:
+## Observed
 
     mapping load {
       source { src_a, src_b }
       target { tgt }
       -> gross_total { "Add @net_amount and @tax_amount" }
-      -> final_total { "@gross_total minus @discount" }
+      -> final_total  { "@gross_total minus @discount" }
     }
 
     $ satsuma coverage
@@ -34,41 +36,72 @@ mapping, not an aside in a note block. For:
       source  src_b   0/2   0%
       target  tgt     2/3  67%
 
-Every source field is reported uncovered, and `--uncovered` lists all five as
-the review queue, even though `field-lineage` resolves them and labels the edges
-`nl-derived`. `coverage --fail-under <n> --role source` is therefore unusable on
-any spec that leans on the idiom, and the "covered by no mapping" aggregate —
-the one the help text says is "the claim worth acting on" — will send a reader
-to delete live fields.
+All five source fields are reported uncovered and listed by `--uncovered`, while
+`field-lineage` resolves every one of them and labels the edges `nl-derived`.
+The aggregate "covered by no mapping" section — which `coverage --help` calls
+"the claim worth acting on" — names live fields, so a reader who trusts it will
+delete them. `coverage --fail-under --role source` is unusable on any spec that
+leans on the idiom.
 
-The toolchain is already inconsistent about this: `field-lineage`, `arrows` and
-`graph` all follow NL @refs and mark them `nl-derived`; only `coverage` does
-not. `nl-refs` finds them but has no coverage view.
+## Expected (per ADR-036)
 
-Options:
-  1. Keep structural-only, and make the source-role report say so — e.g. flag
-     schemas whose fields are reached only via NL refs, so 0% is legible rather
-     than alarming.
-  2. Count NL-ref coverage as a distinct tier, reported separately from
-     declared coverage (`covered` / `nl-covered` / `uncovered`), leaving the
-     structural percentage untouched. Matches how `arrows` and `graph` already
-     separate `none` / `nl` / `nl-derived`.
-  3. Add an opt-in flag (`--include-nl`) that folds NL-ref coverage into the
-     percentage for teams that treat prose refs as declarations.
+    $ satsuma coverage
+      source  src_a   3/3  100%  (1 declared, 2 nl)
+      source  src_b   1/2   50%  (0 declared, 1 nl)
+      target  tgt     2/3   67%  (2 declared, 0 nl)
 
-Option 2 preserves the existing contract while making the report actionable, and
-reuses classification vocabulary the CLI already ships.
+Two tiers over one denominator. ADR-034's leaf-only denominator is unchanged —
+this splits the numerator only.
 
-Blocked on the two nl-ref path bugs: NL-ref coverage computed today would
-attribute coverage to fabricated field paths for anything nested.
+## Blocked on the resolution defects
+
+`sl-hrql` and `sl-ez36` must land first. Until they do, refs inside
+`each` / `flatten` / `nested_arrow` resolve to fabricated field paths, and this
+change would attribute coverage to fields that do not exist — a silent
+overstatement inside a merge gate.
+
+Interacts with `sl-joeq`: a resolved `@ref` yields a canonical full path, so it
+must be registered as a real path rather than a bare segment.
+
+## Documentation to reconcile
+
+The superseded claim is recorded in five places, all of which must change with
+the code:
+
+- `features/35-coverage-command/PRD.md:233` — Out of Scope bullet
+- `features/38-hierarchical-coverage/PRD.md:576` — Out of Scope bullet
+- `tooling/satsuma-core/src/coverage.ts` — module comment ("deliberately
+  structural only")
+- `tooling/satsuma-cli/src/commands/coverage.ts` — `--help` text
+- `SATSUMA-CLI.md:126`, `:317`, `:383` — including the positioning claim that
+  "`coverage` is a command rather than a workflow precisely because it needs no
+  NL interpretation", which needs restating as *resolution is not
+  interpretation* rather than deletion
 
 ## Acceptance Criteria
 
-- A decision is recorded (spec, PRD, or ADR) on whether coverage stays
-  structural-only, gains a separate NL tier, or gains an opt-in flag.
-- If the answer is "stays structural-only", `coverage --role source` output and
-  the `--fail-under` help text call out that NL-only sources read as 0%, and
-  point at `nl-refs`.
-- The decision names how `--fail-under --role source` should behave for a
-  prose-heavy spec.
-
+- A leaf counts as covered when a declared arrow references it **or** a resolved
+  `@ref` in the same mapping names it. A field covered both ways counts once, in
+  the declared tier.
+- `covered` = `covered_declared` + `covered_nl`; `total` is unchanged and still
+  governed by ADR-034 (leaves only, own flag, records excluded).
+- Unresolved refs contribute nothing — coverage must not rise when a ref breaks.
+- A ref with `context: "source_block"` counts toward source coverage only; it
+  names no target field and cannot contribute target coverage.
+- Each `FieldCoverageEntry` carries the tier that covered it, so a rendered
+  field list and its adjacent count derive from one definition.
+- The rule lives only in `computeMappingCoverage()` (path collection, tagged by
+  origin) and `summarizeFieldCoverage()` (all counting). No consumer computes
+  its own denominator *or* its own split.
+- `--fail-under` gates the combined figure; `--role source` gates combined
+  source coverage.
+- Human output shows the split; `--json` exposes `covered_declared` /
+  `covered_nl` per schema, per namespace, per workspace, and in the aggregate.
+- Tests: a field covered only by NL; covered by both (counted once, declared);
+  covered by an unresolved ref (not counted); a `source_block` ref (source only,
+  never target); NL coverage inside `each` / `flatten` / `nested_arrow` once
+  sl-hrql and sl-ez36 land; and cross-consumer parity per `sl-5nsv`.
+- The five documentation sites above are reconciled in the same PR, each citing
+  ADR-036.
+- `3cc-t6uo` is either fixed or explicitly re-scoped: the VS Code status bar's
+  own rule now disagrees on two axes, not one.

--- a/.tickets/sl-wta4.md
+++ b/.tickets/sl-wta4.md
@@ -1,0 +1,56 @@
+---
+id: sl-wta4
+status: open
+deps: []
+links: []
+created: 2026-07-31T15:54:25Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [cli, arrows]
+---
+# arrows: header count omits intra-target nl-derived arrows that the body then prints
+
+`satsuma arrows <field>` prints a header count and then the arrow rows, and the
+two disagree when an @ref derives one target field from another target field of
+the same mapping.
+
+    schema tgt { gross_total, final_total }
+    mapping load {
+      source { src_a, src_b }
+      target { tgt }
+      -> gross_total { "Add @net_amount and @tax_amount" }
+      -> final_total { "@gross_total minus @discount" }
+    }
+
+    $ satsuma arrows tgt.gross_total
+    tgt.gross_total - 1 arrow (1 as target)
+
+      mapping 'load':
+        (computed) -> gross_total { "Add @net_amount and @tax_amount" }  [nl]
+        ::tgt.gross_total -> final_total { (NL ref) }  [nl-derived]
+
+Two rows, count of 1. The `asSource` classifier in
+`tooling/satsuma-cli/src/commands/arrows.ts:384-389` requires the queried
+schema to appear in `mapping.sources`. For an nl-derived arrow whose @ref
+points at a target field, the queried schema is on the target side, so the row
+is excluded from the count while the printer still emits it.
+
+Intra-target derivation is a legitimate and common idiom — see
+`examples/namespaces/ns-merging.stm:142`
+(`-> variance { "@budget_amount minus @actual_spend" }`).
+
+Cosmetic only; no lineage data is wrong here. Related to the closed cbh-ekvb,
+which fixed a different over-count in the same header.
+
+## Acceptance Criteria
+
+- The header count equals the number of rows printed, for the intra-target
+  nl-derived case above.
+- The `asSource` / `asTarget` classification recognises a field as a source when
+  it is the resolved origin of an nl-derived arrow, regardless of which side of
+  the mapping its schema sits on.
+- Test covering `arrows tgt.gross_total` on a mapping with intra-target NL
+  derivation, asserting both the header string and the row count.
+- The cbh-ekvb regression test still passes.
+

--- a/adrs/adr-036-nl-ref-coverage-tier.md
+++ b/adrs/adr-036-nl-ref-coverage-tier.md
@@ -1,0 +1,136 @@
+# ADR-036 — Resolved @refs Count Toward Coverage, as a Distinct Tier
+
+**Status:** Accepted
+**Date:** 2026-07-31 (sl-qxyl)
+
+## Context
+
+ADR-013 settled what an NL `@ref` means: "an NL `@ref` mention in a mapping
+transform string carries the same lineage weight as a declared source field to
+the left of an arrow", and such refs "are not second-class — they participate
+fully in depth traversal, direction filtering, and reachability analysis". It
+bound "all lineage-aware tools" to follow them, naming `arrows`, `graph`,
+`lineage`, `field-lineage` and the VS Code field-lineage panel. Every one of
+those does, marking the result `nl-derived`. `lint`'s `hidden-source-in-nl` rule
+goes further: it treats an `@ref` to an undeclared schema as an *error*, and its
+auto-fix edits the mapping's `source {}` block to match.
+
+Feature 35 then introduced `satsuma coverage`, and excluded `@refs` from it —
+"NL interpretation: a field populated *implicitly* by prose in a note block is
+uncovered by definition" (`features/35-coverage-command/PRD.md:233`), restated
+in `features/38-hierarchical-coverage/PRD.md:576`, in the `coverage.ts` module
+comment ("deliberately *structural only*"), in `coverage --help`, and in
+`SATSUMA-CLI.md:126`. That carve-out was never recorded as an amendment to
+ADR-013, which remains Accepted and unsuperseded.
+
+The reasoning behind the carve-out does not hold. It rests on equating "follows
+an `@ref`" with "interprets natural language", and those are different acts.
+Resolving `@net_amount` to a declared field is structural resolution of an
+explicit reference: the author wrote `@` as a sigil meaning *this is a
+reference*, and `resolveRef` in `satsuma-core/src/nl-ref.ts` resolves it against
+the workspace index with no reading of the surrounding prose. The CLI's stated
+position — "extracts structural facts and delivers NL content verbatim, does not
+interpret natural language" — survives counting a resolved ref intact, exactly as
+it survives ADR-013.
+
+The cost of the carve-out is not marginal, because `-> target { "... @a and @b" }`
+is a first-class way to declare a mapping, not an aside in a note block. For a
+mapping whose sources appear only in NL, `coverage` reports every source field
+uncovered:
+
+    mapping load {
+      source { src_a, src_b }
+      target { tgt }
+      -> gross_total { "Add @net_amount and @tax_amount" }
+      -> final_total  { "@gross_total minus @discount" }
+    }
+
+    source  src_a   0/3   0%
+    source  src_b   0/2   0%
+
+`--uncovered` lists all five fields as the review queue, and the aggregate
+"covered by no mapping" section — which `coverage --help` calls "the claim worth
+acting on" — names fields that `field-lineage` traces without difficulty. A
+reader who trusts that section will delete live fields.
+`coverage --fail-under --role source` cannot be used at all on such a spec.
+
+Two alternatives were rejected. Folding `@ref` coverage into an undifferentiated
+`mapped: true` is the smallest change, but Feature 36 requires that NL-derived
+hops be "visibly differentiated (they are inferred from prose, not declared —
+reviewers must be able to tell)", and a single flag destroys that distinction at
+the source rather than in the renderer. Gating the new behaviour behind
+`--include-nl` preserves every existing number, but leaves the misleading
+report as the default, which is the failure this ADR exists to remove.
+
+## Decision
+
+A leaf field counts as covered when a declared arrow in the mapping references
+it **or** when a resolved `@ref` in that mapping names it. The two are reported
+as distinct tiers over one denominator: `covered` is the sum, `covered_declared`
+and `covered_nl` are its parts, and `total` is unchanged. A field covered both
+ways counts once, in the `declared` tier — declared coverage is the stronger
+claim and takes precedence.
+
+ADR-034 is untouched and continues to govern the denominator: leaves only, on
+each leaf's own flag, records excluded from both sides. This decision splits the
+numerator; it does not change what is counted.
+
+Only *resolved* refs count. An unresolved `@ref` contributes nothing — reporting
+it is `lint`'s `unresolved-nl-ref`, and letting it count would make coverage
+rise when a spec breaks. A ref carrying `context: "source_block"` counts toward
+**source** coverage only: the mapping demonstrably reads that field to join or
+filter on it, but the ref names no target field and so can never contribute
+target coverage.
+
+The rule lives in two places and nowhere else. `computeMappingCoverage()` in
+`satsuma-core/src/coverage.ts` gains the resolved-ref paths alongside the
+declared arrow paths it already collects, tagging each with its origin; and
+`summarizeFieldCoverage()` in `satsuma-core/src/coverage-rollup.ts` derives every
+count from those tags. Per ADR-034, consumers do not compute their own
+denominators — and they must not compute their own declared/NL split either. Each
+`FieldCoverageEntry` carries the tier that covered it, so a rendered field list
+and the counts printed beside it cannot disagree.
+
+`coverage --fail-under` gates the combined figure. The gate answers "is this
+spec complete", and under ADR-013 an `@ref` is a declaration of intent, not a
+hint.
+
+## Consequences
+
+**Positive:**
+
+- Coverage stops contradicting an accepted ADR. Following a resolved `@ref` is
+  now uniform across `arrows`, `graph`, `lineage`, `field-lineage`, `lint` and
+  `coverage`, rather than five tools agreeing and one dissenting.
+- `--fail-under --role source` becomes usable on prose-heavy specs, which is the
+  population it matters most for.
+- The aggregate "covered by no mapping" list becomes safe to act on. Its entire
+  value is that a reader can delete or investigate what it names.
+- The tier split preserves what the carve-out was protecting. A reviewer can
+  still tell a declared arrow from an inferred one — in the numbers, not only by
+  cross-referencing `nl-refs` — and Feature 36's overlay gets the distinction
+  from core instead of reconstructing it.
+- Requiring resolution, not mention, keeps the count honest: coverage cannot be
+  raised by writing prose that refers to nothing.
+
+**Negative:**
+
+- ADR-013's acknowledged false-positive risk now reaches a merge gate. An `@ref`
+  written purely as documentation inflates coverage, and ADR-013 records that
+  there is no opt-out mechanism. Coverage previously could not be gamed by
+  editing prose; it now can.
+- Existing `--fail-under` thresholds need re-baselining. Percentages can only
+  rise, so a threshold tuned against structural-only figures becomes weaker
+  rather than failing loudly — the unsafe direction for a gate.
+- The per-mapping JSON contract widens (`covered_declared`, `covered_nl`, and a
+  per-field tier), which the VS Code gutter and the Feature 36 overlay both
+  consume. `3cc-t6uo` — the status bar computing its own percentage — must be
+  reconciled rather than carried, since a consumer with its own rule will now
+  disagree on two axes instead of one.
+- Coverage acquires a dependency on `@ref` resolution, so a resolution defect
+  becomes a coverage defect. `sl-hrql` and `sl-ez36` must land first: until they
+  do, refs inside `each` / `flatten` / `nested_arrow` resolve to fabricated field
+  paths, and coverage would attribute coverage to fields that do not exist.
+- Coverage is no longer derivable from the CST alone. It now needs the workspace
+  index to resolve refs, the same departure ADR-013 recorded for `graph-builder`
+  and `arrows`.

--- a/tooling/satsuma-cli/test/field-lineage.test.ts
+++ b/tooling/satsuma-cli/test/field-lineage.test.ts
@@ -172,3 +172,55 @@ describe("field-lineage NL-derived edges in namespaced mappings (sl-njej)", () =
     assert.equal(nlEdges[0].via_mapping, "ns::load_s2");
   });
 });
+
+// ---------------------------------------------------------------------------
+// sl-hrql / sl-ez36: NL @refs inside containers resolved to fabricated paths
+// ---------------------------------------------------------------------------
+describe("field-lineage — NL @refs inside containers (sl-hrql, sl-ez36)", () => {
+  // The canonical SAP example nests a computed arrow two ways at once:
+  //   each Items -> items { .MENGE -> .orderedQty { "... @MEINS ..." } }
+  // @MEINS is declared at Items.MEINS (nested source), and the arrow target is
+  // element-relative. Both ends were wrong, and wrong silently: the edge landed
+  // on ::sap_purchase_order.MEINS -> ::mfcs_purchase_order.orderedQty, neither
+  // of which is a declared field. Guarding the shipped corpus rather than a
+  // fixture keeps the regression tied to a shape real specs use.
+  const SAP = resolve(__dirname, "../../../examples/sap-po-to-mfcs/pipeline.stm");
+
+  it("anchors the nl-derived edge on the nested source field, not the schema root", async () => {
+    const { stdout, code } = await run(
+      "field-lineage", "sap_purchase_order.Items.MEINS", SAP, "--json", "--downstream",
+    );
+    assert.equal(code, 0, `expected exit 0\n${stdout}`);
+    const nlEdges = (JSON.parse(stdout).downstream as any[])
+      .filter((e) => e.classification === "nl-derived");
+    assert.deepEqual(
+      nlEdges.map((e) => e.field),
+      ["::mfcs_purchase_order.items.orderedQty"],
+      "the @MEINS ref must resolve to Items.MEINS and target items.orderedQty",
+    );
+  });
+
+  it("leaves no lineage on the phantom top-level path the bug invented", async () => {
+    // sap_purchase_order has no top-level MEINS. The command still resolves the
+    // name (the index is indexed by leaf too), so the assertion that matters is
+    // that no edge hangs off it any more.
+    const { stdout, code } = await run(
+      "field-lineage", "sap_purchase_order.MEINS", SAP, "--json", "--downstream",
+    );
+    assert.equal(code, 0, `expected exit 0\n${stdout}`);
+    assert.deepEqual(JSON.parse(stdout).downstream, []);
+  });
+
+  it("agrees with the declared arrow index on the target of the same arrow", async () => {
+    // The clearest statement of the target-side bug: `graph` emitted an `nl`
+    // edge to items.orderedQty and an `nl-derived` edge to orderedQty for one
+    // source line. Any consumer building a graph got two nodes for one field.
+    const { stdout, code } = await run("graph", SAP, "--json");
+    assert.equal(code, 0, `expected exit 0\n${stdout}`);
+    const edges = (JSON.parse(stdout).edges as any[])
+      .filter((e) => e.to.endsWith("orderedQty"));
+    const targets = [...new Set(edges.map((e) => e.to))];
+    assert.deepEqual(targets, ["::mfcs_purchase_order.items.orderedQty"],
+      "nl and nl-derived edges for one arrow must name one target field");
+  });
+});

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -324,30 +324,55 @@ function getExpandedFields(schema: SchemaLike, lookup: DefinitionLookup): FieldD
   return expandEntityFields(schema as SpreadEntity, schema.namespace ?? null, resolveRef, lookupFrag);
 }
 
+// ── Field lookup: matching a ref to a declared field path ─────────────────────
+//
+// Every helper below answers "where is this field?", not "does it exist?".
+// Returning the path is what keeps resolution honest: a ref may legally omit
+// leading path components (`@city` for `address.city`), and reporting the name
+// as written would name a field that is not declared anywhere. Consumers build
+// lineage edges out of these paths, so a fabricated one becomes a fabricated
+// graph node rather than a visible error (sl-ez36).
+
 /**
- * Check if a field tree contains a field with the given name (flat or nested).
+ * Shallowest declared path to a field named `name`, or null when absent.
+ *
+ * Breadth-first by design, so the match is the one an author would predict:
+ * a top-level `city` wins over a nested `address.city`, and among fields at the
+ * same depth the first declared wins. Depth-first order would instead let a
+ * deeply nested field under the first declaration beat a top-level field
+ * declared second — an arbitrary result that shifts when fields are reordered.
  */
-function hasField(fields: FieldDecl[], name: string): boolean {
-  for (const f of fields) {
-    if (f.name === name) return true;
-    if (f.children && hasField(f.children, name)) return true;
+function findFieldPath(fields: FieldDecl[], name: string): string | null {
+  // Each queue entry is a field plus the dotted path that reaches it.
+  let level: { field: FieldDecl; path: string }[] =
+    fields.map((f) => ({ field: f, path: f.name }));
+
+  while (level.length > 0) {
+    for (const { field, path } of level) {
+      if (field.name === name) return path;
+    }
+    level = level.flatMap(({ field, path }) =>
+      (field.children ?? []).map((c) => ({ field: c, path: `${path}.${c.name}` })),
+    );
   }
-  return false;
+  return null;
 }
 
 /**
- * Check if a path (as pre-split segment names) resolves to a nested field
- * within a field tree. Segment names are matched verbatim — splitting happens
- * at parse time so literal (backticked) names keep their embedded dots.
+ * Declared path for a ref given as pre-split segments, or null when it matches
+ * nothing. Segment names are matched verbatim — splitting happens at parse time
+ * so literal (backticked) names keep their embedded dots.
  *
  * Tries two strategies in order:
- *  1. matchPath — treat the path as anchored from the root of the field tree.
- *  2. searchNestedPath — search for the path starting from any nested record
- *     field, to handle refs that omit leading path segments.
+ *  1. Anchored at the root of the field tree, which is how a fully-spelled ref
+ *     (`@address.city`) is written.
+ *  2. Anchored at any nested record, for a ref that omits leading segments
+ *     (`@contents.sku` for `parcels.contents.sku`). The prefix that reached the
+ *     match is prepended, so the returned path is complete.
  */
-function hasNestedFieldPath(fields: FieldDecl[], segments: string[]): boolean {
-  if (matchPath(fields, segments)) return true;
-  return searchNestedPath(fields, segments);
+function findNestedFieldPath(fields: FieldDecl[], segments: string[]): string | null {
+  if (matchPath(fields, segments)) return segments.join(".");
+  return searchNestedPath(fields, segments, "");
 }
 
 /**
@@ -370,40 +395,53 @@ function matchPath(fields: FieldDecl[], segments: string[]): boolean {
 }
 
 /**
- * Recursively search all record fields for a subtree where matchPath succeeds.
- * Used when the ref omits a leading path component (e.g., writing "city"
- * instead of "address.city") — we descend into record children to find a match.
+ * Search every record subtree for one where `segments` matches when anchored
+ * there, returning the full path from the original root. `prefix` accumulates
+ * the ancestors walked so far.
+ *
+ * Breadth-first for the same reason as findFieldPath: prefer the shallowest
+ * record whose subtree matches.
  */
-function searchNestedPath(fields: FieldDecl[], segments: string[]): boolean {
-  for (const f of fields) {
-    if (f.children) {
-      if (matchPath(f.children, segments)) return true;
-      if (searchNestedPath(f.children, segments)) return true;
-    }
+function searchNestedPath(fields: FieldDecl[], segments: string[], prefix: string): string | null {
+  const records = fields.filter((f) => f.children && f.children.length > 0);
+
+  for (const f of records) {
+    const path = prefix ? `${prefix}.${f.name}` : f.name;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: filtered to fields with children above
+    if (matchPath(f.children!, segments)) return `${path}.${segments.join(".")}`;
   }
-  return false;
+  for (const f of records) {
+    const path = prefix ? `${prefix}.${f.name}` : f.name;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: same filter
+    const found = searchNestedPath(f.children!, segments, path);
+    if (found) return found;
+  }
+  return null;
 }
 
 /**
- * Check if a field path (parsed segments) exists on a schema, consulting
- * fragment-spread expansion when declared fields alone don't match.
+ * Declared path for a ref on a schema, consulting fragment-spread expansion
+ * when declared fields alone don't match. Returns null when the ref matches no
+ * field.
  *
  * A single segment is matched as an exact field name — a literal (backticked)
  * segment may contain "." or "::" but still names ONE field, never a nested
  * path (sl-g6ga). Multi-segment paths walk the field tree per segment.
  */
-function hasFieldWithSpreads(schema: SchemaLike, fieldSegs: RefSegment[], lookup: DefinitionLookup): boolean {
+function findFieldPathWithSpreads(schema: SchemaLike, fieldSegs: RefSegment[], lookup: DefinitionLookup): string | null {
   const names = fieldSegs.map((s) => s.name);
   if (names.length > 1) {
-    if (hasNestedFieldPath(schema.fields, names)) return true;
-    if (!schema.hasSpreads) return false;
+    const direct = findNestedFieldPath(schema.fields, names);
+    if (direct) return direct;
+    if (!schema.hasSpreads) return null;
     const expanded = getExpandedFields(schema, lookup);
-    return hasNestedFieldPath([...schema.fields, ...expanded], names);
+    return findNestedFieldPath([...schema.fields, ...expanded], names);
   }
   const fieldName = names[0]!;
-  if (hasField(schema.fields, fieldName)) return true;
-  if (!schema.hasSpreads) return false;
-  return hasField(getExpandedFields(schema, lookup), fieldName);
+  const direct = findFieldPath(schema.fields, fieldName);
+  if (direct) return direct;
+  if (!schema.hasSpreads) return null;
+  return findFieldPath(getExpandedFields(schema, lookup), fieldName);
 }
 
 /**
@@ -470,10 +508,10 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
     const firstDot = separators.indexOf(".");
     const schemaRef = segments.slice(0, firstDot + 1).map((s) => s.name).join("::");
     const fieldSegs = segments.slice(firstDot + 1);
-    const fieldName = fieldSegs.map((s) => s.name).join(".");
     const schema = lookup.getSchema(schemaRef);
-    if (schema && hasFieldWithSpreads(schema, fieldSegs, lookup)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldName}` } };
+    const fieldPath = schema ? findFieldPathWithSpreads(schema, fieldSegs, lookup) : null;
+    if (fieldPath) {
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldPath}` } };
     }
     return { resolved: false, resolvedTo: null };
   }
@@ -482,20 +520,21 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
     const names = segments.map((s) => s.name);
     const schemaName = names[0]!;
     const fieldSegs = segments.slice(1);
-    const fieldName = fieldSegs.map((s) => s.name).join(".");
-    const fullPath = names.join(".");
 
     const allSchemas = [...(mappingContext.sources ?? []), ...(mappingContext.targets ?? [])];
     for (const s of allSchemas) {
       const key = contextSchemaKey(s, mappingContext.namespace, lookup);
       const schema = lookup.getSchema(key);
-      if (schema && hasNestedFieldPath(schema.fields, names)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
+      if (!schema) continue;
+      const direct = findNestedFieldPath(schema.fields, names);
+      if (direct) {
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${direct}` } };
       }
-      if (schema?.hasSpreads) {
+      if (schema.hasSpreads) {
         const expanded = getExpandedFields(schema, lookup);
-        if (hasNestedFieldPath([...schema.fields, ...expanded], names)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
+        const viaSpread = findNestedFieldPath([...schema.fields, ...expanded], names);
+        if (viaSpread) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${viaSpread}` } };
         }
       }
     }
@@ -506,8 +545,9 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
       if (baseName === schemaName || s === schemaName) {
         const key = contextSchemaKey(s, mappingContext.namespace, lookup);
         const schema = lookup.getSchema(key);
-        if (schema && hasFieldWithSpreads(schema, fieldSegs, lookup)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
+        const fieldPath = schema ? findFieldPathWithSpreads(schema, fieldSegs, lookup) : null;
+        if (fieldPath) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
         }
       }
     }
@@ -523,13 +563,15 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
         const nsIdx = key.indexOf("::");
         const baseName = nsIdx !== -1 ? key.slice(nsIdx + 2) : key;
         if (baseName === schemaName || key === schemaName) {
-          if (hasFieldWithSpreads(schema, fieldSegs, lookup)) {
-            return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldName}` } };
+          const fieldPath = findFieldPathWithSpreads(schema, fieldSegs, lookup);
+          if (fieldPath) {
+            return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
           }
         }
         // Also try as nested path within this schema
-        if (hasNestedFieldPath(schema.fields, names)) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fullPath}` } };
+        const nestedPath = findNestedFieldPath(schema.fields, names);
+        if (nestedPath) {
+          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${nestedPath}` } };
         }
       }
     }
@@ -543,8 +585,9 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
   for (const s of allSchemaNames) {
     const key = contextSchemaKey(s, mappingContext.namespace, lookup);
     const schema = lookup.getSchema(key);
-    if (schema && hasFieldWithSpreads(schema, segments, lookup)) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${bareName}` } };
+    const fieldPath = schema ? findFieldPathWithSpreads(schema, segments, lookup) : null;
+    if (fieldPath) {
+      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
     }
   }
 
@@ -552,8 +595,9 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
   // searching all workspace schemas for the bare field name.
   if (allSchemaNames.length === 0 && lookup.iterateSchemas) {
     for (const [key, schema] of lookup.iterateSchemas()) {
-      if (hasFieldWithSpreads(schema, segments, lookup)) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${bareName}` } };
+      const fieldPath = findFieldPathWithSpreads(schema, segments, lookup);
+      if (fieldPath) {
+        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
       }
     }
   }
@@ -763,6 +807,62 @@ function extractBlockNoteRefs(
   }
 }
 
+// ── Target qualification inside containers ────────────────────────────────────
+//
+// Arrows nest inside `each`, `flatten` and braced `src -> tgt` (`nested_arrow`)
+// blocks, and inside them a target is written relative to the container
+// (`-> .line_total`). The recorded targetField must be absolute from the target
+// schema root, because downstream qualifyField() prepends the schema and cannot
+// recover a base it was never given: `.line_total` became `tgt.line_total`
+// rather than `tgt.lines.line_total`, inventing a field (sl-hrql).
+//
+// The rule itself is extract.ts's accumulating-prefix contract, which PRD 38
+// records as correct and which declared arrows have always followed; this walk
+// was simply not applying it. coverage.ts solved the same problem in its own CST
+// walker, and PRD 38 Open Question 1 has since resolved to delete that walker
+// and derive covered paths from extraction instead (sl-vu22) — so treat
+// extract.ts as the reference here, not coverage.ts.
+
+/** True when a tgt_path was authored relative to the current element (`.field`). */
+function isRelativeTargetPath(pathNode: SyntaxNode | undefined): boolean {
+  return pathNode?.namedChildren.some((x) => x.type === "relative_field_path") ?? false;
+}
+
+/**
+ * Append a target leaf to the base its enclosing container established,
+ * dropping the leading `.` that marks the leaf as element-relative. Returns the
+ * base unchanged when the node carries no target (an arrow with no tgt_path).
+ */
+function qualifyTarget(base: string | null, leaf: string | null): string | null {
+  if (leaf === null) return base;
+  const relative = leaf.startsWith(".") ? leaf.slice(1) : leaf;
+  return base ? `${base}.${relative}` : relative;
+}
+
+/**
+ * The target base a container establishes for the arrows inside it.
+ *
+ * `each` and `nested_arrow` always establish one: their target names a field,
+ * and their children are written against it.
+ *
+ * `flatten` is the exception, and the grammar says which case applies. In spec
+ * §4.6's top-level form the target names the target *schema*
+ * (`flatten contacts -> tgt`) and the block unnests into schema-root fields, so
+ * there is no base. Written relative — `flatten .contents -> .packed_items`
+ * inside an `each` — it names a list field on the current element and its
+ * arrows are relative to that. A `relative_field_path` node is the authored
+ * signal separating the two.
+ */
+function containerTargetBase(
+  node: SyntaxNode,
+  rawTgt: SyntaxNode | undefined,
+  outerTgt: string | null,
+): string | null {
+  if (!rawTgt) return outerTgt;
+  if (node.type === "flatten_block" && !isRelativeTargetPath(rawTgt)) return outerTgt;
+  return qualifyTarget(outerTgt, extractPathText(rawTgt));
+}
+
 function walkArrowsForNL(
   node: SyntaxNode,
   mappingName: string,
@@ -823,13 +923,13 @@ function walkArrowsForNL(
     }
     if (c.type === "each_block" || c.type === "flatten_block") {
       const tgtNode = c.namedChildren.find((x) => x.type === "tgt_path");
-      const tgt = extractPathText(tgtNode) ?? targetField;
+      const tgt = containerTargetBase(c, tgtNode, targetField);
       walkArrowsForNL(c, mappingName, namespace, tgt, results);
       continue;
     }
     if (c.type === "map_arrow" || c.type === "computed_arrow" || c.type === "nested_arrow") {
       const tgtNode = c.namedChildren.find((x) => x.type === "tgt_path");
-      const tgt = extractPathText(tgtNode) ?? targetField;
+      const tgt = qualifyTarget(targetField, extractPathText(tgtNode));
 
       const pipeChain = c.namedChildren.find((x) => x.type === "pipe_chain");
       if (pipeChain) {

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -636,3 +636,147 @@ describe("NL ref positions account for string delimiters (sl-o3ea)", () => {
     assert.deepEqual(positionOfRef(src), atPositionIn(src));
   });
 });
+
+// ── Nested field resolution (sl-ez36) ─────────────────────────────────────────
+//
+// A ref may omit leading path components, so resolution must report where the
+// field actually is. Reporting the name as written names a field that is not
+// declared, and consumers turn resolvedTo.name straight into a lineage node —
+// so a wrong path becomes a fabricated graph node rather than a visible error.
+
+describe("resolveRef() — nested field paths (sl-ez36)", () => {
+  // schema src { order_id, address record { city, postcode } }
+  const nestedLookup = () => makeLookup({
+    "::src": {
+      fields: [
+        { name: "order_id" },
+        { name: "address", children: [{ name: "city" }, { name: "postcode" }] },
+      ],
+      hasSpreads: false,
+    },
+  });
+  const ctx = { sources: ["::src"], targets: [], namespace: null };
+
+  it("reports the full path for a bare ref naming a nested field", () => {
+    // @city omits the `address.` prefix. Before the fix this resolved to
+    // ::src.city — a field that does not exist — so field-lineage on the real
+    // ::src.address.city reported no connection at all.
+    const r = resolveRef("city", ctx, nestedLookup());
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::src.address.city");
+  });
+
+  it("leaves a fully-spelled nested ref unchanged", () => {
+    // The anchored path already names the field; the fix must not double it up
+    // into ::src.address.address.city.
+    const r = resolveRef("address.city", ctx, nestedLookup());
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::src.address.city");
+  });
+
+  it("reports the full path for a dotted ref anchored at a nested record", () => {
+    // @contents.sku matches the subtree at parcels.contents, so the ancestor
+    // prefix must be prepended: the ref names parcels.contents.sku.
+    const lookup = makeLookup({
+      "::src": {
+        fields: [{
+          name: "parcels",
+          children: [{ name: "contents", children: [{ name: "sku" }, { name: "qty" }] }],
+        }],
+        hasSpreads: false,
+      },
+    });
+    const r = resolveRef("contents.sku", ctx, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "::src.parcels.contents.sku");
+  });
+
+  it("prefers the shallowest match when a leaf name occurs at two depths", () => {
+    // Pinning the documented rule: breadth-first, so a top-level `city` wins
+    // over a nested `address.city`. Depth-first order would let the nested one
+    // win purely because `address` is declared first, and the answer would
+    // change if the author reordered the fields.
+    const lookup = makeLookup({
+      "::src": {
+        fields: [
+          { name: "address", children: [{ name: "city" }] },
+          { name: "city" },
+        ],
+        hasSpreads: false,
+      },
+    });
+    const r = resolveRef("city", ctx, lookup);
+    assert.equal(r.resolvedTo.name, "::src.city");
+  });
+
+  it("still reports unresolved when no field matches at any depth", () => {
+    // The fix widens what a match *reports*, not what counts as a match.
+    const r = resolveRef("nonexistent", ctx, nestedLookup());
+    assert.equal(r.resolved, false);
+    assert.equal(r.resolvedTo, null);
+  });
+
+  it("reports the full path for a namespace-qualified ref to a nested field", () => {
+    // ns::schema.field goes through the same lookup, so it needs the same fix.
+    const lookup = makeLookup({
+      "crm::src": {
+        fields: [{ name: "address", children: [{ name: "city" }] }],
+        hasSpreads: false,
+      },
+    });
+    const r = resolveRef("crm::src.city", { sources: [], targets: [], namespace: null }, lookup);
+    assert.equal(r.resolved, true);
+    assert.equal(r.resolvedTo.name, "crm::src.address.city");
+  });
+});
+
+// ── Container target qualification (sl-hrql) ──────────────────────────────────
+//
+// targetField must be absolute from the target schema root. Downstream
+// qualifyField() prepends the target schema and cannot recover a base it was
+// never given, so a relative ".line_total" became "tgt.line_total" — a field
+// that does not exist, carrying the edge that the real one then appeared to lack.
+
+describe("extractNLRefData — container target qualification (sl-hrql)", () => {
+  before(async () => {
+    await initParser(WASM_PATH);
+  });
+
+  // One item per ref-bearing NL string (the split into individual @refs
+  // happens later, in resolveAllNLRefs), so a two-ref string yields one entry.
+  function targetFields(src) {
+    return extractNLRefData(getParser().parse(src).rootNode).map((i) => i.targetField);
+  }
+
+  it("qualifies a computed arrow target inside an each block", () => {
+    const src = 'mapping m {\n  each items -> lines {\n    -> .line_total { "Multiply @qty by @price" }\n  }\n}';
+    assert.deepEqual(targetFields(src), ["lines.line_total"]);
+  });
+
+  it("qualifies a computed arrow target inside a nested_arrow block", () => {
+    // A braced `src -> tgt` establishes a target base just as `each` does.
+    const src = 'mapping m {\n  hdr -> head {\n    -> .gross { "Add @amount and @vat" }\n  }\n}';
+    assert.deepEqual(targetFields(src), ["head.gross"]);
+  });
+
+  it("accumulates bases across two levels of nesting", () => {
+    // flatten written relative (`.contents -> .packed_items`) names a list field
+    // on the current element, so its base stacks on the enclosing each.
+    const src = 'mapping m {\n  each parcels -> parcels {\n    flatten .contents -> .packed_items {\n      -> .label { "Label from @sku" }\n    }\n  }\n}';
+    assert.deepEqual(targetFields(src), ["parcels.packed_items.label"]);
+  });
+
+  it("establishes no base for a top-level flatten, whose target names the schema", () => {
+    // Spec 4.6: `flatten contacts -> tgt` unnests into target schema roots, so
+    // `contact_line` is already absolute and must not become `tgt.contact_line`.
+    const src = 'mapping m {\n  flatten contacts -> tgt {\n    -> contact_line { "Format @email" }\n  }\n}';
+    assert.deepEqual(targetFields(src), ["contact_line"]);
+  });
+
+  it("leaves a mapping-body-level arrow target unqualified", () => {
+    // The no-container control: top-level targets were always correct and must
+    // stay byte-identical, since lint's fix targeting matches on this value.
+    const src = 'mapping m {\n  -> gross_total { "Add @net and @tax" }\n}';
+    assert.deepEqual(targetFields(src), ["gross_total"]);
+  });
+});


### PR DESCRIPTION
## Summary

Exploratory testing of how NL text transform `@refs` are followed for lineage
and coverage, focused on the `-> target_field { "... @field1 and @field2" }`
idiom. Fixes both P1 defects found, plus an ADR reversing the coverage carve-out.

Flat mappings were already correct. **Everything inside a container was wrong on
both ends** — and wrong silently: it fabricated graph nodes rather than
reporting nothing.

## The two fixes

For `each Items -> items { .MENGE -> .orderedQty { "... @MEINS ..." } }`
(`examples/sap-po-to-mfcs/pipeline.stm:159`):

| | before | after |
|---|---|---|
| source | `::sap_purchase_order.MEINS` ✗ | `::sap_purchase_order.Items.MEINS` ✓ |
| target | `::mfcs_purchase_order.orderedQty` ✗ | `::mfcs_purchase_order.items.orderedQty` ✓ |

Neither `before` path is a declared field. `field-lineage` on the real nested
field reported no connection while the phantom carried the edge.

**`sl-hrql` — target side.** `walkArrowsForNL` never accumulated the target base
its enclosing `each`/`flatten`/`nested_arrow` established, so `targetField`
stayed relative (`.line_total`) and `qualifyField` attached the leaf to the
schema root. The clearest symptom: `graph --json` emitted two contradictory
target nodes for one source line — `nl` → `tgt.lines.line_total` and
`nl-derived` → `tgt.line_total`. Fixed by threading a base through the walk,
mirroring `coverage.ts`'s `collectBlockItemPaths`, including `flatten`'s two
cases (relative target stacks a base; top-level `flatten contacts -> tgt` names
the schema and establishes none).

**`sl-ez36` — source side.** `resolveRef` located nested fields but reported the
ref as written, so `@qty` resolved to `::src.qty`. Reported `resolved: true`, so
`unresolved-nl-ref` stayed silent. Replaced the boolean field-search helpers with
path-returning ones. Search is now **breadth-first**, so the shallowest match
wins — a top-level `city` beats `address.city` — making the answer independent of
declaration order rather than arbitrary (pinned by test).

## ADR-036 — coverage must count resolved @refs

`coverage` excluded `@refs` as a Feature 35 non-goal. **ADR-013 already decided
the opposite**, and is Accepted and unsuperseded:

> An NL `@ref` mention […] carries the same lineage weight as a declared source
> field to the left of an arrow. […] they are not second-class.

`arrows`, `graph`, `lineage`, `field-lineage` and `lint` all honour it —
`hidden-source-in-nl` treats an undeclared `@ref` as an *error* and auto-fixes
the `source {}` block. Coverage was the sole dissenter, and the carve-out was
never recorded as an amendment to ADR-013. So it is a defect against an existing
decision, not a design choice to relitigate.

The load-bearing claim ADR-036 states: **resolving `@field` to a declared field
is structural resolution of an explicit reference, not interpretation of prose.**
The CLI's "does not interpret natural language" positioning survives intact.

Contract: `covered` = `covered_declared` + `covered_nl` over ADR-034's
**unchanged** leaf denominator (splits the numerator only); both-ways counts once
in the declared tier; unresolved refs count for nothing; `--fail-under` gates the
combined figure. No ADR is superseded.

## Tickets

| Ticket | P | Status |
|---|---|---|
| `sl-hrql` | 1 | **fixed & closed** — target base not accumulated |
| `sl-ez36` | 1 | **fixed & closed** — nested source path discarded |
| `sl-qxyl` | 1 | open — implements ADR-036, **now unblocked** |
| `sl-wta4` | 3 | open — `arrows` header count |
| `sl-0zgi` | 3 | open — ambiguous bare ref needs a lint rule |

`sl-qxyl` was blocked on both P1s: crediting coverage before this landed would
have attributed it to the fabricated paths, inside a merge gate.

## Testing

- core **471 → 482**, cli **966 → 969**; lsp 292, viz-backend 163, viz-model 6,
  vscode 33 all unchanged and green.
- New core tests cover each / nested_arrow / two-level nesting / top-level
  flatten / the no-container control, and nested source resolution including the
  shallowest-match rule and the still-unresolved case.
- Corpus regression tests on `examples/sap-po-to-mfcs/pipeline.stm`, including
  that `nl` and `nl-derived` edges for one arrow now name one target field.
- `lint:js` clean. (The 33 `markdownlint` errors are all in gitignored `tmp/`,
  pre-existing local scratch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)