### PR TITLE
fix(ci): stop the release gate publishing a second Semgrep SARIF config (sl-1wtv)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
   security:
     name: Security gate
     uses: ./.github/workflows/security.yml
+    with:
+      # Gate only. The push-triggered run of Security already publishes this
+      # commit's SARIF; uploading again from here would register a second code
+      # scanning configuration that exists on main but never on a PR, which
+      # makes the "Semgrep OSS" PR check skip instead of gate (sl-1wtv).
+      skip_sarif_upload: true
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
     branches: [main]
   workflow_call: # Allow release.yml to invoke this as a gate
+    inputs:
+      skip_sarif_upload:
+        # GitHub derives a code scanning "configuration" from the CALLING
+        # workflow file plus the job id, so a run invoked from release.yml
+        # publishes its SARIF as `.github/workflows/release.yml:semgrep` — a
+        # second configuration that only ever exists on main. Pull requests run
+        # this workflow directly, so that configuration has no counterpart on
+        # the PR and code scanning gives up on diffing: the "Semgrep OSS" check
+        # reports "1 configuration not found" and skips instead of gating.
+        # Callers must therefore opt out of the upload; the push-triggered run
+        # of this same workflow already publishes the results for that commit.
+        # See sl-1wtv.
+        description: "Run the scan as a gate only, without publishing SARIF to code scanning"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -88,8 +103,13 @@ jobs:
             --severity WARNING \
             $EXCLUDE_ARGS
 
+      # Publishing to code scanning is skipped for callers that only want the
+      # gate (see the `skip_sarif_upload` input) — re-scanning to produce a
+      # SARIF nobody consumes just doubles the job's runtime.
+      # `inputs` is empty for push and pull_request events, so the negation is
+      # true there and both steps run as normal.
       - name: Generate SARIF
-        if: always()
+        if: always() && !inputs.skip_sarif_upload
         shell: bash
         run: |
           semgrep scan \
@@ -98,8 +118,11 @@ jobs:
             --severity WARNING \
             --sarif --sarif-output semgrep-results.sarif || true
 
+      # No explicit `category` here: the default, `.github/workflows/security.yml:semgrep`,
+      # is the configuration the repo's existing code scanning alert history is
+      # filed under. Changing it would orphan those alerts.
       - name: Upload SARIF
-        if: always()
+        if: always() && !inputs.skip_sarif_upload
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: semgrep-results.sarif

--- a/.tickets/sl-1wtv.md
+++ b/.tickets/sl-1wtv.md
@@ -1,0 +1,25 @@
+---
+id: sl-1wtv
+status: in_progress
+deps: []
+links: []
+created: 2026-08-02T06:23:57Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [ci, security]
+---
+# Semgrep OSS PR check reports 'configuration not found' and never gates PRs
+
+The 'Semgrep OSS' code-scanning check on every PR reports neutral ('skipping', '1 configuration not found') instead of gating. Cause: release.yml calls security.yml via workflow_call on pushes to main, so main's code-scanning baseline gains a second configuration, .github/workflows/release.yml:semgrep, alongside .github/workflows/security.yml:semgrep. github/codeql-action/upload-sarif derives the analysis category from the CALLING workflow file, not the workflow that owns the job. PRs only run security.yml directly, so the release.yml configuration has no counterpart on the PR and GitHub cannot diff alerts.
+
+## Acceptance Criteria
+
+1. On a push to main, exactly one Semgrep code-scanning configuration is written. 2. The 'Semgrep OSS' check on a PR reports a real conclusion, not 'skipping / configuration not found'. 3. docs/developer/CI-WORKFLOWS.md explains why the release-invoked security gate does not publish SARIF.
+
+
+## Notes
+
+**2026-08-02T06:25:46Z**
+
+Confirmed via the code scanning API: refs/heads/main carries two Semgrep analyses per push — analysis_key '.github/workflows/security.yml:semgrep' (from the push trigger) and '.github/workflows/release.yml:semgrep' (from release.yml's workflow_call), both 19 results at the same commit. PR check run 91464141061 is conclusion=neutral, output.title '1 configuration not found', naming '.github/workflows/release.yml:semgrep'. Semgrep itself was always running and passing; only the code-scanning diff was broken.

--- a/docs/developer/CI-WORKFLOWS.md
+++ b/docs/developer/CI-WORKFLOWS.md
@@ -263,6 +263,24 @@ Runs Semgrep SAST in a container using the `auto` ruleset at `ERROR` and
 scanning dashboard (requires GitHub Advanced Security). Allowlisted rule IDs
 are excluded via `--exclude-rule` flags.
 
+##### Why the release gate does not upload SARIF
+
+GitHub identifies a code scanning **configuration** by the calling workflow file
+plus the job id, not by the workflow that defines the job. When Release invokes
+this workflow, the upload would therefore land under
+`.github/workflows/release.yml:semgrep` rather than
+`.github/workflows/security.yml:semgrep`.
+
+Because Release only runs on pushes to `main`, that second configuration would
+exist on the default branch but never on a pull request. Code scanning cannot
+diff a PR against a baseline configuration the PR does not produce, so it gives
+up: the **Semgrep OSS** check reports `1 configuration not found` and resolves as
+_neutral_ — visible in the PR checks list as `skipping`, gating nothing.
+
+Release therefore passes `skip_sarif_upload: true` and uses the workflow purely
+as a gate. The push-triggered Security run publishes the SARIF for that same
+commit, so exactly one configuration is ever written to `main`. See sl-1wtv.
+
 ---
 
 ## Deploy Site Workflow


### PR DESCRIPTION
## Problem

The **Semgrep OSS** check on every PR resolves as _neutral_ — `1 configuration not found`, rendered in the checks list as `skipping`. It gates nothing.

Semgrep itself was never broken: the `Semgrep SAST` job runs, scans 1798 files, and passes. What was broken is GitHub's code-scanning **diff** for the PR.

## Cause

`release.yml` invokes `security.yml` via `workflow_call` on pushes to `main`. `github/codeql-action/upload-sarif` derives the code scanning *configuration* from the **calling** workflow file plus the job id — not from the workflow that owns the job. So a push to `main` writes two analyses for the same commit:

```
.github/workflows/security.yml:semgrep   <- the push trigger
.github/workflows/release.yml:semgrep    <- release.yml's workflow_call
```

Confirmed on the live API — both at commit `939d180`, both 19 results, seconds apart:

```
$ gh api repos/EqualExperts/satsuma-lang/code-scanning/analyses
{"ref":"refs/heads/main","analysis_key":".github/workflows/release.yml:semgrep", "results_count":19, ...}
{"ref":"refs/heads/main","analysis_key":".github/workflows/security.yml:semgrep","results_count":19, ...}
```

A PR only runs `security.yml` directly, so the `release.yml` configuration has no counterpart on the PR head. Code scanning cannot diff against a baseline configuration the PR does not reproduce, so it declines to report:

> **Warning**: Code scanning cannot determine the alerts introduced by this pull request, because 1 configuration present on `refs/heads/main` was not found:
> ### Actions workflow (`release.yml`)
> * `.github/workflows/release.yml:semgrep`

The `release.yml` in the tree contains no `semgrep` job, which is why grepping for one finds nothing — the name is synthesised from the caller.

## Fix

`security.yml` gains a `skip_sarif_upload` workflow_call input; `release.yml` passes `true` and uses the workflow purely as a gate. The push-triggered Security run still publishes that commit's SARIF, so exactly one configuration reaches `main`.

The flag is phrased as *skip* rather than *upload* deliberately: for `push` and `pull_request` events the `inputs` context is empty, so `!inputs.skip_sarif_upload` is true and those runs upload as before. An `upload_sarif: true` default would have evaluated falsy and silently disabled the upload everywhere.

No explicit `category:` is set — the default `.github/workflows/security.yml:semgrep` is the configuration the repo's existing alert history is filed under, and changing it would orphan those alerts.

Skipping the upload also skips the redundant second full scan that only existed to produce the SARIF, cutting roughly 25s off every release run.

## Follow-up needed (not in this PR)

The stale `.github/workflows/release.yml:semgrep` analyses already recorded against `main` will keep the warning alive until they are deleted, since GitHub still lists that configuration as present on the baseline. Clearing it means deleting those analyses via `DELETE /repos/{owner}/{repo}/code-scanning/analyses/{id}?confirm_delete`, or via the code scanning **Tool configurations** UI. That destroys data on GitHub, so it is left for @thorbenlouw to approve rather than done here. The duplicated alerts carry no unique findings — they are byte-identical to the `security.yml:semgrep` set.

## Verification

- `yamllint .github/workflows/security.yml .github/workflows/release.yml` — clean
- Parsed both files and asserted the wiring: input declared with `default: false`, both SARIF steps guarded by `always() && !inputs.skip_sarif_upload`, `release.yml` passing `skip_sarif_upload: true`
- Full pre-commit suite green

The real proof is post-merge: the next PR's **Semgrep OSS** check should report a conclusion instead of `skipping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)