### PR TITLE
fix(core): match field coverage by path, not by name (sl-joeq)

### DIFF
--- a/.tickets/sl-joeq.md
+++ b/.tickets/sl-joeq.md
@@ -1,6 +1,6 @@
 ---
 id: sl-joeq
-status: open
+status: closed
 deps: []
 links: [sl-j6g9]
 created: 2026-07-31T14:42:19Z
@@ -78,3 +78,14 @@ Regression tests (each must fail before the fix):
 
 Existing core test at satsuma-core/test/coverage.test.js asserting set.has("city") for the bare leaf is updated, with a comment citing this ticket rather than silently deleted. CLI, core, LSP, viz and vscode suites pass. Coverage-figure change noted in CHANGELOG.md.
 
+
+## Notes
+
+**2026-07-31T15:57:24Z**
+
+Cause: addPathAndPrefixes registered every segment of a covered path as a standalone bare name, so coverage resolved by field NAME rather than by PATH — any field whose own path matched a segment of another covered path in the same schema read as mapped. Removing the bare entries exposed a second defect they had masked: schema-qualified arrows in multi-source mappings (crm.email -> email) matched only via that trailing bare segment, and so could never reach a nested declared path.
+Fix: bare-segment registration removed; new schemaRefPrefixes/schemaLocalFieldPath in coverage-paths.ts resolve an arrow's schema prefix against the schema it names, applied per schema in coverage.ts; satsuma-viz's resolveSchemaLocalFieldPath now delegates to core instead of keeping its own copy. Corpus effect: four example files move — three inflated figures drop (customer_profiles 4/8 -> 2/8; order_transactions, support_tickets and finance_transactions each 1 -> 0, all joined-but-unread schemas crediting a sibling's arrows) and one under-count rises (governance.stm crm_customers 6/13 -> 9/13, the nested consent paths a qualified prefix could not previously reach). Coverage-figure change recorded in CHANGELOG.md under Unreleased. (branch fix/sl-joeq-bare-segment, single commit — the repo rebase-merges, so the landed sha differs)
+
+Scope note on the acceptance criteria: two listed regression tests already passed on main and are kept as guards rather than proofs. The 'fields --unmapped-by on deep-nested-bugs.stm reports GrpHdr.InstdAgt.BIC as unmapped' case and the sibling-record fragment-spread case both pass pre-fix, because main's fields.ts:162 tests only the full path — the mapped.has(f.name) OR clause the ticket cites was removed when sl-oqsj re-based the command onto core. The invariant is covered at core level ('distinguishes repeated leaf names at equal depth under different parents' and 'judges sibling records sharing a leaf name independently'); a CLI-level duplicate was not added, per the no-redundant-tests rule.
+
+Not verified: the viz Playwright harness was not run (it needs a human-launched browser). Its 10 specs make no coverage/mapped assertions, so the changed path is unexercised there; satsuma-viz's 97 unit tests pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Coverage figures will change (`sl-joeq`)
+
+**Recorded coverage percentages will move after this release — in both
+directions.** Anyone tracking a coverage number, or gating CI with
+`coverage --fail-under`, should re-baseline it.
+
+Field coverage resolved by field *name* rather than by *path*. Every segment of
+a covered path was registered as a standalone name, so a field whose own path
+matched a segment of any other covered path in the same schema read as mapped.
+Coverage now matches whole paths only:
+
+- **Figures generally drop.** A top-level `city` no longer counts as mapped
+  because `home_address.city` is; a joined-but-unread source schema that happens
+  to share field names with the schema being read no longer inherits its
+  coverage. Fields that were reported mapped and are now reported unmapped were
+  never mapped — this is the correction, not a regression.
+- **Some figures rise.** Schema-qualified arrows in multi-source mappings
+  (`crm.consent.email_marketing -> consent_email`) previously matched only the
+  trailing leaf name, so they never matched a *nested* declared path and were
+  under-counted. The prefix is now resolved against the schema it names.
+
+Affects `satsuma coverage` (including `--fail-under`), `satsuma fields
+--unmapped-by`, the VS Code coverage gutter and status bar, and the viz coverage
+overlay — all four share one computation, so all four move together.
+
 ## v0.11.0 — 2026-07-22
 
 A maintenance and security-hardening release. No new language constructs and

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -125,6 +125,8 @@ Flags: `--mapping <name>`, `--schema <name>`, `--role source|target`, `--uncover
 
 **Coverage is structural.** A field is covered when at least one arrow references it. Nested paths cover their parents: mapping `address.city` covers `address` but not `address.line1`. Element-relative arrows inside `each`/`flatten` blocks resolve against the iterated list, so `.sku` under `each lines -> rows` covers `lines.sku`. A field described only in prose is uncovered *by definition* — use `nl-refs` to find those, and `lint` for policy judgements about which gaps are acceptable.
 
+**Coverage matches whole paths, never bare field names.** `home_address.city` covers exactly that path — not a top-level `city`, and not `work_address.city`. Repeated leaf names across depths (`id`, `sku`, `code`, `BIC`) are normal in nested schemas, so name matching would report unmapped fields as mapped. In a multi-source mapping, an arrow's schema prefix resolves to the schema it names: `crm.consent.email_marketing` covers `consent.email_marketing` in `crm` and contributes nothing to any other source.
+
 **Percentages count leaf fields only.** A `record` is structure, not data; counting it alongside its children would count the same data twice and let a schema's nesting depth move the number on its own.
 
 #### Per-mapping vs aggregate

--- a/adrs/adr-035-coverage-identity-is-the-qualified-path.md
+++ b/adrs/adr-035-coverage-identity-is-the-qualified-path.md
@@ -1,0 +1,113 @@
+# ADR-035 — Coverage Identity Is the Qualified Field Path
+
+**Status:** Accepted
+**Date:** 2026-07-31 (sl-joeq)
+
+## Context
+
+`computeMappingCoverage()` answers one question per declared field: does any
+arrow in this mapping reference it? The answer is looked up in a `Set<string>`
+of covered paths built by `addPathAndPrefixes()` in
+`satsuma-core/src/coverage-paths.ts`. That function registered three kinds of
+entry for every path an arrow referenced: the full path, each ancestor prefix,
+and — deliberately, with a comment saying so — **each segment on its own**.
+Covering `address.city` produced `{"address", "address.city", "city"}`.
+
+The bare segment existed so a consumer holding only a local field name could
+probe the set without building a qualified path. Its cost is that coverage
+stopped being a question about a path and became a question about a name: a
+field was reported mapped whenever its own path happened to equal *any segment
+of any covered path in the same schema*. Repeated leaf names across depths —
+`id`, `sku`, `code`, `city`, `BIC` — are not an edge case in nested schemas but
+the normal shape of one, so the collision rate rose with exactly the specs
+coverage analysis exists to check. The failure was silent and in the dangerous
+direction: an incomplete spec read as complete. On the example corpus it credited
+three joined-but-unread source schemas with their sibling's arrows purely because
+the two declared the same field names, and it reported a top-level `city` as
+mapped on the strength of `home_address.city`.
+
+Removing the bare entries immediately exposed a second defect they had been
+masking. Multi-source mappings qualify their arrows by schema — every source
+arrow in `examples/filter-flatten-governance/governance.stm` reads
+`crm_customers.email -> email` — but the covered-path walk recorded arrow text as
+authored and never resolved that prefix. `crm_customers.email` matched the
+declared field `email` only via the trailing bare segment. So the two defects had
+been cancelling: one over-counted by matching names, the other would have
+under-counted by never stripping prefixes, and neither was visible while the
+other was present. The same accident meant a qualified arrow could never reach a
+*nested* declared path, since only the final segment was ever compared —
+`crm_customers.consent.email_marketing` left `consent.email_marketing`
+uncovered.
+
+Two other resolutions of the prefix rule already existed in the tree, in
+`satsuma-viz/src/field-coverage.ts` and in the CLI's `arrows.ts` and
+`graph-builder.ts`, each written for its own consumer.
+
+## Decision
+
+**A field's coverage is decided by its qualified path from the schema root, and
+by nothing else.** `addPathAndPrefixes()` registers the full path and its
+ancestor prefixes only. Ancestor registration stays — a record whose descendant
+is covered still matches on its own path, which is what the VS Code gutter
+decorates — but no entry is ever keyed by a local field name, and every consumer
+must pass a qualified schema-local path to `isCoveredFieldPath()`.
+
+The prefix rule that this makes necessary lives in core, as
+`schemaRefPrefixes()` and `schemaLocalFieldPath()` in `coverage-paths.ts`.
+`schemaLocalFieldPath()` reduces an arrow's authored reference to a path local to
+one schema in three ordered rules: a prefix naming this schema is stripped; a
+prefix naming a different schema in the same `source {}` / `target {}` block
+yields `null`, leaving the claim to that schema's own pass; anything else is
+already local and passes through unchanged. A namespaced schema is matched by
+both its qualified id and its bare name, because arrows keep authored text while
+the index reports the canonical key. `coverageForSchema()` in `coverage.ts`
+applies it per schema, which is why the covered-path set is now built per schema
+rather than once per mapping side.
+
+Where a schema and one of its own top-level fields share a name, the declared
+field wins and the path is read as-is: a declaration is concrete evidence, a
+prefix that merely looks like one is not. Callers supply that knowledge through
+the optional `declaresTopLevel` predicate.
+
+`satsuma-viz`'s `resolveSchemaLocalFieldPath()` delegates to
+`schemaLocalFieldPath()` and keeps only the rule specific to rendering a card —
+that an unprefixed reference must be declared by the schema before it is shown
+against it. Consumers must not reimplement prefix resolution.
+
+## Consequences
+
+**Positive:**
+
+- Coverage means what it says. `home_address.city` covers exactly that path, and
+  a schema nobody reads reports 0% however its field names overlap its
+  neighbours'.
+- The over-count is gone in the direction that matters. The prior behaviour hid
+  work; a reviewer or a `--fail-under` gate could not see a gap it had already
+  been told was filled.
+- One implementation of the prefix rule, in core, for `satsuma coverage`,
+  `fields --unmapped-by`, the LSP, the VS Code gutter and the viz overlay. Four
+  surfaces that must agree now cannot drift.
+- Qualified arrows reach nested declared paths, which fixes a genuine
+  *under*-count that the name match could not express.
+- `isCoveredFieldPath()` keeps its signature, so no consumer had to change to
+  keep working.
+
+**Negative:**
+
+- **Recorded coverage figures move, in both directions.** Anyone tracking a
+  number or gating CI with `coverage --fail-under` must re-baseline. On the
+  example corpus four files change: three inflated figures fall and one
+  under-count rises. Every movement is a correction, but a consumer cannot tell
+  that from the number alone, which is why `CHANGELOG.md` states it explicitly.
+- A consumer holding only a local field name can no longer probe the covered
+  set. It must build the qualified path — which is the point, but it makes the
+  set harder to use casually than it was.
+- The covered-path set is now built once per participating schema instead of once
+  per mapping side, because prefix resolution depends on which schema is being
+  reported. For a mapping with many sources this is more work than before; it is
+  linear in schemas × arrow references and has not been measured as significant.
+- The schema-versus-own-field name collision is resolved by a rule, not by the
+  language. Satsuma does not forbid a schema declaring a top-level field of its
+  own name, so `orders.amount` inside `mapping { source { orders } }` is
+  genuinely ambiguous and the resolution here — prefer the declared field — is a
+  convention a future contributor could reasonably question.

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -141,7 +141,7 @@ graph LR
   STR["string-utils.ts\ncapitalize · truncate\nformatList · …"]
   PAR["parser.ts\ninitParser() singleton\nparseSource()"]
   PE["parse-errors.ts\ncollectParseErrors()\nParseError"]
-  COV["coverage.ts\nFieldCoverageEntry\nSchemaCoverageResult\naddPathAndPrefixes()"]
+  COV["coverage.ts · coverage-paths.ts\nFieldCoverageEntry\nSchemaCoverageResult\naddPathAndPrefixes()\nschemaLocalFieldPath()"]
   VAL["validate.ts\nSemanticIndex · SemanticDiagnostic\ncollectSemanticDiagnostics()"]
 
   IDX --> TYPES & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & PAR & PE & COV & VAL

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -28,6 +28,10 @@ const NESTED = resolve(__dirname, "fixtures/unmapped-nested.stm");
 // which makes it the reference case for nested container coverage (sl-qzy3).
 const NESTED_ITERATION = resolve(__dirname, "../../../examples/nested-iteration/pipeline.stm");
 const NESTED_ARROW = resolve(__dirname, "fixtures/nested-arrow-lookup.stm");
+// Two source schemas declaring the same field names, arrows qualified by schema
+// and written inside a namespace — the pairing that exercises prefix resolution
+// against the canonical index key (sl-joeq).
+const MULTI_SOURCE = resolve(__dirname, "fixtures/coverage-multi-source.stm");
 
 const run = (...args: string[]) => _run(CLI, ...args);
 
@@ -142,6 +146,39 @@ describe("satsuma coverage — resolving the workspace index", () => {
       ["crm::annotate contacts", "target"],
       ["crm::load contacts", "target"],
     ]);
+  });
+
+  it("resolves a bare schema prefix on an arrow against the canonical namespaced key", async () => {
+    // Multi-source mappings qualify their arrows by schema, and inside a
+    // namespace they write the bare name (`crm.email`) while the index reports
+    // `warehouse::crm`. The CLI owns that canonicalisation, so this pairing can
+    // only break here — and it must resolve onto nested declared paths too
+    // (`crm.consent.email_marketing` -> `consent.email_marketing`), which the
+    // qualified form silently failed to do before sl-joeq.
+    const { stdout, code } = await run("coverage", MULTI_SOURCE, "--json");
+    assert.equal(code, 0);
+    const crm = schemaEntry(parseJson(stdout), "warehouse::assemble", "source", "warehouse::crm");
+    assert.deepEqual(
+      crm.fields.map((f: any) => [f.path, f.mapped]),
+      [
+        ["customer_id", true],
+        ["email", true],
+        ["consent.email_marketing", true],
+        ["consent.sms_marketing", false],
+      ],
+    );
+  });
+
+  it("does not credit a joined-but-unread source schema that shares field names", async () => {
+    // `ledger` declares customer_id and email exactly as `crm` does but no arrow
+    // reads it. Matching by leaf name reported it as fully mapped — a silent
+    // over-count that makes a source nobody reads look consumed (sl-joeq).
+    const { stdout } = await run("coverage", MULTI_SOURCE, "--json");
+    const ledger = schemaEntry(parseJson(stdout), "warehouse::assemble", "source", "warehouse::ledger");
+    assert.deepEqual(
+      { covered: ledger.covered, total: ledger.total, pct: ledger.pct },
+      { covered: 0, total: 2, pct: 0 },
+    );
   });
 });
 

--- a/tooling/satsuma-cli/test/fixtures/coverage-multi-source.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-multi-source.stm
@@ -1,0 +1,41 @@
+// Fixture for schema-qualified arrow coverage in a multi-source mapping (sl-joeq).
+//
+// Two source schemas that deliberately declare the same field names. Only
+// `crm` is read by an arrow, and every arrow qualifies its source by schema —
+// the style every multi-source example in examples/ uses. That makes this the
+// minimal case for two rules at once:
+//
+//  1. the schema prefix must be resolved away, including onto a NESTED declared
+//     path (`crm.consent.email_marketing` -> `consent.email_marketing`);
+//  2. `ledger`, which shares every field name with `crm`, must stay at 0%.
+
+namespace warehouse {
+  schema crm {
+    customer_id UUID
+    email STRING
+    consent record {
+      email_marketing BOOLEAN
+      sms_marketing   BOOLEAN
+    }
+  }
+
+  schema ledger {
+    customer_id UUID
+    email       STRING
+  }
+
+  schema profile {
+    customer_id    UUID
+    email          STRING
+    consent_email  BOOLEAN
+  }
+
+  mapping assemble {
+    source { crm, ledger }
+    target { profile }
+
+    crm.customer_id -> customer_id
+    crm.email -> email { lowercase }
+    crm.consent.email_marketing -> consent_email
+  }
+}

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -7,6 +7,11 @@
  * references `customer.email`, both `customer` and `customer.email` count as
  * covered — so those rules live here rather than in each UI layer.
  *
+ * It also owns the rule that turns an arrow's *authored* field reference into a
+ * schema-local path: in a multi-source mapping arrows name their schema
+ * (`crm_customers.email -> email`), and every consumer must strip that prefix
+ * the same way before matching against declared fields.
+ *
  * Does not own the CST walk that produces those paths, nor the per-field
  * result shape: both live in coverage.ts, which builds on this module. The
  * dependency runs one way (coverage.ts → coverage-paths.ts) so the two
@@ -17,14 +22,24 @@
  * Register a path and all its ancestor prefixes in the covered-paths set.
  *
  * Strips array-notation brackets (`[]`) before splitting so that list-traversal
- * paths like `"items[].id"` are registered as `"items"`, `"items.id"`, and `"id"`.
+ * paths like `"items[].id"` are registered as `"items"` and `"items.id"`.
  *
  * Registering ancestors means a top-level field `"address"` is considered
  * covered when an arrow targets the nested path `"address.city"` — a consumer
- * that checks `coveredPaths.has(f.name)` will correctly find the parent covered.
+ * checking the record's own path will correctly find the parent covered.
+ *
+ * **Qualified paths only — never bare segments (sl-joeq).** An earlier version
+ * also registered each segment on its own (`"city"` for `"address.city"`) so a
+ * consumer could probe by local field name. That made coverage resolve by NAME
+ * rather than by PATH: any field whose qualified path happened to equal a
+ * segment of some other covered path read as mapped. Leaf-name reuse across
+ * depths (`id`, `sku`, `code`, `city`, `BIC`) is normal in nested schemas, so
+ * the collision rate rose with exactly the schemas coverage analysis is for —
+ * and it failed in the dangerous direction, silently reporting an incomplete
+ * spec as complete. Consumers must pass the schema-local qualified path.
  *
  * Example: addPathAndPrefixes(set, "orders.item_id")
- *   → set now contains "orders", "orders.item_id", "item_id"
+ *   → set now contains "orders" and "orders.item_id"
  */
 export function addPathAndPrefixes(set: Set<string>, path: string): void {
   if (!path) return;
@@ -35,13 +50,12 @@ export function addPathAndPrefixes(set: Set<string>, path: string): void {
   for (const part of parts) {
     prefix = prefix ? `${prefix}.${part}` : part;
     set.add(prefix);
-    set.add(part); // bare leaf so "city" matches even if the full path is "address.city"
   }
 }
 
 /**
  * Expand a collection of field paths into a coverage set containing the full
- * path, its ancestor prefixes, and the leaf segment for each entry.
+ * path and its ancestor prefixes for each entry.
  */
 export function buildCoveredFieldSet(paths: Iterable<string>): Set<string> {
   const covered = new Set<string>();
@@ -52,10 +66,78 @@ export function buildCoveredFieldSet(paths: Iterable<string>): Set<string> {
 /**
  * Return true when a schema-local field path is covered by the expanded set.
  *
- * The caller must pass the schema-local path (`customer.email`, not
- * `orders.customer.email`). Matching is intentionally exact because
- * buildCoveredFieldSet() already registers prefixes and leaves.
+ * The caller must pass the schema-local *qualified* path (`customer.email`, not
+ * `orders.customer.email` and not the bare leaf `email`). Matching is exact:
+ * buildCoveredFieldSet() registers ancestor prefixes, so a record whose
+ * descendant is covered matches on its own path, but a field is never matched
+ * by local name alone (sl-joeq).
  */
 export function isCoveredFieldPath(path: string, coveredPaths: Set<string>): boolean {
   return coveredPaths.has(path);
+}
+
+// ── Schema-qualified arrow references ───────────────────────────────────────
+
+/**
+ * The prefixes an arrow may legitimately use to name one schema.
+ *
+ * A namespaced schema can be referred to by its qualified id (`crm::customers`)
+ * from outside the namespace and by its bare name (`customers`) from inside it,
+ * and arrows keep whichever form the author wrote. Matching only the qualified
+ * form would miss every bare-prefixed reference in a namespaced mapping.
+ */
+export function schemaRefPrefixes(schemaRef: string): string[] {
+  const namespaceEnd = schemaRef.lastIndexOf("::");
+  if (namespaceEnd < 0) return [schemaRef];
+  return [schemaRef, schemaRef.slice(namespaceEnd + 2)];
+}
+
+/**
+ * Reduce an arrow's authored field reference to a path local to one schema, or
+ * null when the reference belongs to a different schema in the same mapping.
+ *
+ * Multi-source mappings qualify their arrows by schema — see
+ * `examples/filter-flatten-governance/governance.stm`, whose every source arrow
+ * reads `crm_customers.email -> email`. Coverage compares against paths declared
+ * *within* a schema, so the prefix has to come off first; before sl-joeq the
+ * qualified form only matched by accident, via bare-segment registration.
+ *
+ * The rules, in order:
+ *  1. The reference names *this* schema → strip the prefix and return the rest.
+ *     Skipped when the schema itself declares a top-level field of that name, so
+ *     a schema and field sharing a name resolves to the concrete field rather
+ *     than to a prefix that only looks like one.
+ *  2. The reference names a *different* schema in the same block → null; that
+ *     schema's own pass will claim it.
+ *  3. Otherwise the reference is already schema-local → return it unchanged.
+ *
+ * @param fieldRef         Path as authored on the arrow, already container-qualified.
+ * @param schemaRefs       Every form this schema may be named by — the reference
+ *                         as written in the mapping and, when it differs, the
+ *                         resolved canonical id.
+ * @param otherSchemaRefs  The other schemas referenced on this side of the mapping.
+ * @param declaresTopLevel True when this schema declares a top-level field of the
+ *                         given name. Supply it to disambiguate rule 1.
+ */
+export function schemaLocalFieldPath(
+  fieldRef: string,
+  schemaRefs: readonly string[],
+  otherSchemaRefs: readonly string[],
+  declaresTopLevel?: (name: string) => boolean,
+): string | null {
+  const firstSegment = fieldRef.split(".")[0] ?? fieldRef;
+  const shadowedByOwnField = declaresTopLevel?.(firstSegment) ?? false;
+
+  if (!shadowedByOwnField) {
+    for (const prefix of schemaRefs.flatMap(schemaRefPrefixes)) {
+      if (fieldRef.startsWith(`${prefix}.`)) return fieldRef.slice(prefix.length + 1);
+    }
+  }
+
+  const namesAnotherSchema = otherSchemaRefs
+    .flatMap(schemaRefPrefixes)
+    .some((prefix) => fieldRef.startsWith(`${prefix}.`));
+  if (namesAnotherSchema) return null;
+
+  return fieldRef;
 }

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -8,9 +8,16 @@
  * schema.
  *
  * "Covered" means:
- *   - source field: its name (or a path that starts with it) appears as a
- *     src_path in at least one arrow anywhere in the mapping.
+ *   - source field: its qualified path from the schema root — or a path that
+ *     starts with it — appears as a src_path in at least one arrow anywhere in
+ *     the mapping.
  *   - target field: the same, as a tgt_path.
+ *
+ * Matching is by path, never by local field name: two records under one schema
+ * routinely declare the same leaf name, and treating a name match as coverage
+ * silently reported unmapped fields as mapped (sl-joeq). The corollary is that
+ * an arrow's schema prefix has to be resolved away before matching, which is
+ * what {@link coverageForSchema} does.
  *
  * Nested record fields are handled recursively. Arrows nest inside three
  * container blocks — `each`, `flatten` and a braced `src -> tgt` (`nested_arrow`)
@@ -32,7 +39,7 @@
  */
 
 import { child, children, labelText, sourceRefStructuralText } from "./cst-utils.js";
-import { addPathAndPrefixes, isCoveredFieldPath } from "./coverage-paths.js";
+import { buildCoveredFieldSet, isCoveredFieldPath, schemaLocalFieldPath } from "./coverage-paths.js";
 import type { SyntaxNode, Tree } from "./types.js";
 
 // ── Resolver input contract ─────────────────────────────────────────────────
@@ -156,34 +163,61 @@ export function computeMappingCoverage(
   const sourceIds = getSchemaIdsFromBlock(body, "source_block");
   const targetIds = getSchemaIdsFromBlock(body, "target_block");
 
-  // Collect all explicit arrow source paths and target paths from the mapping.
-  const coveredSrcPaths = new Set<string>();
-  const coveredTgtPaths = new Set<string>();
-  collectBodyPaths(body, coveredSrcPaths, coveredTgtPaths);
+  // Arrow references as authored, container-qualified but still carrying any
+  // schema prefix — that prefix can only be stripped once we know which schema
+  // we are reporting on, so resolution happens per schema below.
+  const srcRefs: string[] = [];
+  const tgtRefs: string[] = [];
+  collectBodyPaths(body, srcRefs, tgtRefs);
 
   const schemas: SchemaCoverageResult[] = [];
 
   for (const schemaId of sourceIds) {
     const def = resolveSchema(schemaId);
     if (!def) continue;
-    schemas.push({
-      schemaId: def.schemaId ?? schemaId,
-      role: "source",
-      fields: buildFieldCoverage(def.fields, def.uri, "", coveredSrcPaths),
-    });
+    schemas.push(coverageForSchema(def, schemaId, "source", srcRefs, sourceIds));
   }
 
   for (const schemaId of targetIds) {
     const def = resolveSchema(schemaId);
     if (!def) continue;
-    schemas.push({
-      schemaId: def.schemaId ?? schemaId,
-      role: "target",
-      fields: buildFieldCoverage(def.fields, def.uri, "", coveredTgtPaths),
-    });
+    schemas.push(coverageForSchema(def, schemaId, "target", tgtRefs, targetIds));
   }
 
   return { schemas };
+}
+
+/**
+ * Report one schema, resolving the mapping's authored arrow references into
+ * paths local to it before matching them against its declared fields.
+ */
+function coverageForSchema(
+  def: CoverageSchemaDefinition,
+  writtenRef: string,
+  role: "source" | "target",
+  arrowRefs: readonly string[],
+  participatingRefs: readonly string[],
+): SchemaCoverageResult {
+  // An arrow may name this schema by the reference as written in the mapping or
+  // by the id the resolver canonicalised it to, so both forms must resolve.
+  const canonicalRef = def.schemaId ?? writtenRef;
+  const ownRefs = canonicalRef === writtenRef ? [writtenRef] : [writtenRef, canonicalRef];
+  const otherRefs = participatingRefs.filter((ref) => ref !== writtenRef);
+
+  const topLevelNames = new Set(def.fields.map((f) => f.name));
+  const declaresTopLevel = (name: string): boolean => topLevelNames.has(name);
+
+  const localPaths: string[] = [];
+  for (const ref of arrowRefs) {
+    const local = schemaLocalFieldPath(ref, ownRefs, otherRefs, declaresTopLevel);
+    if (local !== null) localPaths.push(local);
+  }
+
+  return {
+    schemaId: canonicalRef,
+    role,
+    fields: buildFieldCoverage(def.fields, def.uri, "", buildCoveredFieldSet(localPaths)),
+  };
 }
 
 // ── Path collection ─────────────────────────────────────────────────────────
@@ -214,51 +248,55 @@ const CONTAINER_BLOCK_TYPES = new Set(["each_block", "flatten_block", "nested_ar
 
 /**
  * Walk every arrow in the mapping body — including those nested inside
- * containers to arbitrary depth — and populate the covered src/tgt path sets.
+ * containers to arbitrary depth — and collect the src/tgt references it makes.
+ *
+ * References come out container-qualified but otherwise as authored: any schema
+ * prefix is left on, because which prefix is strippable depends on the schema
+ * being reported. {@link coverageForSchema} resolves that per schema.
  */
 function collectBodyPaths(
   body: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
+  srcRefs: string[],
+  tgtRefs: string[],
 ): void {
-  collectBlockItemPaths(body.namedChildren, srcPaths, tgtPaths, { src: null, tgt: null });
+  collectBlockItemPaths(body.namedChildren, srcRefs, tgtRefs, { src: null, tgt: null });
 }
 
 /**
- * Collect paths from a list of sibling block items, qualifying each against the
- * bases its enclosing container established.
+ * Collect references from a list of sibling block items, qualifying each against
+ * the bases its enclosing container established.
  */
 function collectBlockItemPaths(
   nodes: SyntaxNode[],
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
+  srcRefs: string[],
+  tgtRefs: string[],
   bases: PathBases,
 ): void {
   for (const node of nodes) {
     if (node.type === "map_arrow") {
       for (const sp of children(node, "src_path")) {
-        addPathAndPrefixes(srcPaths, qualify(bases.src, pathText(sp)));
+        srcRefs.push(qualify(bases.src, pathText(sp)));
       }
       const tp = child(node, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, qualify(bases.tgt, pathText(tp)));
+      if (tp) tgtRefs.push(qualify(bases.tgt, pathText(tp)));
     } else if (node.type === "computed_arrow") {
       // Source-less arrow: the target is still populated by this mapping.
       const tp = child(node, "tgt_path");
-      if (tp) addPathAndPrefixes(tgtPaths, qualify(bases.tgt, pathText(tp)));
+      if (tp) tgtRefs.push(qualify(bases.tgt, pathText(tp)));
     } else if (CONTAINER_BLOCK_TYPES.has(node.type)) {
-      collectContainerPaths(node, srcPaths, tgtPaths, bases);
+      collectContainerPaths(node, srcRefs, tgtRefs, bases);
     }
   }
 }
 
 /**
- * Register a container's own source and target, then recurse into its body with
+ * Record a container's own source and target, then recurse into its body with
  * those as the bases for the level below.
  */
 function collectContainerPaths(
   node: SyntaxNode,
-  srcPaths: Set<string>,
-  tgtPaths: Set<string>,
+  srcRefs: string[],
+  tgtRefs: string[],
   outer: PathBases,
 ): void {
   const rawSrc = child(node, "src_path");
@@ -269,10 +307,10 @@ function collectContainerPaths(
 
   // The container's own paths count as touched: iterating a list consumes it,
   // and writing into one populates it.
-  if (src) addPathAndPrefixes(srcPaths, src);
-  if (tgt) addPathAndPrefixes(tgtPaths, tgt);
+  if (src) srcRefs.push(src);
+  if (tgt) tgtRefs.push(tgt);
 
-  collectBlockItemPaths(node.namedChildren, srcPaths, tgtPaths, { src, tgt });
+  collectBlockItemPaths(node.namedChildren, srcRefs, tgtRefs, { src, tgt });
 }
 
 /**

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -36,7 +36,13 @@ export type {
   CoverageSchemaDefinition,
   CoverageSchemaResolver,
 } from "./coverage.js";
-export { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "./coverage-paths.js";
+export {
+  addPathAndPrefixes,
+  buildCoveredFieldSet,
+  isCoveredFieldPath,
+  schemaLocalFieldPath,
+  schemaRefPrefixes,
+} from "./coverage-paths.js";
 export { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "./coverage-rollup.js";
 export type {
   MappingCoverageInput,

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -9,7 +9,12 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { addPathAndPrefixes, buildCoveredFieldSet, isCoveredFieldPath } from "@satsuma/core";
+import {
+  addPathAndPrefixes,
+  buildCoveredFieldSet,
+  isCoveredFieldPath,
+  schemaLocalFieldPath,
+} from "@satsuma/core";
 
 describe("addPathAndPrefixes()", () => {
   it("registers a leaf-only path unchanged", () => {
@@ -24,9 +29,18 @@ describe("addPathAndPrefixes()", () => {
     // Without prefix registration the parent record always reads as unmapped.
     const set = new Set();
     addPathAndPrefixes(set, "address.city");
-    assert.ok(set.has("address"), "parent prefix 'address' must be registered");
-    assert.ok(set.has("address.city"), "full path must be registered");
-    assert.ok(set.has("city"), "bare leaf 'city' must be registered for cross-level matching");
+    assert.deepEqual([...set].sort(), ["address", "address.city"]);
+  });
+
+  it("does not register a path's segments as standalone bare names", () => {
+    // sl-joeq: this assertion was inverted — the set used to contain "city" so
+    // a consumer could probe by local field name, which made coverage resolve
+    // by NAME rather than PATH and silently reported any same-named field
+    // anywhere in the schema as mapped. Registering only qualified paths is the
+    // invariant every consumer now relies on.
+    const set = new Set();
+    addPathAndPrefixes(set, "address.city");
+    assert.ok(!set.has("city"), "bare leaf 'city' must NOT be registered");
   });
 
   it("expands prefixes recursively, not just one level deep", () => {
@@ -34,11 +48,7 @@ describe("addPathAndPrefixes()", () => {
     // would leave "a.b" unregistered and report the middle record uncovered.
     const set = new Set();
     addPathAndPrefixes(set, "a.b.c");
-    assert.ok(set.has("a"));
-    assert.ok(set.has("a.b"));
-    assert.ok(set.has("a.b.c"));
-    assert.ok(set.has("b"));
-    assert.ok(set.has("c"));
+    assert.deepEqual([...set].sort(), ["a", "a.b", "a.b.c"]);
   });
 
   it("strips [] array notation before splitting", () => {
@@ -48,7 +58,6 @@ describe("addPathAndPrefixes()", () => {
     addPathAndPrefixes(set, "items[].id");
     assert.ok(set.has("items"), "'items' must be registered after stripping '[]'");
     assert.ok(set.has("items.id"));
-    assert.ok(set.has("id"));
     assert.ok(!set.has("items[]"), "bracket-suffixed form must NOT appear in the set");
   });
 
@@ -94,5 +103,91 @@ describe("buildCoveredFieldSet()", () => {
   it("returns false for unrelated paths", () => {
     const covered = buildCoveredFieldSet(["customer.email"]);
     assert.equal(isCoveredFieldPath("customer.tier", covered), false);
+  });
+
+  it("leaves a top-level field uncovered when only a nested field shares its name", () => {
+    // sl-joeq's live failure mode: a top-level field's qualified path IS its
+    // bare name, so bare-segment registration made it collide with any nested
+    // leaf of the same name. Reported 100% for a schema half of whose fields
+    // no arrow touches.
+    const covered = buildCoveredFieldSet(["home_address.city"]);
+    assert.equal(isCoveredFieldPath("city", covered), false);
+  });
+
+  it("leaves every intermediate segment of a deep path uncovered as a top-level name", () => {
+    // Middle segments leaked as well as leaves: with only a.b.c.d covered,
+    // top-level fields named b, c or d all read as mapped.
+    const covered = buildCoveredFieldSet(["a.b.c.d"]);
+    for (const segment of ["b", "c", "d"]) {
+      assert.equal(isCoveredFieldPath(segment, covered), false, `'${segment}' must be uncovered`);
+    }
+    assert.equal(isCoveredFieldPath("a", covered), true, "'a' is a genuine ancestor prefix");
+  });
+
+  it("leaves a sibling record's same-named leaf uncovered", () => {
+    // Sibling records sharing a leaf name (the fragment-spread shape of
+    // examples/lib/sfdc_fragments.stm, where one fragment lands in both
+    // BillingAddress and ShippingAddress) must be judged independently.
+    const covered = buildCoveredFieldSet(["home_address.city"]);
+    assert.equal(isCoveredFieldPath("work_address.city", covered), false);
+  });
+
+  it("leaves a sibling list container's same-named leaf uncovered", () => {
+    // Sibling lists whose element records share field names are the norm in
+    // nested schemas; only the container an arrow actually writes is covered.
+    const covered = buildCoveredFieldSet(["orders.lines[].sku"]);
+    assert.equal(isCoveredFieldPath("orders.lines.sku", covered), true);
+    assert.equal(isCoveredFieldPath("orders.packed.sku", covered), false);
+  });
+});
+
+describe("schemaLocalFieldPath()", () => {
+  // The counterpart rule to path-only matching: because a field is no longer
+  // matched by local name, an arrow's schema prefix must be resolved away
+  // explicitly. Every consumer (CLI coverage, VS Code gutter, viz overlay) runs
+  // this same reduction, so it is pinned once here.
+
+  it("strips a prefix naming the schema itself", () => {
+    assert.equal(schemaLocalFieldPath("crm.email", ["crm"], []), "email");
+  });
+
+  it("leaves an already-local path untouched", () => {
+    // Single-source mappings write bare paths, and a nested path's first segment
+    // is a field name, not a schema name.
+    assert.equal(schemaLocalFieldPath("customer.email", ["orders"], []), "customer.email");
+  });
+
+  it("returns null for a path naming another schema in the same block", () => {
+    // Multi-source mappings report each schema separately; crediting one
+    // schema's arrow to a sibling is the over-count sl-joeq is about.
+    assert.equal(schemaLocalFieldPath("ledger.email", ["crm"], ["ledger"]), null);
+  });
+
+  it("accepts a namespaced schema by its bare name as well as its qualified id", () => {
+    // Arrows keep authored text: inside `namespace crm` an arrow writes
+    // `customers.id` while the index reports `crm::customers` (sl-iqud).
+    assert.equal(schemaLocalFieldPath("customers.id", ["crm::customers"], []), "id");
+    assert.equal(schemaLocalFieldPath("crm::customers.id", ["crm::customers"], []), "id");
+  });
+
+  it("treats a sibling schema's bare-name prefix as belonging to that sibling", () => {
+    // The bare form has to be recognised on the rival side too, or a namespaced
+    // multi-source mapping credits every arrow to every schema.
+    assert.equal(
+      schemaLocalFieldPath("orders.total", ["crm::customers"], ["crm::orders"]),
+      null,
+    );
+  });
+
+  it("prefers a declared field over a schema prefix of the same name", () => {
+    // A schema and one of its own top-level fields can collide. The declared
+    // field is concrete evidence, so the path is read as-is rather than stripped.
+    const declaresTopLevel = (name) => name === "orders";
+    assert.equal(
+      schemaLocalFieldPath("orders.amount", ["orders"], [], declaresTopLevel),
+      "orders.amount",
+    );
+    // Without the declaration the same input is a schema-qualified reference.
+    assert.equal(schemaLocalFieldPath("orders.amount", ["orders"], []), "amount");
   });
 });

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -552,3 +552,182 @@ mapping load {
     assertMapped(t, "orders.packed.sku", true);
   });
 });
+
+// ── Coverage is by path, never by local field name (sl-joeq) ─────────────────
+
+describe("computeMappingCoverage — path identity, not name identity", () => {
+  // The covered set used to register each segment of a covered path as a
+  // standalone bare name, so any field whose own path equalled a segment of some
+  // other covered path read as mapped. Leaf-name reuse across depths (id, sku,
+  // code, city, BIC) is normal in nested schemas, so the collision rate rose
+  // with exactly the specs coverage analysis exists to check — and it failed
+  // toward reporting an incomplete spec as complete.
+
+  it("leaves a top-level field uncovered when only a nested field shares its name", () => {
+    // The bare-segment leak's most direct form: a top-level field's path IS its
+    // name, so it collided with the leaf of every nested path.
+    const src = `
+schema src { city STRING home_address record { city STRING } }
+schema tgt { out STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  home_address.city -> out
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "home_address.city", true);
+    assertMapped(s, "city", false);
+  });
+
+  it("leaves intermediate segments of a deep path uncovered as top-level fields", () => {
+    // Middle segments leaked too, not just leaves: with only a.b.c.d covered,
+    // top-level fields named b, c and d all read as mapped.
+    const src = `
+schema src { b STRING c STRING d STRING a record { b record { c record { d STRING } } } }
+schema tgt { out STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  a.b.c.d -> out
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "a", true);
+    assertMapped(s, "a.b.c.d", true);
+    for (const path of ["b", "c", "d"]) assertMapped(s, path, false);
+  });
+
+  it("judges sibling records sharing a leaf name independently", () => {
+    // The fragment-spread shape: one fragment spread into two sibling records
+    // (examples/lib/sfdc_fragments.stm puts the same leaves under both
+    // BillingAddress and ShippingAddress) means every leaf name exists twice.
+    const src = `
+schema src {
+  BillingAddress record { Street STRING }
+  ShippingAddress record { Street STRING }
+}
+schema tgt { out STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  BillingAddress.Street -> out
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "BillingAddress.Street", true);
+    assertMapped(s, "ShippingAddress.Street", false);
+  });
+
+  it("judges sibling list containers sharing leaf names independently", () => {
+    // An untouched sibling list read as half-mapped purely because the list next
+    // to it declares the same element field names.
+    const src = `
+schema src { orders record {
+  lines list_of record { sku STRING qty INT }
+  packed list_of record { sku STRING units INT }
+} }
+schema tgt { lines list_of record { sku STRING qty INT } }
+mapping load {
+  source { src }
+  target { lines }
+  each orders.lines -> lines {
+    .sku -> .sku
+    .qty -> .qty
+  }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "orders.lines.sku", true);
+    assertMapped(s, "orders.packed.sku", false);
+    assertMapped(s, "orders.packed.units", false);
+  });
+
+  it("distinguishes repeated leaf names at equal depth under different parents", () => {
+    // The ISO-20022 case from tooling/satsuma-cli/test/fixtures/deep-nested-bugs.stm:
+    // four agent records each declare BIC and only three are mapped. Confusing
+    // the instructing with the instructed agent is precisely the error coverage
+    // exists to surface in payment messaging.
+    const src = `
+schema pacs008 { GrpHdr record {
+  InstgAgt record { BIC STRING }
+  InstdAgt record { BIC STRING }
+} }
+schema iso_target { instructing_bic STRING }
+mapping load {
+  source { pacs008 }
+  target { iso_target }
+  GrpHdr.InstgAgt.BIC -> instructing_bic
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "GrpHdr.InstgAgt.BIC", true);
+    assertMapped(s, "GrpHdr.InstdAgt.BIC", false);
+  });
+});
+
+// ── Schema-qualified arrow references ───────────────────────────────────────
+
+describe("computeMappingCoverage — schema-qualified arrow paths", () => {
+  // Multi-source mappings qualify their arrows by schema
+  // (`crm_customers.email -> email`). Coverage matches against paths declared
+  // *within* a schema, so the prefix has to be resolved away first. Before
+  // sl-joeq that only worked by accident — via bare-segment registration, which
+  // matched the trailing leaf name and therefore also matched every same-named
+  // field in every other source schema.
+
+  const SRC = `
+schema orders { amount DECIMAL tax DECIMAL }
+schema billing { amount DECIMAL contact_email STRING }
+schema summary { net_total DECIMAL }
+mapping load {
+  source { orders, billing }
+  target { summary }
+  orders.amount, orders.tax -> net_total
+}`;
+
+  it("strips the schema prefix so the qualified path matches the declared field", () => {
+    const orders = coverage(SRC, "load").schemas.find((s) => s.schemaId === "orders");
+    assertMapped(orders, "amount", true);
+    assertMapped(orders, "tax", true);
+  });
+
+  it("does not credit a sibling source schema that declares the same field name", () => {
+    // `billing` is joined but never read: its identically-named `amount` must
+    // stay uncovered, and its own fields must not inherit orders' coverage.
+    const billing = coverage(SRC, "load").schemas.find((s) => s.schemaId === "billing");
+    assertMapped(billing, "amount", false);
+    assertMapped(billing, "contact_email", false);
+  });
+
+  it("resolves a qualified path onto a nested field of the named schema", () => {
+    // The governance.stm shape: `crm_customers.consent.email_marketing` must
+    // resolve to the declared path `consent.email_marketing`. This case was
+    // silently *under*-counted before — the qualified form matched only the bare
+    // leaf, never the nested declared path.
+    const src = `
+schema crm { consent record { email_marketing BOOLEAN sms_marketing BOOLEAN } }
+schema tgt { consent_email BOOLEAN }
+mapping load {
+  source { crm }
+  target { tgt }
+  crm.consent.email_marketing -> consent_email
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "consent", true);
+    assertMapped(s, "consent.email_marketing", true);
+    assertMapped(s, "consent.sms_marketing", false);
+  });
+
+  it("prefers a declared field over a schema prefix when the two share a name", () => {
+    // A schema and one of its own top-level fields can collide. The declared
+    // field is concrete evidence, so `orders.amount` reads as the nested path
+    // rather than as a prefix that merely looks like one.
+    const src = `
+schema orders { orders record { amount DECIMAL } amount DECIMAL }
+schema tgt { out DECIMAL }
+mapping load {
+  source { orders }
+  target { tgt }
+  orders.amount -> out
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "orders.amount", true);
+    assertMapped(s, "amount", false);
+  });
+});

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -5,7 +5,7 @@
  * the LSP coverage path utilities instead of comparing leaf names ad hoc.
  */
 
-import { buildCoveredFieldSet } from "@satsuma/core/coverage-paths";
+import { buildCoveredFieldSet, schemaLocalFieldPath } from "@satsuma/core/coverage-paths";
 import type { ArrowEntry, FieldEntry, MappingBlock, SchemaCard, VizModel } from "./model.js";
 
 /**
@@ -34,23 +34,15 @@ export function schemaHasFieldPath(schema: FieldPathCard, fieldPath: string): bo
 }
 
 /**
- * Prefixes under which an arrow may reference fields of a schema: the
- * qualified id and, for namespaced schemas, the authored bare id. Arrows keep
- * authored text ("customers.id" inside namespace crm) while the backend
- * resolves sourceRefs and qualifiedId to "crm::customers" — matching only the
- * qualified form would miss every bare-prefixed ref in a namespaced mapping
- * (sl-iqud).
- */
-function schemaRefPrefixes(schemaId: string): string[] {
-  const namespaceEnd = schemaId.lastIndexOf("::");
-  if (namespaceEnd < 0) return [schemaId];
-  return [schemaId, schemaId.slice(namespaceEnd + 2)];
-}
-
-/**
  * Resolve an arrow field reference to the schema-local dotted field path for a
- * specific schema card. Schema prefixes match in both authored (bare) and
- * namespace-qualified form.
+ * specific schema card, or null when it belongs to another schema.
+ *
+ * The prefix rules — including matching a namespaced schema by both its
+ * qualified id and its authored bare name (sl-iqud) — live in core's
+ * {@link schemaLocalFieldPath}, shared with `satsuma coverage` and the VS Code
+ * gutter so the three cannot drift. This wrapper adds the one rule specific to
+ * rendering a card: a path this schema does not declare is not shown against
+ * it, since the viz resolves every arrow against every card on screen.
  *
  * Examples:
  * - `customer_profiles.region` + schema `customer_profiles` -> `region`
@@ -63,20 +55,19 @@ export function resolveSchemaLocalFieldPath(
   schema: FieldPathCard,
   sourceRefs: string[],
 ): string | null {
-  for (const prefix of schemaRefPrefixes(schema.qualifiedId)) {
-    if (fieldRef.startsWith(`${prefix}.`)) {
-      return fieldRef.slice(prefix.length + 1);
-    }
-  }
+  const otherRefs = sourceRefs.filter((ref) => ref !== schema.qualifiedId);
+  const declaresTopLevel = (name: string): boolean =>
+    schema.fields.some((field) => field.name === name);
 
-  const explicitOtherSchema = sourceRefs.some(
-    (sourceRef) =>
-      sourceRef !== schema.qualifiedId &&
-      schemaRefPrefixes(sourceRef).some((prefix) => fieldRef.startsWith(`${prefix}.`)),
-  );
-  if (explicitOtherSchema) return null;
+  const local = schemaLocalFieldPath(fieldRef, [schema.qualifiedId], otherRefs, declaresTopLevel);
+  if (local === null) return null;
 
-  return schemaHasFieldPath(schema, fieldRef) ? fieldRef : null;
+  // An explicit `thisSchema.` prefix is proof enough that the ref is meant for
+  // this card. Only an unprefixed ref — which could belong to any card on
+  // screen — has to be confirmed against the declared fields.
+  if (local !== fieldRef) return local;
+
+  return schemaHasFieldPath(schema, local) ? local : null;
 }
 
 /**


### PR DESCRIPTION
Closes `sl-joeq` (P1). Adds **ADR-035**.

## The bug

`addPathAndPrefixes` registered every segment of a covered path as a standalone
bare name, so coverage resolved by field **name** rather than by **path**. Any
field whose own path equalled a segment of another covered path in the same
schema read as mapped — a silent over-count that makes an incomplete spec look
complete. Repeated leaf names across depths (`id`, `sku`, `code`, `city`, `BIC`)
are the normal shape of a nested schema, so the collision rate rose with exactly
the specs coverage analysis exists to check.

```
schema src { city STRING  home_address record { city STRING } }
...  home_address.city -> out

before:  city  mapped   ← wrong, nothing writes it
after:   city  unmapped
```

## The second defect it was masking

Removing the bare entries exposed one the leak had been cancelling. Multi-source
mappings qualify their arrows by schema (`crm_customers.email -> email` — every
source arrow in `examples/filter-flatten-governance/governance.stm`), and the
covered-path walk never resolved that prefix. The qualified form matched only via
the trailing bare segment, so it could never reach a **nested** declared path:
`crm_customers.consent.email_marketing` left `consent.email_marketing`
uncovered.

Both are fixed. The prefix rule now lives in core as `schemaRefPrefixes` and
`schemaLocalFieldPath`, applied per schema; `satsuma-viz`'s
`resolveSchemaLocalFieldPath` delegates to them instead of keeping its own copy,
so CLI, LSP, VS Code and viz cannot drift.

## Effect on the example corpus

Four files move, and **figures move in both directions** — each movement is a
correction:

| Schema | Before | After | Why |
|---|---|---|---|
| `customer_profiles` (filter-flatten-governance) | 4/8 | 2/8 | joined-but-unread; inherited a sibling's `customer_id`/`email` |
| `order_transactions`, `support_tickets` (multi-source-join) | 1/10, 1/8 | 0 | same, via bare `customer_id` |
| `finance_transactions` (governance) | 1/16 | 0 | same |
| `crm_customers` (governance) | 6/13 | **9/13** | under-count: qualified prefix could not reach `consent.*` |

`CHANGELOG.md` gains an `Unreleased` section saying so plainly — anyone gating CI
with `coverage --fail-under` must re-baseline.

## Tests

- `satsuma-core/test/coverage.test.js` — two new sections: *path identity, not
  name identity* (5 cases: top-level shadowing, deep intermediate segments,
  sibling records, sibling list containers, the ISO-20022 four-`BIC` case) and
  *schema-qualified arrow paths* (4 cases).
- `satsuma-core/test/coverage-paths.test.js` — `schemaLocalFieldPath()` contract;
  the existing assertion on the bare leaf is **inverted with a comment citing
  the ticket**, not deleted.
- `satsuma-cli/test/coverage.test.ts` + new `coverage-multi-source.stm` fixture —
  bare schema prefix resolving against the canonical namespaced index key, and a
  joined-but-unread sibling staying at 0%. This pairing had **no** test before
  and would have regressed silently.

All suites green: core 491, cli 968, lsp 292, viz 97, viz-backend 163,
viz-model 6, vscode golden, tree-sitter 315/315 parses, `npm run lint` clean.

Verified against `main` that the new cases fail before the fix. Two of the
ticket's listed criteria already passed on `main` and are kept as guards rather
than proofs — `fields.ts` tests only the full path since `sl-oqsj` re-based it
onto core, so the `mapped.has(f.name)` clause the ticket cites is already gone.

**Not run:** the viz Playwright harness (needs a human-launched browser). Its 10
specs make no coverage assertions, so the changed path is unexercised there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)