### PR TITLE
feat(core): resolved NL @refs count toward coverage as a distinct tier (sl-qxyl)

### DIFF
--- a/.tickets/3cc-t6uo.md
+++ b/.tickets/3cc-t6uo.md
@@ -1,6 +1,6 @@
 ---
 id: 3cc-t6uo
-status: open
+status: closed
 deps: []
 links: [3cc-iedv, sl-4qvp]
 created: 2026-07-31T14:40:39Z
@@ -23,3 +23,15 @@ Fix direction: delete computeTargetCoverageStats' own counting and call core's s
 
 computeTargetCoverageStats delegates to @satsuma/core summarizeFieldCoverage with no counting logic of its own; a nested-record fixture asserts the status-bar percentage equals what satsuma coverage reports for the same mapping and schema; existing vscode unit tests updated to the leaf-only expectations; the top-level-only rule and its 'nested paths would double-count' comment removed rather than left as a stale explanation.
 
+
+## Notes
+
+**2026-07-31T16:51:57Z**
+
+Cause: computeTargetCoverageStats counted top-level target fields only (filtering !path.includes('.')), a third counting rule alongside ADR-034's leaf-only rule in core. It disagreed with satsuma coverage on any schema with nested records — the sample fixture reported 1/2 (50%) where core reports 2/3 (67%).
+
+Fix: deleted the local counting and delegated to @satsuma/core summarizeFieldCoverage, per the fix direction in the description. The top-level-only rule and its stale 'nested paths would double-count' comment are removed rather than left as an explanation for code that no longer does that. TargetCoverageStats also gains mappedNl so the status-bar tooltip can report how much of the figure came from resolved @refs.
+
+Fixed as part of sl-qxyl rather than separately: ADR-036 requires that a consumer computing its own coverage figure be reconciled rather than carried, because the tier split would have turned one disagreement into two. Status bar, satsuma coverage and (once feature 36 lands) the viz overlay now share one implementation.
+
+vscode suite: 34 pass. The grouping test's marker count moved from 2 to 3 with the fixture — gutter decorations mark every entry including records, unlike the percentage, which counts leaves; that distinction is now stated in the test.

--- a/.tickets/sl-qxyl.md
+++ b/.tickets/sl-qxyl.md
@@ -153,3 +153,8 @@ Docs reconciled, all five sites plus two more: features/35 PRD out-of-scope bull
 Totals: core 514, cli 972, lsp 292, viz 98, viz-backend 166, viz-model 6, vscode 34, tree-sitter 315/315 parses, npm run lint clean.
 
 Not run: the viz Playwright harness (needs a human-launched browser). Deliberately not touched: satsuma-viz's own buildMappedFieldsIndex still derives coverage from the viz model rather than from core, so the viz overlay does not yet show the tier — that is feature 36's R3/R6 work (sl-hcan, sl-5nsv), not this ticket's.
+
+**2026-08-01T18:14:17Z**
+
+Cause: coverage credited only arrow sources and targets, so a field referenced solely by a resolved NL @ref read as uncovered — the sole consumer dissenting from ADR-013, which gives a resolved @ref the same lineage weight as a declared source field.
+Fix: resolved @ref paths now count toward coverage as a distinct tier, reported separately from arrow-covered fields so the weaker evidence stays visible rather than being silently merged (commit 821ae54, PR #413). See ADR-036.

--- a/.tickets/sl-qxyl.md
+++ b/.tickets/sl-qxyl.md
@@ -1,6 +1,6 @@
 ---
 id: sl-qxyl
-status: open
+status: closed
 deps: [sl-hrql, sl-ez36]
 links: []
 created: 2026-07-31T15:54:44Z
@@ -130,3 +130,26 @@ description implies:
 
 ADR-036 is on the branch for PR #409 (adrs/adr-036-nl-ref-coverage-tier.md).
 Numbered 036 because another session took 035 for coverage path identity.
+
+**2026-07-31T16:51:44Z**
+
+Cause: coverage excluded NL @refs as a Feature 35 non-goal, contradicting ADR-013 (Accepted, unsuperseded), which binds all lineage-aware tools to follow a resolved @ref with the same weight as a declared source field. Five commands honoured it; coverage alone dissented.
+
+Fix: implements ADR-036. computeMappingCoverage() takes the workspace's resolved @refs and credits the ones naming declared fields, tagged with their tier; summarizeFieldCoverage() derives every count from those tags. Both are the only places the rule lives.
+
+Design notes:
+- The seam sl-joeq left in place did the heavy lifting. A resolved ref's resolvedTo.name is a canonical schema-qualified path (::src.net_amount), which is exactly the shape schemaLocalFieldPath consumes, so NL paths resolve through the same per-schema step as arrow paths. One addition to schemaRefPrefixes was needed: a bare schema name now also matches its canonical ::name form, or a global schema's NL coverage would never match.
+- NL paths are accepted only when the schema prefix actually came off. A resolved ref is always fully qualified, so requiring the strip keeps another schema's refs out of this schema's set rather than parking unmatchable paths in it.
+- findMappingBlock now returns the namespace-qualified mapping key, so refs are matched on the same key resolveAllNLRefs files them under. Matching on the bare label would have credited two same-named mappings in different namespaces with each other's refs.
+- Human output shows the tier split only on rows that HAVE nl coverage. Annotating every row of every structural-only report with '(n declared, 0 nl)' is a column of noise for no information; --json always carries both counts. This deviates from the illustrative output in the ticket description, which showed '(2 declared, 0 nl)'.
+- LSP: the gutter feeds core the same refs, via a new DefinitionLookup built from the workspace index (schemas, cross-file) plus extractMappings on the current tree (mapping source/target context, which the index does not store in that shape). Without it the editor would have shown fields as unmapped that the CLI reports as covered — a NEW cross-consumer disagreement introduced by this very ticket.
+
+3cc-t6uo: FIXED rather than re-scoped, per ADR-036's requirement that a consumer with its own rule be reconciled. computeTargetCoverageStats now delegates to summarizeFieldCoverage; the top-level-only rule and its stale 'nested paths would double-count' comment are gone, and the tooltip reports the NL share.
+
+Corpus effect: 17 example files gain NL-tier coverage. Notably several source schemas that read 0% now report real figures — order_transactions 0->6, support_tickets 0->5, finance_transactions 0->3, crm_system 0->2, hr_employees 0->2, sat_contact_details 0->4 — which is precisely the failure ADR-036 describes, since the aggregate section named those as covered by no mapping.
+
+Docs reconciled, all five sites plus two more: features/35 PRD out-of-scope bullet (struck through with the reason), features/38 PRD out-of-scope bullet, coverage.ts module comment, coverage --help, SATSUMA-CLI.md :126 (rewritten), :324, :390 (the 'needs no NL interpretation' positioning restated as resolution-is-not-interpretation), plus the SATSUMA-CLI.md JSON contract block — which a CLI test enforces key-for-key against the actual output.
+
+Totals: core 514, cli 972, lsp 292, viz 98, viz-backend 166, viz-model 6, vscode 34, tree-sitter 315/315 parses, npm run lint clean.
+
+Not run: the viz Playwright harness (needs a human-launched browser). Deliberately not touched: satsuma-viz's own buildMappedFieldsIndex still derives coverage from the viz model rather than from core, so the viz overlay does not yet show the tier — that is feature 36's R3/R6 work (sl-hcan, sl-5nsv), not this ticket's.

--- a/.tickets/sl-vu22.md
+++ b/.tickets/sl-vu22.md
@@ -60,3 +60,8 @@ New tests: core 'dotted container targets' — each with a multi-segment target 
 Out of scope, raised as svdfe-s6we: nested_arrow is absent from the VizModel entirely — same defect class, the other construct. Also not run: the viz Playwright harness (needs a human-launched browser); its 10 specs make no arrow-count or coverage assertions.
 
 Totals: core 495, cli 968, lsp 292, viz 98, viz-backend 166, viz-model 6, vscode 21 golden files, tree-sitter 315/315 parses, npm run lint clean.
+
+**2026-08-01T18:14:11Z**
+
+Cause: coverage derived covered paths from its own CST walker, a second implementation of the traversal extract.ts already performed, so the two disagreed and four defects of the same class (relative dots, flatten-inside-each, nested_arrow, unresolved schema prefix) were each found by inspection rather than by a test.
+Fix: computeMappingCoverage now consumes extract.ts's arrow output via the existing collectBodyPaths -> schemaLocalFieldPath seam and the second walker is deleted, making the defect class structurally impossible (commit cd8381d, PR #412). See ADR-035.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+### Resolved NL `@refs` now count toward coverage (`sl-qxyl`, ADR-036)
+
+**Coverage percentages rise, and `--fail-under` thresholds need re-baselining in
+the unsafe direction** — a threshold tuned against structural-only figures becomes
+weaker rather than failing loudly.
+
+`satsuma coverage` treated a field referenced only by a resolved NL `@ref` as
+uncovered, contradicting ADR-013, which every other lineage-aware command
+(`arrows`, `graph`, `lineage`, `field-lineage`, `lint`) honours. A mapping whose
+sources appear only in prose reported every source field uncovered, and the
+aggregate "covered by no mapping" list — which the docs call the claim worth
+acting on — named fields `field-lineage` traces without difficulty.
+
+A resolved `@ref` now counts, as a **distinct tier** over the same denominator:
+
+```text
+  source  legacy_sqlserver    21/21  100%  (15 declared, 6 nl)
+```
+
+- Human output shows the split only where there is NL coverage to distinguish.
+- `--json` gains `covered_declared` and `covered_nl` on every counts object, and a
+  `tier` on every covered field. Both are additive; `covered`, `total` and `pct`
+  keep their meaning, and `covered` is still the figure `--fail-under` gates.
+- Only *resolved* refs count, so coverage cannot rise when a spec breaks. A field
+  prose merely describes without an `@ref` stays uncovered. A ref in a
+  `source {}` join or filter counts toward source coverage only — it names no
+  target field.
+- 17 example files gain NL-tier coverage. Several source schemas that reported 0%
+  now report real figures.
+
+ADR-034's denominator is unchanged: leaves only, on each leaf's own flag.
+
+The VS Code status bar now takes its percentage from core rather than counting
+top-level fields itself (`3cc-t6uo`), so the editor and the CLI agree; its
+tooltip reports how much of the figure came from `@refs`.
+
 ### Coverage figures will change (`sl-joeq`)
 
 **Recorded coverage percentages will move after this release — in both

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -123,7 +123,17 @@ satsuma coverage pipeline.stm --fail-under 90        # CI gate
 
 Flags: `--mapping <name>`, `--schema <name>`, `--role source|target`, `--uncovered`, `--fail-under <pct>`, `--json`. Scoping flags compose — `--schema X --role target` reports only X's target-side coverage, in only the mappings that write to it.
 
-**Coverage is structural.** A field is covered when at least one arrow references it. Nested paths cover their parents: mapping `address.city` covers `address` but not `address.line1`. Element-relative arrows inside `each`/`flatten` blocks resolve against the iterated list, so `.sku` under `each lines -> rows` covers `lines.sku`. A field described only in prose is uncovered *by definition* — use `nl-refs` to find those, and `lint` for policy judgements about which gaps are acceptable.
+**Coverage follows explicit references.** A field is covered when at least one arrow references it — the **declared** tier — or when a resolved NL `@ref` in the same mapping names it — the **nl** tier. Nested paths cover their parents: mapping `address.city` covers `address` but not `address.line1`. Element-relative arrows inside `each`/`flatten` blocks resolve against the iterated list, so `.sku` under `each lines -> rows` covers `lines.sku`.
+
+**The two tiers share one denominator and never double-count.** A field covered both ways is reported as declared, the stronger claim. Rows show the split only when there is NL coverage to distinguish:
+
+```text
+  source  legacy_sqlserver    21/21  100%  (15 declared, 6 nl)
+```
+
+`--json` always carries `covered_declared` and `covered_nl`, and tags each covered field with its `tier`, so a reviewer — or an overlay — can tell a declared arrow from an inferred one. `--fail-under` gates the combined figure: an `@ref` is a declaration of intent, not a hint.
+
+Counting a resolved `@ref` is **resolution, not interpretation**: the author wrote `@` to mark a reference, and resolving it against the index reads no surrounding prose. Two things still do not count — a field prose merely *describes* without an `@ref` (use `nl-refs` to find those), and an `@ref` that resolves to nothing (that is `lint`'s `unresolved-nl-ref`; letting it count would make coverage rise when a spec breaks). Policy judgements about which gaps are acceptable remain `lint`'s. See **ADR-036**, and **ADR-013** for why an `@ref` carries the same lineage weight as a declared source field.
 
 **Coverage matches whole paths, never bare field names.** `home_address.city` covers exactly that path — not a top-level `city`, and not `work_address.city`. Repeated leaf names across depths (`id`, `sku`, `code`, `BIC`) are normal in nested schemas, so name matching would report unmapped fields as mapped. In a multi-source mapping, an arrow's schema prefix resolves to the schema it names: `crm.consent.email_marketing` covers `consent.email_marketing` in `crm` and contributes nothing to any other source.
 
@@ -164,10 +174,13 @@ appears unchanged in both.
       "schema": "::hub_customer",     // canonical schema key
       "role": "target",               // "source" | "target"
       "covered": 8,                   // leaf fields covered by THIS mapping
+      "covered_declared": 6,          // of those, covered by a declared arrow
+      "covered_nl": 2,                // of those, covered only by a resolved @ref
       "total": 11,                    // leaf fields declared
       "pct": 73,                      // covered/total, whole-number percent
       "fields": [
-        { "path": "email", "mapped": true, "file": "/abs/path/pipeline.stm", "line": 42 }
+        { "path": "email", "mapped": true, "tier": "declared",
+          "file": "/abs/path/pipeline.stm", "line": 42 }
       ]
     }]
   }],
@@ -176,13 +189,13 @@ appears unchanged in both.
       "schema": "::hub_customer",
       "role": "target",
       "mappings": ["::load hub", "::enrich hub"],   // the mappings behind the figure
-      "covered": 11, "total": 11, "pct": 100,
+      "covered": 11, "covered_declared": 9, "covered_nl": 2, "total": 11, "pct": 100,
       "fields": [ /* same entry shape; `mapped` is the union across `mappings` */ ]
     }],
     "namespaces": [{
       "namespace": "crm",             // null for schemas at file scope
-      "source": { "covered": 3, "total": 4, "pct": 75 },
-      "target": { "covered": 3, "total": 3, "pct": 100 }
+      "source": { "covered": 3, "covered_declared": 3, "covered_nl": 0, "total": 4, "pct": 75 },
+      "target": { "covered": 3, "covered_declared": 3, "covered_nl": 0, "total": 3, "pct": 100 }
     }],
     "workspace": { "source": { /* … */ }, "target": { /* … */ } }
   },
@@ -192,7 +205,9 @@ appears unchanged in both.
 }
 ```
 
-`fields` lists leaf fields only, matching the counts, so the paths shown and the number beside them are always the same population. `line` is 1-indexed and **omitted** when the declaration position is unknown — never 0, which would send an editor-jump link to line 1 of the wrong file. Fields arriving via a fragment spread report the *consuming* schema's position, not the fragment's.
+`fields` lists leaf fields only, matching the counts, so the paths shown and the number beside them are always the same population. `tier` is present exactly when `mapped` is true, and says which tier covered the field — consumers differentiate declared from NL-derived coverage from this key rather than reconstructing it. `line` is 1-indexed and **omitted** when the declaration position is unknown — never 0, which would send an editor-jump link to line 1 of the wrong file. Fields arriving via a fragment spread report the *consuming* schema's position, not the fragment's.
+
+`covered_declared` and `covered_nl` are the two tiers of `covered` and always sum to it: a field covered both ways is reported as declared, so they are disjoint. They appear on every counts object — per-mapping schema, aggregate schema, namespace subtotal and workspace total.
 
 With `--uncovered`, `fields` is filtered to unmapped entries while `covered`/`total` stay unchanged, so the denominator survives.
 
@@ -316,7 +331,7 @@ satsuma coverage pipeline.stm --schema mart_customer_360 --uncovered --json
 
 Read `aggregate.schemas[].fields[]` for fields **no** mapping covers — that is the claim worth acting on. Read `mappings[].schemas[].fields[]` to see which mapping to edit. The two are not interchangeable: a field mapping A populates appears as a gap in mapping B's section.
 
-The CLI performs the aggregation because that is where callers composing it by hand went wrong — treating a field as unmapped because one mapping ignores it, when another populates it. What remains an agent judgement is *whether a gap matters*: read the arrow classification (`satsuma arrows`) and any NL notes, since a field populated only by prose in a note block is uncovered by definition.
+The CLI performs the aggregation because that is where callers composing it by hand went wrong — treating a field as unmapped because one mapping ignores it, when another populates it. What remains an agent judgement is *whether a gap matters*: read the arrow classification (`satsuma arrows`) and any NL notes. Note that a field a note references with an `@ref` is already counted, in the `nl` tier — the gaps left are fields nothing references at all, plus any whose `@ref` does not resolve (`satsuma lint`).
 
 ### PII audit
 
@@ -382,7 +397,7 @@ satsuma arrows changed_schema.changed_field --as-source --json
 ## What the CLI Does Not Do
 
 - **Does not interpret NL.** Transform strings, notes, and comments are extracted verbatim. The CLI never assesses whether an NL transform is correct, complete, or semantically equivalent to another.
-- **Does not compose analysis workflows.** There are no `impact`, `audit`, `scaffold`, or `inventory` commands. These are agent workflows built from primitives — their correctness depends on NL interpretation that the CLI cannot perform. `coverage` is a command rather than a workflow precisely because it needs no NL interpretation: which fields an arrow references is a fact about the parse tree, and the aggregation across mappings is arithmetic. Judging whether a given gap *matters* stays with the agent.
+- **Does not compose analysis workflows.** There are no `impact`, `audit`, `scaffold`, or `inventory` commands. These are agent workflows built from primitives — their correctness depends on NL interpretation that the CLI cannot perform. `coverage` is a command rather than a workflow precisely because it needs no NL *interpretation*: which fields an arrow references is a fact about the parse tree, resolving an `@ref` is structural resolution of a marked reference rather than a reading of prose, and the aggregation across mappings is arithmetic. Judging whether a given gap *matters* stays with the agent.
 - **Does not call language models.** The CLI is deterministic, fast, and reproducible. Same input, same output, every time.
 - **Does not accept NL queries.** Commands take explicit structural arguments. The agent decides which commands to call based on the user's question.
 

--- a/features/35-coverage-command/PRD.md
+++ b/features/35-coverage-command/PRD.md
@@ -230,9 +230,16 @@ Minimal-snippet tests (per test quality standards), covering at least:
   (see Feature 37 and the lint framework) and must not be baked into the
   deterministic count. The JSON includes field metadata so policy layers can
   filter.
-- NL interpretation: a field populated "implicitly" by prose in a note block
-  is uncovered by definition. Surfacing candidate NL mentions stays with
-  `nl-refs`/`hidden-source-in-nl`.
+- ~~NL interpretation: a field populated "implicitly" by prose in a note block
+  is uncovered by definition.~~ **Superseded by ADR-036** (implemented in
+  `sl-qxyl`). The carve-out equated "follows a resolved `@ref`" with "interprets
+  natural language", and those are different acts: the author wrote `@` as a
+  sigil meaning *this is a reference*, and resolving it reads no surrounding
+  prose. It also contradicted ADR-013, which every other lineage-aware command
+  honoured. A resolved `@ref` now counts, as a distinct `nl` tier over the same
+  denominator. A field prose merely *describes* without an `@ref` is still
+  uncovered, and an unresolved `@ref` still counts for nothing — those remain
+  `nl-refs` and `lint`'s territory.
 
 ## Open Questions
 

--- a/features/38-hierarchical-coverage/PRD.md
+++ b/features/38-hierarchical-coverage/PRD.md
@@ -573,7 +573,11 @@ fixture is the point. Cases 1–9 must **fail** against `fc3d5a5`.
   plausible future lint rule.
 - Revising `each`/`flatten` path *relativity* rules. `extract.ts`'s
   accumulating-prefix contract is correct and is only regression-locked here.
-- NL-derived coverage. A field populated only by prose stays uncovered.
+- ~~NL-derived coverage. A field populated only by prose stays uncovered.~~
+  **Superseded by ADR-036** (implemented in `sl-qxyl`, which landed before this
+  feature). A resolved `@ref` counts, as a distinct `nl` tier. R1's direct/derived
+  split and R2's container tri-state compose with it: the tier says *how* a leaf
+  was covered, the tri-state says *how much* of a container is.
 - Coverage history or trends.
 
 ## Open Questions

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -34,6 +34,7 @@ import {
 import { parsePercentage } from "../option-parsers.js";
 import { canonicalKey, displayKey, resolveIndexKey } from "../index-builder.js";
 import { coverageForWorkspace } from "../coverage-workspace.js";
+import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import type { MappingCoverage } from "../coverage-workspace.js";
 import { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "@satsuma/core";
 import type {
@@ -76,10 +77,20 @@ export function register(program: Command): void {
     .option("--fail-under <pct>", "exit 3 when aggregate coverage is below <pct>", parsePercentage)
     .option("--json", "structured JSON output")
     .addHelpText("after", `
-Coverage is structural: a field counts as covered when at least one arrow in the
-mapping references it. Nested paths cover their parents — mapping 'address.city'
-covers 'address' but not 'address.line1'. A field described only in prose (a note
-block) is uncovered by definition; use 'nl-refs' to find those.
+Coverage follows explicit references. A field counts as covered when an arrow in
+the mapping references it (the 'declared' tier) or a resolved NL @ref names it
+(the 'nl' tier). Nested paths cover their parents — mapping 'address.city' covers
+'address' but not 'address.line1'.
+
+The two tiers share one denominator and never double-count: a field covered both
+ways is reported as declared. Rows show the split only when there is NL coverage
+to distinguish, e.g. "3/3  100%  (1 declared, 2 nl)"; --json always carries both
+counts and tags each covered field with its tier.
+
+Following an @ref is resolution, not interpretation — the author wrote '@' to mark
+a reference, and resolving it reads no prose. A field prose merely describes
+WITHOUT an @ref is still uncovered, and an @ref that resolves to nothing counts
+for nothing: use 'nl-refs' to find the former and 'lint' for the latter.
 
 Percentages count leaf fields only: a record is structure, not data, so counting
 it alongside its children would count the same data twice.
@@ -94,10 +105,13 @@ JSON shape (--json):
       "schemas": [{
         "schema":  str,        # canonical schema key
         "role":    "source" | "target",
-        "covered": int,        # leaf fields covered by THIS mapping
-        "total":   int,        # leaf fields declared
-        "pct":     int,        # covered/total, whole-number percent
-        "fields":  [{"path": str, "mapped": bool, "file": str, "line": int}, ...]
+        "covered":          int,   # leaf fields covered by THIS mapping
+        "covered_declared": int,   # of those, covered by a declared arrow
+        "covered_nl":       int,   # of those, covered only by a resolved @ref
+        "total":            int,   # leaf fields declared
+        "pct":              int,   # covered/total, whole-number percent
+        "fields":  [{"path": str, "mapped": bool, "tier": "declared" | "nl",
+                     "file": str, "line": int}, ...]
       }, ...]
     }, ...]
   }
@@ -105,10 +119,9 @@ JSON shape (--json):
   ... plus an "aggregate" section, unioned across the mappings in scope:
     "aggregate": {
       "schemas":    [{"schema": str, "role": str, "mappings": [str, ...],
-                      "covered": int, "total": int, "pct": int, "fields": [...]}, ...],
+                      <counts as above>, "fields": [...]}, ...],
       "namespaces": [{"namespace": str | null,
-                      "source": {"covered": int, "total": int, "pct": int},
-                      "target": {...}}, ...],
+                      "source": <counts as above>, "target": <counts as above>}, ...],
       "workspace":  {"source": {...}, "target": {...}}
     }
 
@@ -118,15 +131,18 @@ mapping may well populate it. Under "aggregate", uncovered means "no mapping in
 scope touches it", which is the claim worth acting on. Deleting a field on the
 strength of a per-mapping figure will delete a live one.
 
-'fields' lists leaf fields only, matching the counts; 'line' is 1-indexed and
-omitted when the declaration position is unknown. With --uncovered, 'fields' is
-filtered to unmapped entries and the counts are unchanged.
+'fields' lists leaf fields only, matching the counts; 'tier' is present exactly
+when 'mapped' is true; 'line' is 1-indexed and omitted when the declaration
+position is unknown. With --uncovered, 'fields' is filtered to unmapped entries
+and the counts are unchanged.
 
 --fail-under <pct> turns spec completeness into a CI gate, the way 'fmt --check'
 gates formatting. It gates the aggregate percentage for the target role by
 default — the share of declared target fields some mapping populates — or the
 source role with --role source, and it respects --mapping and --schema, so a
 pipeline can gate one mapping or one schema rather than the whole workspace.
+The figure gated is the COMBINED one, both tiers together: the gate asks "is this
+spec complete", and an @ref is a declaration of intent, not a hint.
 
 Exit codes:
   0  report produced (and the --fail-under threshold met, if given)
@@ -161,7 +177,11 @@ Examples:
       const mappingKey = opts.mapping ? resolveScopeName(opts.mapping, "Mapping", index.mappings) : null;
       const schemaKey = opts.schema ? resolveScopeName(opts.schema, "Schema", index.schemas) : null;
 
-      const { mappings, skippedAnonymous } = coverageForWorkspace(index, files);
+      // Resolved once for the whole workspace and reused for every mapping —
+      // resolution is workspace-wide, and it is what makes the NL tier possible
+      // at all (ADR-036).
+      const nlRefs = resolveAllNLRefs(index);
+      const { mappings, skippedAnonymous } = coverageForWorkspace(index, files, nlRefs);
       const scoped = applyScope(mappings, { mappingKey, schemaKey, role });
 
       if (scoped.length === 0) {
@@ -285,17 +305,31 @@ function toJson(mapping: MappingCoverage, opts: CoverageOptions): Record<string,
   return {
     mapping: canonicalKey(mapping.mappingId),
     file: mapping.file,
-    schemas: mapping.result.schemas.map((schema) => {
-      const totals = summarizeFieldCoverage(schema.fields);
-      return {
-        schema: canonicalKey(schema.schemaId),
-        role: schema.role,
-        covered: totals.covered,
-        total: totals.total,
-        pct: totals.pct,
-        fields: reportedFields(schema, opts).map(fieldToJson),
-      };
-    }),
+    schemas: mapping.result.schemas.map((schema) => ({
+      schema: canonicalKey(schema.schemaId),
+      role: schema.role,
+      ...totalsToJson(summarizeFieldCoverage(schema.fields)),
+      fields: reportedFields(schema, opts).map(fieldToJson),
+    })),
+  };
+}
+
+/**
+ * Coverage counts as JSON, in the snake_case the contract uses.
+ *
+ * The single serialiser for {@link CoverageTotals} everywhere it appears — a
+ * per-mapping schema, an aggregate schema, a namespace subtotal and the workspace
+ * total — so the tier keys cannot be present in one section and absent from
+ * another. Core's field names are camelCase; the published contract is
+ * snake_case, and this is the one place that translation happens.
+ */
+function totalsToJson(totals: CoverageTotals): Record<string, number> {
+  return {
+    covered: totals.covered,
+    covered_declared: totals.coveredDeclared,
+    covered_nl: totals.coveredNl,
+    total: totals.total,
+    pct: totals.pct,
   };
 }
 
@@ -310,6 +344,10 @@ function fieldToJson(field: FieldCoverageEntry): Record<string, unknown> {
     mapped: field.mapped,
     file: field.uri,
   };
+  // Present exactly when `mapped` is true — an uncovered field has no tier to
+  // report. Emitted so a consumer differentiates declared from NL-derived
+  // coverage from this contract rather than reconstructing it (ADR-036).
+  if (field.tier !== undefined) entry.tier = field.tier;
   if (field.line !== undefined) entry.line = field.line + 1;
   return entry;
 }
@@ -343,11 +381,9 @@ function printPerMappingReport(mappings: MappingCoverage[], opts: CoverageOption
       ...mapping.result.schemas.map((s) => displayKey(s.schemaId).length),
     );
     for (const schema of mapping.result.schemas) {
-      const totals = summarizeFieldCoverage(schema.fields);
-      const counts = `${totals.covered}/${totals.total}`;
       console.log(
         `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${displayKey(schema.schemaId).padEnd(schemaWidth)}  ` +
-        `${counts.padStart(7)}  ${String(totals.pct).padStart(3)}%`,
+        `${formatTotals(summarizeFieldCoverage(schema.fields))}`,
       );
     }
 
@@ -483,17 +519,18 @@ function aggregateToJson(aggregate: AggregateCoverage, opts: CoverageOptions): R
       schema: canonicalKey(schema.schemaId),
       role: schema.role,
       mappings: schema.mappings.map(canonicalKey),
-      covered: schema.totals.covered,
-      total: schema.totals.total,
-      pct: schema.totals.pct,
+      ...totalsToJson(schema.totals),
       fields: aggregateFields(schema, opts).map(fieldToJson),
     })),
     namespaces: aggregate.namespaces.map((ns) => ({
       namespace: ns.namespace,
-      source: ns.source,
-      target: ns.target,
+      source: totalsToJson(ns.source),
+      target: totalsToJson(ns.target),
     })),
-    workspace: { source: aggregate.workspace.source, target: aggregate.workspace.target },
+    workspace: {
+      source: totalsToJson(aggregate.workspace.source),
+      target: totalsToJson(aggregate.workspace.target),
+    },
   };
 }
 
@@ -573,7 +610,25 @@ function namespaceLabel(namespace: string | null): string {
 
 /** "3/4  75%" — the shared counts-and-percentage cell. */
 function formatTotals(totals: CoverageTotals): string {
-  return `${`${totals.covered}/${totals.total}`.padStart(7)}  ${String(totals.pct).padStart(3)}%`;
+  return (
+    `${`${totals.covered}/${totals.total}`.padStart(7)}  ${String(totals.pct).padStart(3)}%` +
+    formatTierSplit(totals)
+  );
+}
+
+/**
+ * "  (1 declared, 2 nl)" — the tier annotation, or "" when there is nothing to
+ * distinguish (ADR-036).
+ *
+ * Printed only when the row actually has NL-tier coverage. A structural-only
+ * spec has nothing to tell apart, and annotating every row of every report with
+ * "(n declared, 0 nl)" would add a column of noise to the common case; the split
+ * appears exactly where a reviewer needs to know that some coverage is inferred
+ * from prose rather than declared. `--json` always carries both counts.
+ */
+function formatTierSplit(totals: CoverageTotals): string {
+  if (totals.coveredNl === 0) return "";
+  return `  (${totals.coveredDeclared} declared, ${totals.coveredNl} nl)`;
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -16,6 +16,7 @@ import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
 import { coverageForMapping, coveredFieldPaths } from "../coverage-workspace.js";
+import { resolveAllNLRefs } from "../nl-ref-extract.js";
 import type { FieldDecl, ParsedFile, SchemaRecord, FragmentRecord, MetricRecord } from "../types.js";
 
 interface FieldWithTags extends FieldDecl {
@@ -98,7 +99,15 @@ Examples:
           throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
         }
 
-        const coverage = coverageForMapping(resolvedMapping.key, index, parsedFiles);
+        // Resolved @refs count toward coverage (ADR-036), and this command must
+        // give the same answer as `satsuma coverage` — the lock sl-oqsj put in
+        // place — so it feeds core the same refs.
+        const coverage = coverageForMapping(
+          resolvedMapping.key,
+          index,
+          parsedFiles,
+          resolveAllNLRefs(index),
+        );
         // No coverage result means the mapping does not reference this entity at
         // all (or is anonymous, which --unmapped-by cannot name) — every field is
         // then unmapped by it, which is what an empty covered set produces.

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -23,6 +23,7 @@ import type {
   CoverageSchemaResolver,
   MappingCoverageInput,
   MappingCoverageResult,
+  ResolvedNLRef,
 } from "@satsuma/core";
 import { resolveScopedEntityRef } from "./index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "./spread-expand.js";
@@ -110,11 +111,18 @@ function deepCopyFields<T extends { children?: T[] }>(fields: T[]): T[] {
  * not loaded) or when the mapping label cannot be found in that file's tree.
  * Either case means there is nothing to report, which is distinct from a
  * mapping that covers nothing.
+ *
+ * `nlRefs` is the whole workspace's resolved `@refs`; core selects the ones
+ * belonging to this mapping. It is a required parameter rather than an optional
+ * one deliberately — omitting it silently drops the NL tier (ADR-036), which
+ * under-reports every mapping whose sources appear only in prose, and a caller
+ * that forgot would see a plausible-looking number rather than an error.
  */
 export function coverageForMapping(
   mappingKey: string,
   index: ExtractedWorkspace,
   files: ParsedFile[],
+  nlRefs: readonly ResolvedNLRef[],
 ): MappingCoverage | null {
   const mapping = index.mappings.get(mappingKey);
   if (!mapping?.name) return null;
@@ -127,6 +135,7 @@ export function coverageForMapping(
     parsed.tree,
     mapping.name,
     makeSchemaResolver(index, namespace),
+    nlRefs,
   );
   if (result.schemas.length === 0) return null;
 
@@ -138,10 +147,15 @@ export function coverageForMapping(
  *
  * The workspace is whatever `loadWorkspace` resolved — the entry file plus its
  * transitive imports — so coverage answers "this workspace", not "this file".
+ *
+ * `nlRefs` is resolved once by the caller and reused for every mapping: ref
+ * resolution is workspace-wide, and re-resolving per mapping would repeat the
+ * whole index walk for each one.
  */
 export function coverageForWorkspace(
   index: ExtractedWorkspace,
   files: ParsedFile[],
+  nlRefs: readonly ResolvedNLRef[],
 ): WorkspaceCoverage {
   const mappings: MappingCoverage[] = [];
   let skippedAnonymous = 0;
@@ -151,7 +165,7 @@ export function coverageForWorkspace(
       skippedAnonymous += 1;
       continue;
     }
-    const coverage = coverageForMapping(key, index, files);
+    const coverage = coverageForMapping(key, index, files, nlRefs);
     if (coverage) mappings.push(coverage);
   }
 

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -255,7 +255,7 @@ describe("satsuma coverage — JSON contract", () => {
     assert.equal(mapping.file, WORKSPACE);
     assert.deepEqual(
       Object.keys(mapping.schemas[0]),
-      ["schema", "role", "covered", "total", "pct", "fields"],
+      ["schema", "role", "covered", "covered_declared", "covered_nl", "total", "pct", "fields"],
     );
   });
 
@@ -333,8 +333,12 @@ describe("satsuma coverage — aggregate rollups", () => {
     const data = parseJson(stdout);
     const sources = data.aggregate.schemas.filter((s: any) => s.role === "source");
     assert.equal(sources.filter((s: any) => s.schema === "crm::customers").length, 1);
-    // customers 3/4 + invoices 2/3 = 5/7 source leaves across the workspace.
-    assert.deepEqual(data.aggregate.workspace.source, { covered: 5, total: 7, pct: 71 });
+    // customers 3/4 + invoices 2/3 = 5/7 source leaves across the workspace, all
+    // via declared arrows — this fixture uses no @refs, so the nl tier is empty
+    // and the split must say so rather than omitting the keys (ADR-036).
+    assert.deepEqual(data.aggregate.workspace.source, {
+      covered: 5, covered_declared: 5, covered_nl: 0, total: 7, pct: 71,
+    });
   });
 
   it("reports per-namespace subtotals that sum to the workspace total", async () => {

--- a/tooling/satsuma-cli/test/integration.test.ts
+++ b/tooling/satsuma-cli/test/integration.test.ts
@@ -1424,17 +1424,43 @@ describe("satsuma fields", () => {
     assert.match(stdout, /all fields.*mapped/i);
   });
 
-  it("--unmapped-by on source schema filters mapped fields", async () => {
+  it("--unmapped-by counts fields referenced only by a resolved @ref as mapped", async () => {
+    // The corpus's clearest ADR-036 case. `customer migration` writes address_id
+    // from a note that names @ADDR_LINE_1, @CITY and four more with the @ sigil
+    // (pipeline.stm:143) — no arrow lists them, but the mapping demonstrably
+    // consumes them, and field-lineage has always traced them. Before ADR-036
+    // this command listed all six as unmapped, i.e. as the review queue, so a
+    // reader trusting it would have deleted live fields.
     const { stdout, code } = await run(
       "fields", "legacy_sqlserver", "--unmapped-by", "customer migration", DB,
     );
     assert.equal(code, 0);
-    // CUST_ID, FIRST_NM etc. are mapped — should NOT appear
-    assert.doesNotMatch(stdout, /CUST_ID/);
-    assert.doesNotMatch(stdout, /FIRST_NM/);
-    // Address fields aren't directly mapped — should appear
-    assert.match(stdout, /ADDR_LINE_1/);
-    assert.match(stdout, /CITY/);
+    assert.match(stdout, /All fields in 'legacy_sqlserver' are mapped/);
+  });
+
+  it("splits the coverage figure into declared and NL tiers for the same schema", async () => {
+    // The other half of the same claim: reaching 100% must not hide HOW. Fifteen
+    // of the twenty-one fields are covered by arrows and six only by resolved
+    // @refs, and a reviewer has to be able to tell — an inferred hop is weaker
+    // evidence than a declared one even though both count (ADR-036).
+    const { stdout, code } = await run("coverage", DB, "--schema", "legacy_sqlserver", "--json");
+    assert.equal(code, 0);
+    const schema = JSON.parse(stdout).mappings[0].schemas.find(
+      (s: any) => s.role === "source",
+    );
+    assert.equal(schema.covered, 21);
+    assert.equal(schema.covered_declared, 15);
+    assert.equal(schema.covered_nl, 6);
+    assert.equal(
+      schema.fields.find((f: any) => f.path === "ADDR_LINE_1").tier,
+      "nl",
+      "a field named only in prose is covered in the nl tier",
+    );
+    assert.equal(
+      schema.fields.find((f: any) => f.path === "CUST_ID").tier,
+      "declared",
+      "a field an arrow reads is covered in the declared tier",
+    );
   });
 
   it("--with-meta includes tags", async () => {

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -79,16 +79,24 @@ export function isCoveredFieldPath(path: string, coveredPaths: Set<string>): boo
 // ── Schema-qualified arrow references ───────────────────────────────────────
 
 /**
- * The prefixes an arrow may legitimately use to name one schema.
+ * Every prefix a reference may legitimately use to name one schema.
  *
- * A namespaced schema can be referred to by its qualified id (`crm::customers`)
- * from outside the namespace and by its bare name (`customers`) from inside it,
- * and arrows keep whichever form the author wrote. Matching only the qualified
- * form would miss every bare-prefixed reference in a namespaced mapping.
+ * Three spellings of the same schema circulate, and coverage matches references
+ * from sources that use different ones:
+ *
+ *  - `crm::customers` — the namespace-qualified id, written from outside the
+ *    namespace and used as the index key.
+ *  - `customers` — the bare name, written from inside the namespace. Arrows keep
+ *    whichever form the author wrote, so matching only the qualified form would
+ *    miss every bare-prefixed reference in a namespaced mapping (sl-iqud).
+ *  - `::customers` — the *canonical* form of a schema in no namespace, which is
+ *    what `resolveRef` returns for a resolved NL `@ref` (sl-qxyl). A resolved ref
+ *    is always fully canonical, so without this a global schema's NL coverage
+ *    would never match.
  */
 export function schemaRefPrefixes(schemaRef: string): string[] {
   const namespaceEnd = schemaRef.lastIndexOf("::");
-  if (namespaceEnd < 0) return [schemaRef];
+  if (namespaceEnd < 0) return [schemaRef, `::${schemaRef}`];
   return [schemaRef, schemaRef.slice(namespaceEnd + 2)];
 }
 

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -19,7 +19,7 @@
  * (coverage-paths.ts), or how any of it is rendered.
  */
 
-import type { FieldCoverageEntry, MappingCoverageResult } from "./coverage.js";
+import type { CoverageTier, FieldCoverageEntry, MappingCoverageResult } from "./coverage.js";
 
 // ── Inputs ──────────────────────────────────────────────────────────────────
 
@@ -57,8 +57,22 @@ export interface MappingCoverageInput {
  * toward reporting a gap that is not there rather than hiding one that is.
  */
 export interface CoverageTotals {
-  /** Leaf fields whose own entry is marked covered. */
+  /**
+   * Leaf fields whose own entry is marked covered — the sum of the two tiers
+   * below, and the figure `--fail-under` gates. ADR-036 splits the numerator
+   * into tiers; it does not change what is counted.
+   */
   covered: number;
+  /** Of `covered`, the leaves a declared arrow references. */
+  coveredDeclared: number;
+  /**
+   * Of `covered`, the leaves only a resolved NL `@ref` names.
+   *
+   * Disjoint from {@link coveredDeclared} by construction: a field covered both
+   * ways is reported in the declared tier, so the two always sum to `covered`
+   * and a consumer can render the split without risk of double counting.
+   */
+  coveredNl: number;
   /** Leaf fields declared. Zero for a schema with no leaves. */
   total: number;
   /** covered/total as a whole-number percentage; 0 when `total` is 0. */
@@ -129,8 +143,17 @@ export interface AggregateCoverage {
  */
 export function summarizeFieldCoverage(fields: FieldCoverageEntry[]): CoverageTotals {
   const leaves = leafFieldEntries(fields);
-  const covered = leaves.filter((f) => f.mapped).length;
-  return { covered, total: leaves.length, pct: percentage(covered, leaves.length) };
+  const coveredLeaves = leaves.filter((f) => f.mapped);
+  // Count from the per-field tier rather than re-deriving it, so a rendered
+  // field list and the split printed beside it cannot disagree (ADR-036).
+  const coveredNl = coveredLeaves.filter((f) => f.tier === "nl").length;
+  return {
+    covered: coveredLeaves.length,
+    coveredDeclared: coveredLeaves.length - coveredNl,
+    coveredNl,
+    total: leaves.length,
+    pct: percentage(coveredLeaves.length, leaves.length),
+  };
 }
 
 /**
@@ -164,12 +187,16 @@ function percentage(covered: number, total: number): number {
 /** Sum a set of totals, recomputing the percentage from the summed counts. */
 function sumTotals(parts: Iterable<CoverageTotals>): CoverageTotals {
   let covered = 0;
+  let coveredDeclared = 0;
+  let coveredNl = 0;
   let total = 0;
   for (const part of parts) {
     covered += part.covered;
+    coveredDeclared += part.coveredDeclared;
+    coveredNl += part.coveredNl;
     total += part.total;
   }
-  return { covered, total, pct: percentage(covered, total) };
+  return { covered, coveredDeclared, coveredNl, total, pct: percentage(covered, total) };
 }
 
 // ── Aggregation ─────────────────────────────────────────────────────────────
@@ -209,7 +236,7 @@ export function aggregateCoverage(inputs: MappingCoverageInput[]): AggregateCove
           fields: schema.fields.map((f) => ({ ...f })),
           // Placeholder; every entry's totals are computed once all mappings
           // have been unioned in, below.
-          totals: { covered: 0, total: 0, pct: 0 },
+          totals: { covered: 0, coveredDeclared: 0, coveredNl: 0, total: 0, pct: 0 },
         });
         continue;
       }
@@ -252,7 +279,24 @@ function unionInto(accumulated: FieldCoverageEntry[], incoming: FieldCoverageEnt
       continue;
     }
     existing.mapped = existing.mapped || field.mapped;
+    // Tier unions toward the stronger claim: a field one mapping declares and
+    // another only mentions in prose is declared-covered in the aggregate
+    // (ADR-036). Without this the aggregate could report a declared field as
+    // merely inferred, purely on mapping order.
+    const tier = strongerTier(existing.tier, field.tier);
+    if (tier !== undefined) existing.tier = tier;
+    else delete existing.tier;
   }
+}
+
+/** `declared` beats `nl` beats absent — see {@link CoverageTier}. */
+function strongerTier(
+  a: CoverageTier | undefined,
+  b: CoverageTier | undefined,
+): CoverageTier | undefined {
+  if (a === "declared" || b === "declared") return "declared";
+  if (a === "nl" || b === "nl") return "nl";
+  return undefined;
 }
 
 /**

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -9,8 +9,13 @@
  * "Covered" means:
  *   - source field: its qualified path from the schema root — or a path that
  *     starts with it — appears as a src_path in at least one arrow anywhere in
- *     the mapping.
+ *     the mapping, **or** is named by a resolved NL `@ref` in that mapping.
  *   - target field: the same, as a tgt_path.
+ *
+ * The two are reported as distinct tiers over one denominator (ADR-036): a
+ * resolved `@ref` carries the same lineage weight as a declared source field
+ * (ADR-013), which `arrows`, `graph`, `lineage`, `field-lineage` and `lint` have
+ * always honoured and coverage alone did not. See {@link CoverageTier}.
  *
  * Matching is by path, never by local field name: two records under one schema
  * routinely declare the same leaf name, and treating a name match as coverage
@@ -30,9 +35,14 @@
  * references (spec §5's resolved NL @refs, ADR-036) is then one change, in
  * extract.ts, rather than two that can disagree.
  *
- * Coverage is deliberately *structural only*: a field a note block describes in
- * prose is uncovered by definition. NL interpretation belongs to nl-refs, and
- * policy judgements ("optional fields shouldn't count") belong to lint.
+ * Coverage follows *explicit references only*. Resolving `@net_amount` to a
+ * declared field is structural resolution of a reference the author marked with
+ * a sigil — it reads no surrounding prose, which is why counting it does not
+ * make coverage an NL interpreter (ADR-036). A field that prose merely describes
+ * without an `@ref`, and a ref that resolves to nothing, both remain uncovered:
+ * unresolved refs are `lint`'s `unresolved-nl-ref`, and letting them count would
+ * make coverage rise when a spec breaks. Policy judgements ("optional fields
+ * shouldn't count") still belong to lint.
  *
  * This module does not own an index either. Callers supply a
  * {@link CoverageSchemaResolver} that adapts their own workspace model — the
@@ -46,6 +56,7 @@
 import { child, children, labelText, sourceRefStructuralText } from "./cst-utils.js";
 import { buildCoveredFieldSet, isCoveredFieldPath, schemaLocalFieldPath } from "./coverage-paths.js";
 import { extractMappingArrowRecords } from "./extract.js";
+import type { ResolvedNLRef } from "./nl-ref.js";
 import type { SyntaxNode, Tree } from "./types.js";
 
 // ── Resolver input contract ─────────────────────────────────────────────────
@@ -102,6 +113,22 @@ export type CoverageSchemaResolver = (schemaId: string) => CoverageSchemaDefinit
 // ── Public result types ─────────────────────────────────────────────────────
 
 /**
+ * How a field came to be covered (ADR-036).
+ *
+ * `declared` — an arrow in the mapping references the field's path.
+ * `nl` — a resolved NL `@ref` in the mapping names it, and no arrow does.
+ *
+ * The two are tiers over one denominator, not separate denominators: ADR-034
+ * still governs what is counted. `declared` is the stronger claim and wins when
+ * a field is covered both ways, so the tiers never double-count.
+ *
+ * Consumers must render the distinction rather than reconstruct it — an NL-derived
+ * hop is inferred from prose, not declared, and a reviewer has to be able to see
+ * which is which.
+ */
+export type CoverageTier = "declared" | "nl";
+
+/**
  * Coverage status for a single field (leaf or record) in a schema.
  */
 export interface FieldCoverageEntry {
@@ -116,8 +143,13 @@ export interface FieldCoverageEntry {
    * rather than assume 0.
    */
   line?: number;
-  /** True when at least one arrow in the mapping covers this field. */
+  /** True when an arrow or a resolved `@ref` in the mapping covers this field. */
   mapped: boolean;
+  /**
+   * Which tier covered it. Absent exactly when `mapped` is false — the two
+   * always agree, so a consumer may branch on either.
+   */
+  tier?: CoverageTier;
 }
 
 /**
@@ -154,16 +186,23 @@ export interface MappingCoverageResult {
  * @param mappingName  Mapping label to report on; matched against top-level
  *                     and namespaced `mapping` blocks in this tree.
  * @param resolveSchema Adapter from the caller's index to field trees.
+ * @param nlRefs       Resolved NL `@refs` for the workspace, from
+ *                     `resolveAllNLRefs()`. Those belonging to this mapping
+ *                     contribute `nl`-tier coverage (ADR-036). Omit — or pass an
+ *                     empty array — for declared-tier coverage only; note that
+ *                     omitting it under-reports any mapping whose sources appear
+ *                     only in prose, which is the whole reason the tier exists.
  */
 export function computeMappingCoverage(
   tree: Tree,
   mappingName: string,
   resolveSchema: CoverageSchemaResolver,
+  nlRefs: readonly ResolvedNLRef[] = [],
 ): MappingCoverageResult {
-  const mappingNode = findMappingBlock(tree, mappingName);
-  if (!mappingNode) return { schemas: [] };
+  const found = findMappingBlock(tree, mappingName);
+  if (!found) return { schemas: [] };
 
-  const body = child(mappingNode, "mapping_body");
+  const body = child(found.node, "mapping_body");
   if (!body) return { schemas: [] };
 
   const sourceIds = getSchemaIdsFromBlock(body, "source_block");
@@ -177,87 +216,159 @@ export function computeMappingCoverage(
   // The `each`/`flatten`/`nested_arrow` container itself yields a record too, so
   // a container's own source and target are registered as touched: iterating a
   // list consumes it, and writing into one populates it.
-  const arrows = extractMappingArrowRecords(mappingNode);
-  const srcRefs = arrows.flatMap((a) => a.sources);
-  const tgtRefs = arrows.map((a) => a.target).filter((t): t is string => t !== null);
+  const arrows = extractMappingArrowRecords(found.node);
+  const declaredSrc = arrows.flatMap((a) => a.sources);
+  const declaredTgt = arrows.map((a) => a.target).filter((t): t is string => t !== null);
+
+  const nl = nlRefFieldPaths(nlRefs, found.mappingKey);
 
   const schemas: SchemaCoverageResult[] = [];
 
   for (const schemaId of sourceIds) {
     const def = resolveSchema(schemaId);
     if (!def) continue;
-    schemas.push(coverageForSchema(def, schemaId, "source", srcRefs, sourceIds));
+    schemas.push(coverageForSchema(def, schemaId, "source", sourceIds, declaredSrc, nl.anyContext));
   }
 
   for (const schemaId of targetIds) {
     const def = resolveSchema(schemaId);
     if (!def) continue;
-    schemas.push(coverageForSchema(def, schemaId, "target", tgtRefs, targetIds));
+    schemas.push(coverageForSchema(def, schemaId, "target", targetIds, declaredTgt, nl.arrowBodyOnly));
   }
 
   return { schemas };
 }
 
+// ── Resolved NL @ref paths (ADR-036) ────────────────────────────────────────
+
 /**
- * Report one schema, resolving the mapping's authored arrow references into
- * paths local to it before matching them against its declared fields.
+ * The canonical field paths a mapping's resolved `@refs` name, split by whether
+ * a target schema may claim them.
+ *
+ * Only `kind: "field"` resolutions are field references at all — a ref naming a
+ * schema, fragment or transform covers no field. Only *resolved* refs count:
+ * letting an unresolved ref count would make coverage rise when a spec breaks,
+ * and reporting one is `lint`'s `unresolved-nl-ref` (ADR-036).
+ */
+interface NLRefPaths {
+  /**
+   * Every resolved field ref in the mapping. Source schemas may claim any of
+   * them: a ref in a join condition demonstrates the mapping reads that field.
+   */
+  anyContext: string[];
+  /**
+   * Refs from arrow bodies and note blocks only — `context: "source_block"`
+   * excluded. A join condition or filter names no *target* field, so it can
+   * never contribute target coverage (ADR-036).
+   */
+  arrowBodyOnly: string[];
+}
+
+function nlRefFieldPaths(nlRefs: readonly ResolvedNLRef[], mappingKey: string): NLRefPaths {
+  const anyContext: string[] = [];
+  const arrowBodyOnly: string[] = [];
+
+  for (const ref of nlRefs) {
+    if (ref.mapping !== mappingKey) continue;
+    if (!ref.resolved || ref.resolvedTo?.kind !== "field") continue;
+    anyContext.push(ref.resolvedTo.name);
+    if (ref.context !== "source_block") arrowBodyOnly.push(ref.resolvedTo.name);
+  }
+
+  return { anyContext, arrowBodyOnly };
+}
+
+/**
+ * Report one schema, resolving the mapping's references into paths local to it
+ * before matching them against its declared fields.
+ *
+ * Declared and NL references are resolved separately and kept in separate sets,
+ * because the tier a field is reported under depends on which set matched.
  */
 function coverageForSchema(
   def: CoverageSchemaDefinition,
   writtenRef: string,
   role: "source" | "target",
-  arrowRefs: readonly string[],
   participatingRefs: readonly string[],
+  declaredRefs: readonly string[],
+  nlRefPaths: readonly string[],
 ): SchemaCoverageResult {
-  // An arrow may name this schema by the reference as written in the mapping or
-  // by the id the resolver canonicalised it to, so both forms must resolve.
+  // A reference may name this schema by the form written in the mapping or by the
+  // id the resolver canonicalised it to, so both must resolve.
   const canonicalRef = def.schemaId ?? writtenRef;
   const ownRefs = canonicalRef === writtenRef ? [writtenRef] : [writtenRef, canonicalRef];
   const otherRefs = participatingRefs.filter((ref) => ref !== writtenRef);
 
   const topLevelNames = new Set(def.fields.map((f) => f.name));
   const declaresTopLevel = (name: string): boolean => topLevelNames.has(name);
+  const toLocal = (ref: string): string | null =>
+    schemaLocalFieldPath(ref, ownRefs, otherRefs, declaresTopLevel);
 
-  const localPaths: string[] = [];
-  for (const ref of arrowRefs) {
-    const local = schemaLocalFieldPath(ref, ownRefs, otherRefs, declaresTopLevel);
-    if (local !== null) localPaths.push(local);
+  const declaredLocal: string[] = [];
+  for (const ref of declaredRefs) {
+    const local = toLocal(ref);
+    if (local !== null) declaredLocal.push(local);
+  }
+
+  // A resolved @ref is always fully schema-qualified, so it belongs to this
+  // schema only if the prefix actually came off. Requiring that — rather than
+  // accepting the fall-through — keeps another schema's refs out of this set
+  // instead of parking unmatchable paths in it.
+  const nlLocal: string[] = [];
+  for (const ref of nlRefPaths) {
+    const local = toLocal(ref);
+    if (local !== null && local !== ref) nlLocal.push(local);
   }
 
   return {
     schemaId: canonicalRef,
     role,
-    fields: buildFieldCoverage(def.fields, def.uri, "", buildCoveredFieldSet(localPaths)),
+    fields: buildFieldCoverage(def.fields, def.uri, "", {
+      declared: buildCoveredFieldSet(declaredLocal),
+      nl: buildCoveredFieldSet(nlLocal),
+    }),
   };
 }
 
 // ── Field coverage building ─────────────────────────────────────────────────
 
+/** The covered-path sets for one schema, one per tier (ADR-036). */
+interface TieredCoveredPaths {
+  declared: Set<string>;
+  nl: Set<string>;
+}
+
 /**
  * Recursively build the FieldCoverageEntry list for a schema's fields.
  * `prefix` is the path from the schema root to the current level; record
  * fields emit an entry of their own *and* entries for every descendant.
+ *
+ * A field in both sets is reported as `declared`: declared coverage is the
+ * stronger claim, and reporting the weaker one would let a field that an arrow
+ * genuinely writes read as merely inferred from prose (ADR-036).
  */
 function buildFieldCoverage(
   fields: CoverageField[],
   uri: string,
   prefix: string,
-  coveredPaths: Set<string>,
+  covered: TieredCoveredPaths,
 ): FieldCoverageEntry[] {
   const result: FieldCoverageEntry[] = [];
   for (const f of fields) {
     const path = prefix ? `${prefix}.${f.name}` : f.name;
-    const entry: FieldCoverageEntry = {
-      path,
-      uri,
-      mapped: isCoveredFieldPath(path, coveredPaths),
-    };
+    const tier: CoverageTier | undefined = isCoveredFieldPath(path, covered.declared)
+      ? "declared"
+      : isCoveredFieldPath(path, covered.nl)
+        ? "nl"
+        : undefined;
+    const entry: FieldCoverageEntry = { path, uri, mapped: tier !== undefined };
+    if (tier !== undefined) entry.tier = tier;
     // Omit `line` entirely when unknown rather than defaulting to 0 — see the
     // CoverageField.line contract.
     if (f.line !== undefined) entry.line = f.line;
     result.push(entry);
     if (f.children && f.children.length > 0) {
-      result.push(...buildFieldCoverage(f.children, uri, path, coveredPaths));
+      result.push(...buildFieldCoverage(f.children, uri, path, covered));
     }
   }
   return result;
@@ -265,13 +376,36 @@ function buildFieldCoverage(
 
 // ── CST helpers ─────────────────────────────────────────────────────────────
 
+/** A located `mapping` block, with the key its resolved NL refs are filed under. */
+interface LocatedMapping {
+  node: SyntaxNode;
+  /**
+   * Namespace-qualified mapping key (`crm::load`), or the bare label at file
+   * scope — the same key `resolveAllNLRefs` writes to `ResolvedNLRef.mapping`.
+   *
+   * Matching refs on this rather than on the label alone is what keeps two
+   * same-named mappings in different namespaces apart. They are different
+   * mappings, and crediting one with the other's refs would be a silent
+   * over-count of exactly the kind ADR-036's "only resolved refs" rule guards.
+   */
+  mappingKey: string;
+}
+
 /** Find a `mapping` block by label, at file scope or inside a namespace block. */
-function findMappingBlock(tree: Tree, name: string): SyntaxNode | null {
+function findMappingBlock(tree: Tree, name: string): LocatedMapping | null {
   for (const node of tree.rootNode.namedChildren) {
-    if (node.type === "mapping_block" && labelText(node) === name) return node;
+    if (node.type === "mapping_block" && labelText(node) === name) {
+      return { node, mappingKey: name };
+    }
     if (node.type === "namespace_block") {
+      // A namespace's name is its first `identifier` child, not a label — the
+      // same read extract.ts's collectFromNamespaces() does, so the key built
+      // here matches the one resolveAllNLRefs() files refs under.
+      const namespace = node.namedChildren.find((c) => c.type === "identifier")?.text ?? null;
       for (const ch of node.namedChildren) {
-        if (ch.type === "mapping_block" && labelText(ch) === name) return ch;
+        if (ch.type === "mapping_block" && labelText(ch) === name) {
+          return { node: ch, mappingKey: namespace ? `${namespace}::${name}` : name };
+        }
       }
     }
   }

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -29,6 +29,7 @@ export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
 export { computeMappingCoverage } from "./coverage.js";
 export type {
+  CoverageTier,
   FieldCoverageEntry,
   SchemaCoverageResult,
   MappingCoverageResult,

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -42,6 +42,14 @@ function toCoverageFields(fields) {
   }));
 }
 
+/**
+ * Expected CoverageTotals. `nl` defaults to 0 because most fixtures here use
+ * declared arrows only; the tier split (ADR-036) is exercised separately below.
+ */
+function expectTotals(covered, total, pct, nl = 0) {
+  return { covered, coveredDeclared: covered - nl, coveredNl: nl, total, pct };
+}
+
 /** Namespace-qualified id, matching what the CLI's index keys use. */
 function qualify(namespace, name) {
   return namespace ? `${namespace}::${name}` : name;
@@ -97,7 +105,7 @@ describe("summarizeFieldCoverage()", () => {
       { path: "address.line2", uri: "u", mapped: false },
       { path: "id", uri: "u", mapped: true },
     ]);
-    assert.deepEqual(totals, { covered: 2, total: 3, pct: 67 });
+    assert.deepEqual(totals, expectTotals(2, 3, 67));
   });
 
   it("does not let a covered record vouch for its uncovered leaves", () => {
@@ -110,11 +118,11 @@ describe("summarizeFieldCoverage()", () => {
       { path: "address.line1", uri: "u", mapped: true },
       { path: "address.line2", uri: "u", mapped: false },
     ]);
-    assert.deepEqual(totals, { covered: 1, total: 2, pct: 50 });
+    assert.deepEqual(totals, expectTotals(1, 2, 50));
   });
 
   it("reports 0% rather than dividing by zero for a schema with no fields", () => {
-    assert.deepEqual(summarizeFieldCoverage([]), { covered: 0, total: 0, pct: 0 });
+    assert.deepEqual(summarizeFieldCoverage([]), expectTotals(0, 0, 0));
   });
 
   it("rounds the percentage to a whole number", () => {
@@ -187,7 +195,7 @@ mapping load_memos {
     // tgt is a target of two mappings; double counting it would halve the
     // workspace percentage for no reason.
     const { aggregate: result } = aggregate(SRC);
-    assert.deepEqual(entry(result, "target", "tgt").totals, { covered: 2, total: 3, pct: 67 });
+    assert.deepEqual(entry(result, "target", "tgt").totals, expectTotals(2, 3, 67));
   });
 });
 
@@ -229,8 +237,8 @@ mapping load {
   id -> id
 }`;
     const { aggregate: result } = aggregate(src);
-    assert.deepEqual(result.workspace.source, { covered: 1, total: 2, pct: 50 });
-    assert.deepEqual(result.workspace.target, { covered: 1, total: 2, pct: 50 });
+    assert.deepEqual(result.workspace.source, expectTotals(1, 2, 50));
+    assert.deepEqual(result.workspace.target, expectTotals(1, 2, 50));
   });
 });
 
@@ -264,9 +272,9 @@ namespace billing {
     const { aggregate: result } = aggregate(SRC);
     const crm = result.namespaces.find((n) => n.namespace === "crm");
     const billing = result.namespaces.find((n) => n.namespace === "billing");
-    assert.deepEqual(crm.source, { covered: 1, total: 2, pct: 50 }, "crm::customers: id read, email not");
-    assert.deepEqual(billing.source, { covered: 2, total: 3, pct: 67 }, "billing::invoices: memo not read");
-    assert.deepEqual(billing.target, { covered: 2, total: 2, pct: 100 }, "billing::ledger fully populated");
+    assert.deepEqual(crm.source, expectTotals(1, 2, 50), "crm::customers: id read, email not");
+    assert.deepEqual(billing.source, expectTotals(2, 3, 67), "billing::invoices: memo not read");
+    assert.deepEqual(billing.target, expectTotals(2, 2, 100), "billing::ledger fully populated");
   });
 
   it("workspace totals equal the sum of the namespace subtotals", () => {
@@ -305,7 +313,7 @@ describe("aggregateCoverage() — degenerate inputs", () => {
     const result = aggregateCoverage([]);
     assert.deepEqual(result.schemas, []);
     assert.deepEqual(result.namespaces, []);
-    assert.deepEqual(result.workspace.target, { covered: 0, total: 0, pct: 0 });
+    assert.deepEqual(result.workspace.target, expectTotals(0, 0, 0));
   });
 
   it("skips a mapping whose coverage resolved to no schemas", () => {

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -16,7 +16,15 @@ import assert from "node:assert/strict";
 import { describe, it, before } from "node:test";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { initParser, getParser, computeMappingCoverage, extractSchemas } from "@satsuma/core";
+import {
+  initParser,
+  getParser,
+  computeMappingCoverage,
+  extractSchemas,
+  extractMappings,
+  extractNLRefData,
+  resolveAllNLRefs,
+} from "@satsuma/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
@@ -37,8 +45,13 @@ function toCoverageFields(fields) {
 }
 
 /**
- * Run computeMappingCoverage over single-file source text, resolving schemas
- * from that same file.
+ * Run computeMappingCoverage over single-file source text, resolving schemas —
+ * and NL `@refs` — from that same file.
+ *
+ * Resolving refs here rather than stubbing them means these tests exercise the
+ * real `resolveRef` output shape (`{ kind: "field", name: "::schema.path" }`),
+ * which is the contract coverage now depends on (ADR-036). A stub would let the
+ * two drift.
  */
 function coverage(source, mappingName) {
   const tree = getParser().parse(source);
@@ -46,10 +59,39 @@ function coverage(source, mappingName) {
   for (const s of extractSchemas(tree.rootNode)) {
     byId.set(s.namespace ? `${s.namespace}::${s.name}` : s.name, s);
   }
-  return computeMappingCoverage(tree, mappingName, (schemaId) => {
-    const schema = byId.get(schemaId);
-    return schema ? { uri: TEST_URI, fields: toCoverageFields(schema.fields) } : null;
-  });
+  return computeMappingCoverage(
+    tree,
+    mappingName,
+    (schemaId) => {
+      const schema = byId.get(schemaId);
+      return schema ? { uri: TEST_URI, fields: toCoverageFields(schema.fields) } : null;
+    },
+    resolveRefsIn(tree, byId),
+  );
+}
+
+/** Resolve every NL `@ref` in the tree against the schemas and mappings it declares. */
+function resolveRefsIn(tree, schemasById) {
+  const mappingsById = new Map();
+  for (const m of extractMappings(tree.rootNode)) {
+    const key = m.namespace ? `${m.namespace}::${m.name}` : m.name;
+    mappingsById.set(key, { sources: m.sources, targets: m.targets });
+  }
+  const lookup = {
+    hasSchema: (k) => schemasById.has(k),
+    getSchema: (k) => {
+      const s = schemasById.get(k);
+      return s ? { fields: s.fields, hasSpreads: Boolean(s.spreads?.length), namespace: s.namespace } : null;
+    },
+    hasFragment: () => false,
+    getFragment: () => null,
+    hasTransform: () => false,
+    getMapping: (k) => mappingsById.get(k) ?? null,
+    iterateSchemas: () =>
+      [...schemasById.entries()].map(([k, s]) => [k, { fields: s.fields, hasSpreads: false }]),
+  };
+  const items = extractNLRefData(tree.rootNode).map((item) => ({ ...item, file: TEST_URI }));
+  return resolveAllNLRefs(items, lookup);
 }
 
 /** Coverage entries for the single schema playing `role` in the result. */
@@ -64,6 +106,14 @@ function assertMapped(schema, path, expected) {
   const matches = schema.fields.filter((f) => f.path === path);
   assert.equal(matches.length, 1, `expected exactly one "${path}" entry in ${schema.fields.map((f) => f.path)}`);
   assert.equal(matches[0].mapped, expected, `"${path}" should be mapped=${expected}`);
+}
+
+/** Assert `path` is covered and reported under `tier` ("declared" | "nl"). */
+function assertTier(schema, path, tier) {
+  const match = schema.fields.find((f) => f.path === path);
+  assert.ok(match, `expected a "${path}" entry in ${schema.fields.map((f) => f.path)}`);
+  assert.equal(match.mapped, true, `"${path}" should be covered`);
+  assert.equal(match.tier, tier, `"${path}" should be covered in the ${tier} tier`);
 }
 
 // ── Result structure ────────────────────────────────────────────────────────
@@ -550,6 +600,159 @@ mapping load {
     const t = forRole(result, "target");
     assertMapped(t, "email", true);
     assertMapped(t, "orders.packed.sku", true);
+  });
+});
+
+// ── Resolved NL @refs count, as a distinct tier (ADR-036, sl-qxyl) ───────────
+
+describe("computeMappingCoverage — resolved NL @ref tier", () => {
+  // ADR-013 settled that a resolved @ref carries the same lineage weight as a
+  // declared source field, and arrows/graph/lineage/field-lineage/lint all honour
+  // it. Coverage alone did not, so a mapping whose sources appear only in prose
+  // reported every source field uncovered — and the aggregate "covered by no
+  // mapping" list, which the docs call the claim worth acting on, named live
+  // fields. ADR-036 reverses that and defines these tiers.
+
+  it("counts a source field named only by a resolved @ref", () => {
+    // The headline case from ADR-036: no arrow reads net_amount, but the prose
+    // references it explicitly with the @ sigil and it resolves to a real field.
+    const src = `
+schema src { net_amount DECIMAL tax_amount DECIMAL unused DECIMAL }
+schema tgt { gross_total DECIMAL }
+mapping load {
+  source { src }
+  target { tgt }
+  -> gross_total { "Add @net_amount and @tax_amount" }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertTier(s, "net_amount", "nl");
+    assertTier(s, "tax_amount", "nl");
+    // Prose that names nothing covers nothing — the gap must survive.
+    assertMapped(s, "unused", false);
+  });
+
+  it("reports a field covered both ways in the declared tier only", () => {
+    // Declared coverage is the stronger claim, so it wins and the field is
+    // counted once. Reporting the weaker tier would make a field an arrow
+    // genuinely writes read as merely inferred from prose.
+    const src = `
+schema src { amount DECIMAL }
+schema tgt { total DECIMAL }
+mapping load {
+  source { src }
+  target { tgt }
+  amount -> total { "rounded @amount" }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertTier(s, "amount", "declared");
+  });
+
+  it("does not count an @ref that resolves to nothing", () => {
+    // Letting an unresolved ref count would make coverage RISE when a spec
+    // breaks. Reporting it is lint's unresolved-nl-ref, not coverage's job.
+    const src = `
+schema src { amount DECIMAL }
+schema tgt { total DECIMAL }
+mapping load {
+  source { src }
+  target { tgt }
+  -> total { "derived from @no_such_field" }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "amount", false);
+  });
+
+  it("does not let an @ref naming a schema or transform cover a field", () => {
+    // Only kind:"field" resolutions are field references. A ref to the schema
+    // itself resolves, but names no field, so it must contribute nothing.
+    const src = `
+schema src { amount DECIMAL }
+schema tgt { total DECIMAL }
+mapping load {
+  source { src }
+  target { tgt }
+  -> total { "sum over @src" }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertMapped(s, "amount", false);
+  });
+
+  it("counts a source_block @ref toward source coverage", () => {
+    // A join condition demonstrably reads the fields it joins on, so they are
+    // consumed even though no arrow lists them.
+    const src = `
+schema a { id UUID }
+schema b { id UUID note_only STRING }
+schema tgt { out UUID }
+mapping load {
+  source {
+    a,
+    b,
+    "Left join on @a.id = @b.id."
+  }
+  target { tgt }
+  a.id -> out
+}`;
+    const b = coverage(src, "load").schemas.find((s) => s.schemaId === "b");
+    assertTier(b, "id", "nl");
+    assertMapped(b, "note_only", false);
+  });
+
+  it("never lets a source_block @ref cover a target field", () => {
+    // A filter or join condition names no target field, so it cannot populate
+    // one. Counting it would credit the target for work the mapping never does.
+    const src = `
+schema src { id UUID }
+schema tgt { id UUID out STRING }
+mapping load {
+  source {
+    src,
+    "Filter where @tgt.out is not null."
+  }
+  target { tgt }
+  src.id -> id
+}`;
+    const t = forRole(coverage(src, "load"), "target");
+    assertTier(t, "id", "declared");
+    assertMapped(t, "out", false);
+  });
+
+  it("resolves an @ref to a nested field path, not a bare leaf name", () => {
+    // Interacts with sl-joeq: coverage matches whole paths, and a resolved ref
+    // yields a canonical absolute path, so the nested field must be credited and
+    // the same-named top-level field must not.
+    const src = `
+schema src { city STRING address record { city STRING } }
+schema tgt { out STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  -> out { "take @address.city" }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertTier(s, "address.city", "nl");
+    assertMapped(s, "city", false);
+  });
+
+  it("credits an @ref inside an each block against the real field path", () => {
+    // Coverage depends on ref resolution now, so a resolution defect becomes a
+    // coverage defect (ADR-036's recorded cost). sl-hrql and sl-ez36 fixed refs
+    // inside each/flatten/nested_arrow resolving to fabricated paths; this pins
+    // that coverage credits the real path and not the phantom.
+    const src = `
+schema src { lines list_of record { sku STRING qty INT } }
+schema tgt { rows list_of record { code STRING note STRING } }
+mapping load {
+  source { src }
+  target { rows }
+  each lines -> rows {
+    .sku -> .code
+    -> .note { "describe @lines.qty" }
+  }
+}`;
+    const s = forRole(coverage(src, "load"), "source");
+    assertTier(s, "lines.sku", "declared");
+    assertTier(s, "lines.qty", "nl");
   });
 });
 

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -1,23 +1,40 @@
 /**
  * coverage.ts — LSP adapter for @satsuma/core mapping coverage.
  *
- * Coverage semantics (which declared fields a mapping's arrows touch) live in
+ * Coverage semantics (which declared fields a mapping covers) live in
  * `@satsuma/core/coverage`, shared with the CLI's `satsuma coverage` command
  * and the viz coverage overlay. This module's only job is to adapt the LSP's
- * `WorkspaceIndex` to core's `CoverageSchemaResolver` and to keep the
+ * `WorkspaceIndex` to the two callbacks core needs — a `CoverageSchemaResolver`
+ * and a `DefinitionLookup` for NL `@ref` resolution — and to keep the
  * `(uri, tree, mappingName, wsIndex)` signature that server.ts's
  * `satsuma/mappingCoverage` request handler already calls.
  *
- * It owns nothing else: no path rules, no field walking. If coverage output
- * looks wrong, the bug is in core unless the schema being reported is the
+ * It owns nothing else: no path rules, no field walking, no counting. If coverage
+ * output looks wrong, the bug is in core unless the schema being reported is the
  * wrong one — that resolution step is what lives here.
+ *
+ * The gutter must agree with `satsuma coverage` field for field, so it feeds core
+ * the same two inputs the CLI does. Resolved `@refs` are one of them (ADR-036):
+ * omitting them would show a field as unmapped in the editor that the CLI reports
+ * as covered, which is the cross-consumer disagreement this whole area exists to
+ * remove.
  */
 
 import type { Tree } from "./parser-utils";
 import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
-import { computeMappingCoverage as computeCoverage } from "@satsuma/core";
-import type { CoverageField, CoverageSchemaDefinition } from "@satsuma/core";
+import {
+  computeMappingCoverage as computeCoverage,
+  extractMappings,
+  extractNLRefData,
+  resolveAllNLRefs,
+} from "@satsuma/core";
+import type {
+  CoverageField,
+  CoverageSchemaDefinition,
+  DefinitionLookup,
+  ResolvedNLRef,
+} from "@satsuma/core";
 
 // Re-export shared types from core so existing LSP code that imports from
 // this module continues to work without import path changes.
@@ -37,13 +54,85 @@ import type { MappingCoverageResult } from "@satsuma/core";
  * because a future scoped resolver may need the requesting document.
  */
 export function computeMappingCoverage(
-  _uri: string,
+  uri: string,
   tree: Tree,
   mappingName: string,
   wsIndex: WorkspaceIndex,
 ): MappingCoverageResult {
-  return computeCoverage(tree, mappingName, (schemaId) => resolveSchema(wsIndex, schemaId));
+  return computeCoverage(
+    tree,
+    mappingName,
+    (schemaId) => resolveSchema(wsIndex, schemaId),
+    resolveNLRefs(uri, tree, wsIndex),
+  );
 }
+
+/**
+ * Resolve the NL `@refs` in this document so core can credit the ones that name
+ * declared fields (ADR-036).
+ *
+ * Scoped to this document deliberately. Core only consults refs belonging to the
+ * mapping being reported, and that mapping is in this tree — so resolving the
+ * whole workspace's prose on every gutter request would be work thrown away.
+ * Schema lookups still span the workspace, via the index, because a source schema
+ * is routinely declared in an imported file.
+ */
+function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): ResolvedNLRef[] {
+  const items = extractNLRefData(tree.rootNode).map((item) => ({ ...item, file: uri }));
+  if (items.length === 0) return [];
+  return resolveAllNLRefs(items, makeDefinitionLookup(tree, wsIndex));
+}
+
+/**
+ * Adapt the LSP index to core's `DefinitionLookup` (ADR-006's callback pattern).
+ *
+ * Schemas and fragments come from the workspace index, so an `@ref` to an
+ * imported schema resolves. Mapping source/target lists are read from this tree
+ * instead: the index does not record them in that shape, and the only mapping
+ * whose context matters is the one declared here.
+ */
+function makeDefinitionLookup(tree: Tree, wsIndex: WorkspaceIndex): DefinitionLookup {
+  const mappings = new Map<string, { sources: string[]; targets: string[] }>();
+  for (const m of extractMappings(tree.rootNode)) {
+    // Anonymous mappings have no label, so no ref can be filed under them.
+    if (!m.name) continue;
+    const key = m.namespace ? `${m.namespace}::${m.name}` : m.name;
+    mappings.set(key, { sources: m.sources, targets: m.targets });
+  }
+
+  const entryOfKind = (key: string, kind: DefinitionEntryKind) =>
+    resolveDefinition(wsIndex, key, null).find((d) => d.kind === kind) ?? null;
+
+  // `hasSpreads: false` because the LSP index stores each schema's fields
+  // already flattened; there is no unresolved spread left for core to expand.
+  const schemaLike = (key: string) => {
+    const def = entryOfKind(key, "schema");
+    return def ? { fields: def.fields, hasSpreads: false, namespace: def.namespace } : null;
+  };
+
+  return {
+    hasSchema: (key) => schemaLike(key) !== null,
+    getSchema: (key) => schemaLike(key),
+    hasFragment: (key) => entryOfKind(key, "fragment") !== null,
+    getFragment: (key) => {
+      const def = entryOfKind(key, "fragment");
+      return def ? { fields: def.fields, hasSpreads: false } : null;
+    },
+    hasTransform: (key) => entryOfKind(key, "transform") !== null,
+    getMapping: (key) => mappings.get(key) ?? null,
+    iterateSchemas: () => {
+      const out: Array<[string, { fields: FieldInfo[]; hasSpreads: boolean }]> = [];
+      for (const [key, entries] of wsIndex.definitions) {
+        const def = entries.find((d) => d.kind === "schema");
+        if (def) out.push([key, { fields: def.fields, hasSpreads: false }]);
+      }
+      return out;
+    },
+  } as DefinitionLookup;
+}
+
+/** The `kind` values a `DefinitionEntry` can carry that this module looks up. */
+type DefinitionEntryKind = "schema" | "fragment" | "transform";
 
 /**
  * Resolve a schema reference to core's coverage input shape.

--- a/tooling/vscode-satsuma/src/commands/coverage-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage-logic.ts
@@ -6,7 +6,14 @@
  * the status bar needs a target-coverage percentage. This module owns those
  * two transformations so they stay unit-testable in plain Node; decoration
  * types, editors, and the status bar live in coverage.ts (sl-89id).
+ *
+ * It owns no counting rule of its own. Percentages come from
+ * `@satsuma/core`'s `summarizeFieldCoverage`, so the status bar, `satsuma
+ * coverage` and the viz overlay cannot report different numbers for one mapping
+ * (ADR-034, ADR-036).
  */
+
+import { summarizeFieldCoverage } from "@satsuma/core";
 
 /** One schema's fields from the LSP satsuma/mappingCoverage response. */
 export interface CoverageSchema {
@@ -14,8 +21,18 @@ export interface CoverageSchema {
   schemaId: string;
   /** Whether the mapping reads from (source) or writes to (target) this schema. */
   role: "source" | "target";
-  /** Every declared field with its location and whether the mapping touches it. */
-  fields: Array<{ path: string; uri: string; line: number; mapped: boolean }>;
+  /**
+   * Every declared field with its location and whether the mapping touches it.
+   * `tier` is present exactly when `mapped` is true and says which tier covered
+   * it — a declared arrow, or a resolved NL `@ref` (ADR-036).
+   */
+  fields: Array<{
+    path: string;
+    uri: string;
+    line: number;
+    mapped: boolean;
+    tier?: "declared" | "nl";
+  }>;
 }
 
 /** A single gutter marker: where it goes and what its hover says. */
@@ -61,26 +78,41 @@ export function groupCoverageByUri(
 
 /** Status-bar summary of how much of the target schema the mapping fills. */
 export interface TargetCoverageStats {
-  /** Count of top-level target fields the mapping writes. */
+  /** Leaf target fields the mapping writes, per ADR-034's counting rule. */
   mapped: number;
-  /** Count of all top-level target fields. */
+  /** Leaf target fields declared. */
   total: number;
   /** Whole-number percentage (mapped/total), 0 when the schema has no fields. */
   pct: number;
+  /** Of `mapped`, the leaves covered only by a resolved NL `@ref` (ADR-036). */
+  mappedNl: number;
 }
 
 /**
- * Compute the target-coverage percentage shown in the status bar, counting
- * only top-level fields (nested paths contain "." and would double-count
- * their parent). Returns undefined when the result has no target schema.
+ * Compute the target-coverage percentage shown in the status bar.
+ *
+ * Delegates the counting to core's `summarizeFieldCoverage`, which is the single
+ * implementation of ADR-034's rule (leaves only, on each leaf's own flag). It
+ * used to count top-level fields only, which disagreed with `satsuma coverage`
+ * on any schema with nested records: a twelve-field `address` record counted as
+ * one unit, so one mapped leaf read as a fully covered record. A user with the
+ * extension open beside a terminal saw two percentages for one mapping and could
+ * not tell which was wrong (3cc-t6uo). ADR-036's tier split would have made that
+ * two disagreements rather than one, which is why this is reconciled here rather
+ * than carried.
+ *
+ * Returns undefined when the result has no target schema.
  */
 export function computeTargetCoverageStats(
   schemas: CoverageSchema[],
 ): TargetCoverageStats | undefined {
   const target = schemas.find((s) => s.role === "target");
   if (!target) return undefined;
-  const topLevel = target.fields.filter((f) => !f.path.includes("."));
-  const mapped = topLevel.filter((f) => f.mapped).length;
-  const total = topLevel.length;
-  return { mapped, total, pct: total > 0 ? Math.round((mapped / total) * 100) : 0 };
+  const totals = summarizeFieldCoverage(target.fields);
+  return {
+    mapped: totals.covered,
+    total: totals.total,
+    pct: totals.pct,
+    mappedNl: totals.coveredNl,
+  };
 }

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -164,9 +164,13 @@ export function registerCoverageCommand(
       const stats = computeTargetCoverageStats(coverageResult.schemas);
       if (stats && coverageBar) {
         coverageBar.text = `$(check) Coverage: ${stats.pct}%`;
+        // The tier split goes in the tooltip rather than the bar: the bar has to
+        // stay short, but a reviewer deciding whether the spec is done needs to
+        // know how much of that figure is inferred from prose (ADR-036).
+        const viaNl = stats.mappedNl > 0 ? ` (${stats.mappedNl} via @ref)` : "";
         coverageBar.tooltip =
           `${stats.mapped}/${stats.total} target fields mapped by ` +
-          `'${mappingName}' — click to clear coverage icons`;
+          `'${mappingName}'${viaNl} — click to clear coverage icons`;
         coverageBar.show();
       }
     }),

--- a/tooling/vscode-satsuma/test/coverage-logic.test.js
+++ b/tooling/vscode-satsuma/test/coverage-logic.test.js
@@ -28,11 +28,13 @@ function sampleSchemas() {
       schemaId: "dim_customer",
       role: "target",
       fields: [
-        { path: "customer_id", uri: "file:///ws/tgt.stm", line: 5, mapped: true },
+        { path: "customer_id", uri: "file:///ws/tgt.stm", line: 5, mapped: true, tier: "declared" },
         { path: "segment", uri: "file:///ws/tgt.stm", line: 6, mapped: false },
-        // Nested path: must appear as a marker but not count toward the
-        // status-bar percentage (its parent already counts).
-        { path: "address.city", uri: "file:///ws/tgt.stm", line: 7, mapped: true },
+        // `address` is a record — structure, not data — so ADR-034 counts its
+        // leaf and not the record itself. Three leaf-bearing entries here yield
+        // a denominator of 3: customer_id, segment, address.city.
+        { path: "address", uri: "file:///ws/tgt.stm", line: 7, mapped: true, tier: "nl" },
+        { path: "address.city", uri: "file:///ws/tgt.stm", line: 8, mapped: true, tier: "nl" },
       ],
     },
   ];
@@ -49,7 +51,10 @@ describe("groupCoverageByUri", () => {
     ]);
     assert.equal(byUri.get("file:///ws/src.stm").mapped.length, 1);
     assert.equal(byUri.get("file:///ws/src.stm").unmapped.length, 1);
-    assert.equal(byUri.get("file:///ws/tgt.stm").mapped.length, 2);
+    // Three mapped entries in tgt.stm: customer_id, the `address` record and
+    // address.city. The gutter marks every entry, records included — unlike the
+    // percentage, which counts leaves only.
+    assert.equal(byUri.get("file:///ws/tgt.stm").mapped.length, 3);
   });
 
   it("labels hovers by schema role: source usage vs target mapping", () => {
@@ -72,11 +77,30 @@ describe("groupCoverageByUri", () => {
 });
 
 describe("computeTargetCoverageStats", () => {
-  it("counts only top-level target fields toward the percentage", () => {
-    // address.city is nested: counting it would report 2/3 mapped instead of
-    // the 1/2 the user sees at the schema's top level.
+  it("counts leaves, agreeing with satsuma coverage rather than its own rule", () => {
+    // 3cc-t6uo: this counted top-level fields only, so it reported 1/2 (50%)
+    // where `satsuma coverage` reported 2/3 (67%) for the same mapping — a
+    // twelve-field `address` record counted as one unit, and one mapped leaf read
+    // as a fully covered record. Two percentages for one mapping, and a user with
+    // the terminal open beside the editor could not tell which was wrong. The
+    // count now comes from core's summarizeFieldCoverage.
     const stats = computeTargetCoverageStats(sampleSchemas());
-    assert.deepEqual(stats, { mapped: 1, total: 2, pct: 50 });
+    assert.deepEqual(stats, { mapped: 2, total: 3, pct: 67, mappedNl: 1 });
+  });
+
+  it("reports how much of the figure is inferred from prose", () => {
+    // ADR-036 would have turned one disagreement into two. The status bar carries
+    // the tier split so a reviewer can tell declared coverage from an @ref.
+    const declaredOnly = [
+      {
+        schemaId: "t", role: "target",
+        fields: [{ path: "a", uri: "file:///t.stm", line: 1, mapped: true, tier: "declared" }],
+      },
+    ];
+    assert.deepEqual(
+      computeTargetCoverageStats(declaredOnly),
+      { mapped: 1, total: 1, pct: 100, mappedNl: 0 },
+    );
   });
 
   it("returns undefined when the result has no target schema", () => {
@@ -90,6 +114,6 @@ describe("computeTargetCoverageStats", () => {
     const stats = computeTargetCoverageStats([
       { schemaId: "empty", role: "target", fields: [] },
     ]);
-    assert.deepEqual(stats, { mapped: 0, total: 0, pct: 0 });
+    assert.deepEqual(stats, { mapped: 0, total: 0, pct: 0, mappedNl: 0 });
   });
 });


### PR DESCRIPTION
Closes `sl-qxyl` (P1) and `3cc-t6uo` (P2). Implements **ADR-036**.

> **Stacked on #412.** Base is `feat/sl-vu22-derive-from-extraction`, not `main`,
> because `sl-qxyl`'s own note says to sequence it *after* the walker swap so the
> NL tier is added to one producer rather than to a walker about to be deleted.
> Merge #412 first; GitHub will retarget this to `main`. Review this PR's own
> commit (`a3b6a9b`) — the diff shown includes #412's until then.

## What changed

Coverage treated a field referenced only by a resolved NL `@ref` as uncovered,
contradicting ADR-013 — which binds *all* lineage-aware tools to follow a resolved
`@ref` with the same weight as a declared source field, and which `arrows`,
`graph`, `lineage`, `field-lineage` and `lint` all honour. Coverage alone dissented.

A resolved `@ref` now counts, as a **distinct tier over one denominator**:

```text
  source  legacy_sqlserver    21/21  100%  (15 declared, 6 nl)
```

`covered = covered_declared + covered_nl`; a field covered both ways is reported as
declared. **ADR-034's denominator is untouched** — leaves only, on each leaf's own
flag. This splits the numerator, nothing else.

Only *resolved* refs count, so coverage cannot rise when a spec breaks. A ref in a
`source {}` join or filter counts toward **source** coverage only — it names no
target field.

## Why `sl-joeq` made this small

A resolved ref's `resolvedTo.name` is a canonical `::schema.field` path — exactly
what `schemaLocalFieldPath` consumes — so NL paths resolve per schema through the
same step arrow paths already do. Two additions were needed:

- `schemaRefPrefixes` gains the `::name` form, without which a *global* schema's NL
  coverage could never match.
- `findMappingBlock` returns the namespace-qualified mapping key, so refs match the
  key `resolveAllNLRefs` files them under. Matching on the bare label would credit
  two same-named mappings in different namespaces with each other's refs.

## Consumers

- **CLI** — human output shows the split only on rows that *have* NL coverage
  (annotating every row of every structural-only report with `(n declared, 0 nl)`
  is a column of noise); `--json` always carries both counts plus a per-field
  `tier`. This deviates from the illustrative output in the ticket, which showed
  `(2 declared, 0 nl)` — say the word and I'll make it unconditional.
- **`fields --unmapped-by`** feeds core the same refs, so the `sl-oqsj` lock holds.
- **LSP gutter** feeds core the same refs too, via a new `DefinitionLookup` built
  from the workspace index (schemas, cross-file) plus `extractMappings` on the
  current tree (mapping context). Without this the editor would show fields as
  unmapped that the CLI reports as covered — a *new* disagreement this change would
  otherwise have introduced.
- **`3cc-t6uo` fixed, not re-scoped.** The status bar stops counting top-level
  fields itself and delegates to `summarizeFieldCoverage`; ADR-036 requires
  reconciling a consumer with its own rule, since the tier split would have made
  that two disagreements instead of one. Its tooltip reports the `@ref` share.

## Corpus effect

17 example files gain NL-tier coverage. The ones that matter are the schemas that
read **0%** and now report real figures — `order_transactions` 0→6,
`support_tickets` 0→5, `finance_transactions` 0→3, `crm_system` 0→2,
`hr_employees` 0→2, `sat_contact_details` 0→4. Those were being listed under
"covered by no mapping", which the docs call the claim worth acting on.

`CHANGELOG.md` says so plainly: percentages rise, so `--fail-under` thresholds
weaken rather than failing loudly — the unsafe direction for a gate.

## Tests

8 new core cases covering every AC bullet: NL-only, both-ways (once, declared),
unresolved (not counted), a ref naming a schema rather than a field, `source_block`
toward source, `source_block` never toward target, nested path not bare leaf, and
inside an `each`. Plus a real-corpus integration test on `db-to-db` asserting the
15/6 split and per-field tiers.

core 514, cli 972, lsp 292, viz 98, viz-backend 166, viz-model 6, vscode 34,
tree-sitter 315/315, `npm run lint` clean.

## Docs

All five sites the ticket names, plus two more: feature 35 and 38 PRD out-of-scope
bullets (struck through *with the reason*), the `coverage.ts` module comment,
`coverage --help`, `SATSUMA-CLI.md` :126 (rewritten), :324, :390 — the "needs no NL
interpretation" positioning restated as *resolution is not interpretation* rather
than deleted — and the JSON contract block, which a CLI test enforces key-for-key.

## Not done

`satsuma-viz`'s own `buildMappedFieldsIndex` still derives coverage from the viz
model, so the overlay does not yet show the tier. That is feature 36's R3/R6 work
(`sl-hcan`, `sl-5nsv`), not this ticket. Viz Playwright harness not run — needs a
human-launched browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)