### PR TITLE
chore(lint): adopt Prettier + ruff format as formatting gates (pfg-9dk8)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; [ -z \"$f\" ] && exit 0; case \"$f\" in *.ts|*.mts|*.cts|*.js|*.mjs|*.cjs) npx prettier --write --ignore-unknown \"$f\" ;; *.py) ruff format \"$f\" ;; esac; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Formatting (prettier/ruff)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# Commits to skip in git blame — bulk mechanical changes with no semantic
+# content. Point blame past them with:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# (documented as a setup step in docs/developer/AGENT-CONTRIBUTIONS.md)
+
+# Repo-wide Prettier (printWidth 100) + ruff format adoption reformat (pfg-9dk8)
+9605b252268cc35741d55205433b0840f707fdfb

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,32 @@
+# Prettier ignore list (pfg-9dk8).
+#
+# Mirrors the `ignores` block in eslint.config.mjs: generated or tool-managed
+# surfaces are not ours to format. Prettier is scoped to JS/TS via the glob in
+# the lint:js script, so markdown/YAML/JSON are untouched (they have their own
+# linters: markdownlint-cli2 and yamllint).
+
+# Dependencies and worktrees
+node_modules/
+.worktrees/
+
+# Agent/tool state
+.claude/
+.tickets/
+
+# Local scratch space (gitignored)
+tmp/
+
+# Generated parser artifacts (tree-sitter output, not hand-written)
+tooling/tree-sitter-satsuma/src/
+tooling/tree-sitter-satsuma/bindings/
+tooling/satsuma-cli/src/generated/
+
+# Build output
+build/
+dist/
+
+# Minified or vendored site assets
+*.min.js
+site/js/tailwind.js
+site/_site/
+site/playground/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+# Prettier configuration for JS/TS formatting (pfg-9dk8).
+#
+# printWidth 100 was measured against the existing codebase, not taken as a
+# default: at Prettier's default 80 the largest files fight the prevailing
+# style badly (elk-layout.ts alone reformats 354 lines at 80 vs 184 at 100),
+# while 120 is too wide for this repo's prose-heavy doc-comments (CLAUDE.md
+# mandates module, function, and type comments everywhere, so lines are
+# comment-dense). 100 is the best fit for how the code is already written.
+#
+# Everything else is Prettier defaults — the prevailing style already matches
+# them (double quotes, semicolons, trailing commas).
+printWidth: 100

--- a/.tickets/pfg-9dk8.md
+++ b/.tickets/pfg-9dk8.md
@@ -1,6 +1,6 @@
 ---
 id: pfg-9dk8
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-08-01T21:39:42Z

--- a/.tickets/pfg-9dk8.md
+++ b/.tickets/pfg-9dk8.md
@@ -1,6 +1,6 @@
 ---
 id: pfg-9dk8
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-01T21:39:42Z
@@ -37,3 +37,10 @@ The repo-wide reformat lands as its own commit containing no other change; its S
 
 Every package's test suite passes after the reformat (the reformat must be behaviour-neutral), and all existing CI checks stay green.
 
+
+## Notes
+
+**2026-08-02T06:30:34Z**
+
+Cause: JS/TS had no formatting gate (ESLint 10 ships no formatting rules) and lint:python never ran ruff format --check.
+Fix: prettier pinned at root with printWidth 100 (.prettierrc documents the measurement) and .prettierignore mirroring eslint's ignores (commit eedb8e4); isolated repo-wide reformat of 230 files (commit 4041154, recorded in .git-blame-ignore-revs — three lit html-template files needed a second prettier pass to reach the fixed point); gates wired into lint:js (prettier --check) and lint:python (ruff format --check) so CI Lint and the pre-commit hook both enforce them, plus npm run format and a Claude Code PostToolUse format-on-edit hook in .claude/settings.json for a tight loop. blame.ignoreRevsFile documented in AGENT-CONTRIBUTIONS.md. Verified by deliberate misformat: npm run lint rejected it, passed after restore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Prettier and `ruff format` are now formatting gates (`pfg-9dk8`)
+
+JS/TS had no formatting gate at all (ESLint 10 ships no formatting rules) and
+Python ran `ruff check` but never `ruff format --check`. Both holes are closed:
+`npm run lint:js` now runs `prettier --check` (printWidth 100, otherwise
+defaults) and `npm run lint:python` runs `ruff format --check`, so the Lint CI
+job and the pre-commit hook both reject unformatted code. `npm run format`
+fixes everything in one shot, and a `PostToolUse` hook in
+`.claude/settings.json` gives Claude Code agents format-on-edit so the gate
+should rarely fire. The one-off repo-wide reformat (230 files) is isolated in
+its own commit and recorded in `.git-blame-ignore-revs` — run
+`git config blame.ignoreRevsFile .git-blame-ignore-revs` once per clone to
+keep `git blame` useful (see AGENT-CONTRIBUTIONS.md).
+
 ### Viz arrow counts and the detail table no longer drop `nested_arrow` blocks (`svdfe-s6we`)
 
 Mappings using the braced `src -> tgt { .a -> .b }` form were undercounted:

--- a/docs/developer/AGENT-CONTRIBUTIONS.md
+++ b/docs/developer/AGENT-CONTRIBUTIONS.md
@@ -83,6 +83,27 @@ List active worktrees:
 git worktree list
 ```
 
+## Formatting and git blame
+
+JS/TS is formatted with Prettier (`.prettierrc`, printWidth 100) and Python with
+`ruff format`. Both are enforced by `npm run lint` (and therefore by the
+pre-commit hook and the Lint CI job). To fix formatting locally:
+
+```bash
+npm run format
+```
+
+The one-off repo-wide adoption reformat is recorded in `.git-blame-ignore-revs`
+so it does not pollute `git blame`. Configure git to use it (once per clone):
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+Agents working in Claude Code get format-on-edit automatically via the
+`PostToolUse` hook in `.claude/settings.json`, which runs `prettier --write` /
+`ruff format` on each edited file — the commit gate should rarely fire.
+
 ## Branch Naming
 
 | Scope | Pattern | Example |
@@ -145,6 +166,7 @@ Before starting work:
 - [ ] Create a worktree: `git worktree add .worktrees/<branch> -b <branch>`
 - [ ] `cd` into the worktree
 - [ ] Run `npm run install:all` to install deps, build WASM, and compile LSP server
+- [ ] Configure blame to skip bulk reformats: `git config blame.ignoreRevsFile .git-blame-ignore-revs`
 
 Before opening a PR:
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,7 +54,7 @@ export default [
       },
     },
     rules: {
-      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
   {
@@ -78,13 +78,13 @@ export default [
       },
     },
     rules: {
-      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
   {
     files: ["tooling/tree-sitter-satsuma/grammar.js"],
     rules: {
-      "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
   // TypeScript test files and the viz harness package (satsuma-cli tests, viz-harness
@@ -93,19 +93,16 @@ export default [
   // they are migrated to include test files in their tsconfigs.
   ...tseslint.configs.recommended.map((config) => ({
     ...config,
-    files: [
-      "tooling/satsuma-cli/test/**/*.ts",
-      "tooling/satsuma-viz-harness/**/*.ts",
-    ],
+    files: ["tooling/satsuma-cli/test/**/*.ts", "tooling/satsuma-viz-harness/**/*.ts"],
   })),
   {
-    files: [
-      "tooling/satsuma-cli/test/**/*.ts",
-      "tooling/satsuma-viz-harness/**/*.ts",
-    ],
+    files: ["tooling/satsuma-cli/test/**/*.ts", "tooling/satsuma-viz-harness/**/*.ts"],
     rules: {
       // Align with the JS convention used throughout the repo
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       // Non-null assertions require targeted inline suppression with a safety justification
       "@typescript-eslint/no-non-null-assertion": "error",
     },
@@ -139,7 +136,10 @@ export default [
       },
     },
     rules: {
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "@typescript-eslint/no-non-null-assertion": "error",
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "eslint": "^10.8.0",
         "globals": "^17.8.0",
         "markdownlint-cli2": "^0.23.2",
+        "prettier": "^3.9.6",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
       }
@@ -2180,6 +2181,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "ci:all": "npm ci && npm ci --prefix tooling/satsuma-core && npm ci --prefix tooling/satsuma-viz-model && npm ci --prefix tooling/satsuma-viz-backend && npm ci --prefix tooling/tree-sitter-satsuma && npm ci --ignore-scripts --prefix tooling/satsuma-cli && npm ci --prefix tooling/satsuma-viz && npm ci --prefix tooling/satsuma-viz-harness && npm ci --prefix tooling/satsuma-lsp && npm ci --prefix tooling/vscode-satsuma",
     "reinstall": "npm run clean:all && npm run install:all",
     "lint": "npm run lint:js && npm run lint:md && npm run lint:yaml && npm run lint:python",
-    "lint:js": "eslint .",
+    "lint:js": "eslint . && prettier --check \"**/*.{ts,mts,cts,js,mjs,cjs}\"",
     "lint:md": "markdownlint-cli2",
     "lint:yaml": "yamllint .github/workflows/",
-    "lint:python": "ruff check scripts/ tooling/tree-sitter-satsuma/scripts/ skills/ smoke-tests/",
+    "lint:python": "ruff check scripts/ tooling/tree-sitter-satsuma/scripts/ skills/ smoke-tests/ && ruff format --check scripts/ tooling/tree-sitter-satsuma/scripts/ skills/ smoke-tests/",
+    "format": "prettier --write \"**/*.{ts,mts,cts,js,mjs,cjs}\" && ruff format scripts/ tooling/tree-sitter-satsuma/scripts/ skills/ smoke-tests/",
     "test:coverage": "npm --prefix tooling/satsuma-core run test:coverage && npm --prefix tooling/satsuma-viz-model run test:coverage && npm --prefix tooling/satsuma-viz-backend run test:coverage && npm --prefix tooling/satsuma-viz run test:coverage && npm --prefix tooling/satsuma-lsp run test:coverage && npm --prefix tooling/satsuma-cli run test:coverage"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint": "^10.8.0",
     "globals": "^17.8.0",
     "markdownlint-cli2": "^0.23.2",
+    "prettier": "^3.9.6",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
   }

--- a/scripts/generate-diary-manifest.py
+++ b/scripts/generate-diary-manifest.py
@@ -39,15 +39,19 @@ for root, dirs, files in os.walk("site/satsuma-diaries"):
         with open(entry_json_path, "w", encoding="utf-8") as fp:
             json.dump({"date": date, "title": title, "markdown": markdown}, fp)
 
-        entries.append({
-            "date": date,
-            "title": title,
-            "contentPath": f"satsuma-diaries/content/{date}.json",
-        })
+        entries.append(
+            {
+                "date": date,
+                "title": title,
+                "contentPath": f"satsuma-diaries/content/{date}.json",
+            }
+        )
 
 entries.sort(key=lambda x: x["date"], reverse=True)
 
 with open("site/_data/diaries.json", "w", encoding="utf-8") as f:
     json.dump(entries, f, indent=2)
 
-print(f"Diary manifest: {len(entries)} entries written; content JSON files in {content_dir}/")
+print(
+    f"Diary manifest: {len(entries)} entries written; content JSON files in {content_dir}/"
+)

--- a/scripts/parse-security-allowlist.py
+++ b/scripts/parse-security-allowlist.py
@@ -35,5 +35,6 @@ def main():
 
     print(",".join(ids))
 
+
 if __name__ == "__main__":
     main()

--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -1,4 +1,4 @@
-module.exports = function(eleventyConfig) {
+module.exports = function (eleventyConfig) {
   // Ignore non-page files
   eleventyConfig.ignores.add("SITE-DEV.md");
   // Diary markdown sources are not templates — ignore so Eleventy doesn't try
@@ -23,15 +23,17 @@ module.exports = function(eleventyConfig) {
   // Returns [{label: "March 2026", entries: [...]}, ...] so the template
   // can iterate over groups without needing variable mutation inside loops,
   // which Nunjucks doesn't support cleanly.
-  eleventyConfig.addFilter("groupByMonth", function(entries) {
+  eleventyConfig.addFilter("groupByMonth", function (entries) {
     const groups = [];
     let current = null;
-    for (const entry of (entries || [])) {
+    for (const entry of entries || []) {
       const ym = entry.date.slice(0, 7); // "2026-03"
       if (!current || current.yearMonth !== ym) {
         const [year, month] = ym.split("-");
-        const label = new Date(parseInt(year), parseInt(month) - 1, 1)
-          .toLocaleDateString("en-GB", { month: "long", year: "numeric" });
+        const label = new Date(parseInt(year), parseInt(month) - 1, 1).toLocaleDateString("en-GB", {
+          month: "long",
+          year: "numeric",
+        });
         current = { yearMonth: ym, label, entries: [] };
         groups.push(current);
       }
@@ -41,9 +43,11 @@ module.exports = function(eleventyConfig) {
   });
 
   // Format "2026-03-29" → "29 Mar" for diary sidebar entry labels
-  eleventyConfig.addFilter("formatDiaryDate", function(dateStr) {
-    return new Date(dateStr + "T12:00:00Z")
-      .toLocaleDateString("en-GB", { day: "numeric", month: "short" });
+  eleventyConfig.addFilter("formatDiaryDate", function (dateStr) {
+    return new Date(dateStr + "T12:00:00Z").toLocaleDateString("en-GB", {
+      day: "numeric",
+      month: "short",
+    });
   });
 
   return {
@@ -52,9 +56,9 @@ module.exports = function(eleventyConfig) {
       output: "_site",
       includes: "_includes",
       layouts: "_layouts",
-      data: "_data"
+      data: "_data",
     },
     htmlTemplateEngine: "njk",
-    markdownTemplateEngine: "njk"
+    markdownTemplateEngine: "njk",
   };
 };

--- a/site/js/diaries.js
+++ b/site/js/diaries.js
@@ -11,10 +11,10 @@
   "use strict";
 
   const entryButtons = document.querySelectorAll(".diary-entry-btn");
-  const contentEl    = document.getElementById("diary-content");
-  const loadingEl    = document.getElementById("diary-loading");
-  const errorEl      = document.getElementById("diary-error");
-  const emptyEl      = document.getElementById("diary-empty");
+  const contentEl = document.getElementById("diary-content");
+  const loadingEl = document.getElementById("diary-loading");
+  const errorEl = document.getElementById("diary-error");
+  const emptyEl = document.getElementById("diary-empty");
 
   if (!entryButtons.length || !contentEl) return;
 
@@ -23,16 +23,16 @@
   function showState(state) {
     contentEl.classList.toggle("hidden", state !== "content");
     loadingEl.classList.toggle("hidden", state !== "loading");
-    errorEl.classList.toggle("hidden",   state !== "error");
-    emptyEl.classList.toggle("hidden",   state !== "empty");
+    errorEl.classList.toggle("hidden", state !== "error");
+    emptyEl.classList.toggle("hidden", state !== "empty");
   }
 
   function setActiveButton(date) {
     entryButtons.forEach(function (btn) {
       const isActive = btn.dataset.date === date;
-      btn.classList.toggle("bg-peach",          isActive);
-      btn.classList.toggle("text-orange-dark",   isActive);
-      btn.classList.toggle("font-semibold",      isActive);
+      btn.classList.toggle("bg-peach", isActive);
+      btn.classList.toggle("text-orange-dark", isActive);
+      btn.classList.toggle("font-semibold", isActive);
     });
   }
 
@@ -72,7 +72,9 @@
   // Load from URL hash on page open, or default to the first (most recent) entry
   const hashDate = window.location.hash.replace("#", "");
   const target = hashDate
-    ? Array.from(entryButtons).find(function (b) { return b.dataset.date === hashDate; })
+    ? Array.from(entryButtons).find(function (b) {
+        return b.dataset.date === hashDate;
+      })
     : entryButtons[0];
 
   if (target) {
@@ -80,4 +82,4 @@
   } else {
     showState("empty");
   }
-}());
+})();

--- a/site/js/main.js
+++ b/site/js/main.js
@@ -1,73 +1,80 @@
 // Mobile menu toggle
-document.addEventListener('DOMContentLoaded', () => {
-  const menuBtn = document.getElementById('menu-btn');
-  const mobileMenu = document.getElementById('mobile-menu');
+document.addEventListener("DOMContentLoaded", () => {
+  const menuBtn = document.getElementById("menu-btn");
+  const mobileMenu = document.getElementById("mobile-menu");
   if (menuBtn && mobileMenu) {
-    menuBtn.addEventListener('click', () => {
-      mobileMenu.classList.toggle('open');
-      const icon = menuBtn.querySelector('svg');
-      if (mobileMenu.classList.contains('open')) {
-        icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>';
+    menuBtn.addEventListener("click", () => {
+      mobileMenu.classList.toggle("open");
+      const icon = menuBtn.querySelector("svg");
+      if (mobileMenu.classList.contains("open")) {
+        icon.innerHTML =
+          '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>';
       } else {
-        icon.innerHTML = '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>';
+        icon.innerHTML =
+          '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>';
       }
     });
   }
 
   // Copy buttons
-  document.querySelectorAll('.copy-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const code = btn.closest('.code-block').querySelector('code').textContent;
+  document.querySelectorAll(".copy-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const code = btn.closest(".code-block").querySelector("code").textContent;
       navigator.clipboard.writeText(code).then(() => {
-        btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+        btn.textContent = "Copied!";
+        setTimeout(() => {
+          btn.textContent = "Copy";
+        }, 2000);
       });
     });
   });
 
   // Scroll reveal
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('visible');
-      }
-    });
-  }, { threshold: 0.1 });
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("visible");
+        }
+      });
+    },
+    { threshold: 0.1 },
+  );
 
-  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+  document.querySelectorAll(".reveal").forEach((el) => observer.observe(el));
 
   // Active nav link
-  const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-  document.querySelectorAll('.nav-link').forEach(link => {
-    const href = link.getAttribute('href');
-    if (href === currentPage || (currentPage === '' && href === 'index.html')) {
-      link.classList.add('active');
+  const currentPage = window.location.pathname.split("/").pop() || "index.html";
+  document.querySelectorAll(".nav-link").forEach((link) => {
+    const href = link.getAttribute("href");
+    if (href === currentPage || (currentPage === "" && href === "index.html")) {
+      link.classList.add("active");
     }
   });
 
   // Example expand/collapse
-  document.querySelectorAll('.example-toggle').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const content = btn.closest('.example-item').querySelector('.example-content');
-      const arrow = btn.querySelector('.arrow');
-      content.classList.toggle('open');
+  document.querySelectorAll(".example-toggle").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const content = btn.closest(".example-item").querySelector(".example-content");
+      const arrow = btn.querySelector(".arrow");
+      content.classList.toggle("open");
       if (arrow) {
-        arrow.style.transform = content.classList.contains('open') ? 'rotate(180deg)' : '';
+        arrow.style.transform = content.classList.contains("open") ? "rotate(180deg)" : "";
       }
     });
   });
 
   // Tab switching
-  document.querySelectorAll('[data-tab-group]').forEach(group => {
-    const btns = group.querySelectorAll('.tab-btn');
-    btns.forEach(btn => {
-      btn.addEventListener('click', () => {
+  document.querySelectorAll("[data-tab-group]").forEach((group) => {
+    const btns = group.querySelectorAll(".tab-btn");
+    btns.forEach((btn) => {
+      btn.addEventListener("click", () => {
         const target = btn.dataset.tab;
         const groupName = group.dataset.tabGroup;
-        btns.forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        document.querySelectorAll(`[data-tab-content="${groupName}"]`).forEach(panel => {
-          panel.style.display = panel.dataset.tabId === target ? '' : 'none';
+        btns.forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        document.querySelectorAll(`[data-tab-content="${groupName}"]`).forEach((panel) => {
+          panel.style.display = panel.dataset.tabId === target ? "" : "none";
         });
       });
     });

--- a/skills/excel-to-satsuma/scripts/excel_tool.py
+++ b/skills/excel-to-satsuma/scripts/excel_tool.py
@@ -30,6 +30,7 @@ MAX_OUTPUT_CHARS = 100_000
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+
 def open_workbook(path: str) -> openpyxl.Workbook:
     p = Path(path)
     if not p.exists():
@@ -105,10 +106,14 @@ def truncate_output(text: str) -> str:
     if len(text) <= MAX_OUTPUT_CHARS:
         return text
     truncated = text[:MAX_OUTPUT_CHARS]
-    return truncated + f"\n\n**WARNING**: Output truncated at {MAX_OUTPUT_CHARS:,} characters.\n"
+    return (
+        truncated
+        + f"\n\n**WARNING**: Output truncated at {MAX_OUTPUT_CHARS:,} characters.\n"
+    )
 
 
 # ── Subcommands ──────────────────────────────────────────────────────
+
 
 def cmd_survey(args: argparse.Namespace) -> str:
     """Survey workbook structure: tabs, row/col counts, previews."""
@@ -151,9 +156,7 @@ def cmd_survey(args: argparse.Namespace) -> str:
         if preview_rows > 0 and cols > 0:
             lines.append("")
             lines.append("**Preview (first 3 rows)**:\n")
-            headers = [
-                get_column_letter(c) for c in range(1, cols + 1)
-            ]
+            headers = [get_column_letter(c) for c in range(1, cols + 1)]
             table_rows = []
             for r in range(1, preview_rows + 1):
                 table_rows.append(
@@ -198,7 +201,9 @@ def cmd_headers(args: argparse.Namespace) -> str:
         )
         if non_empty_r2 > non_empty_r1:
             header_row = 2
-            lines.append(f"*Header row detected at row {header_row} (row 1 appears to be a title)*\n")
+            lines.append(
+                f"*Header row detected at row {header_row} (row 1 appears to be a title)*\n"
+            )
 
     # Column headers
     col_headers = []
@@ -216,8 +221,10 @@ def cmd_headers(args: argparse.Namespace) -> str:
     sample_end = min(sample_start + 4, rows)
     if sample_start <= rows:
         lines.append(f"**Sample rows** ({sample_start}-{sample_end}):\n")
-        headers = [cell_value(ws.cell(row=header_row, column=c)) or get_column_letter(c)
-                    for c in range(1, cols + 1)]
+        headers = [
+            cell_value(ws.cell(row=header_row, column=c)) or get_column_letter(c)
+            for c in range(1, cols + 1)
+        ]
         table_rows = []
         for r in range(sample_start, sample_end + 1):
             table_rows.append(
@@ -337,10 +344,7 @@ def cmd_formatting(args: argparse.Namespace) -> str:
         lines.append("")
 
     # Hidden rows
-    hidden_rows = [
-        r for r in range(1, rows + 1)
-        if ws.row_dimensions[r].hidden
-    ]
+    hidden_rows = [r for r in range(1, rows + 1) if ws.row_dimensions[r].hidden]
     if hidden_rows:
         if len(hidden_rows) <= 20:
             lines.append(f"**Hidden rows**: {', '.join(str(r) for r in hidden_rows)}")
@@ -350,7 +354,8 @@ def cmd_formatting(args: argparse.Namespace) -> str:
 
     # Hidden columns
     hidden_cols = [
-        get_column_letter(c) for c in range(1, cols + 1)
+        get_column_letter(c)
+        for c in range(1, cols + 1)
         if ws.column_dimensions[get_column_letter(c)].hidden
     ]
     if hidden_cols:
@@ -358,7 +363,9 @@ def cmd_formatting(args: argparse.Namespace) -> str:
         lines.append("")
 
     # Data validation rules
-    validations = list(ws.data_validations.dataValidation) if ws.data_validations else []
+    validations = (
+        list(ws.data_validations.dataValidation) if ws.data_validations else []
+    )
     if validations:
         lines.append(f"**Data validation rules**: {len(validations)}\n")
         for dv in validations[:10]:
@@ -369,14 +376,21 @@ def cmd_formatting(args: argparse.Namespace) -> str:
 
     # Row groupings (outline levels)
     grouped_rows = [
-        r for r in range(1, rows + 1)
+        r
+        for r in range(1, rows + 1)
         if ws.row_dimensions[r].outlineLevel and ws.row_dimensions[r].outlineLevel > 0
     ]
     if grouped_rows:
         lines.append(f"**Row groupings**: {len(grouped_rows)} rows with outline levels")
         lines.append("")
 
-    if not fill_counter and not font_styles and not cf_rules and not hidden_rows and not hidden_cols:
+    if (
+        not fill_counter
+        and not font_styles
+        and not cf_rules
+        and not hidden_rows
+        and not hidden_cols
+    ):
         lines.append("No notable formatting detected.")
 
     return truncate_output("\n".join(lines))
@@ -397,7 +411,10 @@ def cmd_range(args: argparse.Namespace) -> str:
             row_start = int(parts[0])
             row_end = int(parts[1])
         else:
-            print(f"Error: invalid row range '{args.rows}'. Use START:END.", file=sys.stderr)
+            print(
+                f"Error: invalid row range '{args.rows}'. Use START:END.",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
     # Parse column range
@@ -408,7 +425,9 @@ def cmd_range(args: argparse.Namespace) -> str:
             col_start = column_index_from_string(parts[0].upper())
             col_end = column_index_from_string(parts[1].upper())
         else:
-            print(f"Error: invalid column range '{args.cols}'. Use A:H.", file=sys.stderr)
+            print(
+                f"Error: invalid column range '{args.cols}'. Use A:H.", file=sys.stderr
+            )
             sys.exit(1)
 
     # Clamp
@@ -418,7 +437,9 @@ def cmd_range(args: argparse.Namespace) -> str:
     col_end = min(col_end, cols)
 
     lines: list[str] = []
-    lines.append(f"# Range: {args.tab} [rows {row_start}:{row_end}, cols {get_column_letter(col_start)}:{get_column_letter(col_end)}]\n")
+    lines.append(
+        f"# Range: {args.tab} [rows {row_start}:{row_end}, cols {get_column_letter(col_start)}:{get_column_letter(col_end)}]\n"
+    )
 
     # Use row 1 (or detected header row) as column headers
     headers = [
@@ -429,7 +450,10 @@ def cmd_range(args: argparse.Namespace) -> str:
     table_rows = []
     for r in range(row_start, row_end + 1):
         table_rows.append(
-            [cell_value(ws.cell(row=r, column=c)) for c in range(col_start, col_end + 1)]
+            [
+                cell_value(ws.cell(row=r, column=c))
+                for c in range(col_start, col_end + 1)
+            ]
         )
 
     lines.append(md_table(headers, table_rows))
@@ -479,6 +503,7 @@ def cmd_lookup(args: argparse.Namespace) -> str:
 
 # ── CLI ──────────────────────────────────────────────────────────────
 
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="excel_tool",
@@ -511,7 +536,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_lookup = sub.add_parser("lookup", help="Extract full lookup tab content")
     p_lookup.add_argument("file", help="Path to .xlsx file")
     p_lookup.add_argument("tab", help="Tab/sheet name")
-    p_lookup.add_argument("--max-rows", type=int, default=500, help="Max data rows (default 500)")
+    p_lookup.add_argument(
+        "--max-rows", type=int, default=500, help="Max data rows (default 500)"
+    )
 
     return parser
 

--- a/skills/excel-to-satsuma/scripts/test_excel_tool.py
+++ b/skills/excel-to-satsuma/scripts/test_excel_tool.py
@@ -25,6 +25,7 @@ def run(args: list[str]) -> subprocess.CompletedProcess:
 
 # ── survey ────────────────────────────────────────────────────────
 
+
 class TestSurvey:
     def test_single_tab(self):
         r = run(["survey", str(SIMPLE)])
@@ -36,8 +37,14 @@ class TestSurvey:
         r = run(["survey", str(MULTI)])
         assert r.returncode == 0
         assert "**Tabs**: 6" in r.stdout
-        for tab in ["Instructions", "Order Header Mapping", "Order Line Mapping",
-                     "Status Codes", "Priority Codes", "Changelog"]:
+        for tab in [
+            "Instructions",
+            "Order Header Mapping",
+            "Order Line Mapping",
+            "Status Codes",
+            "Priority Codes",
+            "Changelog",
+        ]:
             assert tab in r.stdout
 
     def test_preview_rows(self):
@@ -62,6 +69,7 @@ class TestSurvey:
 
 
 # ── headers ───────────────────────────────────────────────────────
+
 
 class TestHeaders:
     def test_simple(self):
@@ -95,6 +103,7 @@ class TestHeaders:
 
 # ── formatting ────────────────────────────────────────────────────
 
+
 class TestFormatting:
     def test_detects_fill_colours(self):
         r = run(["formatting", str(MULTI), "Order Header Mapping"])
@@ -114,6 +123,7 @@ class TestFormatting:
 
 # ── range ─────────────────────────────────────────────────────────
 
+
 class TestRange:
     def test_full_range(self):
         r = run(["range", str(SIMPLE), "Field Mapping"])
@@ -127,19 +137,40 @@ class TestRange:
         assert r.stdout.count("ORDER_ID") >= 1
 
     def test_col_range(self):
-        r = run(["range", str(MULTI), "Order Header Mapping", "--rows", "2:4", "--cols", "A:C"])
+        r = run(
+            [
+                "range",
+                str(MULTI),
+                "Order Header Mapping",
+                "--rows",
+                "2:4",
+                "--cols",
+                "A:C",
+            ]
+        )
         assert r.returncode == 0
         # Should only have 3 columns of data
         assert "ORDER_ID" in r.stdout
 
     def test_row_and_col_range(self):
-        r = run(["range", str(MULTI), "Order Header Mapping", "--rows", "2:3", "--cols", "A:E"])
+        r = run(
+            [
+                "range",
+                str(MULTI),
+                "Order Header Mapping",
+                "--rows",
+                "2:3",
+                "--cols",
+                "A:E",
+            ]
+        )
         assert r.returncode == 0
         assert "ORDER_ID" in r.stdout
         assert "CUST_ID" in r.stdout
 
 
 # ── lookup ────────────────────────────────────────────────────────
+
 
 class TestLookup:
     def test_status_codes(self):
@@ -164,6 +195,7 @@ class TestLookup:
 
 
 # ── integration: all 3 test spreadsheets ──────────────────────────
+
 
 class TestAllSpreadsheets:
     @pytest.mark.parametrize("xlsx", [SIMPLE, MULTI, HEALTH])

--- a/skills/satsuma-sample-data/SKILL.md
+++ b/skills/satsuma-sample-data/SKILL.md
@@ -241,6 +241,7 @@ with open(f"{schema_name}.sql", "w") as f:
 ```python
 import pyarrow as pa
 import pyarrow.parquet as pq
+
 table = pa.Table.from_pylist(rows)
 pq.write_table(table, f"{schema_name}.parquet")
 ```

--- a/skills/satsuma-sample-data/references/field-generators.md
+++ b/skills/satsuma-sample-data/references/field-generators.md
@@ -131,7 +131,10 @@ Always unique. For `(pk)` UUID fields, use `uuid4()` directly.
 
 ```python
 # Salesforce 18-char ID
-fake.lexify("001" + "?" * 15, letters="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+fake.lexify(
+    "001" + "?" * 15,
+    letters="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+)
 ```
 
 ### PICKLIST (Salesforce)
@@ -150,7 +153,7 @@ Generate as a nested dict:
 row["customer"] = {
     "customer_id": str(uuid.uuid4()),
     "email": fake.email(),
-    "tier": random.choice(["standard", "silver", "gold", "platinum"])
+    "tier": random.choice(["standard", "silver", "gold", "platinum"]),
 }
 ```
 
@@ -176,7 +179,7 @@ row["line_items"] = [
         "line_number": i + 1,
         "sku": fake.lexify("SKU-######"),
         "quantity": fake.random_int(1, 10),
-        "unit_price": round(random.uniform(1.0, 500.0), 2)
+        "unit_price": round(random.uniform(1.0, 500.0), 2),
     }
     for i in range(random.randint(1, 5))
 ]
@@ -207,7 +210,9 @@ values for testing filter logic.
 
 ```python
 # Positive values, realistic distribution
-round(random.lognormvariate(3, 1), 2)  # log-normal → right-skewed like real financial data
+round(
+    random.lognormvariate(3, 1), 2
+)  # log-normal → right-skewed like real financial data
 ```
 
 ### `(measure semi_additive)` — balances, inventory

--- a/skills/satsuma-to-excel/scripts/stm_to_excel.py
+++ b/skills/satsuma-to-excel/scripts/stm_to_excel.py
@@ -70,14 +70,28 @@ FONT_HYPERLINK = Font(name="Calibri", size=10, color="0563C1", underline="single
 # ── Fills ───────────────────────────────────────────────────────────────
 
 FILL_HEADER = PatternFill(start_color=HEADER_BG, end_color=HEADER_BG, fill_type="solid")
-FILL_ALT_EVEN = PatternFill(start_color=ALT_ROW_EVEN, end_color=ALT_ROW_EVEN, fill_type="solid")
-FILL_ALT_ODD = PatternFill(start_color=ALT_ROW_ODD, end_color=ALT_ROW_ODD, fill_type="solid")
-FILL_WARNING = PatternFill(start_color=WARNING_BG, end_color=WARNING_BG, fill_type="solid")
-FILL_QUESTION = PatternFill(start_color=QUESTION_BG, end_color=QUESTION_BG, fill_type="solid")
-FILL_COMPUTED = PatternFill(start_color=COMPUTED_BG, end_color=COMPUTED_BG, fill_type="solid")
+FILL_ALT_EVEN = PatternFill(
+    start_color=ALT_ROW_EVEN, end_color=ALT_ROW_EVEN, fill_type="solid"
+)
+FILL_ALT_ODD = PatternFill(
+    start_color=ALT_ROW_ODD, end_color=ALT_ROW_ODD, fill_type="solid"
+)
+FILL_WARNING = PatternFill(
+    start_color=WARNING_BG, end_color=WARNING_BG, fill_type="solid"
+)
+FILL_QUESTION = PatternFill(
+    start_color=QUESTION_BG, end_color=QUESTION_BG, fill_type="solid"
+)
+FILL_COMPUTED = PatternFill(
+    start_color=COMPUTED_BG, end_color=COMPUTED_BG, fill_type="solid"
+)
 FILL_PK = PatternFill(start_color=PK_BG, end_color=PK_BG, fill_type="solid")
-FILL_SNAPSHOT = PatternFill(start_color=SNAPSHOT_BG, end_color=SNAPSHOT_BG, fill_type="solid")
-FILL_LIGHT_GRAY = PatternFill(start_color="F5F5F5", end_color="F5F5F5", fill_type="solid")
+FILL_SNAPSHOT = PatternFill(
+    start_color=SNAPSHOT_BG, end_color=SNAPSHOT_BG, fill_type="solid"
+)
+FILL_LIGHT_GRAY = PatternFill(
+    start_color="F5F5F5", end_color="F5F5F5", fill_type="solid"
+)
 
 ALIGN_CENTER = Alignment(horizontal="center", vertical="center")
 ALIGN_WRAP = Alignment(wrap_text=True, vertical="top")
@@ -87,6 +101,7 @@ THIN_BORDER_BOTTOM = Border(bottom=Side(style="thin", color="DDDDDD"))
 
 
 # ── Data model ──────────────────────────────────────────────────────────
+
 
 @dataclass
 class Comment:
@@ -124,6 +139,7 @@ class SchemaInfo:
 @dataclass
 class MapEntry:
     """A single key-value in a map {} block, used for lookup tabs."""
+
     key: str
     value: str
 
@@ -265,14 +281,14 @@ def _parse_map_block(raw: str) -> tuple[str, list[MapEntry], bool]:
         if not line:
             continue
         # Match key: value patterns
-        kv_match = re.match(r'^([^:]+?):\s*(.+)$', line)
+        kv_match = re.match(r"^([^:]+?):\s*(.+)$", line)
         if kv_match:
             key = kv_match.group(1).strip()
             value = kv_match.group(2).strip()
             # Strip trailing comma if present
             value = value.rstrip(",")
             # Check for conditional operators
-            if re.match(r'^[<>=!]', key) or key == "default":
+            if re.match(r"^[<>=!]", key) or key == "default":
                 is_conditional = True
             entries.append(MapEntry(key=key, value=value))
 
@@ -344,6 +360,7 @@ def translate_transform(
 
 
 # ── Data collection ─────────────────────────────────────────────────────
+
 
 def _run_satsuma(args: list[str]) -> str:
     """Run a satsuma CLI command and return stdout.
@@ -426,21 +443,25 @@ def collect_data(
     # -- Build issues list --
     issues: list[Comment] = []
     for item in warnings_data.get("items", []):
-        issues.append(Comment(
-            kind="warning",
-            text=item["text"],
-            location=f"{item.get('blockType', 'block').title()} {item.get('block', '?')}",
-            block=item.get("block", ""),
-            block_type=item.get("blockType", ""),
-        ))
+        issues.append(
+            Comment(
+                kind="warning",
+                text=item["text"],
+                location=f"{item.get('blockType', 'block').title()} {item.get('block', '?')}",
+                block=item.get("block", ""),
+                block_type=item.get("blockType", ""),
+            )
+        )
     for item in questions_data.get("items", []):
-        issues.append(Comment(
-            kind="question",
-            text=item["text"],
-            location=f"{item.get('blockType', 'block').title()} {item.get('block', '?')}",
-            block=item.get("block", ""),
-            block_type=item.get("blockType", ""),
-        ))
+        issues.append(
+            Comment(
+                kind="question",
+                text=item["text"],
+                location=f"{item.get('blockType', 'block').title()} {item.get('block', '?')}",
+                block=item.get("block", ""),
+                block_type=item.get("blockType", ""),
+            )
+        )
 
     # -- Build schema map from graph nodes --
     graph_schemas: dict[str, dict] = {}
@@ -468,7 +489,8 @@ def collect_data(
         target_set = set(targets)
         # Filter mappings to those targeting requested schemas
         graph_mappings = [
-            m for m in graph_mappings
+            m
+            for m in graph_mappings
             if any(t in target_set for t in m.get("targets", []))
         ]
         # Re-derive sources from filtered mappings
@@ -537,12 +559,14 @@ def collect_data(
                         if fm.name in frag_fields:
                             fm.fragment_origin = frag_name
 
-        schemas.append(SchemaInfo(
-            name=sname,
-            role=role,
-            note=schema_note,
-            fields=fields,
-        ))
+        schemas.append(
+            SchemaInfo(
+                name=sname,
+                role=role,
+                note=schema_note,
+                fields=fields,
+            )
+        )
 
     # Sort: targets first (file order), then sources (file order)
     target_schemas = [s for s in schemas if s.role == "target"]
@@ -585,7 +609,9 @@ def collect_data(
             is_derived = edge.get("derived", False)
 
             human, map_entries, is_conditional = translate_transform(
-                edge_transforms, nl_text, classification,
+                edge_transforms,
+                nl_text,
+                classification,
             )
 
             # Look up source/target types from schemas
@@ -623,7 +649,8 @@ def collect_data(
                         lookup_name = f"{tgt_field}_map" if tgt_field else "lookup"
                         if lookup_name not in lookups:
                             lookups[lookup_name] = LookupTable(
-                                name=lookup_name, entries=entries,
+                                name=lookup_name,
+                                entries=entries,
                             )
 
             arrow = MappingArrow(
@@ -642,13 +669,15 @@ def collect_data(
             )
             arrows.append(arrow)
 
-        mappings.append(MappingInfo(
-            name=mname,
-            sources=gm.get("sources", []),
-            targets=gm.get("targets", []),
-            note=mapping_note,
-            arrows=arrows,
-        ))
+        mappings.append(
+            MappingInfo(
+                name=mname,
+                sources=gm.get("sources", []),
+                targets=gm.get("targets", []),
+                note=mapping_note,
+                arrows=arrows,
+            )
+        )
 
     ts = timestamp or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -667,6 +696,7 @@ def collect_data(
 
 
 # ── Workbook generation ─────────────────────────────────────────────────
+
 
 def _set_header_row(ws: Worksheet, row: int, headers: list[str]) -> None:
     """Write a styled header row."""
@@ -699,7 +729,9 @@ def _apply_data_tab_formatting(
 
     # Auto-filter
     if data_end_row >= header_row:
-        ws.auto_filter.ref = f"A{header_row}:{get_column_letter(col_count)}{data_end_row}"
+        ws.auto_filter.ref = (
+            f"A{header_row}:{get_column_letter(col_count)}{data_end_row}"
+        )
 
     # Print layout
     ws.sheet_properties.pageSetUpPr = openpyxl.worksheet.properties.PageSetupProperties(
@@ -801,7 +833,9 @@ def create_overview_tab(ws: Worksheet, data: WorkbookData) -> None:
 
     for s in data.schemas:
         tab_name = _schema_tab_name(s)
-        toc_entries.append((tab_name, f"{s.role.title()} schema: {len(s.fields)} fields"))
+        toc_entries.append(
+            (tab_name, f"{s.role.title()} schema: {len(s.fields)} fields")
+        )
 
     for lt in data.lookups:
         tab_name = _lookup_tab_name(lt)
@@ -849,7 +883,9 @@ def create_issues_tab(ws: Worksheet, data: WorkbookData) -> None:
 
     if not data.issues:
         ws.merge_cells("A2:D2")
-        ws.cell(row=2, column=1, value="No warnings or open questions found.").font = FONT_DATA
+        ws.cell(
+            row=2, column=1, value="No warnings or open questions found."
+        ).font = FONT_DATA
         _apply_data_tab_formatting(ws, 1, 2, 4)
         return
 
@@ -905,8 +941,18 @@ def _lookup_tab_name(lt: LookupTable) -> str:
 
 def create_mapping_tab(ws: Worksheet, mapping: MappingInfo, data: WorkbookData) -> None:
     """Generate a mapping tab."""
-    headers = ["#", "Source", "Source Type", "", "Target", "Target Type",
-               "Req", "Transform", "Tags", "Notes"]
+    headers = [
+        "#",
+        "Source",
+        "Source Type",
+        "",
+        "Target",
+        "Target Type",
+        "Req",
+        "Transform",
+        "Tags",
+        "Notes",
+    ]
     col_widths = {1: 5, 2: 25, 3: 15, 4: 3, 5: 25, 6: 15, 7: 5, 8: 50, 9: 15, 10: 40}
     _set_column_widths(ws, col_widths)
 
@@ -918,7 +964,9 @@ def create_mapping_tab(ws: Worksheet, mapping: MappingInfo, data: WorkbookData) 
         cell.font = FONT_DATA
         cell.fill = FILL_LIGHT_GRAY
         cell.alignment = ALIGN_WRAP
-        ws.merge_cells(start_row=start_row, start_column=1, end_row=start_row, end_column=10)
+        ws.merge_cells(
+            start_row=start_row, start_column=1, end_row=start_row, end_column=10
+        )
         line_count = mapping.note.count("\n") + 1
         ws.row_dimensions[start_row].height = max(15, line_count * 15)
         start_row += 1
@@ -950,14 +998,18 @@ def create_mapping_tab(ws: Worksheet, mapping: MappingInfo, data: WorkbookData) 
         ws.cell(row=row, column=6, value=arrow.target_type or "").font = FONT_DATA
 
         # Required
-        ws.cell(row=row, column=7, value="Yes" if arrow.is_required else "").font = FONT_DATA
+        ws.cell(
+            row=row, column=7, value="Yes" if arrow.is_required else ""
+        ).font = FONT_DATA
 
         # Transform
         ws.cell(row=row, column=8, value=arrow.transform_human).font = FONT_DATA
         ws.cell(row=row, column=8).alignment = ALIGN_WRAP
 
         # Tags
-        ws.cell(row=row, column=9, value=", ".join(arrow.tags) if arrow.tags else "").font = FONT_DATA
+        ws.cell(
+            row=row, column=9, value=", ".join(arrow.tags) if arrow.tags else ""
+        ).font = FONT_DATA
 
         # Notes
         note_text = ""
@@ -985,7 +1037,9 @@ def create_mapping_tab(ws: Worksheet, mapping: MappingInfo, data: WorkbookData) 
         if arrow.map_entries:
             for ci, entry in enumerate(arrow.map_entries):
                 child_label = f"{idx}{chr(97 + ci)}"  # 5a, 5b, 5c...
-                ws.cell(row=row, column=1, value=child_label).font = FONT_DATA_ITALIC_GRAY
+                ws.cell(
+                    row=row, column=1, value=child_label
+                ).font = FONT_DATA_ITALIC_GRAY
 
                 if entry.key == "default":
                     display = f"default = {entry.value}"
@@ -1007,8 +1061,17 @@ def create_mapping_tab(ws: Worksheet, mapping: MappingInfo, data: WorkbookData) 
 
 def create_schema_tab(ws: Worksheet, schema: SchemaInfo) -> None:
     """Generate a schema reference tab."""
-    headers = ["#", "Field", "Type", "PK", "Required", "Unique",
-               "Default", "Tags", "Notes"]
+    headers = [
+        "#",
+        "Field",
+        "Type",
+        "PK",
+        "Required",
+        "Unique",
+        "Default",
+        "Tags",
+        "Notes",
+    ]
     col_widths = {1: 5, 2: 25, 3: 20, 4: 5, 5: 8, 6: 8, 7: 15, 8: 20, 9: 40}
     _set_column_widths(ws, col_widths)
 
@@ -1020,7 +1083,9 @@ def create_schema_tab(ws: Worksheet, schema: SchemaInfo) -> None:
         cell.font = FONT_DATA
         cell.fill = FILL_LIGHT_GRAY
         cell.alignment = ALIGN_WRAP
-        ws.merge_cells(start_row=start_row, start_column=1, end_row=start_row, end_column=9)
+        ws.merge_cells(
+            start_row=start_row, start_column=1, end_row=start_row, end_column=9
+        )
         start_row += 1
 
     header_row = start_row
@@ -1039,7 +1104,9 @@ def create_schema_tab(ws: Worksheet, schema: SchemaInfo) -> None:
         ws.cell(row=row, column=2, value=f.name).font = FONT_DATA
         ws.cell(row=row, column=3, value=f.type).font = FONT_DATA
         ws.cell(row=row, column=4, value="Yes" if f.is_pk else "").font = FONT_DATA
-        ws.cell(row=row, column=5, value="Yes" if f.is_required else "").font = FONT_DATA
+        ws.cell(
+            row=row, column=5, value="Yes" if f.is_required else ""
+        ).font = FONT_DATA
         ws.cell(row=row, column=6, value="Yes" if f.is_unique else "").font = FONT_DATA
         ws.cell(row=row, column=7, value=f.default or "").font = FONT_DATA
 
@@ -1064,7 +1131,9 @@ def create_schema_tab(ws: Worksheet, schema: SchemaInfo) -> None:
             note_parts.append(f.note)
         if f.fragment_origin:
             note_parts.append(f"From fragment: {f.fragment_origin}")
-        ws.cell(row=row, column=9, value="; ".join(note_parts) if note_parts else "").font = FONT_DATA
+        ws.cell(
+            row=row, column=9, value="; ".join(note_parts) if note_parts else ""
+        ).font = FONT_DATA
         ws.cell(row=row, column=9).alignment = ALIGN_WRAP
 
         # Row fill
@@ -1150,6 +1219,7 @@ def generate_workbook(data: WorkbookData, output_path: str, options: dict) -> No
 
 # ── CLI ──────────────────────────────────────────────────────────────────
 
+
 def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="stm_to_excel",
@@ -1157,11 +1227,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("stm_files", nargs="+", help="Input .stm file(s)")
     parser.add_argument("-o", "--output", required=True, help="Output .xlsx path")
-    parser.add_argument("--targets", help="Comma-separated target schema names to include")
+    parser.add_argument(
+        "--targets", help="Comma-separated target schema names to include"
+    )
     parser.add_argument("--title", help="Override workbook title")
     parser.add_argument("--timestamp", help="Override generation timestamp (ISO 8601)")
     parser.add_argument("--no-issues", action="store_true", help="Omit the Issues tab")
-    parser.add_argument("--no-schemas", action="store_true", help="Omit schema reference tabs")
+    parser.add_argument(
+        "--no-schemas", action="store_true", help="Omit schema reference tabs"
+    )
     return parser
 
 

--- a/skills/satsuma-to-excel/scripts/test_stm_to_excel.py
+++ b/skills/satsuma-to-excel/scripts/test_stm_to_excel.py
@@ -26,6 +26,7 @@ import stm_to_excel  # noqa: E402
 
 # ── Transform translation unit tests ────────────────────────────────────
 
+
 class TestTranslateSingleToken:
     """Test _translate_single_token for individual pipeline steps."""
 
@@ -33,54 +34,90 @@ class TestTranslateSingleToken:
         assert stm_to_excel._translate_single_token("trim") == "trim whitespace"
 
     def test_lowercase(self):
-        assert stm_to_excel._translate_single_token("lowercase") == "convert to lowercase"
+        assert (
+            stm_to_excel._translate_single_token("lowercase") == "convert to lowercase"
+        )
 
     def test_uppercase(self):
-        assert stm_to_excel._translate_single_token("uppercase") == "convert to uppercase"
+        assert (
+            stm_to_excel._translate_single_token("uppercase") == "convert to uppercase"
+        )
 
     def test_title_case(self):
-        assert stm_to_excel._translate_single_token("title_case") == "convert to title case"
+        assert (
+            stm_to_excel._translate_single_token("title_case")
+            == "convert to title case"
+        )
 
     def test_null_if_empty(self):
-        assert stm_to_excel._translate_single_token("null_if_empty") == "set null if empty"
+        assert (
+            stm_to_excel._translate_single_token("null_if_empty") == "set null if empty"
+        )
 
     def test_validate_email(self):
-        assert stm_to_excel._translate_single_token("validate_email") == "validate email format"
+        assert (
+            stm_to_excel._translate_single_token("validate_email")
+            == "validate email format"
+        )
 
     def test_now_utc(self):
-        assert stm_to_excel._translate_single_token("now_utc()") == "current UTC timestamp"
+        assert (
+            stm_to_excel._translate_single_token("now_utc()") == "current UTC timestamp"
+        )
 
     def test_to_iso8601(self):
-        assert stm_to_excel._translate_single_token("to_iso8601") == "format as ISO 8601"
+        assert (
+            stm_to_excel._translate_single_token("to_iso8601") == "format as ISO 8601"
+        )
 
     def test_coalesce(self):
-        assert stm_to_excel._translate_single_token("coalesce(0)") == "default to 0 if null"
+        assert (
+            stm_to_excel._translate_single_token("coalesce(0)")
+            == "default to 0 if null"
+        )
 
     def test_round(self):
-        assert stm_to_excel._translate_single_token("round(2)") == "round to 2 decimal places"
+        assert (
+            stm_to_excel._translate_single_token("round(2)")
+            == "round to 2 decimal places"
+        )
 
     def test_round_bare(self):
-        assert stm_to_excel._translate_single_token("round") == "round to nearest integer"
+        assert (
+            stm_to_excel._translate_single_token("round") == "round to nearest integer"
+        )
 
     def test_truncate(self):
-        assert stm_to_excel._translate_single_token("truncate(5000)") == "truncate to 5000 characters"
+        assert (
+            stm_to_excel._translate_single_token("truncate(5000)")
+            == "truncate to 5000 characters"
+        )
 
     def test_parse(self):
-        assert stm_to_excel._translate_single_token('parse("MM/DD/YYYY")') == 'parse as "MM/DD/YYYY"'
+        assert (
+            stm_to_excel._translate_single_token('parse("MM/DD/YYYY")')
+            == 'parse as "MM/DD/YYYY"'
+        )
 
     def test_encrypt(self):
-        result = stm_to_excel._translate_single_token("encrypt(AES-256-GCM, secrets.tax_encryption_key)")
+        result = stm_to_excel._translate_single_token(
+            "encrypt(AES-256-GCM, secrets.tax_encryption_key)"
+        )
         assert result == "encrypt (AES-256-GCM)"
 
     def test_uuid_v5(self):
-        result = stm_to_excel._translate_single_token('uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID)')
+        result = stm_to_excel._translate_single_token(
+            'uuid_v5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", CUST_ID)'
+        )
         assert result == "generate UUID v5"
 
     def test_multiply(self):
         assert stm_to_excel._translate_single_token("* 100") == "multiply by 100"
 
     def test_nl_string(self):
-        result = stm_to_excel._translate_single_token('"Extract digits and format as E.164"')
+        result = stm_to_excel._translate_single_token(
+            '"Extract digits and format as E.164"'
+        )
         assert result == "Extract digits and format as E.164"
 
     def test_unknown_token_passthrough(self):
@@ -90,16 +127,23 @@ class TestTranslateSingleToken:
         assert stm_to_excel._translate_single_token("") == ""
 
     def test_escape_html(self):
-        assert stm_to_excel._translate_single_token("escape_html") == "escape HTML characters"
+        assert (
+            stm_to_excel._translate_single_token("escape_html")
+            == "escape HTML characters"
+        )
 
     def test_drop_if_invalid(self):
-        assert stm_to_excel._translate_single_token("drop_if_invalid") == "drop if invalid"
+        assert (
+            stm_to_excel._translate_single_token("drop_if_invalid") == "drop if invalid"
+        )
 
     def test_error_if_null(self):
         assert stm_to_excel._translate_single_token("error_if_null") == "error if null"
 
     def test_assume_utc(self):
-        assert stm_to_excel._translate_single_token("assume_utc") == "assume UTC timezone"
+        assert (
+            stm_to_excel._translate_single_token("assume_utc") == "assume UTC timezone"
+        )
 
 
 class TestParseMapBlock:
@@ -138,7 +182,9 @@ class TestTranslateTransform:
 
     def test_pure_nl(self):
         human, entries, cond = stm_to_excel.translate_transform(
-            None, '"Extract all digits and format"', "nl",
+            None,
+            '"Extract all digits and format"',
+            "nl",
         )
         assert human == "Extract all digits and format"
         assert not entries
@@ -147,9 +193,13 @@ class TestTranslateTransform:
     def test_structural_chain(self):
         human, _entries, cond = stm_to_excel.translate_transform(
             ["trim", "lowercase", "validate_email", "null_if_invalid"],
-            None, "structural",
+            None,
+            "structural",
         )
-        assert human == "trim whitespace \u2192 convert to lowercase \u2192 validate email format \u2192 set null if invalid"
+        assert (
+            human
+            == "trim whitespace \u2192 convert to lowercase \u2192 validate email format \u2192 set null if invalid"
+        )
         assert not cond
 
     def test_mixed(self):
@@ -164,14 +214,18 @@ class TestTranslateTransform:
 
     def test_no_transform(self):
         human, _entries, _cond = stm_to_excel.translate_transform(
-            None, None, "none",
+            None,
+            None,
+            "none",
         )
         assert human == ""
 
     def test_map_simple(self):
         raw = 'map {\n      A: "active"\n      S: "suspended"\n    }'
         human, _entries, cond = stm_to_excel.translate_transform(
-            [raw], None, "structural",
+            [raw],
+            None,
+            "structural",
         )
         assert 'A = "active"' in human
         assert not cond
@@ -179,7 +233,9 @@ class TestTranslateTransform:
     def test_map_conditional(self):
         raw = 'map {\n      < 1000: "bronze"\n      default: "platinum"\n    }'
         human, entries, cond = stm_to_excel.translate_transform(
-            [raw], None, "structural",
+            [raw],
+            None,
+            "structural",
         )
         assert cond
         assert "Conditional" in human
@@ -188,12 +244,16 @@ class TestTranslateTransform:
 
 # ── Integration tests (require satsuma CLI) ──────────────────────────────
 
+
 def _skip_if_no_cli():
     """Skip test if satsuma CLI is not available."""
     try:
         result = subprocess.run(
             ["satsuma", "--version"],
-            capture_output=True, text=True, timeout=10, check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
         )
         if result.returncode != 0:
             pytest.skip("satsuma CLI not available")
@@ -201,16 +261,24 @@ def _skip_if_no_cli():
         pytest.skip("satsuma CLI not available")
 
 
-def _run_stm_to_excel(stm_files: list[str], output: str, extra_args: list[str] | None = None) -> str:
+def _run_stm_to_excel(
+    stm_files: list[str], output: str, extra_args: list[str] | None = None
+) -> str:
     """Run stm_to_excel.py and return stdout."""
     cmd = [
-        "python3", str(SCRIPT_DIR / "stm_to_excel.py"),
-        *stm_files, "-o", output,
-        "--timestamp", "2026-01-01T00:00:00Z",
+        "python3",
+        str(SCRIPT_DIR / "stm_to_excel.py"),
+        *stm_files,
+        "-o",
+        output,
+        "--timestamp",
+        "2026-01-01T00:00:00Z",
     ]
     if extra_args:
         cmd.extend(extra_args)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=60, check=False
+    )
     if result.returncode != 0:
         pytest.fail(f"stm_to_excel failed: {result.stderr}")
     return result.stdout
@@ -226,6 +294,7 @@ class TestIntegrationDbToDb:
         self.stm = str(REPO_ROOT / "examples" / "db-to-db" / "pipeline.stm")
         _run_stm_to_excel([self.stm], self.output)
         import openpyxl
+
         self.wb = openpyxl.load_workbook(self.output)
 
     def test_tab_names(self):
@@ -261,7 +330,8 @@ class TestIntegrationDbToDb:
         assert ws is not None
         # Count data rows (after header, excluding note row)
         arrows = sum(
-            1 for r in range(1, ws.max_row + 1)
+            1
+            for r in range(1, ws.max_row + 1)
             if ws.cell(r, 4).value == "\u2192" and isinstance(ws.cell(r, 1).value, int)
         )
         # 19 explicit `->` mappings in the fixture, plus 11 implicit source
@@ -288,8 +358,7 @@ class TestIntegrationDbToDb:
         ws = self.wb["Tgt - postgres_db"]
         # Should have 19 fields (from summary) + header row + note row
         field_count = sum(
-            1 for r in range(1, ws.max_row + 1)
-            if isinstance(ws.cell(r, 1).value, int)
+            1 for r in range(1, ws.max_row + 1) if isinstance(ws.cell(r, 1).value, int)
         )
         assert field_count >= 18  # at least 18 fields
 
@@ -333,6 +402,7 @@ class TestIntegrationSfdc:
         self.stm = str(REPO_ROOT / "examples" / "sfdc-to-snowflake" / "pipeline.stm")
         _run_stm_to_excel([self.stm], self.output)
         import openpyxl
+
         self.wb = openpyxl.load_workbook(self.output)
 
     def test_tab_count(self):
@@ -348,7 +418,8 @@ class TestIntegrationSfdc:
                 break
         assert ws is not None
         arrows = sum(
-            1 for r in range(1, ws.max_row + 1)
+            1
+            for r in range(1, ws.max_row + 1)
             if ws.cell(r, 4).value == "\u2192" and isinstance(ws.cell(r, 1).value, int)
         )
         # 10 explicit `->` mappings in the fixture, plus 2 implicit source
@@ -377,6 +448,7 @@ class TestIntegrationOptions:
         output = str(tmp_path / "no-issues.xlsx")
         _run_stm_to_excel([self.stm], output, ["--no-issues"])
         import openpyxl
+
         wb = openpyxl.load_workbook(output)
         assert "Issues" not in wb.sheetnames
 
@@ -384,6 +456,7 @@ class TestIntegrationOptions:
         output = str(tmp_path / "no-schemas.xlsx")
         _run_stm_to_excel([self.stm], output, ["--no-schemas"])
         import openpyxl
+
         wb = openpyxl.load_workbook(output)
         assert not any(n.startswith(("Src", "Tgt")) for n in wb.sheetnames)
 
@@ -391,6 +464,7 @@ class TestIntegrationOptions:
         output = str(tmp_path / "titled.xlsx")
         _run_stm_to_excel([self.stm], output, ["--title", "Custom Title"])
         import openpyxl
+
         wb = openpyxl.load_workbook(output)
         assert wb["Overview"].cell(1, 1).value == "Custom Title"
 
@@ -401,6 +475,7 @@ class TestIntegrationOptions:
         _run_stm_to_excel([self.stm], out1)
         _run_stm_to_excel([self.stm], out2)
         import openpyxl
+
         wb1 = openpyxl.load_workbook(out1)
         wb2 = openpyxl.load_workbook(out2)
         assert wb1.sheetnames == wb2.sheetnames
@@ -426,6 +501,7 @@ class TestIntegrationFragments:
         self.stm = str(REPO_ROOT / "examples" / "sfdc-to-snowflake" / "pipeline.stm")
         _run_stm_to_excel([self.stm], self.output)
         import openpyxl
+
         self.wb = openpyxl.load_workbook(self.output)
 
     def test_fragment_notes_in_schema(self):

--- a/skills/satsuma-to-openlineage/references/event-template.md
+++ b/skills/satsuma-to-openlineage/references/event-template.md
@@ -117,6 +117,7 @@ import uuid
 
 SATSUMA_NAMESPACE = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")  # URL namespace
 
+
 def run_id(job_namespace: str, job_name: str) -> str:
     return str(uuid.uuid5(SATSUMA_NAMESPACE, f"{job_namespace}/{job_name}"))
 ```
@@ -134,13 +135,21 @@ the OpenLineage client:
 ```python
 from openlineage.client import OpenLineageClient
 from openlineage.client.run import (
-    RunEvent, RunState, Run, Job, Dataset,
-    InputDataset, OutputDataset
+    RunEvent,
+    RunState,
+    Run,
+    Job,
+    Dataset,
+    InputDataset,
+    OutputDataset,
 )
 from openlineage.client.facet_v2 import (
-    schema_dataset, column_lineage_dataset,
-    documentation_dataset, documentation_job,
-    ownership_dataset, job_type_job
+    schema_dataset,
+    column_lineage_dataset,
+    documentation_dataset,
+    documentation_job,
+    ownership_dataset,
+    job_type_job,
 )
 import uuid
 from datetime import datetime, timezone

--- a/smoke-tests/conftest.py
+++ b/smoke-tests/conftest.py
@@ -127,7 +127,9 @@ def query_arrows_expect_exit(field: str, code: int, ctx: dict) -> None:
     ctx["exit_code"] = _run_exit_only(["arrows", field], ctx["fixture"])
 
 
-@when(parsers.parse('I query arrows for "{field}" as source expecting exit code {code:d}'))
+@when(
+    parsers.parse('I query arrows for "{field}" as source expecting exit code {code:d}')
+)
 def query_arrows_as_source_expect_exit(field: str, code: int, ctx: dict) -> None:
     ctx["exit_code"] = _run_exit_only(["arrows", field, "--as-source"], ctx["fixture"])
 

--- a/tooling/satsuma-cli/scripts/prebuild.js
+++ b/tooling/satsuma-cli/scripts/prebuild.js
@@ -62,7 +62,7 @@ for (const { src, dest, label } of wasmFiles) {
   } else {
     throw new Error(
       `prebuild: required ${label} not found at ${src}. ` +
-      "Build tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm before packaging the CLI.",
+        "Build tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm before packaging the CLI.",
     );
   }
 }

--- a/tooling/satsuma-cli/scripts/verify-pack.js
+++ b/tooling/satsuma-cli/scripts/verify-pack.js
@@ -25,8 +25,8 @@ const dotDotEntries = contents.split("\n").filter((e) => e.includes(".."));
 if (dotDotEntries.length > 0) {
   throw new Error(
     `verify-pack: tarball contains entries with '..' in their paths — ` +
-    `npm will reject these on install.\n` +
-    dotDotEntries.map((e) => `  ${e}`).join("\n")
+      `npm will reject these on install.\n` +
+      dotDotEntries.map((e) => `  ${e}`).join("\n"),
   );
 }
 
@@ -54,7 +54,7 @@ const verbose = execFileSync("tar", ["-tvf", tarballPath, "package/dist/index.js
 if (!/^-rwx/.test(verbose)) {
   throw new Error(
     `verify-pack: dist/index.js is not executable in the tarball. ` +
-    `Permissions: ${verbose.split(/\s+/)[0]}`
+      `Permissions: ${verbose.split(/\s+/)[0]}`,
   );
 }
 

--- a/tooling/satsuma-cli/src/command-loader.ts
+++ b/tooling/satsuma-cli/src/command-loader.ts
@@ -29,9 +29,6 @@ import { pathToFileURL } from "node:url";
  *                            "commands/summary.js".
  * @returns A `file://` URL string suitable for `import()`.
  */
-export function commandModuleSpecifier(
-  entryDir: string,
-  relativeModulePath: string,
-): string {
+export function commandModuleSpecifier(entryDir: string, relativeModulePath: string): string {
   return pathToFileURL(join(entryDir, relativeModulePath)).href;
 }

--- a/tooling/satsuma-cli/src/command-runner.ts
+++ b/tooling/satsuma-cli/src/command-runner.ts
@@ -114,8 +114,9 @@ export class CommandError extends Error {
  * "soft" non-zero exits (e.g. validate exiting 2 because findings were
  * reported) without throwing.
  */
-export type CommandHandler<Args extends unknown[]> =
-  (...args: Args) => Promise<number | void> | number | void;
+export type CommandHandler<Args extends unknown[]> = (
+  ...args: Args
+) => Promise<number | void> | number | void;
 
 /**
  * Wrap a Commander `.action(...)` handler so it participates in the

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -27,7 +27,9 @@ export function register(program: Command): void {
     .option("--as-source", "only arrows where the field is the source")
     .option("--as-target", "only arrows where the field is the target")
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 The field reference is <schema>.<field> — the schema name followed by a
 dot and the field name. Namespace-qualified names work (e.g. pos::stores.STORE_ID).
 
@@ -49,276 +51,311 @@ JSON shape (--json): array of arrow objects
 Examples:
   satsuma arrows hub_customer.email                  # all arrows for this field
   satsuma arrows hub_customer.email --as-source      # only outbound arrows
-  satsuma arrows pos::stores.STORE_ID --json         # namespace-qualified`)
-    .action(runCommand(async (fieldRef: string, pathArg: string | undefined, opts: { asSource?: boolean; asTarget?: boolean; json?: boolean }) => {
-      const dot = fieldRef.indexOf(".");
-      if (dot === -1) {
-        throw new CommandError(
-          `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
-          EXIT_PARSE_ERROR,
-        );
-      }
-
-      const schemaName = fieldRef.slice(0, dot);
-      const fieldName = fieldRef.slice(dot + 1);
-
-      const { index } = await loadWorkspace(pathArg);
-
-      // Validate schema exists
-      const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
-      if (!resolvedSchema) {
-        const close = [...index.schemas.keys()].find(
-          (k) => k.toLowerCase() === schemaName.toLowerCase(),
-        );
-        const lines = [`Schema '${schemaName}' not found.`];
-        if (close) lines.push(`Did you mean '${close}'?`);
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-
-      // Validate field exists in schema (including fragment spread fields and nested children)
-      const schema = resolvedSchema.entry;
-      const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
-      const allFields = [...schema.fields, ...spreadFields];
-      const fieldExists = findFieldByPath(allFields, fieldName) !== null ||
-        collectFieldNames(allFields).includes(fieldName);
-      if (!fieldExists) {
-        // Suggest close matches from top-level and nested fields
-        const allNames = collectFieldNames(allFields);
-        const close = allNames.find(
-          (n) => n.toLowerCase() === fieldName.toLowerCase(),
-        );
-        const lines = [`Field '${fieldName}' not found in schema '${schemaName}'.`];
-        if (close) lines.push(`Did you mean '${close}'?`);
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-
-      // Find matching arrows using schema-qualified key
-      // Try full dotted path, bare field name, and leaf name for nested fields
-      const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
-      let arrows = findFieldArrows(qualifiedField, index);
-
-      // Also search by bare field name (handles nested child fields indexed by leaf name)
-      // Only include arrows from mappings involving the resolved schema, and only
-      // when the arrow's source/target field path actually exists in the queried schema.
-      // This prevents false positives from leaf-name collisions across schemas.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: split always produces at least one element
-      const leafName = fieldName.includes(".") ? fieldName.split(".").pop()! : fieldName;
-      const seen = new Set(arrows.map((a) => `${a.mapping}:${a.namespace}:${a.sources.join(",")}:${a.target}:${a.line}`));
-      const schemaKey = resolvedSchema.key;
-      for (const altKey of [fieldName, leafName]) {
-        for (const a of findFieldArrows(altKey, index)) {
-          const dedupKey = `${a.mapping}:${a.namespace}:${a.sources.join(",")}:${a.target}:${a.line}`;
-          if (seen.has(dedupKey)) continue;
-          const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
-          const mapping = index.mappings.get(qMapping);
-          if (!mapping) continue;
-
-          // Verify the arrow's source or target field path exists in the queried schema's
-          // field tree. Strip any schema prefix before the lookup.
-          const pathExistsInSchema = (rawPath: string): boolean => {
-            const bare = rawPath.replace(/^\./, "");
-            const path = bare.startsWith(schemaKey + ".") ? bare.slice(schemaKey.length + 1) : bare;
-            return findFieldByPath(allFields, path) !== null || collectFieldNames(allFields).includes(path);
-          };
-
-          const asSourceMatch = mapping.sources.includes(schemaKey) &&
-            a.sources.some((s) => pathExistsInSchema(s));
-          const asTargetMatch = mapping.targets.includes(schemaKey) &&
-            a.target != null && pathExistsInSchema(a.target);
-
-          if (!asSourceMatch && !asTargetMatch) continue;
-          seen.add(dedupKey);
-          arrows.push(a);
-        }
-      }
-
-      // When the user specifies a deeply nested path (e.g. CdtTrfTxInf.DbtrAgt.BIC),
-      // filter out arrows whose source/target path doesn't match the requested path.
-      // This allows disambiguating fields that share a leaf name at different nesting levels.
-      if (fieldName.includes(".")) {
-        arrows = arrows.filter((a) => {
-          return a.sources.some((s) => arrowPathMatches(s, fieldName)) || arrowPathMatches(a.target, fieldName);
-        });
-      }
-
-      // Add NL-derived arrows when the queried field is the @ref source.
-      //
-      // An @ref like `@source8.amount` in `-> total { "Sum @source8.amount" }`
-      // produces an nl-derived arrow: source8.amount → target8.total.
-      // This arrow is discoverable when querying source8.amount (the ref
-      // resolves to the queried field). Target-side discovery uses field-lineage.
-      const nlRefs = resolveAllNLRefs(index);
-      const canonicalQualified = canonicalKey(qualifiedField);
-      for (const nlRef of nlRefs) {
-        if (!nlRef.resolved || !nlRef.resolvedTo) continue;
-        // NL refs from source blocks describe join conditions, not data flow —
-        // skip them to avoid false NL-derived arrows on join-key fields.
-        if (nlRef.context === "source_block") continue;
-        const resolvedTo = nlRef.resolvedTo.name;
-
-        // nlRef.mapping is already fully qualified by resolveAllNLRefs
-        // (it is built as `${namespace}::${mapping}` or bare name before being
-        // stored). Double-qualifying by prepending nlRef.namespace again would
-        // produce "crm::crm::load_dim_customer", causing the mapping lookup and
-        // the alreadyDeclared dedup check to fail, resulting in duplicate
-        // nl-derived arrows when @ref references the arrow's own source (sl-qxn5).
-        const nlMappingKey = nlRef.mapping;
-
-        if (resolvedTo !== canonicalQualified) continue;
-        const nlMapping = index.mappings.get(nlMappingKey);
-
-        // Skip if the queried field is already a declared source for the same
-        // arrow (e.g. `c -> d { "clean up @s1.c" }` — don't emit a duplicate
-        // nl-derived arrow on top of the existing declared one). Only suppress
-        // when the declared arrow actually lists the @ref field as a source;
-        // derived arrows (source=null) from `-> tgt { "@src.field" }` lack
-        // the source info that the nl-derived arrow adds (sl-k797).
-        const alreadyDeclared = arrows.some((a) => {
-          if (a.classification === "nl-derived") return false;
-          const aMappingKey = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
-          if (aMappingKey !== nlMappingKey || a.target !== nlRef.targetField) return false;
-          // Arrow sources may be bare field names (e.g. "c") while resolvedTo is
-          // canonical (e.g. "::s1.c"). Qualify each source against the mapping's
-          // source schemas to compare properly.
-          const srcSchemas = nlMapping?.sources ?? [];
-          return a.sources.some((s) => {
-            if (s === resolvedTo || canonicalKey(s) === resolvedTo) return true;
-            for (const schema of srcSchemas) {
-              if (canonicalKey(`${schema}.${s}`) === resolvedTo) return true;
-            }
-            return false;
-          });
-        });
-        if (alreadyDeclared) continue;
-
-        // Deduplicate against nl-derived arrows already added (an NL string may
-        // contain multiple @refs resolving to different fields, each producing an
-        // arrow with the same target).
-        const dedupKey = `${nlMappingKey}:${resolvedTo}:${nlRef.targetField}:${nlRef.line}`;
-        if (seen.has(dedupKey)) continue;
-        seen.add(dedupKey);
-
-        // Use the fully resolved path as the source so cross-schema refs
-        // are correctly attributed (sl-uk9q)
-        arrows.push({
-          mapping: nlRef.namespace && nlRef.mapping?.startsWith(`${nlRef.namespace}::`)
-            ? nlRef.mapping.slice(nlRef.namespace.length + 2)
-            : nlRef.mapping,
-          namespace: nlRef.namespace,
-          sources: [resolvedTo],
-          target: nlRef.targetField,
-          transform_raw: `(NL ref)`,
-          steps: [],
-          classification: "nl-derived",
-          derived: true,
-          line: nlRef.line,
-          file: nlRef.file,
-        });
-      }
-
-      // Apply direction filters — verify the queried schema is on the correct
-      // side of the mapping, not just that the field name matches
-      if (opts.asSource) {
-        arrows = arrows.filter((a) => {
-          const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
-          const m = index.mappings.get(qMapping);
-          // For nl-derived arrows, sources may be fully-qualified canonical paths
-          // (e.g. "::s1.a") rather than bare field names — match both forms.
-          return m?.sources.includes(resolvedSchema.key) &&
-            a.sources.some((s) =>
-              s === fieldName || s === leafName ||
-              s === canonicalQualified || s.endsWith(`.${fieldName}`)
+  satsuma arrows pos::stores.STORE_ID --json         # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          fieldRef: string,
+          pathArg: string | undefined,
+          opts: { asSource?: boolean; asTarget?: boolean; json?: boolean },
+        ) => {
+          const dot = fieldRef.indexOf(".");
+          if (dot === -1) {
+            throw new CommandError(
+              `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
+              EXIT_PARSE_ERROR,
             );
-        });
-      } else if (opts.asTarget) {
-        arrows = arrows.filter((a) => {
-          const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
-          const m = index.mappings.get(qMapping);
-          return m?.targets.includes(resolvedSchema.key) &&
-            (a.target === fieldName || a.target === leafName);
-        });
-      }
-
-      if (arrows.length === 0) {
-        console.log(`No arrows found for '${fieldRef}'.`);
-        return EXIT_NOT_FOUND;
-      }
-
-      if (opts.json) {
-        const jsonArrows = arrows.map((a) => {
-          const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : a.mapping;
-          const mapping = index.mappings.get(qMapping ?? "");
-          const sourceSchemas = mapping?.sources ?? [];
-          const targetSchemas = mapping?.targets ?? [];
-
-          // Determine which schema the target field belongs to
-          let targetSchema: string;
-          if (targetSchemas.includes(resolvedSchema.key)) {
-            targetSchema = resolvedSchema.key;
-          } else {
-            targetSchema = targetSchemas[0] ?? resolvedSchema.key;
           }
 
-          const qualifyPath = (path: string | null, schema: string): string | null => {
-            if (!path) return null;
-            if (path.startsWith(schema + ".") || path === schema) return path;
-            // If path is already schema-qualified (contains a dot and the prefix
-            // is a known schema), don't double-qualify
-            const dotIdx = path.indexOf(".");
-            if (dotIdx > 0) {
-              const prefix = path.slice(0, dotIdx);
-              if (index.schemas.has(prefix)) return path;
-            }
-            return `${schema}.${path}`;
-          };
+          const schemaName = fieldRef.slice(0, dot);
+          const fieldName = fieldRef.slice(dot + 1);
 
-          // For multi-source arrows, find the actual schema that owns each source field
-          // rather than attributing all fields to the queried schema.
-          const resolveSourceField = (path: string): string => {
-            // Already in canonical form (::schema.field or ns::schema.field)
-            if (path.includes("::")) return path;
-            // Already fully qualified with a known schema prefix
-            const dotIdx = path.indexOf(".");
-            if (dotIdx > 0) {
-              const prefix = path.slice(0, dotIdx);
-              if (index.schemas.has(prefix)) return path;
-            }
-            // Search each source schema for a field matching path
-            for (const schemaKey of sourceSchemas) {
-              const s = index.schemas.get(schemaKey);
-              if (!s) continue;
-              const sSpread = expandEntityFields(s, s.namespace ?? null, index);
-              const allNames = [...s.fields, ...sSpread].map((f) => f.name);
-              if (allNames.includes(path)) return `${schemaKey}.${path}`;
-            }
-            // Fallback: use first source schema
-            return `${sourceSchemas[0] ?? resolvedSchema.key}.${path}`;
-          };
+          const { index } = await loadWorkspace(pathArg);
 
-          const result: Record<string, unknown> = {
-            mapping: qMapping ? canonicalKey(qMapping) : null,
-            source: a.sources.length === 0 ? null : a.sources.map((s) => canonicalKey(resolveSourceField(s))).join(", "),
-            target: a.target ? canonicalKey(qualifyPath(a.target, targetSchema) ?? a.target) : null,
-            classification: a.classification,
-            transform_raw: a.transform_raw,
-            steps: a.steps,
-            derived: a.derived,
-            file: a.file,
-            line: a.line + 1,
-          };
-          if (a.metadata && a.metadata.length > 0) {
-            result.metadata = a.metadata;
+          // Validate schema exists
+          const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
+          if (!resolvedSchema) {
+            const close = [...index.schemas.keys()].find(
+              (k) => k.toLowerCase() === schemaName.toLowerCase(),
+            );
+            const lines = [`Schema '${schemaName}' not found.`];
+            if (close) lines.push(`Did you mean '${close}'?`);
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
           }
-          return result;
-        });
-        console.log(JSON.stringify(jsonArrows, null, 2));
-        return;
-      }
 
-      // Pass the resolved schema key so printDefault can match against index
-      // entries even when the user queried with a bare (unqualified) name (sl-ltv6).
-      printDefault(fieldRef, arrows, index, resolvedSchema.key);
-    }));
+          // Validate field exists in schema (including fragment spread fields and nested children)
+          const schema = resolvedSchema.entry;
+          const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
+          const allFields = [...schema.fields, ...spreadFields];
+          const fieldExists =
+            findFieldByPath(allFields, fieldName) !== null ||
+            collectFieldNames(allFields).includes(fieldName);
+          if (!fieldExists) {
+            // Suggest close matches from top-level and nested fields
+            const allNames = collectFieldNames(allFields);
+            const close = allNames.find((n) => n.toLowerCase() === fieldName.toLowerCase());
+            const lines = [`Field '${fieldName}' not found in schema '${schemaName}'.`];
+            if (close) lines.push(`Did you mean '${close}'?`);
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          }
+
+          // Find matching arrows using schema-qualified key
+          // Try full dotted path, bare field name, and leaf name for nested fields
+          const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
+          let arrows = findFieldArrows(qualifiedField, index);
+
+          // Also search by bare field name (handles nested child fields indexed by leaf name)
+          // Only include arrows from mappings involving the resolved schema, and only
+          // when the arrow's source/target field path actually exists in the queried schema.
+          // This prevents false positives from leaf-name collisions across schemas.
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: split always produces at least one element
+          const leafName = fieldName.includes(".") ? fieldName.split(".").pop()! : fieldName;
+          const seen = new Set(
+            arrows.map(
+              (a) => `${a.mapping}:${a.namespace}:${a.sources.join(",")}:${a.target}:${a.line}`,
+            ),
+          );
+          const schemaKey = resolvedSchema.key;
+          for (const altKey of [fieldName, leafName]) {
+            for (const a of findFieldArrows(altKey, index)) {
+              const dedupKey = `${a.mapping}:${a.namespace}:${a.sources.join(",")}:${a.target}:${a.line}`;
+              if (seen.has(dedupKey)) continue;
+              const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
+              const mapping = index.mappings.get(qMapping);
+              if (!mapping) continue;
+
+              // Verify the arrow's source or target field path exists in the queried schema's
+              // field tree. Strip any schema prefix before the lookup.
+              const pathExistsInSchema = (rawPath: string): boolean => {
+                const bare = rawPath.replace(/^\./, "");
+                const path = bare.startsWith(schemaKey + ".")
+                  ? bare.slice(schemaKey.length + 1)
+                  : bare;
+                return (
+                  findFieldByPath(allFields, path) !== null ||
+                  collectFieldNames(allFields).includes(path)
+                );
+              };
+
+              const asSourceMatch =
+                mapping.sources.includes(schemaKey) && a.sources.some((s) => pathExistsInSchema(s));
+              const asTargetMatch =
+                mapping.targets.includes(schemaKey) &&
+                a.target != null &&
+                pathExistsInSchema(a.target);
+
+              if (!asSourceMatch && !asTargetMatch) continue;
+              seen.add(dedupKey);
+              arrows.push(a);
+            }
+          }
+
+          // When the user specifies a deeply nested path (e.g. CdtTrfTxInf.DbtrAgt.BIC),
+          // filter out arrows whose source/target path doesn't match the requested path.
+          // This allows disambiguating fields that share a leaf name at different nesting levels.
+          if (fieldName.includes(".")) {
+            arrows = arrows.filter((a) => {
+              return (
+                a.sources.some((s) => arrowPathMatches(s, fieldName)) ||
+                arrowPathMatches(a.target, fieldName)
+              );
+            });
+          }
+
+          // Add NL-derived arrows when the queried field is the @ref source.
+          //
+          // An @ref like `@source8.amount` in `-> total { "Sum @source8.amount" }`
+          // produces an nl-derived arrow: source8.amount → target8.total.
+          // This arrow is discoverable when querying source8.amount (the ref
+          // resolves to the queried field). Target-side discovery uses field-lineage.
+          const nlRefs = resolveAllNLRefs(index);
+          const canonicalQualified = canonicalKey(qualifiedField);
+          for (const nlRef of nlRefs) {
+            if (!nlRef.resolved || !nlRef.resolvedTo) continue;
+            // NL refs from source blocks describe join conditions, not data flow —
+            // skip them to avoid false NL-derived arrows on join-key fields.
+            if (nlRef.context === "source_block") continue;
+            const resolvedTo = nlRef.resolvedTo.name;
+
+            // nlRef.mapping is already fully qualified by resolveAllNLRefs
+            // (it is built as `${namespace}::${mapping}` or bare name before being
+            // stored). Double-qualifying by prepending nlRef.namespace again would
+            // produce "crm::crm::load_dim_customer", causing the mapping lookup and
+            // the alreadyDeclared dedup check to fail, resulting in duplicate
+            // nl-derived arrows when @ref references the arrow's own source (sl-qxn5).
+            const nlMappingKey = nlRef.mapping;
+
+            if (resolvedTo !== canonicalQualified) continue;
+            const nlMapping = index.mappings.get(nlMappingKey);
+
+            // Skip if the queried field is already a declared source for the same
+            // arrow (e.g. `c -> d { "clean up @s1.c" }` — don't emit a duplicate
+            // nl-derived arrow on top of the existing declared one). Only suppress
+            // when the declared arrow actually lists the @ref field as a source;
+            // derived arrows (source=null) from `-> tgt { "@src.field" }` lack
+            // the source info that the nl-derived arrow adds (sl-k797).
+            const alreadyDeclared = arrows.some((a) => {
+              if (a.classification === "nl-derived") return false;
+              const aMappingKey = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
+              if (aMappingKey !== nlMappingKey || a.target !== nlRef.targetField) return false;
+              // Arrow sources may be bare field names (e.g. "c") while resolvedTo is
+              // canonical (e.g. "::s1.c"). Qualify each source against the mapping's
+              // source schemas to compare properly.
+              const srcSchemas = nlMapping?.sources ?? [];
+              return a.sources.some((s) => {
+                if (s === resolvedTo || canonicalKey(s) === resolvedTo) return true;
+                for (const schema of srcSchemas) {
+                  if (canonicalKey(`${schema}.${s}`) === resolvedTo) return true;
+                }
+                return false;
+              });
+            });
+            if (alreadyDeclared) continue;
+
+            // Deduplicate against nl-derived arrows already added (an NL string may
+            // contain multiple @refs resolving to different fields, each producing an
+            // arrow with the same target).
+            const dedupKey = `${nlMappingKey}:${resolvedTo}:${nlRef.targetField}:${nlRef.line}`;
+            if (seen.has(dedupKey)) continue;
+            seen.add(dedupKey);
+
+            // Use the fully resolved path as the source so cross-schema refs
+            // are correctly attributed (sl-uk9q)
+            arrows.push({
+              mapping:
+                nlRef.namespace && nlRef.mapping?.startsWith(`${nlRef.namespace}::`)
+                  ? nlRef.mapping.slice(nlRef.namespace.length + 2)
+                  : nlRef.mapping,
+              namespace: nlRef.namespace,
+              sources: [resolvedTo],
+              target: nlRef.targetField,
+              transform_raw: `(NL ref)`,
+              steps: [],
+              classification: "nl-derived",
+              derived: true,
+              line: nlRef.line,
+              file: nlRef.file,
+            });
+          }
+
+          // Apply direction filters — verify the queried schema is on the correct
+          // side of the mapping, not just that the field name matches
+          if (opts.asSource) {
+            arrows = arrows.filter((a) => {
+              const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
+              const m = index.mappings.get(qMapping);
+              // For nl-derived arrows, sources may be fully-qualified canonical paths
+              // (e.g. "::s1.a") rather than bare field names — match both forms.
+              return (
+                m?.sources.includes(resolvedSchema.key) &&
+                a.sources.some(
+                  (s) =>
+                    s === fieldName ||
+                    s === leafName ||
+                    s === canonicalQualified ||
+                    s.endsWith(`.${fieldName}`),
+                )
+              );
+            });
+          } else if (opts.asTarget) {
+            arrows = arrows.filter((a) => {
+              const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : (a.mapping ?? "");
+              const m = index.mappings.get(qMapping);
+              return (
+                m?.targets.includes(resolvedSchema.key) &&
+                (a.target === fieldName || a.target === leafName)
+              );
+            });
+          }
+
+          if (arrows.length === 0) {
+            console.log(`No arrows found for '${fieldRef}'.`);
+            return EXIT_NOT_FOUND;
+          }
+
+          if (opts.json) {
+            const jsonArrows = arrows.map((a) => {
+              const qMapping = a.namespace ? `${a.namespace}::${a.mapping}` : a.mapping;
+              const mapping = index.mappings.get(qMapping ?? "");
+              const sourceSchemas = mapping?.sources ?? [];
+              const targetSchemas = mapping?.targets ?? [];
+
+              // Determine which schema the target field belongs to
+              let targetSchema: string;
+              if (targetSchemas.includes(resolvedSchema.key)) {
+                targetSchema = resolvedSchema.key;
+              } else {
+                targetSchema = targetSchemas[0] ?? resolvedSchema.key;
+              }
+
+              const qualifyPath = (path: string | null, schema: string): string | null => {
+                if (!path) return null;
+                if (path.startsWith(schema + ".") || path === schema) return path;
+                // If path is already schema-qualified (contains a dot and the prefix
+                // is a known schema), don't double-qualify
+                const dotIdx = path.indexOf(".");
+                if (dotIdx > 0) {
+                  const prefix = path.slice(0, dotIdx);
+                  if (index.schemas.has(prefix)) return path;
+                }
+                return `${schema}.${path}`;
+              };
+
+              // For multi-source arrows, find the actual schema that owns each source field
+              // rather than attributing all fields to the queried schema.
+              const resolveSourceField = (path: string): string => {
+                // Already in canonical form (::schema.field or ns::schema.field)
+                if (path.includes("::")) return path;
+                // Already fully qualified with a known schema prefix
+                const dotIdx = path.indexOf(".");
+                if (dotIdx > 0) {
+                  const prefix = path.slice(0, dotIdx);
+                  if (index.schemas.has(prefix)) return path;
+                }
+                // Search each source schema for a field matching path
+                for (const schemaKey of sourceSchemas) {
+                  const s = index.schemas.get(schemaKey);
+                  if (!s) continue;
+                  const sSpread = expandEntityFields(s, s.namespace ?? null, index);
+                  const allNames = [...s.fields, ...sSpread].map((f) => f.name);
+                  if (allNames.includes(path)) return `${schemaKey}.${path}`;
+                }
+                // Fallback: use first source schema
+                return `${sourceSchemas[0] ?? resolvedSchema.key}.${path}`;
+              };
+
+              const result: Record<string, unknown> = {
+                mapping: qMapping ? canonicalKey(qMapping) : null,
+                source:
+                  a.sources.length === 0
+                    ? null
+                    : a.sources.map((s) => canonicalKey(resolveSourceField(s))).join(", "),
+                target: a.target
+                  ? canonicalKey(qualifyPath(a.target, targetSchema) ?? a.target)
+                  : null,
+                classification: a.classification,
+                transform_raw: a.transform_raw,
+                steps: a.steps,
+                derived: a.derived,
+                file: a.file,
+                line: a.line + 1,
+              };
+              if (a.metadata && a.metadata.length > 0) {
+                result.metadata = a.metadata;
+              }
+              return result;
+            });
+            console.log(JSON.stringify(jsonArrows, null, 2));
+            return;
+          }
+
+          // Pass the resolved schema key so printDefault can match against index
+          // entries even when the user queried with a bare (unqualified) name (sl-ltv6).
+          printDefault(fieldRef, arrows, index, resolvedSchema.key);
+        },
+      ),
+    );
 }
 
 /**
@@ -370,13 +407,19 @@ function findFieldArrows(fieldKey: string, index: ExtractedWorkspace): ArrowReco
  *   query string, so that mapping source/target lookups hit correctly even
  *   when the user queried with a bare unqualified name (sl-ltv6).
  */
-function printDefault(fieldRef: string, arrows: ArrowRecord[], index: ExtractedWorkspace, resolvedSchemaKey: string): void {
+function printDefault(
+  fieldRef: string,
+  arrows: ArrowRecord[],
+  index: ExtractedWorkspace,
+  resolvedSchemaKey: string,
+): void {
   const dot = fieldRef.indexOf(".");
   const schemaName = resolvedSchemaKey;
   const fieldPath = dot >= 0 ? fieldRef.slice(dot + 1) : fieldRef;
   const leafName = fieldPath.split(".").pop();
   const matchesField = (val: string | null) =>
-    val === fieldPath || val === leafName ||
+    val === fieldPath ||
+    val === leafName ||
     (val != null && (val.endsWith(`.${fieldPath}`) || val.endsWith(`.${leafName}`)));
 
   // Schema-aware source/target classification: verify the queried schema
@@ -400,9 +443,7 @@ function printDefault(fieldRef: string, arrows: ArrowRecord[], index: ExtractedW
   // arrows that are both (field used on both sides) — avoid double-count
   const total = new Set([...asSource, ...asTarget]).size;
 
-  console.log(
-    `${fieldRef} — ${total} arrow${total !== 1 ? "s" : ""} (${parts.join(", ")})`,
-  );
+  console.log(`${fieldRef} — ${total} arrow${total !== 1 ? "s" : ""} (${parts.join(", ")})`);
   console.log();
 
   // Group by qualified mapping name

--- a/tooling/satsuma-cli/src/commands/context.ts
+++ b/tooling/satsuma-cli/src/commands/context.ts
@@ -43,7 +43,9 @@ export function register(program: Command): void {
     .option("--budget <n>", "token budget", parsePositiveInt, 4000)
     .option("--compact", "omit notes and transform bodies")
     .option("--json", "emit ranked JSON list")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Scores blocks by keyword relevance: block name (+10), field names (+5),
 notes (+2), metadata (+1). Emits highest-scoring blocks within the token
 budget (~4 chars per token). --json bypasses the budget and emits all scores.
@@ -52,56 +54,65 @@ Examples:
   satsuma context "customer mapping"                 # blocks about customers
   satsuma context "loyalty tier" --budget 8000       # larger context window
   satsuma context "pii email" --compact              # compact output
-  satsuma context "order" --json                     # all scores as JSON`)
-    .action(runCommand(async (query: string, pathArg: string | undefined, opts: { budget: number; compact?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma context "order" --json                     # all scores as JSON`,
+    )
+    .action(
+      runCommand(
+        async (
+          query: string,
+          pathArg: string | undefined,
+          opts: { budget: number; compact?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      const terms = tokenize(query);
-      const candidates = scoreAll(index, terms, parsedFiles);
-      candidates.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+          const terms = tokenize(query);
+          const candidates = scoreAll(index, terms, parsedFiles);
+          candidates.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
 
-      if (opts.json) {
-        console.log(
-          JSON.stringify(
-            candidates.map(({ name, type, score, file, line }) => ({
-              name,
-              type,
-              score,
-              file,
-              line,
-            })),
-            null,
-            2,
-          ),
-        );
-        return;
-      }
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                candidates.map(({ name, type, score, file, line }) => ({
+                  name,
+                  type,
+                  score,
+                  file,
+                  line,
+                })),
+                null,
+                2,
+              ),
+            );
+            return;
+          }
 
-      // Emit within token budget
-      const budget = opts.budget;
-      let used = 0;
-      const emitted: Array<ScoredCandidate & { block: string }> = [];
+          // Emit within token budget
+          const budget = opts.budget;
+          let used = 0;
+          const emitted: Array<ScoredCandidate & { block: string }> = [];
 
-      for (const c of candidates) {
-        const block = renderBlock(index, c, opts.compact);
-        const tokens = estimateTokens(block);
-        if (used + tokens > budget && emitted.length > 0) break;
-        used += tokens;
-        emitted.push({ ...c, block });
-      }
+          for (const c of candidates) {
+            const block = renderBlock(index, c, opts.compact);
+            const tokens = estimateTokens(block);
+            if (used + tokens > budget && emitted.length > 0) break;
+            used += tokens;
+            emitted.push({ ...c, block });
+          }
 
-      if (emitted.length === 0) {
-        console.log("No relevant blocks found.");
-        return EXIT_NOT_FOUND;
-      }
+          if (emitted.length === 0) {
+            console.log("No relevant blocks found.");
+            return EXIT_NOT_FOUND;
+          }
 
-      console.log(`// Context for: ${query}  (${used} tokens, ${emitted.length} blocks)`);
-      console.log();
-      for (const { block } of emitted) {
-        console.log(block);
-        console.log();
-      }
-    }));
+          console.log(`// Context for: ${query}  (${used} tokens, ${emitted.length} blocks)`);
+          console.log();
+          for (const { block } of emitted) {
+            console.log(block);
+            console.log();
+          }
+        },
+      ),
+    );
 }
 
 // ── Scoring ───────────────────────────────────────────────────────────────────
@@ -125,7 +136,11 @@ function scoreText(text: string, terms: string[]): number {
  * Score all blocks in the index against terms.
  * Returns [{name, type, score, file, line}]
  */
-function scoreAll(index: ExtractedWorkspace, terms: string[], parsedFiles: ParsedFile[]): ScoredCandidate[] {
+function scoreAll(
+  index: ExtractedWorkspace,
+  terms: string[],
+  parsedFiles: ParsedFile[],
+): ScoredCandidate[] {
   const results: ScoredCandidate[] = [];
 
   // Collect NL content (comments, notes) grouped by parent block name
@@ -149,7 +164,18 @@ function scoreAll(index: ExtractedWorkspace, terms: string[], parsedFiles: Parse
     collectRawBlockText(tree.rootNode, null, rawTextByBlock);
   }
 
-  const scoreEntry = (name: string, type: string, entry: { note?: string | null; fields?: Array<{ name: string; type: string }>; sources?: string[]; targets?: string[]; file: string; row: number }) => {
+  const scoreEntry = (
+    name: string,
+    type: string,
+    entry: {
+      note?: string | null;
+      fields?: Array<{ name: string; type: string }>;
+      sources?: string[];
+      targets?: string[];
+      file: string;
+      row: number;
+    },
+  ) => {
     let score = 0;
     score += scoreText(name, terms) * 10;
     if (entry.note) score += scoreText(entry.note, terms) * 2;
@@ -227,7 +253,13 @@ function scoreAll(index: ExtractedWorkspace, terms: string[], parsedFiles: Parse
         } else {
           const m = index.mappings.get(mappingKey);
           if (m) {
-            results.push({ name: mappingKey, type: "mapping", score: nlScore, file: m.file, line: m.row + 1 });
+            results.push({
+              name: mappingKey,
+              type: "mapping",
+              score: nlScore,
+              file: m.file,
+              line: m.row + 1,
+            });
           }
         }
       }
@@ -244,7 +276,11 @@ function estimateTokens(text: string): number {
 }
 
 /** Render a block as a compact string for output. */
-function renderBlock(index: ExtractedWorkspace, candidate: ScoredCandidate, compact?: boolean): string {
+function renderBlock(
+  index: ExtractedWorkspace,
+  candidate: ScoredCandidate,
+  compact?: boolean,
+): string {
   const { name, type } = candidate;
   const lines: string[] = [];
 
@@ -262,7 +298,7 @@ function renderBlock(index: ExtractedWorkspace, candidate: ScoredCandidate, comp
     const m = index.metrics.get(name);
     const display = m?.displayName ? ` "${m.displayName}"` : "";
     lines.push(`metric ${name}${display} {`);
-    const maxLen = Math.max(20, ...((m?.fields ?? []).map((f) => f.name.length + 1)));
+    const maxLen = Math.max(20, ...(m?.fields ?? []).map((f) => f.name.length + 1));
     for (const f of m?.fields ?? []) lines.push(`  ${f.name.padEnd(maxLen)}${f.type}`);
     lines.push("}");
   } else if (type === "mapping") {
@@ -275,7 +311,7 @@ function renderBlock(index: ExtractedWorkspace, candidate: ScoredCandidate, comp
   } else if (type === "fragment") {
     const f = index.fragments.get(name);
     lines.push(`fragment '${name}' {`);
-    const maxLen = Math.max(24, ...((f?.fields ?? []).map((fld) => fld.name.length + 1)));
+    const maxLen = Math.max(24, ...(f?.fields ?? []).map((fld) => fld.name.length + 1));
     for (const fld of f?.fields ?? []) lines.push(`  ${fld.name.padEnd(maxLen)}${fld.type}`);
     lines.push("}");
   } else if (type === "transform") {
@@ -288,10 +324,7 @@ function renderBlock(index: ExtractedWorkspace, candidate: ScoredCandidate, comp
 // ── Metadata collection ──────────────────────────────────────────────────────
 
 // metric_block is removed — metrics are now schema_block nodes with the `metric` tag.
-const BLOCK_TYPES = new Set([
-  "schema_block", "mapping_block",
-  "fragment_block", "transform_block",
-]);
+const BLOCK_TYPES = new Set(["schema_block", "mapping_block", "fragment_block", "transform_block"]);
 
 function getBlockName(node: SyntaxNode): string | null {
   const label = node.namedChildren.find((c) => c.type === "block_label");
@@ -310,7 +343,11 @@ function getBlockName(node: SyntaxNode): string | null {
  * Walk the CST and collect raw block text grouped by block name.
  * Used for full-text keyword search (flatten, list_of, governance, etc.).
  */
-function collectRawBlockText(node: SyntaxNode, _parent: string | null, result: Map<string, string>): void {
+function collectRawBlockText(
+  node: SyntaxNode,
+  _parent: string | null,
+  result: Map<string, string>,
+): void {
   for (const c of node.namedChildren) {
     if (BLOCK_TYPES.has(c.type)) {
       const name = getBlockName(c);
@@ -327,7 +364,11 @@ function collectRawBlockText(node: SyntaxNode, _parent: string | null, result: M
 /**
  * Walk the CST and collect metadata_block text grouped by parent block name.
  */
-function collectMetadataText(node: SyntaxNode, parent: string | null, result: Map<string, string[]>): void {
+function collectMetadataText(
+  node: SyntaxNode,
+  parent: string | null,
+  result: Map<string, string[]>,
+): void {
   for (const c of node.namedChildren) {
     let newParent = parent;
     if (BLOCK_TYPES.has(c.type)) {

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -76,7 +76,9 @@ export function register(program: Command): void {
     .option("--uncovered", "list only the fields nothing maps")
     .option("--fail-under <pct>", "exit 3 when aggregate coverage is below <pct>", parsePercentage)
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Coverage follows explicit references. A field counts as covered when an arrow in
 the mapping references it (the 'declared' tier) or a resolved NL @ref names it
 (the 'nl' tier). Nested paths cover their parents — mapping 'address.city' covers
@@ -167,51 +169,58 @@ Examples:
   satsuma coverage pipeline.stm --json                    # machine-readable
   satsuma coverage pipeline.stm --fail-under 90            # CI gate on target coverage
   satsuma coverage pipeline.stm --fail-under 80 --role source
-  satsuma coverage pipeline.stm --fail-under 95 --mapping 'load hub'`)
-    .action(runCommand(async (pathArg: string | undefined, opts: CoverageOptions) => {
-      const role = (opts.role ?? null) as Role | null;
-      const { files, index } = await loadWorkspace(pathArg);
+  satsuma coverage pipeline.stm --fail-under 95 --mapping 'load hub'`,
+    )
+    .action(
+      runCommand(async (pathArg: string | undefined, opts: CoverageOptions) => {
+        const role = (opts.role ?? null) as Role | null;
+        const { files, index } = await loadWorkspace(pathArg);
 
-      // Resolve scope arguments before doing any work, so a typo reports itself
-      // as a typo (exit 1) rather than as an empty — and misleading — report.
-      const mappingKey = opts.mapping ? resolveScopeName(opts.mapping, "Mapping", index.mappings) : null;
-      const schemaKey = opts.schema ? resolveScopeName(opts.schema, "Schema", index.schemas) : null;
+        // Resolve scope arguments before doing any work, so a typo reports itself
+        // as a typo (exit 1) rather than as an empty — and misleading — report.
+        const mappingKey = opts.mapping
+          ? resolveScopeName(opts.mapping, "Mapping", index.mappings)
+          : null;
+        const schemaKey = opts.schema
+          ? resolveScopeName(opts.schema, "Schema", index.schemas)
+          : null;
 
-      // Resolved once for the whole workspace and reused for every mapping —
-      // resolution is workspace-wide, and it is what makes the NL tier possible
-      // at all (ADR-036).
-      const nlRefs = resolveAllNLRefs(index);
-      const { mappings, skippedAnonymous } = coverageForWorkspace(index, files, nlRefs);
-      const scoped = applyScope(mappings, { mappingKey, schemaKey, role });
+        // Resolved once for the whole workspace and reused for every mapping —
+        // resolution is workspace-wide, and it is what makes the NL tier possible
+        // at all (ADR-036).
+        const nlRefs = resolveAllNLRefs(index);
+        const { mappings, skippedAnonymous } = coverageForWorkspace(index, files, nlRefs);
+        const scoped = applyScope(mappings, { mappingKey, schemaKey, role });
 
-      if (scoped.length === 0) {
-        console.log(describeEmptyScope(mappings.length, { mappingKey, schemaKey, role }));
-        return EXIT_NOT_FOUND;
-      }
+        if (scoped.length === 0) {
+          console.log(describeEmptyScope(mappings.length, { mappingKey, schemaKey, role }));
+          return EXIT_NOT_FOUND;
+        }
 
-      // Aggregate over the *scoped* mappings, so `--schema X` reports X's
-      // workspace-wide coverage rather than the whole workspace's.
-      const aggregate = aggregateCoverage(scoped);
-      const gate = evaluateGate(aggregate, role, opts.failUnder);
+        // Aggregate over the *scoped* mappings, so `--schema X` reports X's
+        // workspace-wide coverage rather than the whole workspace's.
+        const aggregate = aggregateCoverage(scoped);
+        const gate = evaluateGate(aggregate, role, opts.failUnder);
 
-      if (opts.json) {
-        const report: Record<string, unknown> = {
-          mappings: scoped.map((m) => toJson(m, opts)),
-          aggregate: aggregateToJson(aggregate, opts),
-        };
-        if (gate) report.gate = gate;
-        console.log(JSON.stringify(report, null, 2));
-      } else {
-        printPerMappingReport(scoped, opts);
-        printAggregateReport(aggregate, opts);
-        if (gate) printGate(gate);
-        if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
-      }
+        if (opts.json) {
+          const report: Record<string, unknown> = {
+            mappings: scoped.map((m) => toJson(m, opts)),
+            aggregate: aggregateToJson(aggregate, opts),
+          };
+          if (gate) report.gate = gate;
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          printPerMappingReport(scoped, opts);
+          printAggregateReport(aggregate, opts);
+          if (gate) printGate(gate);
+          if (skippedAnonymous > 0) printAnonymousNote(skippedAnonymous);
+        }
 
-      // The report is printed either way — a failed gate must still show the
-      // reviewer which fields are missing, not just that a number was too low.
-      return gate && !gate.met ? EXIT_THRESHOLD_NOT_MET : undefined;
-    }));
+        // The report is printed either way — a failed gate must still show the
+        // reviewer which fields are missing, not just that a number was too low.
+        return gate && !gate.met ? EXIT_THRESHOLD_NOT_MET : undefined;
+      }),
+    );
 }
 
 // ── Scope resolution ────────────────────────────────────────────────────────
@@ -252,7 +261,9 @@ function applyScope(mappings: MappingCoverage[], scope: Scope): MappingCoverage[
   for (const mapping of mappings) {
     if (scope.mappingKey && mapping.mappingId !== scope.mappingKey) continue;
     const schemas = mapping.result.schemas.filter(
-      (s) => (!scope.schemaKey || s.schemaId === scope.schemaKey) && (!scope.role || s.role === scope.role),
+      (s) =>
+        (!scope.schemaKey || s.schemaId === scope.schemaKey) &&
+        (!scope.role || s.role === scope.role),
     );
     if (schemas.length === 0) continue;
     result.push({ ...mapping, result: { schemas } });
@@ -371,7 +382,9 @@ const WORKSPACE_LABEL = "workspace";
  * than leaving a reviewer to infer it.
  */
 function printPerMappingReport(mappings: MappingCoverage[], opts: CoverageOptions): void {
-  console.log(`Coverage — ${mappings.length} mapping${mappings.length !== 1 ? "s" : ""}, per mapping`);
+  console.log(
+    `Coverage — ${mappings.length} mapping${mappings.length !== 1 ? "s" : ""}, per mapping`,
+  );
 
   for (const mapping of mappings) {
     console.log();
@@ -383,7 +396,7 @@ function printPerMappingReport(mappings: MappingCoverage[], opts: CoverageOption
     for (const schema of mapping.result.schemas) {
       console.log(
         `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${displayKey(schema.schemaId).padEnd(schemaWidth)}  ` +
-        `${formatTotals(summarizeFieldCoverage(schema.fields))}`,
+          `${formatTotals(summarizeFieldCoverage(schema.fields))}`,
       );
     }
 
@@ -407,7 +420,7 @@ function printFieldList(schema: SchemaCoverageResult, opts: CoverageOptions): vo
 
   console.log(
     `    uncovered in ${displayKey(schema.schemaId)} (${schema.role}): ` +
-    `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
+      `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
   );
   for (const line of wrapPaths(uncovered.map((f) => f.path))) {
     console.log(`      ${line}`);
@@ -477,8 +490,8 @@ function evaluateGate(
   if (totals.total === 0) {
     throw new CommandError(
       `No ${gatedRole}-role coverage in scope to gate with --fail-under.\n` +
-      `Nothing in scope declares ${gatedRole} fields; ` +
-      `use --role ${gatedRole === "target" ? "source" : "target"} or widen the scope.`,
+        `Nothing in scope declares ${gatedRole} fields; ` +
+        `use --role ${gatedRole === "target" ? "source" : "target"} or widen the scope.`,
       EXIT_NOT_FOUND,
     );
   }
@@ -497,7 +510,7 @@ function printGate(gate: CoverageGate): void {
   console.log();
   console.log(
     `--fail-under: ${gate.role} coverage ${gate.pct}% vs threshold ${gate.threshold}% — ` +
-    `${gate.met ? "met" : "NOT met"}`,
+      `${gate.met ? "met" : "NOT met"}`,
   );
 }
 
@@ -513,7 +526,10 @@ function printGate(gate: CoverageGate): void {
  * mapping does not. Keeping them in separate objects means a consumer has to
  * choose which claim it is making.
  */
-function aggregateToJson(aggregate: AggregateCoverage, opts: CoverageOptions): Record<string, unknown> {
+function aggregateToJson(
+  aggregate: AggregateCoverage,
+  opts: CoverageOptions,
+): Record<string, unknown> {
   return {
     schemas: aggregate.schemas.map((schema) => ({
       schema: canonicalKey(schema.schemaId),
@@ -538,7 +554,10 @@ function aggregateToJson(aggregate: AggregateCoverage, opts: CoverageOptions): R
  * The aggregate field entries to report, filtered exactly as the per-mapping
  * ones are so the two sections stay comparable line for line.
  */
-function aggregateFields(schema: AggregateSchemaCoverage, opts: CoverageOptions): FieldCoverageEntry[] {
+function aggregateFields(
+  schema: AggregateSchemaCoverage,
+  opts: CoverageOptions,
+): FieldCoverageEntry[] {
   const leaves = leafFieldEntries(schema.fields);
   return opts.uncovered ? leaves.filter((f) => !f.mapped) : leaves;
 }
@@ -555,13 +574,11 @@ function printAggregateReport(aggregate: AggregateCoverage, opts: CoverageOption
   console.log();
   console.log("Aggregate — a field is uncovered here only when NO mapping in scope covers it");
 
-  const schemaWidth = Math.max(
-    ...aggregate.schemas.map((s) => displayKey(s.schemaId).length),
-  );
+  const schemaWidth = Math.max(...aggregate.schemas.map((s) => displayKey(s.schemaId).length));
   for (const schema of aggregate.schemas) {
     console.log(
       `  ${schema.role.padEnd(ROLE_COLUMN_WIDTH)}  ${displayKey(schema.schemaId).padEnd(schemaWidth)}  ` +
-      `${formatTotals(schema.totals)}`,
+        `${formatTotals(schema.totals)}`,
     );
   }
 
@@ -570,7 +587,7 @@ function printAggregateReport(aggregate: AggregateCoverage, opts: CoverageOption
     if (uncovered.length === 0) continue;
     console.log(
       `    covered by no mapping — ${displayKey(schema.schemaId)} (${schema.role}): ` +
-      `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
+        `${uncovered.length} field${uncovered.length !== 1 ? "s" : ""}`,
     );
     for (const line of wrapPaths(uncovered.map((f) => f.path))) {
       console.log(`      ${line}`);
@@ -591,7 +608,9 @@ function printSubtotals(aggregate: AggregateCoverage): void {
   const showNamespaces = aggregate.namespaces.length > 1;
   // One label width across namespace rows and the workspace row, so the
   // percentages line up into a column the eye can scan down.
-  const labels = showNamespaces ? aggregate.namespaces.map((ns) => namespaceLabel(ns.namespace)) : [];
+  const labels = showNamespaces
+    ? aggregate.namespaces.map((ns) => namespaceLabel(ns.namespace))
+    : [];
   const labelWidth = Math.max(...labels.map((l) => l.length), WORKSPACE_LABEL.length);
 
   console.log();
@@ -657,6 +676,6 @@ function printAnonymousNote(count: number): void {
   console.log();
   console.log(
     `Note: ${count} anonymous mapping${count !== 1 ? "s" : ""} not reported ` +
-    `(coverage is looked up by mapping name; name the mapping to include it).`,
+      `(coverage is looked up by mapping name; name the mapping to include it).`,
   );
 }

--- a/tooling/satsuma-cli/src/commands/diff.ts
+++ b/tooling/satsuma-cli/src/commands/diff.ts
@@ -25,33 +25,41 @@ type ChangeKind = SchemaChange["kind"] | MappingChange["kind"] | TransformChange
  * single-line description. Replaces the prior 14-branch if-else chain
  * (sl-3kmd) and gives TypeScript exhaustiveness checking via `satisfies`.
  */
-const CHANGE_PRINTERS: Record<ChangeKind, (c: SchemaChange | MappingChange | TransformChange) => string> = {
+const CHANGE_PRINTERS: Record<
+  ChangeKind,
+  (c: SchemaChange | MappingChange | TransformChange) => string
+> = {
   // Schema / metric field changes
-  "field-added":     (c) => `      + field ${(c as SchemaChange).field}`,
-  "field-removed":   (c) => `      - field ${(c as SchemaChange).field}`,
-  "type-changed":    (c) => `      ~ ${(c as SchemaChange).field}: ${String(c.from)} -> ${String(c.to)}`,
-  "metadata-changed":(c) => `      ~ ${(c as SchemaChange).field} metadata: ${String(c.from)} -> ${String(c.to)}`,
+  "field-added": (c) => `      + field ${(c as SchemaChange).field}`,
+  "field-removed": (c) => `      - field ${(c as SchemaChange).field}`,
+  "type-changed": (c) =>
+    `      ~ ${(c as SchemaChange).field}: ${String(c.from)} -> ${String(c.to)}`,
+  "metadata-changed": (c) =>
+    `      ~ ${(c as SchemaChange).field} metadata: ${String(c.from)} -> ${String(c.to)}`,
 
   // Metric header attributes
-  "source-changed":  (c) => `      ~ source: ${String(c.from)} -> ${String(c.to)}`,
-  "grain-changed":   (c) => `      ~ grain: ${String(c.from)} -> ${String(c.to)}`,
-  "slices-changed":  (c) => `      ~ slices: ${String(c.from)} -> ${String(c.to)}`,
+  "source-changed": (c) => `      ~ source: ${String(c.from)} -> ${String(c.to)}`,
+  "grain-changed": (c) => `      ~ grain: ${String(c.from)} -> ${String(c.to)}`,
+  "slices-changed": (c) => `      ~ slices: ${String(c.from)} -> ${String(c.to)}`,
 
   // Mapping arrow changes
-  "arrow-count-changed":     (c) => `      ~ arrows: ${String(c.from)} -> ${String(c.to)}`,
-  "sources-changed":         (c) => `      ~ sources: ${(c.from as string[]).join(", ")} -> ${(c.to as string[]).join(", ")}`,
-  "targets-changed":         (c) => `      ~ targets: ${(c.from as string[]).join(", ")} -> ${(c.to as string[]).join(", ")}`,
-  "arrow-added":             (c) => `      + arrow ${String((c as MappingChange).arrow)}`,
-  "arrow-removed":           (c) => `      - arrow ${String((c as MappingChange).arrow)}`,
-  "arrow-transform-changed": (c) => `      ~ arrow ${String((c as MappingChange).arrow)}: ${String(c.from)} -> ${String(c.to)}`,
+  "arrow-count-changed": (c) => `      ~ arrows: ${String(c.from)} -> ${String(c.to)}`,
+  "sources-changed": (c) =>
+    `      ~ sources: ${(c.from as string[]).join(", ")} -> ${(c.to as string[]).join(", ")}`,
+  "targets-changed": (c) =>
+    `      ~ targets: ${(c.from as string[]).join(", ")} -> ${(c.to as string[]).join(", ")}`,
+  "arrow-added": (c) => `      + arrow ${String((c as MappingChange).arrow)}`,
+  "arrow-removed": (c) => `      - arrow ${String((c as MappingChange).arrow)}`,
+  "arrow-transform-changed": (c) =>
+    `      ~ arrow ${String((c as MappingChange).arrow)}: ${String(c.from)} -> ${String(c.to)}`,
 
   // Note changes (schema-level note tag and block notes)
-  "note-changed":  (c) => `      ~ note: ${String(c.from)} -> ${String(c.to)}`,
-  "note-added":    (c) => `      + note ${JSON.stringify(String(c.from))}`,
-  "note-removed":  (c) => `      - note ${JSON.stringify(String(c.from))}`,
+  "note-changed": (c) => `      ~ note: ${String(c.from)} -> ${String(c.to)}`,
+  "note-added": (c) => `      + note ${JSON.stringify(String(c.from))}`,
+  "note-removed": (c) => `      - note ${JSON.stringify(String(c.from))}`,
 
   // Transform body changes
-  "body-changed":  (c) => `      ~ body: ${String(c.from)} -> ${String(c.to)}`,
+  "body-changed": (c) => `      ~ body: ${String(c.from)} -> ${String(c.to)}`,
 } satisfies Record<ChangeKind, (c: SchemaChange | MappingChange | TransformChange) => string>;
 
 export function register(program: Command): void {
@@ -61,7 +69,9 @@ export function register(program: Command): void {
     .option("--json", "structured JSON output")
     .option("--names-only", "list changed block names only")
     .option("--stat", "summary counts only")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Compares two Satsuma files structurally (not text diff). Only the two
 files themselves are compared — imports are not followed.
 
@@ -79,63 +89,78 @@ Examples:
   satsuma diff v1/pipeline.stm v2/pipeline.stm      # compare two versions
   satsuma diff old.stm new.stm --stat               # summary counts
   satsuma diff old.stm new.stm --json               # full structural delta
-  satsuma diff old.stm new.stm --names-only         # just changed block names`)
-    .action(runCommand(async (pathA: string, pathB: string, opts: { json?: boolean; namesOnly?: boolean; stat?: boolean }) => {
-      let filesA: string[], filesB: string[];
-      try {
-        filesA = await resolveInput(pathA, { followImports: false });
-        filesB = await resolveInput(pathB, { followImports: false });
-      } catch (err: unknown) {
-        // diff is one of the three commands that resolve directly rather
-        // than through loadWorkspace — it needs `followImports: false` and
-        // two separate inputs (see load-workspace.ts header).
-        throw new CommandError(
-          `Error resolving paths: ${(err as Error).message}`,
-          EXIT_PARSE_ERROR,
-        );
-      }
+  satsuma diff old.stm new.stm --names-only         # just changed block names`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathA: string,
+          pathB: string,
+          opts: { json?: boolean; namesOnly?: boolean; stat?: boolean },
+        ) => {
+          let filesA: string[], filesB: string[];
+          try {
+            filesA = await resolveInput(pathA, { followImports: false });
+            filesB = await resolveInput(pathB, { followImports: false });
+          } catch (err: unknown) {
+            // diff is one of the three commands that resolve directly rather
+            // than through loadWorkspace — it needs `followImports: false` and
+            // two separate inputs (see load-workspace.ts header).
+            throw new CommandError(
+              `Error resolving paths: ${(err as Error).message}`,
+              EXIT_PARSE_ERROR,
+            );
+          }
 
-      const indexA = buildIndex(filesA.map((f) => parseFile(f)));
-      const indexB = buildIndex(filesB.map((f) => parseFile(f)));
-      const delta = diffIndex(indexA, indexB);
+          const indexA = buildIndex(filesA.map((f) => parseFile(f)));
+          const indexB = buildIndex(filesB.map((f) => parseFile(f)));
+          const delta = diffIndex(indexA, indexB);
 
-      if (opts.json) {
-        console.log(JSON.stringify(delta, null, 2));
-        return;
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(delta, null, 2));
+            return;
+          }
 
-      const sectionHasChanges = (s: { added: unknown[]; removed: unknown[]; changed: unknown[] }) =>
-        s.added.length > 0 || s.removed.length > 0 || s.changed.length > 0;
-      const notesChanged = delta.notes.added.length > 0 || delta.notes.removed.length > 0;
-      const hasChanges =
-        sectionHasChanges(delta.schemas) ||
-        sectionHasChanges(delta.mappings) ||
-        sectionHasChanges(delta.metrics) ||
-        sectionHasChanges(delta.fragments) ||
-        sectionHasChanges(delta.transforms) ||
-        notesChanged;
+          const sectionHasChanges = (s: {
+            added: unknown[];
+            removed: unknown[];
+            changed: unknown[];
+          }) => s.added.length > 0 || s.removed.length > 0 || s.changed.length > 0;
+          const notesChanged = delta.notes.added.length > 0 || delta.notes.removed.length > 0;
+          const hasChanges =
+            sectionHasChanges(delta.schemas) ||
+            sectionHasChanges(delta.mappings) ||
+            sectionHasChanges(delta.metrics) ||
+            sectionHasChanges(delta.fragments) ||
+            sectionHasChanges(delta.transforms) ||
+            notesChanged;
 
-      if (!hasChanges) {
-        console.log("No structural differences.");
-        return;
-      }
+          if (!hasChanges) {
+            console.log("No structural differences.");
+            return;
+          }
 
-      if (opts.stat) {
-        printStat(delta);
-        return;
-      }
+          if (opts.stat) {
+            printStat(delta);
+            return;
+          }
 
-      if (opts.namesOnly) {
-        printNamesOnly(delta);
-        return;
-      }
+          if (opts.namesOnly) {
+            printNamesOnly(delta);
+            return;
+          }
 
-      printDefault(delta);
-    }));
+          printDefault(delta);
+        },
+      ),
+    );
 }
 
 function printStat(delta: Delta): void {
-  function statSection(label: string, section: { added: unknown[]; removed: unknown[]; changed: unknown[] }): void {
+  function statSection(
+    label: string,
+    section: { added: unknown[]; removed: unknown[]; changed: unknown[] },
+  ): void {
     if (section.added.length > 0) console.log(`  ${section.added.length} ${label} added`);
     if (section.removed.length > 0) console.log(`  ${section.removed.length} ${label} removed`);
     if (section.changed.length > 0) console.log(`  ${section.changed.length} ${label} changed`);
@@ -151,7 +176,11 @@ function printStat(delta: Delta): void {
 
 function printNamesOnly(delta: Delta): void {
   const names = new Set<string>();
-  function collectNames(section: { added: string[]; removed: string[]; changed: Array<{ name: string }> }): void {
+  function collectNames(section: {
+    added: string[];
+    removed: string[];
+    changed: Array<{ name: string }>;
+  }): void {
     for (const n of section.added) names.add(n);
     for (const n of section.removed) names.add(n);
     for (const c of section.changed) names.add(c.name);
@@ -189,9 +218,11 @@ function printNotes(delta: Delta): void {
   console.log();
 }
 
-function printSection(label: string, section: BlockDelta<SchemaChange | MappingChange | TransformChange>): void {
-  const total =
-    section.added.length + section.removed.length + section.changed.length;
+function printSection(
+  label: string,
+  section: BlockDelta<SchemaChange | MappingChange | TransformChange>,
+): void {
+  const total = section.added.length + section.removed.length + section.changed.length;
   if (total === 0) return;
 
   console.log(`${label}:`);

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -24,7 +24,7 @@ import type { ExtractedWorkspace } from "../types.js";
 
 interface FieldEdgeEntry {
   from: string | null; // canonical field path or null for derived/no-source
-  to: string;          // canonical field path
+  to: string; // canonical field path
   via_mapping: string; // canonical mapping key
   classification: string;
 }
@@ -43,7 +43,9 @@ export function register(program: Command): void {
     .option("--downstream", "only downstream chain")
     .option("--depth <n>", "maximum traversal depth", parsePositiveInt, 10)
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Traces all fields that flow into (upstream) and out of (downstream) the given
 field, following declared arrows and NL-derived references. Detects cycles.
 
@@ -61,79 +63,91 @@ Examples:
   satsuma field-lineage s2.a                     # full upstream + downstream
   satsuma field-lineage s2.a --upstream          # only upstream chain
   satsuma field-lineage s2.a --json              # structured output
-  satsuma field-lineage ns::s2.a --downstream    # namespace-qualified`)
-    .action(runCommand(async (fieldRef: string, pathArg: string | undefined, opts: {
-      upstream?: boolean;
-      downstream?: boolean;
-      depth: number;
-      json?: boolean;
-    }) => {
-      const dot = fieldRef.indexOf(".");
-      if (dot === -1) {
-        throw new CommandError(
-          `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
-          EXIT_PARSE_ERROR,
-        );
-      }
+  satsuma field-lineage ns::s2.a --downstream    # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          fieldRef: string,
+          pathArg: string | undefined,
+          opts: {
+            upstream?: boolean;
+            downstream?: boolean;
+            depth: number;
+            json?: boolean;
+          },
+        ) => {
+          const dot = fieldRef.indexOf(".");
+          if (dot === -1) {
+            throw new CommandError(
+              `Invalid field reference '${fieldRef}'. Expected format: schema.field`,
+              EXIT_PARSE_ERROR,
+            );
+          }
 
-      const schemaName = fieldRef.slice(0, dot);
-      const fieldName = fieldRef.slice(dot + 1);
+          const schemaName = fieldRef.slice(0, dot);
+          const fieldName = fieldRef.slice(dot + 1);
 
-      const { index } = await loadWorkspace(pathArg);
+          const { index } = await loadWorkspace(pathArg);
 
-      // Resolve the schema
-      const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
-      if (!resolvedSchema) {
-        throw new CommandError(`Schema '${schemaName}' not found.`, EXIT_NOT_FOUND);
-      }
+          // Resolve the schema
+          const resolvedSchema = resolveIndexKey(schemaName, index.schemas);
+          if (!resolvedSchema) {
+            throw new CommandError(`Schema '${schemaName}' not found.`, EXIT_NOT_FOUND);
+          }
 
-      // Validate field exists (including spread fields)
-      const schema = resolvedSchema.entry;
-      const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
-      const allFields = [...schema.fields, ...spreadFields];
-      const fieldExists = findFieldByPath(allFields, fieldName) !== null ||
-        collectFieldNames(allFields).includes(fieldName);
-      if (!fieldExists) {
-        throw new CommandError(
-          `Field '${fieldName}' not found in schema '${schemaName}'.`,
-          EXIT_NOT_FOUND,
-        );
-      }
+          // Validate field exists (including spread fields)
+          const schema = resolvedSchema.entry;
+          const spreadFields = expandEntityFields(schema, schema.namespace ?? null, index);
+          const allFields = [...schema.fields, ...spreadFields];
+          const fieldExists =
+            findFieldByPath(allFields, fieldName) !== null ||
+            collectFieldNames(allFields).includes(fieldName);
+          if (!fieldExists) {
+            throw new CommandError(
+              `Field '${fieldName}' not found in schema '${schemaName}'.`,
+              EXIT_NOT_FOUND,
+            );
+          }
 
-      const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
-      const canonicalField = canonicalKey(qualifiedField);
+          const qualifiedField = `${resolvedSchema.key}.${fieldName}`;
+          const canonicalField = canonicalKey(qualifiedField);
 
-      // Build the field-level edge graph (declared + nl-derived)
-      const edges = buildFieldEdgeGraph(index);
+          // Build the field-level edge graph (declared + nl-derived)
+          const edges = buildFieldEdgeGraph(index);
 
-      // Determine which directions to trace.
-      // If both flags are set (or neither), trace both directions.
-      const doUpstream = opts.upstream || !opts.downstream;
-      const doDownstream = opts.downstream || !opts.upstream;
+          // Determine which directions to trace.
+          // If both flags are set (or neither), trace both directions.
+          const doUpstream = opts.upstream || !opts.downstream;
+          const doDownstream = opts.downstream || !opts.upstream;
 
-      const upstream: Array<{ field: string; via_mapping: string; classification: string }> = [];
-      const downstream: Array<{ field: string; via_mapping: string; classification: string }> = [];
+          const upstream: Array<{ field: string; via_mapping: string; classification: string }> =
+            [];
+          const downstream: Array<{ field: string; via_mapping: string; classification: string }> =
+            [];
 
-      if (doUpstream) {
-        traceUpstream(canonicalField, edges, opts.depth, upstream);
-      }
-      if (doDownstream) {
-        traceDownstream(canonicalField, edges, opts.depth, downstream);
-      }
+          if (doUpstream) {
+            traceUpstream(canonicalField, edges, opts.depth, upstream);
+          }
+          if (doDownstream) {
+            traceDownstream(canonicalField, edges, opts.depth, downstream);
+          }
 
-      const result: FieldLineageResult = {
-        field: canonicalField,
-        upstream,
-        downstream,
-      };
+          const result: FieldLineageResult = {
+            field: canonicalField,
+            upstream,
+            downstream,
+          };
 
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(result, null, 2));
+            return;
+          }
 
-      printDefault(result, doUpstream, doDownstream);
-    }));
+          printDefault(result, doUpstream, doDownstream);
+        },
+      ),
+    );
 }
 
 // ── Field-edge graph ──────────────────────────────────────────────────────────
@@ -158,15 +172,11 @@ function buildFieldEdgeGraph(index: ExtractedWorkspace): FieldEdgeEntry[] {
     const sourceSchemas = mapping?.sources ?? [];
     const targetSchemas = mapping?.targets ?? [];
 
-    const toField = record.target
-      ? canonicalKey(qualifyField(record.target, targetSchemas))
-      : null;
+    const toField = record.target ? canonicalKey(qualifyField(record.target, targetSchemas)) : null;
     if (!toField) continue;
 
     for (const src of record.sources.length > 0 ? record.sources : [null]) {
-      const fromField = src
-        ? canonicalKey(qualifyField(src, sourceSchemas))
-        : null;
+      const fromField = src ? canonicalKey(qualifyField(src, sourceSchemas)) : null;
       edges.push({
         from: fromField,
         to: toField,
@@ -204,8 +214,11 @@ function buildFieldEdgeGraph(index: ExtractedWorkspace): FieldEdgeEntry[] {
     // source to the same target in the same mapping
     const mappingCanonical = canonicalKey(rawMappingKey);
     const alreadyCovered = edges.some(
-      (e) => e.from === sourceField && e.to === targetField &&
-             e.via_mapping === mappingCanonical && e.classification !== "nl-derived",
+      (e) =>
+        e.from === sourceField &&
+        e.to === targetField &&
+        e.via_mapping === mappingCanonical &&
+        e.classification !== "nl-derived",
     );
     if (alreadyCovered) continue;
 

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -17,7 +17,13 @@ import { resolveIndexKey } from "../index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../spread-expand.js";
 import { coverageForMapping, coveredFieldPaths } from "../coverage-workspace.js";
 import { resolveAllNLRefs } from "../nl-ref-extract.js";
-import type { FieldDecl, ParsedFile, SchemaRecord, FragmentRecord, MetricRecord } from "../types.js";
+import type {
+  FieldDecl,
+  ParsedFile,
+  SchemaRecord,
+  FragmentRecord,
+  MetricRecord,
+} from "../types.js";
 
 interface FieldWithTags extends FieldDecl {
   tags?: string[];
@@ -30,7 +36,9 @@ export function register(program: Command): void {
     .option("--with-meta", "include metadata tags")
     .option("--unmapped-by <mapping>", "only unmapped fields relative to a mapping")
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Looks up <name> in schemas first, then fragments, then metrics.
 Names can be namespace-qualified (e.g. pos::stores).
 
@@ -42,100 +50,122 @@ Examples:
   satsuma fields hub_customer                                    # list all fields
   satsuma fields hub_customer --with-meta                        # include tags
   satsuma fields hub_customer --unmapped-by 'load hub_customer'  # coverage gaps
-  satsuma fields pos::stores --json                              # namespace-qualified`)
-    .action(runCommand(async (schemaName: string, pathArg: string | undefined, opts: { withMeta?: boolean; unmappedBy?: string; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma fields pos::stores --json                              # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          schemaName: string,
+          pathArg: string | undefined,
+          opts: { withMeta?: boolean; unmappedBy?: string; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      // Search schemas first, then fragments, then metrics
-      type ResolvedEntity = { key: string; entry: SchemaRecord | FragmentRecord | MetricRecord };
-      let resolved: ResolvedEntity | null = resolveIndexKey(schemaName, index.schemas);
-      let entityKind = "schema";
-      if (!resolved) {
-        resolved = resolveIndexKey(schemaName, index.fragments);
-        entityKind = "fragment";
-      }
-      if (!resolved) {
-        resolved = resolveIndexKey(schemaName, index.metrics);
-        entityKind = "metric";
-      }
-      if (!resolved) {
-        const allKeys = [...index.schemas.keys(), ...index.fragments.keys(), ...index.metrics.keys()];
-        const close = allKeys.find(
-          (k) => k.toLowerCase() === schemaName.toLowerCase(),
-        );
-        const lines = [`'${schemaName}' not found in schemas, fragments, or metrics.`];
-        if (close) lines.push(`Did you mean '${close}'?`);
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-      const resolvedSchemaName = resolved.key;
+          // Search schemas first, then fragments, then metrics
+          type ResolvedEntity = {
+            key: string;
+            entry: SchemaRecord | FragmentRecord | MetricRecord;
+          };
+          let resolved: ResolvedEntity | null = resolveIndexKey(schemaName, index.schemas);
+          let entityKind = "schema";
+          if (!resolved) {
+            resolved = resolveIndexKey(schemaName, index.fragments);
+            entityKind = "fragment";
+          }
+          if (!resolved) {
+            resolved = resolveIndexKey(schemaName, index.metrics);
+            entityKind = "metric";
+          }
+          if (!resolved) {
+            const allKeys = [
+              ...index.schemas.keys(),
+              ...index.fragments.keys(),
+              ...index.metrics.keys(),
+            ];
+            const close = allKeys.find((k) => k.toLowerCase() === schemaName.toLowerCase());
+            const lines = [`'${schemaName}' not found in schemas, fragments, or metrics.`];
+            if (close) lines.push(`Did you mean '${close}'?`);
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          }
+          const resolvedSchemaName = resolved.key;
 
-      const entity = resolved.entry;
-      let fields: FieldWithTags[] = deepCopyFields(entity.fields);
+          const entity = resolved.entry;
+          let fields: FieldWithTags[] = deepCopyFields(entity.fields);
 
-      // Expand fragment spreads — inline fields from spread fragments (schemas and fragments only)
-      if (entityKind !== "metric") {
-        // Expand nested record-level spreads in place first
-        expandNestedSpreads(fields, entity.namespace ?? null, index);
-        // Then expand schema-level spreads
-        const spreadFields = expandEntityFields(entity as SchemaRecord | FragmentRecord, entity.namespace ?? null, index);
-        fields = [...fields, ...spreadFields];
-      }
+          // Expand fragment spreads — inline fields from spread fragments (schemas and fragments only)
+          if (entityKind !== "metric") {
+            // Expand nested record-level spreads in place first
+            expandNestedSpreads(fields, entity.namespace ?? null, index);
+            // Then expand schema-level spreads
+            const spreadFields = expandEntityFields(
+              entity as SchemaRecord | FragmentRecord,
+              entity.namespace ?? null,
+              index,
+            );
+            fields = [...fields, ...spreadFields];
+          }
 
-      // Enrich with metadata if requested
-      if (opts.withMeta) {
-        enrichFieldMeta(entity.name, fields, parsedFiles);
-      }
+          // Enrich with metadata if requested
+          if (opts.withMeta) {
+            enrichFieldMeta(entity.name, fields, parsedFiles);
+          }
 
-      // Filter to unmapped fields
-      if (opts.unmappedBy) {
-        const resolvedMapping = resolveIndexKey(opts.unmappedBy, index.mappings);
-        if (!resolvedMapping) {
-          const close = [...index.mappings.keys()].find(
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by outer opts.unmappedBy check
-            (k) => k.toLowerCase() === opts.unmappedBy!.toLowerCase(),
-          );
-          const lines = [`Mapping '${opts.unmappedBy}' not found.`];
-          if (close) lines.push(`Did you mean '${close}'?`);
-          throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-        }
+          // Filter to unmapped fields
+          if (opts.unmappedBy) {
+            const resolvedMapping = resolveIndexKey(opts.unmappedBy, index.mappings);
+            if (!resolvedMapping) {
+              const close = [...index.mappings.keys()].find(
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by outer opts.unmappedBy check
+                (k) => k.toLowerCase() === opts.unmappedBy!.toLowerCase(),
+              );
+              const lines = [`Mapping '${opts.unmappedBy}' not found.`];
+              if (close) lines.push(`Did you mean '${close}'?`);
+              throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+            }
 
-        // Resolved @refs count toward coverage (ADR-036), and this command must
-        // give the same answer as `satsuma coverage` — the lock sl-oqsj put in
-        // place — so it feeds core the same refs.
-        const coverage = coverageForMapping(
-          resolvedMapping.key,
-          index,
-          parsedFiles,
-          resolveAllNLRefs(index),
-        );
-        // No coverage result means the mapping does not reference this entity at
-        // all (or is anonymous, which --unmapped-by cannot name) — every field is
-        // then unmapped by it, which is what an empty covered set produces.
-        const covered = coverage ? coveredFieldPaths(coverage, resolvedSchemaName) : new Set<string>();
-        fields = filterUnmappedFields(fields, covered, "");
-      }
+            // Resolved @refs count toward coverage (ADR-036), and this command must
+            // give the same answer as `satsuma coverage` — the lock sl-oqsj put in
+            // place — so it feeds core the same refs.
+            const coverage = coverageForMapping(
+              resolvedMapping.key,
+              index,
+              parsedFiles,
+              resolveAllNLRefs(index),
+            );
+            // No coverage result means the mapping does not reference this entity at
+            // all (or is anonymous, which --unmapped-by cannot name) — every field is
+            // then unmapped by it, which is what an empty covered set produces.
+            const covered = coverage
+              ? coveredFieldPaths(coverage, resolvedSchemaName)
+              : new Set<string>();
+            fields = filterUnmappedFields(fields, covered, "");
+          }
 
-      if (opts.json) {
-        console.log(JSON.stringify(fields, null, 2));
-        return;
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(fields, null, 2));
+            return;
+          }
 
-      if (fields.length === 0) {
-        // Use resolvedSchemaName (the canonical index key) so bare-name queries
-        // still produce the qualified name in output (e.g. "crm::customers" not
-        // "customers") — see sl-wfgx.
-        if (opts.unmappedBy) {
-          console.log(
-            `All fields in '${resolvedSchemaName}' are mapped by '${opts.unmappedBy}'.`,
-          );
-        } else {
-          console.log(`${entityKind.charAt(0).toUpperCase() + entityKind.slice(1)} '${resolvedSchemaName}' has no fields.`);
-        }
-        return;
-      }
+          if (fields.length === 0) {
+            // Use resolvedSchemaName (the canonical index key) so bare-name queries
+            // still produce the qualified name in output (e.g. "crm::customers" not
+            // "customers") — see sl-wfgx.
+            if (opts.unmappedBy) {
+              console.log(
+                `All fields in '${resolvedSchemaName}' are mapped by '${opts.unmappedBy}'.`,
+              );
+            } else {
+              console.log(
+                `${entityKind.charAt(0).toUpperCase() + entityKind.slice(1)} '${resolvedSchemaName}' has no fields.`,
+              );
+            }
+            return;
+          }
 
-      printDefault(resolvedSchemaName, fields, opts);
-    }));
+          printDefault(resolvedSchemaName, fields, opts);
+        },
+      ),
+    );
 }
 
 function deepCopyFields(fields: FieldDecl[]): FieldWithTags[] {
@@ -159,7 +189,11 @@ function deepCopyFields(fields: FieldDecl[]): FieldWithTags[] {
  * ancestor of a covered child, so treating it as covered would hide its
  * remaining gaps.
  */
-function filterUnmappedFields(fields: FieldWithTags[], covered: Set<string>, prefix: string): FieldWithTags[] {
+function filterUnmappedFields(
+  fields: FieldWithTags[],
+  covered: Set<string>,
+  prefix: string,
+): FieldWithTags[] {
   const result: FieldWithTags[] = [];
   for (const f of fields) {
     const path = prefix ? `${prefix}.${f.name}` : f.name;
@@ -179,7 +213,11 @@ function filterUnmappedFields(fields: FieldWithTags[], covered: Set<string>, pre
  * Enrich field objects with metadata tags from the FieldDecl metadata array.
  * Recurses into children for record/list blocks.
  */
-function enrichFieldMeta(_schemaName: string, fields: FieldWithTags[], _parsedFiles: ParsedFile[]): void {
+function enrichFieldMeta(
+  _schemaName: string,
+  fields: FieldWithTags[],
+  _parsedFiles: ParsedFile[],
+): void {
   function enrich(fieldList: FieldWithTags[]): void {
     for (const field of fieldList) {
       if (field.metadata && field.metadata.length > 0) {
@@ -199,11 +237,19 @@ function enrichFieldMeta(_schemaName: string, fields: FieldWithTags[], _parsedFi
   enrich(fields);
 }
 
-function printDefault(_schemaName: string, fields: FieldWithTags[], opts: { withMeta?: boolean }): void {
+function printDefault(
+  _schemaName: string,
+  fields: FieldWithTags[],
+  opts: { withMeta?: boolean },
+): void {
   printFieldTree(fields, opts, 1);
 }
 
-function printFieldTree(fields: FieldWithTags[], opts: { withMeta?: boolean }, indent: number): void {
+function printFieldTree(
+  fields: FieldWithTags[],
+  opts: { withMeta?: boolean },
+  indent: number,
+): void {
   const maxName = Math.max(...fields.map((f) => f.name.length), 4);
   const displayType = (f: FieldWithTags): string => {
     if (!f.isList) return f.type;

--- a/tooling/satsuma-cli/src/commands/find.ts
+++ b/tooling/satsuma-cli/src/commands/find.ts
@@ -41,7 +41,9 @@ export function register(program: Command): void {
     .option("--in <scope>", "scope: schema|metric|fragment|all", "all")
     .option("--compact", "one match per line")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Searches all field metadata for the given tag token or key-value key.
 Common tags: pk, required, unique, pii, encrypt, indexed, measure, ref, enum.
 
@@ -61,36 +63,44 @@ Examples:
   satsuma find --tag pii                     # all PII-tagged fields
   satsuma find --tag measure --in metric     # measure fields in metrics only
   satsuma find --tag ref --json              # all foreign key refs as JSON
-  satsuma find --tag enum --compact          # compact one-per-line output`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { tag: string; in?: string; compact?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma find --tag enum --compact          # compact one-per-line output`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: { tag: string; in?: string; compact?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      const tag = opts.tag.toLowerCase();
-      const scope = opts.in ?? "all";
-      const validScopes = ["all", "schema", "metric", "fragment"];
-      if (!validScopes.includes(scope)) {
-        throw new CommandError(
-          `Invalid scope '${scope}'. Valid scopes: ${validScopes.join(", ")}`,
-          EXIT_NOT_FOUND,
-        );
-      }
-      const matches = searchTag(index, parsedFiles, tag, scope);
+          const tag = opts.tag.toLowerCase();
+          const scope = opts.in ?? "all";
+          const validScopes = ["all", "schema", "metric", "fragment"];
+          if (!validScopes.includes(scope)) {
+            throw new CommandError(
+              `Invalid scope '${scope}'. Valid scopes: ${validScopes.join(", ")}`,
+              EXIT_NOT_FOUND,
+            );
+          }
+          const matches = searchTag(index, parsedFiles, tag, scope);
 
-      if (opts.json) {
-        console.log(JSON.stringify(matches, null, 2));
-      } else if (opts.compact) {
-        for (const m of matches) {
-          console.log(`${m.file}:${m.line}  ${m.block}.${m.field}  [${m.tag}]`);
-        }
-      } else {
-        printDefault(matches);
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(matches, null, 2));
+          } else if (opts.compact) {
+            for (const m of matches) {
+              console.log(`${m.file}:${m.line}  ${m.block}.${m.field}  [${m.tag}]`);
+            }
+          } else {
+            printDefault(matches);
+          }
 
-      // "No matches" is a non-zero exit so shell pipelines can use
-      // `if satsuma find … --tag pii; then` to detect coverage. The
-      // body output (or `[]` JSON) has already been emitted above.
-      if (matches.length === 0) return EXIT_NOT_FOUND;
-    }));
+          // "No matches" is a non-zero exit so shell pipelines can use
+          // `if satsuma find … --tag pii; then` to detect coverage. The
+          // body output (or `[]` JSON) has already been emitted above.
+          if (matches.length === 0) return EXIT_NOT_FOUND;
+        },
+      ),
+    );
 }
 
 // ── Search logic ──────────────────────────────────────────────────────────────
@@ -120,11 +130,21 @@ function isMetricTwin(index: ExtractedWorkspace, name: string, entry: { row: num
 /**
  * Search for fields whose metadata contains the given tag/key.
  */
-function searchTag(index: ExtractedWorkspace, parsedFiles: ParsedFile[], tag: string, scope: string): Match[] {
+function searchTag(
+  index: ExtractedWorkspace,
+  parsedFiles: ParsedFile[],
+  tag: string,
+  scope: string,
+): Match[] {
   const matches: Match[] = [];
   const fileMap = new Map<string, ParsedFile>(parsedFiles.map((p) => [p.filePath, p]));
 
-  const search = (blockType: string, blockName: string, blockEntry: { file: string; row: number; line?: number }, bodyType: string) => {
+  const search = (
+    blockType: string,
+    blockName: string,
+    blockEntry: { file: string; row: number; line?: number },
+    bodyType: string,
+  ) => {
     if (scope !== "all" && scope !== blockType) return;
     const parsed = fileMap.get(blockEntry.file);
     if (!parsed) return;
@@ -191,7 +211,14 @@ function searchTag(index: ExtractedWorkspace, parsedFiles: ParsedFile[], tag: st
  *
  * Exported for unit tests; not part of the command's public surface.
  */
-export function collectFieldMatches(bodyNode: SyntaxNode, blockType: string, blockName: string, file: string, tag: string, acc: Match[]): void {
+export function collectFieldMatches(
+  bodyNode: SyntaxNode,
+  blockType: string,
+  blockName: string,
+  file: string,
+  tag: string,
+  acc: Match[],
+): void {
   for (const c of bodyNode.namedChildren) {
     if (c.type === "field_decl") {
       const nameNode = c.namedChildren.find((x) => x.type === "field_name");
@@ -206,7 +233,11 @@ export function collectFieldMatches(bodyNode: SyntaxNode, blockType: string, blo
         const matched = findTagInMeta(meta, tag);
         if (matched) {
           const allTags = collectAllTags(meta);
-          const isListOf = c.text.trimStart().replace(/^`[^`]*`\s*/, "").replace(/^\S+\s*/, "").startsWith("list_of");
+          const isListOf = c.text
+            .trimStart()
+            .replace(/^`[^`]*`\s*/, "")
+            .replace(/^\S+\s*/, "")
+            .startsWith("list_of");
           let fieldType: string | undefined;
           if (isListOf) {
             fieldType = typeNode ? `list_of ${typeNode.text}` : "list_of record";
@@ -275,10 +306,11 @@ function collectAllTags(metaNode: SyntaxNode): string[] {
       const valueText = renderMetadataValue(val);
       tags.push(valueText ? `${key?.text} ${valueText}` : (key?.text ?? ""));
     } else if (c.type === "note_tag") {
-      const strNode = c.namedChildren.find((x) => x.type === "nl_string" || x.type === "multiline_string");
+      const strNode = c.namedChildren.find(
+        (x) => x.type === "nl_string" || x.type === "multiline_string",
+      );
       tags.push(strNode ? `note ${strNode.text}` : "note");
-    }
-    else if (c.type === "enum_body") tags.push("enum {...}");
+    } else if (c.type === "enum_body") tags.push("enum {...}");
     else if (c.type === "slice_body") tags.push("slice {...}");
   }
   return tags;
@@ -305,8 +337,7 @@ function renderMetadataValue(valueNode: SyntaxNode | undefined): string {
   const text = valueNode.text;
   if (
     text.length >= 2 &&
-    ((text.startsWith("\"") && text.endsWith("\"")) ||
-      (text.startsWith("`") && text.endsWith("`")))
+    ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("`") && text.endsWith("`")))
   ) {
     return text.slice(1, -1);
   }
@@ -383,10 +414,14 @@ function printDefault(matches: Match[]): void {
   }
 
   // Group by block
-  const byBlock = new Map<string, { blockType: string; block: string; file: string; fields: Match[] }>();
+  const byBlock = new Map<
+    string,
+    { blockType: string; block: string; file: string; fields: Match[] }
+  >();
   for (const m of matches) {
     const key = `${m.blockType}:${m.block}`;
-    if (!byBlock.has(key)) byBlock.set(key, { blockType: m.blockType, block: m.block, file: m.file, fields: [] });
+    if (!byBlock.has(key))
+      byBlock.set(key, { blockType: m.blockType, block: m.block, file: m.file, fields: [] });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
     byBlock.get(key)!.fields.push(m);
   }

--- a/tooling/satsuma-cli/src/commands/fmt.ts
+++ b/tooling/satsuma-cli/src/commands/fmt.ts
@@ -17,7 +17,13 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { relative } from "node:path";
 import type { Command } from "commander";
-import { runCommand, CommandError, EXIT_OK, EXIT_NOT_FOUND, EXIT_PARSE_ERROR } from "../command-runner.js";
+import {
+  runCommand,
+  CommandError,
+  EXIT_OK,
+  EXIT_NOT_FOUND,
+  EXIT_PARSE_ERROR,
+} from "../command-runner.js";
 import { resolveInput } from "../workspace.js";
 import { parseFile, parseSource } from "../parser.js";
 import { format } from "../format.js";
@@ -29,7 +35,9 @@ export function register(program: Command): void {
     .option("--check", "exit 1 if any file would change (for CI)")
     .option("--diff", "print unified diff without writing")
     .option("--stdin", "read from stdin, write to stdout")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Formatting is opinionated and zero-config: consistent indentation, spacing,
 and ordering. Safe to run on any valid file — idempotent. Follows imports to
 format the entry file and all transitively imported files.
@@ -38,78 +46,83 @@ Examples:
   satsuma fmt pipeline.stm                   # format file and its imports
   satsuma fmt --check pipeline.stm           # CI mode — exit 1 if any file would change
   satsuma fmt --diff file.stm                # show what would change without writing
-  cat file.stm | satsuma fmt --stdin         # pipe mode`)
-    .action(runCommand(async (
-      pathArg: string | undefined,
-      opts: { check?: boolean; diff?: boolean; stdin?: boolean }
-    ) => {
-      if (opts.stdin) {
-        handleStdin();
-        return;
-      }
+  cat file.stm | satsuma fmt --stdin         # pipe mode`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: { check?: boolean; diff?: boolean; stdin?: boolean },
+        ) => {
+          if (opts.stdin) {
+            handleStdin();
+            return;
+          }
 
-      const root = pathArg ?? ".";
-      let files: string[];
-      try {
-        files = await resolveInput(root);
-      } catch (err: unknown) {
-        // fmt is the third command that bypasses loadWorkspace: it needs
-        // to tolerate parse errors per-file (skipping rather than aborting)
-        // and uses a slightly different "Error: ..." prefix from the rest
-        // of the CLI. The resolve failure itself is still a hard exit.
-        throw new CommandError(`Error: ${(err as Error).message}`, EXIT_PARSE_ERROR);
-      }
+          const root = pathArg ?? ".";
+          let files: string[];
+          try {
+            files = await resolveInput(root);
+          } catch (err: unknown) {
+            // fmt is the third command that bypasses loadWorkspace: it needs
+            // to tolerate parse errors per-file (skipping rather than aborting)
+            // and uses a slightly different "Error: ..." prefix from the rest
+            // of the CLI. The resolve failure itself is still a hard exit.
+            throw new CommandError(`Error: ${(err as Error).message}`, EXIT_PARSE_ERROR);
+          }
 
-      if (files.length === 0) {
-        // Nothing to format — that's a success, not a failure.
-        return EXIT_OK;
-      }
+          if (files.length === 0) {
+            // Nothing to format — that's a success, not a failure.
+            return EXIT_OK;
+          }
 
-      let wouldChange = 0;
-      let parseErrors = 0;
+          let wouldChange = 0;
+          let parseErrors = 0;
 
-      for (const filePath of files) {
-        const parsed = parseFile(filePath);
+          for (const filePath of files) {
+            const parsed = parseFile(filePath);
 
-        if (parsed.errorCount > 0) {
-          const rel = displayPath(filePath);
-          console.error(`skipping ${rel}: parse error (${parsed.errorCount} error(s))`);
-          parseErrors++;
-          continue;
-        }
+            if (parsed.errorCount > 0) {
+              const rel = displayPath(filePath);
+              console.error(`skipping ${rel}: parse error (${parsed.errorCount} error(s))`);
+              parseErrors++;
+              continue;
+            }
 
-        const formatted = format(parsed.tree, parsed.src);
+            const formatted = format(parsed.tree, parsed.src);
 
-        if (formatted === parsed.src) {
-          continue; // already formatted
-        }
+            if (formatted === parsed.src) {
+              continue; // already formatted
+            }
 
-        wouldChange++;
-        const rel = displayPath(filePath);
+            wouldChange++;
+            const rel = displayPath(filePath);
 
-        if (opts.check) {
-          console.log(rel);
-        } else if (opts.diff) {
-          printDiff(rel, parsed.src, formatted);
-        } else {
-          writeFileSync(filePath, formatted, "utf8");
-          console.log(`formatted ${rel}`);
-        }
-      }
+            if (opts.check) {
+              console.log(rel);
+            } else if (opts.diff) {
+              printDiff(rel, parsed.src, formatted);
+            } else {
+              writeFileSync(filePath, formatted, "utf8");
+              console.log(`formatted ${rel}`);
+            }
+          }
 
-      // Surface a hard failure if every input was unparseable (no formatting
-      // happened and no --check assertion was made). This catches the case
-      // of running `satsuma fmt` on a directory of broken files.
-      if (parseErrors > 0 && wouldChange === 0 && !opts.check) {
-        return EXIT_PARSE_ERROR;
-      }
+          // Surface a hard failure if every input was unparseable (no formatting
+          // happened and no --check assertion was made). This catches the case
+          // of running `satsuma fmt` on a directory of broken files.
+          if (parseErrors > 0 && wouldChange === 0 && !opts.check) {
+            return EXIT_PARSE_ERROR;
+          }
 
-      // --check is the CI assertion mode: exit 1 if anything would change.
-      if (opts.check && wouldChange > 0) {
-        console.error(`\n${wouldChange} file(s) would be reformatted`);
-        return EXIT_NOT_FOUND;
-      }
-    }));
+          // --check is the CI assertion mode: exit 1 if anything would change.
+          if (opts.check && wouldChange > 0) {
+            console.error(`\n${wouldChange} file(s) would be reformatted`);
+            return EXIT_NOT_FOUND;
+          }
+        },
+      ),
+    );
 }
 
 /** Return the shorter of the relative and absolute path. */
@@ -144,8 +157,14 @@ function printDiff(filename: string, original: string, formatted: string): void 
 
   // Group into hunks with 3 lines of context
   const CTX = 3;
-  const hunks: Array<{ origStart: number; origLen: number; fmtStart: number; fmtLen: number; lines: string[] }> = [];
-  let hunk: typeof hunks[0] | null = null;
+  const hunks: Array<{
+    origStart: number;
+    origLen: number;
+    fmtStart: number;
+    fmtLen: number;
+    lines: string[];
+  }> = [];
+  let hunk: (typeof hunks)[0] | null = null;
   let oi = 0;
   let fi = 0;
 
@@ -154,7 +173,7 @@ function printDiff(filename: string, original: string, formatted: string): void 
     const op = ops[k]!;
     if (op === "equal") {
       // Check if we need to start or extend a hunk (look ahead for changes within CTX*2+1)
-      const inRange = hunk && (oi - (hunk.origStart + hunk.origLen) < CTX * 2 + 1);
+      const inRange = hunk && oi - (hunk.origStart + hunk.origLen) < CTX * 2 + 1;
       if (hunk && inRange) {
         hunk.lines.push(` ${origLines[oi]}`);
         hunk.origLen = oi - hunk.origStart + 1;
@@ -165,7 +184,13 @@ function printDiff(filename: string, original: string, formatted: string): void 
     } else if (op === "delete") {
       if (!hunk) {
         const ctxStart = Math.max(0, oi - CTX);
-        hunk = { origStart: ctxStart, origLen: 0, fmtStart: Math.max(0, fi - CTX + (oi - ctxStart) - (oi - ctxStart)), fmtLen: 0, lines: [] };
+        hunk = {
+          origStart: ctxStart,
+          origLen: 0,
+          fmtStart: Math.max(0, fi - CTX + (oi - ctxStart) - (oi - ctxStart)),
+          fmtLen: 0,
+          lines: [],
+        };
         hunk.fmtStart = fi - (oi - ctxStart);
         for (let c = ctxStart; c < oi; c++) {
           hunk.lines.push(` ${origLines[c]}`);
@@ -200,8 +225,8 @@ function printDiff(filename: string, original: string, formatted: string): void 
       for (let c = oi; c < trailEnd; c++) {
         hunk.lines.push(` ${origLines[c]}`);
       }
-      hunk.origLen = (oi + Math.min(CTX, origLines.length - oi)) - hunk.origStart;
-      hunk.fmtLen = (fi + Math.min(CTX, fmtLines.length - fi)) - hunk.fmtStart;
+      hunk.origLen = oi + Math.min(CTX, origLines.length - oi) - hunk.origStart;
+      hunk.fmtLen = fi + Math.min(CTX, fmtLines.length - fi) - hunk.fmtStart;
       hunks.push(hunk);
       hunk = null;
     }
@@ -274,21 +299,39 @@ function greedyDiff(a: string[], b: string[]): DiffOp[] {
       let foundI = -1;
       let foundJ = -1;
       for (let d = 1; d < 50; d++) {
-        if (i + d < a.length && a[i + d] === b[j]) { foundI = i + d; break; }
-        if (j + d < b.length && a[i] === b[j + d]) { foundJ = j + d; break; }
+        if (i + d < a.length && a[i + d] === b[j]) {
+          foundI = i + d;
+          break;
+        }
+        if (j + d < b.length && a[i] === b[j + d]) {
+          foundJ = j + d;
+          break;
+        }
       }
       if (foundI >= 0 && (foundJ < 0 || foundI - i <= foundJ - j)) {
-        while (i < foundI) { ops.push("delete"); i++; }
+        while (i < foundI) {
+          ops.push("delete");
+          i++;
+        }
       } else if (foundJ >= 0) {
-        while (j < foundJ) { ops.push("insert"); j++; }
+        while (j < foundJ) {
+          ops.push("insert");
+          j++;
+        }
       } else {
         ops.push("delete");
         i++;
       }
     }
   }
-  while (i < a.length) { ops.push("delete"); i++; }
-  while (j < b.length) { ops.push("insert"); j++; }
+  while (i < a.length) {
+    ops.push("delete");
+    i++;
+  }
+  while (j < b.length) {
+    ops.push("insert");
+    j++;
+  }
   return ops;
 }
 

--- a/tooling/satsuma-cli/src/commands/graph-builder.ts
+++ b/tooling/satsuma-cli/src/commands/graph-builder.ts
@@ -98,7 +98,12 @@ export interface WorkspaceGraph {
  * Collects nodes (schemas, mappings, metrics, transforms), builds schema-level
  * and field-level edges, applies namespace filtering, and computes stats.
  */
-export function buildWorkspaceGraph(index: ExtractedWorkspace, schemaGraph: FullGraph, root: string, opts: GraphBuildOpts): WorkspaceGraph {
+export function buildWorkspaceGraph(
+  index: ExtractedWorkspace,
+  schemaGraph: FullGraph,
+  root: string,
+  opts: GraphBuildOpts,
+): WorkspaceGraph {
   const nsFilter = opts.namespace ?? null;
   const includeNl = opts.includeNl;
   const schemaOnly = opts.schemaOnly;
@@ -201,19 +206,43 @@ export function buildWorkspaceGraph(index: ExtractedWorkspace, schemaGraph: Full
         const schema = index.schemas.get(id);
         if (schema && !index.metrics.has(id)) {
           includedNodeIds.add(id);
-          nodes.push({ id, kind: "schema", namespace: schema.namespace ?? null, file: schema.file, line: schema.row + 1, note: schema.note ?? null });
+          nodes.push({
+            id,
+            kind: "schema",
+            namespace: schema.namespace ?? null,
+            file: schema.file,
+            line: schema.row + 1,
+            note: schema.note ?? null,
+          });
           continue;
         }
         const mapping = index.mappings.get(id);
         if (mapping) {
           includedNodeIds.add(id);
-          nodes.push({ id, kind: "mapping", namespace: mapping.namespace ?? null, file: mapping.file, line: mapping.row + 1, sources: mapping.sources, targets: mapping.targets });
+          nodes.push({
+            id,
+            kind: "mapping",
+            namespace: mapping.namespace ?? null,
+            file: mapping.file,
+            line: mapping.row + 1,
+            sources: mapping.sources,
+            targets: mapping.targets,
+          });
           continue;
         }
         const metric = index.metrics.get(id);
         if (metric) {
           includedNodeIds.add(id);
-          nodes.push({ id, kind: "metric", namespace: metric.namespace ?? null, file: metric.file, line: metric.row + 1, sources: metric.sources, grain: metric.grain ?? null, slices: metric.slices ?? [] });
+          nodes.push({
+            id,
+            kind: "metric",
+            namespace: metric.namespace ?? null,
+            file: metric.file,
+            line: metric.row + 1,
+            sources: metric.sources,
+            grain: metric.grain ?? null,
+            slices: metric.slices ?? [],
+          });
         }
       }
     }
@@ -222,7 +251,13 @@ export function buildWorkspaceGraph(index: ExtractedWorkspace, schemaGraph: Full
   // Always build field edges (needed for --schema-only aggregation too)
   const result = buildFieldEdges(index, includedNodeIds, nsFilter, includeNl);
 
-  const unresolvedNl: Array<{ scope: string; arrow: string; text: string; file: string; line: number }> = [];
+  const unresolvedNl: Array<{
+    scope: string;
+    arrow: string;
+    text: string;
+    file: string;
+    line: number;
+  }> = [];
 
   const fieldEdges: FieldEdge[] = schemaOnly
     ? aggregateFieldEdgesToSchemaLevel(result.edges, index, nsFilter)
@@ -239,13 +274,18 @@ export function buildWorkspaceGraph(index: ExtractedWorkspace, schemaGraph: Full
     workspace: resolve(root),
     stats: {
       // Exclude metric schemas from the schema count — they are counted under metrics.
-      schemas: [...index.schemas.entries()]
-        .filter(([id, s]) => !index.metrics.has(id) && (!nsFilter || s.namespace === nsFilter))
+      schemas: [...index.schemas.entries()].filter(
+        ([id, s]) => !index.metrics.has(id) && (!nsFilter || s.namespace === nsFilter),
+      ).length,
+      mappings: [...index.mappings.values()].filter((m) => !nsFilter || m.namespace === nsFilter)
         .length,
-      mappings: [...index.mappings.values()].filter((m) => !nsFilter || m.namespace === nsFilter).length,
-      metrics: [...index.metrics.values()].filter((m) => !nsFilter || m.namespace === nsFilter).length,
-      fragments: [...index.fragments.values()].filter((f) => !nsFilter || f.namespace === nsFilter).length,
-      transforms: [...index.transforms.values()].filter((t) => !nsFilter || t.namespace === nsFilter).length,
+      metrics: [...index.metrics.values()].filter((m) => !nsFilter || m.namespace === nsFilter)
+        .length,
+      fragments: [...index.fragments.values()].filter((f) => !nsFilter || f.namespace === nsFilter)
+        .length,
+      transforms: [...index.transforms.values()].filter(
+        (t) => !nsFilter || t.namespace === nsFilter,
+      ).length,
       arrows: arrowCount,
       errors: index.totalErrors,
     },
@@ -263,7 +303,12 @@ export function buildWorkspaceGraph(index: ExtractedWorkspace, schemaGraph: Full
  * Build schema-level edges from the directed graph.
  * Each edge has: from, to, role (source/target/metric_source/nl_ref).
  */
-function buildSchemaEdges(index: ExtractedWorkspace, _schemaGraph: FullGraph, includedNodeIds: Set<string>, nsFilter: string | null): SchemaEdge[] {
+function buildSchemaEdges(
+  index: ExtractedWorkspace,
+  _schemaGraph: FullGraph,
+  includedNodeIds: Set<string>,
+  nsFilter: string | null,
+): SchemaEdge[] {
   const edges: SchemaEdge[] = [];
 
   // ── Mapping source/target edges ────────────────────────────────────────────
@@ -271,7 +316,8 @@ function buildSchemaEdges(index: ExtractedWorkspace, _schemaGraph: FullGraph, in
     // When namespace-filtering, include edges if either the mapping is in
     // the namespace OR any of its sources/targets are in the namespace
     if (nsFilter && mapping.namespace !== nsFilter) {
-      const touchesNs = mapping.sources.some((s) => includedNodeIds.has(s)) ||
+      const touchesNs =
+        mapping.sources.some((s) => includedNodeIds.has(s)) ||
         mapping.targets.some((t) => includedNodeIds.has(t));
       if (!touchesNs) continue;
     }
@@ -308,17 +354,19 @@ function buildSchemaEdges(index: ExtractedWorkspace, _schemaGraph: FullGraph, in
   if (index.nlRefData) {
     const seen = new Set<string>();
     for (const item of index.nlRefData) {
-      const mappingKey = item.namespace
-        ? `${item.namespace}::${item.mapping}`
-        : item.mapping;
+      const mappingKey = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
       const mapping = index.mappings.get(mappingKey);
       if (!mapping) continue;
 
-      const backtickRefs = extractNlSchemaRefs(item.text, {
-        sources: mapping.sources ?? [],
-        targets: mapping.targets ?? [],
-        namespace: item.namespace,
-      }, index);
+      const backtickRefs = extractNlSchemaRefs(
+        item.text,
+        {
+          sources: mapping.sources ?? [],
+          targets: mapping.targets ?? [],
+          namespace: item.namespace,
+        },
+        index,
+      );
 
       for (const schemaRef of backtickRefs) {
         const key = `${schemaRef}|${mappingKey}|nl_ref`;
@@ -362,7 +410,10 @@ function extractNlSchemaRefs(
       if (resolution.resolvedTo?.kind === "schema") {
         canonicalSchema = resolution.resolvedTo.name;
       }
-    } else if (classification === "dotted-field" || classification === "namespace-qualified-field") {
+    } else if (
+      classification === "dotted-field" ||
+      classification === "namespace-qualified-field"
+    ) {
       if (resolution.resolvedTo?.kind === "field") {
         const fieldName = resolution.resolvedTo.name;
         const lastDot = fieldName.lastIndexOf(".");
@@ -375,9 +426,7 @@ function extractNlSchemaRefs(
     if (!canonicalSchema) continue;
 
     // Convert canonical form (::name) to index key form (name)
-    const indexKey = canonicalSchema.startsWith("::")
-      ? canonicalSchema.slice(2)
-      : canonicalSchema;
+    const indexKey = canonicalSchema.startsWith("::") ? canonicalSchema.slice(2) : canonicalSchema;
 
     // Skip schemas already declared as source or target
     if (allDeclared.has(indexKey) || allDeclared.has(canonicalSchema)) continue;
@@ -406,9 +455,23 @@ function extractNlSchemaRefs(
  * parent schema names, attaches transform and NL metadata, and resolves
  * nl-derived edges from @ref mentions.
  */
-function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>, nsFilter: string | null, includeNl: boolean): { edges: FieldEdge[]; unresolvedNl: Array<{ scope: string; arrow: string; text: string; file: string; line: number }> } {
+function buildFieldEdges(
+  index: ExtractedWorkspace,
+  includedNodeIds: Set<string>,
+  nsFilter: string | null,
+  includeNl: boolean,
+): {
+  edges: FieldEdge[];
+  unresolvedNl: Array<{ scope: string; arrow: string; text: string; file: string; line: number }>;
+} {
   const edges: FieldEdge[] = [];
-  const unresolvedNl: Array<{ scope: string; arrow: string; text: string; file: string; line: number }> = [];
+  const unresolvedNl: Array<{
+    scope: string;
+    arrow: string;
+    text: string;
+    file: string;
+    line: number;
+  }> = [];
 
   // Iterate all arrow records via the fieldArrows index. distinctArrowRecords
   // deduplicates the multi-key registrations by reference — see its doc-comment
@@ -422,7 +485,8 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
       const mapping = index.mappings.get(mappingKey);
       if (mapping?.namespace !== nsFilter) {
         // Still include if the mapping touches schemas in the namespace
-        const touchesNs = (mapping?.sources ?? []).some((s) => includedNodeIds.has(s)) ||
+        const touchesNs =
+          (mapping?.sources ?? []).some((s) => includedNodeIds.has(s)) ||
           (mapping?.targets ?? []).some((t) => includedNodeIds.has(t));
         if (!touchesNs) continue;
       }
@@ -433,12 +497,11 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
     const sourceSchemas = mapping?.sources ?? [];
     const targetSchemas = mapping?.targets ?? [];
 
-    const fromFields = record.sources.length > 0
-      ? record.sources.map((s) => canonicalKey(qualifyField(s, sourceSchemas)))
-      : [null];
-    const toField = record.target
-      ? canonicalKey(qualifyField(record.target, targetSchemas))
-      : null;
+    const fromFields =
+      record.sources.length > 0
+        ? record.sources.map((s) => canonicalKey(qualifyField(s, sourceSchemas)))
+        : [null];
+    const toField = record.target ? canonicalKey(qualifyField(record.target, targetSchemas)) : null;
 
     for (const fromField of fromFields) {
       const edge: FieldEdge = {
@@ -495,7 +558,8 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
 
     if (nsFilter) {
       if (mapping.namespace !== nsFilter) {
-        const touchesNs = mapping.sources.some((s) => includedNodeIds.has(s)) ||
+        const touchesNs =
+          mapping.sources.some((s) => includedNodeIds.has(s)) ||
           mapping.targets.some((t) => includedNodeIds.has(t));
         if (!touchesNs) continue;
       }
@@ -517,8 +581,11 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
     // source->target in the same mapping (e.g. `c -> d { "@s1.c is processed" }`
     // — c is already the declared source, no need for a duplicate nl-derived edge).
     const alreadyCovered = edges.some(
-      (e) => e.from === sourceField && e.to === targetField &&
-             e.mapping === mappingKey && e.classification !== "nl-derived",
+      (e) =>
+        e.from === sourceField &&
+        e.to === targetField &&
+        e.mapping === mappingKey &&
+        e.classification !== "nl-derived",
     );
     if (alreadyCovered) continue;
 
@@ -543,7 +610,11 @@ function buildFieldEdges(index: ExtractedWorkspace, includedNodeIds: Set<string>
  * with no field edges (e.g. derived-only), adds edges from the declared
  * source/target lists.
  */
-function aggregateFieldEdgesToSchemaLevel(fieldEdges: FieldEdge[], index: ExtractedWorkspace, nsFilter: string | null): FieldEdge[] {
+function aggregateFieldEdgesToSchemaLevel(
+  fieldEdges: FieldEdge[],
+  index: ExtractedWorkspace,
+  nsFilter: string | null,
+): FieldEdge[] {
   const aggregated: FieldEdge[] = [];
   const seen = new Set<string>();
 

--- a/tooling/satsuma-cli/src/commands/graph-format.ts
+++ b/tooling/satsuma-cli/src/commands/graph-format.ts
@@ -26,10 +26,10 @@ export function printDefault(graph: WorkspaceGraph): void {
   // ── Node counts ────────────────────────────────────────────────────────────
   const s = graph.stats;
   console.log("Nodes:");
-  if (s.schemas > 0)    console.log(`  schemas:    ${s.schemas}`);
-  if (s.mappings > 0)   console.log(`  mappings:   ${s.mappings}`);
-  if (s.metrics > 0)    console.log(`  metrics:    ${s.metrics}`);
-  if (s.fragments > 0)  console.log(`  fragments:  ${s.fragments}`);
+  if (s.schemas > 0) console.log(`  schemas:    ${s.schemas}`);
+  if (s.mappings > 0) console.log(`  mappings:   ${s.mappings}`);
+  if (s.metrics > 0) console.log(`  metrics:    ${s.metrics}`);
+  if (s.fragments > 0) console.log(`  fragments:  ${s.fragments}`);
   if (s.transforms > 0) console.log(`  transforms: ${s.transforms}`);
   console.log();
 

--- a/tooling/satsuma-cli/src/commands/graph.ts
+++ b/tooling/satsuma-cli/src/commands/graph.ts
@@ -35,7 +35,9 @@ export function register(program: Command): void {
     .option("--schema-only", "omit field-level edges and field arrays")
     .option("--namespace <ns>", "filter to a namespace")
     .option("--no-nl", "strip NL text from edges")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Output modes (pick one):
   --json          full structured JSON (primary agent interface)
   --compact       flat schema-level adjacency list (minimal tokens)
@@ -64,29 +66,32 @@ Examples:
   satsuma graph pipeline.stm --json                  # full graph
   satsuma graph pipeline.stm --json --schema-only    # topology only
   satsuma graph pipeline.stm --json --namespace crm  # one namespace
-  satsuma graph pipeline.stm --compact               # minimal output`)
-    .action(runCommand(async (pathArg: string | undefined, opts: GraphOpts) => {
-      const root = pathArg ?? ".";
-      const { index } = await loadWorkspace(root);
-      const schemaGraph = buildFullGraph(index);
-      const graph = buildWorkspaceGraph(index, schemaGraph, root, {
-        namespace: opts.namespace ?? null,
-        includeNl: opts.nl !== false, // --no-nl sets opts.nl to false
-        schemaOnly: opts.schemaOnly ?? false,
-      });
+  satsuma graph pipeline.stm --compact               # minimal output`,
+    )
+    .action(
+      runCommand(async (pathArg: string | undefined, opts: GraphOpts) => {
+        const root = pathArg ?? ".";
+        const { index } = await loadWorkspace(root);
+        const schemaGraph = buildFullGraph(index);
+        const graph = buildWorkspaceGraph(index, schemaGraph, root, {
+          namespace: opts.namespace ?? null,
+          includeNl: opts.nl !== false, // --no-nl sets opts.nl to false
+          schemaOnly: opts.schemaOnly ?? false,
+        });
 
-      if (opts.json) {
-        console.log(JSON.stringify(graph, null, 2));
-      } else if (opts.compact) {
-        printCompact(graph);
-      } else {
-        printDefault(graph);
-      }
+        if (opts.json) {
+          console.log(JSON.stringify(graph, null, 2));
+        } else if (opts.compact) {
+          printCompact(graph);
+        } else {
+          printDefault(graph);
+        }
 
-      // The runner flushes stdout/stderr before exit, so we don't need
-      // a manual drain here even though `--json` payloads can be large.
-      if (index.totalErrors > 0) {
-        return EXIT_PARSE_ERROR;
-      }
-    }));
+        // The runner flushes stdout/stderr before exit, so we don't need
+        // a manual drain here even though `--json` payloads can be large.
+        if (index.totalErrors > 0) {
+          return EXIT_PARSE_ERROR;
+        }
+      }),
+    );
 }

--- a/tooling/satsuma-cli/src/commands/lineage.ts
+++ b/tooling/satsuma-cli/src/commands/lineage.ts
@@ -49,7 +49,9 @@ export function register(program: Command): void {
     .option("--depth <n>", "maximum recursion depth", parsePositiveInt, 10)
     .option("--compact", "print names only")
     .option("--json", "emit {nodes, edges} DAG")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 One of --from or --to is required (not both).
   --from  traces downstream: schema → mappings → target schemas → metrics
   --to    traces upstream: BFS path from any source back to the target
@@ -66,65 +68,77 @@ Examples:
   satsuma lineage --from hub_customer              # what does hub_customer feed?
   satsuma lineage --to mart_customer_360           # what feeds mart_customer_360?
   satsuma lineage --from pos::stores --depth 3     # namespace-qualified, limited depth
-  satsuma lineage --from hub_customer --json       # DAG as JSON`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { from?: string; to?: string; depth: number; compact?: boolean; json?: boolean }) => {
-      if (!opts.from && !opts.to) {
-        throw new CommandError("Provide --from <name> or --to <name>.", EXIT_NOT_FOUND);
-      }
+  satsuma lineage --from hub_customer --json       # DAG as JSON`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: { from?: string; to?: string; depth: number; compact?: boolean; json?: boolean },
+        ) => {
+          if (!opts.from && !opts.to) {
+            throw new CommandError("Provide --from <name> or --to <name>.", EXIT_NOT_FOUND);
+          }
 
-      if (opts.from && opts.to) {
-        throw new CommandError(
-          "Cannot specify both --from and --to. Use one at a time.",
-          EXIT_NOT_FOUND,
-        );
-      }
+          if (opts.from && opts.to) {
+            throw new CommandError(
+              "Cannot specify both --from and --to. Use one at a time.",
+              EXIT_NOT_FOUND,
+            );
+          }
 
-      const { index } = await loadWorkspace(pathArg);
-      const graph = buildFullGraph(index);
+          const { index } = await loadWorkspace(pathArg);
+          const graph = buildFullGraph(index);
 
-      // Build a "node not found" CommandError that respects the JSON
-      // contract: JSON callers receive `{"error": ...}` on stdout so the
-      // payload still parses; text callers get the message on stderr.
-      const nodeNotFound = (queried: string): CommandError => {
-        const msg = `Node '${queried}' not found.`;
-        if (opts.json) {
-          return new CommandError(JSON.stringify({ error: msg }, null, 2), EXIT_NOT_FOUND, "stdout");
-        }
-        return new CommandError(msg, EXIT_NOT_FOUND);
-      };
+          // Build a "node not found" CommandError that respects the JSON
+          // contract: JSON callers receive `{"error": ...}` on stdout so the
+          // payload still parses; text callers get the message on stderr.
+          const nodeNotFound = (queried: string): CommandError => {
+            const msg = `Node '${queried}' not found.`;
+            if (opts.json) {
+              return new CommandError(
+                JSON.stringify({ error: msg }, null, 2),
+                EXIT_NOT_FOUND,
+                "stdout",
+              );
+            }
+            return new CommandError(msg, EXIT_NOT_FOUND);
+          };
 
-      if (opts.from) {
-        const resolved = resolveIndexKey(opts.from, graph.nodes);
-        if (!resolved) throw nodeNotFound(opts.from);
-        const start = resolved.key;
-        const dag = buildDownstream(graph, start, opts.depth);
-        if (opts.json) {
-          console.log(JSON.stringify(dag, null, 2));
-        } else if (opts.compact) {
-          printCompact(dag, start);
-        } else {
-          printTree(dag, start, 0);
-        }
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by opts.to existence check in enclosing branch
-        const resolvedTo = resolveIndexKey(opts.to!, graph.nodes);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: same guard
-        if (!resolvedTo) throw nodeNotFound(opts.to!);
-        const target = resolvedTo.key;
-        const dag = buildUpstream(graph, target, opts.depth);
-        if (dag.nodes.length === 0) {
-          console.log(`No upstream path found to '${target}'.`);
-          return EXIT_NOT_FOUND;
-        }
-        if (opts.json) {
-          console.log(JSON.stringify(dag, null, 2));
-        } else if (opts.compact) {
-          for (const n of dag.nodes) console.log(displayKey(n.name));
-        } else {
-          printUpstreamFlat(dag, target);
-        }
-      }
-    }));
+          if (opts.from) {
+            const resolved = resolveIndexKey(opts.from, graph.nodes);
+            if (!resolved) throw nodeNotFound(opts.from);
+            const start = resolved.key;
+            const dag = buildDownstream(graph, start, opts.depth);
+            if (opts.json) {
+              console.log(JSON.stringify(dag, null, 2));
+            } else if (opts.compact) {
+              printCompact(dag, start);
+            } else {
+              printTree(dag, start, 0);
+            }
+          } else {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: guarded by opts.to existence check in enclosing branch
+            const resolvedTo = resolveIndexKey(opts.to!, graph.nodes);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: same guard
+            if (!resolvedTo) throw nodeNotFound(opts.to!);
+            const target = resolvedTo.key;
+            const dag = buildUpstream(graph, target, opts.depth);
+            if (dag.nodes.length === 0) {
+              console.log(`No upstream path found to '${target}'.`);
+              return EXIT_NOT_FOUND;
+            }
+            if (opts.json) {
+              console.log(JSON.stringify(dag, null, 2));
+            } else if (opts.compact) {
+              for (const n of dag.nodes) console.log(displayKey(n.name));
+            } else {
+              printUpstreamFlat(dag, target);
+            }
+          }
+        },
+      ),
+    );
 }
 
 /**

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -34,7 +34,9 @@ export function register(program: Command): void {
     .option("--ignore <rules>", "skip listed rules (comma-separated)")
     .option("--quiet", "exit code only")
     .option("--rules", "list available lint rules and exit")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Rules:
   hidden-source-in-nl  error    NL text references a schema not in the mapping's source/target list
   unresolved-nl-ref    warning  @ reference in NL does not resolve to any known identifier
@@ -52,130 +54,141 @@ Examples:
   satsuma lint pipeline.stm --json           # structured diagnostics
   satsuma lint pipeline.stm --fix            # auto-fix fixable issues
   satsuma lint --rules                       # list available rules
-  satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { json?: boolean; fix?: boolean; select?: string; ignore?: string; quiet?: boolean; rules?: boolean }) => {
-      // --rules: list available rules and exit
-      if (opts.rules) {
-        for (const r of RULES) {
-          console.log(`  ${r.id.padEnd(24)} ${r.description}`);
-        }
-        return;
-      }
-
-      const { files, index } = await loadWorkspace(pathArg);
-      const fileCount = files.length;
-
-      // Run lint rules
-      const ruleOpts: { select?: string[]; ignore?: string[] } = {};
-      if (opts.select) ruleOpts.select = opts.select.split(",").map((s) => s.trim());
-      if (opts.ignore) ruleOpts.ignore = opts.ignore.split(",").map((s) => s.trim());
-
-      let diagnostics = runLint(index, ruleOpts);
-
-      // --fix: apply safe fixes
-      let appliedFixes: LintFix[] = [];
-      if (opts.fix && diagnostics.some((d) => d.fixable)) {
-        // Read source files that have fixable diagnostics
-        const fixableFiles = new Set(
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: d.fix is checked by the filter predicate
-          diagnostics.filter((d) => d.fixable && d.fix).map((d) => d.fix!.file),
-        );
-        const sourceByFile = new Map<string, string>();
-        for (const f of fixableFiles) {
-          try {
-            sourceByFile.set(f, readFileSync(f, "utf8"));
-          } catch {
-            // skip files that can't be read
-          }
-        }
-
-        const result = applyFixes(sourceByFile, diagnostics);
-        appliedFixes = result.appliedFixes;
-
-        // Write fixed files
-        for (const [file, content] of result.fixedFiles) {
-          writeFileSync(file, content, "utf8");
-        }
-
-        // Remove fixed diagnostics from the output
-        const fixedRules = new Set(appliedFixes.map((f) => `${f.file}:${f.rule}`));
-        diagnostics = diagnostics.filter(
-          (d) => !d.fixable || !fixedRules.has(`${d.file}:${d.rule}`),
-        );
-      }
-
-      const findingCount = diagnostics.length;
-      const errorCount = diagnostics.filter((d) => d.severity === "error").length;
-      const fixableCount = diagnostics.filter((d) => d.fixable).length;
-
-      // Soft exit code: lint uses 2 for "any error-severity finding"
-      // and 0 otherwise. Warning-severity rules never push the exit
-      // non-zero — that's documented in the command help.
-      const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
-
-      // --quiet: exit code only
-      if (opts.quiet) {
-        return exitCode;
-      }
-
-      // --json: structured output
-      if (opts.json) {
-        const payload = {
-          findings: diagnostics.map(({ fix: _fix, ...rest }) => rest),
-          fixes: appliedFixes.map(({ apply: _apply, ...rest }) => rest),
-          summary: {
-            files: fileCount,
-            findings: findingCount,
-            fixable: fixableCount,
-            fixed: appliedFixes.length,
+  satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: {
+            json?: boolean;
+            fix?: boolean;
+            select?: string;
+            ignore?: string;
+            quiet?: boolean;
+            rules?: boolean;
           },
-        };
-        console.log(JSON.stringify(payload, null, 2));
-        return exitCode;
-      }
+        ) => {
+          // --rules: list available rules and exit
+          if (opts.rules) {
+            for (const r of RULES) {
+              console.log(`  ${r.id.padEnd(24)} ${r.description}`);
+            }
+            return;
+          }
 
-      // Text output
-      if (appliedFixes.length > 0) {
-        for (const fix of appliedFixes) {
-          console.log(`Fixed: ${fix.file} [${fix.rule}] ${fix.description}`);
-        }
-        console.log();
-      }
+          const { files, index } = await loadWorkspace(pathArg);
+          const fileCount = files.length;
 
-      if (findingCount === 0 && appliedFixes.length === 0) {
-        console.log(
-          `Linted ${fileCount} file${fileCount !== 1 ? "s" : ""}: no issues found.`,
-        );
-        return;
-      }
+          // Run lint rules
+          const ruleOpts: { select?: string[]; ignore?: string[] } = {};
+          if (opts.select) ruleOpts.select = opts.select.split(",").map((s) => s.trim());
+          if (opts.ignore) ruleOpts.ignore = opts.ignore.split(",").map((s) => s.trim());
 
-      if (findingCount === 0 && appliedFixes.length > 0) {
-        console.log(
-          `${appliedFixes.length} fixed, no remaining issues in ${fileCount} file${fileCount !== 1 ? "s" : ""}`,
-        );
-        return;
-      }
+          let diagnostics = runLint(index, ruleOpts);
 
-      // Print remaining findings grouped by file
-      for (const d of diagnostics) {
-        const sev = d.severity === "error" ? "error" : "warning";
-        const fixTag = d.fixable ? " (fixable)" : "";
-        console.log(
-          `${d.file}:${d.line}:${d.column} ${sev} [${d.rule}] ${d.message}${fixTag}`,
-        );
-      }
+          // --fix: apply safe fixes
+          let appliedFixes: LintFix[] = [];
+          if (opts.fix && diagnostics.some((d) => d.fixable)) {
+            // Read source files that have fixable diagnostics
+            const fixableFiles = new Set(
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: d.fix is checked by the filter predicate
+              diagnostics.filter((d) => d.fixable && d.fix).map((d) => d.fix!.file),
+            );
+            const sourceByFile = new Map<string, string>();
+            for (const f of fixableFiles) {
+              try {
+                sourceByFile.set(f, readFileSync(f, "utf8"));
+              } catch {
+                // skip files that can't be read
+              }
+            }
 
-      console.log();
-      if (appliedFixes.length > 0) {
-        console.log(
-          `${appliedFixes.length} fixed, ${findingCount} remaining in ${fileCount} file${fileCount !== 1 ? "s" : ""} (${fixableCount} fixable)`,
-        );
-      } else {
-        console.log(
-          `${findingCount} finding${findingCount !== 1 ? "s" : ""} in ${fileCount} file${fileCount !== 1 ? "s" : ""} (${fixableCount} fixable)`,
-        );
-      }
+            const result = applyFixes(sourceByFile, diagnostics);
+            appliedFixes = result.appliedFixes;
 
-      return exitCode;
-    }));
+            // Write fixed files
+            for (const [file, content] of result.fixedFiles) {
+              writeFileSync(file, content, "utf8");
+            }
+
+            // Remove fixed diagnostics from the output
+            const fixedRules = new Set(appliedFixes.map((f) => `${f.file}:${f.rule}`));
+            diagnostics = diagnostics.filter(
+              (d) => !d.fixable || !fixedRules.has(`${d.file}:${d.rule}`),
+            );
+          }
+
+          const findingCount = diagnostics.length;
+          const errorCount = diagnostics.filter((d) => d.severity === "error").length;
+          const fixableCount = diagnostics.filter((d) => d.fixable).length;
+
+          // Soft exit code: lint uses 2 for "any error-severity finding"
+          // and 0 otherwise. Warning-severity rules never push the exit
+          // non-zero — that's documented in the command help.
+          const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
+
+          // --quiet: exit code only
+          if (opts.quiet) {
+            return exitCode;
+          }
+
+          // --json: structured output
+          if (opts.json) {
+            const payload = {
+              findings: diagnostics.map(({ fix: _fix, ...rest }) => rest),
+              fixes: appliedFixes.map(({ apply: _apply, ...rest }) => rest),
+              summary: {
+                files: fileCount,
+                findings: findingCount,
+                fixable: fixableCount,
+                fixed: appliedFixes.length,
+              },
+            };
+            console.log(JSON.stringify(payload, null, 2));
+            return exitCode;
+          }
+
+          // Text output
+          if (appliedFixes.length > 0) {
+            for (const fix of appliedFixes) {
+              console.log(`Fixed: ${fix.file} [${fix.rule}] ${fix.description}`);
+            }
+            console.log();
+          }
+
+          if (findingCount === 0 && appliedFixes.length === 0) {
+            console.log(`Linted ${fileCount} file${fileCount !== 1 ? "s" : ""}: no issues found.`);
+            return;
+          }
+
+          if (findingCount === 0 && appliedFixes.length > 0) {
+            console.log(
+              `${appliedFixes.length} fixed, no remaining issues in ${fileCount} file${fileCount !== 1 ? "s" : ""}`,
+            );
+            return;
+          }
+
+          // Print remaining findings grouped by file
+          for (const d of diagnostics) {
+            const sev = d.severity === "error" ? "error" : "warning";
+            const fixTag = d.fixable ? " (fixable)" : "";
+            console.log(`${d.file}:${d.line}:${d.column} ${sev} [${d.rule}] ${d.message}${fixTag}`);
+          }
+
+          console.log();
+          if (appliedFixes.length > 0) {
+            console.log(
+              `${appliedFixes.length} fixed, ${findingCount} remaining in ${fileCount} file${fileCount !== 1 ? "s" : ""} (${fixableCount} fixable)`,
+            );
+          } else {
+            console.log(
+              `${findingCount} finding${findingCount !== 1 ? "s" : ""} in ${fileCount} file${fileCount !== 1 ? "s" : ""} (${fixableCount} fixable)`,
+            );
+          }
+
+          return exitCode;
+        },
+      ),
+    );
 }

--- a/tooling/satsuma-cli/src/commands/mapping.ts
+++ b/tooling/satsuma-cli/src/commands/mapping.ts
@@ -25,43 +25,56 @@ export function register(program: Command): void {
     .option("--compact", "omit transform bodies and notes")
     .option("--arrows-only", "print src → tgt table")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Names can be namespace-qualified (e.g. warehouse::'load hub_store').
 Quote names with spaces (e.g. 'load hub_customer').
 
 Examples:
   satsuma mapping 'load hub_customer'                # full mapping
   satsuma mapping 'load hub_customer' --arrows-only  # just src → tgt
-  satsuma mapping 'load hub_customer' --json         # structured output`)
-    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; arrowsOnly?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma mapping 'load hub_customer' --json         # structured output`,
+    )
+    .action(
+      runCommand(
+        async (
+          name: string,
+          pathArg: string | undefined,
+          opts: { compact?: boolean; arrowsOnly?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      const resolved = resolveIndexKey(name, index.mappings);
-      if (!resolved) {
-        const keys = [...index.mappings.keys()];
-        const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
-        const lines: string[] = [];
-        if (close) {
-          lines.push(`Mapping '${name}' not found. Did you mean '${close}'?`);
-        } else {
-          lines.push(`Mapping '${name}' not found.`);
-          if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
-        }
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-      const entry = resolved.entry;
+          const resolved = resolveIndexKey(name, index.mappings);
+          if (!resolved) {
+            const keys = [...index.mappings.keys()];
+            const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
+            const lines: string[] = [];
+            if (close) {
+              lines.push(`Mapping '${name}' not found. Did you mean '${close}'?`);
+            } else {
+              lines.push(`Mapping '${name}' not found.`);
+              if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
+            }
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          }
+          const entry = resolved.entry;
 
-      const parsed = parsedFiles.find((p) => p.filePath === entry.file);
-      const mappingNode = parsed ? findBlockNode(parsed.tree.rootNode, "mapping_block", resolved.key) : null;
+          const parsed = parsedFiles.find((p) => p.filePath === entry.file);
+          const mappingNode = parsed
+            ? findBlockNode(parsed.tree.rootNode, "mapping_block", resolved.key)
+            : null;
 
-      if (opts.json) {
-        printJson(entry, mappingNode, opts.compact);
-      } else if (opts.arrowsOnly) {
-        printArrowsOnly(entry, mappingNode);
-      } else {
-        printDefault(entry, mappingNode, opts.compact);
-      }
-    }));
+          if (opts.json) {
+            printJson(entry, mappingNode, opts.compact);
+          } else if (opts.arrowsOnly) {
+            printArrowsOnly(entry, mappingNode);
+          } else {
+            printDefault(entry, mappingNode, opts.compact);
+          }
+        },
+      ),
+    );
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────
@@ -92,26 +105,56 @@ function collectArrows(bodyNode: SyntaxNode | undefined): ArrowInfo[] {
       const tgt = c.namedChildren.find((x) => x.type === "tgt_path");
       const hasBody = c.namedChildren.some((x) => x.type === "pipe_chain");
       const meta = c.namedChildren.find((x) => x.type === "metadata_block");
-      arrows.push({ kind: "map", src: pathText(src), tgt: pathText(tgt), hasBody, metaNode: meta, node: c });
+      arrows.push({
+        kind: "map",
+        src: pathText(src),
+        tgt: pathText(tgt),
+        hasBody,
+        metaNode: meta,
+        node: c,
+      });
     } else if (c.type === "computed_arrow") {
       const tgt = c.namedChildren.find((x) => x.type === "tgt_path");
       const hasBody = c.namedChildren.some((x) => x.type === "pipe_chain");
       const meta = c.namedChildren.find((x) => x.type === "metadata_block");
-      arrows.push({ kind: "computed", src: null, tgt: pathText(tgt), hasBody, metaNode: meta, node: c });
+      arrows.push({
+        kind: "computed",
+        src: null,
+        tgt: pathText(tgt),
+        hasBody,
+        metaNode: meta,
+        node: c,
+      });
     } else if (c.type === "nested_arrow") {
       const src = c.namedChildren.find((x) => x.type === "src_path");
       const tgt = c.namedChildren.find((x) => x.type === "tgt_path");
       const meta = c.namedChildren.find((x) => x.type === "metadata_block");
       const children = collectArrows(c);
       const hasChildren = children.length > 0;
-      arrows.push({ kind: hasChildren ? "nested" : "map", src: pathText(src), tgt: pathText(tgt), hasBody: hasChildren, metaNode: meta, node: c, children: hasChildren ? children : undefined });
+      arrows.push({
+        kind: hasChildren ? "nested" : "map",
+        src: pathText(src),
+        tgt: pathText(tgt),
+        hasBody: hasChildren,
+        metaNode: meta,
+        node: c,
+        children: hasChildren ? children : undefined,
+      });
     } else if (c.type === "flatten_block" || c.type === "each_block") {
       const blockKind = c.type === "flatten_block" ? "flatten" : "each";
       const src = c.namedChildren.find((x) => x.type === "src_path");
       const tgt = c.namedChildren.find((x) => x.type === "tgt_path");
       const meta = c.namedChildren.find((x) => x.type === "metadata_block");
       const children = collectArrows(c);
-      arrows.push({ kind: blockKind, src: pathText(src), tgt: pathText(tgt), hasBody: true, metaNode: meta, node: c, children: children.length > 0 ? children : undefined });
+      arrows.push({
+        kind: blockKind,
+        src: pathText(src),
+        tgt: pathText(tgt),
+        hasBody: true,
+        metaNode: meta,
+        node: c,
+        children: children.length > 0 ? children : undefined,
+      });
     }
   }
   return arrows;
@@ -138,7 +181,9 @@ function printJson(entry: MappingRecord, mappingNode: SyntaxNode | null, compact
   function arrowToJson(info: ArrowInfo): Record<string, unknown> {
     const { kind, src, tgt, hasBody, metaNode: arrowMeta, node: arrowNode, children } = info;
     const pipeChain = arrowNode.namedChildren.find((x) => x.type === "pipe_chain");
-    const pipeSteps = pipeChain ? [...pipeChain.namedChildren].filter((x) => x.type === "pipe_step") : [];
+    const pipeSteps = pipeChain
+      ? [...pipeChain.namedChildren].filter((x) => x.type === "pipe_step")
+      : [];
     const classification = classifyTransform(pipeSteps.length > 0 ? pipeSteps : null);
     const hasTransform = hasBody && pipeChain != null;
     const arrowObj: Record<string, unknown> = { kind, src, tgt, hasTransform, classification };
@@ -204,7 +249,9 @@ function printArrowNode(c: SyntaxNode, compact: boolean | undefined, indent: str
   const srcPart = srcStr ? `${srcStr} -> ` : "-> ";
 
   // Check if this is a nested arrow with children
-  const childArrows = c.namedChildren.filter((x) => x.type === "map_arrow" || x.type === "computed_arrow" || x.type === "nested_arrow");
+  const childArrows = c.namedChildren.filter(
+    (x) => x.type === "map_arrow" || x.type === "computed_arrow" || x.type === "nested_arrow",
+  );
 
   if (childArrows.length > 0) {
     console.log(`${indent}${srcPart}${tgtStr}${metaSuffix} {`);
@@ -231,14 +278,22 @@ function printBlockNode(c: SyntaxNode, compact: boolean | undefined, indent: str
   const metaSuffix = meta && !compact ? ` ${meta.text}` : "";
   console.log(`${indent}${keyword} ${srcStr} -> ${tgtStr}${metaSuffix} {`);
   for (const child of c.namedChildren) {
-    if (child.type === "map_arrow" || child.type === "computed_arrow" || child.type === "nested_arrow") {
+    if (
+      child.type === "map_arrow" ||
+      child.type === "computed_arrow" ||
+      child.type === "nested_arrow"
+    ) {
       printArrowNode(child, compact, indent + "  ");
     }
   }
   console.log(`${indent}}`);
 }
 
-function printDefault(entry: MappingRecord, mappingNode: SyntaxNode | null, compact: boolean | undefined): void {
+function printDefault(
+  entry: MappingRecord,
+  mappingNode: SyntaxNode | null,
+  compact: boolean | undefined,
+): void {
   // Use canonicalEntityName so the header includes the namespace prefix, e.g.
   // "mapping 'warehouse::load hub_store'" not "mapping 'load hub_store'" (sl-qofc).
   const nameStr = entry.name ? ` '${canonicalEntityName(entry)}'` : "";
@@ -251,8 +306,10 @@ function printDefault(entry: MappingRecord, mappingNode: SyntaxNode | null, comp
     // source / target blocks
     const srcBlock = body.namedChildren.find((c) => c.type === "source_block");
     const tgtBlock = body.namedChildren.find((c) => c.type === "target_block");
-    if (srcBlock) console.log(`  source { ${srcBlock.namedChildren.map((c) => c.text).join(", ")} }`);
-    if (tgtBlock) console.log(`  target { ${tgtBlock.namedChildren.map((c) => c.text).join(", ")} }`);
+    if (srcBlock)
+      console.log(`  source { ${srcBlock.namedChildren.map((c) => c.text).join(", ")} }`);
+    if (tgtBlock)
+      console.log(`  target { ${tgtBlock.namedChildren.map((c) => c.text).join(", ")} }`);
 
     // Arrows and notes
     for (const c of body.namedChildren) {

--- a/tooling/satsuma-cli/src/commands/match-fields.ts
+++ b/tooling/satsuma-cli/src/commands/match-fields.ts
@@ -26,7 +26,9 @@ export function register(program: Command): void {
     .option("--matched-only", "show only matched pairs")
     .option("--unmatched-only", "show only unmatched fields")
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Both --source and --target are required. Matching is case-insensitive with
 underscores, hyphens, and spaces normalized. Names can be namespace-qualified.
 
@@ -40,99 +42,113 @@ JSON shape (--json):
 Examples:
   satsuma match-fields --source crm --target warehouse
   satsuma match-fields --source pos::stores --target hub_store --matched-only
-  satsuma match-fields --source crm --target warehouse --json`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { source: string; target: string; matchedOnly?: boolean; unmatchedOnly?: boolean; json?: boolean }) => {
-      const { index } = await loadWorkspace(pathArg);
+  satsuma match-fields --source crm --target warehouse --json`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: {
+            source: string;
+            target: string;
+            matchedOnly?: boolean;
+            unmatchedOnly?: boolean;
+            json?: boolean;
+          },
+        ) => {
+          const { index } = await loadWorkspace(pathArg);
 
-      // Resolve and validate both schemas. Hand-rolling the resolution
-      // here (instead of looping) lets TypeScript narrow `srcResolved` /
-      // `tgtResolved` to non-null after each guard, which is cleaner than
-      // the previous loop + non-null assertion dance.
-      const resolveSchema = (name: string): { key: string; entry: SchemaRecord } => {
-        const resolved = resolveIndexKey(name, index.schemas);
-        if (resolved) return resolved;
-        const close = [...index.schemas.keys()].find(
-          (k) => k.toLowerCase() === name.toLowerCase(),
-        );
-        const lines = [`Schema '${name}' not found.`];
-        if (close) lines.push(`Did you mean '${close}'?`);
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      };
+          // Resolve and validate both schemas. Hand-rolling the resolution
+          // here (instead of looping) lets TypeScript narrow `srcResolved` /
+          // `tgtResolved` to non-null after each guard, which is cleaner than
+          // the previous loop + non-null assertion dance.
+          const resolveSchema = (name: string): { key: string; entry: SchemaRecord } => {
+            const resolved = resolveIndexKey(name, index.schemas);
+            if (resolved) return resolved;
+            const close = [...index.schemas.keys()].find(
+              (k) => k.toLowerCase() === name.toLowerCase(),
+            );
+            const lines = [`Schema '${name}' not found.`];
+            if (close) lines.push(`Did you mean '${close}'?`);
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          };
 
-      const srcEntry = resolveSchema(opts.source).entry;
-      const tgtEntry = resolveSchema(opts.target).entry;
-      const srcFields = [
-        ...srcEntry.fields,
-        ...expandEntityFields(srcEntry, srcEntry.namespace ?? null, index),
-      ];
-      const tgtFields = [
-        ...tgtEntry.fields,
-        ...expandEntityFields(tgtEntry, tgtEntry.namespace ?? null, index),
-      ];
-      const result = matchFields(srcFields, tgtFields);
+          const srcEntry = resolveSchema(opts.source).entry;
+          const tgtEntry = resolveSchema(opts.target).entry;
+          const srcFields = [
+            ...srcEntry.fields,
+            ...expandEntityFields(srcEntry, srcEntry.namespace ?? null, index),
+          ];
+          const tgtFields = [
+            ...tgtEntry.fields,
+            ...expandEntityFields(tgtEntry, tgtEntry.namespace ?? null, index),
+          ];
+          const result = matchFields(srcFields, tgtFields);
 
-      if (opts.json) {
-        const filtered = { ...result };
-        if (opts.matchedOnly) {
-          filtered.sourceOnly = [];
-          filtered.targetOnly = [];
-        } else if (opts.unmatchedOnly) {
-          filtered.matched = [];
-        }
-        console.log(JSON.stringify(filtered, null, 2));
-        return;
-      }
+          if (opts.json) {
+            const filtered = { ...result };
+            if (opts.matchedOnly) {
+              filtered.sourceOnly = [];
+              filtered.targetOnly = [];
+            } else if (opts.unmatchedOnly) {
+              filtered.matched = [];
+            }
+            console.log(JSON.stringify(filtered, null, 2));
+            return;
+          }
 
-      if (opts.matchedOnly) {
-        if (result.matched.length === 0) {
-          console.log("No matches found.");
-          return;
-        }
-        for (const m of result.matched) {
-          console.log(`  ${m.source} <-> ${m.target}  (${m.normalized})`);
-        }
-        return;
-      }
+          if (opts.matchedOnly) {
+            if (result.matched.length === 0) {
+              console.log("No matches found.");
+              return;
+            }
+            for (const m of result.matched) {
+              console.log(`  ${m.source} <-> ${m.target}  (${m.normalized})`);
+            }
+            return;
+          }
 
-      if (opts.unmatchedOnly) {
-        if (result.sourceOnly.length === 0 && result.targetOnly.length === 0) {
-          console.log("All fields matched.");
-          return;
-        }
-        if (result.sourceOnly.length > 0) {
-          console.log(`Source-only (${result.sourceOnly.length}):`);
-          for (const f of result.sourceOnly) console.log(`  ${f}`);
-        }
-        if (result.targetOnly.length > 0) {
-          console.log(`Target-only (${result.targetOnly.length}):`);
-          for (const f of result.targetOnly) console.log(`  ${f}`);
-        }
-        return;
-      }
+          if (opts.unmatchedOnly) {
+            if (result.sourceOnly.length === 0 && result.targetOnly.length === 0) {
+              console.log("All fields matched.");
+              return;
+            }
+            if (result.sourceOnly.length > 0) {
+              console.log(`Source-only (${result.sourceOnly.length}):`);
+              for (const f of result.sourceOnly) console.log(`  ${f}`);
+            }
+            if (result.targetOnly.length > 0) {
+              console.log(`Target-only (${result.targetOnly.length}):`);
+              for (const f of result.targetOnly) console.log(`  ${f}`);
+            }
+            return;
+          }
 
-      // Default: show all
-      console.log(
-        `Matched: ${result.matched.length}, Source-only: ${result.sourceOnly.length}, Target-only: ${result.targetOnly.length}`,
-      );
-      console.log();
+          // Default: show all
+          console.log(
+            `Matched: ${result.matched.length}, Source-only: ${result.sourceOnly.length}, Target-only: ${result.targetOnly.length}`,
+          );
+          console.log();
 
-      if (result.matched.length > 0) {
-        console.log("Matched:");
-        for (const m of result.matched) {
-          console.log(`  ${m.source} <-> ${m.target}  (${m.normalized})`);
-        }
-        console.log();
-      }
+          if (result.matched.length > 0) {
+            console.log("Matched:");
+            for (const m of result.matched) {
+              console.log(`  ${m.source} <-> ${m.target}  (${m.normalized})`);
+            }
+            console.log();
+          }
 
-      if (result.sourceOnly.length > 0) {
-        console.log("Source-only:");
-        for (const f of result.sourceOnly) console.log(`  ${f}`);
-        console.log();
-      }
+          if (result.sourceOnly.length > 0) {
+            console.log("Source-only:");
+            for (const f of result.sourceOnly) console.log(`  ${f}`);
+            console.log();
+          }
 
-      if (result.targetOnly.length > 0) {
-        console.log("Target-only:");
-        for (const f of result.targetOnly) console.log(`  ${f}`);
-      }
-    }));
+          if (result.targetOnly.length > 0) {
+            console.log("Target-only:");
+            for (const f of result.targetOnly) console.log(`  ${f}`);
+          }
+        },
+      ),
+    );
 }

--- a/tooling/satsuma-cli/src/commands/meta.ts
+++ b/tooling/satsuma-cli/src/commands/meta.ts
@@ -31,7 +31,9 @@ export function register(program: Command): void {
     .description("Extract metadata for a schema, field, mapping, or metric")
     .option("--tags-only", "only output tag tokens, one per line")
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Scope formats:
   <block-name>     metadata on a schema, mapping, metric, or transform
   <schema.field>   metadata on a specific field (type, tags, constraints)
@@ -49,62 +51,78 @@ Examples:
   satsuma meta hub_customer.email            # field-level metadata
   satsuma meta 'load hub_store'              # mapping metadata
   satsuma meta hub_customer --tags-only      # just tag tokens
-  satsuma meta pos::stores.STORE_ID --json   # namespace-qualified`)
-    .action(runCommand(async (scope: string, pathArg: string | undefined, opts: { tagsOnly?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma meta pos::stores.STORE_ID --json   # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          scope: string,
+          pathArg: string | undefined,
+          opts: { tagsOnly?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      let result: MetaResult;
-      if (scope.includes(".")) {
-        result = extractFieldMeta(scope, parsedFiles, index);
-      } else {
-        result = extractBlockMeta(scope, parsedFiles, index);
-      }
+          let result: MetaResult;
+          if (scope.includes(".")) {
+            result = extractFieldMeta(scope, parsedFiles, index);
+          } else {
+            result = extractBlockMeta(scope, parsedFiles, index);
+          }
 
-      if (opts.tagsOnly) {
-        const tags = result.entries
-          .filter((e): e is Extract<MetaEntry, { kind: "tag" }> => e.kind === "tag")
-          .map((e) => e.tag);
-        if (tags.length === 0) {
-          console.log("No tags found.");
-          return;
-        }
-        for (const tag of tags) {
-          console.log(tag);
-        }
-        return;
-      }
+          if (opts.tagsOnly) {
+            const tags = result.entries
+              .filter((e): e is Extract<MetaEntry, { kind: "tag" }> => e.kind === "tag")
+              .map((e) => e.tag);
+            if (tags.length === 0) {
+              console.log("No tags found.");
+              return;
+            }
+            for (const tag of tags) {
+              console.log(tag);
+            }
+            return;
+          }
 
-      if (opts.json) {
-        console.log(JSON.stringify(result, null, 2));
-        return;
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(result, null, 2));
+            return;
+          }
 
-      printDefault(result);
-    }));
+          printDefault(result);
+        },
+      ),
+    );
 }
 
-function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: ExtractedWorkspace): MetaResult {
+function extractBlockMeta(
+  blockName: string,
+  parsedFiles: ParsedFile[],
+  index: ExtractedWorkspace,
+): MetaResult {
   // Determine block type, resolving namespace-qualified keys
   const blockTypes: string[] = [];
   let resolvedName = blockName;
   const schemaResolved = resolveIndexKey(blockName, index.schemas);
   const mappingResolved = resolveIndexKey(blockName, index.mappings);
   const metricResolved = resolveIndexKey(blockName, index.metrics);
-  if (schemaResolved) { blockTypes.push("schema_block"); resolvedName = schemaResolved.key; }
-  if (mappingResolved) { blockTypes.push("mapping_block"); resolvedName = mappingResolved.key; }
+  if (schemaResolved) {
+    blockTypes.push("schema_block");
+    resolvedName = schemaResolved.key;
+  }
+  if (mappingResolved) {
+    blockTypes.push("mapping_block");
+    resolvedName = mappingResolved.key;
+  }
   // Metrics are schema_block nodes decorated with the `metric` tag — look up by schema_block.
   // A metric name may coincide with a schema name (they ARE the same node), so only add once.
-  if (metricResolved && !schemaResolved) { blockTypes.push("schema_block"); resolvedName = metricResolved.key; }
+  if (metricResolved && !schemaResolved) {
+    blockTypes.push("schema_block");
+    resolvedName = metricResolved.key;
+  }
 
   if (blockTypes.length === 0) {
-    const allNames = [
-      ...index.schemas.keys(),
-      ...index.mappings.keys(),
-      ...index.metrics.keys(),
-    ];
-    const close = allNames.find(
-      (k) => k.toLowerCase() === blockName.toLowerCase(),
-    );
+    const allNames = [...index.schemas.keys(), ...index.mappings.keys(), ...index.metrics.keys()];
+    const close = allNames.find((k) => k.toLowerCase() === blockName.toLowerCase());
     const lines = [`'${blockName}' not found as a schema, mapping, or metric.`];
     if (close) lines.push(`Did you mean '${close}'?`);
     throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
@@ -113,16 +131,12 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: E
   const resolvedEntry =
     schemaResolved?.entry ?? mappingResolved?.entry ?? metricResolved?.entry ?? null;
 
-  const parsed = resolvedEntry
-    ? parsedFiles.find((p) => p.filePath === resolvedEntry.file)
-    : null;
+  const parsed = resolvedEntry ? parsedFiles.find((p) => p.filePath === resolvedEntry.file) : null;
   if (parsed) {
     for (const blockType of blockTypes) {
       const node = findBlockNode(parsed.tree.rootNode, blockType, resolvedName);
       if (!node) continue;
-      const metaNode = node.namedChildren.find(
-        (c) => c.type === "metadata_block",
-      );
+      const metaNode = node.namedChildren.find((c) => c.type === "metadata_block");
       const entries = extractMetadata(metaNode);
 
       // Also extract note blocks from the body (mapping_body or schema_body for metric schemas).
@@ -136,10 +150,12 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: E
               (x: SyntaxNode) => x.type === "nl_string" || x.type === "multiline_string",
             );
             if (strNodes.length > 0) {
-              const text = strNodes.map((s: SyntaxNode) => {
-                if (s.type === "multiline_string") return s.text.slice(3, -3).trim();
-                return s.text.slice(1, -1);
-              }).join("\n");
+              const text = strNodes
+                .map((s: SyntaxNode) => {
+                  if (s.type === "multiline_string") return s.text.slice(3, -3).trim();
+                  return s.text.slice(1, -1);
+                })
+                .join("\n");
               entries.push({ kind: "note" as const, text });
             }
           }
@@ -156,7 +172,11 @@ function extractBlockMeta(blockName: string, parsedFiles: ParsedFile[], index: E
   return { scope: resolvedName, entries: [] };
 }
 
-function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: ExtractedWorkspace): MetaResult {
+function extractFieldMeta(
+  fieldRef: string,
+  parsedFiles: ParsedFile[],
+  index: ExtractedWorkspace,
+): MetaResult {
   const dot = fieldRef.indexOf(".");
   const entityName = fieldRef.slice(0, dot);
   const fieldPath = fieldRef.slice(dot + 1);
@@ -167,7 +187,10 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
   const fieldName = pathSegments[pathSegments.length - 1]!;
 
   // Search schemas, then fragments, then metrics
-  type ResolvedEntity = { key: string; entry: { fields: FieldDecl[]; file: string; namespace?: string } };
+  type ResolvedEntity = {
+    key: string;
+    entry: { fields: FieldDecl[]; file: string; namespace?: string };
+  };
   let resolved: ResolvedEntity | null = resolveIndexKey(entityName, index.schemas);
   let blockType = "schema_block";
   let bodyType = "schema_body";
@@ -195,7 +218,11 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
 
   // If field not found directly, try expanded spread fields
   if (!field && blockType === "schema_block") {
-    const expanded = expandEntityFields(entity as Parameters<typeof expandEntityFields>[0], entity.namespace ?? null, index);
+    const expanded = expandEntityFields(
+      entity as Parameters<typeof expandEntityFields>[0],
+      entity.namespace ?? null,
+      index,
+    );
     const expandedField = expanded.find((f) => f.name === pathSegments[0]);
     if (expandedField) {
       field = expandedField;
@@ -204,10 +231,7 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
   }
 
   if (!field) {
-    throw new CommandError(
-      `Field '${fieldPath}' not found in '${entityName}'.`,
-      EXIT_NOT_FOUND,
-    );
+    throw new CommandError(`Field '${fieldPath}' not found in '${entityName}'.`, EXIT_NOT_FOUND);
   }
 
   // If the field came from a fragment spread, look up metadata from the fragment's CST
@@ -220,9 +244,7 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
         const fragBody = fragNode?.namedChildren.find((c) => c.type === "schema_body");
         if (fragBody) {
           for (const fieldDecl of findFieldDecls(fragBody, fieldName)) {
-            const metaNode = fieldDecl.namedChildren.find(
-              (c) => c.type === "metadata_block",
-            );
+            const metaNode = fieldDecl.namedChildren.find((c) => c.type === "metadata_block");
             const entries = extractMetadata(metaNode);
             return { scope: fieldRef, type: displayType(field), entries };
           }
@@ -239,16 +261,14 @@ function extractFieldMeta(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
     const targetBody = navigateToNestedBody(body, pathSegments.slice(0, -1));
     if (targetBody) {
       for (const fieldDecl of findFieldDecls(targetBody, fieldName)) {
-        const metaNode = fieldDecl.namedChildren.find(
-          (c) => c.type === "metadata_block",
-        );
+        const metaNode = fieldDecl.namedChildren.find((c) => c.type === "metadata_block");
         const entries = extractMetadata(metaNode);
         return {
-            scope: fieldRef,
-            type: displayType(field),
-            entries,
-          };
-        }
+          scope: fieldRef,
+          type: displayType(field),
+          entries,
+        };
+      }
     }
   }
 
@@ -261,9 +281,7 @@ function displayType(field: FieldDecl): string | null {
 }
 
 function getFieldDeclName(fieldDecl: SyntaxNode): string | null {
-  const nameNode = fieldDecl.namedChildren.find(
-    (c) => c.type === "field_name",
-  );
+  const nameNode = fieldDecl.namedChildren.find((c) => c.type === "field_name");
   const inner = nameNode?.namedChildren[0];
   if (!inner) return null;
   if (inner.type === "backtick_name") return inner.text.slice(1, -1);
@@ -317,8 +335,11 @@ function navigateToNestedBody(body: SyntaxNode, intermediateSegments: string[]):
   return current;
 }
 
-
-function findFieldDecls(bodyNode: SyntaxNode, fieldName: string, acc: SyntaxNode[] = []): SyntaxNode[] {
+function findFieldDecls(
+  bodyNode: SyntaxNode,
+  fieldName: string,
+  acc: SyntaxNode[] = [],
+): SyntaxNode[] {
   for (const child of bodyNode.namedChildren) {
     if (child.type === "field_decl") {
       if (getFieldDeclName(child) === fieldName) {

--- a/tooling/satsuma-cli/src/commands/metric.ts
+++ b/tooling/satsuma-cli/src/commands/metric.ts
@@ -26,45 +26,58 @@ export function register(program: Command): void {
     .option("--compact", "suppress note text")
     .option("--sources", "print source schema names only (one per line)")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Names can be namespace-qualified (e.g. analytics::daily_sales).
 
 Examples:
   satsuma metric daily_sales                         # full metric
   satsuma metric daily_sales --sources               # just source schemas
-  satsuma metric analytics::daily_sales --json       # namespace-qualified`)
-    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; sources?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma metric analytics::daily_sales --json       # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          name: string,
+          pathArg: string | undefined,
+          opts: { compact?: boolean; sources?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      const resolved = resolveIndexKey(name, index.metrics);
-      if (!resolved) {
-        const keys = [...index.metrics.keys()];
-        const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
-        const lines: string[] = [];
-        if (close) {
-          lines.push(`Metric '${name}' not found. Did you mean '${close}'?`);
-        } else {
-          lines.push(`Metric '${name}' not found.`);
-          if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
-        }
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-      const entry = resolved.entry;
-      const resolvedName = resolved.key;
+          const resolved = resolveIndexKey(name, index.metrics);
+          if (!resolved) {
+            const keys = [...index.metrics.keys()];
+            const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
+            const lines: string[] = [];
+            if (close) {
+              lines.push(`Metric '${name}' not found. Did you mean '${close}'?`);
+            } else {
+              lines.push(`Metric '${name}' not found.`);
+              if (keys.length > 0) lines.push(`Available: ${keys.join(", ")}`);
+            }
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          }
+          const entry = resolved.entry;
+          const resolvedName = resolved.key;
 
-      const parsed = parsedFiles.find((p) => p.filePath === entry.file);
-      // Metrics are schema_block nodes decorated with the `metric` tag in their
-      // metadata_block. Look up the schema_block by the qualified metric name.
-      const metricNode = parsed ? findBlockNode(parsed.tree.rootNode, "schema_block", resolvedName) : null;
+          const parsed = parsedFiles.find((p) => p.filePath === entry.file);
+          // Metrics are schema_block nodes decorated with the `metric` tag in their
+          // metadata_block. Look up the schema_block by the qualified metric name.
+          const metricNode = parsed
+            ? findBlockNode(parsed.tree.rootNode, "schema_block", resolvedName)
+            : null;
 
-      if (opts.json) {
-        printJson(entry, metricNode);
-      } else if (opts.sources) {
-        for (const s of entry.sources) console.log(s);
-      } else {
-        printDefault(entry, metricNode, opts.compact);
-      }
-    }));
+          if (opts.json) {
+            printJson(entry, metricNode);
+          } else if (opts.sources) {
+            for (const s of entry.sources) console.log(s);
+          } else {
+            printDefault(entry, metricNode, opts.compact);
+          }
+        },
+      ),
+    );
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────
@@ -106,9 +119,7 @@ function extractMetaEntries(metaNode: SyntaxNode | undefined): MetaEntry[] {
         entries.push({ key: "note", value: text, quoted: true });
       }
     } else if (c.type === "slice_body") {
-      const sliceNames = c.namedChildren
-        .filter((x) => x.type === "identifier")
-        .map((x) => x.text);
+      const sliceNames = c.namedChildren.filter((x) => x.type === "identifier").map((x) => x.text);
       entries.push({ key: "slice", value: `{${sliceNames.join(", ")}}` });
     }
   }
@@ -180,7 +191,11 @@ function printJson(entry: MetricRecord, metricNode: SyntaxNode | null): void {
   );
 }
 
-function printDefault(entry: MetricRecord, metricNode: SyntaxNode | null, compact: boolean | undefined): void {
+function printDefault(
+  entry: MetricRecord,
+  metricNode: SyntaxNode | null,
+  compact: boolean | undefined,
+): void {
   const metaNode = metricNode?.namedChildren.find((c) => c.type === "metadata_block");
   const meta = extractMetaEntries(metaNode);
   const metaStr = formatMeta(meta);
@@ -203,7 +218,10 @@ function printDefault(entry: MetricRecord, metricNode: SyntaxNode | null, compac
         console.log(`  ${fname.padEnd(20)}${typeNode?.text ?? ""}${metaDeclText}`);
       } else if (c.type === "note_block" && !compact) {
         console.log(`  note { ... }`);
-      } else if ((c.type === "comment" || c.type === "warning_comment" || c.type === "question_comment") && !compact) {
+      } else if (
+        (c.type === "comment" || c.type === "warning_comment" || c.type === "question_comment") &&
+        !compact
+      ) {
         console.log(`  ${c.text}`);
       }
     }

--- a/tooling/satsuma-cli/src/commands/nl-refs.ts
+++ b/tooling/satsuma-cli/src/commands/nl-refs.ts
@@ -25,7 +25,9 @@ export function register(program: Command): void {
     .option("--mapping <name>", "scope to a specific mapping")
     .option("--json", "structured JSON output")
     .option("--unresolved", "show only unresolved references")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 @ref references are @field_name, @schema.field, or @ns::schema.field
 inside "..." NL strings. Each ref is checked against the file index —
 "resolved" means the referenced field or schema exists, "unresolved" means
@@ -47,39 +49,47 @@ JSON shape (--json): array of ref objects
 Examples:
   satsuma nl-refs pipeline.stm                       # all refs in file and imports
   satsuma nl-refs --mapping 'load hub_customer'      # refs in one mapping
-  satsuma nl-refs pipeline.stm --unresolved --json   # broken refs as JSON`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { mapping?: string; json?: boolean; unresolved?: boolean }) => {
-      const { index } = await loadWorkspace(pathArg);
+  satsuma nl-refs pipeline.stm --unresolved --json   # broken refs as JSON`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: { mapping?: string; json?: boolean; unresolved?: boolean },
+        ) => {
+          const { index } = await loadWorkspace(pathArg);
 
-      let refs = resolveAllNLRefs(index);
+          let refs = resolveAllNLRefs(index);
 
-      // Apply --mapping filter
-      if (opts.mapping) {
-        const resolved = resolveIndexKey(opts.mapping, index.mappings);
-        if (!resolved) {
-          throw new CommandError(`Mapping '${opts.mapping}' not found.`, EXIT_NOT_FOUND);
-        }
-        refs = refs.filter((r) => r.mapping === resolved.key);
-      }
+          // Apply --mapping filter
+          if (opts.mapping) {
+            const resolved = resolveIndexKey(opts.mapping, index.mappings);
+            if (!resolved) {
+              throw new CommandError(`Mapping '${opts.mapping}' not found.`, EXIT_NOT_FOUND);
+            }
+            refs = refs.filter((r) => r.mapping === resolved.key);
+          }
 
-      // Apply --unresolved filter
-      if (opts.unresolved) {
-        refs = refs.filter((r) => !r.resolved);
-      }
+          // Apply --unresolved filter
+          if (opts.unresolved) {
+            refs = refs.filter((r) => !r.resolved);
+          }
 
-      if (opts.json) {
-        const out = refs.map((r) => ({ ...r, line: r.line + 1 }));
-        console.log(JSON.stringify(out, null, 2));
-        return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
-      }
+          if (opts.json) {
+            const out = refs.map((r) => ({ ...r, line: r.line + 1 }));
+            console.log(JSON.stringify(out, null, 2));
+            return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
+          }
 
-      if (refs.length === 0) {
-        console.log("No NL @ref references found.");
-        return EXIT_NOT_FOUND;
-      }
+          if (refs.length === 0) {
+            console.log("No NL @ref references found.");
+            return EXIT_NOT_FOUND;
+          }
 
-      printDefault(refs);
-    }));
+          printDefault(refs);
+        },
+      ),
+    );
 }
 
 function printDefault(refs: ResolvedNLRef[]): void {
@@ -112,10 +122,8 @@ function printDefault(refs: ResolvedNLRef[]): void {
     }
     console.log(`  ${label}:`);
     for (const ref of mappingRefs) {
-      const status = ref.resolved
-        ? `-> ${ref.resolvedTo?.name ?? "?"}`
-        : "(unresolved)";
-      const padRef = (`\`${ref.ref}\``).padEnd(32);
+      const status = ref.resolved ? `-> ${ref.resolvedTo?.name ?? "?"}` : "(unresolved)";
+      const padRef = `\`${ref.ref}\``.padEnd(32);
       const padClass = ref.classification.padEnd(28);
       console.log(`    ${padRef} ${padClass} ${status}  (line ${ref.line + 1})`);
     }

--- a/tooling/satsuma-cli/src/commands/nl.ts
+++ b/tooling/satsuma-cli/src/commands/nl.ts
@@ -29,7 +29,9 @@ export function register(program: Command): void {
     .description("Extract NL content (notes, transforms, comments) from a scope")
     .option("--kind <type>", "filter by kind: note, warning, question, transform")
     .option("--json", "structured JSON output")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Scope formats:
   <block-name>     NL in a schema, mapping, metric, or transform by name
   <schema.field>   NL on a specific field and arrows referencing it
@@ -50,35 +52,44 @@ Examples:
   satsuma nl mart_customer_360.email         # NL on a field
   satsuma nl all pipeline.stm                # all NL in file and imports
   satsuma nl all pipeline.stm --kind warning # only //! warnings
-  satsuma nl hub_customer --json             # structured output`)
-    .action(runCommand(async (scope: string, pathArg: string | undefined, opts: { kind?: string; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma nl hub_customer --json             # structured output`,
+    )
+    .action(
+      runCommand(
+        async (
+          scope: string,
+          pathArg: string | undefined,
+          opts: { kind?: string; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      let items: NLItemWithFile[];
-      if (scope === "all") {
-        items = extractFromAll(parsedFiles);
-      } else if (scope.includes(".")) {
-        items = extractFromField(scope, parsedFiles, index);
-      } else {
-        items = extractFromBlock(scope, parsedFiles, index);
-      }
+          let items: NLItemWithFile[];
+          if (scope === "all") {
+            items = extractFromAll(parsedFiles);
+          } else if (scope.includes(".")) {
+            items = extractFromField(scope, parsedFiles, index);
+          } else {
+            items = extractFromBlock(scope, parsedFiles, index);
+          }
 
-      if (opts.kind) {
-        items = items.filter((i) => i.kind === opts.kind);
-      }
+          if (opts.kind) {
+            items = items.filter((i) => i.kind === opts.kind);
+          }
 
-      if (opts.json) {
-        console.log(JSON.stringify(items, null, 2));
-        return;
-      }
+          if (opts.json) {
+            console.log(JSON.stringify(items, null, 2));
+            return;
+          }
 
-      if (items.length === 0) {
-        console.log(`No NL content found for scope '${scope}'.`);
-        return;
-      }
+          if (items.length === 0) {
+            console.log(`No NL content found for scope '${scope}'.`);
+            return;
+          }
 
-      printDefault(items);
-    }));
+          printDefault(items);
+        },
+      ),
+    );
 }
 
 function extractFromAll(parsedFiles: ParsedFile[]): NLItemWithFile[] {
@@ -91,7 +102,11 @@ function extractFromAll(parsedFiles: ParsedFile[]): NLItemWithFile[] {
   return items;
 }
 
-function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: ExtractedWorkspace): NLItemWithFile[] {
+function extractFromBlock(
+  blockName: string,
+  parsedFiles: ParsedFile[],
+  index: ExtractedWorkspace,
+): NLItemWithFile[] {
   // Check if it's a schema, mapping, metric, or transform (resolving namespace-qualified keys)
   const schemaResolved = resolveIndexKey(blockName, index.schemas);
   const mappingResolved = resolveIndexKey(blockName, index.mappings);
@@ -105,9 +120,7 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: E
       ...index.metrics.keys(),
       ...index.transforms.keys(),
     ];
-    const close = allNames.find(
-      (k) => k.toLowerCase() === blockName.toLowerCase(),
-    );
+    const close = allNames.find((k) => k.toLowerCase() === blockName.toLowerCase());
     const lines = [`'${blockName}' not found as a schema, mapping, metric, or transform.`];
     if (close) lines.push(`Did you mean '${close}'?`);
     throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
@@ -117,11 +130,31 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: E
   // to handle ambiguous names where a schema and mapping share a name
   const items: NLItemWithFile[] = [];
   const matches: Array<{ key: string; entry: { file: string }; blockType: string }> = [];
-  if (schemaResolved) matches.push({ key: schemaResolved.key, entry: schemaResolved.entry, blockType: "schema_block" });
-  if (mappingResolved) matches.push({ key: mappingResolved.key, entry: mappingResolved.entry, blockType: "mapping_block" });
+  if (schemaResolved)
+    matches.push({
+      key: schemaResolved.key,
+      entry: schemaResolved.entry,
+      blockType: "schema_block",
+    });
+  if (mappingResolved)
+    matches.push({
+      key: mappingResolved.key,
+      entry: mappingResolved.entry,
+      blockType: "mapping_block",
+    });
   // Metrics are schema_block nodes — look up by schema_block. Skip if already added via schemaResolved.
-  if (metricResolved && !schemaResolved) matches.push({ key: metricResolved.key, entry: metricResolved.entry, blockType: "schema_block" });
-  if (transformResolved) matches.push({ key: transformResolved.key, entry: transformResolved.entry, blockType: "transform_block" });
+  if (metricResolved && !schemaResolved)
+    matches.push({
+      key: metricResolved.key,
+      entry: metricResolved.entry,
+      blockType: "schema_block",
+    });
+  if (transformResolved)
+    matches.push({
+      key: transformResolved.key,
+      entry: transformResolved.entry,
+      blockType: "transform_block",
+    });
 
   for (const { key, entry, blockType } of matches) {
     const parsed = parsedFiles.find((p) => p.filePath === entry.file);
@@ -139,7 +172,11 @@ function extractFromBlock(blockName: string, parsedFiles: ParsedFile[], index: E
   return items;
 }
 
-function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: ExtractedWorkspace): NLItemWithFile[] {
+function extractFromField(
+  fieldRef: string,
+  parsedFiles: ParsedFile[],
+  index: ExtractedWorkspace,
+): NLItemWithFile[] {
   const dot = fieldRef.indexOf(".");
   const schemaName = fieldRef.slice(0, dot);
   const fieldPath = fieldRef.slice(dot + 1);
@@ -155,9 +192,10 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
 
   const schema = resolvedSchema.entry;
   // For multi-segment paths, require exact path match; for single-segment, use flat search
-  const fieldExists = pathSegments.length > 1
-    ? schemaHasFieldByPath(schema.fields, pathSegments)
-    : schemaHasField(schema.fields, leafName);
+  const fieldExists =
+    pathSegments.length > 1
+      ? schemaHasFieldByPath(schema.fields, pathSegments)
+      : schemaHasField(schema.fields, leafName);
   if (!fieldExists) {
     throw new CommandError(
       `Field '${fieldPath}' not found in schema '${schemaName}'.`,
@@ -167,7 +205,9 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
 
   const items: NLItemWithFile[] = [];
   const parsed = parsedFiles.find((p) => p.filePath === schema.file);
-  const schemaNode = parsed ? findBlockNode(parsed.tree.rootNode, "schema_block", resolvedSchema.key) : null;
+  const schemaNode = parsed
+    ? findBlockNode(parsed.tree.rootNode, "schema_block", resolvedSchema.key)
+    : null;
   const body = schemaNode?.namedChildren.find((c) => c.type === "schema_body");
   if (body) {
     // Navigate to the nested body for intermediate path segments, then find the leaf field
@@ -186,8 +226,7 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
     const mappingSources = mapping.sources ?? [];
     const mappingTargets = mapping.targets ?? [];
     const schemaIsRelevant =
-      mappingSources.includes(resolvedSchemaKey) ||
-      mappingTargets.includes(resolvedSchemaKey);
+      mappingSources.includes(resolvedSchemaKey) || mappingTargets.includes(resolvedSchemaKey);
     if (!schemaIsRelevant) continue;
 
     const mappingParsed = parsedFiles.find((p) => p.filePath === mapping.file);
@@ -199,9 +238,7 @@ function extractFromField(fieldRef: string, parsedFiles: ParsedFile[], index: Ex
     const mappingNode = findBlockNode(mappingParsed.tree.rootNode, "mapping_block", mappingKey);
     if (!mappingNode) continue;
 
-    const mBody = mappingNode.namedChildren.find(
-      (c) => c.type === "mapping_body",
-    );
+    const mBody = mappingNode.namedChildren.find((c) => c.type === "mapping_body");
     if (!mBody) continue;
 
     const parentName = labelText(mappingNode) ?? "?";
@@ -225,8 +262,7 @@ function collectFieldArrowNL(
       collectFieldArrowNL(child.namedChildren, leafName, parentName, file, items);
       continue;
     }
-    if (child.type !== "map_arrow" && child.type !== "computed_arrow")
-      continue;
+    if (child.type !== "map_arrow" && child.type !== "computed_arrow") continue;
     const src = child.namedChildren.find((c) => c.type === "src_path");
     const tgt = child.namedChildren.find((c) => c.type === "tgt_path");
     const srcText = src?.namedChildren[0]?.text?.replace(/^\./, "") ?? null;
@@ -253,9 +289,7 @@ function collectFieldArrowNL(
 }
 
 function getFieldDeclName(fieldDecl: SyntaxNode): string | null {
-  const nameNode = fieldDecl.namedChildren.find(
-    (c) => c.type === "field_name",
-  );
+  const nameNode = fieldDecl.namedChildren.find((c) => c.type === "field_name");
   const inner = nameNode?.namedChildren[0];
   if (!inner) return null;
   if (inner.type === "backtick_name") return inner.text.slice(1, -1);
@@ -303,7 +337,11 @@ function navigateToNestedBody(body: SyntaxNode, intermediateSegments: string[]):
   return current;
 }
 
-function findFieldDecls(bodyNode: SyntaxNode, fieldName: string, acc: SyntaxNode[] = []): SyntaxNode[] {
+function findFieldDecls(
+  bodyNode: SyntaxNode,
+  fieldName: string,
+  acc: SyntaxNode[] = [],
+): SyntaxNode[] {
   for (const child of bodyNode.namedChildren) {
     if (child.type === "field_decl") {
       if (getFieldDeclName(child) === fieldName) {
@@ -320,10 +358,14 @@ function findFieldDecls(bodyNode: SyntaxNode, fieldName: string, acc: SyntaxNode
 
 function printDefault(items: NLItemWithFile[]): void {
   for (const item of items) {
-    const prefix = item.kind === "warning" ? "//! " :
-      item.kind === "question" ? "//? " :
-        item.kind === "transform" ? "[transform] " :
-          "[note] ";
+    const prefix =
+      item.kind === "warning"
+        ? "//! "
+        : item.kind === "question"
+          ? "//? "
+          : item.kind === "transform"
+            ? "[transform] "
+            : "[note] ";
     const parent = item.parent ? ` (${item.parent})` : "";
     console.log(`${prefix}${item.text}${parent}`);
   }

--- a/tooling/satsuma-cli/src/commands/schema.ts
+++ b/tooling/satsuma-cli/src/commands/schema.ts
@@ -26,62 +26,73 @@ export function register(program: Command): void {
     .option("--compact", "omit notes and inline strings")
     .option("--fields-only", "one line per field")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Names can be namespace-qualified (e.g. pos::stores). Quote names with
 spaces (e.g. 'my schema').
 
 Examples:
   satsuma schema hub_customer                        # full schema
   satsuma schema hub_customer --fields-only          # one field per line
-  satsuma schema pos::stores --json                  # namespace-qualified`)
-    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { compact?: boolean; fieldsOnly?: boolean; json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma schema pos::stores --json                  # namespace-qualified`,
+    )
+    .action(
+      runCommand(
+        async (
+          name: string,
+          pathArg: string | undefined,
+          opts: { compact?: boolean; fieldsOnly?: boolean; json?: boolean },
+        ) => {
+          const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      const resolved = resolveIndexKey(name, index.schemas);
-      if (!resolved) {
-        const keys = [...index.schemas.keys()];
-        const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
-        // Check for ambiguous unqualified name
-        const ambiguous = !name.includes("::") && keys.filter((k) => k.endsWith(`::${name}`));
-        let errorMsg: string;
-        if (ambiguous && ambiguous.length > 1) {
-          errorMsg = `Schema '${name}' is ambiguous. Found in: ${ambiguous.join(", ")}`;
-        } else if (close) {
-          errorMsg = `Schema '${name}' not found. Did you mean '${close}'?`;
-        } else {
-          errorMsg = `Schema '${name}' not found.`;
-        }
-        if (opts.json) {
-          // JSON callers want the error on the same channel as success
-          // output so they can pipe `satsuma schema … --json | jq` and
-          // still parse the response. Hand the JSON-shaped message to the
-          // runner with stream: "stdout".
-          const errorObj: Record<string, unknown> = { error: errorMsg };
-          if (keys.length > 0) errorObj.available = keys;
-          throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
-        }
-        const lines: string[] = [errorMsg];
-        if (keys.length > 0 && !(ambiguous && ambiguous.length > 1) && !close) {
-          lines.push(`Available: ${keys.join(", ")}`);
-        }
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
-      const entry = resolved.entry;
+          const resolved = resolveIndexKey(name, index.schemas);
+          if (!resolved) {
+            const keys = [...index.schemas.keys()];
+            const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());
+            // Check for ambiguous unqualified name
+            const ambiguous = !name.includes("::") && keys.filter((k) => k.endsWith(`::${name}`));
+            let errorMsg: string;
+            if (ambiguous && ambiguous.length > 1) {
+              errorMsg = `Schema '${name}' is ambiguous. Found in: ${ambiguous.join(", ")}`;
+            } else if (close) {
+              errorMsg = `Schema '${name}' not found. Did you mean '${close}'?`;
+            } else {
+              errorMsg = `Schema '${name}' not found.`;
+            }
+            if (opts.json) {
+              // JSON callers want the error on the same channel as success
+              // output so they can pipe `satsuma schema … --json | jq` and
+              // still parse the response. Hand the JSON-shaped message to the
+              // runner with stream: "stdout".
+              const errorObj: Record<string, unknown> = { error: errorMsg };
+              if (keys.length > 0) errorObj.available = keys;
+              throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
+            }
+            const lines: string[] = [errorMsg];
+            if (keys.length > 0 && !(ambiguous && ambiguous.length > 1) && !close) {
+              lines.push(`Available: ${keys.join(", ")}`);
+            }
+            throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
+          }
+          const entry = resolved.entry;
 
-      // Find the raw CST node for richer reconstruction
-      const parsed = parsedFiles.find((p) => p.filePath === entry.file);
-      const schemaNode = parsed
-        ? findBlockNode(parsed.tree.rootNode, "schema_block", resolved.key)
-        : null;
+          // Find the raw CST node for richer reconstruction
+          const parsed = parsedFiles.find((p) => p.filePath === entry.file);
+          const schemaNode = parsed
+            ? findBlockNode(parsed.tree.rootNode, "schema_block", resolved.key)
+            : null;
 
-      if (opts.json) {
-        printJson(entry, schemaNode, index, opts);
-      } else if (opts.fieldsOnly) {
-        printFieldsOnly(entry);
-      } else {
-        printDefault(entry, schemaNode, opts.compact);
-      }
-    }));
+          if (opts.json) {
+            printJson(entry, schemaNode, index, opts);
+          } else if (opts.fieldsOnly) {
+            printFieldsOnly(entry);
+          } else {
+            printDefault(entry, schemaNode, opts.compact);
+          }
+        },
+      ),
+    );
 }
 
 // ── CST helpers ───────────────────────────────────────────────────────────────
@@ -100,7 +111,11 @@ function fieldHasListOf(fd: SyntaxNode): boolean {
 }
 
 /** Collect edge comments (before first field / after last field) from a block node. */
-function collectEdgeComments(blockNode: SyntaxNode, position: "before" | "after", bodyNode: SyntaxNode): CollectedLine[] {
+function collectEdgeComments(
+  blockNode: SyntaxNode,
+  position: "before" | "after",
+  bodyNode: SyntaxNode,
+): CollectedLine[] {
   const lines: CollectedLine[] = [];
   const commentTypes = new Set(["comment", "warning_comment", "question_comment"]);
   for (const c of blockNode.children) {
@@ -149,7 +164,10 @@ function collectFields(bodyNode: SyntaxNode, indent: number = 0): CollectedLine[
         const isList = fieldHasListOf(c);
         const typePrefix = isList ? "list_of " : "";
         const metaText = meta ? ` ${meta.text}` : "";
-        lines.push({ indent, text: `${pad}${fname.padEnd(24)}${typePrefix}${typeNode?.text ?? ""}${metaText}` });
+        lines.push({
+          indent,
+          text: `${pad}${fname.padEnd(24)}${typePrefix}${typeNode?.text ?? ""}${metaText}`,
+        });
       }
     } else if (c.type === "fragment_spread") {
       const lbl = c.namedChildren.find((x) => x.type === "spread_label");
@@ -160,13 +178,22 @@ function collectFields(bodyNode: SyntaxNode, indent: number = 0): CollectedLine[
           sname = q.text;
         } else {
           sname = lbl.namedChildren
-            .filter((x) => x.type === "identifier" || x.type === "continuation_word" || x.type === "qualified_name")
+            .filter(
+              (x) =>
+                x.type === "identifier" ||
+                x.type === "continuation_word" ||
+                x.type === "qualified_name",
+            )
             .map((x) => x.text)
             .join(" ");
         }
       }
       lines.push({ indent, text: `${pad}...${sname}` });
-    } else if (c.type === "comment" || c.type === "warning_comment" || c.type === "question_comment") {
+    } else if (
+      c.type === "comment" ||
+      c.type === "warning_comment" ||
+      c.type === "question_comment"
+    ) {
       lines.push({ indent, text: `${pad}${c.text}` });
     }
   }
@@ -175,7 +202,12 @@ function collectFields(bodyNode: SyntaxNode, indent: number = 0): CollectedLine[
 
 // ── Formatters ────────────────────────────────────────────────────────────────
 
-function printJson(entry: SchemaRecord, schemaNode: SyntaxNode | null, index: ExtractedWorkspace, opts: { compact?: boolean; fieldsOnly?: boolean }): void {
+function printJson(
+  entry: SchemaRecord,
+  schemaNode: SyntaxNode | null,
+  index: ExtractedWorkspace,
+  opts: { compact?: boolean; fieldsOnly?: boolean },
+): void {
   const spreadFields = expandEntityFields(entry, entry.namespace ?? null, index);
   const allFields = [...entry.fields, ...spreadFields];
 
@@ -227,7 +259,11 @@ function printFieldsOnly(entry: SchemaRecord): void {
   }
 }
 
-function printDefault(entry: SchemaRecord, schemaNode: SyntaxNode | null, compact: boolean | undefined): void {
+function printDefault(
+  entry: SchemaRecord,
+  schemaNode: SyntaxNode | null,
+  compact: boolean | undefined,
+): void {
   const metaNode = schemaNode?.namedChildren.find((c) => c.type === "metadata_block");
   const metaText = metaNode && !compact ? ` ${metaNode.text}` : "";
   const baseName = entry.name && entry.name.includes(" ") ? `'${entry.name}'` : (entry.name ?? "");
@@ -246,7 +282,11 @@ function printDefault(entry: SchemaRecord, schemaNode: SyntaxNode | null, compac
         if (compact) {
           // Strip comments and inline note text in compact mode
           if (text.trimStart().startsWith("//")) continue;
-          console.log(text.replace(/\s*\(\s*note\s+"""[\s\S]*?"""\s*\)/, "").replace(/\s*\(note\s+"[^"]*"\)/, ""));
+          console.log(
+            text
+              .replace(/\s*\(\s*note\s+"""[\s\S]*?"""\s*\)/, "")
+              .replace(/\s*\(note\s+"[^"]*"\)/, ""),
+          );
         } else {
           console.log(text);
         }

--- a/tooling/satsuma-cli/src/commands/summary.ts
+++ b/tooling/satsuma-cli/src/commands/summary.ts
@@ -22,11 +22,17 @@ import { countNlDerivedEdgesByMapping } from "../nl-ref-extract.js";
 import { canonicalEntityName } from "@satsuma/core";
 import type { FieldDecl, ExtractedWorkspace, SchemaRecord } from "../types.js";
 
-function totalFieldCount(schema: { fields: FieldDecl[]; namespace?: string | null }, index: ExtractedWorkspace): number {
-  const expanded = expandEntityFields(schema as Parameters<typeof expandEntityFields>[0], schema.namespace ?? null, index);
+function totalFieldCount(
+  schema: { fields: FieldDecl[]; namespace?: string | null },
+  index: ExtractedWorkspace,
+): number {
+  const expanded = expandEntityFields(
+    schema as Parameters<typeof expandEntityFields>[0],
+    schema.namespace ?? null,
+    index,
+  );
   return schema.fields.length + expanded.length;
 }
-
 
 export function register(program: Command): void {
   program
@@ -34,7 +40,9 @@ export function register(program: Command): void {
     .description("Summarise a Satsuma file and its imports")
     .option("--compact", "show names only")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 JSON shape (--json):
   {
     "schemas":      [{"name": str, "fieldCount": int, "note": str|null, "file": str, "line": int}, ...],
@@ -52,18 +60,23 @@ JSON shape (--json):
 Examples:
   satsuma summary pipeline.stm           # human overview
   satsuma summary pipeline.stm --json    # structured index
-  satsuma summary pipeline.stm --compact # names only`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { compact?: boolean; json?: boolean }) => {
-      const { files: parsed, index } = await loadWorkspace(pathArg);
+  satsuma summary pipeline.stm --compact # names only`,
+    )
+    .action(
+      runCommand(
+        async (pathArg: string | undefined, opts: { compact?: boolean; json?: boolean }) => {
+          const { files: parsed, index } = await loadWorkspace(pathArg);
 
-      if (opts.json) {
-        printJson(index, parsed.length, opts.compact);
-      } else if (opts.compact) {
-        printCompact(index);
-      } else {
-        printDefault(index, parsed.length);
-      }
-    }));
+          if (opts.json) {
+            printJson(index, parsed.length, opts.compact);
+          } else if (opts.compact) {
+            printCompact(index);
+          } else {
+            printDefault(index, parsed.length);
+          }
+        },
+      ),
+    );
 }
 
 // ── Formatters ────────────────────────────────────────────────────────────────
@@ -85,30 +98,57 @@ function printJson(index: ExtractedWorkspace, fileCount: number, compact?: boole
 
   const out: Record<string, unknown> = {
     schemas: [...nonMetricSchemas(index).values()].map((s) => {
-      const obj: Record<string, unknown> = { name: displayName(s), fieldCount: totalFieldCount(s, index) };
-      if (!compact) { obj.note = s.note; obj.file = s.file; obj.line = s.row + 1; }
+      const obj: Record<string, unknown> = {
+        name: displayName(s),
+        fieldCount: totalFieldCount(s, index),
+      };
+      if (!compact) {
+        obj.note = s.note;
+        obj.file = s.file;
+        obj.line = s.row + 1;
+      }
       return obj;
     }),
     metrics: [...index.metrics.values()].map((m) => {
       const obj: Record<string, unknown> = { name: displayName(m), fieldCount: m.fields.length };
-      if (!compact) { obj.displayName = m.displayName; obj.grain = m.grain; obj.sources = m.sources; obj.file = m.file; obj.line = m.row + 1; }
+      if (!compact) {
+        obj.displayName = m.displayName;
+        obj.grain = m.grain;
+        obj.sources = m.sources;
+        obj.file = m.file;
+        obj.line = m.row + 1;
+      }
       return obj;
     }),
     mappings: [...index.mappings.entries()].map(([key, m]) => {
       const nlDerived = nlDerivedCounts.get(key) ?? 0;
-      const obj: Record<string, unknown> = { name: displayName(m), arrowCount: m.arrowCount + nlDerived };
+      const obj: Record<string, unknown> = {
+        name: displayName(m),
+        arrowCount: m.arrowCount + nlDerived,
+      };
       if (nlDerived > 0) obj.nlDerivedArrowCount = nlDerived;
-      if (!compact) { obj.sources = m.sources; obj.targets = m.targets; obj.file = m.file; obj.line = m.row + 1; }
+      if (!compact) {
+        obj.sources = m.sources;
+        obj.targets = m.targets;
+        obj.file = m.file;
+        obj.line = m.row + 1;
+      }
       return obj;
     }),
     fragments: [...index.fragments.values()].map((f) => {
       const obj: Record<string, unknown> = { name: displayName(f), fieldCount: f.fields.length };
-      if (!compact) { obj.file = f.file; obj.line = f.row + 1; }
+      if (!compact) {
+        obj.file = f.file;
+        obj.line = f.row + 1;
+      }
       return obj;
     }),
     transforms: [...index.transforms.values()].map((t) => {
       const obj: Record<string, unknown> = { name: displayName(t) };
-      if (!compact) { obj.file = t.file; obj.line = t.row + 1; }
+      if (!compact) {
+        obj.file = t.file;
+        obj.line = t.row + 1;
+      }
       return obj;
     }),
     fileCount,
@@ -200,7 +240,11 @@ function printDefault(index: ExtractedWorkspace, fileCount: number): void {
   }
 
   const notes: string[] = [];
-  if (index.warnings.length > 0) notes.push(`${index.warnings.length} warning comment${index.warnings.length !== 1 ? "s" : ""}`);
-  if (index.questions.length > 0) notes.push(`${index.questions.length} question comment${index.questions.length !== 1 ? "s" : ""}`);
+  if (index.warnings.length > 0)
+    notes.push(`${index.warnings.length} warning comment${index.warnings.length !== 1 ? "s" : ""}`);
+  if (index.questions.length > 0)
+    notes.push(
+      `${index.questions.length} question comment${index.questions.length !== 1 ? "s" : ""}`,
+    );
   if (notes.length > 0) console.log(notes.join("  ·  "));
 }

--- a/tooling/satsuma-cli/src/commands/validate.ts
+++ b/tooling/satsuma-cli/src/commands/validate.ts
@@ -27,7 +27,9 @@ export function register(program: Command): void {
     .option("--json", "structured JSON output")
     .option("--errors-only", "suppress warnings")
     .option("--quiet", "exit code only (0=clean, 2=errors)")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 JSON shape (--json):
   {
     "findings": [{"severity": str, "message": str, "file": str, "line": int, "col": int}, ...],
@@ -40,170 +42,185 @@ Examples:
   satsuma validate pipeline.stm              # validate entry file and its imports
   satsuma validate pipeline.stm --json       # structured diagnostics
   satsuma validate pipeline.stm --quiet      # exit code only
-  satsuma validate pipeline.stm --errors-only  # suppress warnings`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { json?: boolean; errorsOnly?: boolean; quiet?: boolean }) => {
-      const root = pathArg ?? ".";
-      let files: string[];
-      try {
-        files = await resolveInput(root);
-      } catch (err: unknown) {
-        // `validate` predates loadWorkspace and is one of the three
-        // commands that resolve the input directly (see load-workspace.ts
-        // header for why). Its `--json` mode reports the resolve failure
-        // as a one-element diagnostics array on stdout so jq pipelines
-        // still parse; the text mode prints to stderr like every other
-        // resolve failure.
-        const msg = `Error resolving path: ${(err as Error).message}`;
-        if (opts.json) {
-          throw new CommandError(
-            JSON.stringify([{ severity: "error", message: msg }], null, 2),
-            EXIT_PARSE_ERROR,
-            "stdout",
-          );
-        }
-        throw new CommandError(msg, EXIT_PARSE_ERROR);
-      }
-
-      // Parse each file and extract data immediately (tree-sitter reuses a
-      // single parser buffer, so prior trees become invalid after a new parse).
-      const extracted = [];
-      const parseErrors: LintDiagnostic[] = [];
-      for (const f of files) {
-        const parsed = parseFile(f);
-        // Collect parse errors and extract data while tree is still valid.
-        // Map core's 0-indexed ParseErrorEntry to CLI's 1-indexed LintDiagnostic.
-        for (const e of collectParseErrors(parsed.tree)) {
-          parseErrors.push({
-            file: parsed.filePath,
-            line: e.startRow + 1,
-            column: e.startColumn + 1,
-            severity: "error",
-            rule: e.isMissing ? "missing-node" : "parse-error",
-            message: e.message,
-            fixable: false,
-          });
-        }
-
-        // Check for missing import files and undefined import names
-        const imports = extractImports(parsed.tree.rootNode);
-        for (const imp of imports) {
-          if (!imp.path) continue;
-          const resolved = resolve(dirname(parsed.filePath), imp.path);
+  satsuma validate pipeline.stm --errors-only  # suppress warnings`,
+    )
+    .action(
+      runCommand(
+        async (
+          pathArg: string | undefined,
+          opts: { json?: boolean; errorsOnly?: boolean; quiet?: boolean },
+        ) => {
+          const root = pathArg ?? ".";
+          let files: string[];
           try {
-            statSync(resolved);
-            // File exists — check that each imported name is defined in the target
-            const targetParsed = parseFile(resolved);
-            const targetData = extractFileData(targetParsed);
-            const targetNames = new Set<string>();
-            const allEntities = [...targetData.mappings, ...targetData.schemas, ...targetData.fragments, ...targetData.transforms];
-            for (const entity of allEntities) {
-              if (entity.name) {
-                targetNames.add(entity.name);
-                if (entity.namespace) targetNames.add(`${entity.namespace}::${entity.name}`);
-              }
+            files = await resolveInput(root);
+          } catch (err: unknown) {
+            // `validate` predates loadWorkspace and is one of the three
+            // commands that resolve the input directly (see load-workspace.ts
+            // header for why). Its `--json` mode reports the resolve failure
+            // as a one-element diagnostics array on stdout so jq pipelines
+            // still parse; the text mode prints to stderr like every other
+            // resolve failure.
+            const msg = `Error resolving path: ${(err as Error).message}`;
+            if (opts.json) {
+              throw new CommandError(
+                JSON.stringify([{ severity: "error", message: msg }], null, 2),
+                EXIT_PARSE_ERROR,
+                "stdout",
+              );
             }
-            for (const name of imp.names) {
-              if (!targetNames.has(name)) {
+            throw new CommandError(msg, EXIT_PARSE_ERROR);
+          }
+
+          // Parse each file and extract data immediately (tree-sitter reuses a
+          // single parser buffer, so prior trees become invalid after a new parse).
+          const extracted = [];
+          const parseErrors: LintDiagnostic[] = [];
+          for (const f of files) {
+            const parsed = parseFile(f);
+            // Collect parse errors and extract data while tree is still valid.
+            // Map core's 0-indexed ParseErrorEntry to CLI's 1-indexed LintDiagnostic.
+            for (const e of collectParseErrors(parsed.tree)) {
+              parseErrors.push({
+                file: parsed.filePath,
+                line: e.startRow + 1,
+                column: e.startColumn + 1,
+                severity: "error",
+                rule: e.isMissing ? "missing-node" : "parse-error",
+                message: e.message,
+                fixable: false,
+              });
+            }
+
+            // Check for missing import files and undefined import names
+            const imports = extractImports(parsed.tree.rootNode);
+            for (const imp of imports) {
+              if (!imp.path) continue;
+              const resolved = resolve(dirname(parsed.filePath), imp.path);
+              try {
+                statSync(resolved);
+                // File exists — check that each imported name is defined in the target
+                const targetParsed = parseFile(resolved);
+                const targetData = extractFileData(targetParsed);
+                const targetNames = new Set<string>();
+                const allEntities = [
+                  ...targetData.mappings,
+                  ...targetData.schemas,
+                  ...targetData.fragments,
+                  ...targetData.transforms,
+                ];
+                for (const entity of allEntities) {
+                  if (entity.name) {
+                    targetNames.add(entity.name);
+                    if (entity.namespace) targetNames.add(`${entity.namespace}::${entity.name}`);
+                  }
+                }
+                for (const name of imp.names) {
+                  if (!targetNames.has(name)) {
+                    parseErrors.push({
+                      file: parsed.filePath,
+                      line: imp.row + 1,
+                      column: 1,
+                      severity: "warning",
+                      rule: "undefined-import",
+                      message: `Import name '${name}' not found in "${imp.path}"`,
+                      fixable: false,
+                    });
+                  }
+                }
+              } catch {
                 parseErrors.push({
                   file: parsed.filePath,
                   line: imp.row + 1,
                   column: 1,
                   severity: "warning",
-                  rule: "undefined-import",
-                  message: `Import name '${name}' not found in "${imp.path}"`,
+                  rule: "missing-import",
+                  message: `Import target "${imp.path}" not found`,
                   fixable: false,
                 });
               }
             }
-          } catch {
-            parseErrors.push({
-              file: parsed.filePath,
-              line: imp.row + 1,
-              column: 1,
-              severity: "warning",
-              rule: "missing-import",
-              message: `Import target "${imp.path}" not found`,
-              fixable: false,
-            });
+
+            extracted.push(extractFileData(parsed));
           }
-        }
 
-        extracted.push(extractFileData(parsed));
-      }
+          const index = buildIndex(extracted);
 
-      const index = buildIndex(extracted);
+          // Collect diagnostics
+          const diagnostics: LintDiagnostic[] = [...parseErrors];
 
-      // Collect diagnostics
-      const diagnostics: LintDiagnostic[] = [...parseErrors];
+          // Semantic diagnostics (errors always included, warnings only when not --errors-only)
+          const semantics = collectSemanticWarnings(index);
+          if (opts.errorsOnly) {
+            diagnostics.push(...semantics.filter((d) => d.severity === "error"));
+          } else {
+            diagnostics.push(...semantics);
+          }
 
-      // Semantic diagnostics (errors always included, warnings only when not --errors-only)
-      const semantics = collectSemanticWarnings(index);
-      if (opts.errorsOnly) {
-        diagnostics.push(...semantics.filter((d) => d.severity === "error"));
-      } else {
-        diagnostics.push(...semantics);
-      }
+          // Sort by file, then line
+          diagnostics.sort(
+            (a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.column - b.column,
+          );
 
-      // Sort by file, then line
-      diagnostics.sort((a, b) =>
-        a.file.localeCompare(b.file) || a.line - b.line || a.column - b.column,
-      );
+          const errorCount = diagnostics.filter((d) => d.severity === "error").length;
+          const warnCount = diagnostics.filter((d) => d.severity === "warning").length;
 
-      const errorCount = diagnostics.filter(
-        (d) => d.severity === "error",
-      ).length;
-      const warnCount = diagnostics.filter(
-        (d) => d.severity === "warning",
-      ).length;
+          // Soft exit code: validate uses 2 for "any error-severity finding"
+          // and 0 otherwise. Warnings never push the exit non-zero — that's
+          // documented in the command help.
+          const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
 
-      // Soft exit code: validate uses 2 for "any error-severity finding"
-      // and 0 otherwise. Warnings never push the exit non-zero — that's
-      // documented in the command help.
-      const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
+          if (opts.quiet) {
+            return exitCode;
+          }
 
-      if (opts.quiet) {
-        return exitCode;
-      }
+          if (opts.json) {
+            console.log(
+              JSON.stringify(
+                {
+                  findings: diagnostics,
+                  summary: {
+                    files: extracted.length,
+                    errors: errorCount,
+                    warnings: warnCount,
+                  },
+                },
+                null,
+                2,
+              ),
+            );
+            return exitCode;
+          }
 
-      if (opts.json) {
-        console.log(JSON.stringify({
-          findings: diagnostics,
-          summary: {
-            files: extracted.length,
-            errors: errorCount,
-            warnings: warnCount,
-          },
-        }, null, 2));
-        return exitCode;
-      }
+          if (diagnostics.length === 0) {
+            console.log(
+              `Validated ${extracted.length} file${extracted.length !== 1 ? "s" : ""}: no issues found.`,
+            );
+            return;
+          }
 
-      if (diagnostics.length === 0) {
-        console.log(
-          `Validated ${extracted.length} file${extracted.length !== 1 ? "s" : ""}: no issues found.`,
-        );
-        return;
-      }
+          // Group by file
+          const byFile = new Map<string, LintDiagnostic[]>();
+          for (const d of diagnostics) {
+            if (!byFile.has(d.file)) byFile.set(d.file, []);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
+            byFile.get(d.file)!.push(d);
+          }
 
-      // Group by file
-      const byFile = new Map<string, LintDiagnostic[]>();
-      for (const d of diagnostics) {
-        if (!byFile.has(d.file)) byFile.set(d.file, []);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
-        byFile.get(d.file)!.push(d);
-      }
+          for (const [file, fileDiags] of byFile) {
+            for (const d of fileDiags) {
+              const sev = d.severity === "error" ? "error" : "warning";
+              console.log(`${file}:${d.line}:${d.column} ${sev} [${d.rule}] ${d.message}`);
+            }
+          }
 
-      for (const [file, fileDiags] of byFile) {
-        for (const d of fileDiags) {
-          const sev = d.severity === "error" ? "error" : "warning";
-          console.log(`${file}:${d.line}:${d.column} ${sev} [${d.rule}] ${d.message}`);
-        }
-      }
+          console.log();
+          console.log(
+            `${errorCount} error${errorCount !== 1 ? "s" : ""}, ${warnCount} warning${warnCount !== 1 ? "s" : ""} in ${extracted.length} file${extracted.length !== 1 ? "s" : ""}`,
+          );
 
-      console.log();
-      console.log(
-        `${errorCount} error${errorCount !== 1 ? "s" : ""}, ${warnCount} warning${warnCount !== 1 ? "s" : ""} in ${extracted.length} file${extracted.length !== 1 ? "s" : ""}`,
-      );
-
-      return exitCode;
-    }));
+          return exitCode;
+        },
+      ),
+    );
 }

--- a/tooling/satsuma-cli/src/commands/warnings.ts
+++ b/tooling/satsuma-cli/src/commands/warnings.ts
@@ -23,7 +23,9 @@ export function register(program: Command): void {
     .description("List warning or question comments in a Satsuma file and its imports")
     .option("--questions", "show question comments (//?  ...) instead")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 JSON shape (--json):
   {
     "kind":  "warning" | "question",
@@ -34,51 +36,65 @@ JSON shape (--json):
 Examples:
   satsuma warnings pipeline.stm              # //! warnings in file and imports
   satsuma warnings pipeline.stm --questions  # //? questions instead
-  satsuma warnings pipeline.stm --json       # structured output`)
-    .action(runCommand(async (pathArg: string | undefined, opts: { questions?: boolean; json?: boolean }) => {
-      const { index } = await loadWorkspace(pathArg);
+  satsuma warnings pipeline.stm --json       # structured output`,
+    )
+    .action(
+      runCommand(
+        async (pathArg: string | undefined, opts: { questions?: boolean; json?: boolean }) => {
+          const { index } = await loadWorkspace(pathArg);
 
-      // By default show both //! and //? comments; --questions shows only //?
-      type TaggedItem = (WarningRecord | QuestionRecord) & { _kind: "warning" | "question" };
-      const taggedWarnings: TaggedItem[] = index.warnings.map((w) => ({ ...w, _kind: "warning" as const }));
-      const taggedQuestions: TaggedItem[] = index.questions.map((q) => ({ ...q, _kind: "question" as const }));
-      const items: TaggedItem[] = opts.questions
-        ? taggedQuestions
-        : [...taggedWarnings, ...taggedQuestions].sort((a, b) =>
-            a.file.localeCompare(b.file) || a.row - b.row);
-      const kind = opts.questions ? "question" : "warning";
+          // By default show both //! and //? comments; --questions shows only //?
+          type TaggedItem = (WarningRecord | QuestionRecord) & { _kind: "warning" | "question" };
+          const taggedWarnings: TaggedItem[] = index.warnings.map((w) => ({
+            ...w,
+            _kind: "warning" as const,
+          }));
+          const taggedQuestions: TaggedItem[] = index.questions.map((q) => ({
+            ...q,
+            _kind: "question" as const,
+          }));
+          const items: TaggedItem[] = opts.questions
+            ? taggedQuestions
+            : [...taggedWarnings, ...taggedQuestions].sort(
+                (a, b) => a.file.localeCompare(b.file) || a.row - b.row,
+              );
+          const kind = opts.questions ? "question" : "warning";
 
-      if (opts.json) {
-        const jsonItems = items.map((item) => ({
-          text: item.text,
-          line: item.row + 1,
-          file: item.file,
-          ...(item.parent ? { block: item.parent, blockType: item.parentType } : {}),
-        }));
-        console.log(JSON.stringify({ kind, count: jsonItems.length, items: jsonItems }, null, 2));
-        return items.length === 0 ? EXIT_NOT_FOUND : undefined;
-      }
+          if (opts.json) {
+            const jsonItems = items.map((item) => ({
+              text: item.text,
+              line: item.row + 1,
+              file: item.file,
+              ...(item.parent ? { block: item.parent, blockType: item.parentType } : {}),
+            }));
+            console.log(
+              JSON.stringify({ kind, count: jsonItems.length, items: jsonItems }, null, 2),
+            );
+            return items.length === 0 ? EXIT_NOT_FOUND : undefined;
+          }
 
-      if (items.length === 0) {
-        console.log(`No ${kind} comments found.`);
-        return EXIT_NOT_FOUND;
-      }
+          if (items.length === 0) {
+            console.log(`No ${kind} comments found.`);
+            return EXIT_NOT_FOUND;
+          }
 
-      // Group by file
-      const byFile = new Map<string, Array<WarningRecord | QuestionRecord>>();
-      for (const item of items) {
-        if (!byFile.has(item.file)) byFile.set(item.file, []);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
-        byFile.get(item.file)!.push(item);
-      }
+          // Group by file
+          const byFile = new Map<string, Array<WarningRecord | QuestionRecord>>();
+          for (const item of items) {
+            if (!byFile.has(item.file)) byFile.set(item.file, []);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: key initialized on previous line
+            byFile.get(item.file)!.push(item);
+          }
 
-      for (const [file, fileItems] of byFile) {
-        console.log(file);
-        for (const item of fileItems) {
-          const prefix = (item as TaggedItem)._kind === "question" ? "//?" : "//!";
-          console.log(`  :${item.row + 1}  ${prefix} ${item.text}`);
-        }
-        console.log();
-      }
-    }));
+          for (const [file, fileItems] of byFile) {
+            console.log(file);
+            for (const item of fileItems) {
+              const prefix = (item as TaggedItem)._kind === "question" ? "//?" : "//!";
+              console.log(`  :${item.row + 1}  ${prefix} ${item.text}`);
+            }
+            console.log();
+          }
+        },
+      ),
+    );
 }

--- a/tooling/satsuma-cli/src/commands/where-used.ts
+++ b/tooling/satsuma-cli/src/commands/where-used.ts
@@ -39,7 +39,9 @@ export function register(program: Command): void {
     .command("where-used <name> [path]")
     .description("Find all references to a schema, fragment, or transform")
     .option("--json", "output JSON")
-    .addHelpText("after", `
+    .addHelpText(
+      "after",
+      `
 Searches mappings (source/target refs), metrics (source refs), schemas
 (fragment spreads, ref metadata), and NL @ref references.
 
@@ -52,63 +54,81 @@ JSON shape (--json):
 Examples:
   satsuma where-used hub_customer                    # who references this schema?
   satsuma where-used audit_fields                    # where is this fragment spread?
-  satsuma where-used trim_and_lower --json           # transform refs as JSON`)
-    .action(runCommand(async (name: string, pathArg: string | undefined, opts: { json?: boolean }) => {
-      const { files: parsedFiles, index } = await loadWorkspace(pathArg);
+  satsuma where-used trim_and_lower --json           # transform refs as JSON`,
+    )
+    .action(
+      runCommand(async (name: string, pathArg: string | undefined, opts: { json?: boolean }) => {
+        const { files: parsedFiles, index } = await loadWorkspace(pathArg);
 
-      // Determine entity type — resolve namespace-qualified lookups
-      const schemaResolved = resolveIndexKey(name, index.schemas);
-      const fragmentResolved = resolveIndexKey(name, index.fragments);
-      const transformResolved = resolveIndexKey(name, index.transforms);
-      const isSchema = schemaResolved != null;
-      const isFragment = fragmentResolved != null;
-      const isTransform = transformResolved != null;
-      const resolvedName = schemaResolved?.key ?? fragmentResolved?.key ?? transformResolved?.key ?? name;
+        // Determine entity type — resolve namespace-qualified lookups
+        const schemaResolved = resolveIndexKey(name, index.schemas);
+        const fragmentResolved = resolveIndexKey(name, index.fragments);
+        const transformResolved = resolveIndexKey(name, index.transforms);
+        const isSchema = schemaResolved != null;
+        const isFragment = fragmentResolved != null;
+        const isTransform = transformResolved != null;
+        const resolvedName =
+          schemaResolved?.key ?? fragmentResolved?.key ?? transformResolved?.key ?? name;
 
-      if (!isSchema && !isFragment && !isTransform) {
-        const errorMsg = `'${name}' not found as a schema, fragment, or transform.`;
-        const allNames = [
-          ...index.schemas.keys(),
-          ...index.fragments.keys(),
-          ...index.transforms.keys(),
-        ];
-        const close = allNames.find((k) => k.toLowerCase() === name.toLowerCase());
-        if (opts.json) {
-          // JSON consumers parse stdout, so the error must land there too —
-          // see schema.ts for the same pattern.
-          const errorObj: Record<string, unknown> = { error: errorMsg };
-          if (close) errorObj.suggestion = close;
-          throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
+        if (!isSchema && !isFragment && !isTransform) {
+          const errorMsg = `'${name}' not found as a schema, fragment, or transform.`;
+          const allNames = [
+            ...index.schemas.keys(),
+            ...index.fragments.keys(),
+            ...index.transforms.keys(),
+          ];
+          const close = allNames.find((k) => k.toLowerCase() === name.toLowerCase());
+          if (opts.json) {
+            // JSON consumers parse stdout, so the error must land there too —
+            // see schema.ts for the same pattern.
+            const errorObj: Record<string, unknown> = { error: errorMsg };
+            if (close) errorObj.suggestion = close;
+            throw new CommandError(JSON.stringify(errorObj, null, 2), EXIT_NOT_FOUND, "stdout");
+          }
+          const lines = [errorMsg];
+          if (close) lines.push(`Did you mean '${close}'?`);
+          throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
         }
-        const lines = [errorMsg];
-        if (close) lines.push(`Did you mean '${close}'?`);
-        throw new CommandError(lines.join("\n"), EXIT_NOT_FOUND);
-      }
 
-      const refs = gatherRefs(resolvedName, index, parsedFiles, isSchema, isFragment, isTransform);
+        const refs = gatherRefs(
+          resolvedName,
+          index,
+          parsedFiles,
+          isSchema,
+          isFragment,
+          isTransform,
+        );
 
-      if (opts.json) {
-        // Use resolvedName (the canonical index key) rather than the raw user
-        // query so that bare-name lookups produce the qualified form, e.g.
-        // "crm::customers" not "::customers" (sl-b0mq).
-        console.log(JSON.stringify({ name: canonicalKey(resolvedName), refs }, null, 2));
-        return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
-      }
+        if (opts.json) {
+          // Use resolvedName (the canonical index key) rather than the raw user
+          // query so that bare-name lookups produce the qualified form, e.g.
+          // "crm::customers" not "::customers" (sl-b0mq).
+          console.log(JSON.stringify({ name: canonicalKey(resolvedName), refs }, null, 2));
+          return refs.length === 0 ? EXIT_NOT_FOUND : undefined;
+        }
 
-      if (refs.length === 0) {
-        // Use resolvedName in text output too so the header always shows the
-        // canonical qualified name regardless of how the user queried (sl-wfgx).
-        console.log(`No references to '${resolvedName}' found.`);
-        return EXIT_NOT_FOUND;
-      }
+        if (refs.length === 0) {
+          // Use resolvedName in text output too so the header always shows the
+          // canonical qualified name regardless of how the user queried (sl-wfgx).
+          console.log(`No references to '${resolvedName}' found.`);
+          return EXIT_NOT_FOUND;
+        }
 
-      printDefault(resolvedName, refs);
-    }));
+        printDefault(resolvedName, refs);
+      }),
+    );
 }
 
 // ── Reference gathering ───────────────────────────────────────────────────────
 
-function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: ParsedFile[], isSchema: boolean, isFragment: boolean, isTransform: boolean): Ref[] {
+function gatherRefs(
+  name: string,
+  index: ExtractedWorkspace,
+  parsedFiles: ParsedFile[],
+  isSchema: boolean,
+  isFragment: boolean,
+  isTransform: boolean,
+): Ref[] {
   const refs: Ref[] = [];
 
   if (isSchema) {
@@ -123,7 +143,12 @@ function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: Parsed
     for (const [metricName, sources] of index.referenceGraph.metricsReferences) {
       if (sources.includes(name)) {
         const m = index.metrics.get(metricName);
-        refs.push({ kind: "metric", name: metricName, file: m?.file ?? "?", line: (m?.row ?? 0) + 1 });
+        refs.push({
+          kind: "metric",
+          name: metricName,
+          file: m?.file ?? "?",
+          line: (m?.row ?? 0) + 1,
+        });
       }
     }
   }
@@ -157,7 +182,12 @@ function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: Parsed
           if (m.kind === "kv" && m.key === "ref") {
             const refTarget = m.value.replace(/^@/, "").split(".")[0];
             if (refTarget === name || refTarget === name.split("::").pop()) {
-              refs.push({ kind: "ref_metadata", name: `${schemaName}.${field.name}`, file: schema.file, line: schema.row + 1 });
+              refs.push({
+                kind: "ref_metadata",
+                name: `${schemaName}.${field.name}`,
+                file: schema.file,
+                line: schema.row + 1,
+              });
             }
           }
         }
@@ -200,9 +230,17 @@ function gatherRefs(name: string, index: ExtractedWorkspace, parsedFiles: Parsed
  * Check whether a resolved ref name matches an entity query.
  * Handles exact match and field-prefixed match in both internal and canonical forms.
  */
-function matchesEntityOrField(resolvedName: string, internalName: string, canonicalName: string): boolean {
-  return resolvedName === internalName || resolvedName === canonicalName ||
-    resolvedName.startsWith(internalName + ".") || resolvedName.startsWith(canonicalName + ".");
+function matchesEntityOrField(
+  resolvedName: string,
+  internalName: string,
+  canonicalName: string,
+): boolean {
+  return (
+    resolvedName === internalName ||
+    resolvedName === canonicalName ||
+    resolvedName.startsWith(internalName + ".") ||
+    resolvedName.startsWith(canonicalName + ".")
+  );
 }
 
 /**
@@ -260,7 +298,9 @@ function walkForSpreads(
   for (const c of bodyNode.namedChildren) {
     if (c.type === "fragment_spread") {
       // fragment_spread children use spread_label, not block_label
-      const lbl = c.namedChildren.find((x) => x.type === "spread_label" || x.type === "block_label");
+      const lbl = c.namedChildren.find(
+        (x) => x.type === "spread_label" || x.type === "block_label",
+      );
       let sname = "";
       if (lbl) {
         const q = lbl.namedChildren.find((x) => x.type === "backtick_name");
@@ -268,7 +308,12 @@ function walkForSpreads(
           sname = q.text.slice(1, -1);
         } else {
           sname = lbl.namedChildren
-            .filter((x) => x.type === "identifier" || x.type === "continuation_word" || x.type === "qualified_name")
+            .filter(
+              (x) =>
+                x.type === "identifier" ||
+                x.type === "continuation_word" ||
+                x.type === "qualified_name",
+            )
             .map((x) => x.text)
             .join(" ");
         }
@@ -388,7 +433,8 @@ function findImportRefs(rootNode: SyntaxNode, name: string): Array<{ path: strin
     }
     if (importedNames.some((n) => n === name)) {
       const pathNode = c.namedChildren.find((x) => x.type === "import_path");
-      const pathStr = pathNode?.namedChildren[0]?.text?.slice(1, -1) ?? pathNode?.text?.slice(1, -1) ?? "";
+      const pathStr =
+        pathNode?.namedChildren[0]?.text?.slice(1, -1) ?? pathNode?.text?.slice(1, -1) ?? "";
       results.push({ path: pathStr, row: c.startPosition.row });
     }
   }

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -101,7 +101,9 @@ function expandedFields(schema: SchemaRecord, index: ExtractedWorkspace) {
 
 /** Recursive copy so in-place spread expansion cannot touch the shared index. */
 function deepCopyFields<T extends { children?: T[] }>(fields: T[]): T[] {
-  return fields.map((f) => (f.children ? { ...f, children: deepCopyFields(f.children) } : { ...f }));
+  return fields.map((f) =>
+    f.children ? { ...f, children: deepCopyFields(f.children) } : { ...f },
+  );
 }
 
 /**

--- a/tooling/satsuma-cli/src/cst-query.ts
+++ b/tooling/satsuma-cli/src/cst-query.ts
@@ -19,7 +19,11 @@ function splitQualifiedName(name: string): QualifiedName {
   };
 }
 
-export function findBlockNode(rootNode: SyntaxNode, nodeType: string, qualifiedName: string): SyntaxNode | null {
+export function findBlockNode(
+  rootNode: SyntaxNode,
+  nodeType: string,
+  qualifiedName: string,
+): SyntaxNode | null {
   // Handle anonymous blocks keyed by <anon>@file:row
   const anonMatch = qualifiedName.match(/^<anon>@.*:(\d+)$/);
   if (anonMatch) {
@@ -47,7 +51,11 @@ export function findBlockNode(rootNode: SyntaxNode, nodeType: string, qualifiedN
   return null;
 }
 
-function findBlockByRow(rootNode: SyntaxNode, nodeType: string, targetRow: number): SyntaxNode | null {
+function findBlockByRow(
+  rootNode: SyntaxNode,
+  nodeType: string,
+  targetRow: number,
+): SyntaxNode | null {
   for (const c of rootNode.namedChildren) {
     if (c.type === nodeType && c.startPosition.row === targetRow) return c;
     if (c.type === "namespace_block") {
@@ -59,7 +67,11 @@ function findBlockByRow(rootNode: SyntaxNode, nodeType: string, targetRow: numbe
   return null;
 }
 
-function findBlockNodeInContainer(containerNode: SyntaxNode, nodeType: string, localName: string): SyntaxNode | null {
+function findBlockNodeInContainer(
+  containerNode: SyntaxNode,
+  nodeType: string,
+  localName: string,
+): SyntaxNode | null {
   for (const c of containerNode.namedChildren) {
     if (c.type === nodeType && labelText(c) === localName) return c;
   }

--- a/tooling/satsuma-cli/src/diff-engine.ts
+++ b/tooling/satsuma-cli/src/diff-engine.ts
@@ -135,7 +135,9 @@ function normalizeAnonMappingKeys(index: ExtractedWorkspace): ExtractedWorkspace
       [...index.fieldArrows].map(([field, records]) => [
         field,
         records.map((r) =>
-          r.mapping && rename.has(r.mapping) ? { ...r, mapping: rename.get(r.mapping) ?? r.mapping } : r,
+          r.mapping && rename.has(r.mapping)
+            ? { ...r, mapping: rename.get(r.mapping) ?? r.mapping }
+            : r,
         ),
       ]),
     ),
@@ -210,12 +212,22 @@ function diffBlockMap<T, C>(
  * even small wording changes are typically meaningful for documentation
  * intent and should be surfaced to the reviewer.
  */
-function diffSchema(a: SchemaRecord, b: SchemaRecord, notesA: Set<string>, notesB: Set<string>): SchemaChange[] {
+function diffSchema(
+  a: SchemaRecord,
+  b: SchemaRecord,
+  notesA: Set<string>,
+  notesB: Set<string>,
+): SchemaChange[] {
   const changes: SchemaChange[] = [];
 
   // Compare schema-level note text (note "..." in metadata block)
   if ((a.note ?? "") !== (b.note ?? "")) {
-    changes.push({ kind: "note-changed", field: "(note)", from: a.note || "(none)", to: b.note || "(none)" });
+    changes.push({
+      kind: "note-changed",
+      field: "(note)",
+      from: a.note || "(none)",
+      to: b.note || "(none)",
+    });
   }
 
   // Compare fields
@@ -246,22 +258,42 @@ function diffSchema(a: SchemaRecord, b: SchemaRecord, notesA: Set<string>, notes
  * is reported as a change because it can affect serialization order in
  * downstream consumers.
  */
-function diffMetric(a: MetricRecord, b: MetricRecord, notesA: Set<string>, notesB: Set<string>): SchemaChange[] {
+function diffMetric(
+  a: MetricRecord,
+  b: MetricRecord,
+  notesA: Set<string>,
+  notesB: Set<string>,
+): SchemaChange[] {
   const changes: SchemaChange[] = [];
 
   // Compare metric header attributes (sl-1meq)
   const aSources = JSON.stringify(a.sources);
   const bSources = JSON.stringify(b.sources);
   if (aSources !== bSources) {
-    changes.push({ kind: "source-changed", field: "(source)", from: a.sources.join(", ") || "(none)", to: b.sources.join(", ") || "(none)" });
+    changes.push({
+      kind: "source-changed",
+      field: "(source)",
+      from: a.sources.join(", ") || "(none)",
+      to: b.sources.join(", ") || "(none)",
+    });
   }
   if ((a.grain ?? "") !== (b.grain ?? "")) {
-    changes.push({ kind: "grain-changed", field: "(grain)", from: a.grain || "(none)", to: b.grain || "(none)" });
+    changes.push({
+      kind: "grain-changed",
+      field: "(grain)",
+      from: a.grain || "(none)",
+      to: b.grain || "(none)",
+    });
   }
   const aSlices = JSON.stringify(a.slices);
   const bSlices = JSON.stringify(b.slices);
   if (aSlices !== bSlices) {
-    changes.push({ kind: "slices-changed", field: "(slices)", from: a.slices.join(", ") || "(none)", to: b.slices.join(", ") || "(none)" });
+    changes.push({
+      kind: "slices-changed",
+      field: "(slices)",
+      from: a.slices.join(", ") || "(none)",
+      to: b.slices.join(", ") || "(none)",
+    });
   }
 
   // Compare fields
@@ -349,7 +381,12 @@ function diffFieldList(aFields: FieldDecl[], bFields: FieldDecl[], prefix = ""):
       const aMeta = serializeMetadata(field.metadata);
       const bMeta = serializeMetadata(bField.metadata);
       if (aMeta !== bMeta) {
-        changes.push({ kind: "metadata-changed", field: qualName, from: aMeta || "(none)", to: bMeta || "(none)" });
+        changes.push({
+          kind: "metadata-changed",
+          field: qualName,
+          from: aMeta || "(none)",
+          to: bMeta || "(none)",
+        });
       }
       // Recurse into nested children
       if (field.children || bField.children) {
@@ -388,7 +425,14 @@ function diffFieldList(aFields: FieldDecl[], bFields: FieldDecl[], prefix = ""):
  *
  *  3. Note changes — by string equality, same as schemas (sl-van1).
  */
-function diffMapping(a: MappingRecord, b: MappingRecord, arrowsA: ArrowRecord[], arrowsB: ArrowRecord[], notesA: Set<string>, notesB: Set<string>): MappingChange[] {
+function diffMapping(
+  a: MappingRecord,
+  b: MappingRecord,
+  arrowsA: ArrowRecord[],
+  arrowsB: ArrowRecord[],
+  notesA: Set<string>,
+  notesB: Set<string>,
+): MappingChange[] {
   const changes: MappingChange[] = [];
 
   if (a.arrowCount !== b.arrowCount) {
@@ -473,17 +517,19 @@ function diffNoteSet(notesA: Set<string>, notesB: Set<string>): SchemaChange[] {
 
   for (const text of notesB) {
     if (!notesA.has(text)) {
-      const preview = text.length > NOTE_PREVIEW_MAX_LENGTH
-        ? text.slice(0, NOTE_PREVIEW_MAX_LENGTH) + "..."
-        : text;
+      const preview =
+        text.length > NOTE_PREVIEW_MAX_LENGTH
+          ? text.slice(0, NOTE_PREVIEW_MAX_LENGTH) + "..."
+          : text;
       changes.push({ kind: "note-added", field: "(note)", from: preview });
     }
   }
   for (const text of notesA) {
     if (!notesB.has(text)) {
-      const preview = text.length > NOTE_PREVIEW_MAX_LENGTH
-        ? text.slice(0, NOTE_PREVIEW_MAX_LENGTH) + "..."
-        : text;
+      const preview =
+        text.length > NOTE_PREVIEW_MAX_LENGTH
+          ? text.slice(0, NOTE_PREVIEW_MAX_LENGTH) + "..."
+          : text;
       changes.push({ kind: "note-removed", field: "(note)", from: preview });
     }
   }
@@ -515,12 +561,14 @@ function diffNotes(notesA: NoteRecord[], notesB: NoteRecord[]): NoteDelta {
 
 function serializeMetadata(metadata: FieldDecl["metadata"]): string {
   if (!metadata || metadata.length === 0) return "";
-  return metadata.map((m) => {
-    if (m.kind === "tag") return m.tag;
-    if (m.kind === "kv") return `${m.key} ${m.value}`;
-    if (m.kind === "enum") return `enum {${m.values.join(", ")}}`;
-    if (m.kind === "note") return `note "${m.text}"`;
-    if (m.kind === "slice") return `slice {${m.values.join(", ")}}`;
-    return JSON.stringify(m);
-  }).join(", ");
+  return metadata
+    .map((m) => {
+      if (m.kind === "tag") return m.tag;
+      if (m.kind === "kv") return `${m.key} ${m.value}`;
+      if (m.kind === "enum") return `enum {${m.values.join(", ")}}`;
+      if (m.kind === "note") return `note "${m.text}"`;
+      if (m.kind === "slice") return `slice {${m.values.join(", ")}}`;
+      return JSON.stringify(m);
+    })
+    .join(", ");
 }

--- a/tooling/satsuma-cli/src/errors.ts
+++ b/tooling/satsuma-cli/src/errors.ts
@@ -84,9 +84,7 @@ export function findSuggestion(name: string, available: string[]): string | null
   if (exact) return exact;
 
   // Prefix match
-  const prefix = available.find((k) =>
-    k.toLowerCase().startsWith(name.toLowerCase().slice(0, 3)),
-  );
+  const prefix = available.find((k) => k.toLowerCase().startsWith(name.toLowerCase().slice(0, 3)));
   return prefix ?? null;
 }
 

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -212,9 +212,18 @@ export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWor
   let totalErrors = 0;
 
   // Track all named definitions per namespace for cross-kind duplicate detection.
-  const namesByNamespace = new Map<string, Map<string, { kind: string; file: string; row: number }>>();
+  const namesByNamespace = new Map<
+    string,
+    Map<string, { kind: string; file: string; row: number }>
+  >();
 
-  function checkDuplicate(kind: string, name: string | null, namespace: string | null | undefined, file: string, row: number): void {
+  function checkDuplicate(
+    kind: string,
+    name: string | null,
+    namespace: string | null | undefined,
+    file: string,
+    row: number,
+  ): void {
     if (!name) return;
     const nsKey = namespace ?? "__global__";
     if (!namesByNamespace.has(nsKey)) namesByNamespace.set(nsKey, new Map());
@@ -237,12 +246,13 @@ export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWor
   }
 
   // Track namespace block metadata for merge conflict detection.
-  const namespaceMeta = new Map<string, Map<string, { value: string; file: string; row: number }>>();
+  const namespaceMeta = new Map<
+    string,
+    Map<string, { value: string; file: string; row: number }>
+  >();
 
   // Accept either pre-extracted data or raw parsedFile objects.
-  const fileDataList = parsedFiles.map((pf) =>
-    "schemas" in pf ? pf : extractFileData(pf),
-  );
+  const fileDataList = parsedFiles.map((pf) => ("schemas" in pf ? pf : extractFileData(pf)));
 
   for (const fileData of fileDataList) {
     const { filePath } = fileData;
@@ -398,17 +408,17 @@ export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWor
   const allDefinitions = new Map([...schemas, ...fragments]);
   for (const mapping of mappings.values()) {
     const currentNs = mapping.namespace ?? null;
-    mapping.sources = mapping.sources.map((ref) =>
-      resolveScopedEntityRef(ref, currentNs, allDefinitions) ?? ref,
+    mapping.sources = mapping.sources.map(
+      (ref) => resolveScopedEntityRef(ref, currentNs, allDefinitions) ?? ref,
     );
-    mapping.targets = mapping.targets.map((ref) =>
-      resolveScopedEntityRef(ref, currentNs, allDefinitions) ?? ref,
+    mapping.targets = mapping.targets.map(
+      (ref) => resolveScopedEntityRef(ref, currentNs, allDefinitions) ?? ref,
     );
   }
   for (const metric of metrics.values()) {
     const currentNs = metric.namespace ?? null;
-    metric.sources = metric.sources.map((ref) =>
-      resolveScopedEntityRef(ref, currentNs, schemas) ?? ref,
+    metric.sources = metric.sources.map(
+      (ref) => resolveScopedEntityRef(ref, currentNs, schemas) ?? ref,
     );
   }
 
@@ -453,7 +463,10 @@ export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWor
 /**
  * Resolve a user-provided entity name against an index map.
  */
-export function resolveIndexKey<T>(name: string, entityMap: Map<string, T>): { key: string; entry: T } | null {
+export function resolveIndexKey<T>(
+  name: string,
+  entityMap: Map<string, T>,
+): { key: string; entry: T } | null {
   if (entityMap.has(name)) {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Safe: .has() check on line above
     return { key: name, entry: entityMap.get(name)! };
@@ -487,7 +500,10 @@ export function resolveIndexKey<T>(name: string, entityMap: Map<string, T>): { k
  * (which use bare paths), and hover/go-to-definition (which may use either)
  * to all share the same index without each needing their own traversal.
  */
-function buildFieldArrows(arrowRecords: ArrowRecord[], mappings: Map<string, MappingRecord>): Map<string, ArrowRecord[]> {
+function buildFieldArrows(
+  arrowRecords: ArrowRecord[],
+  mappings: Map<string, MappingRecord>,
+): Map<string, ArrowRecord[]> {
   const index = new Map<string, ArrowRecord[]>();
 
   function addToIndex(key: string | null, record: ArrowRecord): void {
@@ -558,7 +574,9 @@ function buildFieldArrows(arrowRecords: ArrowRecord[], mappings: Map<string, Map
  * one line), and a positional key silently drops the second arrow from
  * graph/lineage output (sl-201z).
  */
-export function* distinctArrowRecords(fieldArrows: Map<string, ArrowRecord[]>): Generator<ArrowRecord> {
+export function* distinctArrowRecords(
+  fieldArrows: Map<string, ArrowRecord[]>,
+): Generator<ArrowRecord> {
   const seen = new Set<ArrowRecord>();
   for (const records of fieldArrows.values()) {
     for (const record of records) {
@@ -572,7 +590,11 @@ export function* distinctArrowRecords(fieldArrows: Map<string, ArrowRecord[]>): 
 /**
  * Build a reference graph from the extracted items.
  */
-function buildReferenceGraph({ schemas, metrics, mappings }: {
+function buildReferenceGraph({
+  schemas,
+  metrics,
+  mappings,
+}: {
   schemas: Map<string, SchemaRecord>;
   metrics: Map<string, MetricRecord>;
   mappings: Map<string, MappingRecord>;

--- a/tooling/satsuma-cli/src/index.ts
+++ b/tooling/satsuma-cli/src/index.ts
@@ -19,16 +19,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Initialise the WASM parser before registering any commands.
 await initParser(join(__dirname, "tree-sitter-satsuma.wasm"));
-const pkg = JSON.parse(
-  readFileSync(join(__dirname, "../package.json"), "utf8"),
-) as { version: string };
+const pkg = JSON.parse(readFileSync(join(__dirname, "../package.json"), "utf8")) as {
+  version: string;
+};
 
 program
   .name("satsuma")
   .description(
     "Satsuma CLI — deterministic structural extraction for Satsuma workspaces.\n" +
-    "Extracts structural facts and delivers NL content verbatim. Does not interpret natural language.\n\n" +
-    "Run `satsuma <command> --help` for detailed usage, flags, and JSON output shape for each command.",
+      "Extracts structural facts and delivers NL content verbatim. Does not interpret natural language.\n\n" +
+      "Run `satsuma <command> --help` for detailed usage, flags, and JSON output shape for each command.",
   )
   .version(pkg.version)
   .showHelpAfterError(true);
@@ -76,7 +76,9 @@ const commands = [
 for (const cmd of commands) {
   // Import via a file:// URL, not a raw path: Node's ESM loader rejects bare
   // absolute paths like "C:\…\summary.js" on Windows (gh-265). See command-loader.
-  const mod = await import(commandModuleSpecifier(__dirname, cmd)) as { register: (program: Command) => void };
+  const mod = (await import(commandModuleSpecifier(__dirname, cmd))) as {
+    register: (program: Command) => void;
+  };
   mod.register(program);
 }
 

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -46,9 +46,7 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
 
   for (const item of index.nlRefData) {
     const refs = extractAtRefs(item.text);
-    const mappingKey = item.namespace
-      ? `${item.namespace}::${item.mapping}`
-      : item.mapping;
+    const mappingKey = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
     const mapping = index.mappings.get(mappingKey);
     if (!mapping) continue;
 
@@ -73,7 +71,10 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
         if (resolution.resolvedTo?.kind === "schema") {
           referencedSchema = resolution.resolvedTo.name;
         }
-      } else if (classification === "dotted-field" || classification === "namespace-qualified-field") {
+      } else if (
+        classification === "dotted-field" ||
+        classification === "namespace-qualified-field"
+      ) {
         // Dotted field ref like `hidden.code` — extract the schema part.
         // Use the FIRST dot (after any `::` prefix) so that nested sub-field
         // paths like `schema.RECORD.CHILD` correctly yield the schema name
@@ -90,9 +91,10 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
 
       if (referencedSchema && !isSchemaInMappingSources(referencedSchema, mapping)) {
         const { line, column } = computeNLRefPosition(item, offset);
-        const displayRef = item.namespace && referencedSchema.startsWith(`${item.namespace}::`)
-          ? referencedSchema.slice(item.namespace.length + 2)
-          : referencedSchema;
+        const displayRef =
+          item.namespace && referencedSchema.startsWith(`${item.namespace}::`)
+            ? referencedSchema.slice(item.namespace.length + 2)
+            : referencedSchema;
         const sourceBlockFix = makeAddSourceFix(mappingKey, referencedSchema);
         const fixApply = item.targetField
           ? composeFixes(
@@ -138,9 +140,7 @@ function checkHiddenSourceInNl(index: ExtractedWorkspace): LintDiagnostic[] {
  */
 function makeAddSourceFix(mappingKey: string, schemaRef: string): (source: string) => string {
   const nsIdx = mappingKey.indexOf("::");
-  const displayName = nsIdx !== -1
-    ? mappingKey.slice(nsIdx + 2)
-    : mappingKey;
+  const displayName = nsIdx !== -1 ? mappingKey.slice(nsIdx + 2) : mappingKey;
   const mappingNs = nsIdx !== -1 ? mappingKey.slice(0, nsIdx) : null;
 
   // Convert canonical ref (::name) back to source-level form for insertion
@@ -340,11 +340,33 @@ function makeAddArrowSourceFix(
 // This list covers the commonly-used built-ins as of v2. It may not be exhaustive;
 // if a valid function triggers a warning, add it here and cite the spec section.
 const KNOWN_PIPELINE_FUNCTIONS = new Set([
-  "trim", "lowercase", "uppercase", "coalesce", "round", "split", "first",
-  "last", "to_utc", "to_iso8601", "parse", "null_if_empty", "null_if_invalid",
-  "drop_if_invalid", "drop_if_null", "warn_if_invalid", "warn_if_null",
-  "error_if_invalid", "error_if_null", "validate_email", "now_utc",
-  "title_case", "escape_html", "truncate", "to_number", "prepend", "max_length",
+  "trim",
+  "lowercase",
+  "uppercase",
+  "coalesce",
+  "round",
+  "split",
+  "first",
+  "last",
+  "to_utc",
+  "to_iso8601",
+  "parse",
+  "null_if_empty",
+  "null_if_invalid",
+  "drop_if_invalid",
+  "drop_if_null",
+  "warn_if_invalid",
+  "warn_if_null",
+  "error_if_invalid",
+  "error_if_null",
+  "validate_email",
+  "now_utc",
+  "title_case",
+  "escape_html",
+  "truncate",
+  "to_number",
+  "prepend",
+  "max_length",
 ]);
 
 function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
@@ -353,9 +375,7 @@ function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
 
   for (const item of index.nlRefData) {
     const refs = extractAtRefs(item.text);
-    const mappingKey = item.namespace
-      ? `${item.namespace}::${item.mapping}`
-      : item.mapping;
+    const mappingKey = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
     const mapping = index.mappings.get(mappingKey);
 
     const mappingContext = {
@@ -376,9 +396,10 @@ function checkUnresolvedNlRef(index: ExtractedWorkspace): LintDiagnostic[] {
 
     if (isNoteContext) {
       const entityName = stripNLRefScopePrefix(item.mapping);
-      const nsEntityName = item.namespace && entityName !== "(file-level note)"
-        ? `${item.namespace}::${entityName}`
-        : entityName;
+      const nsEntityName =
+        item.namespace && entityName !== "(file-level note)"
+          ? `${item.namespace}::${entityName}`
+          : entityName;
 
       if (item.mapping.startsWith("note:metric:")) {
         scopeLabel = "metric";
@@ -531,7 +552,7 @@ export function applyFixes(
         appliedFixes.push(d.fix!);
       }
     }
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
 
     if (source !== originalSource) {
       fixedFiles.set(file, source);

--- a/tooling/satsuma-cli/src/nl-ref-extract.ts
+++ b/tooling/satsuma-cli/src/nl-ref-extract.ts
@@ -45,9 +45,9 @@ function makeLookup(index: ExtractedWorkspace): DefinitionLookup {
   return {
     hasSchema: (key) => index.schemas.has(key),
     getSchema: (key) => index.schemas.get(key) ?? null,
-    hasFragment: (key) => (index.fragments?.has(key) ?? false),
+    hasFragment: (key) => index.fragments?.has(key) ?? false,
     getFragment: (key) => index.fragments?.get(key) ?? null,
-    hasTransform: (key) => (index.transforms?.has(key) ?? false),
+    hasTransform: (key) => index.transforms?.has(key) ?? false,
     getMapping: (key) => index.mappings.get(key) ?? null,
     iterateSchemas: () => index.schemas.entries(),
     expandSpreads: (entity, ns) => expandEntityFields(entity, ns, index),
@@ -63,7 +63,11 @@ interface MappingContext {
 /**
  * Resolve a single @ref against the workspace index.
  */
-export function resolveRef(ref: string, mappingContext: MappingContext, index: ExtractedWorkspace): Resolution {
+export function resolveRef(
+  ref: string,
+  mappingContext: MappingContext,
+  index: ExtractedWorkspace,
+): Resolution {
   return _resolveRef(ref, mappingContext, makeLookup(index));
 }
 
@@ -79,7 +83,10 @@ export function resolveAllNLRefs(index: ExtractedWorkspace): ResolvedNLRef[] {
  * Check if a schema reference from an NL block is declared in the mapping's
  * source or target list.
  */
-export function isSchemaInMappingSources(schemaRef: string, mapping: MappingRecord | undefined): boolean {
+export function isSchemaInMappingSources(
+  schemaRef: string,
+  mapping: MappingRecord | undefined,
+): boolean {
   return _isSchemaInMappingSources(schemaRef, mapping);
 }
 
@@ -117,9 +124,7 @@ export function countNlDerivedEdgesByMapping(index: ExtractedWorkspace): Map<str
     const sourceSchemas = mapping?.sources ?? [];
     const targetSchemas = mapping?.targets ?? [];
 
-    const toField = record.target
-      ? canonicalKey(qualifyField(record.target, targetSchemas))
-      : null;
+    const toField = record.target ? canonicalKey(qualifyField(record.target, targetSchemas)) : null;
     if (!toField) continue;
 
     for (const src of record.sources) {

--- a/tooling/satsuma-cli/src/normalize.ts
+++ b/tooling/satsuma-cli/src/normalize.ts
@@ -85,7 +85,7 @@ export function matchFields(sourceFields: FieldDecl[], targetFields: FieldDecl[]
       const leaf = f.name.split(".").pop()!;
       return !matchedTargetNorms.has(norm) && !matchedTargetNorms.has(normalizeName(leaf));
     })
-  /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
     .map((f) => f.name);
 
   return { matched, sourceOnly, targetOnly };

--- a/tooling/satsuma-cli/src/parser.ts
+++ b/tooling/satsuma-cli/src/parser.ts
@@ -48,7 +48,7 @@ export function parseSource(src: string): { src: string; tree: Tree; errorCount:
  * tree-sitter produces.  See @satsuma/core parse-errors.ts for details.
  */
 function countErrors(node: SyntaxNode): number {
-  let n = (node.type === "ERROR" || node.isMissing) ? 1 : 0;
+  let n = node.type === "ERROR" || node.isMissing ? 1 : 0;
   for (const child of node.namedChildren) n += countErrors(child);
   return n;
 }

--- a/tooling/satsuma-cli/src/schema-graph.ts
+++ b/tooling/satsuma-cli/src/schema-graph.ts
@@ -65,9 +65,7 @@ export function buildFullGraph(index: ExtractedWorkspace): FullGraph {
   if (index.nlRefData) {
     const seen = new Set<string>();
     for (const item of index.nlRefData) {
-      const mappingKey = item.namespace
-        ? `${item.namespace}::${item.mapping}`
-        : item.mapping;
+      const mappingKey = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
       const mapping = index.mappings.get(mappingKey);
       if (!mapping) continue;
 
@@ -88,8 +86,12 @@ export function buildFullGraph(index: ExtractedWorkspace): FullGraph {
 
         let canonicalSchema: string | null = null;
         if (classification === "namespace-qualified-schema" || classification === "bare") {
-          if (resolution.resolvedTo?.kind === "schema") canonicalSchema = resolution.resolvedTo.name;
-        } else if (classification === "dotted-field" || classification === "namespace-qualified-field") {
+          if (resolution.resolvedTo?.kind === "schema")
+            canonicalSchema = resolution.resolvedTo.name;
+        } else if (
+          classification === "dotted-field" ||
+          classification === "namespace-qualified-field"
+        ) {
           if (resolution.resolvedTo?.kind === "field") {
             const fieldName = resolution.resolvedTo.name;
             const lastDot = fieldName.lastIndexOf(".");
@@ -98,7 +100,9 @@ export function buildFullGraph(index: ExtractedWorkspace): FullGraph {
         }
         if (!canonicalSchema) continue;
 
-        const indexKey = canonicalSchema.startsWith("::") ? canonicalSchema.slice(2) : canonicalSchema;
+        const indexKey = canonicalSchema.startsWith("::")
+          ? canonicalSchema.slice(2)
+          : canonicalSchema;
         if (allDeclared.has(indexKey) || allDeclared.has(canonicalSchema)) continue;
 
         const edgeKey = `${indexKey}|${mappingKey}`;

--- a/tooling/satsuma-cli/src/spread-expand.ts
+++ b/tooling/satsuma-cli/src/spread-expand.ts
@@ -17,11 +17,7 @@ import {
   expandEntityFields as _expandEntityFields,
   expandNestedSpreads as _expandNestedSpreads,
 } from "@satsuma/core";
-import type {
-  SpreadEntity,
-  SpreadDiagnostic,
-  ExpandedField,
-} from "@satsuma/core";
+import type { SpreadEntity, SpreadDiagnostic, ExpandedField } from "@satsuma/core";
 import { resolveScopedEntityRef } from "./index-builder.js";
 import type { FieldDecl, ExtractedWorkspace } from "./types.js";
 
@@ -49,7 +45,15 @@ export function expandSpreads(
   const resolveRef = makeIndexRefResolver(currentNs, index.fragments);
   const lookupFragment = (key: string) => index.fragments.get(key);
   const lookupSchema = (key: string) => index.schemas.get(key);
-  return _expandSpreads(schemaKeys, currentNs, resolveRef, lookupFragment, fieldPaths, diagnostics, lookupSchema);
+  return _expandSpreads(
+    schemaKeys,
+    currentNs,
+    resolveRef,
+    lookupFragment,
+    fieldPaths,
+    diagnostics,
+    lookupSchema,
+  );
 }
 
 /**

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -252,14 +252,32 @@ export type RegisterFn = (rule: LintRule) => void;
 // ── Diff types ──────────────────────────────────────────────────────────────
 
 export interface SchemaChange {
-  kind: "field-removed" | "field-added" | "type-changed" | "metadata-changed" | "source-changed" | "grain-changed" | "slices-changed" | "note-changed" | "note-added" | "note-removed";
+  kind:
+    | "field-removed"
+    | "field-added"
+    | "type-changed"
+    | "metadata-changed"
+    | "source-changed"
+    | "grain-changed"
+    | "slices-changed"
+    | "note-changed"
+    | "note-added"
+    | "note-removed";
   field: string;
   from?: string;
   to?: string;
 }
 
 export interface MappingChange {
-  kind: "arrow-count-changed" | "sources-changed" | "targets-changed" | "arrow-added" | "arrow-removed" | "arrow-transform-changed" | "note-added" | "note-removed";
+  kind:
+    | "arrow-count-changed"
+    | "sources-changed"
+    | "targets-changed"
+    | "arrow-added"
+    | "arrow-removed"
+    | "arrow-transform-changed"
+    | "note-added"
+    | "note-removed";
   from?: unknown;
   to?: unknown;
   arrow?: string;

--- a/tooling/satsuma-cli/src/workspace.ts
+++ b/tooling/satsuma-cli/src/workspace.ts
@@ -102,7 +102,10 @@ function followImports(entryFile: string): string[] {
  * a clear error (ADR-022). When given a file, follows import declarations
  * to discover the full transitive import graph unless followImports is false.
  */
-export async function resolveInput(pathArg: string, opts?: { followImports?: boolean }): Promise<string[]> {
+export async function resolveInput(
+  pathArg: string,
+  opts?: { followImports?: boolean },
+): Promise<string[]> {
   const abs = resolve(pathArg);
   const s = await stat(abs);
   if (s.isDirectory()) {

--- a/tooling/satsuma-cli/test/arrow-extract.test.ts
+++ b/tooling/satsuma-cli/test/arrow-extract.test.ts
@@ -22,9 +22,7 @@ function ident(text: string): MockNode {
 }
 
 function blockLabel(name: string): MockNode {
-  const inner = name.startsWith("'")
-    ? n("backtick_name", [], name)
-    : n("identifier", [], name);
+  const inner = name.startsWith("'") ? n("backtick_name", [], name) : n("identifier", [], name);
   return n("block_label", [inner]);
 }
 
@@ -106,10 +104,7 @@ describe("extractArrowRecords", () => {
   });
 
   it("extracts an NL arrow with bare identifier steps", () => {
-    const steps = [
-      pipeStep("pipe_text", "trim"),
-      pipeStep("pipe_text", "lowercase"),
-    ];
+    const steps = [pipeStep("pipe_text", "trim"), pipeStep("pipe_text", "lowercase")];
     const arrow = mapArrow("EMAIL", "email", steps, 20);
     const mapping = mappingBlock("m1", [arrow]);
     const root = n("source_file", [mapping]);
@@ -215,7 +210,12 @@ describe("extractArrowRecords", () => {
   });
 
   it("extracts multiple sources from multi-source arrow", () => {
-    const arrow = n("map_arrow", [srcPath("first_name"), srcPath("last_name"), tgtPath("full_name")], "", 40);
+    const arrow = n(
+      "map_arrow",
+      [srcPath("first_name"), srcPath("last_name"), tgtPath("full_name")],
+      "",
+      40,
+    );
     const mapping = mappingBlock("m1", [arrow]);
     const root = n("source_file", [mapping]);
 
@@ -226,7 +226,12 @@ describe("extractArrowRecords", () => {
   });
 
   it("extracts three sources from multi-source arrow", () => {
-    const arrow = n("map_arrow", [srcPath("city"), srcPath("state"), srcPath("zip"), tgtPath("address")], "", 41);
+    const arrow = n(
+      "map_arrow",
+      [srcPath("city"), srcPath("state"), srcPath("zip"), tgtPath("address")],
+      "",
+      41,
+    );
     const mapping = mappingBlock("m1", [arrow]);
     const root = n("source_file", [mapping]);
 
@@ -246,7 +251,12 @@ describe("extractArrowRecords", () => {
   });
 
   it("produces canonical form for namespaced source paths", () => {
-    const arrow = n("map_arrow", [srcPathNs("crm", "customers", "email"), tgtPath("email_addr")], "", 30);
+    const arrow = n(
+      "map_arrow",
+      [srcPathNs("crm", "customers", "email"), tgtPath("email_addr")],
+      "",
+      30,
+    );
     const mapping = mappingBlock("m1", [arrow]);
     const root = n("source_file", [mapping]);
 
@@ -289,9 +299,7 @@ describe("extractArrowRecords against real examples", () => {
     }
 
     // Check an NL arrow with bare identifier steps
-    const trimArrow = records.find(
-      (r) => r.sources[0] === "FIRST_NM" && r.target === "first_name",
-    );
+    const trimArrow = records.find((r) => r.sources[0] === "FIRST_NM" && r.target === "first_name");
     assert.ok(trimArrow, "should find FIRST_NM -> first_name");
     assert.equal(trimArrow.classification, "nl");
     assert.equal(trimArrow.derived, false);
@@ -303,9 +311,7 @@ describe("extractArrowRecords against real examples", () => {
     assert.equal(phoneArrow.classification, "nl");
 
     // Check an NL arrow with quoted text
-    const notesArrow = records.find(
-      (r) => r.sources[0] === "NOTES" && r.target === "notes",
-    );
+    const notesArrow = records.find((r) => r.sources[0] === "NOTES" && r.target === "notes");
     assert.ok(notesArrow);
     assert.equal(notesArrow.classification, "nl");
 
@@ -359,7 +365,9 @@ describe("extractArrowRecords against real examples", () => {
     // extractArrowRecords returns one record per leaf arrow (map_arrow,
     // computed_arrow, nested_arrow). Flatten/each containers are not
     // themselves arrows — they wrap child arrows.
-    const { tree } = parseFile(resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm"));
+    const { tree } = parseFile(
+      resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm"),
+    );
     const records = extractArrowRecords(tree.rootNode);
     const mapping = records.filter((r) => r.mapping === "order line facts");
     // 3 outer map arrows + 5 flatten children + 1 nested container + 3 computed = 12

--- a/tooling/satsuma-cli/test/bug-purge.test.ts
+++ b/tooling/satsuma-cli/test/bug-purge.test.ts
@@ -31,7 +31,11 @@ const PLATFORM = resolve(__dirname, "fixtures/platform.stm");
 
 const run = (...args: string[]) => _run(CLI, ...args);
 
-function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: { schemas?: any[]; mappings?: any[]; nlRefData?: any[] } = {}) {
+function makeIndex({
+  schemas = [],
+  mappings = [],
+  nlRefData = [],
+}: { schemas?: any[]; mappings?: any[]; nlRefData?: any[] } = {}) {
   const schemaMap = new Map();
   for (const s of schemas) {
     schemaMap.set(s.name, { ...s, file: s.file ?? "test.stm", row: s.row ?? 0 });
@@ -49,7 +53,11 @@ function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: { schemas?: 
     warnings: [],
     questions: [],
     fieldArrows: new Map(),
-    referenceGraph: { usedByMappings: new Map(), fragmentsUsedIn: new Map(), metricsReferences: new Map() },
+    referenceGraph: {
+      usedByMappings: new Map(),
+      fragmentsUsedIn: new Map(),
+      metricsReferences: new Map(),
+    },
     namespaceNames: new Set(),
     nlRefData,
     totalErrors: 0,
@@ -94,15 +102,13 @@ describe("sl-j1eb: graph --json no doubled schema prefix", () => {
         // Only check 3+ part paths for doubling; 2-part schema.field is legitimate
         // when flatten targets share the schema name
         if (parts.length >= 3) {
-          assert.notEqual(parts[0], parts[1],
-            `Doubled schema prefix in from: ${edge.from}`);
+          assert.notEqual(parts[0], parts[1], `Doubled schema prefix in from: ${edge.from}`);
         }
       }
       if (edge.to) {
         const parts = edge.to.split(".");
         if (parts.length >= 3) {
-          assert.notEqual(parts[0], parts[1],
-            `Doubled schema prefix in to: ${edge.to}`);
+          assert.notEqual(parts[0], parts[1], `Doubled schema prefix in to: ${edge.to}`);
         }
       }
     }
@@ -119,12 +125,10 @@ describe("sl-bl5e: graph --json no double-dot paths", () => {
 
     for (const edge of data.edges) {
       if (edge.from) {
-        assert.ok(!edge.from.includes(".."),
-          `Double-dot in from: ${edge.from}`);
+        assert.ok(!edge.from.includes(".."), `Double-dot in from: ${edge.from}`);
       }
       if (edge.to) {
-        assert.ok(!edge.to.includes(".."),
-          `Double-dot in to: ${edge.to}`);
+        assert.ok(!edge.to.includes(".."), `Double-dot in to: ${edge.to}`);
       }
     }
   });
@@ -145,12 +149,10 @@ describe("sl-n464: graph --schema-only aggregates field edges", () => {
     const data = JSON.parse(stdout);
     for (const edge of data.edges) {
       if (edge.from) {
-        assert.ok(!edge.from.includes("."),
-          `Edge from should be schema-level: ${edge.from}`);
+        assert.ok(!edge.from.includes("."), `Edge from should be schema-level: ${edge.from}`);
       }
       if (edge.to) {
-        assert.ok(!edge.to.includes("."),
-          `Edge to should be schema-level: ${edge.to}`);
+        assert.ok(!edge.to.includes("."), `Edge to should be schema-level: ${edge.to}`);
       }
     }
   });
@@ -178,20 +180,24 @@ describe("sl-04pv: hidden-source-in-nl fires on bare and dotted refs", () => {
         { name: "hidden", fields: [{ name: "code" }] },
         { name: "tgt", fields: [{ name: "id" }] },
       ],
-      mappings: [{
-        name: "test",
-        sources: ["src"],
-        targets: ["tgt"],
-      }],
-      nlRefData: [{
-        text: "Look up @hidden to get the code",
-        mapping: "test",
-        namespace: null,
-        targetField: "id",
-        file: "test.stm",
-        line: 10,
-        column: 0,
-      }],
+      mappings: [
+        {
+          name: "test",
+          sources: ["src"],
+          targets: ["tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Look up @hidden to get the code",
+          mapping: "test",
+          namespace: null,
+          targetField: "id",
+          file: "test.stm",
+          line: 10,
+          column: 0,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -206,20 +212,24 @@ describe("sl-04pv: hidden-source-in-nl fires on bare and dotted refs", () => {
         { name: "hidden", fields: [{ name: "code" }] },
         { name: "tgt", fields: [{ name: "id" }] },
       ],
-      mappings: [{
-        name: "test",
-        sources: ["src"],
-        targets: ["tgt"],
-      }],
-      nlRefData: [{
-        text: "Use @hidden.code for the value",
-        mapping: "test",
-        namespace: null,
-        targetField: "id",
-        file: "test.stm",
-        line: 10,
-        column: 0,
-      }],
+      mappings: [
+        {
+          name: "test",
+          sources: ["src"],
+          targets: ["tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Use @hidden.code for the value",
+          mapping: "test",
+          namespace: null,
+          targetField: "id",
+          file: "test.stm",
+          line: 10,
+          column: 0,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -233,20 +243,24 @@ describe("sl-04pv: hidden-source-in-nl fires on bare and dotted refs", () => {
         { name: "src", fields: [{ name: "id" }] },
         { name: "tgt", fields: [{ name: "id" }] },
       ],
-      mappings: [{
-        name: "test",
-        sources: ["src"],
-        targets: ["tgt"],
-      }],
-      nlRefData: [{
-        text: "Copy @src.id value",
-        mapping: "test",
-        namespace: null,
-        targetField: "id",
-        file: "test.stm",
-        line: 10,
-        column: 0,
-      }],
+      mappings: [
+        {
+          name: "test",
+          sources: ["src"],
+          targets: ["tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Copy @src.id value",
+          mapping: "test",
+          namespace: null,
+          targetField: "id",
+          file: "test.stm",
+          line: 10,
+          column: 0,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -264,20 +278,24 @@ describe("sl-80jy: unresolved-nl-ref no false positive on dotted-field", () => {
         { name: "hidden", fields: [{ name: "code" }] },
         { name: "tgt", fields: [{ name: "id" }] },
       ],
-      mappings: [{
-        name: "test",
-        sources: ["src"],
-        targets: ["tgt"],
-      }],
-      nlRefData: [{
-        text: "Use @hidden.code for the value",
-        mapping: "test",
-        namespace: null,
-        targetField: "id",
-        file: "test.stm",
-        line: 10,
-        column: 0,
-      }],
+      mappings: [
+        {
+          name: "test",
+          sources: ["src"],
+          targets: ["tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Use @hidden.code for the value",
+          mapping: "test",
+          namespace: null,
+          targetField: "id",
+          file: "test.stm",
+          line: 10,
+          column: 0,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -290,20 +308,24 @@ describe("sl-80jy: unresolved-nl-ref no false positive on dotted-field", () => {
         { name: "src", fields: [{ name: "id" }] },
         { name: "tgt", fields: [{ name: "id" }] },
       ],
-      mappings: [{
-        name: "test",
-        sources: ["src"],
-        targets: ["tgt"],
-      }],
-      nlRefData: [{
-        text: "Use @nonexistent.field for the value",
-        mapping: "test",
-        namespace: null,
-        targetField: "id",
-        file: "test.stm",
-        line: 10,
-        column: 0,
-      }],
+      mappings: [
+        {
+          name: "test",
+          sources: ["src"],
+          targets: ["tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Use @nonexistent.field for the value",
+          mapping: "test",
+          namespace: null,
+          targetField: "id",
+          file: "test.stm",
+          line: 10,
+          column: 0,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -321,23 +343,34 @@ describe("sl-j9ew: unresolved-nl-ref message says 'metric' not 'mapping' for met
     // to get the bare entity name for the scope label.
     const index = makeIndex({
       schemas: [{ name: "orders", fields: [{ name: "total" }] }],
-      nlRefData: [{
-        text: "Sum @nonexistent_table.amount grouped by month",
-        mapping: "note:metric:revenue",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      nlRefData: [
+        {
+          text: "Sum @nonexistent_table.amount grouped by month",
+          mapping: "note:metric:revenue",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
     index.metrics.set("revenue", { sources: [], fields: [], file: "test.stm", row: 2 });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
     assert.equal(diags.length, 1, "should produce one unresolved-nl-ref warning");
-    assert.ok(diags[0].message.includes("metric"), `message should say 'metric', got: ${diags[0].message}`);
-    assert.ok(!diags[0].message.includes("mapping"), `message should not say 'mapping', got: ${diags[0].message}`);
-    assert.ok(diags[0].message.includes("revenue"), `message should include metric name, got: ${diags[0].message}`);
+    assert.ok(
+      diags[0].message.includes("metric"),
+      `message should say 'metric', got: ${diags[0].message}`,
+    );
+    assert.ok(
+      !diags[0].message.includes("mapping"),
+      `message should not say 'mapping', got: ${diags[0].message}`,
+    );
+    assert.ok(
+      diags[0].message.includes("revenue"),
+      `message should include metric name, got: ${diags[0].message}`,
+    );
   });
 });
 
@@ -350,15 +383,17 @@ describe("sl-tslm: collectSemanticWarnings emits 'unresolved-nl-ref' to match li
     const index = makeIndex({
       schemas: [{ name: "src", fields: [{ name: "id" }] }],
       mappings: [{ name: "m1", sources: ["src"], targets: ["src"] }],
-      nlRefData: [{
-        text: "Check @nonexistent",
-        mapping: "m1",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 0,
-      }],
+      nlRefData: [
+        {
+          text: "Check @nonexistent",
+          mapping: "m1",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 0,
+        },
+      ],
     });
 
     // runLint wraps the CLI lint-engine; collectSemanticWarnings wraps core validate.
@@ -436,7 +471,11 @@ describe("sc-8g9a: validate no false-positive field-not-in-schema on flatten", (
     const { stdout, stderr } = await run("validate", FFG);
     const output = stdout + stderr;
     const fieldNotInSchema = output.split("\n").filter((l) => l.includes("field-not-in-schema"));
-    assert.equal(fieldNotInSchema.length, 0, `unexpected field-not-in-schema warnings:\n${fieldNotInSchema.join("\n")}`);
+    assert.equal(
+      fieldNotInSchema.length,
+      0,
+      `unexpected field-not-in-schema warnings:\n${fieldNotInSchema.join("\n")}`,
+    );
   });
 });
 

--- a/tooling/satsuma-cli/test/canonical-ref.test.ts
+++ b/tooling/satsuma-cli/test/canonical-ref.test.ts
@@ -1,7 +1,14 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { canonicalRef, canonicalEntityName } from "@satsuma/core";
-import { buildIndex, canonicalKey, distinctArrowRecords, resolveCanonicalKey, resolveScopedEntityRef, resolveIndexKey } from "#src/index-builder.js";
+import {
+  buildIndex,
+  canonicalKey,
+  distinctArrowRecords,
+  resolveCanonicalKey,
+  resolveScopedEntityRef,
+  resolveIndexKey,
+} from "#src/index-builder.js";
 
 describe("canonicalRef", () => {
   it("returns ::schema.field when no namespace", () => {
@@ -198,7 +205,16 @@ describe("distinctArrowRecords", () => {
       { name: "t", namespace: null, fields: [], row: 1 },
     ],
     metrics: [],
-    mappings: [{ name: "m", namespace: null, sources: ["s"], targets: ["t"], arrowCount: arrowRecords.length, row: 2 }],
+    mappings: [
+      {
+        name: "m",
+        namespace: null,
+        sources: ["s"],
+        targets: ["t"],
+        arrowCount: arrowRecords.length,
+        row: 2,
+      },
+    ],
     fragments: [],
     transforms: [],
     warnings: [],

--- a/tooling/satsuma-cli/test/command-runner.test.ts
+++ b/tooling/satsuma-cli/test/command-runner.test.ts
@@ -90,7 +90,9 @@ describe("runCommand return values", () => {
   it("exits 0 when the handler returns void", async () => {
     // The most common case: a successful command that printed its output
     // and has nothing more to say. The wrapper must default void → EXIT_OK.
-    const code = await runAndExpectExit(() => { /* no-op */ });
+    const code = await runAndExpectExit(() => {
+      /* no-op */
+    });
     assert.equal(code, EXIT_OK);
     assert.deepEqual(stderrLines, []);
     assert.deepEqual(stdoutLines, []);

--- a/tooling/satsuma-cli/test/context.test.ts
+++ b/tooling/satsuma-cli/test/context.test.ts
@@ -36,9 +36,9 @@ function scoreAll(index: any, terms: string[]) {
     if (entry.targets) for (const t of entry.targets) score += scoreText(t, terms);
     if (score > 0) results.push({ name, type, score, file: entry.file ?? "", row: entry.row ?? 0 });
   };
-  for (const [name, e] of (index.schemas ?? new Map())) scoreEntry(name, "schema", e);
-  for (const [name, e] of (index.metrics ?? new Map())) scoreEntry(name, "metric", e);
-  for (const [name, e] of (index.mappings ?? new Map())) scoreEntry(name, "mapping", e);
+  for (const [name, e] of index.schemas ?? new Map()) scoreEntry(name, "schema", e);
+  for (const [name, e] of index.metrics ?? new Map()) scoreEntry(name, "metric", e);
+  for (const [name, e] of index.mappings ?? new Map()) scoreEntry(name, "mapping", e);
   return results;
 }
 
@@ -103,8 +103,14 @@ describe("scoreAll", () => {
   it("scores field name match (×5)", () => {
     const index = {
       schemas: new Map([
-        ["orders", { fields: [{ name: "email", type: "VARCHAR(255)" }], note: null, file: "a.stm", row: 0 }],
-        ["products", { fields: [{ name: "sku", type: "STRING(20)" }], note: null, file: "a.stm", row: 5 }],
+        [
+          "orders",
+          { fields: [{ name: "email", type: "VARCHAR(255)" }], note: null, file: "a.stm", row: 0 },
+        ],
+        [
+          "products",
+          { fields: [{ name: "sku", type: "STRING(20)" }], note: null, file: "a.stm", row: 5 },
+        ],
       ]),
     };
     const terms = ["email"];
@@ -125,8 +131,22 @@ describe("scoreAll", () => {
   it("surfaces the correct block for PII query", () => {
     const index = {
       schemas: new Map([
-        ["customer", { fields: [{ name: "email", type: "VARCHAR(255)" }, { name: "tax_id", type: "VARCHAR(20)" }], note: "Customer PII data", file: "c.stm", row: 0 }],
-        ["products", { fields: [{ name: "sku", type: "STRING" }], note: null, file: "p.stm", row: 0 }],
+        [
+          "customer",
+          {
+            fields: [
+              { name: "email", type: "VARCHAR(255)" },
+              { name: "tax_id", type: "VARCHAR(20)" },
+            ],
+            note: "Customer PII data",
+            file: "c.stm",
+            row: 0,
+          },
+        ],
+        [
+          "products",
+          { fields: [{ name: "sku", type: "STRING" }], note: null, file: "p.stm", row: 0 },
+        ],
       ]),
     };
     const terms = tokenize("add a PII field to the customer schema");
@@ -160,7 +180,13 @@ describe("satsuma context metric deduplication (sl-s2mh)", () => {
     // Metric schemas live in both index.schemas and index.metrics; scoring
     // both rendered the same block twice and wasted the token budget the
     // command exists to manage.
-    const { stdout, code } = await runCli(CLI, "context", "monthly recurring revenue", "--json", METRICS_EXAMPLE);
+    const { stdout, code } = await runCli(
+      CLI,
+      "context",
+      "monthly recurring revenue",
+      "--json",
+      METRICS_EXAMPLE,
+    );
 
     assert.equal(code, 0);
     const candidates = JSON.parse(stdout) as Array<{ name: string; type: string }>;

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -47,7 +47,10 @@ function parseJson(stdout: string): any {
 /** The JSON entry for one mapping. */
 function mappingEntry(data: any, mapping: string): any {
   const found = data.mappings.find((m: any) => m.mapping === mapping);
-  assert.ok(found, `expected mapping ${mapping} in ${JSON.stringify(data.mappings.map((m: any) => m.mapping))}`);
+  assert.ok(
+    found,
+    `expected mapping ${mapping} in ${JSON.stringify(data.mappings.map((m: any) => m.mapping))}`,
+  );
   return found;
 }
 
@@ -69,7 +72,9 @@ describe("satsuma coverage — default report", () => {
     const { stdout, code } = await run("coverage", WORKSPACE, "--json");
     assert.equal(code, 0);
     assert.deepEqual(
-      parseJson(stdout).mappings.map((m: any) => m.mapping).sort(),
+      parseJson(stdout)
+        .mappings.map((m: any) => m.mapping)
+        .sort(),
       ["billing::flatten invoices", "crm::annotate contacts", "crm::load contacts"],
     );
   });
@@ -100,7 +105,9 @@ describe("satsuma coverage — resolving the workspace index", () => {
     // schema across two keys when results are rolled up.
     const { stdout, code } = await run("coverage", WORKSPACE, "--json");
     assert.equal(code, 0);
-    const schemas = parseJson(stdout).mappings.flatMap((m: any) => m.schemas.map((s: any) => s.schema));
+    const schemas = parseJson(stdout).mappings.flatMap((m: any) =>
+      m.schemas.map((s: any) => s.schema),
+    );
     for (const schema of schemas) {
       assert.match(schema, /^(crm|billing)::/, `expected a namespace-qualified key, got ${schema}`);
     }
@@ -113,7 +120,12 @@ describe("satsuma coverage — resolving the workspace index", () => {
     const source = schemaEntry(parseJson(stdout), "crm::load contacts", "source", "crm::customers");
     assert.deepEqual(
       source.fields.map((f: any) => [f.path, f.mapped]),
-      [["id", true], ["address.city", true], ["address.line1", false], ["nickname", false]],
+      [
+        ["id", true],
+        ["address.city", true],
+        ["address.line1", false],
+        ["nickname", false],
+      ],
     );
     assert.deepEqual(
       { covered: source.covered, total: source.total, pct: source.pct },
@@ -129,10 +141,25 @@ describe("satsuma coverage — resolving the workspace index", () => {
     const source = schemaEntry(data, "billing::flatten invoices", "source", "billing::invoices");
     assert.deepEqual(
       source.fields.map((f: any) => [f.path, f.mapped]),
-      [["id", true], ["lines.sku", true], ["lines.qty", false]],
+      [
+        ["id", true],
+        ["lines.sku", true],
+        ["lines.qty", false],
+      ],
     );
-    const target = schemaEntry(data, "billing::flatten invoices", "target", "billing::invoice_rows");
-    assert.deepEqual(target.fields.map((f: any) => [f.path, f.mapped]), [["id", true], ["rows.code", true]]);
+    const target = schemaEntry(
+      data,
+      "billing::flatten invoices",
+      "target",
+      "billing::invoice_rows",
+    );
+    assert.deepEqual(
+      target.fields.map((f: any) => [f.path, f.mapped]),
+      [
+        ["id", true],
+        ["rows.code", true],
+      ],
+    );
   });
 
   it("reports a schema written by one mapping and read by another under both roles", async () => {
@@ -174,7 +201,12 @@ describe("satsuma coverage — resolving the workspace index", () => {
     // reads it. Matching by leaf name reported it as fully mapped — a silent
     // over-count that makes a source nobody reads look consumed (sl-joeq).
     const { stdout } = await run("coverage", MULTI_SOURCE, "--json");
-    const ledger = schemaEntry(parseJson(stdout), "warehouse::assemble", "source", "warehouse::ledger");
+    const ledger = schemaEntry(
+      parseJson(stdout),
+      "warehouse::assemble",
+      "source",
+      "warehouse::ledger",
+    );
     assert.deepEqual(
       { covered: ledger.covered, total: ledger.total, pct: ledger.pct },
       { covered: 0, total: 2, pct: 0 },
@@ -186,19 +218,40 @@ describe("satsuma coverage — resolving the workspace index", () => {
 
 describe("satsuma coverage — scoping flags", () => {
   it("--mapping restricts the report to one mapping", async () => {
-    const { stdout, code } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
+    const { stdout, code } = await run(
+      "coverage",
+      WORKSPACE,
+      "--mapping",
+      "load contacts",
+      "--json",
+    );
     assert.equal(code, 0);
-    assert.deepEqual(parseJson(stdout).mappings.map((m: any) => m.mapping), ["crm::load contacts"]);
+    assert.deepEqual(
+      parseJson(stdout).mappings.map((m: any) => m.mapping),
+      ["crm::load contacts"],
+    );
   });
 
   it("--schema keeps only that schema, across every mapping using it", async () => {
     // The single-schema view a reviewer wants when auditing one target table.
-    const { stdout, code } = await run("coverage", WORKSPACE, "--schema", "crm::customers", "--json");
+    const { stdout, code } = await run(
+      "coverage",
+      WORKSPACE,
+      "--schema",
+      "crm::customers",
+      "--json",
+    );
     assert.equal(code, 0);
     const data = parseJson(stdout);
-    assert.deepEqual(data.mappings.map((m: any) => m.mapping).sort(), ["crm::annotate contacts", "crm::load contacts"]);
+    assert.deepEqual(data.mappings.map((m: any) => m.mapping).sort(), [
+      "crm::annotate contacts",
+      "crm::load contacts",
+    ]);
     for (const mapping of data.mappings) {
-      assert.deepEqual(mapping.schemas.map((s: any) => s.schema), ["crm::customers"]);
+      assert.deepEqual(
+        mapping.schemas.map((s: any) => s.schema),
+        ["crm::customers"],
+      );
     }
   });
 
@@ -213,7 +266,13 @@ describe("satsuma coverage — scoping flags", () => {
     // Filters have to intersect, not override: this is how --fail-under will
     // later gate one specific figure (sl-268g).
     const { stdout, code } = await run(
-      "coverage", WORKSPACE, "--schema", "crm::customers", "--role", "target", "--json",
+      "coverage",
+      WORKSPACE,
+      "--schema",
+      "crm::customers",
+      "--role",
+      "target",
+      "--json",
     );
     // crm::customers is never a target, so the intersection is empty.
     assert.equal(code, 1);
@@ -223,23 +282,50 @@ describe("satsuma coverage — scoping flags", () => {
   it("--uncovered drops the covered fields and the schemas with no gaps", async () => {
     // The review-queue view: everything left on screen is work to do.
     const { stdout, code } = await run(
-      "coverage", WORKSPACE, "--mapping", "flatten invoices", "--uncovered", "--json",
+      "coverage",
+      WORKSPACE,
+      "--mapping",
+      "flatten invoices",
+      "--uncovered",
+      "--json",
     );
     assert.equal(code, 0);
     const data = parseJson(stdout);
-    const target = schemaEntry(data, "billing::flatten invoices", "target", "billing::invoice_rows");
-    assert.deepEqual(target.fields, [], "invoice_rows is fully populated, so it has no uncovered fields");
+    const target = schemaEntry(
+      data,
+      "billing::flatten invoices",
+      "target",
+      "billing::invoice_rows",
+    );
+    assert.deepEqual(
+      target.fields,
+      [],
+      "invoice_rows is fully populated, so it has no uncovered fields",
+    );
     const source = schemaEntry(data, "billing::flatten invoices", "source", "billing::invoices");
-    assert.deepEqual(source.fields.map((f: any) => f.path), ["lines.qty"]);
+    assert.deepEqual(
+      source.fields.map((f: any) => f.path),
+      ["lines.qty"],
+    );
   });
 
   it("--uncovered leaves the counts as the full denominator", async () => {
     // "1 of 3" is the useful figure; recomputing counts over the filtered list
     // would report "0 of 1" and lose the scale of the gap.
     const { stdout } = await run(
-      "coverage", WORKSPACE, "--mapping", "flatten invoices", "--uncovered", "--json",
+      "coverage",
+      WORKSPACE,
+      "--mapping",
+      "flatten invoices",
+      "--uncovered",
+      "--json",
     );
-    const source = schemaEntry(parseJson(stdout), "billing::flatten invoices", "source", "billing::invoices");
+    const source = schemaEntry(
+      parseJson(stdout),
+      "billing::flatten invoices",
+      "source",
+      "billing::invoices",
+    );
     assert.deepEqual({ covered: source.covered, total: source.total }, { covered: 2, total: 3 });
   });
 });
@@ -253,10 +339,16 @@ describe("satsuma coverage — JSON contract", () => {
     const mapping = mappingEntry(parseJson(stdout), "crm::load contacts");
     assert.deepEqual(Object.keys(mapping), ["mapping", "file", "schemas"]);
     assert.equal(mapping.file, WORKSPACE);
-    assert.deepEqual(
-      Object.keys(mapping.schemas[0]),
-      ["schema", "role", "covered", "covered_declared", "covered_nl", "total", "pct", "fields"],
-    );
+    assert.deepEqual(Object.keys(mapping.schemas[0]), [
+      "schema",
+      "role",
+      "covered",
+      "covered_declared",
+      "covered_nl",
+      "total",
+      "pct",
+      "fields",
+    ]);
   });
 
   it("reports field lines 1-indexed, matching every other command's JSON", async () => {
@@ -276,7 +368,10 @@ describe("satsuma coverage — JSON contract", () => {
     const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
     const source = schemaEntry(parseJson(stdout), "crm::load contacts", "source", "crm::customers");
     assert.equal(source.fields.length, source.total);
-    assert.ok(!source.fields.some((f: any) => f.path === "address"), "the 'address' record must not be listed");
+    assert.ok(
+      !source.fields.some((f: any) => f.path === "address"),
+      "the 'address' record must not be listed",
+    );
   });
 });
 
@@ -286,7 +381,10 @@ describe("satsuma coverage — aggregate rollups", () => {
   /** The aggregate entry for one schema and role. */
   function aggregateEntry(data: any, role: string, schema: string): any {
     const found = data.aggregate.schemas.find((s: any) => s.role === role && s.schema === schema);
-    assert.ok(found, `expected aggregate ${role} ${schema} in ${JSON.stringify(data.aggregate.schemas.map((s: any) => [s.role, s.schema]))}`);
+    assert.ok(
+      found,
+      `expected aggregate ${role} ${schema} in ${JSON.stringify(data.aggregate.schemas.map((s: any) => [s.role, s.schema]))}`,
+    );
     return found;
   }
 
@@ -308,11 +406,16 @@ describe("satsuma coverage — aggregate rollups", () => {
     // reviewer who reads the wrong one deletes a field another mapping populates.
     const { stdout } = await run("coverage", WORKSPACE, "--json");
     const data = parseJson(stdout);
-    const perMapping = schemaEntry(data, "crm::load contacts", "target", "crm::contacts")
-      .fields.find((f: any) => f.path === "memo");
+    const perMapping = schemaEntry(
+      data,
+      "crm::load contacts",
+      "target",
+      "crm::contacts",
+    ).fields.find((f: any) => f.path === "memo");
     assert.equal(perMapping.mapped, false);
-    const aggregated = aggregateEntry(data, "target", "crm::contacts")
-      .fields.find((f: any) => f.path === "memo");
+    const aggregated = aggregateEntry(data, "target", "crm::contacts").fields.find(
+      (f: any) => f.path === "memo",
+    );
     assert.equal(aggregated.mapped, true);
   });
 
@@ -320,10 +423,10 @@ describe("satsuma coverage — aggregate rollups", () => {
     // Without them an aggregate gap is not actionable — the reviewer cannot tell
     // which mapping to go and edit.
     const { stdout } = await run("coverage", WORKSPACE, "--json");
-    assert.deepEqual(
-      aggregateEntry(parseJson(stdout), "target", "crm::contacts").mappings.sort(),
-      ["crm::annotate contacts", "crm::load contacts"],
-    );
+    assert.deepEqual(aggregateEntry(parseJson(stdout), "target", "crm::contacts").mappings.sort(), [
+      "crm::annotate contacts",
+      "crm::load contacts",
+    ]);
   });
 
   it("counts a schema once however many mappings reference it", async () => {
@@ -337,7 +440,11 @@ describe("satsuma coverage — aggregate rollups", () => {
     // via declared arrows — this fixture uses no @refs, so the nl tier is empty
     // and the split must say so rather than omitting the keys (ADR-036).
     assert.deepEqual(data.aggregate.workspace.source, {
-      covered: 5, covered_declared: 5, covered_nl: 0, total: 7, pct: 71,
+      covered: 5,
+      covered_declared: 5,
+      covered_nl: 0,
+      total: 7,
+      pct: 71,
     });
   });
 
@@ -347,7 +454,10 @@ describe("satsuma coverage — aggregate rollups", () => {
     const { namespaces, workspace } = parseJson(stdout).aggregate;
     assert.deepEqual(namespaces.map((n: any) => n.namespace).sort(), ["billing", "crm"]);
     const summed = namespaces.reduce(
-      (acc: any, ns: any) => ({ covered: acc.covered + ns.source.covered, total: acc.total + ns.source.total }),
+      (acc: any, ns: any) => ({
+        covered: acc.covered + ns.source.covered,
+        total: acc.total + ns.source.total,
+      }),
       { covered: 0, total: 0 },
     );
     assert.deepEqual(summed, { covered: workspace.source.covered, total: workspace.source.total });
@@ -359,15 +469,24 @@ describe("satsuma coverage — aggregate rollups", () => {
     const { stdout } = await run("coverage", WORKSPACE, "--mapping", "load contacts", "--json");
     const data = parseJson(stdout);
     const contacts = aggregateEntry(data, "target", "crm::contacts");
-    assert.deepEqual({ covered: contacts.covered, total: contacts.total }, { covered: 2, total: 3 });
-    assert.deepEqual(data.aggregate.namespaces.map((n: any) => n.namespace), ["crm"]);
+    assert.deepEqual(
+      { covered: contacts.covered, total: contacts.total },
+      { covered: 2, total: 3 },
+    );
+    assert.deepEqual(
+      data.aggregate.namespaces.map((n: any) => n.namespace),
+      ["crm"],
+    );
   });
 
   it("labels the human aggregate section with the claim it is making", async () => {
     // A section title alone is too easy to skim past; the stronger claim has to
     // be stated where the numbers are read.
     const { stdout } = await run("coverage", WORKSPACE);
-    assert.match(stdout, /Aggregate — a field is uncovered here only when NO mapping in scope covers it/);
+    assert.match(
+      stdout,
+      /Aggregate — a field is uncovered here only when NO mapping in scope covers it/,
+    );
     assert.match(stdout, /covered by no mapping — crm::customers \(source\)/);
   });
 
@@ -382,7 +501,10 @@ describe("satsuma coverage — aggregate rollups", () => {
     // look for a difference that cannot exist.
     const { stdout } = await run("coverage", NESTED);
     assert.match(stdout, /^ {2}workspace\s+source/m);
-    assert.ok(!/\(file scope\)/.test(stdout), `single-group subtotal row should be suppressed:\n${stdout}`);
+    assert.ok(
+      !/\(file scope\)/.test(stdout),
+      `single-group subtotal row should be suppressed:\n${stdout}`,
+    );
   });
 });
 
@@ -434,17 +556,34 @@ describe("satsuma coverage vs fields --unmapped-by", () => {
     // computation; if this ever fails, one of them has grown its own copy again.
     const [viaFields, viaCoverage] = await Promise.all([
       run("fields", "nested_tgt", "--unmapped-by", "partial_map", "--json", NESTED),
-      run("coverage", NESTED, "--uncovered", "--mapping", "partial_map", "--schema", "nested_tgt", "--json"),
+      run(
+        "coverage",
+        NESTED,
+        "--uncovered",
+        "--mapping",
+        "partial_map",
+        "--schema",
+        "nested_tgt",
+        "--json",
+      ),
     ]);
     assert.equal(viaFields.code, 0);
     assert.equal(viaCoverage.code, 0);
 
     const fromFields = leafPaths(parseJson(viaFields.stdout)).sort();
-    const fromCoverage = schemaEntry(parseJson(viaCoverage.stdout), "::partial_map", "target", "::nested_tgt")
+    const fromCoverage = schemaEntry(
+      parseJson(viaCoverage.stdout),
+      "::partial_map",
+      "target",
+      "::nested_tgt",
+    )
       .fields.map((f: any) => f.path)
       .sort();
     assert.deepEqual(fromCoverage, fromFields);
-    assert.ok(fromFields.length > 0, "the fixture must actually have gaps for this to prove anything");
+    assert.ok(
+      fromFields.length > 0,
+      "the fixture must actually have gaps for this to prove anything",
+    );
   });
 
   it("agrees that a fully-mapped schema has no uncovered fields", async () => {
@@ -452,7 +591,16 @@ describe("satsuma coverage vs fields --unmapped-by", () => {
     // reporting the record shell it pruned differently.
     const [viaFields, viaCoverage] = await Promise.all([
       run("fields", "nested_tgt", "--unmapped-by", "full_map", "--json", NESTED),
-      run("coverage", NESTED, "--uncovered", "--mapping", "full_map", "--schema", "nested_tgt", "--json"),
+      run(
+        "coverage",
+        NESTED,
+        "--uncovered",
+        "--mapping",
+        "full_map",
+        "--schema",
+        "nested_tgt",
+        "--json",
+      ),
     ]);
     assert.deepEqual(parseJson(viaFields.stdout), []);
     assert.deepEqual(
@@ -483,14 +631,24 @@ describe("satsuma coverage --fail-under", () => {
     // The case that motivated a separate code. If both were 1, a misspelled
     // mapping name and genuine under-coverage would be indistinguishable, and CI
     // could not tell "fix the pipeline" from "finish the mapping".
-    const { stderr, code } = await run("coverage", WORKSPACE, "--fail-under", "90", "--mapping", "typo");
+    const { stderr, code } = await run(
+      "coverage",
+      WORKSPACE,
+      "--fail-under",
+      "90",
+      "--mapping",
+      "typo",
+    );
     assert.equal(code, 1);
     assert.match(stderr, /Mapping 'typo' not found/);
   });
 
   it("exits 2 for a parse or filesystem error, whatever the threshold", async () => {
     const { code } = await run(
-      "coverage", resolve(__dirname, "fixtures/does-not-exist.stm"), "--fail-under", "90",
+      "coverage",
+      resolve(__dirname, "fixtures/does-not-exist.stm"),
+      "--fail-under",
+      "90",
     );
     assert.equal(code, 2);
   });
@@ -506,20 +664,42 @@ describe("satsuma coverage --fail-under", () => {
 
   it("gates source consumption when combined with --role source", async () => {
     const { stdout, code } = await run(
-      "coverage", WORKSPACE, "--fail-under", "90", "--role", "source", "--json",
+      "coverage",
+      WORKSPACE,
+      "--fail-under",
+      "90",
+      "--role",
+      "source",
+      "--json",
     );
     assert.equal(code, 3);
-    assert.deepEqual(parseJson(stdout).gate, { role: "source", threshold: 90, pct: 71, met: false });
+    assert.deepEqual(parseJson(stdout).gate, {
+      role: "source",
+      threshold: 90,
+      pct: 71,
+      met: false,
+    });
   });
 
   it("gates the scoped percentage when --mapping narrows the report", async () => {
     // 'load contacts' alone leaves memo unwritten, so the same workspace that
     // passes at 100% aggregate fails once the scope is one mapping.
     const { stdout, code } = await run(
-      "coverage", WORKSPACE, "--mapping", "load contacts", "--fail-under", "100", "--json",
+      "coverage",
+      WORKSPACE,
+      "--mapping",
+      "load contacts",
+      "--fail-under",
+      "100",
+      "--json",
     );
     assert.equal(code, 3);
-    assert.deepEqual(parseJson(stdout).gate, { role: "target", threshold: 100, pct: 67, met: false });
+    assert.deepEqual(parseJson(stdout).gate, {
+      role: "target",
+      threshold: 100,
+      pct: 67,
+      met: false,
+    });
   });
 
   it("still prints the report when the gate fails", async () => {
@@ -534,7 +714,12 @@ describe("satsuma coverage --fail-under", () => {
     // crm::customers is only ever a source, so gating target coverage measures
     // nothing. Reporting that as 0% would blame the spec for an invocation error.
     const { stderr, code } = await run(
-      "coverage", WORKSPACE, "--schema", "crm::customers", "--fail-under", "90",
+      "coverage",
+      WORKSPACE,
+      "--schema",
+      "crm::customers",
+      "--fail-under",
+      "90",
     );
     assert.equal(code, 1);
     assert.match(stderr, /No target-role coverage in scope to gate/);
@@ -574,7 +759,12 @@ describe("satsuma coverage — nested containers", () => {
   it("reports the fully-mapped nested-iteration target as 100%", async () => {
     const { stdout, code } = await run("coverage", NESTED_ITERATION, "--json");
     assert.equal(code, 0);
-    const target = schemaEntry(parseJson(stdout), "::dispatch manifest", "target", "::dispatch_manifest_json");
+    const target = schemaEntry(
+      parseJson(stdout),
+      "::dispatch manifest",
+      "target",
+      "::dispatch_manifest_json",
+    );
     assert.deepEqual(
       { covered: target.covered, total: target.total, pct: target.pct },
       { covered: 8, total: 8, pct: 100 },
@@ -585,8 +775,16 @@ describe("satsuma coverage — nested containers", () => {
     // orders.parcels.barcode is never referenced by any arrow; every other
     // source leaf is, including those reached only through the nested flatten.
     const { stdout } = await run("coverage", NESTED_ITERATION, "--uncovered", "--json");
-    const source = schemaEntry(parseJson(stdout), "::dispatch manifest", "source", "::warehouse_dispatch_events");
-    assert.deepEqual(source.fields.map((f: any) => f.path), ["orders.parcels.barcode"]);
+    const source = schemaEntry(
+      parseJson(stdout),
+      "::dispatch manifest",
+      "source",
+      "::warehouse_dispatch_events",
+    );
+    assert.deepEqual(
+      source.fields.map((f: any) => f.path),
+      ["orders.parcels.barcode"],
+    );
     assert.deepEqual(
       { covered: source.covered, total: source.total, pct: source.pct },
       { covered: 8, total: 9, pct: 89 },
@@ -599,7 +797,12 @@ describe("satsuma coverage — nested containers", () => {
     // This pins the two commands together on a nested fixture, which is where
     // they diverged.
     const { stdout, code } = await run(
-      "fields", "warehouse_dispatch_events", "--unmapped-by", "dispatch manifest", NESTED_ITERATION, "--json",
+      "fields",
+      "warehouse_dispatch_events",
+      "--unmapped-by",
+      "dispatch manifest",
+      NESTED_ITERATION,
+      "--json",
     );
     assert.equal(code, 0);
     const leaves: string[] = [];
@@ -620,7 +823,10 @@ describe("satsuma coverage — nested containers", () => {
     const { stdout, code } = await run("coverage", NESTED_ARROW, "--json");
     assert.equal(code, 0);
     const data = parseJson(stdout);
-    for (const [role, schema] of [["source", "::src_sys"], ["target", "::tgt_sys"]] as const) {
+    for (const [role, schema] of [
+      ["source", "::src_sys"],
+      ["target", "::tgt_sys"],
+    ] as const) {
       const entry = schemaEntry(data, "::addr_map", role, schema);
       assert.equal(entry.pct, 100, `${role} ${schema} should be fully covered`);
     }

--- a/tooling/satsuma-cli/test/cst-query.test.ts
+++ b/tooling/satsuma-cli/test/cst-query.test.ts
@@ -77,9 +77,7 @@ describe("findBlockNode: anonymous blocks", () => {
   it("finds a block by <anon>@file:row key", () => {
     const { tree } = parseFile(resolve(__dirname, "../../../examples/db-to-db/pipeline.stm"));
     // Use the actual row of the first schema_block
-    const firstSchema = tree.rootNode.namedChildren.find(
-      (c: any) => c.type === "schema_block",
-    );
+    const firstSchema = tree.rootNode.namedChildren.find((c: any) => c.type === "schema_block");
     assert.ok(firstSchema, "should have at least one schema block");
     const key = `<anon>@test:${firstSchema.startPosition.row}`;
     const node = findBlockNode(tree.rootNode, "schema_block", key);

--- a/tooling/satsuma-cli/test/diff.test.ts
+++ b/tooling/satsuma-cli/test/diff.test.ts
@@ -13,7 +13,17 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { diffIndex } from "#src/diff-engine.js";
 
-function makeIndex(schemas: any = {}, mappings: any = {}, { metrics = {}, fragments = {}, transforms = {}, notes = [] as any[], fieldArrows = {} }: any = {}) {
+function makeIndex(
+  schemas: any = {},
+  mappings: any = {},
+  {
+    metrics = {},
+    fragments = {},
+    transforms = {},
+    notes = [] as any[],
+    fieldArrows = {},
+  }: any = {},
+) {
   return {
     schemas: new Map(Object.entries(schemas)),
     mappings: new Map(Object.entries(mappings)),
@@ -91,8 +101,29 @@ describe("diffIndex", () => {
   // ── Metric metadata detection (sl-1meq) ─────────────────────────────────
 
   it("detects metric source changes (sl-1meq)", () => {
-    const a = makeIndex({}, {}, { metrics: { rev: { sources: ["fact_orders"], grain: "monthly", slices: ["region"], fields: [] } } });
-    const b = makeIndex({}, {}, { metrics: { rev: { sources: ["fact_orders", "dim_date"], grain: "monthly", slices: ["region"], fields: [] } } });
+    const a = makeIndex(
+      {},
+      {},
+      {
+        metrics: {
+          rev: { sources: ["fact_orders"], grain: "monthly", slices: ["region"], fields: [] },
+        },
+      },
+    );
+    const b = makeIndex(
+      {},
+      {},
+      {
+        metrics: {
+          rev: {
+            sources: ["fact_orders", "dim_date"],
+            grain: "monthly",
+            slices: ["region"],
+            fields: [],
+          },
+        },
+      },
+    );
     const delta = diffIndex(a, b);
     assert.equal(delta.metrics.changed.length, 1);
     assert.equal(delta.metrics.changed[0].changes[0].kind, "source-changed");
@@ -101,16 +132,36 @@ describe("diffIndex", () => {
   });
 
   it("detects metric grain changes (sl-1meq)", () => {
-    const a = makeIndex({}, {}, { metrics: { rev: { sources: ["s"], grain: "monthly", slices: [], fields: [] } } });
-    const b = makeIndex({}, {}, { metrics: { rev: { sources: ["s"], grain: "quarterly", slices: [], fields: [] } } });
+    const a = makeIndex(
+      {},
+      {},
+      { metrics: { rev: { sources: ["s"], grain: "monthly", slices: [], fields: [] } } },
+    );
+    const b = makeIndex(
+      {},
+      {},
+      { metrics: { rev: { sources: ["s"], grain: "quarterly", slices: [], fields: [] } } },
+    );
     const delta = diffIndex(a, b);
     assert.equal(delta.metrics.changed.length, 1);
     assert.equal(delta.metrics.changed[0].changes[0].kind, "grain-changed");
   });
 
   it("detects metric slices changes (sl-1meq)", () => {
-    const a = makeIndex({}, {}, { metrics: { rev: { sources: ["s"], grain: null, slices: ["region"], fields: [] } } });
-    const b = makeIndex({}, {}, { metrics: { rev: { sources: ["s"], grain: null, slices: ["region", "channel"], fields: [] } } });
+    const a = makeIndex(
+      {},
+      {},
+      { metrics: { rev: { sources: ["s"], grain: null, slices: ["region"], fields: [] } } },
+    );
+    const b = makeIndex(
+      {},
+      {},
+      {
+        metrics: {
+          rev: { sources: ["s"], grain: null, slices: ["region", "channel"], fields: [] },
+        },
+      },
+    );
     const delta = diffIndex(a, b);
     assert.equal(delta.metrics.changed.length, 1);
     assert.equal(delta.metrics.changed[0].changes[0].kind, "slices-changed");
@@ -121,14 +172,28 @@ describe("diffIndex", () => {
   it("detects arrow transform changes via transform_raw (sl-edrw)", () => {
     /** Verifies that diffIndex compares arrow transform bodies, not just endpoints. */
     const arrowA = {
-      mapping: "m1", namespace: null, sources: ["src.name"], target: "tgt.name",
-      transform_raw: "trim | upper", steps: [], classification: "nl",
-      derived: false, line: 5, file: "a.stm",
+      mapping: "m1",
+      namespace: null,
+      sources: ["src.name"],
+      target: "tgt.name",
+      transform_raw: "trim | upper",
+      steps: [],
+      classification: "nl",
+      derived: false,
+      line: 5,
+      file: "a.stm",
     };
     const arrowB = {
-      mapping: "m1", namespace: null, sources: ["src.name"], target: "tgt.name",
-      transform_raw: "trim | lower", steps: [], classification: "nl",
-      derived: false, line: 5, file: "b.stm",
+      mapping: "m1",
+      namespace: null,
+      sources: ["src.name"],
+      target: "tgt.name",
+      transform_raw: "trim | lower",
+      steps: [],
+      classification: "nl",
+      derived: false,
+      line: 5,
+      file: "b.stm",
     };
     const a = makeIndex(
       {},
@@ -142,7 +207,9 @@ describe("diffIndex", () => {
     );
     const delta = diffIndex(a, b);
     assert.equal(delta.mappings.changed.length, 1);
-    const transformChange = delta.mappings.changed[0].changes.find((c) => c.kind === "arrow-transform-changed");
+    const transformChange = delta.mappings.changed[0].changes.find(
+      (c) => c.kind === "arrow-transform-changed",
+    );
     assert.ok(transformChange, "expected an arrow-transform-changed change");
     assert.equal(transformChange.from, "trim | upper");
     assert.equal(transformChange.to, "trim | lower");
@@ -150,9 +217,16 @@ describe("diffIndex", () => {
 
   it("reports no arrow changes when transform bodies are identical (sl-edrw)", () => {
     const arrow = {
-      mapping: "m1", namespace: null, sources: ["src.name"], target: "tgt.name",
-      transform_raw: "trim | upper", steps: [], classification: "nl",
-      derived: false, line: 5, file: "a.stm",
+      mapping: "m1",
+      namespace: null,
+      sources: ["src.name"],
+      target: "tgt.name",
+      transform_raw: "trim | upper",
+      steps: [],
+      classification: "nl",
+      derived: false,
+      line: 5,
+      file: "a.stm",
     };
     const idx = makeIndex(
       {},
@@ -183,22 +257,36 @@ describe("diffIndex", () => {
   });
 
   it("mapping notes do not appear as top-level note changes (sl-van1)", () => {
-    const a = makeIndex({}, { m1: { sources: ["a"], targets: ["b"], arrowCount: 1 } }, { notes: [] });
+    const a = makeIndex(
+      {},
+      { m1: { sources: ["a"], targets: ["b"], arrowCount: 1 } },
+      { notes: [] },
+    );
     const b = makeIndex(
       {},
       { m1: { sources: ["a"], targets: ["b"], arrowCount: 1 } },
       { notes: [{ text: "Block note.", parent: "m1", file: "x.stm", row: 5, namespace: null }] },
     );
     const delta = diffIndex(a, b);
-    assert.equal(delta.notes.added.length, 0, "block-owned notes should not appear in top-level notes");
+    assert.equal(
+      delta.notes.added.length,
+      0,
+      "block-owned notes should not appear in top-level notes",
+    );
   });
 
   it("detects standalone top-level note additions (sl-van1)", () => {
     /** Top-level notes (parent === null) should appear in delta.notes. */
     const a = makeIndex({}, {}, { notes: [] });
-    const b = makeIndex({}, {}, {
-      notes: [{ text: "New standalone note.", parent: null, file: "x.stm", row: 1, namespace: null }],
-    });
+    const b = makeIndex(
+      {},
+      {},
+      {
+        notes: [
+          { text: "New standalone note.", parent: null, file: "x.stm", row: 1, namespace: null },
+        ],
+      },
+    );
     const delta = diffIndex(a, b);
     assert.deepEqual(delta.notes.added, ["New standalone note."]);
     assert.deepEqual(delta.notes.removed, []);
@@ -206,12 +294,20 @@ describe("diffIndex", () => {
 
   it("detects standalone top-level note text changes (sl-van1)", () => {
     /** When a standalone note's text changes, both the old and new appear. */
-    const a = makeIndex({}, {}, {
-      notes: [{ text: "Original note.", parent: null, file: "x.stm", row: 1, namespace: null }],
-    });
-    const b = makeIndex({}, {}, {
-      notes: [{ text: "Updated note.", parent: null, file: "x.stm", row: 1, namespace: null }],
-    });
+    const a = makeIndex(
+      {},
+      {},
+      {
+        notes: [{ text: "Original note.", parent: null, file: "x.stm", row: 1, namespace: null }],
+      },
+    );
+    const b = makeIndex(
+      {},
+      {},
+      {
+        notes: [{ text: "Updated note.", parent: null, file: "x.stm", row: 1, namespace: null }],
+      },
+    );
     const delta = diffIndex(a, b);
     assert.deepEqual(delta.notes.added, ["Updated note."]);
     assert.deepEqual(delta.notes.removed, ["Original note."]);
@@ -220,8 +316,12 @@ describe("diffIndex", () => {
   // ── Schema note detection (sl-fkwb) ─────────────────────────────────────
 
   it("detects schema-level note text changes via note tag (sl-4gio)", () => {
-    const a = makeIndex({ foo: { note: "Raw source data", fields: [{ name: "id", type: "INT" }] } });
-    const b = makeIndex({ foo: { note: "Updated description", fields: [{ name: "id", type: "INT" }] } });
+    const a = makeIndex({
+      foo: { note: "Raw source data", fields: [{ name: "id", type: "INT" }] },
+    });
+    const b = makeIndex({
+      foo: { note: "Updated description", fields: [{ name: "id", type: "INT" }] },
+    });
     const delta = diffIndex(a, b);
     assert.equal(delta.schemas.changed.length, 1);
     assert.equal(delta.schemas.changed[0].changes[0].kind, "note-changed");
@@ -246,12 +346,36 @@ describe("diffIndex", () => {
 
   it("detects schema note block changes attributed under schema (sl-fkwb)", () => {
     /** Note blocks inside schema body should produce note-added/note-removed under the schema. */
-    const a = makeIndex({ data: { note: null, fields: [{ name: "id", type: "INT" }] } }, {}, {
-      notes: [{ text: "This schema holds customer data.", parent: "data", file: "a.stm", row: 1, namespace: null }],
-    });
-    const b = makeIndex({ data: { note: null, fields: [{ name: "id", type: "INT" }] } }, {}, {
-      notes: [{ text: "This schema holds updated customer data with PII.", parent: "data", file: "b.stm", row: 1, namespace: null }],
-    });
+    const a = makeIndex(
+      { data: { note: null, fields: [{ name: "id", type: "INT" }] } },
+      {},
+      {
+        notes: [
+          {
+            text: "This schema holds customer data.",
+            parent: "data",
+            file: "a.stm",
+            row: 1,
+            namespace: null,
+          },
+        ],
+      },
+    );
+    const b = makeIndex(
+      { data: { note: null, fields: [{ name: "id", type: "INT" }] } },
+      {},
+      {
+        notes: [
+          {
+            text: "This schema holds updated customer data with PII.",
+            parent: "data",
+            file: "b.stm",
+            row: 1,
+            namespace: null,
+          },
+        ],
+      },
+    );
     const delta = diffIndex(a, b);
     assert.equal(delta.schemas.changed.length, 1);
     assert.equal(delta.schemas.changed[0].name, "data");
@@ -276,7 +400,11 @@ describe("diffIndex", () => {
 
   it("detects transform body text changes (sl-7ow3)", () => {
     const a = makeIndex({}, {}, { transforms: { "clean address": { body: "trim | lowercase" } } });
-    const b = makeIndex({}, {}, { transforms: { "clean address": { body: "trim | lowercase | capitalize" } } });
+    const b = makeIndex(
+      {},
+      {},
+      { transforms: { "clean address": { body: "trim | lowercase | capitalize" } } },
+    );
     const delta = diffIndex(a, b);
     assert.equal(delta.transforms.changed.length, 1);
     assert.equal(delta.transforms.changed[0].name, "clean address");
@@ -286,8 +414,8 @@ describe("diffIndex", () => {
   });
 
   it("identical transform bodies produce no change", () => {
-    const a = makeIndex({}, {}, { transforms: { "clean": { body: "trim" } } });
-    const b = makeIndex({}, {}, { transforms: { "clean": { body: "trim" } } });
+    const a = makeIndex({}, {}, { transforms: { clean: { body: "trim" } } });
+    const b = makeIndex({}, {}, { transforms: { clean: { body: "trim" } } });
     const delta = diffIndex(a, b);
     assert.equal(delta.transforms.changed.length, 0);
   });
@@ -295,14 +423,22 @@ describe("diffIndex", () => {
   // ── Metric note detection ────────────────────────────────────────────────
 
   it("detects metric note changes attributed under metric, not top-level (sl-kf76)", () => {
-    const a = makeIndex({}, {}, {
-      metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
-      notes: [{ text: "Old note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
-    });
-    const b = makeIndex({}, {}, {
-      metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
-      notes: [{ text: "New note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
-    });
+    const a = makeIndex(
+      {},
+      {},
+      {
+        metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
+        notes: [{ text: "Old note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
+      },
+    );
+    const b = makeIndex(
+      {},
+      {},
+      {
+        metrics: { rev: { sources: ["s"], grain: null, slices: [], fields: [] } },
+        notes: [{ text: "New note.", parent: "rev", file: "x.stm", row: 3, namespace: null }],
+      },
+    );
     const delta = diffIndex(a, b);
     // Should appear under metrics, not top-level notes
     assert.equal(delta.metrics.changed.length, 1);
@@ -328,14 +464,28 @@ describe("diffIndex", () => {
   it("detects added and removed arrows", () => {
     /** Verifies that added/removed arrows are detected by source->target key. */
     const arrowA = {
-      mapping: "m1", namespace: null, sources: ["src.id"], target: "tgt.id",
-      transform_raw: "", steps: [], classification: "nl",
-      derived: false, line: 5, file: "a.stm",
+      mapping: "m1",
+      namespace: null,
+      sources: ["src.id"],
+      target: "tgt.id",
+      transform_raw: "",
+      steps: [],
+      classification: "nl",
+      derived: false,
+      line: 5,
+      file: "a.stm",
     };
     const arrowB = {
-      mapping: "m1", namespace: null, sources: ["src.name"], target: "tgt.name",
-      transform_raw: "", steps: [], classification: "nl",
-      derived: false, line: 5, file: "b.stm",
+      mapping: "m1",
+      namespace: null,
+      sources: ["src.name"],
+      target: "tgt.name",
+      transform_raw: "",
+      steps: [],
+      classification: "nl",
+      derived: false,
+      line: 5,
+      file: "b.stm",
     };
     const a = makeIndex(
       {},
@@ -400,20 +550,24 @@ describe("diffIndex", () => {
   it("detects changes in nested child fields", () => {
     const a = makeIndex({
       s1: {
-        fields: [{
-          name: "address",
-          type: "record",
-          children: [{ name: "city", type: "VARCHAR" }],
-        }],
+        fields: [
+          {
+            name: "address",
+            type: "record",
+            children: [{ name: "city", type: "VARCHAR" }],
+          },
+        ],
       },
     });
     const b = makeIndex({
       s1: {
-        fields: [{
-          name: "address",
-          type: "record",
-          children: [{ name: "city", type: "TEXT" }],
-        }],
+        fields: [
+          {
+            name: "address",
+            type: "record",
+            children: [{ name: "city", type: "TEXT" }],
+          },
+        ],
       },
     });
     const delta = diffIndex(a, b);
@@ -431,7 +585,13 @@ describe("diffIndex", () => {
 
 describe("diffIndex anonymous mappings (sl-ndtz)", () => {
   /** Build a minimal anonymous MappingRecord stored under its internal positional key. */
-  const anonMapping = (file: string, row: number, sources: string[], targets: string[], arrowCount = 1) => ({
+  const anonMapping = (
+    file: string,
+    row: number,
+    sources: string[],
+    targets: string[],
+    arrowCount = 1,
+  ) => ({
     [`<anon>@${file}:${row}`]: { name: null, sources, targets, arrowCount, file, row },
   });
 
@@ -466,7 +626,10 @@ describe("diffIndex anonymous mappings (sl-ndtz)", () => {
       ...anonMapping(file, 2, ["src"], ["tgt"]),
       ...anonMapping(file, 9, ["src"], ["tgt"]),
     });
-    const delta = diffIndex(makeIndex({}, twoAnon("/v1/pipe.stm")), makeIndex({}, twoAnon("/v2/pipe.stm")));
+    const delta = diffIndex(
+      makeIndex({}, twoAnon("/v1/pipe.stm")),
+      makeIndex({}, twoAnon("/v2/pipe.stm")),
+    );
 
     assert.equal(delta.mappings.added.length, 0);
     assert.equal(delta.mappings.removed.length, 0);
@@ -476,8 +639,32 @@ describe("diffIndex anonymous mappings (sl-ndtz)", () => {
   it("preserves the namespace prefix on normalized anonymous mapping ids", () => {
     // Namespaced anon mappings are keyed `ns::<anon>@path:row`; the structural
     // id must stay namespace-qualified so scoped blocks do not cross-match.
-    const a = makeIndex({}, { "crm::<anon>@/v1/p.stm:4": { name: null, sources: ["s"], targets: ["t"], arrowCount: 1, file: "/v1/p.stm", row: 4 } });
-    const b = makeIndex({}, { "crm::<anon>@/v2/p.stm:4": { name: null, sources: ["s"], targets: ["t"], arrowCount: 2, file: "/v2/p.stm", row: 4 } });
+    const a = makeIndex(
+      {},
+      {
+        "crm::<anon>@/v1/p.stm:4": {
+          name: null,
+          sources: ["s"],
+          targets: ["t"],
+          arrowCount: 1,
+          file: "/v1/p.stm",
+          row: 4,
+        },
+      },
+    );
+    const b = makeIndex(
+      {},
+      {
+        "crm::<anon>@/v2/p.stm:4": {
+          name: null,
+          sources: ["s"],
+          targets: ["t"],
+          arrowCount: 2,
+          file: "/v2/p.stm",
+          row: 4,
+        },
+      },
+    );
 
     const delta = diffIndex(a, b);
     assert.equal(delta.mappings.changed.length, 1);
@@ -515,7 +702,10 @@ describe("fmt-roundtrip structural identity (sl-dxjh)", () => {
       const s = delta[section];
       for (const name of s.added) lines.push(`${section} added: ${name}`);
       for (const name of s.removed) lines.push(`${section} removed: ${name}`);
-      for (const c of s.changed) lines.push(`${section} changed: ${c.name} (${c.changes.map((ch: any) => ch.kind).join(", ")})`);
+      for (const c of s.changed)
+        lines.push(
+          `${section} changed: ${c.name} (${c.changes.map((ch: any) => ch.kind).join(", ")})`,
+        );
     }
     for (const t of delta.notes.added) lines.push(`note added: ${t.slice(0, 40)}`);
     for (const t of delta.notes.removed) lines.push(`note removed: ${t.slice(0, 40)}`);
@@ -541,7 +731,11 @@ describe("fmt-roundtrip structural identity (sl-dxjh)", () => {
 
       const delta = diffIndex(indexA, indexB);
       const differences = describeDelta(delta);
-      assert.deepEqual(differences, [], `fmt-only changes reported as structural:\n  ${differences.join("\n  ")}`);
+      assert.deepEqual(
+        differences,
+        [],
+        `fmt-only changes reported as structural:\n  ${differences.join("\n  ")}`,
+      );
     });
   }
 });

--- a/tooling/satsuma-cli/test/docs.test.ts
+++ b/tooling/satsuma-cli/test/docs.test.ts
@@ -45,7 +45,10 @@ describe("SATSUMA-CLI.md command coverage", () => {
     const names = commandNamesFromHelp(stdout);
     // Sanity floor: if help parsing ever breaks, fail loudly here rather
     // than silently asserting nothing below.
-    assert.ok(names.length >= 20, `expected to parse a full command list from --help, got ${names.length}`);
+    assert.ok(
+      names.length >= 20,
+      `expected to parse a full command list from --help, got ${names.length}`,
+    );
 
     const reference = readFileSync(CLI_REFERENCE, "utf8");
     const undocumented = names.filter((name) => !reference.includes(`\`${name}`));
@@ -79,13 +82,21 @@ describe("SATSUMA-CLI.md coverage JSON contract", () => {
     // mention, the contract has silently changed — which is exactly the drift
     // calling it "stable" is meant to prevent.
     const { stdout, code } = await runCli(
-      CLI, "coverage", COVERAGE_FIXTURE, "--fail-under", "50", "--json",
+      CLI,
+      "coverage",
+      COVERAGE_FIXTURE,
+      "--fail-under",
+      "50",
+      "--json",
     );
     assert.equal(code, 0);
 
     const keys = [...allKeys(JSON.parse(stdout))];
     // Sanity floor: a parsing slip here must fail loudly, not assert nothing.
-    assert.ok(keys.length >= 10, `expected a populated coverage payload, got keys: ${keys.join(", ")}`);
+    assert.ok(
+      keys.length >= 10,
+      `expected a populated coverage payload, got keys: ${keys.join(", ")}`,
+    );
 
     const reference = readFileSync(CLI_REFERENCE, "utf8");
     const contract = reference.slice(reference.indexOf("#### JSON contract"));

--- a/tooling/satsuma-cli/test/errors.test.ts
+++ b/tooling/satsuma-cli/test/errors.test.ts
@@ -65,7 +65,10 @@ describe("loadFiles", () => {
     // warning goes to stderr.
     const stderrCaptured: string[] = [];
     const origWrite = process.stderr.write;
-    process.stderr.write = ((s: string) => { stderrCaptured.push(s); return true; }) as never;
+    process.stderr.write = ((s: string) => {
+      stderrCaptured.push(s);
+      return true;
+    }) as never;
     try {
       const mockParse = (f: string) => ({ filePath: f, tree: {}, errorCount: 2 });
       const result = loadFiles(["bad.stm"], mockParse as never);
@@ -85,15 +88,18 @@ describe("loadFiles", () => {
     // an empty message because the runner would otherwise double-print).
     const stderrCaptured: string[] = [];
     const origWrite = process.stderr.write;
-    process.stderr.write = ((s: string) => { stderrCaptured.push(s); return true; }) as never;
+    process.stderr.write = ((s: string) => {
+      stderrCaptured.push(s);
+      return true;
+    }) as never;
     try {
-      const mockParse = (_f: string) => { throw new Error("ENOENT"); };
+      const mockParse = (_f: string) => {
+        throw new Error("ENOENT");
+      };
       assert.throws(
         () => loadFiles(["missing.stm"], mockParse as never),
         (err: unknown) =>
-          err instanceof CommandError &&
-          err.code === EXIT_PARSE_ERROR &&
-          err.message === "",
+          err instanceof CommandError && err.code === EXIT_PARSE_ERROR && err.message === "",
       );
       assert.ok(
         stderrCaptured.some((s) => s.includes("could not read or parse missing.stm")),
@@ -134,9 +140,7 @@ describe("notFound", () => {
     // because dumping it is cheaper than making them re-query.
     assert.throws(
       () => notFound("Schema", "xyz", ["a", "b", "c"]),
-      (err: unknown) =>
-        err instanceof CommandError &&
-        err.message.includes("Available: a, b, c"),
+      (err: unknown) => err instanceof CommandError && err.message.includes("Available: a, b, c"),
     );
   });
 
@@ -147,8 +151,7 @@ describe("notFound", () => {
     assert.throws(
       () => notFound("Schema", "xyz", many),
       (err: unknown) =>
-        err instanceof CommandError &&
-        err.message.includes("15 schemas in workspace"),
+        err instanceof CommandError && err.message.includes("15 schemas in workspace"),
     );
   });
 
@@ -158,9 +161,7 @@ describe("notFound", () => {
     // findSuggestion's exact-match branch.
     assert.throws(
       () => notFound("Schema", "orders", ["orders", "customers"]),
-      (err: unknown) =>
-        err instanceof CommandError &&
-        !err.message.includes("Did you mean"),
+      (err: unknown) => err instanceof CommandError && !err.message.includes("Did you mean"),
     );
   });
 });

--- a/tooling/satsuma-cli/test/field-lineage.test.ts
+++ b/tooling/satsuma-cli/test/field-lineage.test.ts
@@ -27,15 +27,31 @@ describe("field-lineage --upstream --downstream (sl-nknd)", () => {
     // intermediate_b.id has both upstream (source_a.id) and downstream (intermediate_c.id)
     const chainFixture = resolve(FIXTURES, "lineage-chain.stm");
     const { stdout: bothOut, code: bothCode } = await run(
-      "field-lineage", "intermediate_b.id", chainFixture, "--json", "--upstream", "--downstream",
+      "field-lineage",
+      "intermediate_b.id",
+      chainFixture,
+      "--json",
+      "--upstream",
+      "--downstream",
     );
     assert.equal(bothCode, 0, `expected exit 0, got ${bothCode}\n${bothOut}`);
     const both = JSON.parse(bothOut);
-    assert.ok(both.upstream.length > 0, "upstream should be non-empty when --upstream --downstream");
-    assert.ok(both.downstream.length > 0, "downstream should be non-empty when --upstream --downstream");
+    assert.ok(
+      both.upstream.length > 0,
+      "upstream should be non-empty when --upstream --downstream",
+    );
+    assert.ok(
+      both.downstream.length > 0,
+      "downstream should be non-empty when --upstream --downstream",
+    );
 
     // Should match result with no direction flags
-    const { stdout: allOut } = await run("field-lineage", "intermediate_b.id", chainFixture, "--json");
+    const { stdout: allOut } = await run(
+      "field-lineage",
+      "intermediate_b.id",
+      chainFixture,
+      "--json",
+    );
     const all = JSON.parse(allOut);
     assert.deepEqual(both.upstream, all.upstream, "upstream should match no-flag result");
     assert.deepEqual(both.downstream, all.downstream, "downstream should match no-flag result");
@@ -43,7 +59,13 @@ describe("field-lineage --upstream --downstream (sl-nknd)", () => {
 
   it("--upstream alone only returns upstream", async () => {
     const chainFixture = resolve(FIXTURES, "lineage-chain.stm");
-    const { stdout, code } = await run("field-lineage", "intermediate_b.id", chainFixture, "--json", "--upstream");
+    const { stdout, code } = await run(
+      "field-lineage",
+      "intermediate_b.id",
+      chainFixture,
+      "--json",
+      "--upstream",
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.upstream.length > 0, "upstream should be non-empty");
@@ -52,7 +74,13 @@ describe("field-lineage --upstream --downstream (sl-nknd)", () => {
 
   it("--downstream alone only returns downstream", async () => {
     const chainFixture = resolve(FIXTURES, "lineage-chain.stm");
-    const { stdout, code } = await run("field-lineage", "intermediate_b.id", chainFixture, "--json", "--downstream");
+    const { stdout, code } = await run(
+      "field-lineage",
+      "intermediate_b.id",
+      chainFixture,
+      "--json",
+      "--downstream",
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.upstream.length, 0, "upstream should be empty with --downstream only");
@@ -69,7 +97,10 @@ describe("field-lineage anonymous mappings (sl-m44v)", () => {
     const { stdout, code } = await run("field-lineage", "invoices.total", fixture, "--json");
     assert.equal(code, 0, `expected exit 0, got ${code}\n${stdout}`);
     const data = JSON.parse(stdout);
-    assert.ok(data.upstream.length > 0, "upstream should contain orders.amount via anonymous mapping");
+    assert.ok(
+      data.upstream.length > 0,
+      "upstream should contain orders.amount via anonymous mapping",
+    );
     const upstreamFields = data.upstream.map((u: any) => u.field);
     assert.ok(
       upstreamFields.some((f: any) => f.includes("orders") && f.includes("amount")),
@@ -82,7 +113,10 @@ describe("field-lineage anonymous mappings (sl-m44v)", () => {
     const { stdout, code } = await run("field-lineage", "orders.amount", fixture, "--json");
     assert.equal(code, 0, `expected exit 0, got ${code}\n${stdout}`);
     const data = JSON.parse(stdout);
-    assert.ok(data.downstream.length > 0, "downstream should contain invoices.total via anonymous mapping");
+    assert.ok(
+      data.downstream.length > 0,
+      "downstream should contain invoices.total via anonymous mapping",
+    );
     const downstreamFields = data.downstream.map((d: any) => d.field);
     assert.ok(
       downstreamFields.some((f: any) => f.includes("invoices") && f.includes("total")),
@@ -111,7 +145,12 @@ describe("field-lineage with typeless fields", () => {
   const fixture = resolve(FIXTURES, "typeless-field-lineage.stm");
 
   it("finds a typeless direct field before spreads in its schema", async () => {
-    const { stdout, code, stderr } = await run("field-lineage", "source_schema.PK_ID", fixture, "--json");
+    const { stdout, code, stderr } = await run(
+      "field-lineage",
+      "source_schema.PK_ID",
+      fixture,
+      "--json",
+    );
     assert.equal(code, 0, `expected exit 0, got ${code}\n${stderr}`);
     const data = JSON.parse(stdout);
     assert.ok(
@@ -148,8 +187,11 @@ describe("field-lineage same-line arrows sharing a target (sl-201z)", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const upstreamFields = (data.upstream as any[]).map((e) => e.field).sort();
-    assert.deepEqual(upstreamFields, ["::s.a", "::s.b"],
-      "both same-line arrows should contribute an upstream connection");
+    assert.deepEqual(
+      upstreamFields,
+      ["::s.a", "::s.b"],
+      "both same-line arrows should contribute an upstream connection",
+    );
   });
 });
 
@@ -163,11 +205,21 @@ describe("field-lineage NL-derived edges in namespaced mappings (sl-njej)", () =
     // producing "ns::ns::load_s2" — the mapping lookup failed and the
     // nl-derived edge was silently dropped (graph showed it; field-lineage didn't).
     const fixture = resolve(FIXTURES, "ns-nl-lineage.stm");
-    const { stdout, code } = await run("field-lineage", "ns::s2.x", fixture, "--json", "--upstream");
+    const { stdout, code } = await run(
+      "field-lineage",
+      "ns::s2.x",
+      fixture,
+      "--json",
+      "--upstream",
+    );
     assert.equal(code, 0, `expected exit 0\n${stdout}`);
     const data = JSON.parse(stdout);
     const nlEdges = (data.upstream as any[]).filter((e) => e.classification === "nl-derived");
-    assert.equal(nlEdges.length, 1, `expected one nl-derived upstream edge, got: ${JSON.stringify(data.upstream)}`);
+    assert.equal(
+      nlEdges.length,
+      1,
+      `expected one nl-derived upstream edge, got: ${JSON.stringify(data.upstream)}`,
+    );
     assert.equal(nlEdges[0].field, "ns::s1.a");
     assert.equal(nlEdges[0].via_mapping, "ns::load_s2");
   });
@@ -188,11 +240,16 @@ describe("field-lineage — NL @refs inside containers (sl-hrql, sl-ez36)", () =
 
   it("anchors the nl-derived edge on the nested source field, not the schema root", async () => {
     const { stdout, code } = await run(
-      "field-lineage", "sap_purchase_order.Items.MEINS", SAP, "--json", "--downstream",
+      "field-lineage",
+      "sap_purchase_order.Items.MEINS",
+      SAP,
+      "--json",
+      "--downstream",
     );
     assert.equal(code, 0, `expected exit 0\n${stdout}`);
-    const nlEdges = (JSON.parse(stdout).downstream as any[])
-      .filter((e) => e.classification === "nl-derived");
+    const nlEdges = (JSON.parse(stdout).downstream as any[]).filter(
+      (e) => e.classification === "nl-derived",
+    );
     assert.deepEqual(
       nlEdges.map((e) => e.field),
       ["::mfcs_purchase_order.items.orderedQty"],
@@ -205,7 +262,11 @@ describe("field-lineage — NL @refs inside containers (sl-hrql, sl-ez36)", () =
     // name (the index is indexed by leaf too), so the assertion that matters is
     // that no edge hangs off it any more.
     const { stdout, code } = await run(
-      "field-lineage", "sap_purchase_order.MEINS", SAP, "--json", "--downstream",
+      "field-lineage",
+      "sap_purchase_order.MEINS",
+      SAP,
+      "--json",
+      "--downstream",
     );
     assert.equal(code, 0, `expected exit 0\n${stdout}`);
     assert.deepEqual(JSON.parse(stdout).downstream, []);
@@ -217,10 +278,12 @@ describe("field-lineage — NL @refs inside containers (sl-hrql, sl-ez36)", () =
     // source line. Any consumer building a graph got two nodes for one field.
     const { stdout, code } = await run("graph", SAP, "--json");
     assert.equal(code, 0, `expected exit 0\n${stdout}`);
-    const edges = (JSON.parse(stdout).edges as any[])
-      .filter((e) => e.to.endsWith("orderedQty"));
+    const edges = (JSON.parse(stdout).edges as any[]).filter((e) => e.to.endsWith("orderedQty"));
     const targets = [...new Set(edges.map((e) => e.to))];
-    assert.deepEqual(targets, ["::mfcs_purchase_order.items.orderedQty"],
-      "nl and nl-derived edges for one arrow must name one target field");
+    assert.deepEqual(
+      targets,
+      ["::mfcs_purchase_order.items.orderedQty"],
+      "nl and nl-derived edges for one arrow must name one target field",
+    );
   });
 });

--- a/tooling/satsuma-cli/test/field-positions.test.ts
+++ b/tooling/satsuma-cli/test/field-positions.test.ts
@@ -54,7 +54,12 @@ describe("fieldDeclarationRow()", () => {
     // startRow here is row 3 of the *fragment's* file. Reporting it alongside
     // the consuming schema's file would send a jump link into the wrong file at
     // a plausible-looking line, so the consuming entity's row wins.
-    const field: ExpandedField = { name: "email", type: "STRING", startRow: 3, fromFragment: "contact" };
+    const field: ExpandedField = {
+      name: "email",
+      type: "STRING",
+      startRow: 3,
+      fromFragment: "contact",
+    };
     assert.equal(fieldDeclarationRow(field, CONSUMER, false), CONSUMER.row);
   });
 
@@ -105,13 +110,8 @@ schema customer {
     const root = parse(source).rootNode;
     const schema = extractSchemas(root).find((s) => s.name === "customer");
     assert.ok(schema, "expected the customer schema to be extracted");
-    const index = buildIndex([
-      parsedFile(SCHEMA_FILE, source),
-    ]);
-    const fields = [
-      ...schema.fields,
-      ...expandEntityFields(schema, null, index),
-    ];
+    const index = buildIndex([parsedFile(SCHEMA_FILE, source)]);
+    const fields = [...schema.fields, ...expandEntityFields(schema, null, index)];
     const projected = toCoverageFields(fields, { file: SCHEMA_FILE, row: schema.row });
     assert.deepEqual(projected, [
       // `id` is declared at row 5 of this file, so it keeps its own position.
@@ -140,9 +140,7 @@ schema place {
     const root = parse(source).rootNode;
     const schema = extractSchemas(root).find((s) => s.name === "place");
     assert.ok(schema, "expected the place schema to be extracted");
-    const index = buildIndex([
-      parsedFile(SCHEMA_FILE, source),
-    ]);
+    const index = buildIndex([parsedFile(SCHEMA_FILE, source)]);
     expandNestedSpreads(schema.fields, null, index);
     const projected = toCoverageFields(schema.fields, { file: SCHEMA_FILE, row: schema.row });
     const location = projected[0];
@@ -166,14 +164,15 @@ describe("FieldDecl positions through the index", () => {
   id INT
   name STRING
 }`;
-    const index = buildIndex([
-      parsedFile(SCHEMA_FILE, source),
-    ]);
+    const index = buildIndex([parsedFile(SCHEMA_FILE, source)]);
     const schema = index.schemas.get("src");
     assert.ok(schema, "expected schema 'src' in the index");
     assert.deepEqual(
       schema.fields.map((f) => [f.name, f.startRow, f.startColumn]),
-      [["id", 1, 2], ["name", 2, 2]],
+      [
+        ["id", 1, 2],
+        ["name", 2, 2],
+      ],
     );
   });
 
@@ -188,10 +187,7 @@ describe("FieldDecl positions through the index", () => {
 
   extra STRING
 }`;
-    const index = buildIndex([
-      parsedFile(SCHEMA_FILE, fileA),
-      parsedFile(SECOND_FILE, fileB),
-    ]);
+    const index = buildIndex([parsedFile(SCHEMA_FILE, fileA), parsedFile(SECOND_FILE, fileB)]);
     const schema = index.schemas.get("src");
     assert.ok(schema, "expected schema 'src' in the index");
     const extra = schema.fields.find((f) => f.name === "extra");
@@ -204,9 +200,11 @@ describe("extracted fragments carry positions too", () => {
     // The spread rule exists precisely because fragment fields have real rows
     // in the wrong file. If fragments carried no rows the rule would be moot,
     // so this pins the premise the rule rests on.
-    const [fragment] = extractFragments(parse(`fragment contact {
+    const [fragment] = extractFragments(
+      parse(`fragment contact {
   email STRING
-}`).rootNode);
+}`).rootNode,
+    );
     assert.equal(fragment.fields[0]?.startRow, 1);
   });
 });

--- a/tooling/satsuma-cli/test/fmt.test.ts
+++ b/tooling/satsuma-cli/test/fmt.test.ts
@@ -40,8 +40,10 @@ describe("satsuma fmt --check", () => {
     try {
       const { code, stdout } = await satsuma("fmt", "--check", messyFile);
       assert.equal(code, 1, "should exit 1 when file would change");
-      assert.ok(stdout.includes("messy.stm") || stdout.includes("messy"),
-        "should print the filename that would change");
+      assert.ok(
+        stdout.includes("messy.stm") || stdout.includes("messy"),
+        "should print the filename that would change",
+      );
     } finally {
       unlinkSync(messyFile);
     }

--- a/tooling/satsuma-cli/test/graph.test.ts
+++ b/tooling/satsuma-cli/test/graph.test.ts
@@ -129,7 +129,9 @@ describe("satsuma graph --json", () => {
     // consumers complete metric field information.
     const { stdout } = await run("graph", "--json", PLATFORM);
     const data = JSON.parse(stdout);
-    const metric = data.nodes.find((n: any) => n.kind === "metric" && n.fields && n.fields.length > 0);
+    const metric = data.nodes.find(
+      (n: any) => n.kind === "metric" && n.fields && n.fields.length > 0,
+    );
     assert.ok(metric, "should have a metric node with fields");
     assert.ok(Array.isArray(metric.fields));
     assert.ok("name" in metric.fields[0]);
@@ -231,18 +233,32 @@ describe("satsuma graph --schema-only", () => {
   });
 
   it("produces no duplicate edges for namespaced mappings (sl-057k)", async () => {
-    const { stdout, code } = await run("graph", "--json", "--schema-only", resolve(FIXTURES, "namespaces.stm"));
+    const { stdout, code } = await run(
+      "graph",
+      "--json",
+      "--schema-only",
+      resolve(FIXTURES, "namespaces.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     // Collect all edge keys to detect duplicates
     const edgeKeys = data.edges.map((e: any) => `${e.from}->${e.to}:${e.mapping}`);
     const unique = new Set(edgeKeys);
-    assert.equal(edgeKeys.length, unique.size, `duplicate edges found: ${JSON.stringify(edgeKeys)}`);
+    assert.equal(
+      edgeKeys.length,
+      unique.size,
+      `duplicate edges found: ${JSON.stringify(edgeKeys)}`,
+    );
     // Edges for the namespaced mapping should use qualified name
-    const warehouseEdges = data.edges.filter((e: any) => e.mapping && e.mapping.includes("warehouse::"));
+    const warehouseEdges = data.edges.filter(
+      (e: any) => e.mapping && e.mapping.includes("warehouse::"),
+    );
     assert.ok(warehouseEdges.length > 0, "should have edges with namespace-qualified mapping name");
     for (const e of warehouseEdges) {
-      assert.ok(e.mapping.startsWith("warehouse::"), `mapping should be namespace-qualified: ${e.mapping}`);
+      assert.ok(
+        e.mapping.startsWith("warehouse::"),
+        `mapping should be namespace-qualified: ${e.mapping}`,
+      );
     }
   });
 
@@ -270,7 +286,10 @@ describe("satsuma graph --namespace", () => {
     const warehouseNodes = data.nodes.filter((n: any) => n.namespace === "warehouse");
     assert.ok(warehouseNodes.length > 0, "should have warehouse-namespace nodes");
     assert.ok(data.stats.schemas > 0, "stats.schemas should count warehouse schemas");
-    assert.ok(data.stats.schemas < 49, "stats.schemas should be less than the full workspace count");
+    assert.ok(
+      data.stats.schemas < 49,
+      "stats.schemas should be less than the full workspace count",
+    );
   });
 
   it("schema_edges reference only nodes present in the nodes array (sl-p895)", async () => {
@@ -290,7 +309,9 @@ describe("satsuma graph --namespace", () => {
     const { stdout } = await run("graph", "--json", "--namespace", "warehouse", PLATFORM);
     const data = JSON.parse(stdout);
     // warehouse mappings have sources from other namespaces (e.g. pos::stores)
-    const crossNs = data.schema_edges.find((e: any) => e.from.includes("pos::") || e.from.includes("ecom::"));
+    const crossNs = data.schema_edges.find(
+      (e: any) => e.from.includes("pos::") || e.from.includes("ecom::"),
+    );
     assert.ok(crossNs, "should include cross-namespace source edges");
   });
 
@@ -373,7 +394,11 @@ describe("satsuma graph (nl-derived edges in namespace workspaces)", () => {
     // Before this fix, the graph builder double-prefixed the namespace on
     // the mapping key (ns::ns::name), causing zero nl-derived edges for
     // namespace workspaces despite nl-refs resolving successfully.
-    const { stdout, code } = await run("graph", "--json", resolve(EXAMPLES, "namespaces/ns-merging.stm"));
+    const { stdout, code } = await run(
+      "graph",
+      "--json",
+      resolve(EXAMPLES, "namespaces/ns-merging.stm"),
+    );
     assert.ok(code === 0 || code === 2);
     const data = JSON.parse(stdout);
     const nlDerived = data.edges.filter((e: any) => e.classification === "nl-derived");
@@ -381,7 +406,10 @@ describe("satsuma graph (nl-derived edges in namespace workspaces)", () => {
 
     // All nl-derived edges should reference namespace-qualified mappings
     for (const e of nlDerived) {
-      assert.ok(e.mapping.includes("::"), `nl-derived edge mapping should be namespace-qualified: ${e.mapping}`);
+      assert.ok(
+        e.mapping.includes("::"),
+        `nl-derived edge mapping should be namespace-qualified: ${e.mapping}`,
+      );
     }
   });
 });
@@ -434,7 +462,11 @@ describe("satsuma graph (slices)", () => {
   });
 
   it("nested arrow children have correct from/to (sl-6dt1, sl-9uh0)", async () => {
-    const { stdout, code } = await run("graph", "--json", resolve(EXAMPLES, "sap-po-to-mfcs/pipeline.stm"));
+    const { stdout, code } = await run(
+      "graph",
+      "--json",
+      resolve(EXAMPLES, "sap-po-to-mfcs/pipeline.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
 
@@ -454,7 +486,10 @@ describe("satsuma graph (slices)", () => {
     // Specifically check .TXZ01 -> .description (the last nested arrow, previously broken)
     const txz = childEdges.find((e: any) => e.from.endsWith(".TXZ01"));
     assert.ok(txz, "should find TXZ01 edge");
-    assert.ok(txz.to.endsWith(".description"), `TXZ01 target should be .description, got ${txz.to}`);
+    assert.ok(
+      txz.to.endsWith(".description"),
+      `TXZ01 target should be .description, got ${txz.to}`,
+    );
   });
 });
 
@@ -472,8 +507,10 @@ describe("satsuma graph (anonymous mapping edges, sl-riw5)", () => {
 
     for (const edge of data.edges) {
       // mapping key must not be empty
-      assert.ok(edge.mapping && edge.mapping.length > 0,
-        `edge mapping key should not be empty: ${JSON.stringify(edge)}`);
+      assert.ok(
+        edge.mapping && edge.mapping.length > 0,
+        `edge mapping key should not be empty: ${JSON.stringify(edge)}`,
+      );
 
       // from/to must be schema-qualified (contain a dot or :: prefix)
       if (edge.from) {
@@ -491,7 +528,9 @@ describe("satsuma graph (anonymous mapping edges, sl-riw5)", () => {
     }
 
     // The anonymous mapping node should appear in nodes[] with the <anon> key
-    const anonMapping = data.nodes.find((n: any) => n.kind === "mapping" && n.id.includes("<anon>"));
+    const anonMapping = data.nodes.find(
+      (n: any) => n.kind === "mapping" && n.id.includes("<anon>"),
+    );
     assert.ok(anonMapping, "should have an anonymous mapping node with <anon> in id");
 
     // Edges should reference that anonymous mapping key
@@ -500,11 +539,18 @@ describe("satsuma graph (anonymous mapping edges, sl-riw5)", () => {
 
     // Specifically: orders.amount -> invoices.total
     const amountToTotal = data.edges.find(
-      (e: any) => e.from && e.from.includes("orders") && e.from.includes("amount") &&
-             e.to && e.to.includes("invoices") && e.to.includes("total"),
+      (e: any) =>
+        e.from &&
+        e.from.includes("orders") &&
+        e.from.includes("amount") &&
+        e.to &&
+        e.to.includes("invoices") &&
+        e.to.includes("total"),
     );
-    assert.ok(amountToTotal,
-      `should have edge orders.amount -> invoices.total, got: ${JSON.stringify(data.edges)}`);
+    assert.ok(
+      amountToTotal,
+      `should have edge orders.amount -> invoices.total, got: ${JSON.stringify(data.edges)}`,
+    );
   });
 });
 
@@ -533,15 +579,22 @@ describe("satsuma graph vs summary (nl-derived count consistency)", () => {
     const summaryData = JSON.parse(summaryResult.stdout);
 
     // graph stats.arrows counts all edges in the output array.
-    assert.equal(graphData.stats.arrows, graphData.edges.length,
-      "stats.arrows should equal the number of edges in the output");
+    assert.equal(
+      graphData.stats.arrows,
+      graphData.edges.length,
+      "stats.arrows should equal the number of edges in the output",
+    );
 
     // summary arrowCount must equal graph stats.arrows for the same workspace.
     const summaryTotal = (summaryData.mappings as any[]).reduce(
-      (sum: number, m: any) => sum + (m.arrowCount as number), 0,
+      (sum: number, m: any) => sum + (m.arrowCount as number),
+      0,
     );
-    assert.equal(summaryTotal, graphData.stats.arrows,
-      "summary arrowCount sum should equal graph stats.arrows for the same workspace");
+    assert.equal(
+      summaryTotal,
+      graphData.stats.arrows,
+      "summary arrowCount sum should equal graph stats.arrows for the same workspace",
+    );
   });
 });
 
@@ -559,8 +612,10 @@ describe("satsuma graph (same-line arrows sharing a target, sl-201z)", () => {
     const data = JSON.parse(stdout);
     const pairs = (data.edges as any[]).map((e) => `${e.from}->${e.to}`);
     assert.ok(pairs.includes("::s.a->::t.x"), "edge from s.a should be present");
-    assert.ok(pairs.includes("::s.b->::t.x"),
-      "edge from s.b (same line, same target as s.a->x) should be present");
+    assert.ok(
+      pairs.includes("::s.b->::t.x"),
+      "edge from s.b (same line, same target as s.a->x) should be present",
+    );
     assert.equal(data.stats.arrows, 2, "both same-line arrows should be counted");
   });
 });

--- a/tooling/satsuma-cli/test/helpers.ts
+++ b/tooling/satsuma-cli/test/helpers.ts
@@ -29,7 +29,7 @@ export function run(cli: string, ...args: string[]): Promise<RunResult> {
       resolve({
         stdout: stdout ?? "",
         stderr: stderr ?? "",
-        code: err ? err.code ?? 1 : 0,
+        code: err ? (err.code ?? 1) : 0,
       });
     });
   });
@@ -46,7 +46,10 @@ export interface MockNode {
   text: string;
   startPosition: { row: number; column: number };
   namedChildren: MockNode[];
-  children: Array<MockNode | { type: string; text: string; isNamed: boolean; namedChildren: never[]; children: never[] }>;
+  children: Array<
+    | MockNode
+    | { type: string; text: string; isNamed: boolean; namedChildren: never[]; children: never[] }
+  >;
   isNamed: boolean;
 }
 
@@ -61,8 +64,11 @@ export function mockNode(
   const children: MockNode["children"] = [];
   children.push(
     ...anonymousChildren.map((t) => ({
-      type: t, text: t, isNamed: false as const,
-      namedChildren: [] as never[], children: [] as never[],
+      type: t,
+      text: t,
+      isNamed: false as const,
+      namedChildren: [] as never[],
+      children: [] as never[],
     })),
   );
   children.push(...namedChildren.map((c) => ({ ...c, isNamed: true as const })));

--- a/tooling/satsuma-cli/test/import-reachability.test.ts
+++ b/tooling/satsuma-cli/test/import-reachability.test.ts
@@ -21,10 +21,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 import { run as _run } from "./helpers.js";
-import {
-  computeSymbolDependencies,
-  computeImportReachability,
-} from "@satsuma/core";
+import { computeSymbolDependencies, computeImportReachability } from "@satsuma/core";
 import type { SemanticIndex } from "@satsuma/core";
 
 const describe = (name: string, fn: () => void) => _describe(name, { concurrency: true }, fn);
@@ -40,7 +37,13 @@ const run = (...args: string[]) => _run(CLI, ...args);
 function makeSemanticIndex(opts: {
   schemas?: Array<{ key: string; file: string; namespace?: string; spreads?: string[] }>;
   fragments?: Array<{ key: string; file: string; namespace?: string; spreads?: string[] }>;
-  mappings?: Array<{ key: string; file: string; namespace?: string; sources: string[]; targets: string[] }>;
+  mappings?: Array<{
+    key: string;
+    file: string;
+    namespace?: string;
+    sources: string[];
+    targets: string[];
+  }>;
   metrics?: Array<{ key: string; file: string; namespace?: string; sources?: string[] }>;
   transforms?: Array<{ key: string; file: string }>;
 }): SemanticIndex {
@@ -122,8 +125,10 @@ describe("computeSymbolDependencies", () => {
       fragments: [{ key: "shared_fields", file: "a.stm" }],
     });
     const deps = computeSymbolDependencies(index);
-    assert.ok(deps.get("my_schema")?.has("shared_fields"),
-      "schema should depend on its spread fragment");
+    assert.ok(
+      deps.get("my_schema")?.has("shared_fields"),
+      "schema should depend on its spread fragment",
+    );
   });
 
   it("records mapping → source and target schema dependencies", () => {
@@ -133,10 +138,14 @@ describe("computeSymbolDependencies", () => {
         { key: "src_schema", file: "a.stm" },
         { key: "tgt_schema", file: "a.stm" },
       ],
-      mappings: [{
-        key: "my_mapping", file: "a.stm",
-        sources: ["src_schema"], targets: ["tgt_schema"],
-      }],
+      mappings: [
+        {
+          key: "my_mapping",
+          file: "a.stm",
+          sources: ["src_schema"],
+          targets: ["tgt_schema"],
+        },
+      ],
     });
     const deps = computeSymbolDependencies(index);
     const mappingDeps = deps.get("my_mapping");
@@ -153,8 +162,10 @@ describe("computeSymbolDependencies", () => {
       ],
     });
     const deps = computeSymbolDependencies(index);
-    assert.ok(deps.get("extended_fields")?.has("base_fields"),
-      "fragment should depend on its spread fragment");
+    assert.ok(
+      deps.get("extended_fields")?.has("base_fields"),
+      "fragment should depend on its spread fragment",
+    );
   });
 
   it("records metric → source schema dependency", () => {
@@ -164,8 +175,10 @@ describe("computeSymbolDependencies", () => {
       metrics: [{ key: "revenue", file: "a.stm", sources: ["revenue_data"] }],
     });
     const deps = computeSymbolDependencies(index);
-    assert.ok(deps.get("revenue")?.has("revenue_data"),
-      "metric should depend on its source schema");
+    assert.ok(
+      deps.get("revenue")?.has("revenue_data"),
+      "metric should depend on its source schema",
+    );
   });
 
   it("returns empty deps for symbols with no references", () => {
@@ -195,10 +208,14 @@ describe("computeImportReachability", () => {
       ["/b.stm", []],
     ]);
     const result = computeImportReachability(index, fileImports);
-    assert.ok(result.reachableSymbols.get("/a.stm")?.has("local_a"),
-      "a.stm should see its own symbol");
-    assert.ok(!result.reachableSymbols.get("/a.stm")?.has("local_b"),
-      "a.stm should NOT see b.stm's symbol without an import");
+    assert.ok(
+      result.reachableSymbols.get("/a.stm")?.has("local_a"),
+      "a.stm should see its own symbol",
+    );
+    assert.ok(
+      !result.reachableSymbols.get("/a.stm")?.has("local_b"),
+      "a.stm should NOT see b.stm's symbol without an import",
+    );
   });
 
   it("explicitly imported symbols are reachable", () => {
@@ -214,8 +231,10 @@ describe("computeImportReachability", () => {
       ["/top.stm", [{ names: ["imported_schema"], resolvedFile: "/base.stm" }]],
     ]);
     const result = computeImportReachability(index, fileImports);
-    assert.ok(result.reachableSymbols.get("/top.stm")?.has("imported_schema"),
-      "top.stm should see explicitly imported symbol");
+    assert.ok(
+      result.reachableSymbols.get("/top.stm")?.has("imported_schema"),
+      "top.stm should see explicitly imported symbol",
+    );
   });
 
   it("transitive dependencies of imported symbols are reachable", () => {
@@ -234,10 +253,11 @@ describe("computeImportReachability", () => {
     });
     const result = computeImportReachability(index2, fileImports);
     const topReachable = result.reachableSymbols.get("/top.stm");
-    assert.ok(topReachable?.has("my_schema"),
-      "imported schema should be reachable");
-    assert.ok(topReachable?.has("shared_fields"),
-      "spread fragment (transitive dep) should be reachable");
+    assert.ok(topReachable?.has("my_schema"), "imported schema should be reachable");
+    assert.ok(
+      topReachable?.has("shared_fields"),
+      "spread fragment (transitive dep) should be reachable",
+    );
   });
 
   it("unrelated symbols in transitively reachable files are NOT reachable (sl-cf9t repro)", () => {
@@ -266,10 +286,14 @@ describe("computeImportReachability", () => {
     });
     const result = computeImportReachability(fullIndex, fileImports);
     const topReachable = result.reachableSymbols.get("/top.stm");
-    assert.ok(topReachable?.has("middle_schema"),
-      "middle_schema should be reachable (explicitly imported)");
-    assert.ok(!topReachable?.has("my_transform"),
-      "my_transform should NOT be reachable (not a dependency of middle_schema)");
+    assert.ok(
+      topReachable?.has("middle_schema"),
+      "middle_schema should be reachable (explicitly imported)",
+    );
+    assert.ok(
+      !topReachable?.has("my_transform"),
+      "my_transform should NOT be reachable (not a dependency of middle_schema)",
+    );
   });
 
   it("resolves namespace-qualified import names", () => {
@@ -285,8 +309,10 @@ describe("computeImportReachability", () => {
       ["/top.stm", [{ names: ["ns::my_schema"], resolvedFile: "/base.stm" }]],
     ]);
     const result = computeImportReachability(index, fileImports);
-    assert.ok(result.reachableSymbols.get("/top.stm")?.has("ns::my_schema"),
-      "namespace-qualified import should be reachable");
+    assert.ok(
+      result.reachableSymbols.get("/top.stm")?.has("ns::my_schema"),
+      "namespace-qualified import should be reachable",
+    );
   });
 
   it("resolves bare import names to namespace-qualified keys", () => {
@@ -303,8 +329,10 @@ describe("computeImportReachability", () => {
       ["/top.stm", [{ names: ["my_schema"], resolvedFile: "/base.stm" }]],
     ]);
     const result = computeImportReachability(index, fileImports);
-    assert.ok(result.reachableSymbols.get("/top.stm")?.has("ns::my_schema"),
-      "bare name should resolve to namespace-qualified key in imported file");
+    assert.ok(
+      result.reachableSymbols.get("/top.stm")?.has("ns::my_schema"),
+      "bare name should resolve to namespace-qualified key in imported file",
+    );
   });
 
   it("chains transitive dependencies through multiple import hops", () => {
@@ -326,8 +354,10 @@ describe("computeImportReachability", () => {
     const result = computeImportReachability(index, fileImports);
     const topReachable = result.reachableSymbols.get("/top.stm");
     assert.ok(topReachable?.has("middle_schema"), "imported schema should be reachable");
-    assert.ok(topReachable?.has("shared_fields"),
-      "fragment spread by imported schema should be transitively reachable");
+    assert.ok(
+      topReachable?.has("shared_fields"),
+      "fragment spread by imported schema should be transitively reachable",
+    );
   });
 });
 
@@ -338,11 +368,7 @@ describe("satsuma validate import-scope (sl-cf9t)", () => {
     // Repro case from sl-cf9t: top.stm uses my_transform via middle.stm's
     // import graph, but my_transform is not a dependency of middle_schema.
     const dir = createTempWorkspace({
-      "base.stm": [
-        "transform my_transform {",
-        "  trim | lowercase",
-        "}",
-      ].join("\n"),
+      "base.stm": ["transform my_transform {", "  trim | lowercase", "}"].join("\n"),
       "middle.stm": [
         'import { my_transform } from "./base.stm"',
         "",
@@ -373,11 +399,7 @@ describe("satsuma validate import-scope (sl-cf9t)", () => {
   it("passes when all referenced symbols are properly imported", async () => {
     // Correctly importing my_transform should produce no import-scope errors.
     const dir = createTempWorkspace({
-      "base.stm": [
-        "transform my_transform {",
-        "  trim | lowercase",
-        "}",
-      ].join("\n"),
+      "base.stm": ["transform my_transform {", "  trim | lowercase", "}"].join("\n"),
       "pipeline.stm": [
         'import { my_transform } from "./base.stm"',
         "",
@@ -396,8 +418,10 @@ describe("satsuma validate import-scope (sl-cf9t)", () => {
     });
     const { stdout, stderr, code: _code } = await run("validate", join(dir, "pipeline.stm"));
     const output = stdout + stderr;
-    assert.ok(!output.includes("import-scope"),
-      `should not report import-scope violation for properly imported symbols, got: ${output}`);
+    assert.ok(
+      !output.includes("import-scope"),
+      `should not report import-scope violation for properly imported symbols, got: ${output}`,
+    );
   });
 
   it("allows references to locally-defined symbols without imports", async () => {
@@ -416,8 +440,10 @@ describe("satsuma validate import-scope (sl-cf9t)", () => {
     });
     const { stdout, stderr, code: _code } = await run("validate", join(dir, "standalone.stm"));
     const output = stdout + stderr;
-    assert.ok(!output.includes("import-scope"),
-      `single-file workspace should not produce import-scope errors, got: ${output}`);
+    assert.ok(
+      !output.includes("import-scope"),
+      `single-file workspace should not produce import-scope errors, got: ${output}`,
+    );
   });
 
   it("reports error for fragment spread from unreachable file", async () => {

--- a/tooling/satsuma-cli/test/integration.test.ts
+++ b/tooling/satsuma-cli/test/integration.test.ts
@@ -116,8 +116,10 @@ describe("satsuma summary", () => {
     const data = JSON.parse(stdout);
     const mapping = data.mappings[0];
     assert.ok(mapping.nlDerivedArrowCount > 0, "should have nl-derived arrows");
-    assert.ok(mapping.arrowCount > mapping.nlDerivedArrowCount,
-      "arrowCount should include both declared and nl-derived arrows");
+    assert.ok(
+      mapping.arrowCount > mapping.nlDerivedArrowCount,
+      "arrowCount should include both declared and nl-derived arrows",
+    );
   });
 
   it("--json totalErrors counts MISSING nodes, not just ERROR nodes (sl-8s4b)", async () => {
@@ -174,7 +176,12 @@ describe("satsuma schema", () => {
 
   it("--json line is 1-indexed (sl-2usp)", async () => {
     // 0→1 offset conversion tested in extract.test.ts; here we verify CLI end-to-end.
-    const { stdout, code } = await run("schema", "country_codes", "--json", resolve(EXAMPLES, "lib/common.stm"));
+    const { stdout, code } = await run(
+      "schema",
+      "country_codes",
+      "--json",
+      resolve(EXAMPLES, "lib/common.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.line, 4, "country_codes starts on line 4 (1-indexed)");
@@ -289,7 +296,10 @@ describe("satsuma schema", () => {
     const F = resolve(import.meta.dirname, "fixtures", "nested-record-spread.stm");
     const { stdout, code } = await run("validate", F);
     assert.equal(code, 0);
-    assert.ok(!stdout.includes("field-not-in-schema"), "should not report field-not-in-schema for spread fields");
+    assert.ok(
+      !stdout.includes("field-not-in-schema"),
+      "should not report field-not-in-schema for spread fields",
+    );
   });
 
   it("--json --compact strips comments from fieldLines (sl-xtpd)", async () => {
@@ -303,7 +313,13 @@ describe("satsuma schema", () => {
   });
 
   it("--json --compact omits note field (sl-5fbn)", async () => {
-    const { stdout, code } = await run("schema", "country_codes", "--json", "--compact", resolve(EXAMPLES, "lib/common.stm"));
+    const { stdout, code } = await run(
+      "schema",
+      "country_codes",
+      "--json",
+      "--compact",
+      resolve(EXAMPLES, "lib/common.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(!("note" in data), "compact JSON should omit note");
@@ -326,7 +342,13 @@ describe("satsuma schema", () => {
   });
 
   it("--json --fields-only returns just the fields array (sl-5fbn)", async () => {
-    const { stdout, code } = await run("schema", "country_codes", "--json", "--fields-only", resolve(EXAMPLES, "lib/common.stm"));
+    const { stdout, code } = await run(
+      "schema",
+      "country_codes",
+      "--json",
+      "--fields-only",
+      resolve(EXAMPLES, "lib/common.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data), "should be a plain array of fields");
@@ -340,7 +362,7 @@ describe("satsuma schema", () => {
     const { stdout, code } = await run("schema", "legacy_sqlserver", "--compact", DB);
     assert.equal(code, 0);
     assert.match(stdout, /PHONE_NBR/);
-    assert.doesNotMatch(stdout, /"""/,  "triple-quoted note should be stripped in compact mode");
+    assert.doesNotMatch(stdout, /"""/, "triple-quoted note should be stripped in compact mode");
     assert.doesNotMatch(stdout, /No consistent format/, "note content should be stripped");
   });
 
@@ -358,7 +380,10 @@ describe("satsuma schema", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data.metadata), "should have metadata array");
-    assert.ok(data.metadata.some((m: any) => m.key === "format"), "should include format entry");
+    assert.ok(
+      data.metadata.some((m: any) => m.key === "format"),
+      "should include format entry",
+    );
   });
 
   it("text output preserves record/list block-level metadata (sl-s8xn)", async () => {
@@ -366,8 +391,16 @@ describe("satsuma schema", () => {
     const { stdout, code } = await run("schema", "commerce_order", XML);
     assert.equal(code, 0);
     assert.match(stdout, /Order record \(xpath/, "record block should show xpath metadata");
-    assert.match(stdout, /Discounts list_of record \(xpath/, "list block should show xpath metadata");
-    assert.match(stdout, /LineItems list_of record \(xpath/, "list block should show xpath metadata");
+    assert.match(
+      stdout,
+      /Discounts list_of record \(xpath/,
+      "list block should show xpath metadata",
+    );
+    assert.match(
+      stdout,
+      /LineItems list_of record \(xpath/,
+      "list block should show xpath metadata",
+    );
   });
 
   it("--json includes metadata on nested record/list fields (sl-s8xn)", async () => {
@@ -577,12 +610,19 @@ describe("satsuma mapping", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     for (const a of data.arrows) {
-      assert.equal("transform" in a, false, `arrow ${a.src} -> ${a.tgt} should not have transform in compact mode`);
+      assert.equal(
+        "transform" in a,
+        false,
+        `arrow ${a.src} -> ${a.tgt} should not have transform in compact mode`,
+      );
     }
     // hasTransform and classification should still be present
     const withTransform = data.arrows.filter((a: any) => a.hasTransform);
     assert.ok(withTransform.length > 0, "hasTransform should still be present");
-    assert.ok(data.arrows.every((a: any) => "classification" in a), "classification should still be present");
+    assert.ok(
+      data.arrows.every((a: any) => "classification" in a),
+      "classification should still be present",
+    );
   });
 
   it("--json --compact omits note and metadata from output (sl-gqoy)", async () => {
@@ -593,8 +633,16 @@ describe("satsuma mapping", () => {
     assert.equal("note" in data, false, "top-level note should be omitted in compact mode");
     assert.equal("metadata" in data, false, "top-level metadata should be omitted in compact mode");
     for (const a of data.arrows) {
-      assert.equal("metadata" in a, false, `arrow ${a.src} -> ${a.tgt} should not have metadata in compact mode`);
-      assert.equal("transform" in a, false, `arrow ${a.src} -> ${a.tgt} should not have transform in compact mode`);
+      assert.equal(
+        "metadata" in a,
+        false,
+        `arrow ${a.src} -> ${a.tgt} should not have metadata in compact mode`,
+      );
+      assert.equal(
+        "transform" in a,
+        false,
+        `arrow ${a.src} -> ${a.tgt} should not have transform in compact mode`,
+      );
     }
   });
 
@@ -606,7 +654,10 @@ describe("satsuma mapping", () => {
     const withTransform = data.arrows.filter((a: any) => a.hasTransform);
     assert.ok(withTransform.length > 0, "should have arrows with transforms");
     for (const a of withTransform) {
-      assert.ok(typeof a.transform === "string", `arrow ${a.src} -> ${a.tgt} should have transform text`);
+      assert.ok(
+        typeof a.transform === "string",
+        `arrow ${a.src} -> ${a.tgt} should have transform text`,
+      );
       assert.ok(a.transform.length > 0);
     }
   });
@@ -623,7 +674,10 @@ describe("satsuma mapping", () => {
       );
     }
     // Should have at least one NL arrow (transform with steps)
-    assert.ok(data.arrows.some((a: any) => a.classification === "nl"), "expected at least one nl arrow");
+    assert.ok(
+      data.arrows.some((a: any) => a.classification === "nl"),
+      "expected at least one nl arrow",
+    );
   });
 
   it("--json container arrows have hasTransform:false (sl-zfi0)", async () => {
@@ -635,7 +689,11 @@ describe("satsuma mapping", () => {
     assert.ok(containers.length > 0, "should have container arrows");
     for (const c of containers) {
       if (!c.transform) {
-        assert.equal(c.hasTransform, false, `container arrow ${c.src}->${c.tgt} without pipe_chain should have hasTransform:false`);
+        assert.equal(
+          c.hasTransform,
+          false,
+          `container arrow ${c.src}->${c.tgt} without pipe_chain should have hasTransform:false`,
+        );
       }
     }
   });
@@ -689,10 +747,15 @@ describe("satsuma mapping", () => {
     const { stdout, code } = await run("mapping", "order line facts", "--json", FFG);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.equal(data.topLevelArrowCount, data.arrows.length,
-      "topLevelArrowCount should equal arrows.length");
-    assert.ok(data.arrowCount > data.topLevelArrowCount,
-      "arrowCount (leaf) should exceed topLevelArrowCount for hierarchical mappings");
+    assert.equal(
+      data.topLevelArrowCount,
+      data.arrows.length,
+      "topLevelArrowCount should equal arrows.length",
+    );
+    assert.ok(
+      data.arrowCount > data.topLevelArrowCount,
+      "arrowCount (leaf) should exceed topLevelArrowCount for hierarchical mappings",
+    );
   });
 
   it("--json preserves backtick-quoted source field names (cbh-sttt)", async () => {
@@ -768,12 +831,24 @@ describe("satsuma find", () => {
   // CST node exists), so the metric scope must search schema_block nodes.
   it("--in metric matches fields in metric-tagged schemas (sl-xav4)", async () => {
     const METRICS = resolve(EXAMPLES, "metrics-platform/metrics.stm");
-    const { stdout, code } = await run("find", "--tag", "measure", "--in", "metric", "--json", METRICS);
+    const { stdout, code } = await run(
+      "find",
+      "--tag",
+      "measure",
+      "--in",
+      "metric",
+      "--json",
+      METRICS,
+    );
     assert.equal(code, 0, "metric scope should find measure fields, not exit 1");
     const data = JSON.parse(stdout);
     assert.ok(data.length > 0, "expected measure-tagged fields in metric blocks");
     for (const m of data) {
-      assert.equal(m.blockType, "metric", `${m.block}.${m.field} should report blockType metric, not ${m.blockType}`);
+      assert.equal(
+        m.blockType,
+        "metric",
+        `${m.block}.${m.field} should report blockType metric, not ${m.blockType}`,
+      );
     }
   });
 
@@ -827,8 +902,14 @@ describe("satsuma find", () => {
     const schemaLevel = data.filter((m: any) => m.field === "(schema)");
     assert.ok(schemaLevel.length > 0, "expected schema-level matches");
     for (const m of schemaLevel) {
-      assert.ok(Array.isArray(m.metadata), `schema-level entry for ${m.block} should include metadata array`);
-      assert.ok(m.metadata.some((t: any) => /classification/.test(t)), "metadata should include matched tag value");
+      assert.ok(
+        Array.isArray(m.metadata),
+        `schema-level entry for ${m.block} should include metadata array`,
+      );
+      assert.ok(
+        m.metadata.some((t: any) => /classification/.test(t)),
+        "metadata should include matched tag value",
+      );
     }
   });
 
@@ -839,7 +920,9 @@ describe("satsuma find", () => {
     const { stdout, code } = await run("find", "--tag", "classification", "--json", FFG);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    const schemaLevel = data.find((m: any) => m.block === "completed_orders_parquet" && m.field === "(schema)");
+    const schemaLevel = data.find(
+      (m: any) => m.block === "completed_orders_parquet" && m.field === "(schema)",
+    );
     assert.ok(schemaLevel, "expected completed_orders_parquet schema-level match");
     assert.ok(schemaLevel.metadata.includes("classification INTERNAL"));
     assert.ok(!schemaLevel.metadata.includes('classification "INTERNAL"'));
@@ -856,7 +939,10 @@ describe("satsuma find", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.length > 0, "should find fields with note metadata");
-    assert.ok(data.some((m: any) => m.tag === "note"), "tag should be 'note'");
+    assert.ok(
+      data.some((m: any) => m.tag === "note"),
+      "tag should be 'note'",
+    );
   });
 
   it("finds tagged fields from fragment spreads in consuming schema (sl-z6z9)", async () => {
@@ -872,7 +958,9 @@ describe("satsuma find", () => {
     const { stdout, code } = await run("find", "--tag", "required", "--json", FIXTURE);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    const schemaMatch = data.find((m: any) => m.blockType === "schema" && m.block === "uses_fragment");
+    const schemaMatch = data.find(
+      (m: any) => m.blockType === "schema" && m.block === "uses_fragment",
+    );
     assert.ok(schemaMatch, "expected uses_fragment match from spread");
     assert.equal(schemaMatch.field, "created_at");
   });
@@ -914,7 +1002,13 @@ describe("satsuma lineage", () => {
   });
 
   it("--compact prints names only", async () => {
-    const { stdout, code } = await run("lineage", "--from", "legacy_sqlserver", "--compact", PLATFORM);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "legacy_sqlserver",
+      "--compact",
+      PLATFORM,
+    );
     assert.equal(code, 0);
     assert.match(stdout, /legacy_sqlserver/);
   });
@@ -928,7 +1022,13 @@ describe("satsuma lineage", () => {
   it("--json returns JSON error object for unknown --from schema (sl-xfxd)", async () => {
     // When --json is passed, not-found errors must return a JSON object
     // instead of plain text, consistent with other commands like schema.
-    const { stdout, code } = await run("lineage", "--from", "no_such_schema_xyz", "--json", PLATFORM);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "no_such_schema_xyz",
+      "--json",
+      PLATFORM,
+    );
     assert.equal(code, 1);
     const data = JSON.parse(stdout);
     assert.ok(data.error, "should have error key in JSON");
@@ -957,7 +1057,14 @@ describe("satsuma lineage", () => {
   });
 
   it("errors when both --from and --to are specified", async () => {
-    const { code, stderr } = await run("lineage", "--from", "legacy_sqlserver", "--to", "postgres_db", PLATFORM);
+    const { code, stderr } = await run(
+      "lineage",
+      "--from",
+      "legacy_sqlserver",
+      "--to",
+      "postgres_db",
+      PLATFORM,
+    );
     assert.equal(code, 1);
     assert.match(stderr, /cannot specify both/i);
   });
@@ -1011,7 +1118,15 @@ describe("satsuma lineage", () => {
 
   it("--depth --json edges only reference nodes in the nodes array (sl-iliz)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "lineage-chain.stm");
-    const { stdout, code } = await run("lineage", "--from", "source_a", "--depth", "1", "--json", F);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "source_a",
+      "--depth",
+      "1",
+      "--json",
+      F,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const nodeNames = new Set(data.nodes.map((n: any) => n.name));
@@ -1065,7 +1180,10 @@ describe("satsuma where-used", () => {
     const data = JSON.parse(stdout);
     const refMetaRefs = data.refs.filter((r: any) => r.kind === "ref_metadata");
     assert.ok(refMetaRefs.length > 0, "should find ref metadata references");
-    assert.ok(refMetaRefs.some((r: any) => r.name.includes("customer_id")), "should reference customer_id field");
+    assert.ok(
+      refMetaRefs.some((r: any) => r.name.includes("customer_id")),
+      "should reference customer_id field",
+    );
   });
 
   it("detects transform spread references (sl-iw85)", async () => {
@@ -1123,7 +1241,10 @@ describe("satsuma warnings", () => {
   });
 
   it("exits 1 when no warnings found", async () => {
-    const { code } = await run("warnings", resolve(import.meta.dirname, "fixtures", "lint-clean.stm"));
+    const { code } = await run(
+      "warnings",
+      resolve(import.meta.dirname, "fixtures", "lint-clean.stm"),
+    );
     assert.equal(code, 1, "should exit 1 when no warnings found");
   });
 
@@ -1177,7 +1298,10 @@ describe("satsuma context", () => {
     const { stdout, code } = await run("context", "phone", F, "--json");
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.ok(data.some((d: any) => d.name === "crm_customers"), "should match crm_customers via //? comment");
+    assert.ok(
+      data.some((d: any) => d.name === "crm_customers"),
+      "should match crm_customers via //? comment",
+    );
   });
 
   it("searches warning comments for query matches (sl-8zij)", async () => {
@@ -1185,7 +1309,10 @@ describe("satsuma context", () => {
     const { stdout, code } = await run("context", "conversion", F, "--json");
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.ok(data.some((d: any) => d.name === "raw_orders"), "should match raw_orders via //! comment");
+    assert.ok(
+      data.some((d: any) => d.name === "raw_orders"),
+      "should match raw_orders via //! comment",
+    );
   });
 
   it("finds blocks containing language keywords like flatten and list_of (sc-rj24)", async () => {
@@ -1245,18 +1372,14 @@ describe("satsuma arrows", () => {
   });
 
   it("--as-source filters to source arrows only", async () => {
-    const { stdout, code } = await run(
-      "arrows", "legacy_sqlserver.CUST_ID", "--as-source", DB,
-    );
+    const { stdout, code } = await run("arrows", "legacy_sqlserver.CUST_ID", "--as-source", DB);
     assert.equal(code, 0);
     assert.match(stdout, /CUST_ID -> customer_id/);
     assert.match(stdout, /as source/);
   });
 
   it("--as-target filters to target arrows only", async () => {
-    const { stdout, code } = await run(
-      "arrows", "postgres_db.customer_id", "--as-target", DB,
-    );
+    const { stdout, code } = await run("arrows", "postgres_db.customer_id", "--as-target", DB);
     assert.equal(code, 0);
     assert.match(stdout, /as target/);
     assert.match(stdout, /CUST_ID -> customer_id/);
@@ -1279,9 +1402,7 @@ describe("satsuma arrows", () => {
   });
 
   it("--json includes decomposed steps array", async () => {
-    const { stdout, code } = await run(
-      "arrows", "legacy_sqlserver.CUST_ID", "--json", DB,
-    );
+    const { stdout, code } = await run("arrows", "legacy_sqlserver.CUST_ID", "--json", DB);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data));
@@ -1295,9 +1416,7 @@ describe("satsuma arrows", () => {
   });
 
   it("--json includes file and line", async () => {
-    const { stdout, code } = await run(
-      "arrows", "legacy_sqlserver.CUST_ID", "--json", DB,
-    );
+    const { stdout, code } = await run("arrows", "legacy_sqlserver.CUST_ID", "--json", DB);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data[0].file);
@@ -1324,7 +1443,11 @@ describe("satsuma arrows", () => {
     const data = JSON.parse(stdout);
     const arrow = data.find((a: any) => a.source);
     assert.ok(arrow, "should have arrow with source");
-    assert.match(arrow.source, /sfdc_opportunity\./, "source should reference sfdc_opportunity, not snowflake_opps");
+    assert.match(
+      arrow.source,
+      /sfdc_opportunity\./,
+      "source should reference sfdc_opportunity, not snowflake_opps",
+    );
     assert.doesNotMatch(arrow.source, /snowflake_opps\.Id/, "source should not use lookup schema");
   });
 
@@ -1334,7 +1457,9 @@ describe("satsuma arrows", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data[0].metadata, "should have metadata on arrow");
-    assert.ok(data[0].metadata.some((m: any) => m.kind === "note" && m.text === "Arrow metadata note"));
+    assert.ok(
+      data[0].metadata.some((m: any) => m.kind === "note" && m.text === "Arrow metadata note"),
+    );
   });
 
   it("--json includes tag metadata on arrows (sl-6ctd)", async () => {
@@ -1374,7 +1499,6 @@ describe("satsuma arrows", () => {
   // sl-9gvb index-builder assertions moved to namespace-index.test.ts
 });
 
-
 // ---------------------------------------------------------------------------
 // satsuma fields
 // ---------------------------------------------------------------------------
@@ -1409,15 +1533,23 @@ describe("satsuma fields", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const customerEmail = data.find((field: any) => field.name === "customer_email");
-    const classification = customerEmail.metadata.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
-    const retention = customerEmail.metadata.find((entry: any) => entry.kind === "kv" && entry.key === "retention");
+    const classification = customerEmail.metadata.find(
+      (entry: any) => entry.kind === "kv" && entry.key === "classification",
+    );
+    const retention = customerEmail.metadata.find(
+      (entry: any) => entry.kind === "kv" && entry.key === "retention",
+    );
     assert.equal(classification?.value, "RESTRICTED");
     assert.equal(retention?.value, "3y");
   });
 
   it("--unmapped-by on target schema returns correct set difference", async () => {
     const { stdout, code } = await run(
-      "fields", "postgres_db", "--unmapped-by", "customer migration", DB,
+      "fields",
+      "postgres_db",
+      "--unmapped-by",
+      "customer migration",
+      DB,
     );
     assert.equal(code, 0);
     // All postgres_db fields are mapped in db-to-db.stm
@@ -1432,7 +1564,11 @@ describe("satsuma fields", () => {
     // this command listed all six as unmapped, i.e. as the review queue, so a
     // reader trusting it would have deleted live fields.
     const { stdout, code } = await run(
-      "fields", "legacy_sqlserver", "--unmapped-by", "customer migration", DB,
+      "fields",
+      "legacy_sqlserver",
+      "--unmapped-by",
+      "customer migration",
+      DB,
     );
     assert.equal(code, 0);
     assert.match(stdout, /All fields in 'legacy_sqlserver' are mapped/);
@@ -1445,9 +1581,7 @@ describe("satsuma fields", () => {
     // evidence than a declared one even though both count (ADR-036).
     const { stdout, code } = await run("coverage", DB, "--schema", "legacy_sqlserver", "--json");
     assert.equal(code, 0);
-    const schema = JSON.parse(stdout).mappings[0].schemas.find(
-      (s: any) => s.role === "source",
-    );
+    const schema = JSON.parse(stdout).mappings[0].schemas.find((s: any) => s.role === "source");
     assert.equal(schema.covered, 21);
     assert.equal(schema.covered_declared, 15);
     assert.equal(schema.covered_nl, 6);
@@ -1464,9 +1598,7 @@ describe("satsuma fields", () => {
   });
 
   it("--with-meta includes tags", async () => {
-    const { stdout, code } = await run(
-      "fields", "legacy_sqlserver", "--with-meta", DB,
-    );
+    const { stdout, code } = await run("fields", "legacy_sqlserver", "--with-meta", DB);
     assert.equal(code, 0);
     assert.match(stdout, /pii/);
   });
@@ -1474,19 +1606,32 @@ describe("satsuma fields", () => {
   it("--unmapped-by does not report nested list as unmapped", async () => {
     const SAP = resolve(EXAMPLES, "sap-po-to-mfcs/pipeline.stm");
     const { stdout, code } = await run(
-      "fields", "mfcs_purchase_order", "--unmapped-by", "sap po to mfcs", "--json", SAP,
+      "fields",
+      "mfcs_purchase_order",
+      "--unmapped-by",
+      "sap po to mfcs",
+      "--json",
+      SAP,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const names = data.map((f: any) => f.name);
     // "items" list is targeted by nested arrow Items[] -> items[], so should NOT be unmapped
-    assert.ok(!names.includes("items"), `"items" should not be reported as unmapped, got: ${names}`);
+    assert.ok(
+      !names.includes("items"),
+      `"items" should not be reported as unmapped, got: ${names}`,
+    );
   });
 
   it("--unmapped-by filters mapped children from record blocks (sl-4mh2)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "unmapped-nested.stm");
     const { stdout, code } = await run(
-      "fields", "nested_tgt", "--unmapped-by", "partial_map", "--json", F,
+      "fields",
+      "nested_tgt",
+      "--unmapped-by",
+      "partial_map",
+      "--json",
+      F,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
@@ -1500,7 +1645,12 @@ describe("satsuma fields", () => {
   it("--unmapped-by excludes record when all children mapped (sl-4mh2)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "unmapped-nested.stm");
     const { stdout, code } = await run(
-      "fields", "nested_tgt", "--unmapped-by", "full_map", "--json", F,
+      "fields",
+      "nested_tgt",
+      "--unmapped-by",
+      "full_map",
+      "--json",
+      F,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
@@ -1517,7 +1667,11 @@ describe("satsuma fields", () => {
   });
 
   it("lists fields of a fragment (sl-3o9n)", async () => {
-    const { stdout, code } = await run("fields", "audit columns", resolve(EXAMPLES, "lib/common.stm"));
+    const { stdout, code } = await run(
+      "fields",
+      "audit columns",
+      resolve(EXAMPLES, "lib/common.stm"),
+    );
     assert.equal(code, 0);
     assert.match(stdout, /created_at/);
     assert.match(stdout, /updated_at/);
@@ -1544,7 +1698,10 @@ describe("satsuma fields", () => {
     // Child should be more indented
     const parentIndent = lines[itemsLine].match(/^\s*/)![0].length;
     const childIndent = childLine.match(/^\s*/)![0].length;
-    assert.ok(childIndent > parentIndent, `child indent ${childIndent} should be > parent indent ${parentIndent}`);
+    assert.ok(
+      childIndent > parentIndent,
+      `child indent ${childIndent} should be > parent indent ${parentIndent}`,
+    );
   });
 
   it("--with-meta --json includes tags on nested record/list child fields (sl-gf8d)", async () => {
@@ -1573,9 +1730,7 @@ describe("satsuma nl", () => {
   });
 
   it("--kind transform filters to transform content", async () => {
-    const { stdout, code } = await run(
-      "nl", "customer migration", "--kind", "transform", DB,
-    );
+    const { stdout, code } = await run("nl", "customer migration", "--kind", "transform", DB);
     assert.equal(code, 0);
     assert.match(stdout, /\[transform\]/);
     assert.ok(!stdout.includes("[note]"));
@@ -1583,9 +1738,7 @@ describe("satsuma nl", () => {
   });
 
   it("--json returns structured items", async () => {
-    const { stdout, code } = await run(
-      "nl", "customer migration", "--json", DB,
-    );
+    const { stdout, code } = await run("nl", "customer migration", "--json", DB);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data));
@@ -1596,9 +1749,7 @@ describe("satsuma nl", () => {
   });
 
   it("--json line numbers are 1-indexed", async () => {
-    const { stdout, code } = await run(
-      "nl", "customer migration", "--json", DB,
-    );
+    const { stdout, code } = await run("nl", "customer migration", "--json", DB);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.length > 0);
@@ -1614,9 +1765,7 @@ describe("satsuma nl", () => {
   });
 
   it("field scope extracts NL from arrows", async () => {
-    const { stdout, code } = await run(
-      "nl", "legacy_sqlserver.PHONE_NBR", DB,
-    );
+    const { stdout, code } = await run("nl", "legacy_sqlserver.PHONE_NBR", DB);
     assert.equal(code, 0);
     assert.match(stdout, /\[transform\]/);
     assert.match(stdout, /digits/i);
@@ -1646,7 +1795,11 @@ describe("satsuma nl", () => {
     assert.ok(note, "should have a note item");
     // Words at string boundaries should not run together
     assert.doesNotMatch(note.text, /note\.Second/, "should not run words together at boundaries");
-    assert.match(note.text, /note\.\n?.*Second/, "should have separator between concatenated strings");
+    assert.match(
+      note.text,
+      /note\.\n?.*Second/,
+      "should have separator between concatenated strings",
+    );
   });
 
   it("concatenated note strings are fully extracted (sl-gu24)", async () => {
@@ -1655,7 +1808,12 @@ describe("satsuma nl", () => {
     // for cart_abandonment_rate has two concatenated nl_strings spanning "checkout"
     // and "divided by". The metric_name tag also surfaces as a note item, so we
     // search all note items for the one containing the expected body text.
-    const { stdout, code } = await run("nl", "cart_abandonment_rate", resolve(EXAMPLES, "metrics-platform/metrics.stm"), "--json");
+    const { stdout, code } = await run(
+      "nl",
+      "cart_abandonment_rate",
+      resolve(EXAMPLES, "metrics-platform/metrics.stm"),
+      "--json",
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const bodyNote = data.find((d: any) => d.kind === "note" && /checkout/i.test(d.text));
@@ -1671,9 +1829,15 @@ describe("satsuma nl", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const addressItems = data.filter((d: any) => d.parent === "nested_test.address");
-    assert.ok(addressItems.length >= 1, "address block items should have parent 'nested_test.address'");
+    assert.ok(
+      addressItems.length >= 1,
+      "address block items should have parent 'nested_test.address'",
+    );
     const contactItems = data.filter((d: any) => d.parent === "nested_test.contacts");
-    assert.ok(contactItems.length >= 1, "contacts block items should have parent 'nested_test.contacts'");
+    assert.ok(
+      contactItems.length >= 1,
+      "contacts block items should have parent 'nested_test.contacts'",
+    );
   });
 
   it("returns NL from both schema and mapping when names collide (sl-vw49)", async () => {
@@ -1681,8 +1845,14 @@ describe("satsuma nl", () => {
     const { stdout, code } = await run("nl", "customers", F, "--json");
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.ok(data.some((d: any) => d.kind === "note"), "should include schema note");
-    assert.ok(data.some((d: any) => d.kind === "transform"), "should include mapping transform");
+    assert.ok(
+      data.some((d: any) => d.kind === "note"),
+      "should include schema note",
+    );
+    assert.ok(
+      data.some((d: any) => d.kind === "transform"),
+      "should include mapping transform",
+    );
     assert.ok(data.length >= 2, "should have at least 2 NL items from both blocks");
   });
 
@@ -1692,7 +1862,10 @@ describe("satsuma nl", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.length > 0, "should find NL content in transform block");
-    assert.ok(data.some((d: any) => d.parent === "nl transform"), "parent should be transform name");
+    assert.ok(
+      data.some((d: any) => d.parent === "nl transform"),
+      "parent should be transform name",
+    );
   });
 
   it("unescapes escape sequences in NL strings (sl-j014)", async () => {
@@ -1702,7 +1875,7 @@ describe("satsuma nl", () => {
     const data = JSON.parse(stdout);
     const note = data.find((d: any) => d.kind === "note");
     assert.ok(note, "should have a note");
-    assert.match(note.text, /Contains "quoted" text/, "should unescape \\\" to \"");
+    assert.match(note.text, /Contains "quoted" text/, 'should unescape \\" to "');
     assert.doesNotMatch(note.text, /\\"/, "should not contain escaped quotes");
   });
 });
@@ -1729,9 +1902,7 @@ describe("satsuma meta", () => {
   });
 
   it("--tags-only returns just tag tokens", async () => {
-    const { stdout, code } = await run(
-      "meta", "legacy_sqlserver.EMAIL_ADDR", "--tags-only", DB,
-    );
+    const { stdout, code } = await run("meta", "legacy_sqlserver.EMAIL_ADDR", "--tags-only", DB);
     assert.equal(code, 0);
     assert.match(stdout, /pii/);
     // Should not contain kv or enum formatting
@@ -1739,9 +1910,7 @@ describe("satsuma meta", () => {
   });
 
   it("--json returns structured metadata", async () => {
-    const { stdout, code } = await run(
-      "meta", "legacy_sqlserver.CUST_TYPE", "--json", DB,
-    );
+    const { stdout, code } = await run("meta", "legacy_sqlserver.CUST_TYPE", "--json", DB);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.scope, "legacy_sqlserver.CUST_TYPE");
@@ -1757,7 +1926,9 @@ describe("satsuma meta", () => {
     const { stdout, code } = await run("meta", "completed_orders_parquet", "--json", FFG);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    const classification = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
+    const classification = data.entries.find(
+      (entry: any) => entry.kind === "kv" && entry.key === "classification",
+    );
     assert.equal(classification?.value, "INTERNAL");
   });
 
@@ -1765,11 +1936,20 @@ describe("satsuma meta", () => {
     // Field-level metadata uses the same shared extractor and must normalize
     // string-valued kv metadata identically.
     const FFG = resolve(EXAMPLES, "filter-flatten-governance/filter-flatten-governance.stm");
-    const { stdout, code } = await run("meta", "completed_orders_parquet.customer_email", "--json", FFG);
+    const { stdout, code } = await run(
+      "meta",
+      "completed_orders_parquet.customer_email",
+      "--json",
+      FFG,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    const classification = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "classification");
-    const retention = data.entries.find((entry: any) => entry.kind === "kv" && entry.key === "retention");
+    const classification = data.entries.find(
+      (entry: any) => entry.kind === "kv" && entry.key === "classification",
+    );
+    const retention = data.entries.find(
+      (entry: any) => entry.kind === "kv" && entry.key === "retention",
+    );
     assert.equal(classification?.value, "RESTRICTED");
     assert.equal(retention?.value, "3y");
   });
@@ -1781,14 +1961,23 @@ describe("satsuma meta", () => {
   });
 
   it("extracts metric field metadata (sl-eglw)", async () => {
-    const { stdout, code } = await run("meta", "order_revenue.gross_revenue", resolve(EXAMPLES, "metrics-platform/metrics.stm"));
+    const { stdout, code } = await run(
+      "meta",
+      "order_revenue.gross_revenue",
+      resolve(EXAMPLES, "metrics-platform/metrics.stm"),
+    );
     assert.equal(code, 0);
     assert.match(stdout, /type: DECIMAL/);
     assert.match(stdout, /measure/);
   });
 
   it("extracts metric field metadata as JSON (sl-eglw)", async () => {
-    const { stdout, code } = await run("meta", "order_revenue.gross_revenue", "--json", resolve(EXAMPLES, "metrics-platform/metrics.stm"));
+    const { stdout, code } = await run(
+      "meta",
+      "order_revenue.gross_revenue",
+      "--json",
+      resolve(EXAMPLES, "metrics-platform/metrics.stm"),
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.entries.some((e: any) => e.kind === "kv" && e.key === "measure"));
@@ -1806,7 +1995,10 @@ describe("satsuma meta", () => {
     const { stdout, code } = await run("meta", "commerce_order.Discounts", "--json", XML);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.ok(data.entries.some((e: any) => e.kind === "kv" && e.key === "xpath"), "list block should have xpath metadata");
+    assert.ok(
+      data.entries.some((e: any) => e.kind === "kv" && e.key === "xpath"),
+      "list block should have xpath metadata",
+    );
   });
 
   it("supports nested field paths schema.record.field (sl-bfue)", async () => {
@@ -1815,7 +2007,10 @@ describe("satsuma meta", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.type, "STRING");
-    assert.ok(data.entries.some((e: any) => e.kind === "kv" && e.key === "xpath"), "nested field should have xpath");
+    assert.ok(
+      data.entries.some((e: any) => e.kind === "kv" && e.key === "xpath"),
+      "nested field should have xpath",
+    );
   });
 
   it("disambiguates same-named fields via nested path (sl-bfue)", async () => {
@@ -1872,7 +2067,12 @@ describe("satsuma match-fields", () => {
 
   it("matches fields by normalized name (FirstName = first_name)", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "legacy_sqlserver", "--target", "postgres_db", DB,
+      "match-fields",
+      "--source",
+      "legacy_sqlserver",
+      "--target",
+      "postgres_db",
+      DB,
     );
     assert.equal(code, 0);
     // NOTES matches notes (both normalize to "notes")
@@ -1881,7 +2081,12 @@ describe("satsuma match-fields", () => {
 
   it("shows source-only and target-only lists", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "legacy_sqlserver", "--target", "postgres_db", DB,
+      "match-fields",
+      "--source",
+      "legacy_sqlserver",
+      "--target",
+      "postgres_db",
+      DB,
     );
     assert.equal(code, 0);
     assert.match(stdout, /Source-only/);
@@ -1890,8 +2095,13 @@ describe("satsuma match-fields", () => {
 
   it("--matched-only shows only matches", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "legacy_sqlserver", "--target", "postgres_db",
-      "--matched-only", DB,
+      "match-fields",
+      "--source",
+      "legacy_sqlserver",
+      "--target",
+      "postgres_db",
+      "--matched-only",
+      DB,
     );
     assert.equal(code, 0);
     assert.ok(!stdout.includes("Source-only"));
@@ -1899,8 +2109,13 @@ describe("satsuma match-fields", () => {
 
   it("--unmatched-only shows only unmatched", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "legacy_sqlserver", "--target", "postgres_db",
-      "--unmatched-only", DB,
+      "match-fields",
+      "--source",
+      "legacy_sqlserver",
+      "--target",
+      "postgres_db",
+      "--unmatched-only",
+      DB,
     );
     assert.equal(code, 0);
     assert.match(stdout, /Source-only/);
@@ -1910,8 +2125,13 @@ describe("satsuma match-fields", () => {
 
   it("--json returns structured output", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "legacy_sqlserver", "--target", "postgres_db",
-      "--json", DB,
+      "match-fields",
+      "--source",
+      "legacy_sqlserver",
+      "--target",
+      "postgres_db",
+      "--json",
+      DB,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
@@ -1923,8 +2143,14 @@ describe("satsuma match-fields", () => {
   it("--json --matched-only filters out unmatched fields (sl-vexa)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "match-fields-test.stm");
     const { stdout, code } = await run(
-      "match-fields", "--source", "src_match", "--target", "tgt_match",
-      "--matched-only", "--json", F,
+      "match-fields",
+      "--source",
+      "src_match",
+      "--target",
+      "tgt_match",
+      "--matched-only",
+      "--json",
+      F,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
@@ -1936,30 +2162,51 @@ describe("satsuma match-fields", () => {
   it("--json --unmatched-only filters out matched fields (sl-vexa)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "match-fields-test.stm");
     const { stdout, code } = await run(
-      "match-fields", "--source", "src_match", "--target", "tgt_match",
-      "--unmatched-only", "--json", F,
+      "match-fields",
+      "--source",
+      "src_match",
+      "--target",
+      "tgt_match",
+      "--unmatched-only",
+      "--json",
+      F,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.deepStrictEqual(data.matched, [], "matched should be empty with --unmatched-only");
-    assert.ok(data.sourceOnly.length > 0 || data.targetOnly.length > 0, "should have some unmatched");
+    assert.ok(
+      data.sourceOnly.length > 0 || data.targetOnly.length > 0,
+      "should have some unmatched",
+    );
   });
 
   it("normalizes spaces in backtick-quoted field names (sl-u2qa)", async () => {
     const F = resolve(import.meta.dirname, "fixtures", "backtick-match.stm");
     const { stdout, code } = await run(
-      "match-fields", "--source", "backtick_src", "--target", "backtick_tgt",
-      "--json", F,
+      "match-fields",
+      "--source",
+      "backtick_src",
+      "--target",
+      "backtick_tgt",
+      "--json",
+      F,
     );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    const spaceMatch = data.matched.find((m: any) => m.source.includes("Spaces") || m.target.includes("spaces"));
+    const spaceMatch = data.matched.find(
+      (m: any) => m.source.includes("Spaces") || m.target.includes("spaces"),
+    );
     assert.ok(spaceMatch, "backtick field with spaces should match snake_case equivalent");
   });
 
   it("exits 1 for unknown schema", async () => {
     const { stderr, code } = await run(
-      "match-fields", "--source", "nonexistent", "--target", "postgres_db", DB,
+      "match-fields",
+      "--source",
+      "nonexistent",
+      "--target",
+      "postgres_db",
+      DB,
     );
     assert.equal(code, 1);
     assert.match(stderr, /not found/i);
@@ -1971,9 +2218,7 @@ describe("satsuma match-fields", () => {
 // ---------------------------------------------------------------------------
 describe("satsuma validate", () => {
   it("valid workspace produces 0 errors", async () => {
-    const { stdout, code } = await run(
-      "validate", resolve(EXAMPLES, "lib/common.stm"),
-    );
+    const { stdout, code } = await run("validate", resolve(EXAMPLES, "lib/common.stm"));
     assert.equal(code, 0);
     assert.match(stdout, /no issues/i);
   });
@@ -1987,9 +2232,7 @@ describe("satsuma validate", () => {
   });
 
   it("--quiet returns exit code only", async () => {
-    const { stdout, code } = await run(
-      "validate", "--quiet", resolve(EXAMPLES, "lib/common.stm"),
-    );
+    const { stdout, code } = await run("validate", "--quiet", resolve(EXAMPLES, "lib/common.stm"));
     assert.equal(code, 0);
     assert.equal(stdout.trim(), "");
   });
@@ -2060,7 +2303,11 @@ describe("satsuma validate", () => {
     // Use a structural assertion that the warning message itself does not name 'cleanup',
     // rather than scanning the full stdout — file paths printed in diagnostics can legitimately
     // contain the word "cleanup" (e.g. when the test runs from a worktree under chore/cleanup-*).
-    assert.doesNotMatch(stdout, /undefined transform 'cleanup'/, "known transform 'cleanup' should not be flagged");
+    assert.doesNotMatch(
+      stdout,
+      /undefined transform 'cleanup'/,
+      "known transform 'cleanup' should not be flagged",
+    );
     assert.match(stdout, /1 warning/);
   });
 
@@ -2069,7 +2316,10 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", BAD, "--json");
     assert.equal(code, 0, "missing import is a warning, not an error");
     const data = JSON.parse(stdout);
-    assert.ok(data.findings.some((d: any) => d.rule === "missing-import"), "should have missing-import diagnostic");
+    assert.ok(
+      data.findings.some((d: any) => d.rule === "missing-import"),
+      "should have missing-import diagnostic",
+    );
   });
 
   it("warns on undefined import name (sl-t5k4)", async () => {
@@ -2087,10 +2337,15 @@ describe("satsuma validate", () => {
     const { stdout, code } = await run("validate", F, "--json");
     assert.equal(code, 0, "ref warning is not an error");
     const data = JSON.parse(stdout);
-    const refWarning = data.findings.find((d: any) => d.rule === "undefined-ref" && d.message.includes("nonexistent_table"));
+    const refWarning = data.findings.find(
+      (d: any) => d.rule === "undefined-ref" && d.message.includes("nonexistent_table"),
+    );
     assert.ok(refWarning, "should warn about ref to nonexistent_table");
     // Valid ref to customers should NOT produce a warning
-    assert.ok(!data.findings.some((d: any) => d.message.includes("customers")), "valid ref should not warn");
+    assert.ok(
+      !data.findings.some((d: any) => d.message.includes("customers")),
+      "valid ref should not warn",
+    );
   });
 
   it("target-only mapping parses without errors (sl-icqz)", async () => {
@@ -2142,7 +2397,8 @@ describe("satsuma diff", () => {
 
   it("--json produces valid delta object", async () => {
     const { stdout, code } = await run(
-      "diff", "--json",
+      "diff",
+      "--json",
       resolve(EXAMPLES, "db-to-db/pipeline.stm"),
       resolve(EXAMPLES, "lib/common.stm"),
     );
@@ -2156,7 +2412,8 @@ describe("satsuma diff", () => {
 
   it("--stat shows summary counts", async () => {
     const { stdout, code } = await run(
-      "diff", "--stat",
+      "diff",
+      "--stat",
       resolve(EXAMPLES, "db-to-db/pipeline.stm"),
       resolve(EXAMPLES, "lib/common.stm"),
     );
@@ -2167,7 +2424,8 @@ describe("satsuma diff", () => {
 
   it("--names-only lists changed block names", async () => {
     const { stdout, code } = await run(
-      "diff", "--names-only",
+      "diff",
+      "--names-only",
       resolve(EXAMPLES, "db-to-db/pipeline.stm"),
       resolve(EXAMPLES, "lib/common.stm"),
     );
@@ -2179,7 +2437,8 @@ describe("satsuma diff", () => {
     // Anonymous mappings were keyed by absolute path + row internally, so two
     // identical files at different paths always produced phantom +/- entries.
     const dir = mkdtempSync(join(tmpdir(), "satsuma-diff-"));
-    const source = "schema s {\n  id INTEGER\n}\n\nschema t {\n  id INTEGER\n}\n\nmapping {\n  source { s }\n  target { t }\n  id -> id\n}\n";
+    const source =
+      "schema s {\n  id INTEGER\n}\n\nschema t {\n  id INTEGER\n}\n\nmapping {\n  source { s }\n  target { t }\n  id -> id\n}\n";
     const v1 = join(dir, "v1.stm");
     const v2 = join(dir, "v2.stm");
     writeFileSync(v1, source);
@@ -2418,7 +2677,11 @@ describe("satsuma diff", () => {
     const { stdout, code } = await run("diff", lib, consumer);
     assert.equal(code, 0);
     assert.match(stdout, /- ref_data/, "schema from lib not in consumer should appear as removed");
-    assert.match(stdout, /- audit_fields/, "fragment from lib not in consumer should appear as removed");
+    assert.match(
+      stdout,
+      /- audit_fields/,
+      "fragment from lib not in consumer should appear as removed",
+    );
     assert.match(stdout, /\+ orders/, "schema only in consumer should appear as added");
   });
 
@@ -2430,7 +2693,10 @@ describe("satsuma diff", () => {
     const data = JSON.parse(stdout);
     assert.ok(data.schemas.removed.includes("ref_data"), "ref_data should be in schemas.removed");
     assert.ok(data.schemas.added.includes("orders"), "orders should be in schemas.added");
-    assert.ok(data.fragments.removed.includes("audit_fields"), "audit_fields should be in fragments.removed");
+    assert.ok(
+      data.fragments.removed.includes("audit_fields"),
+      "audit_fields should be in fragments.removed",
+    );
   });
 });
 
@@ -2600,26 +2866,20 @@ describe("satsuma find (namespaces)", () => {
 
 describe("satsuma lineage (namespaces)", () => {
   it("traces lineage from qualified namespace schema", async () => {
-    const { stdout, code } = await run(
-      "lineage", "--from", "pos::stores", NS_FIXTURE,
-    );
+    const { stdout, code } = await run("lineage", "--from", "pos::stores", NS_FIXTURE);
     assert.equal(code, 0);
     // pos::stores -> load hub_store -> warehouse::hub_store
     assert.match(stdout, /load hub_store|hub_store/);
   });
 
   it("traces lineage from unqualified unique schema", async () => {
-    const { stdout, code } = await run(
-      "lineage", "--from", "stores", NS_FIXTURE,
-    );
+    const { stdout, code } = await run("lineage", "--from", "stores", NS_FIXTURE);
     assert.equal(code, 0);
     assert.match(stdout, /hub_store/);
   });
 
   it("--json produces DAG with namespace-qualified names", async () => {
-    const { stdout, code } = await run(
-      "lineage", "--from", "pos::stores", "--json", NS_FIXTURE,
-    );
+    const { stdout, code } = await run("lineage", "--from", "pos::stores", "--json", NS_FIXTURE);
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data.nodes));
@@ -2629,9 +2889,7 @@ describe("satsuma lineage (namespaces)", () => {
   });
 
   it("exits 1 for unknown qualified schema", async () => {
-    const { code, stderr } = await run(
-      "lineage", "--from", "nonexistent::schema", NS_FIXTURE,
-    );
+    const { code, stderr } = await run("lineage", "--from", "nonexistent::schema", NS_FIXTURE);
     assert.equal(code, 1);
     assert.match(stderr, /not found/i);
   });
@@ -2681,7 +2939,9 @@ describe("satsuma mapping (namespaces)", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(data.name);
-    assert.ok(data.sources.includes("pos::stores") || data.sources.some((s: any) => s.includes("stores")));
+    assert.ok(
+      data.sources.includes("pos::stores") || data.sources.some((s: any) => s.includes("stores")),
+    );
   });
 
   it("--json includes namespace field for namespaced mappings (sl-x8yp)", async () => {
@@ -2724,7 +2984,10 @@ describe("satsuma arrows (namespace bugs)", () => {
     assert.ok(data.length >= 1);
     // Target should be resolved, not "?.email"
     const arrow = data.find((a: any) => a.target);
-    assert.ok(arrow.target.includes("sat_contact_details"), `expected qualified target, got ${arrow.target}`);
+    assert.ok(
+      arrow.target.includes("sat_contact_details"),
+      `expected qualified target, got ${arrow.target}`,
+    );
     assert.doesNotMatch(arrow.target, /^\?/);
   });
 
@@ -2739,7 +3002,10 @@ describe("satsuma arrows (namespace bugs)", () => {
     const total = parseInt(totalMatch[1]);
     const asSource = sourceMatch ? parseInt(sourceMatch[1]) : 0;
     const asTarget = targetMatch ? parseInt(targetMatch[1]) : 0;
-    assert.ok(total <= asSource + asTarget, `total ${total} should be <= source ${asSource} + target ${asTarget}`);
+    assert.ok(
+      total <= asSource + asTarget,
+      `total ${total} should be <= source ${asSource} + target ${asTarget}`,
+    );
   });
 });
 
@@ -2762,7 +3028,13 @@ describe("satsuma lineage --from (namespace bugs)", () => {
   });
 
   it("--json nodes include namespace prefix", async () => {
-    const { stdout, code } = await run("lineage", "--from", "raw::crm_deals", "--json", NS_PLATFORM);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "raw::crm_deals",
+      "--json",
+      NS_PLATFORM,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const nodeNames = data.nodes.map((n: any) => n.name);
@@ -2882,7 +3154,11 @@ describe("satsuma where-used (namespace bugs)", () => {
 describe("satsuma fields --unmapped-by (namespace bugs)", () => {
   it("returns only unmapped fields for namespace-scoped mapping", async () => {
     const { stdout, code } = await run(
-      "fields", "mart::dim_contact", "--unmapped-by", "build dim_contact", NS_PLATFORM,
+      "fields",
+      "mart::dim_contact",
+      "--unmapped-by",
+      "build dim_contact",
+      NS_PLATFORM,
     );
     assert.equal(code, 0);
     // Only is_current, valid_from, valid_to are unmapped
@@ -2899,7 +3175,11 @@ describe("satsuma fields --unmapped-by (namespace bugs)", () => {
 
   it("works with qualified mapping name", async () => {
     const { stdout, code } = await run(
-      "fields", "mart::dim_contact", "--unmapped-by", "mart::build dim_contact", NS_PLATFORM,
+      "fields",
+      "mart::dim_contact",
+      "--unmapped-by",
+      "mart::build dim_contact",
+      NS_PLATFORM,
     );
     assert.equal(code, 0);
     assert.match(stdout, /is_current/);
@@ -2933,7 +3213,11 @@ describe("satsuma nl-refs", () => {
 
   it("supports --mapping filter", async () => {
     const { stdout, code } = await run(
-      "nl-refs", "--mapping", "stage gl entries", "--json", NS_MERGING,
+      "nl-refs",
+      "--mapping",
+      "stage gl entries",
+      "--json",
+      NS_MERGING,
     );
     assert.equal(code, 0);
     const refs = JSON.parse(stdout);
@@ -3030,15 +3314,21 @@ describe("satsuma nl-refs", () => {
     assert.equal(code, 0);
     const refs = JSON.parse(stdout);
     // Standalone note: @src_accounts
-    const standaloneRef = refs.find((r: any) => r.ref === "src_accounts" && r.mapping.startsWith("note:"));
+    const standaloneRef = refs.find(
+      (r: any) => r.ref === "src_accounts" && r.mapping.startsWith("note:"),
+    );
     assert.ok(standaloneRef, "should find @src_accounts in standalone note");
     // Schema note: @balance, @currency
     const balanceRef = refs.find((r: any) => r.ref === "balance" && r.mapping.startsWith("note:"));
     assert.ok(balanceRef, "should find @balance in schema note");
-    const currencyRef = refs.find((r: any) => r.ref === "currency" && r.mapping.startsWith("note:"));
+    const currencyRef = refs.find(
+      (r: any) => r.ref === "currency" && r.mapping.startsWith("note:"),
+    );
     assert.ok(currencyRef, "should find @currency in schema note");
     // Arrow NL: @balance, @currency (in mapping body)
-    const arrowBalance = refs.find((r: any) => r.ref === "balance" && !r.mapping.startsWith("note:"));
+    const arrowBalance = refs.find(
+      (r: any) => r.ref === "balance" && !r.mapping.startsWith("note:"),
+    );
     assert.ok(arrowBalance, "should find @balance in arrow NL");
   });
 
@@ -3086,7 +3376,10 @@ describe("satsuma where-used (NL refs)", () => {
     const result = JSON.parse(stdout);
     const nlRefs = result.refs.filter((r: any) => r.kind === "nl_ref");
     assert.ok(nlRefs.length >= 1, "should find NL ref in standalone note block");
-    assert.ok(nlRefs.some((r: any) => r.name === "(file-level note)"), "standalone note should use descriptive placeholder name");
+    assert.ok(
+      nlRefs.some((r: any) => r.name === "(file-level note)"),
+      "standalone note should use descriptive placeholder name",
+    );
   });
 
   it("finds NL @refs in metric note blocks", async () => {
@@ -3095,7 +3388,10 @@ describe("satsuma where-used (NL refs)", () => {
     const result = JSON.parse(stdout);
     const nlRefs = result.refs.filter((r: any) => r.kind === "nl_ref");
     assert.ok(nlRefs.length >= 1, "should find NL ref in metric note block");
-    assert.ok(nlRefs.some((r: any) => r.name === "order_count"), "should use bare entity name without internal scope prefix");
+    assert.ok(
+      nlRefs.some((r: any) => r.name === "order_count"),
+      "should use bare entity name without internal scope prefix",
+    );
   });
 
   it("text output uses 'Referenced in NL text' label", async () => {
@@ -3133,13 +3429,21 @@ describe("satsuma lint", () => {
 
   it("--quiet exits 0 for warning-only findings (sl-8o37)", async () => {
     // Warning-severity findings must not cause exit 2, only errors should.
-    const { stdout, code } = await run("lint", "--quiet", resolve(LINT_FIXTURES, "lint-unresolved.stm"));
+    const { stdout, code } = await run(
+      "lint",
+      "--quiet",
+      resolve(LINT_FIXTURES, "lint-unresolved.stm"),
+    );
     assert.equal(code, 0);
     assert.equal(stdout.trim(), "");
   });
 
   it("--json produces valid structured output", async () => {
-    const { stdout, code } = await run("lint", "--json", resolve(LINT_FIXTURES, "lint-hidden-source.stm"));
+    const { stdout, code } = await run(
+      "lint",
+      "--json",
+      resolve(LINT_FIXTURES, "lint-hidden-source.stm"),
+    );
     assert.equal(code, 2);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data.findings));
@@ -3160,7 +3464,11 @@ describe("satsuma lint", () => {
   });
 
   it("--quiet returns only exit code", async () => {
-    const { stdout, code } = await run("lint", "--quiet", resolve(LINT_FIXTURES, "lint-hidden-source.stm"));
+    const { stdout, code } = await run(
+      "lint",
+      "--quiet",
+      resolve(LINT_FIXTURES, "lint-hidden-source.stm"),
+    );
     assert.equal(code, 2);
     assert.equal(stdout.trim(), "");
   });
@@ -3181,7 +3489,9 @@ describe("satsuma lint", () => {
 
   it("--select filters to specified rules only", async () => {
     const { stdout } = await run(
-      "lint", "--select", "unresolved-nl-ref",
+      "lint",
+      "--select",
+      "unresolved-nl-ref",
       resolve(LINT_FIXTURES, "lint-hidden-source.stm"),
     );
     // Should only show unresolved-nl-ref, not hidden-source-in-nl
@@ -3304,7 +3614,10 @@ describe("satsuma lint --fix", () => {
     const content = readFileSync(file, "utf8");
     // Should insert "contacts" (local name), not "crm::contacts" (qualified)
     assert.match(content, /source \{ accounts, contacts \}/);
-    assert.ok(!content.includes("crm::contacts"), "should not use namespace-qualified ref inside same namespace");
+    assert.ok(
+      !content.includes("crm::contacts"),
+      "should not use namespace-qualified ref inside same namespace",
+    );
     unlinkSync(file);
   });
 
@@ -3347,9 +3660,18 @@ describe("import resolution: summary", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const names = data.schemas.map((s: any) => s.name);
-    assert.ok(names.includes("src::customers"), `transitive: expected src::customers, got ${names}`);
-    assert.ok(names.includes("mart::dim_customers"), `transitive: expected mart::dim_customers, got ${names}`);
-    assert.ok(names.includes("analytics::customer_stats"), `transitive: expected analytics::customer_stats, got ${names}`);
+    assert.ok(
+      names.includes("src::customers"),
+      `transitive: expected src::customers, got ${names}`,
+    );
+    assert.ok(
+      names.includes("mart::dim_customers"),
+      `transitive: expected mart::dim_customers, got ${names}`,
+    );
+    assert.ok(
+      names.includes("analytics::customer_stats"),
+      `transitive: expected analytics::customer_stats, got ${names}`,
+    );
   });
 });
 
@@ -3395,7 +3717,10 @@ describe("satsuma graph: schema_edges NL-referenced schemas (sl-n11t)", () => {
     const sourceNames = sourceEdges.map((e: any) => e.from);
     assert.ok(sourceNames.includes("crm_accounts"), "should have declared source");
     assert.ok(sourceNames.includes("erp_customers"), "should have declared source");
-    assert.ok(!sourceNames.includes("web_profiles"), "should NOT include NL-referenced schema as source");
+    assert.ok(
+      !sourceNames.includes("web_profiles"),
+      "should NOT include NL-referenced schema as source",
+    );
   });
 
   it("emits nl_ref edges for NL-referenced schemas not in source list", async () => {
@@ -3454,7 +3779,9 @@ describe("satsuma graph: fragment fields (sl-yibt, sl-p0hz)", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     // Find a schema that uses fragment spreads and verify its fields are expanded
-    const schemasWithFields = data.nodes.filter((n: any) => n.kind === "schema" && Array.isArray(n.fields) && n.fields.length > 0);
+    const schemasWithFields = data.nodes.filter(
+      (n: any) => n.kind === "schema" && Array.isArray(n.fields) && n.fields.length > 0,
+    );
     assert.ok(schemasWithFields.length > 0, "schema nodes should have non-empty fields");
   });
 });
@@ -3479,7 +3806,11 @@ describe("import resolution: validate", () => {
 
 describe("import resolution: missing target", () => {
   it("warns on stderr for missing import target", async () => {
-    const { stderr, code } = await run("summary", "--json", resolve(__dirname, "fixtures", "import-missing.stm"));
+    const { stderr, code } = await run(
+      "summary",
+      "--json",
+      resolve(__dirname, "fixtures", "import-missing.stm"),
+    );
     // Should still succeed (warn, not fail)
     assert.equal(code, 0);
     assert.match(stderr, /import target.*not found/i);
@@ -3536,14 +3867,23 @@ describe("satsuma lineage --to upstream branches (sg-pufq)", () => {
   });
 
   it("--json returns nodes and edges DAG for --to", async () => {
-    const { stdout, code } = await run("lineage", "--to", "mart::dim_contact", "--json", NS_PLATFORM);
+    const { stdout, code } = await run(
+      "lineage",
+      "--to",
+      "mart::dim_contact",
+      "--json",
+      NS_PLATFORM,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(Array.isArray(data.nodes));
     assert.ok(Array.isArray(data.edges));
     const names = data.nodes.map((n: any) => n.name);
     assert.ok(names.includes("vault::hub_contact"), `expected vault::hub_contact in ${names}`);
-    assert.ok(names.includes("vault::sat_contact_details"), `expected vault::sat_contact_details in ${names}`);
+    assert.ok(
+      names.includes("vault::sat_contact_details"),
+      `expected vault::sat_contact_details in ${names}`,
+    );
   });
 });
 
@@ -3570,13 +3910,21 @@ describe("satsuma lineage: @ref edge traversal (lsp-4hai)", () => {
   });
 
   it("--from --json includes @ref-derived edges", async () => {
-    const { stdout, code } = await run("lineage", "--from", "web_profiles", "--json", HIDDEN_SOURCE_FIXTURE);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "web_profiles",
+      "--json",
+      HIDDEN_SOURCE_FIXTURE,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const names = data.nodes.map((n: any) => n.name);
     assert.ok(names.includes("web_profiles"));
     assert.ok(names.includes("build dim_customer"));
-    const edge = data.edges.find((e: any) => e.from === "web_profiles" && e.to === "build dim_customer");
+    const edge = data.edges.find(
+      (e: any) => e.from === "web_profiles" && e.to === "build dim_customer",
+    );
     assert.ok(edge, "should have edge from web_profiles to build dim_customer");
   });
 });
@@ -3613,7 +3961,12 @@ describe("satsuma fields — fragment spread expansion (sl-3aff)", () => {
   });
 
   it("includes transitive spread fields", async () => {
-    const { stdout, code } = await run("fields", "customer_with_full_address", "--json", SPREAD_FIXTURE);
+    const { stdout, code } = await run(
+      "fields",
+      "customer_with_full_address",
+      "--json",
+      SPREAD_FIXTURE,
+    );
     assert.equal(code, 0);
     const fields = JSON.parse(stdout);
     const names = fields.map((f: any) => f.name);
@@ -3671,8 +4024,13 @@ describe("satsuma arrows — fragment spread expansion (sl-h1b0)", () => {
 describe("satsuma match-fields — fragment spread expansion (sl-wrzl)", () => {
   it("matches fields from shared fragment spreads", async () => {
     const { stdout, code } = await run(
-      "match-fields", "--source", "src_customers", "--target", "tgt_customers",
-      "--json", SPREAD_FIXTURE,
+      "match-fields",
+      "--source",
+      "src_customers",
+      "--target",
+      "tgt_customers",
+      "--json",
+      SPREAD_FIXTURE,
     );
     assert.equal(code, 0);
     const result = JSON.parse(stdout);
@@ -3693,7 +4051,10 @@ describe("satsuma graph --json — fragment spread expansion (sl-t6lt)", () => {
     assert.ok(tgtNode, "tgt_customers node should exist");
     const fieldNames = tgtNode.fields.map((f: any) => f.name);
     assert.ok(fieldNames.includes("created_at"), "should include created_at from audit fields");
-    assert.ok(fieldNames.includes("street_line_1"), "should include street_line_1 from address fields");
+    assert.ok(
+      fieldNames.includes("street_line_1"),
+      "should include street_line_1 from address fields",
+    );
   });
 
   it("no fragment_spread schema_edges (sl-p0hz: fragments are not graph nodes)", async () => {
@@ -3701,7 +4062,11 @@ describe("satsuma graph --json — fragment spread expansion (sl-t6lt)", () => {
     assert.equal(code, 0);
     const graph = JSON.parse(stdout);
     const spreadEdges = graph.schema_edges.filter((e: any) => e.role === "fragment_spread");
-    assert.equal(spreadEdges.length, 0, "fragment_spread edges must not appear (fragments are not nodes)");
+    assert.equal(
+      spreadEdges.length,
+      0,
+      "fragment_spread edges must not appear (fragments are not nodes)",
+    );
   });
 });
 
@@ -3721,7 +4086,8 @@ describe("satsuma graph: nested array arrow edges (sl-4e5c)", () => {
     const { stdout } = await run("graph", FIXTURE, "--json");
     const data = JSON.parse(stdout);
     for (const e of data.edges) {
-      if (e.from) assert.ok(!e.from.includes("\n"), `from path should not contain newline: ${e.from}`);
+      if (e.from)
+        assert.ok(!e.from.includes("\n"), `from path should not contain newline: ${e.from}`);
       if (e.to) assert.ok(!e.to.includes("\n"), `to path should not contain newline: ${e.to}`);
     }
   });
@@ -3729,7 +4095,9 @@ describe("satsuma graph: nested array arrow edges (sl-4e5c)", () => {
   it("parent array edge exists", async () => {
     const { stdout } = await run("graph", FIXTURE, "--json");
     const data = JSON.parse(stdout);
-    const parentEdge = data.edges.find((e: any) => e.from === "::order_api.line_items" && e.to === "::order_flat.items");
+    const parentEdge = data.edges.find(
+      (e: any) => e.from === "::order_api.line_items" && e.to === "::order_flat.items",
+    );
     assert.ok(parentEdge, "should have parent array edge");
   });
 });
@@ -3743,7 +4111,10 @@ describe("satsuma schema --json — fragment spread expansion (sl-zjec)", () => 
     assert.ok(fieldNames.includes("created_at"), "should include created_at from audit fields");
     assert.ok(fieldNames.includes("updated_at"), "should include updated_at from audit fields");
     assert.ok(fieldNames.includes("created_by"), "should include created_by from audit fields");
-    assert.ok(fieldNames.includes("street_line_1"), "should include street_line_1 from address fields");
+    assert.ok(
+      fieldNames.includes("street_line_1"),
+      "should include street_line_1 from address fields",
+    );
   });
 
   it("still shows spread syntax in fieldLines", async () => {
@@ -3831,7 +4202,12 @@ describe("satsuma arrows — deeply nested paths (sl-xj4p)", () => {
   });
 
   it("--json includes full nested path for source", async () => {
-    const { stdout, code } = await run("arrows", "pacs008.CdtTrfTxInf.DbtrAgt.BIC", "--json", DEEP_NESTED);
+    const { stdout, code } = await run(
+      "arrows",
+      "pacs008.CdtTrfTxInf.DbtrAgt.BIC",
+      "--json",
+      DEEP_NESTED,
+    );
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.length, 1);
@@ -4004,7 +4380,16 @@ describe("satsuma arrows — nl-derived duplicate suppression (sl-k797)", () => 
   it("no duplicate nl-derived when declared arrow already has the source", async () => {
     // `c -> d { "clean up @s1.c" }` — declared arrow has source c, @ref is s1.c.
     // Should return 1 arrow, not 2.
-    const fixture = resolve(import.meta.dirname, "..", "..", "..", "smoke-tests", "arrows", "10-pipe-flatten", "fixture.stm");
+    const fixture = resolve(
+      import.meta.dirname,
+      "..",
+      "..",
+      "..",
+      "smoke-tests",
+      "arrows",
+      "10-pipe-flatten",
+      "fixture.stm",
+    );
     const { stdout, code } = await run("arrows", "s2.d", "--json", fixture);
     assert.equal(code, 0);
     const arrows = JSON.parse(stdout);

--- a/tooling/satsuma-cli/test/lineage.test.ts
+++ b/tooling/satsuma-cli/test/lineage.test.ts
@@ -47,7 +47,15 @@ describe("satsuma lineage", () => {
   it("emits depth-limited downstream JSON without dangling edges", async () => {
     // Depth limits must truncate the DAG coherently: every edge endpoint should
     // still be present in the nodes array.
-    const { stdout, code } = await run("lineage", "--from", "source_a", "--depth", "1", "--json", LINEAGE_CHAIN);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "source_a",
+      "--depth",
+      "1",
+      "--json",
+      LINEAGE_CHAIN,
+    );
 
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
@@ -67,7 +75,15 @@ describe("satsuma lineage", () => {
   it("prints compact downstream output as names only", async () => {
     // Compact mode is intended for scripts and quick scans, so it should omit
     // type annotations while preserving traversal order.
-    const { stdout, code } = await run("lineage", "--from", "source_a", "--depth", "1", "--compact", LINEAGE_CHAIN);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "source_a",
+      "--depth",
+      "1",
+      "--compact",
+      LINEAGE_CHAIN,
+    );
 
     assert.equal(code, 0);
     assert.deepEqual(stdout.trim().split(/\r?\n/), ["source_a", "a_to_b", "intermediate_b"]);
@@ -87,15 +103,28 @@ describe("satsuma lineage", () => {
     // Diamond graph: s0→s1→s2→s3 plus shortcut s0→s2. A first-visit-wins
     // visited set expands s2 at depth 2 (via s1) and never re-expands it when
     // the shortcut reaches it at depth 1, wrongly dropping s3 from --depth 2.
-    const { stdout, code } = await run("lineage", "--from", "s0", "--depth", "2", "--json", LINEAGE_DIAMOND);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "s0",
+      "--depth",
+      "2",
+      "--json",
+      LINEAGE_DIAMOND,
+    );
 
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     const names = data.nodes.map((node: { name: string }) => node.name);
-    assert.ok(names.includes("s3"), `s3 is two schema hops from s0 via the shortcut; got: ${names.join(", ")}`);
+    assert.ok(
+      names.includes("s3"),
+      `s3 is two schema hops from s0 via the shortcut; got: ${names.join(", ")}`,
+    );
     // Re-expansion must not duplicate nodes or edges in the emitted DAG.
     assert.equal(new Set(names).size, names.length, "nodes must be unique");
-    const edgeKeys = data.edges.map((edge: { from: string; to: string }) => `${edge.from}->${edge.to}`);
+    const edgeKeys = data.edges.map(
+      (edge: { from: string; to: string }) => `${edge.from}->${edge.to}`,
+    );
     assert.equal(new Set(edgeKeys).size, edgeKeys.length, "edges must be unique");
   });
 
@@ -109,8 +138,16 @@ describe("satsuma lineage", () => {
     const names = data.nodes.map((node: { name: string }) => node.name);
     assert.ok(names.includes("source_a"));
     assert.ok(names.includes("target_d"));
-    assert.ok(data.edges.some((edge: { from: string; to: string }) => edge.from === "source_a" && edge.to === "a_to_b"));
-    assert.ok(data.edges.some((edge: { from: string; to: string }) => edge.from === "c_to_d" && edge.to === "target_d"));
+    assert.ok(
+      data.edges.some(
+        (edge: { from: string; to: string }) => edge.from === "source_a" && edge.to === "a_to_b",
+      ),
+    );
+    assert.ok(
+      data.edges.some(
+        (edge: { from: string; to: string }) => edge.from === "c_to_d" && edge.to === "target_d",
+      ),
+    );
   });
 
   it("renders upstream text paths covering every JSON node when upstream contains a cycle (sl-h5cx)", async () => {
@@ -126,9 +163,15 @@ describe("satsuma lineage", () => {
     // fixture declares no namespace); --json keeps the canonical "::cycle_a".
     // The two spellings are deliberate — see displayKey() in index-builder.ts.
     const jsonNames = JSON.parse(json.stdout).nodes.map((node: { name: string }) => node.name);
-    assert.ok(jsonNames.length >= 4, `cycle fixture should yield all 4 nodes in JSON, got: ${jsonNames.join(", ")}`);
+    assert.ok(
+      jsonNames.length >= 4,
+      `cycle fixture should yield all 4 nodes in JSON, got: ${jsonNames.join(", ")}`,
+    );
     for (const name of jsonNames) {
-      assert.ok(text.stdout.includes(name), `text output must mention '${name}'; got:\n${text.stdout}`);
+      assert.ok(
+        text.stdout.includes(name),
+        `text output must mention '${name}'; got:\n${text.stdout}`,
+      );
     }
     // The upstream path itself must be visible, not just the target line.
     assert.match(text.stdout, /cycle_b -> b_to_a -> cycle_a/);
@@ -169,7 +212,13 @@ describe("satsuma lineage", () => {
 
   it("keeps not-found errors parseable in JSON mode", async () => {
     // JSON callers rely on structured error payloads even for failed lookups.
-    const { stdout, code } = await run("lineage", "--from", "missing_schema", "--json", LINEAGE_CHAIN);
+    const { stdout, code } = await run(
+      "lineage",
+      "--from",
+      "missing_schema",
+      "--json",
+      LINEAGE_CHAIN,
+    );
 
     assert.equal(code, 1);
     assert.deepEqual(JSON.parse(stdout), { error: "Node 'missing_schema' not found." });

--- a/tooling/satsuma-cli/test/lint-engine.test.ts
+++ b/tooling/satsuma-cli/test/lint-engine.test.ts
@@ -37,7 +37,11 @@ interface MockNLRef {
 }
 
 /** Build a minimal ExtractedWorkspace for lint testing. */
-function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: {
+function makeIndex({
+  schemas = [],
+  mappings = [],
+  nlRefData = [],
+}: {
   schemas?: MockSchema[];
   mappings?: MockMapping[];
   nlRefData?: MockNLRef[];
@@ -60,7 +64,11 @@ function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: {
     warnings: [],
     questions: [],
     fieldArrows: new Map(),
-    referenceGraph: { usedByMappings: new Map(), fragmentsUsedIn: new Map(), metricsReferences: new Map() },
+    referenceGraph: {
+      usedByMappings: new Map(),
+      fragmentsUsedIn: new Map(),
+      metricsReferences: new Map(),
+    },
     namespaceNames: new Set(),
     nlRefData,
     duplicates: [],
@@ -78,21 +86,25 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "staging::stage gl",
-        namespace: "staging",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Lookup @department from @source::hr_employees",
-        mapping: "stage gl",
-        namespace: "staging",
-        targetField: "department",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage gl",
+          namespace: "staging",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup @department from @source::hr_employees",
+          mapping: "stage gl",
+          namespace: "staging",
+          targetField: "department",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -109,21 +121,25 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "staging::stage gl",
-        namespace: "staging",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Copy from @source::finance_gl",
-        mapping: "stage gl",
-        namespace: "staging",
-        targetField: "department",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage gl",
+          namespace: "staging",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Copy from @source::finance_gl",
+          mapping: "stage gl",
+          namespace: "staging",
+          targetField: "department",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -144,20 +160,24 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "stage gl",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees",
-        mapping: "stage gl",
-        namespace: null,
-        targetField: "department",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "stage gl",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees",
+          mapping: "stage gl",
+          namespace: null,
+          targetField: "department",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -190,20 +210,24 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "stage gl",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees",
-        mapping: "stage gl",
-        namespace: null,
-        targetField: "stg_gl.department",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "stage gl",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees",
+          mapping: "stage gl",
+          namespace: null,
+          targetField: "stg_gl.department",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -238,20 +262,24 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "stage gl",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees",
-        mapping: "stage gl",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "stage gl",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees",
+          mapping: "stage gl",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -276,20 +304,24 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "stage gl",
-        sources: ["source::finance_gl", "source::hr_employees"],
-        targets: ["staging::stg_gl"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees",
-        mapping: "stage gl",
-        namespace: null,
-        targetField: "department",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "stage gl",
+          sources: ["source::finance_gl", "source::hr_employees"],
+          targets: ["staging::stg_gl"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees",
+          mapping: "stage gl",
+          namespace: null,
+          targetField: "department",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     // After fix, schema is in source list so no diagnostics
@@ -307,30 +339,31 @@ describe("lint: hidden-source-in-nl", () => {
           fields: [
             {
               name: "PERSONAL_NAME",
-              children: [
-                { name: "FIRST_NAME" },
-                { name: "LAST_NAME" },
-              ],
+              children: [{ name: "FIRST_NAME" }, { name: "LAST_NAME" }],
             },
             { name: "email" },
           ],
         },
         { name: "tgt_person", fields: [{ name: "first_name" }] },
       ],
-      mappings: [{
-        name: "map_person",
-        sources: ["src_contact"],
-        targets: ["tgt_person"],
-      }],
-      nlRefData: [{
-        text: "Copy from @PERSONAL_NAME.FIRST_NAME",
-        mapping: "map_person",
-        namespace: null,
-        targetField: "first_name",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "map_person",
+          sources: ["src_contact"],
+          targets: ["tgt_person"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Copy from @PERSONAL_NAME.FIRST_NAME",
+          mapping: "map_person",
+          namespace: null,
+          targetField: "first_name",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -346,20 +379,24 @@ describe("lint: hidden-source-in-nl", () => {
         { name: "other_schema", fields: [{ name: "some_field" }] },
         { name: "tgt_person", fields: [{ name: "first_name" }] },
       ],
-      mappings: [{
-        name: "map_person",
-        sources: ["src_contact"],
-        targets: ["tgt_person"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @other_schema.some_field",
-        mapping: "map_person",
-        namespace: null,
-        targetField: "first_name",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "map_person",
+          sources: ["src_contact"],
+          targets: ["tgt_person"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @other_schema.some_field",
+          mapping: "map_person",
+          namespace: null,
+          targetField: "first_name",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["hidden-source-in-nl"] });
@@ -377,21 +414,25 @@ describe("lint: unresolved-nl-ref", () => {
         { name: "source::orders", fields: [{ name: "order_id" }] },
         { name: "staging::stg_orders", fields: [{ name: "order_id" }] },
       ],
-      mappings: [{
-        name: "staging::stage orders",
-        namespace: "staging",
-        sources: ["source::orders"],
-        targets: ["staging::stg_orders"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @nonexistent_thing",
-        mapping: "stage orders",
-        namespace: "staging",
-        targetField: "order_id",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage orders",
+          namespace: "staging",
+          sources: ["source::orders"],
+          targets: ["staging::stg_orders"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @nonexistent_thing",
+          mapping: "stage orders",
+          namespace: "staging",
+          targetField: "order_id",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -406,21 +447,25 @@ describe("lint: unresolved-nl-ref", () => {
         { name: "source::orders", fields: [{ name: "order_id" }] },
         { name: "staging::stg_orders", fields: [{ name: "order_id" }] },
       ],
-      mappings: [{
-        name: "staging::stage orders",
-        namespace: "staging",
-        sources: ["source::orders"],
-        targets: ["staging::stg_orders"],
-      }],
-      nlRefData: [{
-        text: "Copy @order_id from source",
-        mapping: "stage orders",
-        namespace: "staging",
-        targetField: "order_id",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage orders",
+          namespace: "staging",
+          sources: ["source::orders"],
+          targets: ["staging::stg_orders"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Copy @order_id from source",
+          mapping: "stage orders",
+          namespace: "staging",
+          targetField: "order_id",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -431,18 +476,18 @@ describe("lint: unresolved-nl-ref", () => {
     // Bug sl-vjvf: unresolved @refs in file-level notes were previously skipped.
     // They should now produce unresolved-nl-ref warnings like any other note context.
     const index = makeIndex({
-      schemas: [
-        { name: "source::orders", fields: [{ name: "order_id" }] },
+      schemas: [{ name: "source::orders", fields: [{ name: "order_id" }] }],
+      nlRefData: [
+        {
+          text: "The @flatten transform is used for @pii compliance",
+          mapping: "note:",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 1,
+          column: 0,
+        },
       ],
-      nlRefData: [{
-        text: "The @flatten transform is used for @pii compliance",
-        mapping: "note:",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 1,
-        column: 0,
-      }],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -451,18 +496,18 @@ describe("lint: unresolved-nl-ref", () => {
 
   it("still flags unresolved refs in metric/schema note blocks", () => {
     const index = makeIndex({
-      schemas: [
-        { name: "source::orders", fields: [{ name: "order_id" }] },
+      schemas: [{ name: "source::orders", fields: [{ name: "order_id" }] }],
+      nlRefData: [
+        {
+          text: "Lookup from @nonexistent_thing",
+          mapping: "note:source::orders",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
       ],
-      nlRefData: [{
-        text: "Lookup from @nonexistent_thing",
-        mapping: "note:source::orders",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
     });
 
     const diags = runLint(index, { select: ["unresolved-nl-ref"] });
@@ -476,9 +521,7 @@ describe("lint: unresolved-nl-ref", () => {
 describe("lint: duplicate-definition", () => {
   it("flags schema declared twice in same namespace", () => {
     const index = makeIndex({
-      schemas: [
-        { name: "staging::orders", fields: [{ name: "order_id" }] },
-      ],
+      schemas: [{ name: "staging::orders", fields: [{ name: "order_id" }] }],
     });
     index.duplicates = [
       {
@@ -579,21 +622,25 @@ describe("lint engine: rule filtering", () => {
         { name: "source::orders", fields: [{ name: "order_id" }] },
         { name: "staging::stg_orders", fields: [{ name: "order_id" }] },
       ],
-      mappings: [{
-        name: "staging::stage orders",
-        namespace: "staging",
-        sources: ["source::orders"],
-        targets: ["staging::stg_orders"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @nonexistent_thing",
-        mapping: "stage orders",
-        namespace: "staging",
-        targetField: "order_id",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage orders",
+          namespace: "staging",
+          sources: ["source::orders"],
+          targets: ["staging::stg_orders"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @nonexistent_thing",
+          mapping: "stage orders",
+          namespace: "staging",
+          targetField: "order_id",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const all = runLint(index);
@@ -611,21 +658,25 @@ describe("lint diagnostic shape", () => {
         { name: "source::orders", fields: [{ name: "order_id" }] },
         { name: "staging::stg_orders", fields: [{ name: "order_id" }] },
       ],
-      mappings: [{
-        name: "staging::stage orders",
-        namespace: "staging",
-        sources: ["source::orders"],
-        targets: ["staging::stg_orders"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @nonexistent_thing",
-        mapping: "stage orders",
-        namespace: "staging",
-        targetField: "order_id",
-        file: "test.stm",
-        line: 5,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage orders",
+          namespace: "staging",
+          sources: ["source::orders"],
+          targets: ["staging::stg_orders"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @nonexistent_thing",
+          mapping: "stage orders",
+          namespace: "staging",
+          targetField: "order_id",
+          file: "test.stm",
+          line: 5,
+          column: 6,
+        },
+      ],
     });
 
     const diags = runLint(index);

--- a/tooling/satsuma-cli/test/load-workspace.test.ts
+++ b/tooling/satsuma-cli/test/load-workspace.test.ts
@@ -51,7 +51,10 @@ describe("loadWorkspace", () => {
     const { files, index } = await loadWorkspace(entry);
 
     assert.ok(files.length >= 1, "expected at least the entry file to be parsed");
-    assert.ok(files.every((f) => f.tree && f.src), "every parsed file must carry a tree and source");
+    assert.ok(
+      files.every((f) => f.tree && f.src),
+      "every parsed file must carry a tree and source",
+    );
     assert.ok(index.schemas.size > 0, "common.stm defines schemas — index should be populated");
   });
 
@@ -114,8 +117,7 @@ describe("loadWorkspace failure handling", () => {
     const bogus = "/definitely/does/not/exist.stm";
     await assert.rejects(
       () => loadWorkspace(bogus),
-      (err: unknown) =>
-        err instanceof CommandError && err.message.includes(`'${bogus}'`),
+      (err: unknown) => err instanceof CommandError && err.message.includes(`'${bogus}'`),
     );
   });
 });

--- a/tooling/satsuma-cli/test/mapping.test.ts
+++ b/tooling/satsuma-cli/test/mapping.test.ts
@@ -10,7 +10,9 @@ import { describe, it } from "node:test";
 function n(type: string, namedChildren: any[] = [], text = "") {
   return { type, text, startPosition: { row: 0, column: 0 }, namedChildren };
 }
-function ident(t: string) { return n("identifier", [], t); }
+function ident(t: string) {
+  return n("identifier", [], t);
+}
 function blockLabel(name: string) {
   return n("block_label", [ident(name)]);
 }
@@ -40,7 +42,12 @@ function collectArrows(bodyNode: any): any[] {
       const tgt = c.namedChildren.find((x: any) => x.type === "tgt_path");
       const children: any[] = collectArrows(c);
       const hasChildren: boolean = children.length > 0;
-      arrows.push({ kind: hasChildren ? "nested" : "map", src: pathText(src), tgt: pathText(tgt), hasBody: hasChildren });
+      arrows.push({
+        kind: hasChildren ? "nested" : "map",
+        src: pathText(src),
+        tgt: pathText(tgt),
+        hasBody: hasChildren,
+      });
     }
   }
   return arrows;

--- a/tooling/satsuma-cli/test/metric.test.ts
+++ b/tooling/satsuma-cli/test/metric.test.ts
@@ -10,7 +10,9 @@ import { describe, it } from "node:test";
 function n(type: string, namedChildren: any[] = [], text = "") {
   return { type, text, startPosition: { row: 0, column: 0 }, namedChildren };
 }
-function ident(t: string) { return n("identifier", [], t); }
+function ident(t: string) {
+  return n("identifier", [], t);
+}
 
 // ── Inline extractMetaEntries (mirrors metric.js) ─────────────────────────────
 
@@ -39,7 +41,8 @@ function extractMetaEntries(metaNode: any) {
 
 function formatMeta(entries: { key: string; value: string | null }[]) {
   if (entries.length === 0) return "";
-  const format = (e: { key: string; value: string | null }) => (e.value !== null ? `${e.key} ${e.value}` : e.key);
+  const format = (e: { key: string; value: string | null }) =>
+    e.value !== null ? `${e.key} ${e.value}` : e.key;
   if (entries.length <= 2) {
     return ` (${entries.map(format).join(", ")})`;
   }
@@ -62,7 +65,11 @@ describe("extractMetaEntries", () => {
   });
 
   it("strips nl_string quotes from values", () => {
-    const kvVal = n("value_text", [n("nl_string", [], '"status = \'active\'"')], '"status = \'active\'"');
+    const kvVal = n(
+      "value_text",
+      [n("nl_string", [], "\"status = 'active'\"")],
+      "\"status = 'active'\"",
+    );
     const kv = n("tag_with_value", [ident("filter"), kvVal]);
     const meta = n("metadata_block", [kv]);
 

--- a/tooling/satsuma-cli/test/namespace-bugs.test.ts
+++ b/tooling/satsuma-cli/test/namespace-bugs.test.ts
@@ -79,13 +79,24 @@ describe("namespace collision regressions", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.ok(
-      data.schema_edges.some((e: any) => e.from === "beta::customer" && e.to === "beta::load_customer" && e.role === "source"),
+      data.schema_edges.some(
+        (e: any) =>
+          e.from === "beta::customer" && e.to === "beta::load_customer" && e.role === "source",
+      ),
     );
     assert.ok(
-      data.schema_edges.some((e: any) => e.from === "beta::load_customer" && e.to === "beta::customer_out" && e.role === "target"),
+      data.schema_edges.some(
+        (e: any) =>
+          e.from === "beta::load_customer" && e.to === "beta::customer_out" && e.role === "target",
+      ),
     );
     assert.ok(
-      data.schema_edges.some((e: any) => e.from === "beta::customer_out" && e.to === "beta::customer_health" && e.role === "metric_source"),
+      data.schema_edges.some(
+        (e: any) =>
+          e.from === "beta::customer_out" &&
+          e.to === "beta::customer_health" &&
+          e.role === "metric_source",
+      ),
     );
   });
 });
@@ -101,27 +112,42 @@ describe("namespace output canonicalization regressions", () => {
     const { stdout, code } = await run("where-used", "customers", OUTPUT_BUGS_FIXTURE, "--json");
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
-    assert.equal(data.name, "crm::customers",
-      "JSON 'name' must be the qualified canonical key, not the bare query string");
+    assert.equal(
+      data.name,
+      "crm::customers",
+      "JSON 'name' must be the qualified canonical key, not the bare query string",
+    );
   });
 
   it("sl-ltv6: arrows text header shows correct count for bare-name field queries", async () => {
     // Querying with bare "customers.email" should produce the same arrow count
     // in the header as the fully-qualified "crm::customers.email".
-    const { stdout: bareOut, code: bareCode } = await run("arrows", "customers.email", OUTPUT_BUGS_FIXTURE);
+    const { stdout: bareOut, code: bareCode } = await run(
+      "arrows",
+      "customers.email",
+      OUTPUT_BUGS_FIXTURE,
+    );
     assert.equal(bareCode, 0);
-    const { stdout: qualOut, code: qualCode } = await run("arrows", "crm::customers.email", OUTPUT_BUGS_FIXTURE);
+    const { stdout: qualOut, code: qualCode } = await run(
+      "arrows",
+      "crm::customers.email",
+      OUTPUT_BUGS_FIXTURE,
+    );
     assert.equal(qualCode, 0);
     // Both should show the same non-zero arrow count in the header line.
     // The header format is "<field> — N arrow(s) (...)".
     const extractCount = (out: string): string => out.split("\n")[0] ?? "";
-    assert.doesNotMatch(extractCount(bareOut), /— 0 arrows/,
-      "bare-name header must not report 0 arrows");
-    assert.match(extractCount(bareOut), /1 as source/,
-      "bare-name header must report 1 as source");
-    assert.equal(extractCount(bareOut).replace("customers.email", "crm::customers.email"),
+    assert.doesNotMatch(
+      extractCount(bareOut),
+      /— 0 arrows/,
+      "bare-name header must not report 0 arrows",
+    );
+    assert.match(extractCount(bareOut), /1 as source/, "bare-name header must report 1 as source");
+    assert.equal(
+      extractCount(bareOut).replace("customers.email", "crm::customers.email"),
       extractCount(qualOut),
-      "bare-name and qualified arrow counts must match");
+      "bare-name and qualified arrow counts must match",
+    );
   });
 
   it("sl-pb47: warnings JSON 'block' field carries namespace-qualified name", async () => {
@@ -132,8 +158,7 @@ describe("namespace output canonicalization regressions", () => {
     const data = JSON.parse(stdout);
     const item = data.items[0];
     assert.ok(item, "expected at least one warning item");
-    assert.equal(item.block, "crm::customers",
-      "JSON 'block' must include the namespace prefix");
+    assert.equal(item.block, "crm::customers", "JSON 'block' must include the namespace prefix");
   });
 
   it("sl-qofc: mapping text output shows namespace-qualified name in header", async () => {
@@ -141,8 +166,11 @@ describe("namespace output canonicalization regressions", () => {
     // rather than "mapping 'load dim_customer' {".
     const { stdout, code } = await run("mapping", "crm::load dim_customer", OUTPUT_BUGS_FIXTURE);
     assert.equal(code, 0);
-    assert.match(stdout, /mapping 'crm::load dim_customer'/,
-      "mapping text header must include namespace prefix");
+    assert.match(
+      stdout,
+      /mapping 'crm::load dim_customer'/,
+      "mapping text header must include namespace prefix",
+    );
   });
 
   it("sl-qxn5: arrows does not emit a duplicate nl-derived arrow when @ref is the arrow's own source", async () => {
@@ -152,8 +180,11 @@ describe("namespace output canonicalization regressions", () => {
     const { stdout, code } = await run("arrows", "crm::customers.email", OUTPUT_BUGS_FIXTURE);
     assert.equal(code, 0);
     const arrowLines = stdout.split("\n").filter((l) => l.includes("->"));
-    assert.equal(arrowLines.length, 1,
-      "only the explicit arrow should appear; no duplicate nl-derived arrow");
+    assert.equal(
+      arrowLines.length,
+      1,
+      "only the explicit arrow should appear; no duplicate nl-derived arrow",
+    );
   });
 
   it("sl-wfgx: nl JSON parent field uses canonical name for bare-name block queries", async () => {
@@ -165,8 +196,11 @@ describe("namespace output canonicalization regressions", () => {
     assert.ok(items.length > 0, "expected NL items for the mapping");
     for (const item of items) {
       if (item.parent) {
-        assert.equal(item.parent, "crm::load dim_customer",
-          "NL item parent must use the canonical qualified name");
+        assert.equal(
+          item.parent,
+          "crm::load dim_customer",
+          "NL item parent must use the canonical qualified name",
+        );
       }
     }
   });
@@ -175,17 +209,26 @@ describe("namespace output canonicalization regressions", () => {
     // satsuma mapping 'load dim_customer' should show the qualified name in the header.
     const { stdout, code } = await run("mapping", "load dim_customer", OUTPUT_BUGS_FIXTURE);
     assert.equal(code, 0);
-    assert.match(stdout, /mapping 'crm::load dim_customer'/,
-      "text header must always show the namespace-qualified name");
+    assert.match(
+      stdout,
+      /mapping 'crm::load dim_customer'/,
+      "text header must always show the namespace-qualified name",
+    );
   });
 
   it("sl-wfgx: where-used text header uses canonical name for bare-name queries", async () => {
     // "References to 'crm::customers' (N):" not "References to 'customers' (N):".
     const { stdout, code } = await run("where-used", "customers", OUTPUT_BUGS_FIXTURE);
     assert.equal(code, 0);
-    assert.match(stdout, /References to 'crm::customers'/,
-      "text header must show the canonical qualified name");
-    assert.doesNotMatch(stdout, /References to 'customers' /,
-      "text header must not echo the bare query string");
+    assert.match(
+      stdout,
+      /References to 'crm::customers'/,
+      "text header must show the canonical qualified name",
+    );
+    assert.doesNotMatch(
+      stdout,
+      /References to 'customers' /,
+      "text header must not echo the bare query string",
+    );
   });
 });

--- a/tooling/satsuma-cli/test/namespace-index.test.ts
+++ b/tooling/satsuma-cli/test/namespace-index.test.ts
@@ -144,7 +144,11 @@ describe("per-namespace duplicate detection", () => {
       ],
     });
     const index = buildIndex([data]);
-    assert.equal(index.duplicates.length, 0, "Same name in different namespaces should not conflict");
+    assert.equal(
+      index.duplicates.length,
+      0,
+      "Same name in different namespaces should not conflict",
+    );
     assert.ok(index.schemas.has("crm::customer"));
     assert.ok(index.schemas.has("billing::customer"));
   });
@@ -157,7 +161,11 @@ describe("per-namespace duplicate detection", () => {
       ],
     });
     const index = buildIndex([data]);
-    assert.equal(index.duplicates.length, 0, "Same name in namespace and global should not conflict");
+    assert.equal(
+      index.duplicates.length,
+      0,
+      "Same name in namespace and global should not conflict",
+    );
     assert.ok(index.schemas.has("customer"));
     assert.ok(index.schemas.has("crm::customer"));
   });
@@ -274,14 +282,16 @@ describe("namespace-aware reference resolution", () => {
         { name: "pos_oracle", namespace: "pos", fields: [], row: 0 },
         { name: "hub_store", namespace: "vault", fields: [], row: 5 },
       ],
-      mappings: [{
-        name: "load",
-        namespace: "vault",
-        sources: ["pos::pos_oracle"],
-        targets: ["hub_store"],
-        arrowCount: 0,
-        row: 10,
-      }],
+      mappings: [
+        {
+          name: "load",
+          namespace: "vault",
+          sources: ["pos::pos_oracle"],
+          targets: ["hub_store"],
+          arrowCount: 0,
+          row: 10,
+        },
+      ],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
@@ -295,14 +305,16 @@ describe("namespace-aware reference resolution", () => {
         { name: "shared_lookup", namespace: null, fields: [], row: 0 },
         { name: "hub_store", namespace: "vault", fields: [], row: 5 },
       ],
-      mappings: [{
-        name: "load",
-        namespace: "vault",
-        sources: ["shared_lookup"],
-        targets: ["hub_store"],
-        arrowCount: 0,
-        row: 10,
-      }],
+      mappings: [
+        {
+          name: "load",
+          namespace: "vault",
+          sources: ["shared_lookup"],
+          targets: ["hub_store"],
+          arrowCount: 0,
+          row: 10,
+        },
+      ],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
@@ -316,14 +328,16 @@ describe("namespace-aware reference resolution", () => {
         { name: "pos_oracle", namespace: "pos", fields: [], row: 0 },
         { name: "hub_store", namespace: "vault", fields: [], row: 5 },
       ],
-      mappings: [{
-        name: "bad_ref",
-        namespace: "vault",
-        sources: ["pos_oracle"],
-        targets: ["hub_store"],
-        arrowCount: 0,
-        row: 10,
-      }],
+      mappings: [
+        {
+          name: "bad_ref",
+          namespace: "vault",
+          sources: ["pos_oracle"],
+          targets: ["hub_store"],
+          arrowCount: 0,
+          row: 10,
+        },
+      ],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
@@ -339,21 +353,26 @@ describe("namespace-aware reference resolution", () => {
         { name: "customer", namespace: "billing", fields: [], row: 5 },
         { name: "target", namespace: null, fields: [], row: 10 },
       ],
-      mappings: [{
-        name: "load",
-        namespace: null,
-        sources: ["customer"],
-        targets: ["target"],
-        arrowCount: 0,
-        row: 15,
-      }],
+      mappings: [
+        {
+          name: "load",
+          namespace: null,
+          sources: ["customer"],
+          targets: ["target"],
+          arrowCount: 0,
+          row: 15,
+        },
+      ],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
     const refWarnings = warnings.filter((w: any) => w.rule === "undefined-ref");
     assert.equal(refWarnings.length, 1);
     assert.ok(refWarnings[0].message.includes("hint"), "Should include a hint");
-    assert.ok(refWarnings[0].message.includes("crm::customer") || refWarnings[0].message.includes("billing::customer"));
+    assert.ok(
+      refWarnings[0].message.includes("crm::customer") ||
+        refWarnings[0].message.includes("billing::customer"),
+    );
   });
 
   it("resolves qualified reference directly", () => {
@@ -362,14 +381,16 @@ describe("namespace-aware reference resolution", () => {
         { name: "pos_oracle", namespace: "pos", fields: [], row: 0 },
         { name: "target", namespace: null, fields: [], row: 5 },
       ],
-      mappings: [{
-        name: "load",
-        namespace: null,
-        sources: ["pos::pos_oracle"],
-        targets: ["target"],
-        arrowCount: 0,
-        row: 10,
-      }],
+      mappings: [
+        {
+          name: "load",
+          namespace: null,
+          sources: ["pos::pos_oracle"],
+          targets: ["target"],
+          arrowCount: 0,
+          row: 10,
+        },
+      ],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
@@ -379,17 +400,17 @@ describe("namespace-aware reference resolution", () => {
 
   it("warns for qualified reference to non-existent namespace", () => {
     const data = makeFileData({
-      schemas: [
-        { name: "target", namespace: null, fields: [], row: 0 },
+      schemas: [{ name: "target", namespace: null, fields: [], row: 0 }],
+      mappings: [
+        {
+          name: "load",
+          namespace: null,
+          sources: ["nonexistent::schema"],
+          targets: ["target"],
+          arrowCount: 0,
+          row: 5,
+        },
       ],
-      mappings: [{
-        name: "load",
-        namespace: null,
-        sources: ["nonexistent::schema"],
-        targets: ["target"],
-        arrowCount: 0,
-        row: 5,
-      }],
     });
     const index = buildIndex([data]);
     const warnings = collectSemanticWarnings(index);
@@ -430,14 +451,16 @@ describe("backward compatibility: global-only workspaces", () => {
         { name: "orders", namespace: null, fields: [{ name: "id", type: "INT" }], row: 0 },
         { name: "customers", namespace: null, fields: [{ name: "name", type: "VARCHAR" }], row: 5 },
       ],
-      mappings: [{
-        name: "load",
-        namespace: null,
-        sources: ["orders"],
-        targets: ["customers"],
-        arrowCount: 0,
-        row: 10,
-      }],
+      mappings: [
+        {
+          name: "load",
+          namespace: null,
+          sources: ["orders"],
+          targets: ["customers"],
+          arrowCount: 0,
+          row: 10,
+        },
+      ],
     });
     const index = buildIndex([data]);
     assert.ok(index.schemas.has("orders"));
@@ -468,27 +491,31 @@ describe("schema field merging across files", () => {
   it("merges fields from duplicate schema declarations", () => {
     const data1 = makeFileData({
       filePath: "hub-customer.stm",
-      schemas: [{
-        name: "pos_oracle",
-        namespace: null,
-        fields: [
-          { name: "CUSTOMER_ID", type: "VARCHAR(20)" },
-          { name: "FIRST_NAME", type: "VARCHAR(100)" },
-        ],
-        row: 49,
-      }],
+      schemas: [
+        {
+          name: "pos_oracle",
+          namespace: null,
+          fields: [
+            { name: "CUSTOMER_ID", type: "VARCHAR(20)" },
+            { name: "FIRST_NAME", type: "VARCHAR(100)" },
+          ],
+          row: 49,
+        },
+      ],
     });
     const data2 = makeFileData({
       filePath: "hub-store.stm",
-      schemas: [{
-        name: "pos_oracle",
-        namespace: null,
-        fields: [
-          { name: "STORE_ID", type: "VARCHAR(20)" },
-          { name: "STORE_NAME", type: "VARCHAR(100)" },
-        ],
-        row: 20,
-      }],
+      schemas: [
+        {
+          name: "pos_oracle",
+          namespace: null,
+          fields: [
+            { name: "STORE_ID", type: "VARCHAR(20)" },
+            { name: "STORE_NAME", type: "VARCHAR(100)" },
+          ],
+          row: 20,
+        },
+      ],
     });
     const index = buildIndex([data1, data2]);
     const schema = index.schemas.get("pos_oracle");
@@ -504,58 +531,74 @@ describe("schema field merging across files", () => {
   it("does not duplicate fields present in both declarations", () => {
     const data1 = makeFileData({
       filePath: "a.stm",
-      schemas: [{
-        name: "shared",
-        namespace: null,
-        fields: [
-          { name: "id", type: "INT" },
-          { name: "name", type: "VARCHAR" },
-        ],
-        row: 0,
-      }],
+      schemas: [
+        {
+          name: "shared",
+          namespace: null,
+          fields: [
+            { name: "id", type: "INT" },
+            { name: "name", type: "VARCHAR" },
+          ],
+          row: 0,
+        },
+      ],
     });
     const data2 = makeFileData({
       filePath: "b.stm",
-      schemas: [{
-        name: "shared",
-        namespace: null,
-        fields: [
-          { name: "id", type: "INT" },
-          { name: "email", type: "VARCHAR" },
-        ],
-        row: 5,
-      }],
+      schemas: [
+        {
+          name: "shared",
+          namespace: null,
+          fields: [
+            { name: "id", type: "INT" },
+            { name: "email", type: "VARCHAR" },
+          ],
+          row: 5,
+        },
+      ],
     });
     const index = buildIndex([data1, data2]);
     const schema = index.schemas.get("shared")!;
     const fieldNames = schema.fields.map((f: any) => f.name);
-    assert.equal(fieldNames.filter((n: any) => n === "id").length, 1, "Should not duplicate shared field");
+    assert.equal(
+      fieldNames.filter((n: any) => n === "id").length,
+      1,
+      "Should not duplicate shared field",
+    );
     assert.equal(schema.fields.length, 3, "id + name + email");
   });
 
   it("merges hasSpreads flag across declarations", () => {
     const data1 = makeFileData({
       filePath: "a.stm",
-      schemas: [{
-        name: "src",
-        namespace: null,
-        fields: [{ name: "id", type: "INT" }],
-        hasSpreads: false,
-        row: 0,
-      }],
+      schemas: [
+        {
+          name: "src",
+          namespace: null,
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: false,
+          row: 0,
+        },
+      ],
     });
     const data2 = makeFileData({
       filePath: "b.stm",
-      schemas: [{
-        name: "src",
-        namespace: null,
-        fields: [{ name: "name", type: "VARCHAR" }],
-        hasSpreads: true,
-        row: 5,
-      }],
+      schemas: [
+        {
+          name: "src",
+          namespace: null,
+          fields: [{ name: "name", type: "VARCHAR" }],
+          hasSpreads: true,
+          row: 5,
+        },
+      ],
     });
     const index = buildIndex([data1, data2]);
-    assert.equal(index.schemas.get("src")!.hasSpreads, true, "hasSpreads should be true if any declaration has spreads");
+    assert.equal(
+      index.schemas.get("src")!.hasSpreads,
+      true,
+      "hasSpreads should be true if any declaration has spreads",
+    );
   });
 
   it("merged schema fields resolve correctly in field-not-in-schema check", () => {
@@ -575,48 +618,58 @@ describe("schema field merging across files", () => {
           row: 70,
         },
       ],
-      mappings: [{
-        name: "pos to hub_customer",
-        namespace: null,
-        sources: ["pos_oracle"],
-        targets: ["hub_customer"],
-        arrowCount: 1,
-        row: 80,
-      }],
-      arrowRecords: [{
-        mapping: "pos to hub_customer",
-        namespace: null,
-        sources: ["CUSTOMER_ID"],
-        target: "customer_id",
-        row: 85,
-      }],
+      mappings: [
+        {
+          name: "pos to hub_customer",
+          namespace: null,
+          sources: ["pos_oracle"],
+          targets: ["hub_customer"],
+          arrowCount: 1,
+          row: 80,
+        },
+      ],
+      arrowRecords: [
+        {
+          mapping: "pos to hub_customer",
+          namespace: null,
+          sources: ["CUSTOMER_ID"],
+          target: "customer_id",
+          row: 85,
+        },
+      ],
     });
     const data2 = makeFileData({
       filePath: "hub-store.stm",
-      schemas: [{
-        name: "pos_oracle",
-        namespace: null,
-        fields: [
-          { name: "STORE_ID", type: "VARCHAR(20)" },
-          { name: "STORE_NAME", type: "VARCHAR(100)" },
-        ],
-        row: 20,
-      }],
-      mappings: [{
-        name: "pos to hub_store",
-        namespace: null,
-        sources: ["pos_oracle"],
-        targets: ["hub_store"],
-        arrowCount: 1,
-        row: 40,
-      }],
-      arrowRecords: [{
-        mapping: "pos to hub_store",
-        namespace: null,
-        sources: ["STORE_NAME"],
-        target: null,
-        row: 45,
-      }],
+      schemas: [
+        {
+          name: "pos_oracle",
+          namespace: null,
+          fields: [
+            { name: "STORE_ID", type: "VARCHAR(20)" },
+            { name: "STORE_NAME", type: "VARCHAR(100)" },
+          ],
+          row: 20,
+        },
+      ],
+      mappings: [
+        {
+          name: "pos to hub_store",
+          namespace: null,
+          sources: ["pos_oracle"],
+          targets: ["hub_store"],
+          arrowCount: 1,
+          row: 40,
+        },
+      ],
+      arrowRecords: [
+        {
+          mapping: "pos to hub_store",
+          namespace: null,
+          sources: ["STORE_NAME"],
+          target: null,
+          row: 45,
+        },
+      ],
     });
     // Add the hub_store target schema in data2
     data2.schemas.push({
@@ -660,14 +713,16 @@ describe("schema field merging across files", () => {
           row: 20,
         },
       ],
-      mappings: [{
-        name: "customer to hub_customer",
-        namespace: null,
-        sources: ["customer"],
-        targets: ["hub_customer"],
-        arrowCount: 2,
-        row: 30,
-      }],
+      mappings: [
+        {
+          name: "customer to hub_customer",
+          namespace: null,
+          sources: ["customer"],
+          targets: ["hub_customer"],
+          arrowCount: 2,
+          row: 30,
+        },
+      ],
       arrowRecords: [
         {
           mapping: "customer to hub_customer",
@@ -682,33 +737,39 @@ describe("schema field merging across files", () => {
     // File B declares the same "customer" schema with "address" having child "city"
     const data2 = makeFileData({
       filePath: "file-b.stm",
-      schemas: [{
-        name: "customer",
-        namespace: null,
-        fields: [
-          {
-            name: "address",
-            type: "record",
-            children: [{ name: "city", type: "VARCHAR(100)" }],
-          },
-        ],
-        row: 1,
-      }],
-      mappings: [{
-        name: "customer to hub_customer_b",
-        namespace: null,
-        sources: ["customer"],
-        targets: ["hub_customer"],
-        arrowCount: 1,
-        row: 10,
-      }],
-      arrowRecords: [{
-        mapping: "customer to hub_customer_b",
-        namespace: null,
-        sources: ["address.city"],
-        target: "address_city",
-        row: 15,
-      }],
+      schemas: [
+        {
+          name: "customer",
+          namespace: null,
+          fields: [
+            {
+              name: "address",
+              type: "record",
+              children: [{ name: "city", type: "VARCHAR(100)" }],
+            },
+          ],
+          row: 1,
+        },
+      ],
+      mappings: [
+        {
+          name: "customer to hub_customer_b",
+          namespace: null,
+          sources: ["customer"],
+          targets: ["hub_customer"],
+          arrowCount: 1,
+          row: 10,
+        },
+      ],
+      arrowRecords: [
+        {
+          mapping: "customer to hub_customer_b",
+          namespace: null,
+          sources: ["address.city"],
+          target: "address_city",
+          row: 15,
+        },
+      ],
     });
 
     const index = buildIndex([data1, data2]);
@@ -726,7 +787,11 @@ describe("schema field merging across files", () => {
     // Verify no false field-not-in-schema warnings
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "Nested record children should merge without false warnings");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "Nested record children should merge without false warnings",
+    );
   });
 });
 
@@ -749,9 +814,10 @@ describe("fieldArrows index: nested child arrow keys (sl-9gvb)", () => {
     const parsed = parseFile(resolve(EXAMPLES, "cobol-to-avro/pipeline.stm"));
     const data = extractFileData(parsed);
     const index = buildIndex([data]);
-    assert.ok(index.fieldArrows.has("PHONE_TYPE"),
-      "should index bare PHONE_TYPE");
-    assert.ok(index.fieldArrows.has("cobol_customer_master.PHONE_NUMBERS.PHONE_TYPE"),
-      "should index fully qualified PHONE_TYPE");
+    assert.ok(index.fieldArrows.has("PHONE_TYPE"), "should index bare PHONE_TYPE");
+    assert.ok(
+      index.fieldArrows.has("cobol_customer_master.PHONE_NUMBERS.PHONE_TYPE"),
+      "should index fully qualified PHONE_TYPE",
+    );
   });
 });

--- a/tooling/satsuma-cli/test/nl-ref-extract.test.ts
+++ b/tooling/satsuma-cli/test/nl-ref-extract.test.ts
@@ -30,12 +30,10 @@ describe("extractAtRefs", () => {
       "Lookup @department from @source::hr_employees using @posted_by -> @employee_id",
     );
     assert.equal(refs.length, 4);
-    assert.deepEqual(refs.map((r) => r.ref), [
-      "department",
-      "source::hr_employees",
-      "posted_by",
-      "employee_id",
-    ]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["department", "source::hr_employees", "posted_by", "employee_id"],
+    );
   });
 
   it("returns empty array for text without @refs", () => {
@@ -78,11 +76,12 @@ describe("classifyRef", () => {
 // ── resolveRef ──────────────────────────────────────────────────────────────
 
 describe("resolveRef", () => {
-  const makeIndex = (schemas: any = {}, transforms: any = {}, fragments: any = {}) => ({
-    schemas: new Map(Object.entries(schemas)),
-    transforms: new Map(Object.entries(transforms)),
-    fragments: new Map(Object.entries(fragments)),
-  } as any);
+  const makeIndex = (schemas: any = {}, transforms: any = {}, fragments: any = {}) =>
+    ({
+      schemas: new Map(Object.entries(schemas)),
+      transforms: new Map(Object.entries(transforms)),
+      fragments: new Map(Object.entries(fragments)),
+    }) as any;
 
   it("resolves namespace-qualified schema", () => {
     const index = makeIndex({
@@ -220,13 +219,17 @@ describe("resolveRef", () => {
   it("resolves deeply nested path (4+ segments)", () => {
     const index = makeIndex({
       "src::msg": {
-        fields: [{
-          name: "header",
-          children: [{
-            name: "sender",
-            children: [{ name: "name" }],
-          }],
-        }],
+        fields: [
+          {
+            name: "header",
+            children: [
+              {
+                name: "sender",
+                children: [{ name: "name" }],
+              },
+            ],
+          },
+        ],
       },
     });
     const result = resolveRef("src::msg.header.sender.name", {} as any, index);
@@ -251,11 +254,12 @@ describe("resolveRef", () => {
 // ── resolveRef with fragment spreads ─────────────────────────────────────────
 
 describe("resolveRef — fragment spread expansion", () => {
-  const makeIndex = (schemas: any = {}, transforms: any = {}, fragments: any = {}) => ({
-    schemas: new Map(Object.entries(schemas)),
-    transforms: new Map(Object.entries(transforms)),
-    fragments: new Map(Object.entries(fragments)),
-  } as any);
+  const makeIndex = (schemas: any = {}, transforms: any = {}, fragments: any = {}) =>
+    ({
+      schemas: new Map(Object.entries(schemas)),
+      transforms: new Map(Object.entries(transforms)),
+      fragments: new Map(Object.entries(fragments)),
+    }) as any;
 
   it("resolves namespace-qualified field via fragment spread", () => {
     const index = makeIndex(
@@ -384,7 +388,10 @@ describe("resolveRef — fragment spread expansion", () => {
 
 describe("isSchemaInMappingSources", () => {
   it("returns true when schema is in sources", () => {
-    const mapping = { sources: ["source::hr_employees"], targets: ["staging::stg_employees"] } as any;
+    const mapping = {
+      sources: ["source::hr_employees"],
+      targets: ["staging::stg_employees"],
+    } as any;
     assert.equal(isSchemaInMappingSources("source::hr_employees", mapping), true);
   });
 
@@ -413,29 +420,37 @@ describe("resolveAllNLRefs", () => {
         ["source::finance_gl", { fields: [{ name: "posted_by" }] }],
       ]),
       mappings: new Map([
-        ["staging::stage gl entries", {
-          sources: ["source::finance_gl", "source::hr_employees"],
-          targets: ["staging::stg_gl_entries"],
-        }],
+        [
+          "staging::stage gl entries",
+          {
+            sources: ["source::finance_gl", "source::hr_employees"],
+            targets: ["staging::stg_gl_entries"],
+          },
+        ],
       ]),
       transforms: new Map(),
       fragments: new Map(),
-      nlRefData: [{
-        text: "Lookup @department from @source::hr_employees using @posted_by -> @employee_id",
-        mapping: "stage gl entries",
-        namespace: "staging",
-        targetField: "department",
-        file: "namespaces/ns-merging.stm",
-        line: 99,
-        column: 6,
-      }],
+      nlRefData: [
+        {
+          text: "Lookup @department from @source::hr_employees using @posted_by -> @employee_id",
+          mapping: "stage gl entries",
+          namespace: "staging",
+          targetField: "department",
+          file: "namespaces/ns-merging.stm",
+          line: 99,
+          column: 6,
+        },
+      ],
     };
 
     const results = resolveAllNLRefs(index as any);
     assert.equal(results.length, 4);
 
     // All should resolve
-    assert.ok(results.every((r: any) => r.resolved), "all refs should resolve");
+    assert.ok(
+      results.every((r: any) => r.resolved),
+      "all refs should resolve",
+    );
 
     // Check specific resolutions
     const deptRef = results.find((r: any) => r.ref === "department") as any;

--- a/tooling/satsuma-cli/test/nl-ref-validate.test.ts
+++ b/tooling/satsuma-cli/test/nl-ref-validate.test.ts
@@ -7,7 +7,11 @@ import { describe, it } from "node:test";
 import { collectSemanticWarnings } from "#src/semantic-warnings.js";
 
 /** Build a minimal ExtractedWorkspace with nlRefData for testing. */
-function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: {
+function makeIndex({
+  schemas = [],
+  mappings = [],
+  nlRefData = [],
+}: {
   schemas?: any[];
   mappings?: any[];
   nlRefData?: any[];
@@ -30,7 +34,11 @@ function makeIndex({ schemas = [], mappings = [], nlRefData = [] }: {
     warnings: [],
     questions: [],
     fieldArrows: new Map(),
-    referenceGraph: { usedByMappings: new Map(), fragmentsUsedIn: new Map(), metricsReferences: new Map() },
+    referenceGraph: {
+      usedByMappings: new Map(),
+      fragmentsUsedIn: new Map(),
+      metricsReferences: new Map(),
+    },
     namespaceNames: new Set(),
     nlRefData,
     duplicates: [],
@@ -46,25 +54,31 @@ describe("NL ref validation: unresolved-nl-ref", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl_entries", fields: [{ name: "department" }] },
       ],
-      mappings: [{
-        name: "staging::stage gl entries",
-        namespace: "staging",
-        sources: ["source::finance_gl", "source::hr_employees"],
-        targets: ["staging::stg_gl_entries"],
-      }],
-      nlRefData: [{
-        text: "Lookup @department from @source::hr_employees using @posted_by -> @employee_id",
-        mapping: "stage gl entries",
-        namespace: "staging",
-        targetField: "department",
-        file: "test.stm",
-        line: 99,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::stage gl entries",
+          namespace: "staging",
+          sources: ["source::finance_gl", "source::hr_employees"],
+          targets: ["staging::stg_gl_entries"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup @department from @source::hr_employees using @posted_by -> @employee_id",
+          mapping: "stage gl entries",
+          namespace: "staging",
+          targetField: "department",
+          file: "test.stm",
+          line: 99,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Valid NL refs should produce no warnings");
   });
 
@@ -74,21 +88,25 @@ describe("NL ref validation: unresolved-nl-ref", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl_entries", fields: [] },
       ],
-      mappings: [{
-        name: "staging::my_mapping",
-        namespace: "staging",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl_entries"],
-      }],
-      nlRefData: [{
-        text: "Lookup @nonexistent_field from @source::unknown_schema",
-        mapping: "my_mapping",
-        namespace: "staging",
-        targetField: "foo",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::my_mapping",
+          namespace: "staging",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl_entries"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup @nonexistent_field from @source::unknown_schema",
+          mapping: "my_mapping",
+          namespace: "staging",
+          targetField: "foo",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -107,21 +125,25 @@ describe("NL ref validation: nl-ref-not-in-source", () => {
         { name: "source::finance_gl", fields: [{ name: "posted_by" }] },
         { name: "staging::stg_gl_entries", fields: [] },
       ],
-      mappings: [{
-        name: "staging::my_mapping",
-        namespace: "staging",
-        sources: ["source::finance_gl"],
-        targets: ["staging::stg_gl_entries"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees using @posted_by",
-        mapping: "my_mapping",
-        namespace: "staging",
-        targetField: "dept",
-        file: "test.stm",
-        line: 15,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::my_mapping",
+          namespace: "staging",
+          sources: ["source::finance_gl"],
+          targets: ["staging::stg_gl_entries"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees using @posted_by",
+          mapping: "my_mapping",
+          namespace: "staging",
+          targetField: "dept",
+          file: "test.stm",
+          line: 15,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -138,21 +160,25 @@ describe("NL ref validation: nl-ref-not-in-source", () => {
         { name: "source::finance_gl", fields: [] },
         { name: "staging::stg_gl_entries", fields: [] },
       ],
-      mappings: [{
-        name: "staging::my_mapping",
-        namespace: "staging",
-        sources: ["source::finance_gl", "source::hr_employees"],
-        targets: ["staging::stg_gl_entries"],
-      }],
-      nlRefData: [{
-        text: "Lookup from @source::hr_employees",
-        mapping: "my_mapping",
-        namespace: "staging",
-        targetField: "dept",
-        file: "test.stm",
-        line: 15,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::my_mapping",
+          namespace: "staging",
+          sources: ["source::finance_gl", "source::hr_employees"],
+          targets: ["staging::stg_gl_entries"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Lookup from @source::hr_employees",
+          mapping: "my_mapping",
+          namespace: "staging",
+          targetField: "dept",
+          file: "test.stm",
+          line: 15,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -174,12 +200,14 @@ describe("NL ref validation: fragment spread fields", () => {
         },
         { name: "ex::summary_day", fields: [{ name: "TOTAL_SALES" }, { name: "TOTAL_RETURNS" }] },
       ],
-      mappings: [{
-        name: "ex::Product to Summary",
-        namespace: "ex",
-        sources: ["ex::product_day"],
-        targets: ["ex::summary_day"],
-      }],
+      mappings: [
+        {
+          name: "ex::Product to Summary",
+          namespace: "ex",
+          sources: ["ex::product_day"],
+          targets: ["ex::summary_day"],
+        },
+      ],
       nlRefData: [
         {
           text: "SUM(@ex::product_day.SALES_VALUE)",
@@ -209,7 +237,11 @@ describe("NL ref validation: fragment spread fields", () => {
 
     const warnings = collectSemanticWarnings(index);
     const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref");
-    assert.equal(nlWarnings.length, 0, "Fields from fragment spreads should not produce unresolved-nl-ref warnings");
+    assert.equal(
+      nlWarnings.length,
+      0,
+      "Fields from fragment spreads should not produce unresolved-nl-ref warnings",
+    );
   });
 
   it("still warns for genuine misses even when schema has spreads", () => {
@@ -224,21 +256,25 @@ describe("NL ref validation: fragment spread fields", () => {
         },
         { name: "ex::summary_day", fields: [{ name: "TOTAL" }] },
       ],
-      mappings: [{
-        name: "ex::m1",
-        namespace: "ex",
-        sources: ["ex::product_day"],
-        targets: ["ex::summary_day"],
-      }],
-      nlRefData: [{
-        text: "SUM(@ex::product_day.NONEXISTENT)",
-        mapping: "m1",
-        namespace: "ex",
-        targetField: "TOTAL",
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "ex::m1",
+          namespace: "ex",
+          sources: ["ex::product_day"],
+          targets: ["ex::summary_day"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "SUM(@ex::product_day.NONEXISTENT)",
+          mapping: "m1",
+          namespace: "ex",
+          targetField: "TOTAL",
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
     index.fragments.set("ex::common_measures", {
       fields: [{ name: "SALES_VALUE" }],
@@ -260,60 +296,70 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
         { name: "source_system", fields: [{ name: "user_id" }] },
         { name: "target_system", fields: [{ name: "id" }] },
       ],
-      nlRefData: [{
-        text: "Converts @source_system records into @target_system",
-        mapping: "note:",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
+      nlRefData: [
+        {
+          text: "Converts @source_system records into @target_system",
+          mapping: "note:",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Schema refs in standalone notes should not warn");
   });
 
   it("does not warn for bare field refs in standalone notes", () => {
     // A bare @fieldName that resolves globally should not produce unresolved-nl-ref warnings.
     const index = makeIndex({
-      schemas: [
-        { name: "my_schema", fields: [{ name: "user_id" }, { name: "email" }] },
+      schemas: [{ name: "my_schema", fields: [{ name: "user_id" }, { name: "email" }] }],
+      nlRefData: [
+        {
+          text: "The @user_id field is the primary key",
+          mapping: "note:",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
       ],
-      nlRefData: [{
-        text: "The @user_id field is the primary key",
-        mapping: "note:",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
-    assert.equal(nlWarnings.length, 0, "Bare field refs in standalone notes should resolve without warnings");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
+    assert.equal(
+      nlWarnings.length,
+      0,
+      "Bare field refs in standalone notes should resolve without warnings",
+    );
   });
 
   it("warns for unresolvable refs in file-level notes (sl-vjvf)", () => {
     // Bug sl-vjvf: file-level note @refs that don't resolve to any known identifier
     // should produce an unresolved-nl-ref warning. Previously these were silently skipped.
     const index = makeIndex({
-      schemas: [
-        { name: "my_schema", fields: [{ name: "user_id" }] },
+      schemas: [{ name: "my_schema", fields: [{ name: "user_id" }] }],
+      nlRefData: [
+        {
+          text: "Needs @external_config_key to be provisioned",
+          mapping: "note:",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
       ],
-      nlRefData: [{
-        text: "Needs @external_config_key to be provisioned",
-        mapping: "note:",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -325,44 +371,48 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
   it("does not warn for dotted field refs in standalone notes", () => {
     // Dotted @schema.field refs that resolve should not warn.
     const index = makeIndex({
-      schemas: [
-        { name: "source_system", fields: [{ name: "email_addr" }] },
+      schemas: [{ name: "source_system", fields: [{ name: "email_addr" }] }],
+      nlRefData: [
+        {
+          text: "See @source_system.email_addr for details",
+          mapping: "note:",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
       ],
-      nlRefData: [{
-        text: "See @source_system.email_addr for details",
-        mapping: "note:",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Dotted field refs in standalone notes should not warn");
   });
 
   it("does not warn for refs in schema-scoped notes (note:<parent>)", () => {
     // Schema-scoped notes use a note:<name> mapping key. Resolved @refs should not warn.
     const index = makeIndex({
-      schemas: [
-        { name: "my_schema", fields: [{ name: "user_id" }] },
+      schemas: [{ name: "my_schema", fields: [{ name: "user_id" }] }],
+      nlRefData: [
+        {
+          text: "The @user_id is sequential",
+          mapping: "note:my_schema",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
       ],
-      nlRefData: [{
-        text: "The @user_id is sequential",
-        mapping: "note:my_schema",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Refs in schema-scoped notes should not warn");
   });
 
@@ -376,19 +426,23 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
         { name: "crm::foo", namespace: "crm", fields: [{ name: "id" }] },
         { name: "crm::other", namespace: "crm", fields: [{ name: "key" }] },
       ],
-      nlRefData: [{
-        text: "derived from @other",
-        mapping: "note:schema:foo",
-        namespace: "crm",
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
+      nlRefData: [
+        {
+          text: "derived from @other",
+          mapping: "note:schema:foo",
+          namespace: "crm",
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Resolvable refs in namespaced notes should not warn");
   });
 
@@ -396,25 +450,31 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
     // Unresolvable refs in namespaced notes should warn with a human-readable
     // scope ("schema 'crm::foo'"), not the internal key ("crm::note:schema:foo").
     const index = makeIndex({
-      schemas: [
-        { name: "crm::foo", namespace: "crm", fields: [{ name: "id" }] },
+      schemas: [{ name: "crm::foo", namespace: "crm", fields: [{ name: "id" }] }],
+      nlRefData: [
+        {
+          text: "needs @does_not_exist provisioned",
+          mapping: "note:schema:foo",
+          namespace: "crm",
+          targetField: null,
+          file: "test.stm",
+          line: 5,
+          column: 2,
+        },
       ],
-      nlRefData: [{
-        text: "needs @does_not_exist provisioned",
-        mapping: "note:schema:foo",
-        namespace: "crm",
-        targetField: null,
-        file: "test.stm",
-        line: 5,
-        column: 2,
-      }],
     });
 
     const warnings = collectSemanticWarnings(index);
     const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref");
     assert.equal(nlWarnings.length, 1, "Unresolvable ref in a namespaced note should still warn");
-    assert.ok(nlWarnings[0].message.includes("schema 'crm::foo'"), `message names the schema scope: ${nlWarnings[0].message}`);
-    assert.ok(!nlWarnings[0].message.includes("note:"), `internal note: prefix must not leak: ${nlWarnings[0].message}`);
+    assert.ok(
+      nlWarnings[0].message.includes("schema 'crm::foo'"),
+      `message names the schema scope: ${nlWarnings[0].message}`,
+    );
+    assert.ok(
+      !nlWarnings[0].message.includes("note:"),
+      `internal note: prefix must not leak: ${nlWarnings[0].message}`,
+    );
   });
 
   it("still warns for unresolved refs inside mapping notes", () => {
@@ -423,25 +483,33 @@ describe("NL ref validation: standalone notes (sl-xrc8)", () => {
         { name: "source::src", fields: [{ name: "amount" }] },
         { name: "target::tgt", fields: [] },
       ],
-      mappings: [{
-        name: "my_mapping",
-        sources: ["source::src"],
-        targets: ["target::tgt"],
-      }],
-      nlRefData: [{
-        text: "Check @nonexistent_field before proceeding",
-        mapping: "my_mapping",
-        namespace: null,
-        targetField: null,
-        file: "test.stm",
-        line: 10,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "my_mapping",
+          sources: ["source::src"],
+          targets: ["target::tgt"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Check @nonexistent_field before proceeding",
+          mapping: "my_mapping",
+          namespace: null,
+          targetField: null,
+          file: "test.stm",
+          line: 10,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const unresolvedWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref");
-    assert.equal(unresolvedWarnings.length, 1, "Mapping notes should still warn for unresolved refs");
+    assert.equal(
+      unresolvedWarnings.length,
+      1,
+      "Mapping notes should still warn for unresolved refs",
+    );
   });
 });
 
@@ -452,25 +520,31 @@ describe("NL ref validation: bare field matching", () => {
         { name: "source::gl", fields: [{ name: "amount" }, { name: "department" }] },
         { name: "staging::stg", fields: [{ name: "amount" }] },
       ],
-      mappings: [{
-        name: "staging::m1",
-        namespace: "staging",
-        sources: ["source::gl"],
-        targets: ["staging::stg"],
-      }],
-      nlRefData: [{
-        text: "Sum of @amount grouped by @department",
-        mapping: "m1",
-        namespace: "staging",
-        targetField: "total",
-        file: "test.stm",
-        line: 20,
-        column: 6,
-      }],
+      mappings: [
+        {
+          name: "staging::m1",
+          namespace: "staging",
+          sources: ["source::gl"],
+          targets: ["staging::stg"],
+        },
+      ],
+      nlRefData: [
+        {
+          text: "Sum of @amount grouped by @department",
+          mapping: "m1",
+          namespace: "staging",
+          targetField: "total",
+          file: "test.stm",
+          line: 20,
+          column: 6,
+        },
+      ],
     });
 
     const warnings = collectSemanticWarnings(index);
-    const nlWarnings = warnings.filter((w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source");
+    const nlWarnings = warnings.filter(
+      (w) => w.rule === "unresolved-nl-ref" || w.rule === "nl-ref-not-in-source",
+    );
     assert.equal(nlWarnings.length, 0, "Bare fields matching source schema should not warn");
   });
 });

--- a/tooling/satsuma-cli/test/normalize.test.ts
+++ b/tooling/satsuma-cli/test/normalize.test.ts
@@ -47,11 +47,13 @@ describe("matchFields", () => {
 
   it("flattens nested fields into dotted paths for matching", () => {
     // Nested source "address.city" should match flat target "city" by leaf name.
-    const src = [{
-      name: "address",
-      type: "record",
-      children: [{ name: "city", type: "VARCHAR" }],
-    }];
+    const src = [
+      {
+        name: "address",
+        type: "record",
+        children: [{ name: "city", type: "VARCHAR" }],
+      },
+    ];
     const tgt = [{ name: "city", type: "VARCHAR" }];
     const result = matchFields(src, tgt);
     assert.ok(
@@ -63,11 +65,13 @@ describe("matchFields", () => {
   it("matches cross-level: flat source matches nested target by leaf name", () => {
     // Flat source "city" should match nested target "address.city" by leaf.
     const src = [{ name: "city", type: "VARCHAR" }];
-    const tgt = [{
-      name: "address",
-      type: "record",
-      children: [{ name: "city", type: "VARCHAR" }],
-    }];
+    const tgt = [
+      {
+        name: "address",
+        type: "record",
+        children: [{ name: "city", type: "VARCHAR" }],
+      },
+    ];
     const result = matchFields(src, tgt);
     assert.ok(
       result.matched.some((m) => m.source === "city"),
@@ -90,15 +94,19 @@ describe("matchFields", () => {
 
   it("deeply nested fields are flattened correctly", () => {
     // Two levels of nesting: address.billing.zip
-    const src = [{
-      name: "address",
-      type: "record",
-      children: [{
-        name: "billing",
+    const src = [
+      {
+        name: "address",
         type: "record",
-        children: [{ name: "zip", type: "VARCHAR" }],
-      }],
-    }];
+        children: [
+          {
+            name: "billing",
+            type: "record",
+            children: [{ name: "zip", type: "VARCHAR" }],
+          },
+        ],
+      },
+    ];
     const tgt = [{ name: "zip", type: "VARCHAR" }];
     const result = matchFields(src, tgt);
     assert.ok(
@@ -109,11 +117,13 @@ describe("matchFields", () => {
 
   it("parent record names appear as both container and matchable fields", () => {
     // "address" itself is a field, plus its child "city" is also a field.
-    const src = [{
-      name: "address",
-      type: "record",
-      children: [{ name: "city", type: "VARCHAR" }],
-    }];
+    const src = [
+      {
+        name: "address",
+        type: "record",
+        children: [{ name: "city", type: "VARCHAR" }],
+      },
+    ];
     const tgt = [
       { name: "address", type: "record" },
       { name: "city", type: "VARCHAR" },

--- a/tooling/satsuma-cli/test/option-parsers.test.ts
+++ b/tooling/satsuma-cli/test/option-parsers.test.ts
@@ -37,7 +37,11 @@ describe("parsePositiveInt", () => {
     // All must now raise Commander's usage error instead of silently
     // changing behaviour.
     for (const bad of ["banana", "-1", "0", "12abc", "3.5", ""]) {
-      assert.throws(() => parsePositiveInt(bad), InvalidArgumentError, `expected "${bad}" to be rejected`);
+      assert.throws(
+        () => parsePositiveInt(bad),
+        InvalidArgumentError,
+        `expected "${bad}" to be rejected`,
+      );
     }
   });
 });
@@ -45,7 +49,14 @@ describe("parsePositiveInt", () => {
 describe("numeric options reject garbage as a usage error", () => {
   it("lineage --depth banana exits non-zero with an invalid-argument message", async () => {
     // Before sl-bvd0 this printed only the start node and exited 0.
-    const { stderr, code } = await run("lineage", "--from", "source_a", "--depth", "banana", LINEAGE_CHAIN);
+    const { stderr, code } = await run(
+      "lineage",
+      "--from",
+      "source_a",
+      "--depth",
+      "banana",
+      LINEAGE_CHAIN,
+    );
 
     assert.notEqual(code, 0);
     assert.match(stderr, /option '--depth <n>' argument 'banana' is invalid/);
@@ -53,7 +64,13 @@ describe("numeric options reject garbage as a usage error", () => {
 
   it("field-lineage --depth -1 exits non-zero with an invalid-argument message", async () => {
     // Negative depths previously walked nothing and annotated the start node [?].
-    const { stderr, code } = await run("field-lineage", "schema_b.field_b", "--depth", "-1", LINEAGE_CHAIN);
+    const { stderr, code } = await run(
+      "field-lineage",
+      "schema_b.field_b",
+      "--depth",
+      "-1",
+      LINEAGE_CHAIN,
+    );
 
     assert.notEqual(code, 0);
     assert.match(stderr, /option '--depth <n>' argument '-1' is invalid/);
@@ -87,7 +104,11 @@ describe("parsePercentage", () => {
     // Bare parseInt would turn "90.5" into 90 and "ninety" into NaN, silently
     // gating on a threshold the caller never asked for (the sl-bvd0 shape).
     for (const bad of ["90.5", "ninety", "-1", "", "90abc"]) {
-      assert.throws(() => parsePercentage(bad), InvalidArgumentError, `expected "${bad}" to be rejected`);
+      assert.throws(
+        () => parsePercentage(bad),
+        InvalidArgumentError,
+        `expected "${bad}" to be rejected`,
+      );
     }
   });
 });

--- a/tooling/satsuma-cli/test/recovery.test.ts
+++ b/tooling/satsuma-cli/test/recovery.test.ts
@@ -51,10 +51,7 @@ describe("CLI error recovery — broken .stm input", () => {
   it("summary degrades gracefully on an unterminated schema body", async () => {
     // Closing brace of `customers` is missing; tree-sitter will recover with
     // a MISSING `}` node. summary should still print the section headings.
-    const file = writeBroken(
-      "summary",
-      "schema customers {\n  id UUID\n  name VARCHAR\n",
-    );
+    const file = writeBroken("summary", "schema customers {\n  id UUID\n  name VARCHAR\n");
     const result = await satsuma("summary", file);
     assertGraceful(result);
     // The recovered tree still contains a `customers` schema definition.
@@ -79,8 +76,9 @@ describe("CLI error recovery — broken .stm input", () => {
     // structured error message — both are acceptable. What is *not* acceptable
     // is an unhandled crash.
     if (result.stdout.trim().length > 0) {
-      assert.doesNotThrow(() => { JSON.parse(result.stdout); },
-        "stdout should be valid JSON when produced");
+      assert.doesNotThrow(() => {
+        JSON.parse(result.stdout);
+      }, "stdout should be valid JSON when produced");
     } else {
       assert.notEqual(result.code, 0, "empty stdout must coincide with non-zero exit");
       assert.ok(result.stderr.length > 0, "non-zero exit must report a reason on stderr");

--- a/tooling/satsuma-cli/test/schema.test.ts
+++ b/tooling/satsuma-cli/test/schema.test.ts
@@ -9,14 +9,32 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 
 // ── Mock CST helpers ──────────────────────────────────────────────────────────
 
-function n(type: string, namedChildren: any[] = [], text = "", row = 0, anonymousChildren: string[] = []) {
+function n(
+  type: string,
+  namedChildren: any[] = [],
+  text = "",
+  row = 0,
+  anonymousChildren: string[] = [],
+) {
   const children: any[] = [];
-  children.push(...anonymousChildren.map((t: string) => ({ type: t, text: t, isNamed: false, namedChildren: [], children: [] })));
+  children.push(
+    ...anonymousChildren.map((t: string) => ({
+      type: t,
+      text: t,
+      isNamed: false,
+      namedChildren: [],
+      children: [],
+    })),
+  );
   children.push(...namedChildren.map((c: any) => ({ ...c, isNamed: true })));
   return { type, text, startPosition: { row, column: 0 }, namedChildren, children, isNamed: true };
 }
-function ident(t: string) { return n("identifier", [], t); }
-function quoted(t: string) { return n("backtick_name", [], `'${t}'`); }
+function ident(t: string) {
+  return n("identifier", [], t);
+}
+function quoted(t: string) {
+  return n("backtick_name", [], `'${t}'`);
+}
 function _blockLabel(name: string) {
   const inner = name.startsWith("'") ? quoted(name.slice(1, -1)) : ident(name);
   return n("block_label", [inner]);
@@ -25,8 +43,12 @@ function spreadLabel(name: string) {
   if (name.startsWith("'")) return n("spread_label", [quoted(name.slice(1, -1))]);
   return n("spread_label", name.split(" ").map(ident));
 }
-function fieldName(name: string) { return n("field_name", [ident(name)]); }
-function typeExpr(t: string) { return n("type_expr", [], t); }
+function fieldName(name: string) {
+  return n("field_name", [ident(name)]);
+}
+function typeExpr(t: string) {
+  return n("type_expr", [], t);
+}
 function fieldDecl(name: string, type: string, meta: any = null) {
   const children = [fieldName(name), typeExpr(type)];
   if (meta) children.push(meta);
@@ -90,10 +112,7 @@ function collectFields(bodyNode: any, indent = 0): { indent: number; text: strin
 
 describe("collectFields", () => {
   it("renders flat fields with padding", () => {
-    const body = n("schema_body", [
-      fieldDecl("id", "INT"),
-      fieldDecl("name", "VARCHAR(100)"),
-    ]);
+    const body = n("schema_body", [fieldDecl("id", "INT"), fieldDecl("name", "VARCHAR(100)")]);
     const lines = collectFields(body, 1);
     assert.equal(lines.length, 2);
     assert.ok(lines[0].text.startsWith("  id"));
@@ -156,11 +175,20 @@ describe("collectFields", () => {
 describe("fields-only format", () => {
   let output: string[] = [];
   let origLog: typeof console.log;
-  beforeEach(() => { output = []; origLog = console.log; console.log = (...a: any[]) => output.push(a.join(" ")); });
-  afterEach(() => { console.log = origLog; });
+  beforeEach(() => {
+    output = [];
+    origLog = console.log;
+    console.log = (...a: any[]) => output.push(a.join(" "));
+  });
+  afterEach(() => {
+    console.log = origLog;
+  });
 
   it("prints name and type tab-padded", () => {
-    const fields = [{ name: "customer_id", type: "UUID" }, { name: "email", type: "VARCHAR(255)" }];
+    const fields = [
+      { name: "customer_id", type: "UUID" },
+      { name: "email", type: "VARCHAR(255)" },
+    ];
     for (const f of fields) console.log(`${f.name.padEnd(24)}${f.type}`);
     assert.ok(output[0].startsWith("customer_id"));
     assert.ok(output[0].includes("UUID"));
@@ -172,7 +200,10 @@ describe("fields-only format", () => {
 
 describe("schema not-found", () => {
   it("finds case-insensitive match", () => {
-    const schemas = new Map([["Orders", {}], ["customers", {}]]);
+    const schemas = new Map([
+      ["Orders", {}],
+      ["customers", {}],
+    ]);
     const name = "orders";
     const keys = [...schemas.keys()];
     const close = keys.find((k) => k.toLowerCase() === name.toLowerCase());

--- a/tooling/satsuma-cli/test/summary.test.ts
+++ b/tooling/satsuma-cli/test/summary.test.ts
@@ -55,10 +55,10 @@ describe("satsuma summary", () => {
     assert.equal(code, 0);
     const data = JSON.parse(stdout);
     assert.equal(data.fileCount, 2);
-    assert.deepEqual(
-      data.schemas.map((schema: { name: string }) => schema.name).sort(),
-      ["mart::dim_customers", "src::customers"],
-    );
+    assert.deepEqual(data.schemas.map((schema: { name: string }) => schema.name).sort(), [
+      "mart::dim_customers",
+      "src::customers",
+    ]);
     assert.equal(data.mappings[0].name, "::build dim_customers");
     assert.deepEqual(data.mappings[0].sources, ["src::customers"]);
     assert.deepEqual(data.mappings[0].targets, ["mart::dim_customers"]);
@@ -104,7 +104,10 @@ describe("satsuma summary", () => {
     assert.ok(data.metrics.length > 0, "metrics-platform example should yield metric entries");
     const schemaNames = new Set(data.schemas.map((s: { name: string }) => s.name));
     for (const metric of data.metrics) {
-      assert.ok(!schemaNames.has(metric.name), `metric '${metric.name}' must not also be listed as a schema`);
+      assert.ok(
+        !schemaNames.has(metric.name),
+        `metric '${metric.name}' must not also be listed as a schema`,
+      );
     }
   });
 });
@@ -125,7 +128,10 @@ describe("summary nl-derived coverage with same-line arrows (sl-201z)", () => {
     const mapping = (data.mappings as any[]).find((m) => m.name === "::m");
     assert.ok(mapping, "mapping ::m should be reported");
     assert.equal(mapping.arrowCount, 2, "only the two declared arrows should be counted");
-    assert.equal(mapping.nlDerivedArrowCount, undefined,
-      "@b annotates its own declared arrow and must not count as nl-derived");
+    assert.equal(
+      mapping.nlDerivedArrowCount,
+      undefined,
+      "@b annotates its own declared arrow and must not count as nl-derived",
+    );
   });
 });

--- a/tooling/satsuma-cli/test/validate-bugs.test.ts
+++ b/tooling/satsuma-cli/test/validate-bugs.test.ts
@@ -17,11 +17,32 @@ import { extractSchemas, extractMetrics } from "@satsuma/core";
 
 // ── Mock helpers ─────────────────────────────────────────────────────────────
 
-function n(type: any, namedChildren: any[] = [], text = "", row = 0, anonymousChildren: any[] = []) {
+function n(
+  type: any,
+  namedChildren: any[] = [],
+  text = "",
+  row = 0,
+  anonymousChildren: any[] = [],
+) {
   const children: any[] = [];
-  children.push(...anonymousChildren.map((t: any) => ({ type: t, text: t, isNamed: false, namedChildren: [], children: [] })));
+  children.push(
+    ...anonymousChildren.map((t: any) => ({
+      type: t,
+      text: t,
+      isNamed: false,
+      namedChildren: [],
+      children: [],
+    })),
+  );
   children.push(...namedChildren.map((c: any) => ({ ...c, isNamed: true })));
-  return { type, text, startPosition: { row, column: 0 }, namedChildren, children, isNamed: true } as any;
+  return {
+    type,
+    text,
+    startPosition: { row, column: 0 },
+    namedChildren,
+    children,
+    isNamed: true,
+  } as any;
 }
 
 function ident(text: any, row = 0) {
@@ -45,12 +66,22 @@ function fieldDecl(name: any, type: any, row = 0) {
 }
 
 function kvPair(key: any, valNode: any) {
-  const valText = n("value_text", valNode.type === "value_text" ? valNode.namedChildren : [valNode], valNode.text);
+  const valText = n(
+    "value_text",
+    valNode.type === "value_text" ? valNode.namedChildren : [valNode],
+    valNode.text,
+  );
   return n("tag_with_value", [ident(key), valText]);
 }
 
 /** Build a minimal ExtractedWorkspace for testing semantic warnings. */
-function makeIndex({ schemas = [], mappings = [], metrics = [], fragments = [], fieldArrows = [] }: {
+function makeIndex({
+  schemas = [],
+  mappings = [],
+  metrics = [],
+  fragments = [],
+  fieldArrows = [],
+}: {
   schemas?: any[];
   mappings?: any[];
   metrics?: any[];
@@ -75,7 +106,7 @@ function makeIndex({ schemas = [], mappings = [], metrics = [], fragments = [], 
   }
   const arrowMap = new Map();
   for (const a of fieldArrows) {
-    for (const source of (a.sources ?? (a.source ? [a.source] : []))) {
+    for (const source of a.sources ?? (a.source ? [a.source] : [])) {
       if (!arrowMap.has(source)) arrowMap.set(source, []);
       arrowMap.get(source).push(a);
     }
@@ -93,7 +124,11 @@ function makeIndex({ schemas = [], mappings = [], metrics = [], fragments = [], 
     warnings: [],
     questions: [],
     fieldArrows: arrowMap,
-    referenceGraph: { usedByMappings: new Map(), fragmentsUsedIn: new Map(), metricsReferences: new Map() },
+    referenceGraph: {
+      usedByMappings: new Map(),
+      fragmentsUsedIn: new Map(),
+      metricsReferences: new Map(),
+    },
     totalErrors: 0,
   };
 }
@@ -107,7 +142,9 @@ describe("Bug 1: nested field path resolution", () => {
       fieldDecl("MESSGFUN", "CHAR(3)"),
     ]);
     // Unified syntax: field_decl with "record" keyword as anonymous child
-    const recordField = n("field_decl", [fieldName("BeginningOfMessage"), innerBody], "", 0, ["record"]);
+    const recordField = n("field_decl", [fieldName("BeginningOfMessage"), innerBody], "", 0, [
+      "record",
+    ]);
     const outerBody = n("schema_body", [recordField, fieldDecl("top_field", "INT")]);
     const block = n("schema_block", [blockLabel("my_schema"), outerBody]);
     const root = n("source_file", [block]);
@@ -124,7 +161,10 @@ describe("Bug 1: nested field path resolution", () => {
   it("extracts nested list fields with isList flag", () => {
     const innerBody = n("schema_body", [fieldDecl("unit_price", "DECIMAL")]);
     // Unified syntax: field_decl with "list_of" and "record" keywords
-    const listField = n("field_decl", [fieldName("CartLines"), innerBody], "", 0, ["list_of", "record"]);
+    const listField = n("field_decl", [fieldName("CartLines"), innerBody], "", 0, [
+      "list_of",
+      "record",
+    ]);
     const outerBody = n("schema_body", [listField]);
     const block = n("schema_block", [blockLabel("my_schema"), outerBody]);
     const root = n("source_file", [block]);
@@ -136,26 +176,44 @@ describe("Bug 1: nested field path resolution", () => {
 
   it("validates dotted paths against nested field tree", () => {
     const index = makeIndex({
-      schemas: [{
-        name: "src_schema",
-        fields: [{
-          name: "Order",
-          type: "record",
-          children: [
-            { name: "OrderId", type: "INT" },
-            { name: "Customer", type: "record", children: [
-              { name: "Email", type: "STRING" },
-            ] },
+      schemas: [
+        {
+          name: "src_schema",
+          fields: [
+            {
+              name: "Order",
+              type: "record",
+              children: [
+                { name: "OrderId", type: "INT" },
+                { name: "Customer", type: "record", children: [{ name: "Email", type: "STRING" }] },
+              ],
+            },
           ],
-        }],
-      }, {
-        name: "tgt_schema",
-        fields: [{ name: "order_id", type: "INT" }, { name: "email", type: "STRING" }],
-      }],
+        },
+        {
+          name: "tgt_schema",
+          fields: [
+            { name: "order_id", type: "INT" },
+            { name: "email", type: "STRING" },
+          ],
+        },
+      ],
       mappings: [{ name: "m1", sources: ["src_schema"], targets: ["tgt_schema"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["Order.OrderId"], target: "order_id", file: "test.stm", line: 10 },
-        { mapping: "m1", sources: ["Order.Customer.Email"], target: "email", file: "test.stm", line: 11 },
+        {
+          mapping: "m1",
+          sources: ["Order.OrderId"],
+          target: "order_id",
+          file: "test.stm",
+          line: 10,
+        },
+        {
+          mapping: "m1",
+          sources: ["Order.Customer.Email"],
+          target: "email",
+          file: "test.stm",
+          line: 11,
+        },
       ],
     });
 
@@ -166,21 +224,32 @@ describe("Bug 1: nested field path resolution", () => {
 
   it("validates list dotted paths against nested field tree", () => {
     const index = makeIndex({
-      schemas: [{
-        name: "src_schema",
-        fields: [{
-          name: "CartLines",
-          type: "record",
-          isList: true,
-          children: [{ name: "unit_price", type: "DECIMAL" }],
-        }],
-      }, {
-        name: "tgt_schema",
-        fields: [{ name: "price", type: "DECIMAL" }],
-      }],
+      schemas: [
+        {
+          name: "src_schema",
+          fields: [
+            {
+              name: "CartLines",
+              type: "record",
+              isList: true,
+              children: [{ name: "unit_price", type: "DECIMAL" }],
+            },
+          ],
+        },
+        {
+          name: "tgt_schema",
+          fields: [{ name: "price", type: "DECIMAL" }],
+        },
+      ],
       mappings: [{ name: "m1", sources: ["src_schema"], targets: ["tgt_schema"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["CartLines.unit_price"], target: "price", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["CartLines.unit_price"],
+          target: "price",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
@@ -191,13 +260,16 @@ describe("Bug 1: nested field path resolution", () => {
 
   it("accepts relative paths (.REFNUM) without warning", () => {
     const index = makeIndex({
-      schemas: [{
-        name: "src_schema",
-        fields: [{ name: "top_field", type: "INT" }],
-      }, {
-        name: "tgt_schema",
-        fields: [{ name: "out", type: "INT" }],
-      }],
+      schemas: [
+        {
+          name: "src_schema",
+          fields: [{ name: "top_field", type: "INT" }],
+        },
+        {
+          name: "tgt_schema",
+          fields: [{ name: "out", type: "INT" }],
+        },
+      ],
       mappings: [{ name: "m1", sources: ["src_schema"], targets: ["tgt_schema"] }],
       fieldArrows: [
         { mapping: "m1", sources: [".REFNUM"], target: ".orderNo", file: "test.stm", line: 10 },
@@ -216,20 +288,48 @@ describe("Bug 2: schema-qualified references in multi-source mappings", () => {
   it("resolves schema.field paths in multi-source mappings", () => {
     const index = makeIndex({
       schemas: [
-        { name: "crm_customers", fields: [{ name: "customer_id", type: "INT" }, { name: "email", type: "STRING" }] },
+        {
+          name: "crm_customers",
+          fields: [
+            { name: "customer_id", type: "INT" },
+            { name: "email", type: "STRING" },
+          ],
+        },
         { name: "orders", fields: [{ name: "order_id", type: "INT" }] },
-        { name: "target", fields: [{ name: "id", type: "INT" }, { name: "email", type: "STRING" }] },
+        {
+          name: "target",
+          fields: [
+            { name: "id", type: "INT" },
+            { name: "email", type: "STRING" },
+          ],
+        },
       ],
       mappings: [{ name: "m1", sources: ["crm_customers", "orders"], targets: ["target"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["crm_customers.customer_id"], target: "id", file: "test.stm", line: 10 },
-        { mapping: "m1", sources: ["crm_customers.email"], target: "email", file: "test.stm", line: 11 },
+        {
+          mapping: "m1",
+          sources: ["crm_customers.customer_id"],
+          target: "id",
+          file: "test.stm",
+          line: 10,
+        },
+        {
+          mapping: "m1",
+          sources: ["crm_customers.email"],
+          target: "email",
+          file: "test.stm",
+          line: 11,
+        },
       ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "Schema-qualified paths should resolve in multi-source mappings");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "Schema-qualified paths should resolve in multi-source mappings",
+    );
   });
 
   it("still warns for unknown schema qualifiers in multi-source mappings", () => {
@@ -241,7 +341,13 @@ describe("Bug 2: schema-qualified references in multi-source mappings", () => {
       ],
       mappings: [{ name: "m1", sources: ["crm_customers", "orders"], targets: ["target"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["unknown_schema.email"], target: "email", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["unknown_schema.email"],
+          target: "email",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
@@ -253,24 +359,68 @@ describe("Bug 2: schema-qualified references in multi-source mappings", () => {
   it("does not cross-wire arrows between same-named mappings in different namespaces", () => {
     const index = makeIndex({
       schemas: [
-        { name: "alpha::customer", namespace: "alpha", fields: [{ name: "alpha_flag", type: "STRING" }] },
-        { name: "alpha::customer_out", namespace: "alpha", fields: [{ name: "alpha_flag", type: "STRING" }] },
-        { name: "beta::customer", namespace: "beta", fields: [{ name: "beta_score", type: "NUMBER" }] },
-        { name: "beta::customer_out", namespace: "beta", fields: [{ name: "beta_score", type: "NUMBER" }] },
+        {
+          name: "alpha::customer",
+          namespace: "alpha",
+          fields: [{ name: "alpha_flag", type: "STRING" }],
+        },
+        {
+          name: "alpha::customer_out",
+          namespace: "alpha",
+          fields: [{ name: "alpha_flag", type: "STRING" }],
+        },
+        {
+          name: "beta::customer",
+          namespace: "beta",
+          fields: [{ name: "beta_score", type: "NUMBER" }],
+        },
+        {
+          name: "beta::customer_out",
+          namespace: "beta",
+          fields: [{ name: "beta_score", type: "NUMBER" }],
+        },
       ],
       mappings: [
-        { name: "alpha::load_customer", namespace: "alpha", sources: ["alpha::customer"], targets: ["alpha::customer_out"] },
-        { name: "beta::load_customer", namespace: "beta", sources: ["beta::customer"], targets: ["beta::customer_out"] },
+        {
+          name: "alpha::load_customer",
+          namespace: "alpha",
+          sources: ["alpha::customer"],
+          targets: ["alpha::customer_out"],
+        },
+        {
+          name: "beta::load_customer",
+          namespace: "beta",
+          sources: ["beta::customer"],
+          targets: ["beta::customer_out"],
+        },
       ],
       fieldArrows: [
-        { mapping: "load_customer", namespace: "alpha", sources: ["alpha_flag"], target: "alpha_flag", file: "test.stm", line: 10 },
-        { mapping: "load_customer", namespace: "beta", sources: ["beta_score"], target: "beta_score", file: "test.stm", line: 20 },
+        {
+          mapping: "load_customer",
+          namespace: "alpha",
+          sources: ["alpha_flag"],
+          target: "alpha_flag",
+          file: "test.stm",
+          line: 10,
+        },
+        {
+          mapping: "load_customer",
+          namespace: "beta",
+          sources: ["beta_score"],
+          target: "beta_score",
+          file: "test.stm",
+          line: 20,
+        },
       ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "same-named mappings in different namespaces should validate independently");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "same-named mappings in different namespaces should validate independently",
+    );
   });
 });
 
@@ -300,10 +450,11 @@ describe("Bug 3: metric source extraction", () => {
 
   it("extracts block-form metric sources from schema_block decorated with metric tag", () => {
     // Validates that multi-identifier `source` values are all extracted.
-    const valText = n("value_text", [
-      ident("fact_subscriptions"),
-      ident("dim_customer"),
-    ], "{fact_subscriptions, dim_customer}");
+    const valText = n(
+      "value_text",
+      [ident("fact_subscriptions"), ident("dim_customer")],
+      "{fact_subscriptions, dim_customer}",
+    );
     const meta = n("metadata_block", [
       metricTag(),
       n("tag_with_value", [ident("source"), valText]),
@@ -323,7 +474,9 @@ describe("Bug 3: metric source extraction", () => {
     });
 
     const warnings = collectSemanticWarnings(index);
-    const metricWarnings = warnings.filter((w: any) => w.rule === "undefined-ref" && w.message.includes("Metric"));
+    const metricWarnings = warnings.filter(
+      (w: any) => w.rule === "undefined-ref" && w.message.includes("Metric"),
+    );
     assert.equal(metricWarnings.length, 1, "Should warn for undefined metric source");
     assert.match(metricWarnings[0].message, /external_table/);
   });
@@ -374,27 +527,54 @@ describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
       ],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["created_at"], target: "created_at", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["created_at"],
+          target: "created_at",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "Should not warn for target schema with unresolved spreads");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "Should not warn for target schema with unresolved spreads",
+    );
   });
 
   it("expands fragment fields and validates arrow targets", () => {
     const index = makeIndex({
       schemas: [
         { name: "src", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
-        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
+        {
+          name: "tgt",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["audit_fields"],
+        },
       ],
       fragments: [
-        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }, { name: "updated_at", type: "TIMESTAMP" }] },
+        {
+          name: "audit_fields",
+          fields: [
+            { name: "created_at", type: "TIMESTAMP" },
+            { name: "updated_at", type: "TIMESTAMP" },
+          ],
+        },
       ],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["created_at"], target: "created_at", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["created_at"],
+          target: "created_at",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
@@ -407,14 +587,23 @@ describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
     const index = makeIndex({
       schemas: [
         { name: "src", fields: [{ name: "bogus_field", type: "VARCHAR" }] },
-        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
+        {
+          name: "tgt",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["audit_fields"],
+        },
       ],
-      fragments: [
-        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
-      ],
+      fragments: [{ name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] }],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["bogus_field"], target: "nonexistent_field", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["bogus_field"],
+          target: "nonexistent_field",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
@@ -427,21 +616,40 @@ describe("Bug 4: suppress field-not-in-schema for schemas with spreads", () => {
   it("expands fragment fields for source schemas", () => {
     const index = makeIndex({
       schemas: [
-        { name: "src", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["audit_fields"] },
-        { name: "tgt", fields: [{ name: "id", type: "INT" }, { name: "created_at", type: "TIMESTAMP" }] },
+        {
+          name: "src",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["audit_fields"],
+        },
+        {
+          name: "tgt",
+          fields: [
+            { name: "id", type: "INT" },
+            { name: "created_at", type: "TIMESTAMP" },
+          ],
+        },
       ],
-      fragments: [
-        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
-      ],
+      fragments: [{ name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }] }],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["created_at"], target: "created_at", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["created_at"],
+          target: "created_at",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "Fragment-contributed source field should pass validation");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "Fragment-contributed source field should pass validation",
+    );
   });
 });
 
@@ -452,21 +660,47 @@ describe("Bug 4b: fragment spread cycles and nested expansion", () => {
     const index = makeIndex({
       schemas: [
         { name: "src", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
-        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["base_fields"] },
+        {
+          name: "tgt",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["base_fields"],
+        },
       ],
       fragments: [
-        { name: "base_fields", fields: [{ name: "name", type: "VARCHAR" }], hasSpreads: true, spreads: ["audit_fields"] },
-        { name: "audit_fields", fields: [{ name: "created_at", type: "TIMESTAMP" }, { name: "updated_at", type: "TIMESTAMP" }] },
+        {
+          name: "base_fields",
+          fields: [{ name: "name", type: "VARCHAR" }],
+          hasSpreads: true,
+          spreads: ["audit_fields"],
+        },
+        {
+          name: "audit_fields",
+          fields: [
+            { name: "created_at", type: "TIMESTAMP" },
+            { name: "updated_at", type: "TIMESTAMP" },
+          ],
+        },
       ],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
       fieldArrows: [
-        { mapping: "m1", sources: ["created_at"], target: "created_at", file: "test.stm", line: 10 },
+        {
+          mapping: "m1",
+          sources: ["created_at"],
+          target: "created_at",
+          file: "test.stm",
+          line: 10,
+        },
       ],
     });
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 0, "Transitively spread fragment field should pass validation");
+    assert.equal(
+      fieldWarnings.length,
+      0,
+      "Transitively spread fragment field should pass validation",
+    );
   });
 
   it("detects self-referential fragment spread", () => {
@@ -479,9 +713,7 @@ describe("Bug 4b: fragment spread cycles and nested expansion", () => {
         { name: "loop", fields: [{ name: "x", type: "INT" }], hasSpreads: true, spreads: ["loop"] },
       ],
       mappings: [{ name: "m1", sources: ["src"], targets: ["tgt"] }],
-      fieldArrows: [
-        { mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 },
-      ],
+      fieldArrows: [{ mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 }],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -493,16 +725,29 @@ describe("Bug 4b: fragment spread cycles and nested expansion", () => {
   it("detects mutual cycle between two fragments", () => {
     const index = makeIndex({
       schemas: [
-        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["frag_a"] },
+        {
+          name: "tgt",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["frag_a"],
+        },
       ],
       fragments: [
-        { name: "frag_a", fields: [{ name: "a", type: "INT" }], hasSpreads: true, spreads: ["frag_b"] },
-        { name: "frag_b", fields: [{ name: "b", type: "INT" }], hasSpreads: true, spreads: ["frag_a"] },
+        {
+          name: "frag_a",
+          fields: [{ name: "a", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["frag_b"],
+        },
+        {
+          name: "frag_b",
+          fields: [{ name: "b", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["frag_a"],
+        },
       ],
       mappings: [{ name: "m1", sources: ["tgt"], targets: ["tgt"] }],
-      fieldArrows: [
-        { mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 },
-      ],
+      fieldArrows: [{ mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 }],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -516,17 +761,30 @@ describe("Bug 4b: fragment spread cycles and nested expansion", () => {
     // No cycle — just shared dependency.
     const index = makeIndex({
       schemas: [
-        { name: "tgt", fields: [{ name: "id", type: "INT" }], hasSpreads: true, spreads: ["frag_a", "frag_b"] },
+        {
+          name: "tgt",
+          fields: [{ name: "id", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["frag_a", "frag_b"],
+        },
       ],
       fragments: [
-        { name: "frag_a", fields: [{ name: "a", type: "INT" }], hasSpreads: true, spreads: ["base"] },
-        { name: "frag_b", fields: [{ name: "b", type: "INT" }], hasSpreads: true, spreads: ["base"] },
+        {
+          name: "frag_a",
+          fields: [{ name: "a", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["base"],
+        },
+        {
+          name: "frag_b",
+          fields: [{ name: "b", type: "INT" }],
+          hasSpreads: true,
+          spreads: ["base"],
+        },
         { name: "base", fields: [{ name: "created_at", type: "TIMESTAMP" }] },
       ],
       mappings: [{ name: "m1", sources: ["tgt"], targets: ["tgt"] }],
-      fieldArrows: [
-        { mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 },
-      ],
+      fieldArrows: [{ mapping: "m1", sources: ["id"], target: "id", file: "test.stm", line: 1 }],
     });
 
     const warnings = collectSemanticWarnings(index);
@@ -541,18 +799,25 @@ describe("Bug 6: duplicate named definitions", () => {
   it("emits error when the same schema name is defined twice", () => {
     const index = makeIndex({
       schemas: [
-        { name: "pos_oracle", fields: [{ name: "STORE_ID", type: "VARCHAR(20)" }], file: "hub-store.stm", row: 20 },
+        {
+          name: "pos_oracle",
+          fields: [{ name: "STORE_ID", type: "VARCHAR(20)" }],
+          file: "hub-store.stm",
+          row: 20,
+        },
       ],
     });
-    index.duplicates = [{
-      kind: "schema",
-      previousKind: "schema",
-      name: "pos_oracle",
-      file: "link-sale.stm",
-      row: 26,
-      previousFile: "hub-store.stm",
-      previousRow: 20,
-    }];
+    index.duplicates = [
+      {
+        kind: "schema",
+        previousKind: "schema",
+        name: "pos_oracle",
+        file: "link-sale.stm",
+        row: 26,
+        previousFile: "hub-store.stm",
+        previousRow: 20,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -567,9 +832,7 @@ describe("Bug 6: duplicate named definitions", () => {
 
   it("emits multiple errors for a schema defined in three files", () => {
     const index = makeIndex({
-      schemas: [
-        { name: "pos_oracle", fields: [], file: "link-sale.stm", row: 26 },
-      ],
+      schemas: [{ name: "pos_oracle", fields: [], file: "link-sale.stm", row: 26 }],
     });
     index.duplicates = [
       {
@@ -601,15 +864,17 @@ describe("Bug 6: duplicate named definitions", () => {
     const index = makeIndex({
       metrics: [{ name: "mrr", sources: [], fields: [], file: "b.stm", row: 10 }],
     });
-    index.duplicates = [{
-      kind: "metric",
-      previousKind: "metric",
-      name: "mrr",
-      file: "b.stm",
-      row: 10,
-      previousFile: "a.stm",
-      previousRow: 5,
-    }];
+    index.duplicates = [
+      {
+        kind: "metric",
+        previousKind: "metric",
+        name: "mrr",
+        file: "b.stm",
+        row: 10,
+        previousFile: "a.stm",
+        previousRow: 5,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -620,17 +885,21 @@ describe("Bug 6: duplicate named definitions", () => {
 
   it("emits error for duplicate named mappings", () => {
     const index = makeIndex({
-      mappings: [{ name: "load customers", sources: ["s"], targets: ["t"], file: "b.stm", row: 15 }],
+      mappings: [
+        { name: "load customers", sources: ["s"], targets: ["t"], file: "b.stm", row: 15 },
+      ],
     });
-    index.duplicates = [{
-      kind: "mapping",
-      previousKind: "mapping",
-      name: "load customers",
-      file: "b.stm",
-      row: 15,
-      previousFile: "a.stm",
-      previousRow: 8,
-    }];
+    index.duplicates = [
+      {
+        kind: "mapping",
+        previousKind: "mapping",
+        name: "load customers",
+        file: "b.stm",
+        row: 15,
+        previousFile: "a.stm",
+        previousRow: 8,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -643,15 +912,17 @@ describe("Bug 6: duplicate named definitions", () => {
     const index = makeIndex({
       fragments: [{ name: "audit_fields", fields: [], file: "b.stm", row: 3 }],
     });
-    index.duplicates = [{
-      kind: "fragment",
-      previousKind: "fragment",
-      name: "audit_fields",
-      file: "b.stm",
-      row: 3,
-      previousFile: "a.stm",
-      previousRow: 1,
-    }];
+    index.duplicates = [
+      {
+        kind: "fragment",
+        previousKind: "fragment",
+        name: "audit_fields",
+        file: "b.stm",
+        row: 3,
+        previousFile: "a.stm",
+        previousRow: 1,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -661,15 +932,17 @@ describe("Bug 6: duplicate named definitions", () => {
 
   it("emits error for duplicate transforms", () => {
     const index = makeIndex({});
-    index.duplicates = [{
-      kind: "transform",
-      previousKind: "transform",
-      name: "dv_hash",
-      file: "b.stm",
-      row: 7,
-      previousFile: "a.stm",
-      previousRow: 2,
-    }];
+    index.duplicates = [
+      {
+        kind: "transform",
+        previousKind: "transform",
+        name: "dv_hash",
+        file: "b.stm",
+        row: 7,
+        previousFile: "a.stm",
+        previousRow: 2,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -683,15 +956,17 @@ describe("Bug 6: duplicate named definitions", () => {
       schemas: [{ name: "customer", fields: [], file: "a.stm", row: 5 }],
       metrics: [{ name: "customer", sources: [], fields: [], file: "b.stm", row: 10 }],
     });
-    index.duplicates = [{
-      kind: "metric",
-      previousKind: "schema",
-      name: "customer",
-      file: "b.stm",
-      row: 10,
-      previousFile: "a.stm",
-      previousRow: 5,
-    }];
+    index.duplicates = [
+      {
+        kind: "metric",
+        previousKind: "schema",
+        name: "customer",
+        file: "b.stm",
+        row: 10,
+        previousFile: "a.stm",
+        previousRow: 5,
+      },
+    ];
 
     const warnings = collectSemanticWarnings(index);
     const dupErrors = warnings.filter((w: any) => w.rule === "duplicate-definition");
@@ -720,7 +995,13 @@ describe("Bug 6: duplicate named definitions", () => {
 
 describe("Bug 5: duplicate warning elimination", () => {
   it("emits at most one warning per arrow", () => {
-    const arrow = { mapping: "m1", sources: ["unknown_field"], target: "also_unknown", file: "test.stm", line: 10 };
+    const arrow = {
+      mapping: "m1",
+      sources: ["unknown_field"],
+      target: "also_unknown",
+      file: "test.stm",
+      line: 10,
+    };
     const index = makeIndex({
       schemas: [
         { name: "src", fields: [{ name: "id", type: "INT" }] },
@@ -757,19 +1038,35 @@ describe("sl-akdg: field-not-in-schema fires for anonymous mapping arrows", () =
     const mappingMap = new Map<string, any>([
       [anonKey, { name: null, sources: ["src"], targets: ["tgt"], file: "test.stm", row: 4 }],
     ]);
-    const arrow = { mapping: anonKey, namespace: null, sources: ["nonexistent_field"], target: "id", file: "test.stm", line: 5 };
+    const arrow = {
+      mapping: anonKey,
+      namespace: null,
+      sources: ["nonexistent_field"],
+      target: "id",
+      file: "test.stm",
+      line: 5,
+    };
     const arrowMap = new Map<string, any>([
       ["nonexistent_field", [arrow]],
       ["id", [arrow]],
     ]);
     const index = {
-      schemas: schemaMap, mappings: mappingMap, metrics: new Map(), fragments: new Map(),
-      transforms: new Map(), fieldArrows: arrowMap, totalErrors: 0,
+      schemas: schemaMap,
+      mappings: mappingMap,
+      metrics: new Map(),
+      fragments: new Map(),
+      transforms: new Map(),
+      fieldArrows: arrowMap,
+      totalErrors: 0,
     } as any;
 
     const warnings = collectSemanticWarnings(index);
     const fieldWarnings = warnings.filter((w: any) => w.rule === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 1, "should report field-not-in-schema for anonymous mapping arrow");
+    assert.equal(
+      fieldWarnings.length,
+      1,
+      "should report field-not-in-schema for anonymous mapping arrow",
+    );
     assert.ok(fieldWarnings[0].message.includes("nonexistent_field"));
   });
 
@@ -783,11 +1080,23 @@ describe("sl-akdg: field-not-in-schema fires for anonymous mapping arrows", () =
     const mappingMap = new Map<string, any>([
       [anonKey, { name: null, sources: ["src"], targets: ["tgt"], file: "test.stm", row: 4 }],
     ]);
-    const arrow = { mapping: anonKey, namespace: null, sources: ["id"], target: "id", file: "test.stm", line: 5 };
+    const arrow = {
+      mapping: anonKey,
+      namespace: null,
+      sources: ["id"],
+      target: "id",
+      file: "test.stm",
+      line: 5,
+    };
     const arrowMap = new Map<string, any>([["id", [arrow]]]);
     const index = {
-      schemas: schemaMap, mappings: mappingMap, metrics: new Map(), fragments: new Map(),
-      transforms: new Map(), fieldArrows: arrowMap, totalErrors: 0,
+      schemas: schemaMap,
+      mappings: mappingMap,
+      metrics: new Map(),
+      fragments: new Map(),
+      transforms: new Map(),
+      fieldArrows: arrowMap,
+      totalErrors: 0,
     } as any;
 
     const warnings = collectSemanticWarnings(index);

--- a/tooling/satsuma-cli/test/warnings.test.ts
+++ b/tooling/satsuma-cli/test/warnings.test.ts
@@ -56,7 +56,11 @@ describe("satsuma warnings", () => {
       data.items.map((item: { line: number }) => item.line),
       [4, 5, 12, 13],
     );
-    assert.ok(data.items.every((item: { block: string; blockType: string }) => item.block && item.blockType));
+    assert.ok(
+      data.items.every(
+        (item: { block: string; blockType: string }) => item.block && item.blockType,
+      ),
+    );
   });
 
   it("emits question-only JSON with the question kind and filtered count", async () => {

--- a/tooling/satsuma-cli/test/where-used.test.ts
+++ b/tooling/satsuma-cli/test/where-used.test.ts
@@ -37,12 +37,25 @@ describe("where-used: transforms defined inside a namespace (sl-l3m8)", () => {
     const calls = refsOfKind(stdout, "transform_call");
     const byMapping = new Map(calls.map((r) => [r.name, r.line]));
     // `...tidy` spread inside the namespace binds to crm::tidy
-    assert.ok(byMapping.has("crm::clean_customers"), "bare ...spread inside namespace must be found");
+    assert.ok(
+      byMapping.has("crm::clean_customers"),
+      "bare ...spread inside namespace must be found",
+    );
     // bare `tidy` pipe step inside the namespace binds to crm::tidy
-    assert.ok(byMapping.has("crm::clean_customers_again"), "bare pipe invocation inside namespace must be found");
+    assert.ok(
+      byMapping.has("crm::clean_customers_again"),
+      "bare pipe invocation inside namespace must be found",
+    );
     // `...crm::tidy` from outside the namespace binds to crm::tidy
-    assert.ok(byMapping.has("clean_global_users"), "qualified ...spread from outside namespace must be found");
-    assert.equal(calls.length, 3, "exactly the three crm::tidy call sites — no fan-out to the global tidy");
+    assert.ok(
+      byMapping.has("clean_global_users"),
+      "qualified ...spread from outside namespace must be found",
+    );
+    assert.equal(
+      calls.length,
+      3,
+      "exactly the three crm::tidy call sites — no fan-out to the global tidy",
+    );
   });
 
   it("does not attribute bare references inside the namespace to a same-named global transform", async () => {
@@ -54,7 +67,10 @@ describe("where-used: transforms defined inside a namespace (sl-l3m8)", () => {
     const data = JSON.parse(stdout);
     assert.equal(data.name, "::tidy", "bare query resolves to the global transform");
     const calls = refsOfKind(stdout, "transform_call");
-    assert.deepEqual(calls.map((r) => r.name), ["shout_global_users"]);
+    assert.deepEqual(
+      calls.map((r) => r.name),
+      ["shout_global_users"],
+    );
   });
 });
 
@@ -76,7 +92,10 @@ describe("where-used: fragments defined inside a namespace (sl-l3m8)", () => {
     assert.equal(code, 0);
     const spreads = refsOfKind(stdout, "fragment_spread");
     assert.ok(spreads.length >= 5, `expected the corpus's many spreads, got ${spreads.length}`);
-    assert.ok(spreads.some((r) => r.name.includes("::")), "spread targets include namespaced schemas");
+    assert.ok(
+      spreads.some((r) => r.name.includes("::")),
+      "spread targets include namespaced schemas",
+    );
   });
 
   it("finds spreads of multi-word backticked fragment names", async () => {
@@ -85,6 +104,9 @@ describe("where-used: fragments defined inside a namespace (sl-l3m8)", () => {
     const { stdout, code } = await run("where-used", "common keys", FIXTURE, "--json");
     assert.equal(code, 0);
     const spreads = refsOfKind(stdout, "fragment_spread");
-    assert.deepEqual(spreads.map((r) => r.name), ["global_users"]);
+    assert.deepEqual(
+      spreads.map((r) => r.name),
+      ["global_users"],
+    );
   });
 });

--- a/tooling/satsuma-cli/test/workspace.test.ts
+++ b/tooling/satsuma-cli/test/workspace.test.ts
@@ -146,7 +146,10 @@ describe("loadWorkspace", () => {
     // namespace qualification so downstream commands can resolve scoped names.
     const { files, index } = await loadWorkspace(IMPORT_ENTRY);
 
-    assert.deepEqual(files.map((file) => file.filePath), [IMPORT_ENTRY, IMPORT_SOURCE].sort());
+    assert.deepEqual(
+      files.map((file) => file.filePath),
+      [IMPORT_ENTRY, IMPORT_SOURCE].sort(),
+    );
     assert.ok(index.schemas.has("src::customers"));
     assert.ok(index.schemas.has("mart::dim_customers"));
     assert.ok(index.mappings.has("build dim_customers"));

--- a/tooling/satsuma-core/src/canonical-ref.ts
+++ b/tooling/satsuma-core/src/canonical-ref.ts
@@ -37,7 +37,10 @@ export function canonicalRef(
  *   canonicalEntityName({ name: "customers" })                     → "::customers"
  *   canonicalEntityName({ name: null })                            → "::"
  */
-export function canonicalEntityName(entity: { namespace?: string | null; name: string | null }): string {
+export function canonicalEntityName(entity: {
+  namespace?: string | null;
+  name: string | null;
+}): string {
   return canonicalRef(entity.namespace, entity.name ?? "");
 }
 
@@ -81,7 +84,11 @@ export function qualifyField(field: string, schemas: string[]): string {
  *
  * Returns the canonical key that exists in the map, or null when unresolvable.
  */
-export function resolveScopedEntityRef(ref: string, currentNs: string | null, entityMap: Map<string, unknown>): string | null {
+export function resolveScopedEntityRef(
+  ref: string,
+  currentNs: string | null,
+  entityMap: Map<string, unknown>,
+): string | null {
   if (ref.includes("::")) {
     return entityMap.has(ref) ? ref : null;
   }

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -234,7 +234,9 @@ export function computeMappingCoverage(
   for (const schemaId of targetIds) {
     const def = resolveSchema(schemaId);
     if (!def) continue;
-    schemas.push(coverageForSchema(def, schemaId, "target", targetIds, declaredTgt, nl.arrowBodyOnly));
+    schemas.push(
+      coverageForSchema(def, schemaId, "target", targetIds, declaredTgt, nl.arrowBodyOnly),
+    );
   }
 
   return { schemas };
@@ -422,7 +424,10 @@ function findMappingBlock(tree: Tree, name: string): LocatedMapping | null {
 }
 
 /** Schema references declared in the mapping's `source {}` or `target {}` block. */
-function getSchemaIdsFromBlock(body: SyntaxNode, blockType: "source_block" | "target_block"): string[] {
+function getSchemaIdsFromBlock(
+  body: SyntaxNode,
+  blockType: "source_block" | "target_block",
+): string[] {
   for (const node of body.namedChildren) {
     if (node.type === blockType) {
       const ids: string[] = [];

--- a/tooling/satsuma-core/src/cst-utils.ts
+++ b/tooling/satsuma-core/src/cst-utils.ts
@@ -37,7 +37,11 @@ export function children(node: SyntaxNode, type: string): SyntaxNode[] {
 /**
  * Collect all descendants of a given type (depth-first).
  */
-export function allDescendants(node: SyntaxNode, type: string, acc: SyntaxNode[] = []): SyntaxNode[] {
+export function allDescendants(
+  node: SyntaxNode,
+  type: string,
+  acc: SyntaxNode[] = [],
+): SyntaxNode[] {
   for (const c of node.namedChildren) {
     if (c !== null) {
       if (c.type === type) acc.push(c);

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -9,7 +9,17 @@
 import { canonicalRef } from "./canonical-ref.js";
 import { classifyTransform, classifyArrow } from "./classify.js";
 import { extractMetadata } from "./meta-extract.js";
-import { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefStructuralText, isPresent } from "./cst-utils.js";
+import {
+  child,
+  children,
+  allDescendants,
+  labelText,
+  stringText,
+  entryText,
+  qualifiedNameText,
+  sourceRefStructuralText,
+  isPresent,
+} from "./cst-utils.js";
 import type { Classification, FieldDecl, MetaEntry, PipeStep, SyntaxNode } from "./types.js";
 
 // ── Internal field tree ────────────────────────────────────────────────────
@@ -229,9 +239,18 @@ export function extractNamespaces(rootNode: SyntaxNode): ExtractedNamespace[] {
     const meta = child(node, "metadata_block");
     const noteTag = meta ? child(meta, "note_tag") : null;
     const noteStr = noteTag
-      ? stringText(noteTag.namedChildren.find((c) => c.type === "nl_string" || c.type === "multiline_string"))
+      ? stringText(
+          noteTag.namedChildren.find(
+            (c) => c.type === "nl_string" || c.type === "multiline_string",
+          ),
+        )
       : null;
-    return { name, note: noteStr, row: node.startPosition.row, startColumn: node.startPosition.column };
+    return {
+      name,
+      note: noteStr,
+      row: node.startPosition.row,
+      startColumn: node.startPosition.column,
+    };
   });
 }
 
@@ -258,10 +277,16 @@ export function extractSchemas(rootNode: SyntaxNode): ExtractedSchema[] {
     const meta = child(node, "metadata_block");
     const noteTag = meta ? child(meta, "note_tag") : null;
     const noteStr = noteTag
-      ? stringText(noteTag.namedChildren.find((c) => c.type === "nl_string" || c.type === "multiline_string"))
+      ? stringText(
+          noteTag.namedChildren.find(
+            (c) => c.type === "nl_string" || c.type === "multiline_string",
+          ),
+        )
       : null;
     const body = child(node, "schema_body");
-    const fieldTree = body ? extractFieldTree(body) : { fields: [], hasSpreads: false, spreads: [] };
+    const fieldTree = body
+      ? extractFieldTree(body)
+      : { fields: [], hasSpreads: false, spreads: [] };
     const blockMeta = meta ? extractMetadata(meta) : [];
     const result: ExtractedSchema = {
       name,
@@ -332,7 +357,9 @@ function extractMetricMeta(meta: SyntaxNode | null): {
       const key = entry.namedChildren[0];
       const val = entry.namedChildren[1];
       if (key?.text === "metric_name") {
-        if (val) displayName = stringText(val.namedChildren.find((c) => c.type === "nl_string")) ?? entryText(val);
+        if (val)
+          displayName =
+            stringText(val.namedChildren.find((c) => c.type === "nl_string")) ?? entryText(val);
       } else if (key?.text === "source") {
         if (!val) continue;
         for (const item of val.namedChildren) {
@@ -372,7 +399,17 @@ export function extractMetrics(rootNode: SyntaxNode): ExtractedMetric[] {
       const { displayName, sources, grain, slices } = extractMetricMeta(meta);
       const body = child(node, "schema_body");
       const fields = body ? extractDirectFields(body) : [];
-      return { name, namespace, displayName, sources, grain, slices, fields, row: node.startPosition.row, startColumn: node.startPosition.column };
+      return {
+        name,
+        namespace,
+        displayName,
+        sources,
+        grain,
+        slices,
+        fields,
+        row: node.startPosition.row,
+        startColumn: node.startPosition.column,
+      };
     });
 }
 
@@ -431,7 +468,15 @@ export function extractMappings(rootNode: SyntaxNode): ExtractedMapping[] {
       namespace && !t.includes("::") ? `${namespace}::${t}` : t,
     );
 
-    return { name, namespace, sources, targets: qualifiedTargets, arrowCount, row: node.startPosition.row, startColumn: node.startPosition.column };
+    return {
+      name,
+      namespace,
+      sources,
+      targets: qualifiedTargets,
+      arrowCount,
+      row: node.startPosition.row,
+      startColumn: node.startPosition.column,
+    };
   });
 }
 
@@ -454,7 +499,9 @@ export function extractFragments(rootNode: SyntaxNode): ExtractedFragment[] {
   return collectFromNamespaces(rootNode, "fragment_block").map(({ node, namespace }) => {
     const name = labelText(node);
     const body = child(node, "schema_body");
-    const fieldTree = body ? extractFieldTree(body) : { fields: [], hasSpreads: false, spreads: [] };
+    const fieldTree = body
+      ? extractFieldTree(body)
+      : { fields: [], hasSpreads: false, spreads: [] };
     return {
       name,
       namespace,
@@ -503,10 +550,7 @@ export function extractTransforms(rootNode: SyntaxNode): ExtractedTransform[] {
   });
 }
 
-const BLOCK_TYPES = new Set([
-  "schema_block", "mapping_block",
-  "fragment_block", "transform_block",
-]);
+const BLOCK_TYPES = new Set(["schema_block", "mapping_block", "fragment_block", "transform_block"]);
 
 function findParentBlock(node: SyntaxNode): { name: string | null; blockType: string | null } {
   let current = node.parent;
@@ -714,11 +758,14 @@ export function extractImports(rootNode: SyntaxNode): ExtractedImport[] {
       .filter((n): n is string => n != null);
 
     const pathNode = child(node, "import_path");
-    const pathStr = pathNode
-      ? stringText(pathNode.namedChildren[0])
-      : null;
+    const pathStr = pathNode ? stringText(pathNode.namedChildren[0]) : null;
 
-    return { names, path: pathStr, row: node.startPosition.row, startColumn: node.startPosition.column };
+    return {
+      names,
+      path: pathStr,
+      row: node.startPosition.row,
+      startColumn: node.startPosition.column,
+    };
   });
 }
 
@@ -737,7 +784,11 @@ function pathText(pathNode: SyntaxNode | null): string | null {
     if (ids.length >= 2) {
       const ns = ids[0]!.text;
       const schema = ids[1]!.text;
-      const field = ids.slice(2).map((c) => c.text).join(".") || null;
+      const field =
+        ids
+          .slice(2)
+          .map((c) => c.text)
+          .join(".") || null;
       return canonicalRef(ns, schema, field);
     }
   }
@@ -797,9 +848,7 @@ function canonicalPipeStepText(inner: SyntaxNode | undefined, fallback: string):
  * text, so fmt-only changes never register as structural differences.
  */
 export function canonicalPipeChainText(pipeSteps: SyntaxNode[]): string {
-  return pipeSteps
-    .map((s) => canonicalPipeStepText(s.namedChildren[0], s.text))
-    .join(" | ");
+  return pipeSteps.map((s) => canonicalPipeStepText(s.namedChildren[0], s.text)).join(" | ");
 }
 
 export interface ExtractedArrow {
@@ -896,8 +945,12 @@ function collectArrowRecords(
         // nested_arrow / each / flatten declare exactly one src_path, so the
         // container's single (already absolute) source is the child prefix.
         collectArrowRecords(
-          node.namedChildren, mappingName, namespace,
-          container.sources[0] ?? null, container.target, records,
+          node.namedChildren,
+          mappingName,
+          namespace,
+          container.sources[0] ?? null,
+          container.target,
+          records,
         );
         break;
       }

--- a/tooling/satsuma-core/src/format.ts
+++ b/tooling/satsuma-core/src/format.ts
@@ -45,9 +45,9 @@ function trimTrailingNewlines(text: string): string {
 }
 
 function isComment(node: SyntaxNode): boolean {
-  return node.type === "comment" ||
-         node.type === "warning_comment" ||
-         node.type === "question_comment";
+  return (
+    node.type === "comment" || node.type === "warning_comment" || node.type === "question_comment"
+  );
 }
 
 function isImport(node: SyntaxNode): boolean {
@@ -74,7 +74,7 @@ function findChild(node: SyntaxNode, type: string): SyntaxNode | null {
 
 /** Find all children of a given type. */
 function findChildren(node: SyntaxNode, type: string): SyntaxNode[] {
-  return node.children.filter(c => c.type === type);
+  return node.children.filter((c) => c.type === type);
 }
 
 // Body-type names recognised when scanning block-level children for gap
@@ -82,9 +82,7 @@ function findChildren(node: SyntaxNode, type: string): SyntaxNode[] {
 // node and `}`).  Tree-sitter places extras (comments) at the nearest
 // enclosing named node, so a comment before the first body child lands as
 // a sibling of the body inside the block — not inside the body itself.
-const BODY_TYPES = new Set([
-  "schema_body", "mapping_body", "pipe_chain",
-]);
+const BODY_TYPES = new Set(["schema_body", "mapping_body", "pipe_chain"]);
 
 /**
  * Collect comments that appear between the opening `{` and the body node.
@@ -97,15 +95,16 @@ const BODY_TYPES = new Set([
  * Returns a formatted string (with leading newline per comment) ready to
  * append after the opening `{` line.
  */
-function collectBlockLeadingComments(
-  node: SyntaxNode, indent: number
-): string {
+function collectBlockLeadingComments(node: SyntaxNode, indent: number): string {
   const comments: string[] = [];
   let braceRow = -1;
 
   for (const child of node.children) {
-    if (child.type === "{") { braceRow = child.startPosition.row; continue; }
-    if (braceRow < 0) continue;                           // still before `{`
+    if (child.type === "{") {
+      braceRow = child.startPosition.row;
+      continue;
+    }
+    if (braceRow < 0) continue; // still before `{`
     if (BODY_TYPES.has(child.type) || child.type === "}") break;
     if (isComment(child)) {
       // Skip inline comments on the brace line — callers keep those on the
@@ -114,9 +113,7 @@ function collectBlockLeadingComments(
       comments.push(formatComment(child, indent + 1));
     }
   }
-  return comments.length > 0
-    ? "\n" + comments.join("\n")
-    : "";
+  return comments.length > 0 ? "\n" + comments.join("\n") : "";
 }
 
 /**
@@ -127,7 +124,7 @@ function collectBlockLeadingComments(
  * brace-row comment belongs after the brace (sl-dz3n).
  */
 function braceLineCommentSuffix(node: SyntaxNode): string {
-  const openBrace = node.children.find(c => c.type === "{");
+  const openBrace = node.children.find((c) => c.type === "{");
   if (!openBrace) return "";
   let suffix = "";
   for (const child of node.children) {
@@ -144,11 +141,13 @@ function braceLineCommentSuffix(node: SyntaxNode): string {
  * on the last body item. Returns the formatted comment lines.
  */
 function collectBlockTrailingComments(
-  node: SyntaxNode, bodyEndRow: number, indent: number
+  node: SyntaxNode,
+  bodyEndRow: number,
+  indent: number,
 ): string {
   const comments: string[] = [];
   let foundBody = false;
-  const openBrace = node.children.find(c => c.type === "{");
+  const openBrace = node.children.find((c) => c.type === "{");
   const openBraceRow = openBrace?.startPosition.row ?? -1;
 
   for (const child of node.children) {
@@ -173,7 +172,7 @@ function collectBlockTrailingComments(
 
 /** Check if a field_decl is multi-line (has a { } body — record or list_of record). */
 function isMultiLineField(node: SyntaxNode): boolean {
-  return node.children.some(c => c.type === "{");
+  return node.children.some((c) => c.type === "{");
 }
 
 /** Get the field name text from a field_decl. */
@@ -186,9 +185,9 @@ function fieldNameText(node: SyntaxNode): string {
 
 /** Get the display type string for a field_decl (for column alignment). */
 function fieldTypeText(node: SyntaxNode): string {
-  const hasListOf = node.children.some(c => c.type === "list_of");
+  const hasListOf = node.children.some((c) => c.type === "list_of");
   const typeExpr = findChild(node, "type_expr");
-  const hasRecord = node.children.some(c => c.type === "record");
+  const hasRecord = node.children.some((c) => c.type === "record");
 
   if (hasListOf && hasRecord) return "list_of record";
   if (hasListOf && typeExpr) return "list_of " + typeExpr.text;
@@ -245,8 +244,8 @@ function topLevelSep(prev: SyntaxNode, curr: SyntaxNode, seenNonComment: boolean
       // Preserve blank line between header comments when source had one
       return hasBlankBetween(prev, curr) ? "\n\n" : "\n";
     }
-    if (isImport(curr)) return "\n";        // header → imports: no blank line
-    return "\n\n";                          // header → first block: one blank line
+    if (isImport(curr)) return "\n"; // header → imports: no blank line
+    return "\n\n"; // header → first block: one blank line
   }
 
   // comment → non-comment: pull tight (comment annotates what follows)
@@ -264,13 +263,20 @@ function topLevelSep(prev: SyntaxNode, curr: SyntaxNode, seenNonComment: boolean
 
 function formatTopLevel(node: SyntaxNode, source: string, indent: number): string {
   switch (node.type) {
-    case "schema_block":    return formatSchemaBlock(node, source, indent);
-    case "fragment_block":  return formatFragmentBlock(node, source, indent);
-    case "mapping_block":   return formatMappingBlock(node, source, indent);
-    case "transform_block": return formatTransformBlock(node, source, indent);
-    case "note_block":      return formatNoteBlock(node, source, indent);
-    case "import_decl":     return formatImportDecl(node, source, indent);
-    case "namespace_block": return formatNamespaceBlock(node, source, indent);
+    case "schema_block":
+      return formatSchemaBlock(node, source, indent);
+    case "fragment_block":
+      return formatFragmentBlock(node, source, indent);
+    case "mapping_block":
+      return formatMappingBlock(node, source, indent);
+    case "transform_block":
+      return formatTransformBlock(node, source, indent);
+    case "note_block":
+      return formatNoteBlock(node, source, indent);
+    case "import_decl":
+      return formatImportDecl(node, source, indent);
+    case "namespace_block":
+      return formatNamespaceBlock(node, source, indent);
     case "comment":
     case "warning_comment":
     case "question_comment":
@@ -428,9 +434,9 @@ function formatSchemaBody(body: SyntaxNode, source: string, indent: number): str
 }
 
 interface FieldAlignment {
-  nameCol: number;   // max name width (capped)
-  typeCol: number;   // column where type starts (relative to indent)
-  metaCol: number;   // column where metadata starts (relative to indent)
+  nameCol: number; // max name width (capped)
+  typeCol: number; // column where type starts (relative to indent)
+  metaCol: number; // column where metadata starts (relative to indent)
 }
 
 /**
@@ -464,8 +470,12 @@ function calcFieldAlignment(fields: SyntaxNode[]): FieldAlignment {
 }
 
 function formatSingleLineField(
-  node: SyntaxNode, source: string, indent: number,
-  _nameCol: number, typeCol: number, metaCol: number
+  node: SyntaxNode,
+  source: string,
+  indent: number,
+  _nameCol: number,
+  typeCol: number,
+  metaCol: number,
 ): string {
   const name = fieldNameText(node);
   const type = fieldTypeText(node);
@@ -499,8 +509,8 @@ function formatSingleLineField(
 
 function formatMultiLineField(node: SyntaxNode, source: string, indent: number): string {
   const name = fieldNameText(node);
-  const hasListOf = node.children.some(c => c.type === "list_of");
-  const hasRecord = node.children.some(c => c.type === "record");
+  const hasListOf = node.children.some((c) => c.type === "list_of");
+  const hasRecord = node.children.some((c) => c.type === "record");
   const meta = findChild(node, "metadata_block");
   const body = findChild(node, "schema_body");
 
@@ -514,7 +524,7 @@ function formatMultiLineField(node: SyntaxNode, source: string, indent: number):
 
   line += " {" + braceLineCommentSuffix(node);
 
-  const openBrace = node.children.find(c => c.type === "{");
+  const openBrace = node.children.find((c) => c.type === "{");
   const leading = collectBlockLeadingComments(node, indent);
 
   if (!body || body.namedChildren.length === 0) {
@@ -545,8 +555,8 @@ function formatFragmentSpread(node: SyntaxNode, indent: number): string {
   }
   // _spread_words: identifier followed by zero or more continuation_words
   const words = label.children
-    .filter(c => c.type === "identifier" || c.type === "continuation_word")
-    .map(c => c.text);
+    .filter((c) => c.type === "identifier" || c.type === "continuation_word")
+    .map((c) => c.text);
   return ind(indent) + "..." + words.join(" ");
 }
 
@@ -643,7 +653,7 @@ type SourceBlockItem = { node: SyntaxNode; text: string; isComment: boolean };
 
 /** Gather refs, join strings, and body comments of a source/target block in order. */
 function collectSourceBlockItems(node: SyntaxNode, source: string): SourceBlockItem[] {
-  const openBrace = node.children.find(c => c.type === "{");
+  const openBrace = node.children.find((c) => c.type === "{");
   const braceRow = openBrace?.startPosition.row ?? -1;
 
   const items: SourceBlockItem[] = [];
@@ -667,9 +677,11 @@ function collectSourceBlockItems(node: SyntaxNode, source: string): SourceBlockI
  * (comma-separated, sl-q9oj); target blocks have no commas.
  */
 function formatSourceBlockBody(
-  items: SourceBlockItem[], indent: number, withCommas: boolean
+  items: SourceBlockItem[],
+  indent: number,
+  withCommas: boolean,
 ): string {
-  const entryCount = items.filter(i => !i.isComment).length;
+  const entryCount = items.filter((i) => !i.isComment).length;
   const lines: string[] = [];
   let entryIdx = 0;
   let prev: SyntaxNode | null = null;
@@ -693,10 +705,10 @@ function formatSourceBlockBody(
 
 function formatSourceBlock(node: SyntaxNode, source: string, indent: number): string {
   const items = collectSourceBlockItems(node, source);
-  const entries = items.filter(i => !i.isComment);
-  const nlStrings = entries.filter(i => i.node.type === "nl_string");
+  const entries = items.filter((i) => !i.isComment);
+  const nlStrings = entries.filter((i) => i.node.type === "nl_string");
   const braceSuffix = braceLineCommentSuffix(node);
-  const hasComments = braceSuffix !== "" || items.some(i => i.isComment);
+  const hasComments = braceSuffix !== "" || items.some((i) => i.isComment);
 
   if (items.length === 0) {
     // An empty block can still carry a brace-row comment: `source {  // c`
@@ -707,9 +719,9 @@ function formatSourceBlock(node: SyntaxNode, source: string, indent: number): st
 
   // Try single-line (comments can never share a single line — they would
   // comment out the closing brace)
-  const entryTexts = entries.map(i => i.text);
+  const entryTexts = entries.map((i) => i.text);
   const singleLine = ind(indent) + "source { " + entryTexts.join(", ") + " }";
-  if (!hasComments && singleLine.length <= 80 && !entryTexts.some(s => s.includes("\n"))) {
+  if (!hasComments && singleLine.length <= 80 && !entryTexts.some((s) => s.includes("\n"))) {
     // For multi-ref sources, use multi-line
     if (entries.length <= 1 && nlStrings.length === 0) {
       return singleLine;
@@ -724,11 +736,12 @@ function formatSourceBlock(node: SyntaxNode, source: string, indent: number): st
 }
 
 function formatTargetBlock(node: SyntaxNode, source: string, indent: number): string {
-  const items = collectSourceBlockItems(node, source)
-    .filter(i => i.isComment || i.node.type === "source_ref");
-  const entries = items.filter(i => !i.isComment);
+  const items = collectSourceBlockItems(node, source).filter(
+    (i) => i.isComment || i.node.type === "source_ref",
+  );
+  const entries = items.filter((i) => !i.isComment);
   const braceSuffix = braceLineCommentSuffix(node);
-  const hasComments = braceSuffix !== "" || items.some(i => i.isComment);
+  const hasComments = braceSuffix !== "" || items.some((i) => i.isComment);
 
   if (items.length === 0) {
     // An empty block can still carry a brace-row comment: `target {  // c`
@@ -751,7 +764,13 @@ function formatSourceRef(node: SyntaxNode, source: string): string {
   for (const child of node.children) {
     if (child.type === "metadata_block") {
       parts.push(formatMetadataInline(child, source));
-    } else if (child.isNamed || child.type === "identifier" || child.type === "qualified_name" || child.type === "backtick_name" || child.type === "nl_string") {
+    } else if (
+      child.isNamed ||
+      child.type === "identifier" ||
+      child.type === "qualified_name" ||
+      child.type === "backtick_name" ||
+      child.type === "nl_string"
+    ) {
       parts.push(child.text);
     }
   }
@@ -768,7 +787,11 @@ function formatSourceRef(node: SyntaxNode, source: string): string {
  * between the chain and `}` (sl-dz3n).
  */
 function formatArrowTransformBody(
-  node: SyntaxNode, pipeChain: SyntaxNode, line: string, source: string, indent: number
+  node: SyntaxNode,
+  pipeChain: SyntaxNode,
+  line: string,
+  source: string,
+  indent: number,
 ): string {
   // Comments that are direct children of the arrow node all live inside the
   // braces: a `//` comment before `{` would comment the brace out.
@@ -783,9 +806,18 @@ function formatArrowTransformBody(
   const braceSuffix = braceLineCommentSuffix(node);
   const leading = collectBlockLeadingComments(node, indent);
   const trailing = collectBlockTrailingComments(node, pipeChain.endPosition.row, indent);
-  return line + " {" + braceSuffix + leading + "\n"
-    + formatPipeChainMultiLine(pipeChain, source, indent + 1)
-    + trailing + "\n" + ind(indent) + "}";
+  return (
+    line +
+    " {" +
+    braceSuffix +
+    leading +
+    "\n" +
+    formatPipeChainMultiLine(pipeChain, source, indent + 1) +
+    trailing +
+    "\n" +
+    ind(indent) +
+    "}"
+  );
 }
 
 function formatMapArrow(node: SyntaxNode, source: string, indent: number): string {
@@ -832,8 +864,8 @@ function formatNestedArrow(node: SyntaxNode, source: string, indent: number): st
   if (meta) line += " " + formatMetadataInline(meta, source, indent);
 
   // Inner arrows
-  const innerArrows = node.children.filter(c =>
-    c.type === "map_arrow" || c.type === "computed_arrow" || c.type === "nested_arrow"
+  const innerArrows = node.children.filter(
+    (c) => c.type === "map_arrow" || c.type === "computed_arrow" || c.type === "nested_arrow",
   );
 
   if (innerArrows.length === 0) {
@@ -844,7 +876,8 @@ function formatNestedArrow(node: SyntaxNode, source: string, indent: number): st
   let prev: SyntaxNode | null = null;
   for (const child of node.children) {
     if (!child.isNamed && !isComment(child)) continue;
-    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block") continue;
+    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block")
+      continue;
 
     if (prev !== null && hasBlankBetween(prev, child)) {
       innerLines.push("");
@@ -876,7 +909,10 @@ function formatNestedArrow(node: SyntaxNode, source: string, indent: number): st
 // ── Each/Flatten Blocks ───────────────────────────────────────────────────────
 
 function formatEachFlattenBlock(
-  node: SyntaxNode, source: string, indent: number, keyword: string
+  node: SyntaxNode,
+  source: string,
+  indent: number,
+  keyword: string,
 ): string {
   const srcPath = findChild(node, "src_path");
   const tgtPath = findChild(node, "tgt_path");
@@ -897,7 +933,8 @@ function formatEachFlattenBlock(
 
   for (const child of node.children) {
     if (!child.isNamed && !isComment(child)) continue;
-    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block") continue;
+    if (child.type === "src_path" || child.type === "tgt_path" || child.type === "metadata_block")
+      continue;
     if (child.type === keyword) continue; // skip the keyword itself
 
     if (prev !== null && hasBlankBetween(prev, child)) {
@@ -1029,14 +1066,14 @@ function formatMapLiteral(node: SyntaxNode, _source: string, indent: number): st
   if (entries.length === 0) return "map { }";
 
   // Try single-line: map { key: val, key: val }
-  const entryStrs = entries.map(e => formatMapEntry(e));
+  const entryStrs = entries.map((e) => formatMapEntry(e));
   const singleLine = "map { " + entryStrs.join(", ") + " }";
   if (singleLine.length + ind(indent).length <= 80 && entries.length <= 3) {
     return singleLine;
   }
 
   // Multi-line
-  const inner = entryStrs.map(e => ind(indent + 1) + e).join("\n");
+  const inner = entryStrs.map((e) => ind(indent + 1) + e).join("\n");
   return "map {\n" + inner + "\n" + ind(indent) + "}";
 }
 
@@ -1073,7 +1110,13 @@ function formatTransformBlock(node: SyntaxNode, source: string, indent: number):
   // Try single-line (only when no comments exist anywhere in the body)
   const chainStr = formatPipeChain(pipeChain, source, indent);
   const singleLine = line + " { " + chainStr + " }";
-  if (!braceSuffix && !leading && !trailing && isInlinePipeChain(pipeChain) && singleLine.length <= 80) {
+  if (
+    !braceSuffix &&
+    !leading &&
+    !trailing &&
+    isInlinePipeChain(pipeChain) &&
+    singleLine.length <= 80
+  ) {
     return line + " {\n" + ind(indent + 1) + chainStr + "\n" + ind(indent) + "}";
   }
 
@@ -1088,7 +1131,7 @@ function formatNoteBlock(node: SyntaxNode, _source: string, indent: number): str
   // Body items in source order: strings plus any comments between them
   // (sl-dz3n). Brace-row comments stay on the `note {` line via the suffix.
   const braceSuffix = braceLineCommentSuffix(node);
-  const openBrace = node.children.find(c => c.type === "{");
+  const openBrace = node.children.find((c) => c.type === "{");
   const braceRow = openBrace?.startPosition.row ?? -1;
 
   const items: SyntaxNode[] = [];
@@ -1166,7 +1209,7 @@ function formatImportName(node: SyntaxNode): string {
 // ── Namespace Block ───────────────────────────────────────────────────────────
 
 function formatNamespaceBlock(node: SyntaxNode, source: string, indent: number): string {
-  const name = node.children.find(c => c.type === "identifier");
+  const name = node.children.find((c) => c.type === "identifier");
   const meta = findChild(node, "metadata_block");
 
   let line = ind(indent) + "namespace " + (name?.text || "");
@@ -1177,7 +1220,10 @@ function formatNamespaceBlock(node: SyntaxNode, source: string, indent: number):
   const innerItems: SyntaxNode[] = [];
   let insideBody = false;
   for (const child of node.children) {
-    if (child.type === "{") { insideBody = true; continue; }
+    if (child.type === "{") {
+      insideBody = true;
+      continue;
+    }
     if (child.type === "}") break;
     if (insideBody && (child.isNamed || isComment(child))) {
       innerItems.push(child);
@@ -1240,13 +1286,14 @@ function formatMetadataBlock(node: SyntaxNode, source: string, indent: number): 
 
   // Comments cannot share a single line (they would comment out everything
   // after them), and multiline strings never fit one — both force multi-line.
-  if (items.some(i => i.isComment) || hasMultilineString(node)) {
+  if (items.some((i) => i.isComment) || hasMultilineString(node)) {
     return formatMetadataMultiLine(items, indent);
   }
 
   // Try single-line
-  const singleLine = "(" + items.map(i => i.text).join(", ") + ")";
-  if (singleLine.length + ind(indent).length + 20 <= 80) { // rough line length check
+  const singleLine = "(" + items.map((i) => i.text).join(", ") + ")";
+  if (singleLine.length + ind(indent).length + 20 <= 80) {
+    // rough line length check
     return singleLine;
   }
 
@@ -1259,16 +1306,16 @@ function formatMetadataInline(node: SyntaxNode, source: string, indent: number =
   // Inline contexts (arrows, source refs) still fall back to the multi-line
   // layout when comments are present — there is no way to keep a `//`
   // comment on a shared line without commenting out the rest of it (sl-dz3n).
-  if (items.some(i => i.isComment)) {
+  if (items.some((i) => i.isComment)) {
     return formatMetadataMultiLine(items, indent);
   }
-  return "(" + items.map(i => i.text).join(", ") + ")";
+  return "(" + items.map((i) => i.text).join(", ") + ")";
 }
 
 function formatMetadataMultiLine(items: MetadataItem[], indent: number): string {
   if (items.length === 0) return "()";
 
-  const entryCount = items.filter(i => !i.isComment).length;
+  const entryCount = items.filter((i) => !i.isComment).length;
   const lines: string[] = ["("];
   let entryIdx = 0;
   let prev: SyntaxNode | null = null;
@@ -1347,7 +1394,8 @@ function formatNoteTag(node: SyntaxNode, _source: string): string {
 function formatEnumBody(node: SyntaxNode): string {
   const items: string[] = [];
   for (const child of node.children) {
-    if (child.type === "enum" || child.type === "{" || child.type === "}" || child.type === ",") continue;
+    if (child.type === "enum" || child.type === "{" || child.type === "}" || child.type === ",")
+      continue;
     items.push(child.text);
   }
   return "enum {" + items.join(", ") + "}";
@@ -1356,9 +1404,9 @@ function formatEnumBody(node: SyntaxNode): string {
 function formatSliceBody(node: SyntaxNode): string {
   const items: string[] = [];
   for (const child of node.children) {
-    if (child.type === "slice" || child.type === "{" || child.type === "}" || child.type === ",") continue;
+    if (child.type === "slice" || child.type === "{" || child.type === "}" || child.type === ",")
+      continue;
     if (child.type === "identifier") items.push(child.text);
   }
   return "slice {" + items.join(", ") + "}";
 }
-

--- a/tooling/satsuma-core/src/import-reachability.ts
+++ b/tooling/satsuma-core/src/import-reachability.ts
@@ -130,15 +130,15 @@ export function computeSymbolDependencies(index: SemanticIndex): Map<string, Set
   // one and record its outgoing dependency edges.
 
   const allDefinitions = new Map<string, unknown>([
-    ...index.schemas as Map<string, unknown>,
-    ...index.fragments as Map<string, unknown>,
+    ...(index.schemas as Map<string, unknown>),
+    ...(index.fragments as Map<string, unknown>),
   ]);
 
   // --- Schemas: depend on spread fragments ---
   for (const [key, schema] of index.schemas) {
     ensureEntry(key);
     const ns = schema.namespace ?? null;
-    for (const spread of (schema.spreads ?? [])) {
+    for (const spread of schema.spreads ?? []) {
       const resolved = resolveScopedEntityRef(spread, ns, index.fragments as Map<string, unknown>);
       if (resolved) addDep(key, resolved);
     }
@@ -148,7 +148,7 @@ export function computeSymbolDependencies(index: SemanticIndex): Map<string, Set
   for (const [key, fragment] of index.fragments) {
     ensureEntry(key);
     const ns = fragment.namespace ?? null;
-    for (const spread of (fragment.spreads ?? [])) {
+    for (const spread of fragment.spreads ?? []) {
       const resolved = resolveScopedEntityRef(spread, ns, index.fragments as Map<string, unknown>);
       if (resolved) addDep(key, resolved);
     }
@@ -172,7 +172,7 @@ export function computeSymbolDependencies(index: SemanticIndex): Map<string, Set
   for (const [key, metric] of index.metrics) {
     ensureEntry(key);
     const ns = metric.namespace ?? null;
-    for (const src of (metric.sources ?? [])) {
+    for (const src of metric.sources ?? []) {
       const resolved = resolveScopedEntityRef(src, ns, index.schemas as Map<string, unknown>);
       if (resolved) addDep(key, resolved);
     }

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -1,9 +1,5 @@
 export { capitalize, normalizeName } from "./string-utils.js";
-export {
-  SATSUMA_FILE_EXTENSIONS,
-  SATSUMA_FILE_GLOB,
-  isSatsumaFilePath,
-} from "./source-files.js";
+export { SATSUMA_FILE_EXTENSIONS, SATSUMA_FILE_GLOB, isSatsumaFilePath } from "./source-files.js";
 export { findFieldByPath, collectFieldNames } from "./field-utils.js";
 export type { FieldTreeNode } from "./field-utils.js";
 export { collectSemanticDiagnostics, validateSemanticWorkspace } from "./validate.js";
@@ -58,10 +54,39 @@ export type {
   AggregateCoverage,
 } from "./coverage-rollup.js";
 export { format } from "./format.js";
-export type { SyntaxNode, Tree, Classification, PipeStep, MetaEntry, MetaEntryTag, MetaEntryKV, MetaEntryEnum, MetaEntryNote, MetaEntrySlice, FieldDecl } from "./types.js";
-export { child, children, allDescendants, labelText, stringText, entryText, qualifiedNameText, sourceRefText, sourceRefStructuralText, fieldNameText, walkDescendants } from "./cst-utils.js";
+export type {
+  SyntaxNode,
+  Tree,
+  Classification,
+  PipeStep,
+  MetaEntry,
+  MetaEntryTag,
+  MetaEntryKV,
+  MetaEntryEnum,
+  MetaEntryNote,
+  MetaEntrySlice,
+  FieldDecl,
+} from "./types.js";
+export {
+  child,
+  children,
+  allDescendants,
+  labelText,
+  stringText,
+  entryText,
+  qualifiedNameText,
+  sourceRefText,
+  sourceRefStructuralText,
+  fieldNameText,
+  walkDescendants,
+} from "./cst-utils.js";
 export { classifyTransform, classifyArrow } from "./classify.js";
-export { canonicalRef, canonicalEntityName, qualifyField, resolveScopedEntityRef } from "./canonical-ref.js";
+export {
+  canonicalRef,
+  canonicalEntityName,
+  qualifyField,
+  resolveScopedEntityRef,
+} from "./canonical-ref.js";
 export { extractMetadata } from "./meta-extract.js";
 export {
   extractFieldTree,

--- a/tooling/satsuma-core/src/meta-extract.ts
+++ b/tooling/satsuma-core/src/meta-extract.ts
@@ -41,8 +41,7 @@ function normalizeMetadataValue(valueNode: SyntaxNode | null | undefined): strin
   const text = valueNode.text;
   if (
     text.length >= 2 &&
-    ((text.startsWith("\"") && text.endsWith("\"")) ||
-      (text.startsWith("`") && text.endsWith("`")))
+    ((text.startsWith('"') && text.endsWith('"')) || (text.startsWith("`") && text.endsWith("`")))
   ) {
     return text.slice(1, -1);
   }
@@ -67,10 +66,10 @@ export function extractMetadata(metaNode: SyntaxNode | null | undefined): MetaEn
       entries.push({ kind: "kv", key: key?.text ?? "", value });
     } else if (c.type === "enum_body") {
       const values = c.namedChildren
-        .filter((x) => x.type === "identifier" || x.type === "nl_string" || x.type === "number_literal")
-        .map((x) =>
-          x.type === "nl_string" ? x.text.slice(1, -1) : x.text,
-        );
+        .filter(
+          (x) => x.type === "identifier" || x.type === "nl_string" || x.type === "number_literal",
+        )
+        .map((x) => (x.type === "nl_string" ? x.text.slice(1, -1) : x.text));
       entries.push({ kind: "enum", values });
     } else if (c.type === "note_tag") {
       const strNode = c.namedChildren.find(
@@ -84,9 +83,7 @@ export function extractMetadata(metaNode: SyntaxNode | null | undefined): MetaEn
         entries.push({ kind: "note", text });
       }
     } else if (c.type === "slice_body") {
-      const values = c.namedChildren
-        .filter((x) => x.type === "identifier")
-        .map((x) => x.text);
+      const values = c.namedChildren.filter((x) => x.type === "identifier").map((x) => x.text);
       entries.push({ kind: "slice", values });
     }
   }

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -27,10 +27,7 @@ export interface AtRef {
 }
 
 export type RefClassification =
-  | "namespace-qualified-field"
-  | "namespace-qualified-schema"
-  | "dotted-field"
-  | "bare";
+  "namespace-qualified-field" | "namespace-qualified-schema" | "dotted-field" | "bare";
 
 export interface Resolution {
   resolved: boolean;
@@ -140,7 +137,8 @@ function canonicalKey(key: string): string {
 // instance (because /g state is mutable) should call createAtRefRegex(); this
 // is the single source of truth shared by core, the LSP, the viz backend and
 // the viz UI to avoid drift between copies.
-export const AT_REF_PATTERN = "(?<=^|[\\s(\\[{,;\"'=:])@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*";
+export const AT_REF_PATTERN =
+  "(?<=^|[\\s(\\[{,;\"'=:])@(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*)(?:::(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))?(?:\\.(`[^`]+`|[a-zA-Z_][a-zA-Z0-9_-]*))*";
 
 /**
  * Build a fresh global @ref regex. Always returns a new instance so callers
@@ -321,7 +319,12 @@ function getExpandedFields(schema: SchemaLike, lookup: DefinitionLookup): FieldD
     return null;
   };
   const lookupFrag: SpreadEntityLookup = (key) => lookup.getFragment(key) ?? null;
-  return expandEntityFields(schema as SpreadEntity, schema.namespace ?? null, resolveRef, lookupFrag);
+  return expandEntityFields(
+    schema as SpreadEntity,
+    schema.namespace ?? null,
+    resolveRef,
+    lookupFrag,
+  );
 }
 
 // ── Field lookup: matching a ref to a declared field path ─────────────────────
@@ -344,8 +347,7 @@ function getExpandedFields(schema: SchemaLike, lookup: DefinitionLookup): FieldD
  */
 function findFieldPath(fields: FieldDecl[], name: string): string | null {
   // Each queue entry is a field plus the dotted path that reaches it.
-  let level: { field: FieldDecl; path: string }[] =
-    fields.map((f) => ({ field: f, path: f.name }));
+  let level: { field: FieldDecl; path: string }[] = fields.map((f) => ({ field: f, path: f.name }));
 
   while (level.length > 0) {
     for (const { field, path } of level) {
@@ -428,7 +430,11 @@ function searchNestedPath(fields: FieldDecl[], segments: string[], prefix: strin
  * segment may contain "." or "::" but still names ONE field, never a nested
  * path (sl-g6ga). Multi-segment paths walk the field tree per segment.
  */
-function findFieldPathWithSpreads(schema: SchemaLike, fieldSegs: RefSegment[], lookup: DefinitionLookup): string | null {
+function findFieldPathWithSpreads(
+  schema: SchemaLike,
+  fieldSegs: RefSegment[],
+  lookup: DefinitionLookup,
+): string | null {
   const names = fieldSegs.map((s) => s.name);
   if (names.length > 1) {
     const direct = findNestedFieldPath(schema.fields, names);
@@ -479,7 +485,11 @@ function findFieldPathWithSpreads(schema: SchemaLike, fieldSegs: RefSegment[], l
  * back to the raw name so global schemas referenced from inside a namespace
  * still resolve.
  */
-function contextSchemaKey(name: string, namespace: string | null, lookup: DefinitionLookup): string {
+function contextSchemaKey(
+  name: string,
+  namespace: string | null,
+  lookup: DefinitionLookup,
+): string {
   if (namespace && !name.includes("::")) {
     const qualified = `${namespace}::${name}`;
     if (lookup.hasSchema(qualified)) return qualified;
@@ -487,7 +497,11 @@ function contextSchemaKey(name: string, namespace: string | null, lookup: Defini
   return name;
 }
 
-export function resolveRef(ref: string, mappingContext: MappingContext, lookup: DefinitionLookup): Resolution {
+export function resolveRef(
+  ref: string,
+  mappingContext: MappingContext,
+  lookup: DefinitionLookup,
+): Resolution {
   // Parse once, honouring backtick quoting: separators inside backticks are
   // part of the name (sl-g6ga). All index lookups and resolvedTo names below
   // use flattened (backtick-free) segment names.
@@ -496,9 +510,12 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
 
   if (classification === "namespace-qualified-schema") {
     const key = segments.map((s) => s.name).join("::");
-    if (lookup.hasSchema(key)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(key) } };
-    if (lookup.hasFragment(key)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(key) } };
-    if (lookup.hasTransform(key)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(key) } };
+    if (lookup.hasSchema(key))
+      return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(key) } };
+    if (lookup.hasFragment(key))
+      return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(key) } };
+    if (lookup.hasTransform(key))
+      return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(key) } };
     return { resolved: false, resolvedTo: null };
   }
 
@@ -506,12 +523,18 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
     // Grammar shape: ns::schema.field(.field)* — every "::" precedes the
     // first ".", so the segments before it form the schema key.
     const firstDot = separators.indexOf(".");
-    const schemaRef = segments.slice(0, firstDot + 1).map((s) => s.name).join("::");
+    const schemaRef = segments
+      .slice(0, firstDot + 1)
+      .map((s) => s.name)
+      .join("::");
     const fieldSegs = segments.slice(firstDot + 1);
     const schema = lookup.getSchema(schemaRef);
     const fieldPath = schema ? findFieldPathWithSpreads(schema, fieldSegs, lookup) : null;
     if (fieldPath) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldPath}` } };
+      return {
+        resolved: true,
+        resolvedTo: { kind: "field", name: `${canonicalKey(schemaRef)}.${fieldPath}` },
+      };
     }
     return { resolved: false, resolvedTo: null };
   }
@@ -528,13 +551,19 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
       if (!schema) continue;
       const direct = findNestedFieldPath(schema.fields, names);
       if (direct) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${direct}` } };
+        return {
+          resolved: true,
+          resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${direct}` },
+        };
       }
       if (schema.hasSpreads) {
         const expanded = getExpandedFields(schema, lookup);
         const viaSpread = findNestedFieldPath([...schema.fields, ...expanded], names);
         if (viaSpread) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${viaSpread}` } };
+          return {
+            resolved: true,
+            resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${viaSpread}` },
+          };
         }
       }
     }
@@ -547,7 +576,10 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
         const schema = lookup.getSchema(key);
         const fieldPath = schema ? findFieldPathWithSpreads(schema, fieldSegs, lookup) : null;
         if (fieldPath) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
+          return {
+            resolved: true,
+            resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` },
+          };
         }
       }
     }
@@ -565,13 +597,19 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
         if (baseName === schemaName || key === schemaName) {
           const fieldPath = findFieldPathWithSpreads(schema, fieldSegs, lookup);
           if (fieldPath) {
-            return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
+            return {
+              resolved: true,
+              resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` },
+            };
           }
         }
         // Also try as nested path within this schema
         const nestedPath = findNestedFieldPath(schema.fields, names);
         if (nestedPath) {
-          return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${nestedPath}` } };
+          return {
+            resolved: true,
+            resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${nestedPath}` },
+          };
         }
       }
     }
@@ -587,7 +625,10 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
     const schema = lookup.getSchema(key);
     const fieldPath = schema ? findFieldPathWithSpreads(schema, segments, lookup) : null;
     if (fieldPath) {
-      return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
+      return {
+        resolved: true,
+        resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` },
+      };
     }
   }
 
@@ -597,21 +638,30 @@ export function resolveRef(ref: string, mappingContext: MappingContext, lookup: 
     for (const [key, schema] of lookup.iterateSchemas()) {
       const fieldPath = findFieldPathWithSpreads(schema, segments, lookup);
       if (fieldPath) {
-        return { resolved: true, resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` } };
+        return {
+          resolved: true,
+          resolvedTo: { kind: "field", name: `${canonicalKey(key)}.${fieldPath}` },
+        };
       }
     }
   }
 
   if (mappingContext.namespace) {
     const nsRef = `${mappingContext.namespace}::${bareName}`;
-    if (lookup.hasSchema(nsRef)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(nsRef) } };
-    if (lookup.hasFragment(nsRef)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(nsRef) } };
-    if (lookup.hasTransform(nsRef)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(nsRef) } };
+    if (lookup.hasSchema(nsRef))
+      return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(nsRef) } };
+    if (lookup.hasFragment(nsRef))
+      return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(nsRef) } };
+    if (lookup.hasTransform(nsRef))
+      return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(nsRef) } };
   }
 
-  if (lookup.hasSchema(bareName)) return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(bareName) } };
-  if (lookup.hasFragment(bareName)) return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(bareName) } };
-  if (lookup.hasTransform(bareName)) return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(bareName) } };
+  if (lookup.hasSchema(bareName))
+    return { resolved: true, resolvedTo: { kind: "schema", name: canonicalKey(bareName) } };
+  if (lookup.hasFragment(bareName))
+    return { resolved: true, resolvedTo: { kind: "fragment", name: canonicalKey(bareName) } };
+  if (lookup.hasTransform(bareName))
+    return { resolved: true, resolvedTo: { kind: "transform", name: canonicalKey(bareName) } };
 
   return { resolved: false, resolvedTo: null };
 }
@@ -632,7 +682,11 @@ export function extractNLRefData(rootNode: SyntaxNode): NLRefDataItemNoFile[] {
   return results;
 }
 
-function walkMappings(node: SyntaxNode, namespace: string | null, results: NLRefDataItemNoFile[]): void {
+function walkMappings(
+  node: SyntaxNode,
+  namespace: string | null,
+  results: NLRefDataItemNoFile[],
+): void {
   for (const c of node.namedChildren) {
     if (c.type === "namespace_block") {
       const nsName = c.namedChildren.find((x) => x.type === "identifier");
@@ -649,7 +703,11 @@ function walkMappings(node: SyntaxNode, namespace: string | null, results: NLRef
   }
 }
 
-function extractMappingNLRefs(mappingNode: SyntaxNode, namespace: string | null, results: NLRefDataItemNoFile[]): void {
+function extractMappingNLRefs(
+  mappingNode: SyntaxNode,
+  namespace: string | null,
+  results: NLRefDataItemNoFile[],
+): void {
   const lbl = mappingNode.namedChildren.find((c) => c.type === "block_label");
   const inner = lbl?.namedChildren[0];
   let mappingName = inner?.text ?? null;
@@ -682,7 +740,7 @@ function nlRefNodesInPipeStep(step: SyntaxNode): SyntaxNode[] {
   if (inner.type === "map_literal") {
     return inner.namedChildren
       .filter((e) => e.type === "map_entry")
-      .flatMap((e) => e.namedChildren)            // map_key and map_value parts
+      .flatMap((e) => e.namedChildren) // map_key and map_value parts
       .flatMap((part) => part.namedChildren.filter(isNL));
   }
   return [];
@@ -702,13 +760,19 @@ function openingDelimiterWidth(node: SyntaxNode): number {
 // at offset zero, making position math identical to the quoted case.
 function nlRefText(node: SyntaxNode): string | null {
   const text =
-    node.type === "multiline_string" ? node.text.slice(3, -3) :
-    node.type === "nl_string" ? node.text.slice(1, -1) :
-    node.text; // at_ref
+    node.type === "multiline_string"
+      ? node.text.slice(3, -3)
+      : node.type === "nl_string"
+        ? node.text.slice(1, -1)
+        : node.text; // at_ref
   return text.includes("`") || /@[a-zA-Z_`]/.test(text) ? text : null;
 }
 
-function extractTransformNLRefs(transformNode: SyntaxNode, namespace: string | null, results: NLRefDataItemNoFile[]): void {
+function extractTransformNLRefs(
+  transformNode: SyntaxNode,
+  namespace: string | null,
+  results: NLRefDataItemNoFile[],
+): void {
   const lbl = transformNode.namedChildren.find((c) => c.type === "block_label");
   const inner = lbl?.namedChildren[0];
   let transformName = inner?.text ?? "";
@@ -745,9 +809,8 @@ function extractStandaloneNoteRefs(
 ): void {
   for (const inner of noteNode.namedChildren) {
     if (inner.type === "nl_string" || inner.type === "multiline_string") {
-      const text = inner.type === "multiline_string"
-        ? inner.text.slice(3, -3)
-        : inner.text.slice(1, -1);
+      const text =
+        inner.type === "multiline_string" ? inner.text.slice(3, -3) : inner.text.slice(1, -1);
       if (text.includes("`") || /@[a-zA-Z_`]/.test(text)) {
         results.push({
           text,
@@ -775,9 +838,12 @@ function extractBlockNoteRefs(
 
   // Metric schemas are schema_block nodes — they use the "schema:" prefix.
   // (The old "metric:" prefix was for the removed metric_block type.)
-  const blockTypePrefix = blockNode.type === "schema_block" ? "schema:"
-    : blockNode.type === "fragment_block" ? "fragment:"
-    : "";
+  const blockTypePrefix =
+    blockNode.type === "schema_block"
+      ? "schema:"
+      : blockNode.type === "fragment_block"
+        ? "fragment:"
+        : "";
   const parentLabel = `${blockTypePrefix}${blockName}`;
 
   // Also scan inline (note "...") metadata in the block declaration header.
@@ -874,9 +940,8 @@ function walkArrowsForNL(
     if (c.type === "note_block") {
       for (const inner of c.namedChildren) {
         if (inner.type === "nl_string" || inner.type === "multiline_string") {
-          const text = inner.type === "multiline_string"
-            ? inner.text.slice(3, -3)
-            : inner.text.slice(1, -1);
+          const text =
+            inner.type === "multiline_string" ? inner.text.slice(3, -3) : inner.text.slice(1, -1);
           if (text.includes("`") || /@[a-zA-Z_`]/.test(text)) {
             results.push({
               text,
@@ -900,12 +965,13 @@ function walkArrowsForNL(
         ...c.namedChildren.filter((x) => x.type === "nl_string" || x.type === "multiline_string"),
         ...c.namedChildren
           .filter((x) => x.type === "source_ref")
-          .flatMap((x) => x.namedChildren.filter((y) => y.type === "nl_string" || y.type === "multiline_string")),
+          .flatMap((x) =>
+            x.namedChildren.filter((y) => y.type === "nl_string" || y.type === "multiline_string"),
+          ),
       ];
       for (const nlNode of nlNodes) {
-        const text = nlNode.type === "multiline_string"
-          ? nlNode.text.slice(3, -3)
-          : nlNode.text.slice(1, -1);
+        const text =
+          nlNode.type === "multiline_string" ? nlNode.text.slice(3, -3) : nlNode.text.slice(1, -1);
         if (text.includes("`") || /@[a-zA-Z_`]/.test(text)) {
           results.push({
             text,
@@ -982,9 +1048,7 @@ export function resolveAllNLRefs(
 
   for (const item of nlRefData) {
     const atRefs = extractAtRefs(item.text);
-    const mappingKey = item.namespace
-      ? `${item.namespace}::${item.mapping}`
-      : item.mapping;
+    const mappingKey = item.namespace ? `${item.namespace}::${item.mapping}` : item.mapping;
     const mapping = lookup.getMapping(mappingKey);
     const mappingContext: MappingContext = {
       sources: mapping?.sources ?? [],
@@ -1059,7 +1123,10 @@ export function stripNLRefScopePrefix(mapping: string): string {
  * Check if a schema reference from an NL block is declared in the mapping's
  * source or target list.
  */
-export function isSchemaInMappingSources(schemaRef: string, mapping: MappingSourcesTargets | null | undefined): boolean {
+export function isSchemaInMappingSources(
+  schemaRef: string,
+  mapping: MappingSourcesTargets | null | undefined,
+): boolean {
   if (!mapping) return false;
   const allRefs = [...(mapping.sources ?? []), ...(mapping.targets ?? [])];
   return allRefs.some((r) => r === schemaRef || canonicalKey(r) === schemaRef);

--- a/tooling/satsuma-core/src/spread-expand.ts
+++ b/tooling/satsuma-core/src/spread-expand.ts
@@ -23,18 +23,13 @@ import type { FieldDecl } from "./types.js";
  * 2. Try `${currentNs}::${name}` if a current namespace is provided.
  * 3. Try the unqualified name directly as a fallback.
  */
-export type EntityRefResolver = (
-  ref: string,
-  currentNs: string | null,
-) => string | null;
+export type EntityRefResolver = (ref: string, currentNs: string | null) => string | null;
 
 /**
  * Look up a spread entity (schema or fragment) by its resolved canonical key.
  * Returns null/undefined if not found.
  */
-export type SpreadEntityLookup = (
-  key: string,
-) => SpreadEntity | null | undefined;
+export type SpreadEntityLookup = (key: string) => SpreadEntity | null | undefined;
 
 export interface SpreadEntity {
   fields: FieldDecl[];
@@ -110,7 +105,18 @@ export function expandSpreads(
   for (const key of schemaKeys) {
     const schema = lookupSchema ? lookupSchema(key) : null;
     if (!schema?.hasSpreads) continue;
-    if (!expandEntitySpreads(schema, currentNs, resolveRef, lookupFragment, fieldPaths, visited, diagnostics, [])) {
+    if (
+      !expandEntitySpreads(
+        schema,
+        currentNs,
+        resolveRef,
+        lookupFragment,
+        fieldPaths,
+        visited,
+        diagnostics,
+        [],
+      )
+    ) {
       hasUnresolved = true;
     }
     // Also expand nested record-level spreads into fieldPaths
@@ -143,7 +149,14 @@ function expandNestedFieldPaths(
       }
     }
     if (field.children) {
-      expandNestedFieldPaths(field.children, prefix + field.name + ".", currentNs, resolveRef, lookupFragment, fieldPaths);
+      expandNestedFieldPaths(
+        field.children,
+        prefix + field.name + ".",
+        currentNs,
+        resolveRef,
+        lookupFragment,
+        fieldPaths,
+      );
     }
   }
 }
@@ -198,7 +211,10 @@ function collectExpandedFields(
     }
 
     if (fragment.hasSpreads) {
-      collectExpandedFields(fragment, currentNs, resolveRef, lookupFragment, fields, visited, [...chain, resolvedKey]);
+      collectExpandedFields(fragment, currentNs, resolveRef, lookupFragment, fields, visited, [
+        ...chain,
+        resolvedKey,
+      ]);
     }
   }
 }
@@ -305,7 +321,18 @@ function expandEntitySpreads(
     }
     collectFieldPaths(fragment.fields, "", fieldPaths);
     if (fragment.hasSpreads) {
-      if (!expandEntitySpreads(fragment, currentNs, resolveRef, lookupFragment, fieldPaths, expanded, diagnostics, [...chain, resolvedKey])) {
+      if (
+        !expandEntitySpreads(
+          fragment,
+          currentNs,
+          resolveRef,
+          lookupFragment,
+          fieldPaths,
+          expanded,
+          diagnostics,
+          [...chain, resolvedKey],
+        )
+      ) {
         allResolved = false;
       }
     }

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -25,7 +25,14 @@
  */
 
 import { capitalize } from "./string-utils.js";
-import { extractAtRefs, classifyRef, resolveRef, isSchemaInMappingSources, stripNLRefScopePrefix, computeNLRefPosition } from "./nl-ref.js";
+import {
+  extractAtRefs,
+  classifyRef,
+  resolveRef,
+  isSchemaInMappingSources,
+  stripNLRefScopePrefix,
+  computeNLRefPosition,
+} from "./nl-ref.js";
 import type { DefinitionLookup } from "./nl-ref.js";
 import { expandSpreads, collectFieldPaths } from "./spread-expand.js";
 import type { SpreadEntity, EntityRefResolver, SpreadEntityLookup } from "./spread-expand.js";
@@ -235,8 +242,9 @@ export function validateSemanticWorkspace(
   index: SemanticIndex,
   options: SemanticValidationOptions = {},
 ): SemanticDiagnostic[] {
-  const reachability = options.reachability
-    ?? (options.fileImports ? computeImportReachability(index, options.fileImports) : undefined);
+  const reachability =
+    options.reachability ??
+    (options.fileImports ? computeImportReachability(index, options.fileImports) : undefined);
   return collectSemanticDiagnosticsWithOptions(index, {
     ...options,
     reachability,
@@ -318,7 +326,7 @@ function checkDuplicates(index: SemanticIndex, diagnostics: SemanticDiagnostic[]
 function checkFragmentSpreads(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): void {
   for (const [name, schema] of index.schemas) {
     const currentNs = schema.namespace ?? null;
-    for (const spread of (schema.spreads ?? [])) {
+    for (const spread of schema.spreads ?? []) {
       if (!resolveScopedEntityRef(spread, currentNs, index.fragments as Map<string, unknown>)) {
         diagnostics.push({
           file: schema.file,
@@ -342,8 +350,8 @@ function checkFragmentSpreads(index: SemanticIndex, diagnostics: SemanticDiagnos
  */
 function checkMappingRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): void {
   const allDefinitions = new Map([
-    ...index.schemas as Map<string, unknown>,
-    ...index.fragments as Map<string, unknown>,
+    ...(index.schemas as Map<string, unknown>),
+    ...(index.fragments as Map<string, unknown>),
   ]);
 
   for (const [name, mapping] of index.mappings) {
@@ -352,16 +360,32 @@ function checkMappingRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[
       if (!resolveScopedEntityRef(src, currentNs, allDefinitions)) {
         let msg = `Mapping '${name}' references undefined source '${src}'`;
         const hints = suggestAlternatives(src, allDefinitions);
-        if (hints.length > 0) msg += `\n  hint: did you mean ${hints.map((h) => `'${h}'`).join(" or ")}?`;
-        diagnostics.push({ file: mapping.file, line: mapping.row + 1, column: 1, severity: "warning", rule: "undefined-ref", message: msg });
+        if (hints.length > 0)
+          msg += `\n  hint: did you mean ${hints.map((h) => `'${h}'`).join(" or ")}?`;
+        diagnostics.push({
+          file: mapping.file,
+          line: mapping.row + 1,
+          column: 1,
+          severity: "warning",
+          rule: "undefined-ref",
+          message: msg,
+        });
       }
     }
     for (const tgt of mapping.targets) {
       if (!resolveScopedEntityRef(tgt, currentNs, allDefinitions)) {
         let msg = `Mapping '${name}' references undefined target '${tgt}'`;
         const hints = suggestAlternatives(tgt, allDefinitions);
-        if (hints.length > 0) msg += `\n  hint: did you mean ${hints.map((h) => `'${h}'`).join(" or ")}?`;
-        diagnostics.push({ file: mapping.file, line: mapping.row + 1, column: 1, severity: "warning", rule: "undefined-ref", message: msg });
+        if (hints.length > 0)
+          msg += `\n  hint: did you mean ${hints.map((h) => `'${h}'`).join(" or ")}?`;
+        diagnostics.push({
+          file: mapping.file,
+          line: mapping.row + 1,
+          column: 1,
+          severity: "warning",
+          rule: "undefined-ref",
+          message: msg,
+        });
       }
     }
   }
@@ -375,7 +399,7 @@ function checkMappingRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[
 function checkMetricRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): void {
   for (const [name, metric] of index.metrics) {
     const currentNs = metric.namespace ?? null;
-    for (const src of (metric.sources ?? [])) {
+    for (const src of metric.sources ?? []) {
       if (!resolveScopedEntityRef(src, currentNs, index.schemas as Map<string, unknown>)) {
         diagnostics.push({
           file: metric.file,
@@ -475,9 +499,8 @@ function checkNLRefs(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): v
  */
 function noteDisplayScope(mapping: string, namespace: string | null): string {
   const entityName = stripNLRefScopePrefix(mapping);
-  const qualifiedName = namespace && entityName !== "(file-level note)"
-    ? `${namespace}::${entityName}`
-    : entityName;
+  const qualifiedName =
+    namespace && entityName !== "(file-level note)" ? `${namespace}::${entityName}` : entityName;
 
   if (mapping === "note:") return "file-level note";
   if (mapping.startsWith("note:metric:")) return `metric '${qualifiedName}'`;
@@ -530,7 +553,10 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
   const uniqueArrows: SemanticArrow[] = [];
   for (const [, arrows] of index.fieldArrows) {
     for (const arrow of arrows) {
-      if (!seenArrows.has(arrow)) { seenArrows.add(arrow); uniqueArrows.push(arrow); }
+      if (!seenArrows.has(arrow)) {
+        seenArrows.add(arrow);
+        uniqueArrows.push(arrow);
+      }
     }
   }
 
@@ -561,7 +587,15 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
     for (const s of resolvedSrcKeys) {
       collectFieldPaths(index.schemas.get(s)?.fields ?? [], "", srcFieldPaths);
     }
-    const srcHasUnresolved = expandSpreads(resolvedSrcKeys, currentNs, resolveRef, lookupFragment, srcFieldPaths, diagnostics as never[], lookupSchema);
+    const srcHasUnresolved = expandSpreads(
+      resolvedSrcKeys,
+      currentNs,
+      resolveRef,
+      lookupFragment,
+      srcFieldPaths,
+      diagnostics as never[],
+      lookupSchema,
+    );
 
     // Multi-source mappings let arrows qualify a path with the authored
     // source name (s2.created_at). The qualified set must include
@@ -571,19 +605,43 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
     // this pass discards them to avoid duplicates.
     if (resolvedSrcKeys.length > 1) {
       for (let i = 0; i < mapping.sources.length; i++) {
-        const key = resolveScopedEntityRef(mapping.sources[i]!, currentNs, index.schemas as Map<string, unknown>);
+        const key = resolveScopedEntityRef(
+          mapping.sources[i]!,
+          currentNs,
+          index.schemas as Map<string, unknown>,
+        );
         if (!key) continue;
         const perSourcePaths = new Set<string>();
         collectFieldPaths(index.schemas.get(key)?.fields ?? [], "", perSourcePaths);
-        expandSpreads([key], currentNs, resolveRef, lookupFragment, perSourcePaths, [], lookupSchema);
+        expandSpreads(
+          [key],
+          currentNs,
+          resolveRef,
+          lookupFragment,
+          perSourcePaths,
+          [],
+          lookupSchema,
+        );
         for (const p of perSourcePaths) srcFieldPaths.add(`${mapping.sources[i]}.${p}`);
       }
     }
 
     const tgtFieldPaths = new Set<string>();
-    collectFieldPaths(resolvedTgtKey ? (index.schemas.get(resolvedTgtKey)?.fields ?? []) : [], "", tgtFieldPaths);
+    collectFieldPaths(
+      resolvedTgtKey ? (index.schemas.get(resolvedTgtKey)?.fields ?? []) : [],
+      "",
+      tgtFieldPaths,
+    );
     const tgtHasUnresolved = resolvedTgtKey
-      ? expandSpreads([resolvedTgtKey], currentNs, resolveRef, lookupFragment, tgtFieldPaths, diagnostics as never[], lookupSchema)
+      ? expandSpreads(
+          [resolvedTgtKey],
+          currentNs,
+          resolveRef,
+          lookupFragment,
+          tgtFieldPaths,
+          diagnostics as never[],
+          lookupSchema,
+        )
       : false;
 
     // Add convention-inferred fields so they don't trigger false positives.
@@ -592,10 +650,15 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
       if (sch) for (const f of getConventionFields(sch)) srcFieldPaths.add(f);
     }
     for (let i = 0; i < mapping.sources.length; i++) {
-      const key = resolveScopedEntityRef(mapping.sources[i]!, currentNs, index.schemas as Map<string, unknown>);
+      const key = resolveScopedEntityRef(
+        mapping.sources[i]!,
+        currentNs,
+        index.schemas as Map<string, unknown>,
+      );
       if (!key) continue;
       const sch = index.schemas.get(key);
-      if (sch) for (const f of getConventionFields(sch)) srcFieldPaths.add(`${mapping.sources[i]}.${f}`);
+      if (sch)
+        for (const f of getConventionFields(sch)) srcFieldPaths.add(`${mapping.sources[i]}.${f}`);
     }
     if (resolvedTgtKey) {
       const sch = index.schemas.get(resolvedTgtKey);
@@ -605,30 +668,40 @@ function checkArrowFieldRefs(index: SemanticIndex, diagnostics: SemanticDiagnost
     for (const arrow of uniqueArrows) {
       // Named mappings match by bare name; anonymous mappings (name=null) match
       // by the synthetic index key (e.g. "<anon>@path:row") stored in arrow.mapping.
-      const mappingMatch = mapping.name !== null
-        ? arrow.mapping === mapping.name
-        : arrow.mapping === bareIndexKey;
+      const mappingMatch =
+        mapping.name !== null ? arrow.mapping === mapping.name : arrow.mapping === bareIndexKey;
       if (!mappingMatch || (arrow.namespace ?? null) !== currentNs) continue;
       if (arrow.file !== mapping.file) continue; // guard against cross-file duplicate mapping names
 
       for (const source of arrow.sources) {
         if (
-          srcSchema && index.schemas.has(srcSchema) && !srcHasUnresolved &&
+          srcSchema &&
+          index.schemas.has(srcSchema) &&
+          !srcHasUnresolved &&
           !resolveFieldPath(source, resolvedSrcKeys, index, srcFieldPaths)
         ) {
           diagnostics.push({
-            file: arrow.file, line: arrow.line + 1, column: 1, severity: "warning",
+            file: arrow.file,
+            line: arrow.line + 1,
+            column: 1,
+            severity: "warning",
             rule: "field-not-in-schema",
             message: `Arrow source '${source}' not declared in schema '${blamedSourceSchema(source, resolvedSrcKeys, srcSchema)}'`,
           });
         }
       }
       if (
-        arrow.target && resolvedTgtKey && index.schemas.has(resolvedTgtKey) && !tgtHasUnresolved &&
+        arrow.target &&
+        resolvedTgtKey &&
+        index.schemas.has(resolvedTgtKey) &&
+        !tgtHasUnresolved &&
         !resolveFieldPath(arrow.target, [resolvedTgtKey], index, tgtFieldPaths)
       ) {
         diagnostics.push({
-          file: arrow.file, line: arrow.line + 1, column: 1, severity: "warning",
+          file: arrow.file,
+          line: arrow.line + 1,
+          column: 1,
+          severity: "warning",
           rule: "field-not-in-schema",
           message: `Arrow target '${arrow.target}' not declared in schema '${resolvedTgtKey}'`,
         });
@@ -656,7 +729,10 @@ function checkTransformSpreads(index: SemanticIndex, diagnostics: SemanticDiagno
           const currentNs = arrow.namespace ?? null;
           if (!resolveScopedEntityRef(spreadName, currentNs, index.transforms)) {
             diagnostics.push({
-              file: arrow.file, line: arrow.line + 1, column: 1, severity: "warning",
+              file: arrow.file,
+              line: arrow.line + 1,
+              column: 1,
+              severity: "warning",
               rule: "undefined-ref",
               message: `Arrow in mapping '${arrow.mapping}' spreads undefined transform '${spreadName}'`,
             });
@@ -675,10 +751,26 @@ function checkTransformSpreads(index: SemanticIndex, diagnostics: SemanticDiagno
  */
 function checkRefMetadata(index: SemanticIndex, diagnostics: SemanticDiagnostic[]): void {
   for (const [schemaName, schema] of index.schemas) {
-    checkFieldRefMetadata(schema.fields, schemaName, schema.file, schema.row, schema.namespace ?? null, index, diagnostics);
+    checkFieldRefMetadata(
+      schema.fields,
+      schemaName,
+      schema.file,
+      schema.row,
+      schema.namespace ?? null,
+      index,
+      diagnostics,
+    );
   }
   for (const [fragName, frag] of index.fragments) {
-    checkFieldRefMetadata(frag.fields, fragName, frag.file, frag.row, frag.namespace ?? null, index, diagnostics);
+    checkFieldRefMetadata(
+      frag.fields,
+      fragName,
+      frag.file,
+      frag.row,
+      frag.namespace ?? null,
+      index,
+      diagnostics,
+    );
   }
 }
 
@@ -696,9 +788,14 @@ function checkFieldRefMetadata(
       for (const m of field.metadata) {
         if (m.kind === "kv" && m.key === "ref") {
           const refTarget = m.value.replace(/^@/, "").split(".")[0]!;
-          if (!resolveScopedEntityRef(refTarget, currentNs, index.schemas as Map<string, unknown>)) {
+          if (
+            !resolveScopedEntityRef(refTarget, currentNs, index.schemas as Map<string, unknown>)
+          ) {
             diagnostics.push({
-              file, line: row + 1, column: 1, severity: "warning",
+              file,
+              line: row + 1,
+              column: 1,
+              severity: "warning",
               rule: "undefined-ref",
               message: `Field '${field.name}' in '${entityName}' references undefined schema '${refTarget}' via (ref ${m.value})`,
             });
@@ -734,8 +831,8 @@ function checkImportScope(
   policy: ImportScopeDiagnosticPolicy = {},
 ): void {
   const allDefinitions = new Map<string, unknown>([
-    ...index.schemas as Map<string, unknown>,
-    ...index.fragments as Map<string, unknown>,
+    ...(index.schemas as Map<string, unknown>),
+    ...(index.fragments as Map<string, unknown>),
   ]);
 
   // Helper: check if a resolved symbol key is reachable from a given file.
@@ -773,24 +870,41 @@ function checkImportScope(
       column: 1,
       severity: "error",
       rule: policy.rule ?? "import-scope",
-      message: policy.message?.(violation)
-        ?? `${capitalize(entityKind)} '${entityName}' references ${refKind} '${resolved}' which is not reachable from this file's imports`,
+      message:
+        policy.message?.(violation) ??
+        `${capitalize(entityKind)} '${entityName}' references ${refKind} '${resolved}' which is not reachable from this file's imports`,
     });
   }
 
   // --- Schema spread fragments ---
   for (const [name, schema] of index.schemas) {
-    for (const spread of (schema.spreads ?? [])) {
-      checkRef(spread, schema.namespace ?? null, index.fragments as Map<string, unknown>,
-        schema.file, "schema", name, schema.row, "fragment");
+    for (const spread of schema.spreads ?? []) {
+      checkRef(
+        spread,
+        schema.namespace ?? null,
+        index.fragments as Map<string, unknown>,
+        schema.file,
+        "schema",
+        name,
+        schema.row,
+        "fragment",
+      );
     }
   }
 
   // --- Fragment spread fragments ---
   for (const [name, fragment] of index.fragments) {
-    for (const spread of (fragment.spreads ?? [])) {
-      checkRef(spread, fragment.namespace ?? null, index.fragments as Map<string, unknown>,
-        fragment.file, "fragment", name, fragment.row, "fragment");
+    for (const spread of fragment.spreads ?? []) {
+      checkRef(
+        spread,
+        fragment.namespace ?? null,
+        index.fragments as Map<string, unknown>,
+        fragment.file,
+        "fragment",
+        name,
+        fragment.row,
+        "fragment",
+      );
     }
   }
 
@@ -798,19 +912,45 @@ function checkImportScope(
   for (const [name, mapping] of index.mappings) {
     const ns = mapping.namespace ?? null;
     for (const src of mapping.sources) {
-      checkRef(src, ns, allDefinitions, mapping.file, "mapping", name ?? "<anonymous>", mapping.row, "source");
+      checkRef(
+        src,
+        ns,
+        allDefinitions,
+        mapping.file,
+        "mapping",
+        name ?? "<anonymous>",
+        mapping.row,
+        "source",
+      );
     }
     for (const tgt of mapping.targets) {
-      checkRef(tgt, ns, allDefinitions, mapping.file, "mapping", name ?? "<anonymous>", mapping.row, "target");
+      checkRef(
+        tgt,
+        ns,
+        allDefinitions,
+        mapping.file,
+        "mapping",
+        name ?? "<anonymous>",
+        mapping.row,
+        "target",
+      );
     }
   }
 
   // --- Metric source refs ---
   for (const [name, metric] of index.metrics) {
     const ns = metric.namespace ?? null;
-    for (const src of (metric.sources ?? [])) {
-      checkRef(src, ns, index.schemas as Map<string, unknown>,
-        metric.file, "metric", name, metric.row, "source");
+    for (const src of metric.sources ?? []) {
+      checkRef(
+        src,
+        ns,
+        index.schemas as Map<string, unknown>,
+        metric.file,
+        "metric",
+        name,
+        metric.row,
+        "source",
+      );
     }
   }
 
@@ -835,16 +975,18 @@ function checkImportScope(
               column: 1,
               severity: "error",
               rule: policy.rule ?? "import-scope",
-              message: policy.message?.({
-                file: arrow.file,
-                row: arrow.line,
-                entityKind: "arrow",
-                entityName: arrow.mapping ?? "<anonymous>",
-                refKind: "transform",
-                ref: spreadName,
-                resolved,
-                definitionFile: definitionFileFor(index.transforms.get(resolved)),
-              }) ?? `Arrow in mapping '${arrow.mapping}' references transform '${resolved}' which is not reachable from this file's imports`,
+              message:
+                policy.message?.({
+                  file: arrow.file,
+                  row: arrow.line,
+                  entityKind: "arrow",
+                  entityName: arrow.mapping ?? "<anonymous>",
+                  refKind: "transform",
+                  ref: spreadName,
+                  resolved,
+                  definitionFile: definitionFileFor(index.transforms.get(resolved)),
+                }) ??
+                `Arrow in mapping '${arrow.mapping}' references transform '${resolved}' which is not reachable from this file's imports`,
             });
           }
         }
@@ -873,9 +1015,7 @@ function definitionFileFor(definition: unknown): string | null {
  *
  * Kept in sync with CONSTRAINT_TAGS in @satsuma/viz-model (badge rendering).
  */
-const CONSTRAINT_FLAG_TOKENS = new Set([
-  "pk", "required", "unique", "indexed", "pii", "encrypt",
-]);
+const CONSTRAINT_FLAG_TOKENS = new Set(["pk", "required", "unique", "indexed", "pii", "encrypt"]);
 
 /** Matches `NAME(args)` type text, capturing the bare name and the raw args. */
 const TYPE_WITH_ARGS = /^([A-Za-z_][A-Za-z0-9_-]*)\((.*)\)$/;
@@ -905,9 +1045,7 @@ function checkFieldTypeParens(
     const match = field.type?.match(TYPE_WITH_ARGS);
     if (match) {
       const [, typeName, rawArgs] = match;
-      const flagged = rawArgs!
-        .split(/[,\s]+/)
-        .filter((arg) => CONSTRAINT_FLAG_TOKENS.has(arg));
+      const flagged = rawArgs!.split(/[,\s]+/).filter((arg) => CONSTRAINT_FLAG_TOKENS.has(arg));
       if (flagged.length > 0) {
         const constraints = flagged.map((f) => `'${f}'`).join(", ");
         diagnostics.push({
@@ -963,7 +1101,13 @@ const DV_LINK_FIELDS = ["load_date", "record_source"] as const;
 const DV_SAT_FIELDS = ["load_date", "load_end_date", "hash_diff", "record_source"] as const;
 
 /** Slowly-changing dimension tracking columns added to Kimball dimensions under scd: 2 or scd: 6. */
-const KIMBALL_SCD_FIELDS = ["surrogate_key", "valid_from", "valid_to", "is_current", "row_hash"] as const;
+const KIMBALL_SCD_FIELDS = [
+  "surrogate_key",
+  "valid_from",
+  "valid_to",
+  "is_current",
+  "row_hash",
+] as const;
 
 /** ETL audit columns present on all Kimball fact tables. */
 const KIMBALL_FACT_FIELDS = ["etl_batch_id", "loaded_at"] as const;
@@ -982,7 +1126,9 @@ const KIMBALL_FACT_FIELDS = ["etl_batch_id", "loaded_at"] as const;
 function getConventionFields(schema: SemanticSchema): Set<string> {
   const fields = new Set<string>();
   const meta = schema.blockMetadata ?? [];
-  const tags = new Set(meta.filter((m): m is MetaEntry & { kind: "tag" } => m.kind === "tag").map((m) => m.tag));
+  const tags = new Set(
+    meta.filter((m): m is MetaEntry & { kind: "tag" } => m.kind === "tag").map((m) => m.tag),
+  );
   const kvs = meta.filter((m): m is MetaEntry & { kind: "kv" } => m.kind === "kv");
 
   // --- Data Vault 2.0 conventions ---
@@ -1037,20 +1183,40 @@ function getConventionFields(schema: SemanticSchema): Set<string> {
  * SemanticIndex. Fragment refs resolve relative to `currentNs` — the
  * namespace of whichever entity owns the spread being expanded.
  */
-function makeSpreadLookups(index: SemanticIndex, currentNs: string | null): {
+function makeSpreadLookups(
+  index: SemanticIndex,
+  currentNs: string | null,
+): {
   resolveRef: EntityRefResolver;
   lookupFragment: SpreadEntityLookup;
   lookupSchema: SpreadEntityLookup;
 } {
   return {
-    resolveRef: (ref, _ns) => resolveScopedEntityRef(ref, currentNs, index.fragments as Map<string, unknown>),
+    resolveRef: (ref, _ns) =>
+      resolveScopedEntityRef(ref, currentNs, index.fragments as Map<string, unknown>),
     lookupFragment: (key): SpreadEntity | undefined => {
       const f = index.fragments.get(key);
-      return f ? { fields: f.fields, hasSpreads: f.hasSpreads ?? false, spreads: f.spreads, file: f.file, row: f.row } : undefined;
+      return f
+        ? {
+            fields: f.fields,
+            hasSpreads: f.hasSpreads ?? false,
+            spreads: f.spreads,
+            file: f.file,
+            row: f.row,
+          }
+        : undefined;
     },
     lookupSchema: (key): SpreadEntity | undefined => {
       const s = index.schemas.get(key);
-      return s ? { fields: s.fields, hasSpreads: s.hasSpreads ?? false, spreads: s.spreads, file: s.file, row: s.row } : undefined;
+      return s
+        ? {
+            fields: s.fields,
+            hasSpreads: s.hasSpreads ?? false,
+            spreads: s.spreads,
+            file: s.file,
+            row: s.row,
+          }
+        : undefined;
     },
   };
 }
@@ -1065,11 +1231,13 @@ function qualifiedSourceSchema(path: string, schemaNames: string[]): string | nu
   const dotIdx = path.indexOf(".");
   if (dotIdx <= 0) return null;
   const qualifier = path.slice(0, dotIdx);
-  return schemaNames.find((s) => {
-    if (s === qualifier) return true;
-    const nsIdx = s.indexOf("::");
-    return nsIdx !== -1 && s.slice(nsIdx + 2) === qualifier;
-  }) ?? null;
+  return (
+    schemaNames.find((s) => {
+      if (s === qualifier) return true;
+      const nsIdx = s.indexOf("::");
+      return nsIdx !== -1 && s.slice(nsIdx + 2) === qualifier;
+    }) ?? null
+  );
 }
 
 /**
@@ -1092,7 +1260,12 @@ function blamedSourceSchema(path: string, schemaNames: string[], firstSource: st
  *  - Qualified paths like "source_schema.field" are resolved by stripping the
  *    prefix; the qualified schema's spread-inherited fields count too (sl-kkao).
  */
-function resolveFieldPath(path: string, schemaNames: string[], index: SemanticIndex, fieldPaths: Set<string>): boolean {
+function resolveFieldPath(
+  path: string,
+  schemaNames: string[],
+  index: SemanticIndex,
+  fieldPaths: Set<string>,
+): boolean {
   if (path.startsWith(".")) return true;
   if (fieldPaths.has(path)) return true;
   if (schemaNames.includes(path)) return true;
@@ -1106,8 +1279,19 @@ function resolveFieldPath(path: string, schemaNames: string[], index: SemanticIn
     if (schema?.hasSpreads) {
       // Spread expansion diagnostics are already emitted when the caller
       // builds its field path sets — discard them here to avoid duplicates.
-      const { resolveRef, lookupFragment, lookupSchema } = makeSpreadLookups(index, schema.namespace ?? null);
-      expandSpreads([matchedSchema], schema.namespace ?? null, resolveRef, lookupFragment, qualPaths, [], lookupSchema);
+      const { resolveRef, lookupFragment, lookupSchema } = makeSpreadLookups(
+        index,
+        schema.namespace ?? null,
+      );
+      expandSpreads(
+        [matchedSchema],
+        schema.namespace ?? null,
+        resolveRef,
+        lookupFragment,
+        qualPaths,
+        [],
+        lookupSchema,
+      );
     }
     if (qualPaths.has(rest)) return true;
   }
@@ -1123,7 +1307,14 @@ function makeSemanticLookup(index: SemanticIndex): DefinitionLookup {
     hasSchema: (key) => index.schemas.has(key),
     getSchema: (key) => {
       const s = index.schemas.get(key);
-      return s ? { fields: s.fields, hasSpreads: s.hasSpreads ?? false, spreads: s.spreads, namespace: s.namespace } : null;
+      return s
+        ? {
+            fields: s.fields,
+            hasSpreads: s.hasSpreads ?? false,
+            spreads: s.spreads,
+            namespace: s.namespace,
+          }
+        : null;
     },
     hasFragment: (key) => index.fragments.has(key),
     getFragment: (key) => {
@@ -1135,6 +1326,17 @@ function makeSemanticLookup(index: SemanticIndex): DefinitionLookup {
       const m = index.mappings.get(key);
       return m ? { sources: m.sources, targets: m.targets, namespace: m.namespace ?? null } : null;
     },
-    iterateSchemas: () => index.schemas.entries() as unknown as Iterable<[string, { fields: FieldDecl[]; hasSpreads: boolean; namespace?: string | null; spreads?: string[] }]>,
+    iterateSchemas: () =>
+      index.schemas.entries() as unknown as Iterable<
+        [
+          string,
+          {
+            fields: FieldDecl[];
+            hasSpreads: boolean;
+            namespace?: string | null;
+            spreads?: string[];
+          },
+        ]
+      >,
   };
 }

--- a/tooling/satsuma-core/test/classify.test.js
+++ b/tooling/satsuma-core/test/classify.test.js
@@ -12,7 +12,14 @@ import { describe, it } from "node:test";
 import { classifyTransform, classifyArrow } from "../dist/classify.js";
 
 function n(type, namedChildren = [], text = "") {
-  return { type, text, isNamed: true, namedChildren, children: namedChildren, startPosition: { row: 0, column: 0 } };
+  return {
+    type,
+    text,
+    isNamed: true,
+    namedChildren,
+    children: namedChildren,
+    startPosition: { row: 0, column: 0 },
+  };
 }
 
 function pipeStep(innerType, innerChildren = [], text = "") {

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -87,7 +87,11 @@ describe("buildCoveredFieldPaths() — the direct/derived model", () => {
     // something that was. A flat set cannot tell these apart.
     const covered = buildCoveredFieldPaths(["address.city"]);
     assert.equal(isDirectlyCovered("address.city", covered), true);
-    assert.equal(isDirectlyCovered("address", covered), false, "'address' is an ancestor, not direct");
+    assert.equal(
+      isDirectlyCovered("address", covered),
+      false,
+      "'address' is an ancestor, not direct",
+    );
     assert.equal(isCoveredPath("address", covered), true, "…but it still counts as covered");
   });
 
@@ -190,10 +194,7 @@ describe("schemaLocalFieldPath()", () => {
   it("treats a sibling schema's bare-name prefix as belonging to that sibling", () => {
     // The bare form has to be recognised on the rival side too, or a namespaced
     // multi-source mapping credits every arrow to every schema.
-    assert.equal(
-      schemaLocalFieldPath("orders.total", ["crm::customers"], ["crm::orders"]),
-      null,
-    );
+    assert.equal(schemaLocalFieldPath("orders.total", ["crm::customers"], ["crm::orders"]), null);
   });
 
   it("returns null for a bare reference that is just the schema's name", () => {
@@ -208,7 +209,10 @@ describe("schemaLocalFieldPath()", () => {
   it("keeps a bare reference that names a declared field, not the schema", () => {
     // A single-source mapping's `id -> id` is a field reference even when the
     // schema is called `id`; the declaration settles it.
-    assert.equal(schemaLocalFieldPath("id", ["id"], [], (n) => n === "id"), "id");
+    assert.equal(
+      schemaLocalFieldPath("id", ["id"], [], (n) => n === "id"),
+      "id",
+    );
   });
 
   it("prefers a declared field over a schema prefix of the same name", () => {

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -29,7 +29,9 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
 
-before(async () => { await initParser(WASM_PATH); });
+before(async () => {
+  await initParser(WASM_PATH);
+});
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -81,7 +83,10 @@ function aggregate(source) {
 /** The aggregate entry for one schema and role. */
 function entry(result, role, schemaId) {
   const found = result.schemas.find((s) => s.role === role && s.schemaId === schemaId);
-  assert.ok(found, `expected ${role} ${schemaId} in ${JSON.stringify(result.schemas.map((s) => [s.role, s.schemaId]))}`);
+  assert.ok(
+    found,
+    `expected ${role} ${schemaId} in ${JSON.stringify(result.schemas.map((s) => [s.role, s.schemaId]))}`,
+  );
   return found;
 }
 
@@ -181,7 +186,11 @@ mapping load_memos {
       .find((s) => s.role === "target")
       .fields.find((f) => f.path === "memo");
     assert.equal(perMapping.mapped, false, "per-mapping: 'load ids' does not write memo");
-    assert.equal(aggregateMapped(result, "target", "tgt", "memo"), true, "aggregate: some mapping writes memo");
+    assert.equal(
+      aggregateMapped(result, "target", "tgt", "memo"),
+      true,
+      "aggregate: some mapping writes memo",
+    );
   });
 
   it("records every mapping that references a schema in a role", () => {
@@ -280,12 +289,22 @@ namespace billing {
   it("workspace totals equal the sum of the namespace subtotals", () => {
     // If these can disagree, one of the two numbers in the report is a lie.
     const { aggregate: result } = aggregate(SRC);
-    const summed = (role) => result.namespaces.reduce(
-      (acc, ns) => ({ covered: acc.covered + ns[role].covered, total: acc.total + ns[role].total }),
-      { covered: 0, total: 0 },
-    );
-    assert.deepEqual(summed("source"), { covered: result.workspace.source.covered, total: result.workspace.source.total });
-    assert.deepEqual(summed("target"), { covered: result.workspace.target.covered, total: result.workspace.target.total });
+    const summed = (role) =>
+      result.namespaces.reduce(
+        (acc, ns) => ({
+          covered: acc.covered + ns[role].covered,
+          total: acc.total + ns[role].total,
+        }),
+        { covered: 0, total: 0 },
+      );
+    assert.deepEqual(summed("source"), {
+      covered: result.workspace.source.covered,
+      total: result.workspace.source.total,
+    });
+    assert.deepEqual(summed("target"), {
+      covered: result.workspace.target.covered,
+      total: result.workspace.target.total,
+    });
   });
 
   it("groups schemas declared at file scope under a null namespace", () => {
@@ -299,7 +318,10 @@ mapping load {
   target { tgt }
   id -> id
 }`);
-    assert.deepEqual(result.namespaces.map((n) => n.namespace), [null]);
+    assert.deepEqual(
+      result.namespaces.map((n) => n.namespace),
+      [null],
+    );
     assert.deepEqual(result.namespaces[0].target, result.workspace.target);
   });
 });

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -31,7 +31,9 @@ const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-sats
 
 const TEST_URI = "file:///test.stm";
 
-before(async () => { await initParser(WASM_PATH); });
+before(async () => {
+  await initParser(WASM_PATH);
+});
 
 // ── Test resolver ───────────────────────────────────────────────────────────
 
@@ -81,7 +83,9 @@ function resolveRefsIn(tree, schemasById) {
     hasSchema: (k) => schemasById.has(k),
     getSchema: (k) => {
       const s = schemasById.get(k);
-      return s ? { fields: s.fields, hasSpreads: Boolean(s.spreads?.length), namespace: s.namespace } : null;
+      return s
+        ? { fields: s.fields, hasSpreads: Boolean(s.spreads?.length), namespace: s.namespace }
+        : null;
     },
     hasFragment: () => false,
     getFragment: () => null,
@@ -97,14 +101,21 @@ function resolveRefsIn(tree, schemasById) {
 /** Coverage entries for the single schema playing `role` in the result. */
 function forRole(result, role) {
   const schema = result.schemas.find((s) => s.role === role);
-  assert.ok(schema, `expected a ${role} schema in ${JSON.stringify(result.schemas.map((s) => s.role))}`);
+  assert.ok(
+    schema,
+    `expected a ${role} schema in ${JSON.stringify(result.schemas.map((s) => s.role))}`,
+  );
   return schema;
 }
 
 /** Assert `path` appears exactly once and carries the expected mapped flag. */
 function assertMapped(schema, path, expected) {
   const matches = schema.fields.filter((f) => f.path === path);
-  assert.equal(matches.length, 1, `expected exactly one "${path}" entry in ${schema.fields.map((f) => f.path)}`);
+  assert.equal(
+    matches.length,
+    1,
+    `expected exactly one "${path}" entry in ${schema.fields.map((f) => f.path)}`,
+  );
   assert.equal(matches[0].mapped, expected, `"${path}" should be mapped=${expected}`);
 }
 
@@ -154,7 +165,10 @@ mapping load {
   id -> id
 }`;
     const result = coverage(src, "load");
-    assert.deepEqual(result.schemas.map((s) => s.schemaId), ["src"]);
+    assert.deepEqual(
+      result.schemas.map((s) => s.schemaId),
+      ["src"],
+    );
   });
 
   it("finds a mapping declared inside a namespace block", () => {

--- a/tooling/satsuma-core/test/cst-utils.test.js
+++ b/tooling/satsuma-core/test/cst-utils.test.js
@@ -53,7 +53,6 @@ function nlStr(inner) {
   return n("nl_string", [], `"${inner}"`);
 }
 
-
 function blockLabel(nameNode) {
   return n("block_label", [nameNode]);
 }

--- a/tooling/satsuma-core/test/extract.test.js
+++ b/tooling/satsuma-core/test/extract.test.js
@@ -36,8 +36,14 @@ import {
 
 function n(type, namedChildren = [], text = "", row = 0, anonymousChildren = [], column = 0) {
   const allChildren = [
-    ...anonymousChildren.map(t => ({ type: t, text: t, isNamed: false, namedChildren: [], children: [] })),
-    ...namedChildren.map(c => ({ ...c, isNamed: true })),
+    ...anonymousChildren.map((t) => ({
+      type: t,
+      text: t,
+      isNamed: false,
+      namedChildren: [],
+      children: [],
+    })),
+    ...namedChildren.map((c) => ({ ...c, isNamed: true })),
   ];
   return {
     type,
@@ -76,7 +82,14 @@ function fieldName(name) {
 }
 
 function fieldDecl(name, type, row = 0, column = 0) {
-  return n("field_decl", [fieldName(name), n("type_expr", [], type)], `${name} ${type}`, row, [], column);
+  return n(
+    "field_decl",
+    [fieldName(name), n("type_expr", [], type)],
+    `${name} ${type}`,
+    row,
+    [],
+    column,
+  );
 }
 
 function nlString(literal) {
@@ -430,7 +443,14 @@ describe("extractTransforms()", () => {
     const root = n("program", [transformBlock]);
 
     assert.deepStrictEqual(extractTransforms(root), [
-      { name: "enrich", body: "lookup(dim)", canonicalBody: "lookup(dim)", namespace: null, row: 0, startColumn: 0 },
+      {
+        name: "enrich",
+        body: "lookup(dim)",
+        canonicalBody: "lookup(dim)",
+        namespace: null,
+        row: 0,
+        startColumn: 0,
+      },
     ]);
   });
 
@@ -457,8 +477,11 @@ describe("extractTransforms()", () => {
     // text. The quoted key and the value are NL content and must pass
     // through verbatim, including casing and inner whitespace.
     const entry = (k, v) => n("map_entry", [n("map_key", [], k), n("map_value", [], v)]);
-    const mapLit = n("map_literal", [entry('"A B"', "first class"), entry("_", "other")],
-      'map {\n  "A B": first class\n  _: other\n}');
+    const mapLit = n(
+      "map_literal",
+      [entry('"A B"', "first class"), entry("_", "other")],
+      'map {\n  "A B": first class\n  _: other\n}',
+    );
     const pipeChain = n("pipe_chain", [n("pipe_step", [mapLit], mapLit.text)], mapLit.text);
     const transformBlock = n("transform_block", [blockLabel("classify"), pipeChain]);
     const root = n("program", [transformBlock]);
@@ -514,7 +537,13 @@ describe("extractFieldTree() — nested records", () => {
     const innerBody = n("schema_body", [innerField]);
     const nameNode = n("field_name", [ident("address")]);
     // record field: has schema_body child and 'record' anonymous child
-    const recordField = n("field_decl", [nameNode, innerBody], "address record { city STRING }", 0, ["record"]);
+    const recordField = n(
+      "field_decl",
+      [nameNode, innerBody],
+      "address record { city STRING }",
+      0,
+      ["record"],
+    );
 
     const body = n("schema_body", [recordField]);
     const result = extractFieldTree(body);
@@ -529,7 +558,13 @@ describe("extractFieldTree() — nested records", () => {
     const innerField = fieldDecl("sku", "STRING");
     const innerBody = n("schema_body", [innerField]);
     const nameNode = n("field_name", [ident("items")]);
-    const listRecordField = n("field_decl", [nameNode, innerBody], "items list_of record { sku STRING }", 0, ["list_of", "record"]);
+    const listRecordField = n(
+      "field_decl",
+      [nameNode, innerBody],
+      "items list_of record { sku STRING }",
+      0,
+      ["list_of", "record"],
+    );
 
     const body = n("schema_body", [listRecordField]);
     const result = extractFieldTree(body);
@@ -602,12 +637,20 @@ describe("FieldDecl metadata enrichment (sl-cvs2)", () => {
 
   it("extracts a key-value entry (e.g. ref) from field metadata", () => {
     // Validates that tag_with_value pairs become {kind: 'kv', key, value}.
-    const kvVal = n("value_text", [n("dotted_name", [], "dim_customer.customer_id")], "dim_customer.customer_id");
+    const kvVal = n(
+      "value_text",
+      [n("dotted_name", [], "dim_customer.customer_id")],
+      "dim_customer.customer_id",
+    );
     const kvPair = n("tag_with_value", [ident("ref"), kvVal]);
     const meta = n("metadata_block", [kvPair]);
     const fd = n("field_decl", [fieldName("customer_id"), n("type_expr", [], "STRING(36)"), meta]);
     const result = extractSchemas(schemaWith([fd]));
-    assert.deepEqual(result[0].fields[0].metadata[0], { kind: "kv", key: "ref", value: "dim_customer.customer_id" });
+    assert.deepEqual(result[0].fields[0].metadata[0], {
+      kind: "kv",
+      key: "ref",
+      value: "dim_customer.customer_id",
+    });
   });
 
   it("extracts an enum entry with all values from field metadata", () => {
@@ -616,7 +659,10 @@ describe("FieldDecl metadata enrichment (sl-cvs2)", () => {
     const meta = n("metadata_block", [enumBody]);
     const fd = n("field_decl", [fieldName("period"), n("type_expr", [], "STRING(10)"), meta]);
     const result = extractSchemas(schemaWith([fd]));
-    assert.deepEqual(result[0].fields[0].metadata[0], { kind: "enum", values: ["monthly", "quarterly", "annual"] });
+    assert.deepEqual(result[0].fields[0].metadata[0], {
+      kind: "enum",
+      values: ["monthly", "quarterly", "annual"],
+    });
   });
 
   it("leaves metadata undefined when the field has no metadata_block", () => {
@@ -630,7 +676,11 @@ describe("FieldDecl metadata enrichment (sl-cvs2)", () => {
   it("extracts metadata from inner fields of a record field", () => {
     // Validates that record-field children are walked and their own metadata is preserved.
     const innerMeta = n("metadata_block", [n("tag_token", [], "required")]);
-    const innerFd = n("field_decl", [fieldName("street"), n("type_expr", [], "VARCHAR(200)"), innerMeta]);
+    const innerFd = n("field_decl", [
+      fieldName("street"),
+      n("type_expr", [], "VARCHAR(200)"),
+      innerMeta,
+    ]);
     const recField = recordFieldDecl("address", { body: [innerFd] });
     const result = extractSchemas(schemaWith([recField]));
     assert.deepEqual(result[0].fields[0].children[0].metadata[0], { kind: "tag", tag: "required" });
@@ -861,7 +911,6 @@ describe("extractQuestions — row and empty case (sl-cvs2)", () => {
     assert.equal(result[0].text, "is this field PII?");
     assert.equal(result[0].row, 8);
   });
-
 });
 
 // ── extractNamespaces ───────────────────────────────────────────────────────
@@ -987,11 +1036,16 @@ describe("extractImports — name forms and arity (sl-cvs2)", () => {
 
   it("extracts multiple ns::name qualified imports from one declaration", () => {
     // Validates that multiple qualified names in a single import_decl are collected in order.
-    const imp = n("import_decl", [
-      n("import_name", [qualifiedName("src", "customers")]),
-      n("import_name", [qualifiedName("mart", "dim_customers")]),
-      n("import_path", [nlString("source.stm")]),
-    ], "", 2);
+    const imp = n(
+      "import_decl",
+      [
+        n("import_name", [qualifiedName("src", "customers")]),
+        n("import_name", [qualifiedName("mart", "dim_customers")]),
+        n("import_path", [nlString("source.stm")]),
+      ],
+      "",
+      2,
+    );
     const root = n("source_file", [imp]);
     const result = extractImports(root);
     assert.deepEqual(result[0].names, ["src::customers", "mart::dim_customers"]);
@@ -1012,21 +1066,24 @@ describe("extractImports — name forms and arity (sl-cvs2)", () => {
 
   it("returns one entry per import_decl when multiple declarations are present", () => {
     // Validates that distinct import_decls produce distinct entries (not merged).
-    const imp1 = n("import_decl", [
-      n("import_name", [ident("foo")]),
-      n("import_path", [nlString("a.stm")]),
-    ], "", 0);
-    const imp2 = n("import_decl", [
-      n("import_name", [ident("bar")]),
-      n("import_path", [nlString("b.stm")]),
-    ], "", 1);
+    const imp1 = n(
+      "import_decl",
+      [n("import_name", [ident("foo")]), n("import_path", [nlString("a.stm")])],
+      "",
+      0,
+    );
+    const imp2 = n(
+      "import_decl",
+      [n("import_name", [ident("bar")]), n("import_path", [nlString("b.stm")])],
+      "",
+      1,
+    );
     const root = n("source_file", [imp1, imp2]);
     const result = extractImports(root);
     assert.equal(result.length, 2);
     assert.equal(result[0].path, "a.stm");
     assert.equal(result[1].path, "b.stm");
   });
-
 });
 
 // ── extractImports: MISSING-name recovery (sl-0nvt) ─────────────────────────

--- a/tooling/satsuma-core/test/format.test.js
+++ b/tooling/satsuma-core/test/format.test.js
@@ -65,7 +65,7 @@ function structureOf(node) {
 // ── Corpus Round-Trip (Idempotency + Structural Equivalence) ─────────────────
 
 describe("corpus round-trip", () => {
-  const stmFiles = readdirSync(examplesDir, { recursive: true }).filter(f => f.endsWith(".stm"));
+  const stmFiles = readdirSync(examplesDir, { recursive: true }).filter((f) => f.endsWith(".stm"));
 
   for (const file of stmFiles) {
     describe(`examples/${file}`, () => {
@@ -84,7 +84,7 @@ describe("corpus round-trip", () => {
         assert.equal(
           structureOf(tree1.rootNode),
           structureOf(tree2.rootNode),
-          "parse trees should be structurally identical"
+          "parse trees should be structurally identical",
         );
       });
     });
@@ -182,7 +182,7 @@ schema b { y STRING }`;
     const out = fmt(src);
     assert.ok(out.includes("INT") && out.includes("// trailing comment"));
     // Check 2-space minimum gap
-    const line = out.split("\n").find(l => l.includes("trailing comment"));
+    const line = out.split("\n").find((l) => l.includes("trailing comment"));
     assert.ok(line);
     assert.match(line, /\S {2}\/\/ trailing comment/);
   });
@@ -202,7 +202,10 @@ describe("block-level comment preservation", () => {
   b STRING
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("//! Data quality warning"), "first comment before first field must be preserved");
+    assert.ok(
+      out.includes("//! Data quality warning"),
+      "first comment before first field must be preserved",
+    );
     assert.ok(out.includes("//! Second warning"), "mid-body comment must also be preserved");
   });
 
@@ -256,8 +259,14 @@ schema test_metric (metric, source orders) {
   // Second comment
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// First comment in metric body"), "leading gap comment in metric must be preserved");
-    assert.ok(out.includes("// Second comment"), "trailing gap comment in metric must be preserved");
+    assert.ok(
+      out.includes("// First comment in metric body"),
+      "leading gap comment in metric must be preserved",
+    );
+    assert.ok(
+      out.includes("// Second comment"),
+      "trailing gap comment in metric must be preserved",
+    );
   });
 
   it("preserves first AND trailing comments in transform bodies (sl-17lk)", () => {
@@ -267,8 +276,14 @@ schema test_metric (metric, source orders) {
   // Trailing comment
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// Comment before first pipe step"), "leading gap comment in transform must be preserved");
-    assert.ok(out.includes("// Trailing comment"), "trailing gap comment in transform must be preserved");
+    assert.ok(
+      out.includes("// Comment before first pipe step"),
+      "leading gap comment in transform must be preserved",
+    );
+    assert.ok(
+      out.includes("// Trailing comment"),
+      "trailing gap comment in transform must be preserved",
+    );
   });
 
   it("preserves first comment in nested record bodies (sl-necw)", () => {
@@ -281,7 +296,10 @@ schema test_metric (metric, source orders) {
   }
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// Street address components"), "first comment inside nested record must be preserved");
+    assert.ok(
+      out.includes("// Street address components"),
+      "first comment inside nested record must be preserved",
+    );
   });
 
   it("preserves first comment in list_of record bodies", () => {
@@ -292,7 +310,10 @@ schema test_metric (metric, source orders) {
   }
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// Item fields"), "first comment inside list_of record must be preserved");
+    assert.ok(
+      out.includes("// Item fields"),
+      "first comment inside list_of record must be preserved",
+    );
   });
 
   it("is idempotent for blocks with leading gap comments", () => {
@@ -302,7 +323,11 @@ schema test_metric (metric, source orders) {
 }`;
     const out1 = fmt(src);
     const out2 = fmt(out1);
-    assert.equal(out1, out2, "format(format(x)) must equal format(x) when leading gap comments exist");
+    assert.equal(
+      out1,
+      out2,
+      "format(format(x)) must equal format(x) when leading gap comments exist",
+    );
   });
 
   it("is idempotent for metric schema blocks with gap comments", () => {
@@ -346,9 +371,15 @@ schema m (metric, source s) {
   }
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// strip whitespace first"), "comment between { and pipe chain must survive");
+    assert.ok(
+      out.includes("// strip whitespace first"),
+      "comment between { and pipe chain must survive",
+    );
     assert.ok(out.includes("// fold to lowercase next"), "comment between pipe steps must survive");
-    assert.ok(out.includes("// then case-fold"), "trailing inline comment on last step must survive");
+    assert.ok(
+      out.includes("// then case-fold"),
+      "trailing inline comment on last step must survive",
+    );
     assert.equal(out, fmt(out), "arrow body comments must be idempotent");
   });
 
@@ -361,7 +392,10 @@ schema m (metric, source s) {
   | lowercase
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// normalise case before comparing"), "comment between pipe steps must survive");
+    assert.ok(
+      out.includes("// normalise case before comparing"),
+      "comment between pipe steps must survive",
+    );
     assert.equal(out, fmt(out), "in-chain transform comments must be idempotent");
   });
 
@@ -376,8 +410,14 @@ schema m (metric, source s) {
   a -> b
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// primary table"), "own-line comment before a source ref must survive");
-    assert.ok(out.includes("// joined secondary"), "inline comment after a source ref must survive");
+    assert.ok(
+      out.includes("// primary table"),
+      "own-line comment before a source ref must survive",
+    );
+    assert.ok(
+      out.includes("// joined secondary"),
+      "inline comment after a source ref must survive",
+    );
     assert.equal(out, fmt(out), "source block comments must be idempotent");
   });
 
@@ -390,8 +430,14 @@ schema m (metric, source s) {
   id INT
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// physical store"), "inline comment after a metadata entry must survive");
-    assert.ok(out.includes("// governance owner is data-eng"), "own-line comment between entries must survive");
+    assert.ok(
+      out.includes("// physical store"),
+      "inline comment after a metadata entry must survive",
+    );
+    assert.ok(
+      out.includes("// governance owner is data-eng"),
+      "own-line comment between entries must survive",
+    );
     assert.equal(out, fmt(out), "metadata comments must be idempotent");
   });
 
@@ -402,7 +448,10 @@ schema m (metric, source s) {
   "Second line"  // trailing
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// reviewed 2026-06"), "own-line comment before a note string must survive");
+    assert.ok(
+      out.includes("// reviewed 2026-06"),
+      "own-line comment before a note string must survive",
+    );
     assert.ok(out.includes("// trailing"), "inline comment after a note string must survive");
     assert.equal(out, fmt(out), "note block comments must be idempotent");
   });
@@ -418,8 +467,14 @@ mapping m { // why this mapping exists
   id -> id
 }`;
     const out = fmt(src);
-    assert.ok(out.includes("// why this schema exists"), "brace-line comment on schema must survive");
-    assert.ok(out.includes("// why this mapping exists"), "brace-line comment on mapping must survive");
+    assert.ok(
+      out.includes("// why this schema exists"),
+      "brace-line comment on schema must survive",
+    );
+    assert.ok(
+      out.includes("// why this mapping exists"),
+      "brace-line comment on mapping must survive",
+    );
     assert.equal(out, fmt(out), "brace-line comments must be idempotent");
   });
 });
@@ -438,7 +493,10 @@ schema b { y STRING }`;
   it("preserves blank line between file header and section comment (cbh-0lhj)", () => {
     const src = `// File header\n\n// Section comment\nschema a { x INT }`;
     const out = fmt(src);
-    assert.ok(out.includes("// File header\n\n// Section comment"), "should preserve blank line between header and section comment");
+    assert.ok(
+      out.includes("// File header\n\n// Section comment"),
+      "should preserve blank line between header and section comment",
+    );
   });
 
   it("no blank lines between consecutive imports", () => {
@@ -693,7 +751,10 @@ describe("edge cases", () => {
     const out = fmt(src);
     assert.ok(out.includes("each orders -> out_orders {"));
     assert.ok(out.includes("  each items -> out_items {"), "inner each header must survive");
-    assert.ok(out.includes("    sku -> out_sku"), "inner each arrows must survive at depth-2 indent");
+    assert.ok(
+      out.includes("    sku -> out_sku"),
+      "inner each arrows must survive at depth-2 indent",
+    );
     assert.equal(out, fmt(out), "nested each output must be idempotent");
   });
 
@@ -709,7 +770,10 @@ describe("edge cases", () => {
 }`;
     const out = fmt(src);
     assert.ok(out.includes("  flatten items -> .rows {"), "inner flatten header must survive");
-    assert.ok(out.includes("    name -> name"), "inner flatten arrows must survive at depth-2 indent");
+    assert.ok(
+      out.includes("    name -> name"),
+      "inner flatten arrows must survive at depth-2 indent",
+    );
     assert.equal(out, fmt(out), "nested flatten output must be idempotent");
   });
 
@@ -720,7 +784,7 @@ describe("edge cases", () => {
   value DECIMAL(14,2) (measure additive)
 }`;
     const out = fmt(src);
-    assert.ok(out.includes('schema mrr ('));
+    assert.ok(out.includes("schema mrr ("));
     assert.ok(out.includes('metric_name "MRR"'));
     assert.ok(out.includes("value  DECIMAL(14,2)  (measure additive)"));
   });
@@ -783,7 +847,7 @@ describe("edge cases", () => {
 // ── Golden Fixture Tests ─────────────────────────────────────────────────────
 
 describe("golden fixture round-trip (all corpus)", () => {
-  const stmFiles = readdirSync(examplesDir, { recursive: true }).filter(f => f.endsWith(".stm"));
+  const stmFiles = readdirSync(examplesDir, { recursive: true }).filter((f) => f.endsWith(".stm"));
 
   for (const file of stmFiles) {
     it(`format(parse(examples/${file})) parses without errors`, () => {

--- a/tooling/satsuma-core/test/meta-extract.test.js
+++ b/tooling/satsuma-core/test/meta-extract.test.js
@@ -51,7 +51,9 @@ describe("extractMetadata()", () => {
     const val = n("value_text", [n("nl_string", [], '"INTERNAL"')], '"INTERNAL"');
     const kv = n("tag_with_value", [key, val]);
     const meta = metaBlock([kv]);
-    assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "classification", value: "INTERNAL" }]);
+    assert.deepEqual(extractMetadata(meta), [
+      { kind: "kv", key: "classification", value: "INTERNAL" },
+    ]);
   });
 
   // sl-cvx9: value_text legally mixes quoted strings with surrounding tokens
@@ -70,7 +72,9 @@ describe("extractMetadata()", () => {
     );
     const kv = n("tag_with_value", [key, val]);
     const meta = metaBlock([kv]);
-    assert.deepEqual(extractMetadata(meta), [{ kind: "kv", key: "default", value: '"unknown" if null' }]);
+    assert.deepEqual(extractMetadata(meta), [
+      { kind: "kv", key: "default", value: '"unknown" if null' },
+    ]);
   });
 
   it("preserves all strings in a multi-string value (sl-cvx9)", () => {

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -29,12 +29,18 @@ const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-sats
 describe("extractAtRefs()", () => {
   it("extracts @ref mentions", () => {
     const refs = extractAtRefs("Sum @amount grouped by @order_id");
-    assert.deepEqual(refs.map(r => r.ref), ["amount", "order_id"]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["amount", "order_id"],
+    );
   });
 
   it("extracts @ns::schema.field refs", () => {
     const refs = extractAtRefs("Join @crm::customers.id to @dim_customer.customer_id");
-    assert.deepEqual(refs.map(r => r.ref), ["crm::customers.id", "dim_customer.customer_id"]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["crm::customers.id", "dim_customer.customer_id"],
+    );
   });
 
   it("handles @`backtick-name` refs", () => {
@@ -48,8 +54,14 @@ describe("extractAtRefs()", () => {
     // indistinguishable from the path @tax.rate. `raw` keeps the quoting so
     // classification and resolution can treat the name as literal.
     const refs = extractAtRefs("uses @`tax.rate` and @plain.path");
-    assert.deepEqual(refs.map((r) => r.ref), ["tax.rate", "plain.path"]);
-    assert.deepEqual(refs.map((r) => r.raw), ["`tax.rate`", "plain.path"]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["tax.rate", "plain.path"],
+    );
+    assert.deepEqual(
+      refs.map((r) => r.raw),
+      ["`tax.rate`", "plain.path"],
+    );
   });
 
   it("returns empty for text with no refs", () => {
@@ -86,15 +98,27 @@ describe("extractAtRefs()", () => {
   it("extracts @ref at start of string", () => {
     // Start-of-string is one of the explicitly allowed positions.
     const refs = extractAtRefs("@customer_id is the key");
-    assert.deepEqual(refs.map(r => r.ref), ["customer_id"]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["customer_id"],
+    );
   });
 
   it("extracts @refs after opening punctuation like ( [ { , ;", () => {
     // Acceptance criterion from sl-gl21: opening punctuation must still
     // qualify as a valid prefix so refs in parenthesised text resolve.
-    assert.deepEqual(extractAtRefs("coalesce(@a, @b)").map(r => r.ref), ["a", "b"]);
-    assert.deepEqual(extractAtRefs("[@a; @b]").map(r => r.ref), ["a", "b"]);
-    assert.deepEqual(extractAtRefs("{@a}").map(r => r.ref), ["a"]);
+    assert.deepEqual(
+      extractAtRefs("coalesce(@a, @b)").map((r) => r.ref),
+      ["a", "b"],
+    );
+    assert.deepEqual(
+      extractAtRefs("[@a; @b]").map((r) => r.ref),
+      ["a", "b"],
+    );
+    assert.deepEqual(
+      extractAtRefs("{@a}").map((r) => r.ref),
+      ["a"],
+    );
   });
 
   // sl-74m6: quotes, `=` and `:` were excluded from the lookbehind as collateral
@@ -105,19 +129,31 @@ describe("extractAtRefs()", () => {
   it("extracts a @ref immediately after a double or single quote (sl-74m6)", () => {
     // Prose like `"@customers" table` quotes the ref itself — the ref must
     // still reach lineage and validation.
-    assert.deepEqual(extractAtRefs('"@customers" table').map(r => r.ref), ["customers"]);
-    assert.deepEqual(extractAtRefs("'@customers' table").map(r => r.ref), ["customers"]);
+    assert.deepEqual(
+      extractAtRefs('"@customers" table').map((r) => r.ref),
+      ["customers"],
+    );
+    assert.deepEqual(
+      extractAtRefs("'@customers' table").map((r) => r.ref),
+      ["customers"],
+    );
   });
 
   it("extracts a @ref immediately after = (sl-74m6)", () => {
     // SQL-ish condition text with no space around the operator:
     // `where id =@customers.id`.
-    assert.deepEqual(extractAtRefs("where id =@customers.id").map(r => r.ref), ["customers.id"]);
+    assert.deepEqual(
+      extractAtRefs("where id =@customers.id").map((r) => r.ref),
+      ["customers.id"],
+    );
   });
 
   it("extracts a @ref immediately after : (sl-74m6)", () => {
     // Key/value prose with no space after the colon: `key:@customers.id`.
-    assert.deepEqual(extractAtRefs("key:@customers.id").map(r => r.ref), ["customers.id"]);
+    assert.deepEqual(
+      extractAtRefs("key:@customers.id").map((r) => r.ref),
+      ["customers.id"],
+    );
   });
 
   it("extracts @refs across multiple lines (after newline counts as whitespace)", () => {
@@ -125,7 +161,10 @@ describe("extractAtRefs()", () => {
     // triple-quoted NL string must still be extracted. This pairs with the
     // multiline-position helper exercised below.
     const refs = extractAtRefs("first line\n@second_line ref");
-    assert.deepEqual(refs.map(r => r.ref), ["second_line"]);
+    assert.deepEqual(
+      refs.map((r) => r.ref),
+      ["second_line"],
+    );
   });
 });
 
@@ -191,7 +230,7 @@ describe("computeNLRefPosition()", () => {
     const item = { text: "first\n    @ref end", line: 2, column: 8 };
     const offset = item.text.indexOf("@");
     const pos = computeNLRefPosition(item, offset);
-    assert.equal(pos.line, 4);  // 2 + 1 newline + 1 (1-based)
+    assert.equal(pos.line, 4); // 2 + 1 newline + 1 (1-based)
     assert.equal(pos.column, 5);
   });
 });
@@ -256,7 +295,9 @@ function makeLookup(schemas = {}, fragments = {}, transforms = {}, mappings = {}
 
 describe("resolveRef()", () => {
   it("resolves a bare field against mapping sources", () => {
-    const lookup = makeLookup({ "::orders": { fields: [{ name: "order_id" }], hasSpreads: false } });
+    const lookup = makeLookup({
+      "::orders": { fields: [{ name: "order_id" }], hasSpreads: false },
+    });
     const ctx = { sources: ["::orders"], targets: [], namespace: null };
     const r = resolveRef("order_id", ctx, lookup);
     assert.equal(r.resolved, true);
@@ -344,7 +385,9 @@ describe("resolveRef()", () => {
   });
 
   it("resolves a backticked field name containing :: (sl-g6ga)", () => {
-    const lookup = makeLookup({ "::legacy": { fields: [{ name: "legacy::thing" }], hasSpreads: false } });
+    const lookup = makeLookup({
+      "::legacy": { fields: [{ name: "legacy::thing" }], hasSpreads: false },
+    });
     const ctx = { sources: ["::legacy"], targets: [], namespace: null };
     const r = resolveRef("`legacy::thing`", ctx, lookup);
     assert.equal(r.resolved, true);
@@ -367,7 +410,9 @@ describe("resolveRef()", () => {
   it("resolves a schema-qualified backticked field name (sl-g6ga)", () => {
     // Compound form: the separator dot picks the schema, the backticked
     // literal names the field exactly.
-    const lookup = makeLookup({ "::customers": { fields: [{ name: "tax.rate" }], hasSpreads: false } });
+    const lookup = makeLookup({
+      "::customers": { fields: [{ name: "tax.rate" }], hasSpreads: false },
+    });
     const ctx = { sources: ["::customers"], targets: [], namespace: null };
     const r = resolveRef("customers.`tax.rate`", ctx, lookup);
     assert.equal(r.resolved, true);
@@ -408,18 +453,21 @@ describe("resolveAllNLRefs()", () => {
     // as one literal name, not a schema.field path.
     const lookup = makeLookup(
       { "::rates": { fields: [{ name: "tax.rate" }], hasSpreads: false } },
-      {}, {},
+      {},
+      {},
       { my_mapping: { sources: ["::rates"], targets: [], namespace: null } },
     );
-    const items = [{
-      text: "apply @`tax.rate` here",
-      mapping: "my_mapping",
-      namespace: null,
-      targetField: null,
-      line: 5,
-      column: 0,
-      file: "test.stm",
-    }];
+    const items = [
+      {
+        text: "apply @`tax.rate` here",
+        mapping: "my_mapping",
+        namespace: null,
+        targetField: null,
+        line: 5,
+        column: 0,
+        file: "test.stm",
+      },
+    ];
     const results = resolveAllNLRefs(items, lookup);
     assert.equal(results.length, 1);
     assert.equal(results[0].ref, "tax.rate");
@@ -550,7 +598,10 @@ describe("extractNLRefData — bare pipe-text at_refs (bptar-l6n8)", () => {
     // Each at_ref is its own CST node; all of them must become items, each
     // anchored at its own position for diagnostics.
     const items = nlRefItems("mapping m {\n  a -> b { @x plus @y }\n}");
-    assert.deepEqual(items.map((i) => i.text), ["@x", "@y"]);
+    assert.deepEqual(
+      items.map((i) => i.text),
+      ["@x", "@y"],
+    );
     assert.notEqual(items[0].column, items[1].column);
   });
 
@@ -646,15 +697,16 @@ describe("NL ref positions account for string delimiters (sl-o3ea)", () => {
 
 describe("resolveRef() — nested field paths (sl-ez36)", () => {
   // schema src { order_id, address record { city, postcode } }
-  const nestedLookup = () => makeLookup({
-    "::src": {
-      fields: [
-        { name: "order_id" },
-        { name: "address", children: [{ name: "city" }, { name: "postcode" }] },
-      ],
-      hasSpreads: false,
-    },
-  });
+  const nestedLookup = () =>
+    makeLookup({
+      "::src": {
+        fields: [
+          { name: "order_id" },
+          { name: "address", children: [{ name: "city" }, { name: "postcode" }] },
+        ],
+        hasSpreads: false,
+      },
+    });
   const ctx = { sources: ["::src"], targets: [], namespace: null };
 
   it("reports the full path for a bare ref naming a nested field", () => {
@@ -679,10 +731,12 @@ describe("resolveRef() — nested field paths (sl-ez36)", () => {
     // prefix must be prepended: the ref names parcels.contents.sku.
     const lookup = makeLookup({
       "::src": {
-        fields: [{
-          name: "parcels",
-          children: [{ name: "contents", children: [{ name: "sku" }, { name: "qty" }] }],
-        }],
+        fields: [
+          {
+            name: "parcels",
+            children: [{ name: "contents", children: [{ name: "sku" }, { name: "qty" }] }],
+          },
+        ],
         hasSpreads: false,
       },
     });
@@ -698,10 +752,7 @@ describe("resolveRef() — nested field paths (sl-ez36)", () => {
     // change if the author reordered the fields.
     const lookup = makeLookup({
       "::src": {
-        fields: [
-          { name: "address", children: [{ name: "city" }] },
-          { name: "city" },
-        ],
+        fields: [{ name: "address", children: [{ name: "city" }] }, { name: "city" }],
         hasSpreads: false,
       },
     });
@@ -749,7 +800,8 @@ describe("extractNLRefData — container target qualification (sl-hrql)", () => 
   }
 
   it("qualifies a computed arrow target inside an each block", () => {
-    const src = 'mapping m {\n  each items -> lines {\n    -> .line_total { "Multiply @qty by @price" }\n  }\n}';
+    const src =
+      'mapping m {\n  each items -> lines {\n    -> .line_total { "Multiply @qty by @price" }\n  }\n}';
     assert.deepEqual(targetFields(src), ["lines.line_total"]);
   });
 
@@ -762,14 +814,16 @@ describe("extractNLRefData — container target qualification (sl-hrql)", () => 
   it("accumulates bases across two levels of nesting", () => {
     // flatten written relative (`.contents -> .packed_items`) names a list field
     // on the current element, so its base stacks on the enclosing each.
-    const src = 'mapping m {\n  each parcels -> parcels {\n    flatten .contents -> .packed_items {\n      -> .label { "Label from @sku" }\n    }\n  }\n}';
+    const src =
+      'mapping m {\n  each parcels -> parcels {\n    flatten .contents -> .packed_items {\n      -> .label { "Label from @sku" }\n    }\n  }\n}';
     assert.deepEqual(targetFields(src), ["parcels.packed_items.label"]);
   });
 
   it("establishes no base for a top-level flatten, whose target names the schema", () => {
     // Spec 4.6: `flatten contacts -> tgt` unnests into target schema roots, so
     // `contact_line` is already absolute and must not become `tgt.contact_line`.
-    const src = 'mapping m {\n  flatten contacts -> tgt {\n    -> contact_line { "Format @email" }\n  }\n}';
+    const src =
+      'mapping m {\n  flatten contacts -> tgt {\n    -> contact_line { "Format @email" }\n  }\n}';
     assert.deepEqual(targetFields(src), ["contact_line"]);
   });
 

--- a/tooling/satsuma-core/test/parse-errors.test.js
+++ b/tooling/satsuma-core/test/parse-errors.test.js
@@ -69,7 +69,7 @@ describe("collectParseErrors", () => {
   it("positions are 0-indexed (matching tree-sitter native format)", () => {
     // The CLI converts to 1-indexed by adding 1; the LSP uses 0-indexed directly.
     // This test pins the native format so consumers know the contract.
-    const tree = parse("%%% bad tokens");  // error at start of file
+    const tree = parse("%%% bad tokens"); // error at start of file
     const errors = collectParseErrors(tree);
     assert.ok(errors.length > 0);
     // Source starts at line 0, column 0

--- a/tooling/satsuma-core/test/parser.test.js
+++ b/tooling/satsuma-core/test/parser.test.js
@@ -90,7 +90,9 @@ describe("parser singleton — post-init", () => {
     // guarantee, so if brackets were ever re-admitted to the grammar this test
     // failing is the signal that path normalisation needs revisiting.
     const parser = getParser();
-    const tree = parser.parse("mapping load {\n  source { src }\n  target { tgt }\n  items[].id -> sku\n}\n");
+    const tree = parser.parse(
+      "mapping load {\n  source { src }\n  target { tgt }\n  items[].id -> sku\n}\n",
+    );
     assert.equal(tree.rootNode.hasError, true, "bracket paths must not parse in v2");
   });
 });

--- a/tooling/satsuma-core/test/source-files.test.js
+++ b/tooling/satsuma-core/test/source-files.test.js
@@ -8,11 +8,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import {
-  SATSUMA_FILE_EXTENSIONS,
-  SATSUMA_FILE_GLOB,
-  isSatsumaFilePath,
-} from "@satsuma/core";
+import { SATSUMA_FILE_EXTENSIONS, SATSUMA_FILE_GLOB, isSatsumaFilePath } from "@satsuma/core";
 
 describe("isSatsumaFilePath", () => {
   it("recognises both registered extensions, on paths and on URIs (sl-v215)", () => {
@@ -46,9 +42,6 @@ describe("SATSUMA_FILE_GLOB", () => {
     // Watchers built from the glob and indexers built from the predicate must
     // agree on the file set, or watched .satsuma edits would be dropped again.
     const globExts = /\{(.+)\}/.exec(SATSUMA_FILE_GLOB)?.[1].split(",") ?? [];
-    assert.deepEqual(
-      globExts.map((e) => `.${e}`).sort(),
-      [...SATSUMA_FILE_EXTENSIONS].sort(),
-    );
+    assert.deepEqual(globExts.map((e) => `.${e}`).sort(), [...SATSUMA_FILE_EXTENSIONS].sort());
   });
 });

--- a/tooling/satsuma-core/test/spread-expand.test.js
+++ b/tooling/satsuma-core/test/spread-expand.test.js
@@ -32,11 +32,7 @@ describe("collectFieldPaths()", () => {
 
   it("collects nested fields with dotted paths", () => {
     const paths = new Set();
-    collectFieldPaths(
-      [field("address", "record", [field("city"), field("zip")])],
-      "",
-      paths,
-    );
+    collectFieldPaths([field("address", "record", [field("city"), field("zip")])], "", paths);
     assert.deepEqual([...paths].sort(), ["address", "address.city", "address.zip"]);
   });
 });
@@ -83,7 +79,7 @@ describe("expandEntityFields()", () => {
     const frag = fragment("::audit_fields", [field("created_at"), field("updated_at")]);
     const entity = { fields: [field("id")], hasSpreads: true, spreads: ["::audit_fields"] };
     const resolve = (ref) => ref;
-    const lookup = (key) => key === "::audit_fields" ? frag : null;
+    const lookup = (key) => (key === "::audit_fields" ? frag : null);
 
     const result = expandEntityFields(entity, null, resolve, lookup);
     assert.equal(result.length, 2);
@@ -97,7 +93,7 @@ describe("expandEntityFields()", () => {
     const fragB = { fields: [field("x")], hasSpreads: true, spreads: ["::fragA"] };
     const entity = { fields: [], hasSpreads: true, spreads: ["::fragA"] };
     const resolve = (ref) => ref;
-    const lookup = (key) => key === "::fragA" ? fragA : key === "::fragB" ? fragB : null;
+    const lookup = (key) => (key === "::fragA" ? fragA : key === "::fragB" ? fragB : null);
 
     // Should not throw or loop
     const result = expandEntityFields(entity, null, resolve, lookup);
@@ -116,7 +112,7 @@ describe("expandEntityFields()", () => {
       key === "::fragA" ? fragA : key === "::fragB" ? fragB : key === "::fragC" ? fragC : null;
 
     const result = expandEntityFields(entity, null, resolve, lookup);
-    assert.equal(result.filter(f => f.name === "shared").length, 1);
+    assert.equal(result.filter((f) => f.name === "shared").length, 1);
   });
 });
 
@@ -135,7 +131,7 @@ describe("expandNestedSpreads()", () => {
     };
     const fields = [nestedField];
     const resolve = (ref) => ref;
-    const lookup = (key) => key === "::addr_frag" ? frag : null;
+    const lookup = (key) => (key === "::addr_frag" ? frag : null);
 
     expandNestedSpreads(fields, null, resolve, lookup);
 

--- a/tooling/satsuma-core/test/validate.test.js
+++ b/tooling/satsuma-core/test/validate.test.js
@@ -106,7 +106,15 @@ describe("duplicate-definition diagnostics", () => {
     // is surfaced as an "error" (not warning) with rule=duplicate-definition.
     const index = makeIndex({
       duplicates: [
-        { kind: "schema", previousKind: "schema", name: "customers", file: "b.stm", row: 5, previousFile: "a.stm", previousRow: 0 },
+        {
+          kind: "schema",
+          previousKind: "schema",
+          name: "customers",
+          file: "b.stm",
+          row: 5,
+          previousFile: "a.stm",
+          previousRow: 0,
+        },
       ],
     });
     const diags = collectSemanticDiagnostics(index);
@@ -122,14 +130,28 @@ describe("duplicate-definition diagnostics", () => {
     // message must mention both kinds so the user knows which two entities conflict.
     const index = makeIndex({
       duplicates: [
-        { kind: "mapping", previousKind: "schema", name: "orders", file: "b.stm", row: 2, previousFile: "a.stm", previousRow: 0 },
+        {
+          kind: "mapping",
+          previousKind: "schema",
+          name: "orders",
+          file: "b.stm",
+          row: 2,
+          previousFile: "a.stm",
+          previousRow: 0,
+        },
       ],
     });
     const diags = collectSemanticDiagnostics(index);
     assert.equal(diags[0].rule, "duplicate-definition");
     // capitalize() uppercases the first letter; test with lower-case after the first character.
-    assert.ok(diags[0].message.toLowerCase().includes("mapping"), "message must name the current kind");
-    assert.ok(diags[0].message.toLowerCase().includes("schema"), "message must name the prior kind");
+    assert.ok(
+      diags[0].message.toLowerCase().includes("mapping"),
+      "message must name the current kind",
+    );
+    assert.ok(
+      diags[0].message.toLowerCase().includes("schema"),
+      "message must name the prior kind",
+    );
   });
 
   it("reports namespace-metadata-conflict when two files disagree on namespace metadata", () => {
@@ -138,9 +160,16 @@ describe("duplicate-definition diagnostics", () => {
     const index = makeIndex({
       duplicates: [
         {
-          kind: "namespace-metadata", previousKind: "namespace-metadata",
-          name: "pos", tag: "note", value: "Oracle", previousValue: "SAP",
-          file: "b.stm", row: 3, previousFile: "a.stm", previousRow: 0,
+          kind: "namespace-metadata",
+          previousKind: "namespace-metadata",
+          name: "pos",
+          tag: "note",
+          value: "Oracle",
+          previousValue: "SAP",
+          file: "b.stm",
+          row: 3,
+          previousFile: "a.stm",
+          previousRow: 0,
         },
       ],
     });
@@ -171,7 +200,9 @@ describe("undefined fragment spread diagnostics", () => {
       schemas: [{ name: "hub_customer", spreads: ["audit_fields"], fields: [] }],
     });
     const diags = collectSemanticDiagnostics(index);
-    const spreadDiag = diags.find((d) => d.rule === "undefined-ref" && d.message.includes("audit_fields"));
+    const spreadDiag = diags.find(
+      (d) => d.rule === "undefined-ref" && d.message.includes("audit_fields"),
+    );
     assert.ok(spreadDiag, "should warn about missing fragment spread");
   });
 
@@ -182,7 +213,9 @@ describe("undefined fragment spread diagnostics", () => {
       fragments: [{ name: "audit_fields", fields: [] }],
     });
     const diags = collectSemanticDiagnostics(index);
-    const spreadDiags = diags.filter((d) => d.rule === "undefined-ref" && d.message.includes("audit_fields"));
+    const spreadDiags = diags.filter(
+      (d) => d.rule === "undefined-ref" && d.message.includes("audit_fields"),
+    );
     assert.equal(spreadDiags.length, 0);
   });
 });
@@ -198,7 +231,9 @@ describe("mapping source/target reference diagnostics", () => {
       schemas: [{ name: "hub_customer", fields: [] }],
     });
     const diags = collectSemanticDiagnostics(index);
-    const srcDiag = diags.find((d) => d.rule === "undefined-ref" && d.message.includes("ghost_schema"));
+    const srcDiag = diags.find(
+      (d) => d.rule === "undefined-ref" && d.message.includes("ghost_schema"),
+    );
     assert.ok(srcDiag, "should warn about missing source schema");
   });
 
@@ -208,7 +243,9 @@ describe("mapping source/target reference diagnostics", () => {
       schemas: [{ name: "orders", fields: [] }],
     });
     const diags = collectSemanticDiagnostics(index);
-    const tgtDiag = diags.find((d) => d.rule === "undefined-ref" && d.message.includes("nonexistent_target"));
+    const tgtDiag = diags.find(
+      (d) => d.rule === "undefined-ref" && d.message.includes("nonexistent_target"),
+    );
     assert.ok(tgtDiag, "should warn about missing target schema");
   });
 
@@ -223,7 +260,9 @@ describe("mapping source/target reference diagnostics", () => {
       ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const srcDiag = diags.find((d) => d.message.includes("customers") && d.message.includes("hint"));
+    const srcDiag = diags.find(
+      (d) => d.message.includes("customers") && d.message.includes("hint"),
+    );
     assert.ok(srcDiag, "should include namespace hint in message");
   });
 
@@ -261,7 +300,9 @@ describe("metric source reference diagnostics", () => {
       schemas: [{ name: "orders", fields: [] }],
     });
     const diags = collectSemanticDiagnostics(index);
-    const metricDiags = diags.filter((d) => d.rule === "undefined-ref" && d.message.includes("mrr"));
+    const metricDiags = diags.filter(
+      (d) => d.rule === "undefined-ref" && d.message.includes("mrr"),
+    );
     assert.equal(metricDiags.length, 0);
   });
 });
@@ -278,31 +319,49 @@ describe("arrow field-not-in-schema diagnostics", () => {
         { name: "hub_orders", fields: [{ name: "order_hk", type: "CHAR(32)" }] },
       ],
       mappings: [{ name: "load orders", sources: ["orders"], targets: ["hub_orders"] }],
-      fieldArrows: [{
-        mapping: "load orders", namespace: null,
-        sources: ["nonexistent_field"],
-        target: "order_hk",
-        steps: [], line: 5, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "load orders",
+          namespace: null,
+          sources: ["nonexistent_field"],
+          target: "order_hk",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const fieldDiag = diags.find((d) => d.rule === "field-not-in-schema" && d.message.includes("nonexistent_field"));
+    const fieldDiag = diags.find(
+      (d) => d.rule === "field-not-in-schema" && d.message.includes("nonexistent_field"),
+    );
     assert.ok(fieldDiag, "should warn about undeclared arrow source field");
   });
 
   it("does not warn when the arrow source field exists in the schema", () => {
     const index = makeIndex({
       schemas: [
-        { name: "orders", fields: [{ name: "id", type: "INT" }, { name: "amount", type: "DECIMAL" }] },
+        {
+          name: "orders",
+          fields: [
+            { name: "id", type: "INT" },
+            { name: "amount", type: "DECIMAL" },
+          ],
+        },
         { name: "hub_orders", fields: [{ name: "order_hk", type: "CHAR(32)" }] },
       ],
       mappings: [{ name: "load orders", sources: ["orders"], targets: ["hub_orders"] }],
-      fieldArrows: [{
-        mapping: "load orders", namespace: null,
-        sources: ["id"],
-        target: "order_hk",
-        steps: [], line: 5, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "load orders",
+          namespace: null,
+          sources: ["id"],
+          target: "order_hk",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
     const fieldDiags = diags.filter((d) => d.rule === "field-not-in-schema");
@@ -318,21 +377,28 @@ describe("arrow field-not-in-schema diagnostics", () => {
         {
           name: "orders",
           fields: [{ name: "id", type: "INT" }],
-          spreads: ["base_fields"],  // unresolvable: base_fields not in fragments
+          spreads: ["base_fields"], // unresolvable: base_fields not in fragments
           hasSpreads: true,
         },
         { name: "hub_orders", fields: [{ name: "order_hk", type: "CHAR(32)" }] },
       ],
       mappings: [{ name: "load orders", sources: ["orders"], targets: ["hub_orders"] }],
-      fieldArrows: [{
-        mapping: "load orders", namespace: null,
-        sources: ["spread_sourced_field"],
-        target: "order_hk",
-        steps: [], line: 5, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "load orders",
+          namespace: null,
+          sources: ["spread_sourced_field"],
+          target: "order_hk",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const fieldDiags = diags.filter((d) => d.rule === "field-not-in-schema" && d.message.includes("spread_sourced_field"));
+    const fieldDiags = diags.filter(
+      (d) => d.rule === "field-not-in-schema" && d.message.includes("spread_sourced_field"),
+    );
     assert.equal(fieldDiags.length, 0, "must not warn when source has unresolved spreads");
   });
 
@@ -350,17 +416,25 @@ describe("arrow field-not-in-schema diagnostics", () => {
         { name: "z", fields: [{ name: "z_created", type: "TIMESTAMP" }] },
       ],
       mappings: [{ name: "m", sources: ["s1", "s2"], targets: ["z"] }],
-      fieldArrows: [{
-        mapping: "m", namespace: null,
-        sources: ["s2.created_at"],
-        target: "z_created",
-        steps: [], line: 5, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "m",
+          namespace: null,
+          sources: ["s2.created_at"],
+          target: "z_created",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
     const fieldDiags = diags.filter((d) => d.rule === "field-not-in-schema");
-    assert.deepEqual(fieldDiags.map((d) => d.message), [],
-      "qualified spread-inherited field must validate clean");
+    assert.deepEqual(
+      fieldDiags.map((d) => d.message),
+      [],
+      "qualified spread-inherited field must validate clean",
+    );
   });
 
   it("blames the schema a qualified path names, not the first source (sl-kkao)", () => {
@@ -373,15 +447,22 @@ describe("arrow field-not-in-schema diagnostics", () => {
         { name: "z", fields: [{ name: "z_created", type: "TIMESTAMP" }] },
       ],
       mappings: [{ name: "m", sources: ["s1", "s2"], targets: ["z"] }],
-      fieldArrows: [{
-        mapping: "m", namespace: null,
-        sources: ["s2.missing"],
-        target: "z_created",
-        steps: [], line: 5, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "m",
+          namespace: null,
+          sources: ["s2.missing"],
+          target: "z_created",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const diag = diags.find((d) => d.rule === "field-not-in-schema" && d.message.includes("s2.missing"));
+    const diag = diags.find(
+      (d) => d.rule === "field-not-in-schema" && d.message.includes("s2.missing"),
+    );
     assert.ok(diag, "should still warn for a genuinely missing qualified field");
     assert.match(diag.message, /schema 's2'/);
     assert.ok(!diag.message.includes("'s1'"), "must not blame the first source schema");
@@ -400,15 +481,22 @@ describe("transform spread diagnostics", () => {
         { name: "tgt", fields: [{ name: "id", type: "INT" }] },
       ],
       mappings: [{ name: "m", sources: ["src"], targets: ["tgt"] }],
-      fieldArrows: [{
-        mapping: "m", namespace: null,
-        sources: ["id"], target: "id",
-        steps: [{ type: "fragment_spread", text: "...ghost_transform" }],
-        line: 3, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "m",
+          namespace: null,
+          sources: ["id"],
+          target: "id",
+          steps: [{ type: "fragment_spread", text: "...ghost_transform" }],
+          line: 3,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const spreadDiag = diags.find((d) => d.rule === "undefined-ref" && d.message.includes("ghost_transform"));
+    const spreadDiag = diags.find(
+      (d) => d.rule === "undefined-ref" && d.message.includes("ghost_transform"),
+    );
     assert.ok(spreadDiag, "should warn about missing transform spread");
   });
 
@@ -420,15 +508,22 @@ describe("transform spread diagnostics", () => {
       ],
       mappings: [{ name: "m", sources: ["src"], targets: ["tgt"] }],
       transforms: [{ name: "hash_pk" }],
-      fieldArrows: [{
-        mapping: "m", namespace: null,
-        sources: ["id"], target: "id",
-        steps: [{ type: "fragment_spread", text: "...hash_pk" }],
-        line: 3, file: "test.stm",
-      }],
+      fieldArrows: [
+        {
+          mapping: "m",
+          namespace: null,
+          sources: ["id"],
+          target: "id",
+          steps: [{ type: "fragment_spread", text: "...hash_pk" }],
+          line: 3,
+          file: "test.stm",
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const spreadDiags = diags.filter((d) => d.rule === "undefined-ref" && d.message.includes("hash_pk"));
+    const spreadDiags = diags.filter(
+      (d) => d.rule === "undefined-ref" && d.message.includes("hash_pk"),
+    );
     assert.equal(spreadDiags.length, 0);
   });
 });
@@ -440,17 +535,23 @@ describe("ref metadata target diagnostics", () => {
     // (ref @ghost_schema) on a field is a cross-schema lineage annotation.
     // An unresolvable ref silently breaks lineage tracing — must be reported.
     const index = makeIndex({
-      schemas: [{
-        name: "hub_customer",
-        fields: [{
-          name: "customer_id",
-          type: "INT",
-          metadata: [{ kind: "kv", key: "ref", value: "@ghost_schema.id" }],
-        }],
-      }],
+      schemas: [
+        {
+          name: "hub_customer",
+          fields: [
+            {
+              name: "customer_id",
+              type: "INT",
+              metadata: [{ kind: "kv", key: "ref", value: "@ghost_schema.id" }],
+            },
+          ],
+        },
+      ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const refDiag = diags.find((d) => d.rule === "undefined-ref" && d.message.includes("ghost_schema"));
+    const refDiag = diags.find(
+      (d) => d.rule === "undefined-ref" && d.message.includes("ghost_schema"),
+    );
     assert.ok(refDiag, "should warn about nonexistent ref metadata target");
   });
 
@@ -459,17 +560,21 @@ describe("ref metadata target diagnostics", () => {
       schemas: [
         {
           name: "hub_customer",
-          fields: [{
-            name: "customer_id",
-            type: "INT",
-            metadata: [{ kind: "kv", key: "ref", value: "@crm_customers.id" }],
-          }],
+          fields: [
+            {
+              name: "customer_id",
+              type: "INT",
+              metadata: [{ kind: "kv", key: "ref", value: "@crm_customers.id" }],
+            },
+          ],
         },
         { name: "crm_customers", fields: [{ name: "id", type: "INT" }] },
       ],
     });
     const diags = collectSemanticDiagnostics(index);
-    const refDiags = diags.filter((d) => d.rule === "undefined-ref" && d.message.includes("crm_customers"));
+    const refDiags = diags.filter(
+      (d) => d.rule === "undefined-ref" && d.message.includes("crm_customers"),
+    );
     assert.equal(refDiags.length, 0);
   });
 });
@@ -481,11 +586,14 @@ describe("validateSemanticWorkspace", () => {
     // This pins the shared consumer contract: callers pass resolved imports,
     // core computes reachability, and out-of-scope symbols use the CLI rule.
     const index = makeIndex({
-      schemas: [
-        { name: "customers", file: "/workspace/customers.stm" },
-      ],
+      schemas: [{ name: "customers", file: "/workspace/customers.stm" }],
       mappings: [
-        { name: "load customers", file: "/workspace/load.stm", sources: ["customers"], targets: ["customers"] },
+        {
+          name: "load customers",
+          file: "/workspace/load.stm",
+          sources: ["customers"],
+          targets: ["customers"],
+        },
       ],
     });
     const diags = validateSemanticWorkspace(index, {
@@ -510,11 +618,14 @@ describe("validateSemanticWorkspace", () => {
     // LSP diagnostics keep their historic public code/message while using the
     // same reachability algorithm as CLI validation.
     const index = makeIndex({
-      schemas: [
-        { name: "orders", file: "file:///workspace/orders.stm" },
-      ],
+      schemas: [{ name: "orders", file: "file:///workspace/orders.stm" }],
       mappings: [
-        { name: "load orders", file: "file:///workspace/load.stm", sources: ["orders"], targets: [] },
+        {
+          name: "load orders",
+          file: "file:///workspace/load.stm",
+          sources: ["orders"],
+          targets: [],
+        },
       ],
     });
     const diags = validateSemanticWorkspace(index, {
@@ -541,12 +652,16 @@ describe("constraint-in-type-args", () => {
     // `customer_id UUID(pk)` parses cleanly with (pk) as part of the type
     // token; without this diagnostic the pk constraint silently disappears.
     const index = makeIndex({
-      schemas: [{
-        name: "customers",
-        fields: [{ name: "customer_id", type: "UUID(pk)", startRow: 3 }],
-      }],
+      schemas: [
+        {
+          name: "customers",
+          fields: [{ name: "customer_id", type: "UUID(pk)", startRow: 3 }],
+        },
+      ],
     });
-    const diags = collectSemanticDiagnostics(index).filter((d) => d.rule === "constraint-in-type-args");
+    const diags = collectSemanticDiagnostics(index).filter(
+      (d) => d.rule === "constraint-in-type-args",
+    );
     assert.equal(diags.length, 1);
     assert.equal(diags[0].severity, "warning");
     assert.equal(diags[0].line, 4); // startRow 3 → 1-indexed line 4
@@ -558,33 +673,46 @@ describe("constraint-in-type-args", () => {
     // Type vocabulary is open-ended (spec 3.2); numeric and vendor args are
     // exactly what type parentheses are for.
     const index = makeIndex({
-      schemas: [{
-        name: "orders",
-        fields: [
-          { name: "amount", type: "DECIMAL(12,2)" },
-          { name: "notes", type: "VARCHAR(MAX)" },
-        ],
-      }],
+      schemas: [
+        {
+          name: "orders",
+          fields: [
+            { name: "amount", type: "DECIMAL(12,2)" },
+            { name: "notes", type: "VARCHAR(MAX)" },
+          ],
+        },
+      ],
     });
-    const diags = collectSemanticDiagnostics(index).filter((d) => d.rule === "constraint-in-type-args");
+    const diags = collectSemanticDiagnostics(index).filter(
+      (d) => d.rule === "constraint-in-type-args",
+    );
     assert.deepEqual(diags, []);
   });
 
   it("recurses into record children and checks fragments too", () => {
     const index = makeIndex({
-      schemas: [{
-        name: "order",
-        fields: [{
-          name: "customer", type: "record",
-          children: [{ name: "id", type: "STRING(required)", startRow: 5 }],
-        }],
-      }],
-      fragments: [{
-        name: "audit",
-        fields: [{ name: "created_by", type: "VARCHAR(100)" }],
-      }],
+      schemas: [
+        {
+          name: "order",
+          fields: [
+            {
+              name: "customer",
+              type: "record",
+              children: [{ name: "id", type: "STRING(required)", startRow: 5 }],
+            },
+          ],
+        },
+      ],
+      fragments: [
+        {
+          name: "audit",
+          fields: [{ name: "created_by", type: "VARCHAR(100)" }],
+        },
+      ],
     });
-    const diags = collectSemanticDiagnostics(index).filter((d) => d.rule === "constraint-in-type-args");
+    const diags = collectSemanticDiagnostics(index).filter(
+      (d) => d.rule === "constraint-in-type-args",
+    );
     assert.equal(diags.length, 1);
     assert.match(diags[0].message, /'required'/);
   });

--- a/tooling/satsuma-lsp/src/action-context.ts
+++ b/tooling/satsuma-lsp/src/action-context.ts
@@ -42,9 +42,10 @@ export function computeActionContext(
  * Walk up the CST from the cursor node to find an enclosing named mapping_block,
  * then extract the mapping name and the first target schema reference.
  */
-function inferMappingContext(
-  node: SyntaxNode,
-): { mappingName: string | null; targetSchema: string | null } {
+function inferMappingContext(node: SyntaxNode): {
+  mappingName: string | null;
+  targetSchema: string | null;
+} {
   let current: SyntaxNode | null = node;
   while (current) {
     if (current.type === "mapping_block") {
@@ -123,31 +124,20 @@ function inferSchemaFromNlRef(name: string): string | null {
   return parts.length >= 2 ? parts.slice(0, -1).join(".") : null;
 }
 
-function inferArrowFieldPath(
-  schemas: string[],
-  rawPath: string | null,
-): string | null {
+function inferArrowFieldPath(schemas: string[], rawPath: string | null): string | null {
   const normalizedPath = normalizeArrowPath(rawPath);
   if (!normalizedPath) return null;
 
   for (const schema of schemas) {
-    if (
-      normalizedPath === schema ||
-      normalizedPath.startsWith(`${schema}.`)
-    ) {
+    if (normalizedPath === schema || normalizedPath.startsWith(`${schema}.`)) {
       return normalizedPath;
     }
   }
 
-  return schemas.length === 1 && schemas[0]
-    ? `${schemas[0]}.${normalizedPath}`
-    : null;
+  return schemas.length === 1 && schemas[0] ? `${schemas[0]}.${normalizedPath}` : null;
 }
 
-function inferSchemaFromPath(
-  schemas: string[],
-  rawPath: string | null,
-): string | null {
+function inferSchemaFromPath(schemas: string[], rawPath: string | null): string | null {
   const fullPath = inferArrowFieldPath(schemas, rawPath);
   if (!fullPath) {
     return schemas.length === 1 ? (schemas[0] ?? null) : null;

--- a/tooling/satsuma-lsp/src/codelens.ts
+++ b/tooling/satsuma-lsp/src/codelens.ts
@@ -1,26 +1,14 @@
-import {
-  CodeLens,
-  Command,
-  Range,
-} from "vscode-languageserver";
+import { CodeLens, Command, Range } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, walkDescendants } from "./parser-utils";
 import { isMetricSchema, sourceRefStructuralText } from "@satsuma/core";
-import {
-  WorkspaceIndex,
-  findReferences,
-  findMappingsUsing,
-} from "./workspace-index";
+import { WorkspaceIndex, findReferences, findMappingsUsing } from "./workspace-index";
 
 /**
  * Compute CodeLens annotations for all top-level blocks in a file.
  * Uses the workspace index for counts — no CLI calls.
  */
-export function computeCodeLenses(
-  tree: Tree,
-  uri: string,
-  index: WorkspaceIndex,
-): CodeLens[] {
+export function computeCodeLenses(tree: Tree, uri: string, index: WorkspaceIndex): CodeLens[] {
   const lenses: CodeLens[] = [];
   for (const node of tree.rootNode.namedChildren) {
     collectLenses(node, null, uri, index, lenses);
@@ -94,32 +82,24 @@ function schemaLenses(
   return [
     {
       range,
-      command: makeCommand(
-        "Lineage from",
-        "satsuma.showLineage",
-        { schemaName: qualName, direction: "from" },
-      ),
+      command: makeCommand("Lineage from", "satsuma.showLineage", {
+        schemaName: qualName,
+        direction: "from",
+      }),
     },
     {
       range,
-      command: makeCommand(
-        "Lineage to",
-        "satsuma.showLineage",
-        { schemaName: qualName, direction: "to" },
-      ),
+      command: makeCommand("Lineage to", "satsuma.showLineage", {
+        schemaName: qualName,
+        direction: "to",
+      }),
     },
     { range, command: makeCommand(title) },
   ];
 }
 
-function fragmentLens(
-  qualName: string,
-  range: Range,
-  index: WorkspaceIndex,
-): CodeLens {
-  const spreadRefs = findReferences(index, qualName).filter(
-    (r) => r.context === "spread",
-  );
+function fragmentLens(qualName: string, range: Range, index: WorkspaceIndex): CodeLens {
+  const spreadRefs = findReferences(index, qualName).filter((r) => r.context === "spread");
   const title = `spread in ${spreadRefs.length} place(s)`;
   return { range, command: makeCommand(title) };
 }
@@ -155,36 +135,21 @@ function metricLens(node: SyntaxNode, range: Range): CodeLens {
     });
   }
 
-  const title =
-    sourceNames.length > 0
-      ? `sources: ${sourceNames.join(", ")}`
-      : "metric";
+  const title = sourceNames.length > 0 ? `sources: ${sourceNames.join(", ")}` : "metric";
 
   return { range, command: makeCommand(title) };
 }
 
-function transformLens(
-  qualName: string,
-  range: Range,
-  index: WorkspaceIndex,
-): CodeLens {
-  const spreadRefs = findReferences(index, qualName).filter(
-    (r) => r.context === "spread",
-  );
+function transformLens(qualName: string, range: Range, index: WorkspaceIndex): CodeLens {
+  const spreadRefs = findReferences(index, qualName).filter((r) => r.context === "spread");
   const title = `used in ${spreadRefs.length} place(s)`;
   return { range, command: makeCommand(title) };
 }
 
 // ---------- Helpers ----------
 
-function makeCommand(
-  title: string,
-  command = "",
-  ...arguments_: unknown[]
-): Command {
-  return arguments_.length > 0
-    ? { title, command, arguments: arguments_ }
-    : { title, command };
+function makeCommand(title: string, command = "", ...arguments_: unknown[]): Command {
+  return arguments_.length > 0 ? { title, command, arguments: arguments_ } : { title, command };
 }
 
 function extractRefNames(body: SyntaxNode, blockType: string): string[] {

--- a/tooling/satsuma-lsp/src/completion.ts
+++ b/tooling/satsuma-lsp/src/completion.ts
@@ -1,16 +1,8 @@
-import {
-  CompletionItem,
-  CompletionItemKind,
-} from "vscode-languageserver";
+import { CompletionItem, CompletionItemKind } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, nodeAtPosition } from "./parser-utils";
 import { sourceRefStructuralText } from "@satsuma/core";
-import {
-  WorkspaceIndex,
-  allBlockNames,
-  getFields,
-  FieldInfo,
-} from "./workspace-index";
+import { WorkspaceIndex, allBlockNames, getFields, FieldInfo } from "./workspace-index";
 
 /**
  * Compute context-aware completions at the given position.
@@ -73,8 +65,12 @@ function detectCompletionContext(node: SyntaxNode): CompletionContext | null {
     // nested_arrow node itself. The user has just opened a transform body —
     // suggest pipe functions (sl-0tgo). Arrows with actual nested declarations
     // resolve deeper nodes first, so this only fires for empty bodies.
-    if (current.type === "nested_arrow" && !child(current, "map_arrow") &&
-        !child(current, "computed_arrow") && !child(current, "nested_arrow")) {
+    if (
+      current.type === "nested_arrow" &&
+      !child(current, "map_arrow") &&
+      !child(current, "computed_arrow") &&
+      !child(current, "nested_arrow")
+    ) {
       return { kind: "pipe_chain" };
     }
 
@@ -239,10 +235,7 @@ function importNameCompletions(index: WorkspaceIndex): CompletionItem[] {
   return items;
 }
 
-function namespaceMemberCompletions(
-  index: WorkspaceIndex,
-  nsName: string,
-): CompletionItem[] {
+function namespaceMemberCompletions(index: WorkspaceIndex, nsName: string): CompletionItem[] {
   const items: CompletionItem[] = [];
   const prefix = `${nsName}::`;
 
@@ -260,10 +253,7 @@ function namespaceMemberCompletions(
   return items;
 }
 
-function fieldCompletions(
-  index: WorkspaceIndex,
-  schemas: string[],
-): CompletionItem[] {
+function fieldCompletions(index: WorkspaceIndex, schemas: string[]): CompletionItem[] {
   const items: CompletionItem[] = [];
   const seen = new Set<string>();
 
@@ -275,11 +265,7 @@ function fieldCompletions(
   return items;
 }
 
-function addFieldItems(
-  items: CompletionItem[],
-  fields: FieldInfo[],
-  seen: Set<string>,
-): void {
+function addFieldItems(items: CompletionItem[], fields: FieldInfo[], seen: Set<string>): void {
   for (const f of fields) {
     if (seen.has(f.name)) continue;
     seen.add(f.name);
@@ -293,10 +279,7 @@ function addFieldItems(
 
 // ---------- Mapping schema helpers ----------
 
-function findMappingSchemas(
-  pathNode: SyntaxNode,
-  blockType: "source" | "target",
-): string[] {
+function findMappingSchemas(pathNode: SyntaxNode, blockType: "source" | "target"): string[] {
   // Walk up to find the enclosing mapping_body
   let current: SyntaxNode | null = pathNode.parent;
   while (current) {
@@ -308,10 +291,7 @@ function findMappingSchemas(
   return [];
 }
 
-function findMappingSchemasFromBody(
-  body: SyntaxNode,
-  blockType: "source" | "target",
-): string[] {
+function findMappingSchemasFromBody(body: SyntaxNode, blockType: "source" | "target"): string[] {
   const targetType = blockType === "source" ? "source_block" : "target_block";
   const schemas: string[] = [];
 

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -141,10 +141,7 @@ type DefinitionEntryKind = "schema" | "fragment" | "transform";
  * blocks may name something the index also knows as another kind, and coverage
  * is defined over declared schema fields.
  */
-function resolveSchema(
-  wsIndex: WorkspaceIndex,
-  schemaId: string,
-): CoverageSchemaDefinition | null {
+function resolveSchema(wsIndex: WorkspaceIndex, schemaId: string): CoverageSchemaDefinition | null {
   const defs = resolveDefinition(wsIndex, schemaId, null);
   const def = defs.find((d) => d.kind === "schema");
   if (!def) return null;

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -2,11 +2,7 @@ import { Location } from "vscode-languageserver";
 import { createAtRefRegex, fieldNameText, qualifiedNameText, sourceRefText } from "@satsuma/core";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText, nodeAtPosition } from "./parser-utils";
-import {
-  WorkspaceIndex,
-  resolveDefinition,
-  FieldInfo,
-} from "./workspace-index";
+import { WorkspaceIndex, resolveDefinition, FieldInfo } from "./workspace-index";
 
 /**
  * Compute go-to-definition for the node at the given position.
@@ -268,10 +264,7 @@ function resolveContext(
       if (blockDefs.length > 0) return defsToLocations(blockDefs);
 
       // Try as a field name in the enclosing mapping's source/target schemas
-      const allSchemas = [
-        ...(ctx.mappingSources ?? []),
-        ...(ctx.mappingTargets ?? []),
-      ];
+      const allSchemas = [...(ctx.mappingSources ?? []), ...(ctx.mappingTargets ?? [])];
       const fieldLoc = resolveFieldInSchemas(index, allSchemas, ctx.name, ctx.namespace);
       if (fieldLoc) return fieldLoc;
 
@@ -463,11 +456,7 @@ const AT_REF_RE = createAtRefRegex();
  * Check if the cursor is on an @ref reference inside an NL string.
  * Returns a NodeContext with kind "nl_ref" if so.
  */
-function tryNlRefContext(
-  node: SyntaxNode,
-  line: number,
-  character: number,
-): NodeContext | null {
+function tryNlRefContext(node: SyntaxNode, line: number, character: number): NodeContext | null {
   // The node itself might be the nl_string, or it might be a descendant.
   // Walk up to find the nl_string or multiline_string node.
   let nlNode: SyntaxNode | null = node;
@@ -517,8 +506,6 @@ function tryNlRefContext(
       };
     }
   }
-
-
 
   return null;
 }

--- a/tooling/satsuma-lsp/src/diagnostics.ts
+++ b/tooling/satsuma-lsp/src/diagnostics.ts
@@ -1,8 +1,4 @@
-import {
-  Diagnostic,
-  DiagnosticSeverity,
-  DiagnosticTag,
-} from "vscode-languageserver";
+import { Diagnostic, DiagnosticSeverity, DiagnosticTag } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange } from "./parser-utils";
 import { collectParseErrors } from "@satsuma/core";
@@ -54,7 +50,10 @@ export function ensureNonEmptyMessages(diags: Diagnostic[]): Diagnostic[] {
   return diags.map((d) =>
     hasNonEmptyMessage(d)
       ? d
-      : { ...d, message: d.code ? `Diagnostic '${d.code}' (no message)` : "Diagnostic (no message)" },
+      : {
+          ...d,
+          message: d.code ? `Diagnostic '${d.code}' (no message)` : "Diagnostic (no message)",
+        },
   );
 }
 

--- a/tooling/satsuma-lsp/src/full-lineage.ts
+++ b/tooling/satsuma-lsp/src/full-lineage.ts
@@ -14,11 +14,7 @@
  */
 
 import type { Tree } from "./parser-utils";
-import {
-  WorkspaceIndex,
-  getImportReachableUris,
-  createScopedIndex,
-} from "./workspace-index";
+import { WorkspaceIndex, getImportReachableUris, createScopedIndex } from "./workspace-index";
 import { buildVizModel, mergeVizModels } from "@satsuma/viz-backend";
 import type { VizModel } from "@satsuma/viz-backend";
 

--- a/tooling/satsuma-lsp/src/hover.ts
+++ b/tooling/satsuma-lsp/src/hover.ts
@@ -14,11 +14,7 @@ const MAX_HOVER_FIELDS = 8;
  * Per-file only — no workspace index.  Shows structural information
  * derived from the CST: block summaries, field types, metadata, etc.
  */
-export function computeHover(
-  tree: Tree,
-  line: number,
-  character: number,
-): Hover | null {
+export function computeHover(tree: Tree, line: number, character: number): Hover | null {
   const node = nodeAtPosition(tree, line, character);
   if (!node) return null;
 
@@ -136,7 +132,9 @@ function hoverBlock(node: SyntaxNode): HoverResult | null {
       if (body) {
         const fields = children(body, "field_decl");
         const spreads = children(body, "fragment_spread");
-        lines.push(`${fields.length} field(s)${spreads.length > 0 ? `, ${spreads.length} spread(s)` : ""}`);
+        lines.push(
+          `${fields.length} field(s)${spreads.length > 0 ? `, ${spreads.length} spread(s)` : ""}`,
+        );
         // Show a preview of the first MAX_HOVER_FIELDS fields; truncate the rest.
         const fieldSummary = fields.slice(0, MAX_HOVER_FIELDS).map((f) => {
           const fn = child(f, "field_name");
@@ -167,8 +165,10 @@ function hoverBlock(node: SyntaxNode): HoverResult | null {
         if (sources.length > 0 || targets.length > 0) {
           const srcNames = sources.map((s) => backtickText(s)).filter(Boolean);
           const tgtNames = targets.map((t) => backtickText(t)).filter(Boolean);
-          if (srcNames.length > 0) lines.push(`Source: ${srcNames.map((n) => `\`${n}\``).join(", ")}`);
-          if (tgtNames.length > 0) lines.push(`Target: ${tgtNames.map((n) => `\`${n}\``).join(", ")}`);
+          if (srcNames.length > 0)
+            lines.push(`Source: ${srcNames.map((n) => `\`${n}\``).join(", ")}`);
+          if (tgtNames.length > 0)
+            lines.push(`Target: ${tgtNames.map((n) => `\`${n}\``).join(", ")}`);
         }
       }
       break;

--- a/tooling/satsuma-lsp/src/parser-utils.ts
+++ b/tooling/satsuma-lsp/src/parser-utils.ts
@@ -13,10 +13,7 @@
  * the concrete Node type used by other LSP server code.
  */
 
-import {
-  Range,
-  Position,
-} from "vscode-languageserver";
+import { Range, Position } from "vscode-languageserver";
 import type { Parser, Language, Tree, Node } from "web-tree-sitter";
 
 // Re-export web-tree-sitter types under the names the rest of the server uses.

--- a/tooling/satsuma-lsp/src/rename.ts
+++ b/tooling/satsuma-lsp/src/rename.ts
@@ -1,8 +1,4 @@
-import {
-  Range,
-  WorkspaceEdit,
-  TextEdit,
-} from "vscode-languageserver";
+import { Range, WorkspaceEdit, TextEdit } from "vscode-languageserver";
 import type { Tree } from "./parser-utils";
 import { nodeRange, nodeAtPosition } from "./parser-utils";
 import { findNodeContext, NodeContext } from "./definition";

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -14,10 +14,7 @@
 
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
-import {
-  Diagnostic,
-  DiagnosticSeverity,
-} from "vscode-languageserver";
+import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
 import type { Tree } from "./parser-utils";
 import type { WorkspaceIndex, DefinitionEntry } from "./workspace-index";
 import {
@@ -26,9 +23,7 @@ import {
   createScopedIndex,
   getImportReachableUris,
 } from "./workspace-index";
-import {
-  validateSemanticWorkspace,
-} from "@satsuma/core";
+import { validateSemanticWorkspace } from "@satsuma/core";
 import type {
   SemanticIndex,
   SemanticSchema,
@@ -99,8 +94,9 @@ export function computeMissingImportDiagnostics(
   uri: string,
   wsIndex: WorkspaceIndex,
 ): Diagnostic[] {
-  return computeSemanticValidationDiagnostics(uri, wsIndex)
-    .filter((d) => d.code === MISSING_IMPORT_RULE);
+  return computeSemanticValidationDiagnostics(uri, wsIndex).filter(
+    (d) => d.code === MISSING_IMPORT_RULE,
+  );
 }
 
 // ---------- Core semantic diagnostics (adapter) ----------
@@ -128,21 +124,17 @@ export function computeSemanticValidationDiagnostics(
   });
 
   // Filter to diagnostics for the specified file and convert to LSP format
-  return coreDiags
-    .filter((d) => d.file === uri)
-    .map(semanticDiagToLsp);
+  return coreDiags.filter((d) => d.file === uri).map(semanticDiagToLsp);
 }
 
 /**
  * Backward-compatible wrapper kept for tests and call sites that still name
  * the old adapter. It now uses the unified core validation entry point.
  */
-export function computeCoreSemanticDiagnostics(
-  uri: string,
-  wsIndex: WorkspaceIndex,
-): Diagnostic[] {
-  return computeSemanticValidationDiagnostics(uri, wsIndex)
-    .filter((d) => d.code !== MISSING_IMPORT_RULE);
+export function computeCoreSemanticDiagnostics(uri: string, wsIndex: WorkspaceIndex): Diagnostic[] {
+  return computeSemanticValidationDiagnostics(uri, wsIndex).filter(
+    (d) => d.code !== MISSING_IMPORT_RULE,
+  );
 }
 
 function missingImportMessage(uri: string, violation: ImportScopeViolation): string {
@@ -172,9 +164,7 @@ function semanticDiagToLsp(d: SemanticDiagnostic): Diagnostic {
  * ResolvedFileImport format. Resolves relative import paths to absolute
  * file URIs using the importing file's directory as the base.
  */
-function buildFileImportsMap(
-  wsIndex: WorkspaceIndex,
-): Map<string, ResolvedFileImport[]> {
+function buildFileImportsMap(wsIndex: WorkspaceIndex): Map<string, ResolvedFileImport[]> {
   const result = new Map<string, ResolvedFileImport[]>();
 
   for (const [importerUri, entries] of wsIndex.imports) {
@@ -223,8 +213,13 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
   const metrics = new Map<string, SemanticMetric>();
   const transforms = new Map<string, unknown>();
   const duplicates: Array<{
-    kind: string; name: string; file: string; row: number;
-    previousKind: string; previousFile: string; previousRow: number;
+    kind: string;
+    name: string;
+    file: string;
+    row: number;
+    previousKind: string;
+    previousFile: string;
+    previousRow: number;
   }> = [];
 
   for (const [name, entries] of wsIndex.definitions) {
@@ -313,7 +308,7 @@ function buildSemanticIndex(wsIndex: WorkspaceIndex): SemanticIndex {
     mappings,
     metrics,
     transforms,
-    fieldArrows: new Map(),   // Not available from LSP workspace index
+    fieldArrows: new Map(), // Not available from LSP workspace index
     duplicates,
   };
 }

--- a/tooling/satsuma-lsp/src/semantic-tokens.ts
+++ b/tooling/satsuma-lsp/src/semantic-tokens.ts
@@ -13,27 +13,27 @@ import type { SyntaxNode } from "./parser-utils";
 
 /** Ordered token types — index positions are referenced by the builder. */
 const tokenTypes: string[] = [
-  SemanticTokenTypes.keyword,       // 0
-  SemanticTokenTypes.type,          // 1
-  SemanticTokenTypes.function,      // 2
-  SemanticTokenTypes.variable,      // 3
-  SemanticTokenTypes.property,      // 4
-  SemanticTokenTypes.string,        // 5
-  SemanticTokenTypes.comment,       // 6
-  SemanticTokenTypes.decorator,     // 7
-  SemanticTokenTypes.namespace,     // 8
-  SemanticTokenTypes.operator,      // 9
-  SemanticTokenTypes.enumMember,    // 10
-  SemanticTokenTypes.number,        // 11 (unused, but standard)
+  SemanticTokenTypes.keyword, // 0
+  SemanticTokenTypes.type, // 1
+  SemanticTokenTypes.function, // 2
+  SemanticTokenTypes.variable, // 3
+  SemanticTokenTypes.property, // 4
+  SemanticTokenTypes.string, // 5
+  SemanticTokenTypes.comment, // 6
+  SemanticTokenTypes.decorator, // 7
+  SemanticTokenTypes.namespace, // 8
+  SemanticTokenTypes.operator, // 9
+  SemanticTokenTypes.enumMember, // 10
+  SemanticTokenTypes.number, // 11 (unused, but standard)
 ];
 
 /** Ordered token modifiers — bitmask positions. */
 const tokenModifiers: string[] = [
-  SemanticTokenModifiers.definition,    // 0
-  SemanticTokenModifiers.declaration,   // 1
-  SemanticTokenModifiers.readonly,      // 2
-  SemanticTokenModifiers.defaultLibrary,// 3
-  "nlRef",                              // 4 — @ref inside NL string
+  SemanticTokenModifiers.definition, // 0
+  SemanticTokenModifiers.declaration, // 1
+  SemanticTokenModifiers.readonly, // 2
+  SemanticTokenModifiers.defaultLibrary, // 3
+  "nlRef", // 4 — @ref inside NL string
 ];
 
 export const semanticTokensLegend: SemanticTokensLegend = {
@@ -54,45 +54,45 @@ interface TokenMapping {
  */
 const CAPTURE_MAP: Record<string, TokenMapping> = {
   // Keywords
-  "keyword":            { typeIndex: 0, modifierBits: 0 },
-  "keyword.import":     { typeIndex: 0, modifierBits: 0 },
-  "keyword.context":    { typeIndex: 0, modifierBits: 0 },
-  "keyword.operator":   { typeIndex: 0, modifierBits: 0 },
+  keyword: { typeIndex: 0, modifierBits: 0 },
+  "keyword.import": { typeIndex: 0, modifierBits: 0 },
+  "keyword.context": { typeIndex: 0, modifierBits: 0 },
+  "keyword.operator": { typeIndex: 0, modifierBits: 0 },
 
   // Block labels — definitions
-  "type.definition":    { typeIndex: 1, modifierBits: 1 << 0 },  // type + definition
-  "function.definition":{ typeIndex: 2, modifierBits: 1 << 0 },  // function + definition
-  "module":             { typeIndex: 8, modifierBits: 0 },        // namespace
+  "type.definition": { typeIndex: 1, modifierBits: 1 << 0 }, // type + definition
+  "function.definition": { typeIndex: 2, modifierBits: 1 << 0 }, // function + definition
+  module: { typeIndex: 8, modifierBits: 0 }, // namespace
 
   // Fields and variables
-  "variable.field":     { typeIndex: 4, modifierBits: 0 },        // property
-  "variable":           { typeIndex: 3, modifierBits: 0 },        // variable
+  "variable.field": { typeIndex: 4, modifierBits: 0 }, // property
+  variable: { typeIndex: 3, modifierBits: 0 }, // variable
 
   // Types
-  "type":               { typeIndex: 1, modifierBits: 0 },
+  type: { typeIndex: 1, modifierBits: 0 },
 
   // Metadata / decorators
-  "attribute":          { typeIndex: 7, modifierBits: 0 },        // decorator
+  attribute: { typeIndex: 7, modifierBits: 0 }, // decorator
 
   // Strings
-  "string":             { typeIndex: 5, modifierBits: 0 },
-  "string.special":     { typeIndex: 5, modifierBits: 0 },
-  "string.multiline":   { typeIndex: 5, modifierBits: 0 },
-  "string.path":        { typeIndex: 5, modifierBits: 0 },
+  string: { typeIndex: 5, modifierBits: 0 },
+  "string.special": { typeIndex: 5, modifierBits: 0 },
+  "string.multiline": { typeIndex: 5, modifierBits: 0 },
+  "string.path": { typeIndex: 5, modifierBits: 0 },
 
   // Comments
-  "comment":            { typeIndex: 6, modifierBits: 0 },
-  "comment.warning":    { typeIndex: 6, modifierBits: 0 },
-  "comment.question":   { typeIndex: 6, modifierBits: 0 },
+  comment: { typeIndex: 6, modifierBits: 0 },
+  "comment.warning": { typeIndex: 6, modifierBits: 0 },
+  "comment.question": { typeIndex: 6, modifierBits: 0 },
 
   // Constants (enum values, map keys/values, builtins)
-  "constant":           { typeIndex: 10, modifierBits: 0 },       // enumMember
-  "constant.builtin":   { typeIndex: 10, modifierBits: 1 << 3 },  // enumMember + defaultLibrary
+  constant: { typeIndex: 10, modifierBits: 0 }, // enumMember
+  "constant.builtin": { typeIndex: 10, modifierBits: 1 << 3 }, // enumMember + defaultLibrary
 
   // Operators / punctuation
-  "operator":           { typeIndex: 9, modifierBits: 0 },
-  "punctuation.bracket":{ typeIndex: 9, modifierBits: 0 },
-  "punctuation.delimiter":{ typeIndex: 9, modifierBits: 0 },
+  operator: { typeIndex: 9, modifierBits: 0 },
+  "punctuation.bracket": { typeIndex: 9, modifierBits: 0 },
+  "punctuation.delimiter": { typeIndex: 9, modifierBits: 0 },
 };
 
 // ---------- Query loading ----------
@@ -111,7 +111,8 @@ export function setHighlightsSource(source: string): void {
 
 function getHighlightsQuery(): Query {
   if (_query) return _query;
-  if (!_highlightsSource) throw new Error("highlights.scm not loaded — call setHighlightsSource() first");
+  if (!_highlightsSource)
+    throw new Error("highlights.scm not loaded — call setHighlightsSource() first");
   const language = getLanguage();
   _query = createQuery(language, _highlightsSource);
   return _query;
@@ -222,7 +223,10 @@ function collectNlRefNodes(root: SyntaxNode): Set<string> {
     if (cursor.gotoFirstChild()) continue;
     if (cursor.gotoNextSibling()) continue;
     while (true) {
-      if (!cursor.gotoParent()) { reachedRoot = true; break; }
+      if (!cursor.gotoParent()) {
+        reachedRoot = true;
+        break;
+      }
       if (cursor.gotoNextSibling()) break;
     }
   } while (!reachedRoot);
@@ -232,19 +236,16 @@ function collectNlRefNodes(root: SyntaxNode): Set<string> {
 
 /** Segment type for split string tokenisation. */
 interface Segment {
-  offset: number;    // byte offset within node text
+  offset: number; // byte offset within node text
   length: number;
-  isRef: boolean;    // true = @ref (variable), false = string
+  isRef: boolean; // true = @ref (variable), false = string
 }
 
 /**
  * For an nl_string or multiline_string that contains @refs,
  * emit interleaved string and variable tokens instead of one big string token.
  */
-function emitSplitStringTokens(
-  node: SyntaxNode,
-  builder: SemanticTokensBuilder,
-): void {
+function emitSplitStringTokens(node: SyntaxNode, builder: SemanticTokensBuilder): void {
   const text = node.text;
   const startRow = node.startPosition.row;
   const startCol = node.startPosition.column;
@@ -282,9 +283,9 @@ function emitSplitStringTokens(
   }
 
   // Emit each segment, splitting across lines as needed
-  const nlRefBit = 1 << 4;  // nlRef modifier bitmask
+  const nlRefBit = 1 << 4; // nlRef modifier bitmask
   for (const seg of segments) {
-    const typeIndex = seg.isRef ? 3 : 5;  // variable or string
+    const typeIndex = seg.isRef ? 3 : 5; // variable or string
     const modBits = seg.isRef ? nlRefBit : 0;
     const segText = text.slice(seg.offset, seg.offset + seg.length);
     const segLines = segText.split("\n");
@@ -292,7 +293,10 @@ function emitSplitStringTokens(
     // Find starting line for this segment
     let segLineIdx = 0;
     for (let l = lineOffsets.length - 1; l >= 0; l--) {
-      if (seg.offset >= lineOffsets[l]!) { segLineIdx = l; break; }
+      if (seg.offset >= lineOffsets[l]!) {
+        segLineIdx = l;
+        break;
+      }
     }
 
     for (let i = 0; i < segLines.length; i++) {

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -321,13 +321,7 @@ connection.onPrepareRename((params) => {
   const uri = params.textDocument.uri;
   const tree = trees.get(uri);
   if (!tree) return null;
-  return prepareRename(
-    tree,
-    params.position.line,
-    params.position.character,
-    uri,
-    scopeIndex(uri),
-  );
+  return prepareRename(tree, params.position.line, params.position.character, uri, scopeIndex(uri));
 });
 
 connection.onRenameRequest((params) => {
@@ -371,14 +365,11 @@ connection.onRequest("satsuma/blockNames", () => {
 });
 
 /** Return the VizModel for a document (for mapping visualization). */
-connection.onRequest(
-  "satsuma/vizModel",
-  (params: { uri: string }) => {
-    const tree = trees.get(params.uri);
-    if (!tree) return null;
-    return buildVizModel(params.uri, tree, scopeIndex(params.uri));
-  },
-);
+connection.onRequest("satsuma/vizModel", (params: { uri: string }) => {
+  const tree = trees.get(params.uri);
+  if (!tree) return null;
+  return buildVizModel(params.uri, tree, scopeIndex(params.uri));
+});
 
 /**
  * Return a merged VizModel spanning the full transitive lineage reachable from
@@ -388,12 +379,9 @@ connection.onRequest(
  * open in any editor are parsed straight from disk, so the lineage really is
  * the full import closure, not just the open tabs (sl-mg63).
  */
-connection.onRequest(
-  "satsuma/vizFullLineage",
-  (params: { uri: string }) => {
-    return computeFullLineage(params.uri, wsIndex, (uri) => trees.get(uri) ?? parseTreeFromDisk(uri));
-  },
-);
+connection.onRequest("satsuma/vizFullLineage", (params: { uri: string }) => {
+  return computeFullLineage(params.uri, wsIndex, (uri) => trees.get(uri) ?? parseTreeFromDisk(uri));
+});
 
 /** Return linked file URIs for cross-file lineage expansion in the viz. */
 connection.onRequest(
@@ -413,34 +401,28 @@ connection.onRequest(
 );
 
 /** Return field locations for a schema/fragment (for coverage decorations). */
-connection.onRequest(
-  "satsuma/fieldLocations",
-  (params: { name: string }) => {
-    const defs = resolveDefinition(wsIndex, params.name, null);
-    if (defs.length === 0) return [];
-    const def = defs[0]!;
-    const result: { name: string; uri: string; line: number }[] = [];
-    function collect(fields: typeof def.fields, prefix: string): void {
-      for (const f of fields) {
-        const dotPath = prefix ? `${prefix}.${f.name}` : f.name;
-        result.push({ name: dotPath, uri: def.uri, line: f.range.start.line });
-        if (f.children.length > 0) collect(f.children, dotPath);
-      }
+connection.onRequest("satsuma/fieldLocations", (params: { name: string }) => {
+  const defs = resolveDefinition(wsIndex, params.name, null);
+  if (defs.length === 0) return [];
+  const def = defs[0]!;
+  const result: { name: string; uri: string; line: number }[] = [];
+  function collect(fields: typeof def.fields, prefix: string): void {
+    for (const f of fields) {
+      const dotPath = prefix ? `${prefix}.${f.name}` : f.name;
+      result.push({ name: dotPath, uri: def.uri, line: f.range.start.line });
+      if (f.children.length > 0) collect(f.children, dotPath);
     }
-    collect(def.fields, "");
-    return result;
-  },
-);
+  }
+  collect(def.fields, "");
+  return result;
+});
 
 /** Return per-field coverage for both source and target schemas of a mapping. */
-connection.onRequest(
-  "satsuma/mappingCoverage",
-  (params: { uri: string; mappingName: string }) => {
-    const tree = trees.get(params.uri);
-    if (!tree) return { schemas: [] };
-    return computeMappingCoverage(params.uri, tree, params.mappingName, scopeIndex(params.uri));
-  },
-);
+connection.onRequest("satsuma/mappingCoverage", (params: { uri: string; mappingName: string }) => {
+  const tree = trees.get(params.uri);
+  if (!tree) return { schemas: [] };
+  return computeMappingCoverage(params.uri, tree, params.mappingName, scopeIndex(params.uri));
+});
 
 connection.onRequest(
   "satsuma/actionContext",
@@ -497,9 +479,7 @@ function sendMergedDiagnostics(uri: string, tree: Tree): void {
   // Deduplicate: core semantic diagnostics may overlap with CLI validate
   // diagnostics. Use rule + line as the dedup key, preferring CLI results
   // (they may have more precise position data from full file parsing).
-  const validateKeys = new Set(
-    validateDiags.map((d) => `${d.code}:${d.range.start.line}`),
-  );
+  const validateKeys = new Set(validateDiags.map((d) => `${d.code}:${d.range.start.line}`));
   const dedupedSemanticDiags = semanticDiags.filter(
     (d) => !validateKeys.has(`${d.code}:${d.range.start.line}`),
   );
@@ -508,11 +488,7 @@ function sendMergedDiagnostics(uri: string, tree: Tree): void {
   // diagnostic conversion and freezes all diagnostics for the file (sl-sme1).
   connection.sendDiagnostics({
     uri,
-    diagnostics: ensureNonEmptyMessages([
-      ...parseDiags,
-      ...validateDiags,
-      ...dedupedSemanticDiags,
-    ]),
+    diagnostics: ensureNonEmptyMessages([...parseDiags, ...validateDiags, ...dedupedSemanticDiags]),
   });
 }
 

--- a/tooling/satsuma-lsp/src/symbols.ts
+++ b/tooling/satsuma-lsp/src/symbols.ts
@@ -1,7 +1,4 @@
-import {
-  DocumentSymbol,
-  SymbolKind,
-} from "vscode-languageserver";
+import { DocumentSymbol, SymbolKind } from "vscode-languageserver";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, stringText } from "./parser-utils";
 import { fieldNameText, isMetricSchema } from "@satsuma/core";
@@ -109,7 +106,9 @@ function fieldSymbols(body: SyntaxNode): DocumentSymbol[] {
     const isNested = nestedBody !== null;
     const isList = fieldNode.children.some((c) => c.type === "list_of");
     const isRecord = fieldNode.children.some(
-      (c) => c.type === "record" || (c.type === "list_of" && fieldNode.children.some((d) => d.type === "record")),
+      (c) =>
+        c.type === "record" ||
+        (c.type === "list_of" && fieldNode.children.some((d) => d.type === "record")),
     );
 
     let detail: string | undefined;

--- a/tooling/satsuma-lsp/src/validate-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/validate-diagnostics.ts
@@ -1,9 +1,4 @@
-import {
-  Diagnostic,
-  DiagnosticSeverity,
-  Range,
-  Position,
-} from "vscode-languageserver";
+import { Diagnostic, DiagnosticSeverity, Range, Position } from "vscode-languageserver";
 import { execFile } from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { canonicalizeFileUri } from "./workspace-index";
@@ -103,10 +98,7 @@ export async function runValidate(
             const col = Math.max(0, entry.column - 1);
 
             const diag: Diagnostic = {
-              range: Range.create(
-                Position.create(line, col),
-                Position.create(line, col),
-              ),
+              range: Range.create(Position.create(line, col), Position.create(line, col)),
               severity: SEVERITY_MAP[entry.severity] ?? DiagnosticSeverity.Warning,
               source: "satsuma-validate",
               code: entry.rule,

--- a/tooling/satsuma-lsp/src/web-tree-sitter.d.ts
+++ b/tooling/satsuma-lsp/src/web-tree-sitter.d.ts
@@ -44,7 +44,11 @@ declare module "web-tree-sitter" {
     constructor();
     delete(): void;
     setLanguage(language: Language | null): this;
-    parse(input: string | ParseCallback, oldTree?: Tree | null, options?: ParseOptions): Tree | null;
+    parse(
+      input: string | ParseCallback,
+      oldTree?: Tree | null,
+      options?: ParseOptions,
+    ): Tree | null;
     reset(): void;
     getIncludedRanges(): Range[];
     getTimeoutMicros(): number;

--- a/tooling/satsuma-lsp/test/action-context.test.js
+++ b/tooling/satsuma-lsp/test/action-context.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { computeActionContext } = require("../dist/action-context");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 function contextAt(source, line, col) {
   const uri = "file:///workspace/test.stm";

--- a/tooling/satsuma-lsp/test/codelens.test.js
+++ b/tooling/satsuma-lsp/test/codelens.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { computeCodeLenses } = require("../dist/codelens");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 function buildIndex(files) {
   const idx = createWorkspaceIndex();
@@ -58,7 +60,8 @@ describe("computeCodeLenses", () => {
     const result = lenses(
       {
         "file:///a.stm": "schema customers {\n  id UUID\n}",
-        "file:///b.stm": "mapping `self` {\n  source { customers }\n  target { customers }\n  id -> id\n}",
+        "file:///b.stm":
+          "mapping `self` {\n  source { customers }\n  target { customers }\n  id -> id\n}",
       },
       "file:///a.stm",
     );
@@ -69,16 +72,15 @@ describe("computeCodeLenses", () => {
   });
 
   it("adds clickable lineage actions for schemas", () => {
-    const result = lenses(
-      { "file:///a.stm": "schema customers {\n  id UUID\n}" },
-      "file:///a.stm",
-    );
+    const result = lenses({ "file:///a.stm": "schema customers {\n  id UUID\n}" }, "file:///a.stm");
     const lineageFrom = result.find((lens) => lens.command.title === "Lineage from");
     const lineageTo = result.find((lens) => lens.command.title === "Lineage to");
 
     assert.ok(lineageFrom);
     assert.equal(lineageFrom.command.command, "satsuma.showLineage");
-    assert.deepEqual(lineageFrom.command.arguments, [{ schemaName: "customers", direction: "from" }]);
+    assert.deepEqual(lineageFrom.command.arguments, [
+      { schemaName: "customers", direction: "from" },
+    ]);
 
     assert.ok(lineageTo);
     assert.equal(lineageTo.command.command, "satsuma.showLineage");
@@ -151,9 +153,7 @@ mapping \`test\` {
       },
       "file:///a.stm",
     );
-    const transformLens = result.find((l) =>
-      l.command.title.includes("used in"),
-    );
+    const transformLens = result.find((l) => l.command.title.includes("used in"));
     assert.ok(transformLens);
   });
 
@@ -174,10 +174,7 @@ mapping \`test\` {
   });
 
   it("lens range points to block label", () => {
-    const result = lenses(
-      { "file:///a.stm": "schema customers {\n  id UUID\n}" },
-      "file:///a.stm",
-    );
+    const result = lenses({ "file:///a.stm": "schema customers {\n  id UUID\n}" }, "file:///a.stm");
     assert.equal(result.length, 3);
     assert.equal(result[0].range.start.line, 0);
   });

--- a/tooling/satsuma-lsp/test/completion.test.js
+++ b/tooling/satsuma-lsp/test/completion.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { computeCompletions } = require("../dist/completion");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 function buildIndex(files) {
   const idx = createWorkspaceIndex();
@@ -231,15 +233,17 @@ mapping \`test\` {
     // be confusing because schemas are not callable in a pipe.
     const items = complete(
       {
-        "file:///a.stm":
-          "schema customers { id UUID }\ntransform `clean` {\n  trim | lowercase\n}",
+        "file:///a.stm": "schema customers { id UUID }\ntransform `clean` {\n  trim | lowercase\n}",
       },
       "file:///a.stm",
       2,
       10,
     );
     const labels = items.map((i) => i.label);
-    assert.ok(labels.includes("trim"), "expected pipe-chain context to surface transform functions");
+    assert.ok(
+      labels.includes("trim"),
+      "expected pipe-chain context to surface transform functions",
+    );
     assert.ok(!labels.includes("customers"), "schema names must not leak into pipe completions");
   });
 
@@ -264,8 +268,7 @@ mapping \`test\` {
     // block names; namespace-qualified blocks should be discoverable too.
     const items = complete(
       {
-        "file:///defs.stm":
-          "namespace crm {\n  schema customers { id UUID }\n}\n",
+        "file:///defs.stm": "namespace crm {\n  schema customers { id UUID }\n}\n",
         "file:///entry.stm": 'import { c } from "defs.stm"',
       },
       "file:///entry.stm",
@@ -285,8 +288,7 @@ mapping \`test\` {
     // of detectCompletionContext.
     const items = complete(
       {
-        "file:///a.stm":
-          `schema src {
+        "file:///a.stm": `schema src {
   id UUID
   name VARCHAR
 }
@@ -325,7 +327,10 @@ mapping \`m\` {
       12,
     );
     assert.ok(items.length >= 2);
-    assert.ok(items.every((i) => i.kind === 7), "every schema completion must use CompletionItemKind.Class");
+    assert.ok(
+      items.every((i) => i.kind === 7),
+      "every schema completion must use CompletionItemKind.Class",
+    );
   });
 
   // ── MISSING-node (parser recovery) cases ─────────────────────────────────────

--- a/tooling/satsuma-lsp/test/coverage.test.js
+++ b/tooling/satsuma-lsp/test/coverage.test.js
@@ -14,7 +14,9 @@ const { initTestParser, parse } = require("./helper");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 const { computeMappingCoverage } = require("../dist/coverage");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Run computeMappingCoverage on a single-file source text. */
 function coverage(source, mappingName, uri = "file:///test.stm") {
@@ -45,7 +47,10 @@ describe("LSP coverage adapter", () => {
     const result = coverage(SRC, "load");
     assert.deepEqual(
       result.schemas.map((s) => [s.role, s.schemaId]),
-      [["source", "src"], ["target", "tgt"]],
+      [
+        ["source", "src"],
+        ["target", "tgt"],
+      ],
     );
   });
 
@@ -80,7 +85,11 @@ mapping load {
     const source = coverage(src, "load").schemas.find((s) => s.role === "source");
     assert.deepEqual(
       source.fields.map((f) => [f.path, f.mapped]),
-      [["address", true], ["address.line1", true], ["address.line2", false]],
+      [
+        ["address", true],
+        ["address.line1", true],
+        ["address.line2", false],
+      ],
     );
   });
 });

--- a/tooling/satsuma-lsp/test/definition.test.js
+++ b/tooling/satsuma-lsp/test/definition.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { computeDefinition } = require("../dist/definition");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Build an index from { uri: source } and return { index, trees }. */
 function buildIndex(files) {
@@ -130,7 +132,8 @@ schema customers {
     const result = definition(
       {
         "file:///a.stm": "schema customers {\n  id UUID\n}",
-        "file:///b.stm": "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+        "file:///b.stm":
+          "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
       },
       "file:///b.stm",
       1,
@@ -183,7 +186,8 @@ mapping \`test\` {
   it("returns null for unresolvable reference", () => {
     const result = definition(
       {
-        "file:///a.stm": "mapping `test` {\n  source { nonexistent }\n  target { dim }\n  id -> id\n}",
+        "file:///a.stm":
+          "mapping `test` {\n  source { nonexistent }\n  target { dim }\n  id -> id\n}",
       },
       "file:///a.stm",
       1,

--- a/tooling/satsuma-lsp/test/diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/diagnostics.test.js
@@ -3,7 +3,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { computeDiagnostics } = require("../dist/diagnostics");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 describe("computeDiagnostics", () => {
   it("returns empty diagnostics for valid input", () => {

--- a/tooling/satsuma-lsp/test/field-locations.test.js
+++ b/tooling/satsuma-lsp/test/field-locations.test.js
@@ -10,7 +10,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { createWorkspaceIndex, indexFile, resolveDefinition } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Mimic the fieldLocations handler logic: recursively flatten FieldInfo tree. */
 function flattenFields(fields, prefix = "") {
@@ -44,7 +46,10 @@ schema orders {
 
   it("returns all top-level fields", () => {
     const locs = fieldLocations(SRC, "orders");
-    assert.deepEqual(locs.map(l => l.name), ["id", "amount", "status"]);
+    assert.deepEqual(
+      locs.map((l) => l.name),
+      ["id", "amount", "status"],
+    );
   });
 
   it("returns correct line numbers", () => {
@@ -70,7 +75,7 @@ schema customer {
 
   it("includes nested record fields with dotted paths", () => {
     const locs = fieldLocations(SRC, "customer");
-    const names = locs.map(l => l.name);
+    const names = locs.map((l) => l.name);
     assert.ok(names.includes("address"), "should include 'address'");
     assert.ok(names.includes("address.street"), "should include 'address.street'");
     assert.ok(names.includes("address.city"), "should include 'address.city'");
@@ -79,14 +84,14 @@ schema customer {
 
   it("includes top-level fields alongside nested ones", () => {
     const locs = fieldLocations(SRC, "customer");
-    const names = locs.map(l => l.name);
+    const names = locs.map((l) => l.name);
     assert.ok(names.includes("id"), "should include 'id'");
     assert.ok(names.includes("name"), "should include 'name'");
   });
 
   it("returns fields in tree-order (parent before children)", () => {
     const locs = fieldLocations(SRC, "customer");
-    const names = locs.map(l => l.name);
+    const names = locs.map((l) => l.name);
     const addressIdx = names.indexOf("address");
     const streetIdx = names.indexOf("address.street");
     assert.ok(addressIdx < streetIdx, "parent field should come before child");
@@ -107,7 +112,7 @@ schema invoice {
 
   it("includes nested list_of record fields", () => {
     const locs = fieldLocations(SRC, "invoice");
-    const names = locs.map(l => l.name);
+    const names = locs.map((l) => l.name);
     assert.ok(names.includes("line_items.product_id"), "should include 'line_items.product_id'");
     assert.ok(names.includes("line_items.quantity"), "should include 'line_items.quantity'");
     assert.ok(names.includes("line_items.unit_price"), "should include 'line_items.unit_price'");

--- a/tooling/satsuma-lsp/test/folding.test.js
+++ b/tooling/satsuma-lsp/test/folding.test.js
@@ -3,7 +3,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { computeFoldingRanges } = require("../dist/folding");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 describe("computeFoldingRanges", () => {
   it("returns fold ranges for schema blocks", () => {
@@ -34,8 +36,13 @@ mapping \`baz\` {
 }`);
     const ranges = computeFoldingRanges(tree);
     // At least 3 top-level blocks
-    const topLevelFolds = ranges.filter((r) => r.startLine === 0 || r.startLine === 4 || r.startLine === 8);
-    assert.ok(topLevelFolds.length >= 3, `Expected 3+ top-level folds, got ${topLevelFolds.length}`);
+    const topLevelFolds = ranges.filter(
+      (r) => r.startLine === 0 || r.startLine === 4 || r.startLine === 8,
+    );
+    assert.ok(
+      topLevelFolds.length >= 3,
+      `Expected 3+ top-level folds, got ${topLevelFolds.length}`,
+    );
   });
 
   it("returns fold ranges for nested structures", () => {

--- a/tooling/satsuma-lsp/test/formatting.test.js
+++ b/tooling/satsuma-lsp/test/formatting.test.js
@@ -41,7 +41,8 @@ describe("computeFormatting", () => {
   });
 
   it("handles mapping with arrows", () => {
-    const src = "mapping test {\n  source { s }\n  target { t }\n  s.x -> t.x { trim | lowercase }\n}";
+    const src =
+      "mapping test {\n  source { s }\n  target { t }\n  s.x -> t.x { trim | lowercase }\n}";
     const tree = parse(src);
     const edits = computeFormatting(tree, src);
     const result = edits.length > 0 ? edits[0].newText : src;

--- a/tooling/satsuma-lsp/test/helper.js
+++ b/tooling/satsuma-lsp/test/helper.js
@@ -10,10 +10,7 @@
 const path = require("path");
 const { initParser, getParser, getLanguage } = require("@satsuma/core");
 
-const WASM_PATH = path.resolve(
-  __dirname,
-  "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm",
-);
+const WASM_PATH = path.resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
 
 /** Initialise the WASM parser.  Must be awaited once before parse() is called. */
 async function initTestParser() {

--- a/tooling/satsuma-lsp/test/hover.test.js
+++ b/tooling/satsuma-lsp/test/hover.test.js
@@ -3,7 +3,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { computeHover } = require("../dist/hover");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Shorthand: get the markdown hover text at a position. */
 function hover(source, line, col) {
@@ -18,11 +20,7 @@ describe("computeHover", () => {
   });
 
   it("shows schema summary on block label", () => {
-    const md = hover(
-      "schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}",
-      0,
-      8,
-    );
+    const md = hover("schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}", 0, 8);
     assert.ok(md);
     assert.ok(md.includes("**schema** `customers`"));
     assert.ok(md.includes("2 field(s)"));
@@ -34,11 +32,7 @@ describe("computeHover", () => {
   it("shows the schema summary when the cursor sits at the end of the block label (sl-ogd5)", () => {
     // Word-end regression: column 16 is immediately after the final "s" of
     // "customers"; hover must resolve the label, not the following node.
-    const md = hover(
-      "schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}",
-      0,
-      16,
-    );
+    const md = hover("schema customers {\n  id UUID (pk)\n  name VARCHAR(200)\n}", 0, 16);
     assert.ok(md, "expected hover content at end-of-identifier cursor");
     assert.ok(md.includes("**schema** `customers`"));
   });
@@ -55,11 +49,7 @@ describe("computeHover", () => {
   });
 
   it("shows field info with type and parent", () => {
-    const md = hover(
-      "schema customers {\n  email VARCHAR(255) (pii)\n}",
-      1,
-      3,
-    );
+    const md = hover("schema customers {\n  email VARCHAR(255) (pii)\n}", 1, 3);
     assert.ok(md);
     assert.ok(md.includes("**field** `email`"));
     assert.ok(md.includes("Type: `VARCHAR(255)`"));
@@ -93,11 +83,7 @@ describe("computeHover", () => {
   });
 
   it("shows transform summary with body", () => {
-    const md = hover(
-      "transform clean {\n  trim | lowercase\n}",
-      0,
-      11,
-    );
+    const md = hover("transform clean {\n  trim | lowercase\n}", 0, 11);
     assert.ok(md);
     assert.ok(md.includes("**transform** `clean`"));
     assert.ok(md.includes("trim"));
@@ -162,11 +148,7 @@ describe("computeHover", () => {
   });
 
   it("shows namespace info", () => {
-    const md = hover(
-      "namespace crm {\n  schema customers {\n    id UUID\n  }\n}",
-      0,
-      11,
-    );
+    const md = hover("namespace crm {\n  schema customers {\n    id UUID\n  }\n}", 0, 11);
     assert.ok(md);
     assert.ok(md.includes("**namespace** `crm`"));
   });
@@ -198,11 +180,7 @@ describe("computeHover", () => {
   });
 
   it("handles list_of record fields", () => {
-    const md = hover(
-      "schema order {\n  items list_of record {\n    sku STRING\n  }\n}",
-      1,
-      3,
-    );
+    const md = hover("schema order {\n  items list_of record {\n    sku STRING\n  }\n}", 1, 3);
     assert.ok(md);
     assert.ok(md.includes("**field** `items`"));
     assert.ok(md.includes("Structure: `list_of record`"));

--- a/tooling/satsuma-lsp/test/parser-utils.test.js
+++ b/tooling/satsuma-lsp/test/parser-utils.test.js
@@ -12,7 +12,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { nodeAtPosition } = require("../dist/parser-utils");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 // Column reference for the fixture below (line 4):
 //   "  source { customers }"

--- a/tooling/satsuma-lsp/test/recovery.test.js
+++ b/tooling/satsuma-lsp/test/recovery.test.js
@@ -24,7 +24,9 @@ const { computeDiagnostics } = require("../dist/diagnostics");
 const { computeDocumentSymbols } = require("../dist/symbols");
 const { computeCompletions } = require("../dist/completion");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Parse `source`, index it under `uri`, and return {tree, index}. */
 function indexed(source, uri = "file:///broken.stm") {
@@ -42,7 +44,9 @@ describe("LSP error recovery — handlers on MISSING-node trees", () => {
     // collecting parse errors; it must produce a (non-empty) array.
     const { tree } = indexed("schema customers {\n  id UUID\n  name VARCHAR\n");
     let diags;
-    assert.doesNotThrow(() => { diags = computeDiagnostics(tree); });
+    assert.doesNotThrow(() => {
+      diags = computeDiagnostics(tree);
+    });
     assert.ok(Array.isArray(diags));
     assert.ok(diags.length >= 1, "an unterminated schema body should yield ≥1 parse diagnostic");
   });
@@ -63,7 +67,9 @@ mapping \`m\` {
 `,
     );
     let symbols;
-    assert.doesNotThrow(() => { symbols = computeDocumentSymbols(tree); });
+    assert.doesNotThrow(() => {
+      symbols = computeDocumentSymbols(tree);
+    });
     assert.ok(Array.isArray(symbols));
     const names = symbols.map((s) => s.name);
     assert.ok(names.includes("customers"), "well-formed schema must still appear in symbol list");

--- a/tooling/satsuma-lsp/test/references.test.js
+++ b/tooling/satsuma-lsp/test/references.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { computeReferences } = require("../dist/references");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 function buildIndex(files) {
   const idx = createWorkspaceIndex();
@@ -188,7 +190,8 @@ mapping \`a\` {
     const result = refs(
       {
         "file:///a.stm": "schema customers {\n  id UUID\n}",
-        "file:///b.stm": 'import { customers } from "a.stm"\nmapping x {\n  source { customers }\n  target { d }\n  id -> id\n}',
+        "file:///b.stm":
+          'import { customers } from "a.stm"\nmapping x {\n  source { customers }\n  target { d }\n  id -> id\n}',
       },
       "file:///a.stm",
       0,

--- a/tooling/satsuma-lsp/test/rename.test.js
+++ b/tooling/satsuma-lsp/test/rename.test.js
@@ -4,7 +4,9 @@ const { initTestParser, parse } = require("./helper");
 const { prepareRename, computeRename } = require("../dist/rename");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 function buildIndex(files) {
   const idx = createWorkspaceIndex();
@@ -22,29 +24,16 @@ describe("prepareRename", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",
     });
-    const result = prepareRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-    );
+    const result = prepareRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index);
     assert.ok(result);
     assert.equal(result.placeholder, "customers");
   });
 
   it("returns range for source ref", () => {
     const { index, trees } = buildIndex({
-      "file:///a.stm":
-        "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+      "file:///a.stm": "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
     });
-    const result = prepareRename(
-      trees["file:///a.stm"],
-      1,
-      12,
-      "file:///a.stm",
-      index,
-    );
+    const result = prepareRename(trees["file:///a.stm"], 1, 12, "file:///a.stm", index);
     assert.ok(result);
     assert.equal(result.placeholder, "customers");
   });
@@ -73,13 +62,7 @@ describe("prepareRename", () => {
       "file:///a.stm": "schema customers {\n  id UUID\n}",
     });
     // Cursor on "schema" keyword (not a renameable node)
-    const result = prepareRename(
-      trees["file:///a.stm"],
-      0,
-      2,
-      "file:///a.stm",
-      index,
-    );
+    const result = prepareRename(trees["file:///a.stm"], 0, 2, "file:///a.stm", index);
     assert.equal(result, null);
   });
 });
@@ -93,16 +76,13 @@ function applyEdits(source, edits) {
   const lines = source.split("\n");
   const sorted = [...edits].sort(
     (a, b) =>
-      b.range.start.line - a.range.start.line ||
-      b.range.start.character - a.range.start.character,
+      b.range.start.line - a.range.start.line || b.range.start.character - a.range.start.character,
   );
   for (const e of sorted) {
     assert.equal(e.range.start.line, e.range.end.line, "expected single-line edit");
     const line = lines[e.range.start.line];
     lines[e.range.start.line] =
-      line.slice(0, e.range.start.character) +
-      e.newText +
-      line.slice(e.range.end.character);
+      line.slice(0, e.range.start.character) + e.newText + line.slice(e.range.end.character);
   }
   return lines.join("\n");
 }
@@ -147,34 +127,18 @@ describe("computeRename", () => {
   it("renames schema definition and all references", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",
-      "file:///b.stm":
-        "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+      "file:///b.stm": "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
     });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "clients");
     assert.ok(edit);
     assert.ok(edit.changes);
     // Should have edits in both files
     assert.ok(edit.changes["file:///a.stm"]);
     assert.ok(edit.changes["file:///b.stm"]);
     // Definition edit
-    assert.ok(
-      edit.changes["file:///a.stm"].some(
-        (e) => e.newText === "clients",
-      ),
-    );
+    assert.ok(edit.changes["file:///a.stm"].some((e) => e.newText === "clients"));
     // Reference edit
-    assert.ok(
-      edit.changes["file:///b.stm"].some(
-        (e) => e.newText === "clients",
-      ),
-    );
+    assert.ok(edit.changes["file:///b.stm"].some((e) => e.newText === "clients"));
   });
 
   it("renames fragment and all spread sites", () => {
@@ -205,8 +169,7 @@ schema customers {
 
   it("refuses rename to existing name", () => {
     const { index, trees } = buildIndex({
-      "file:///a.stm":
-        "schema customers {\n  id UUID\n}\nschema orders {\n  id UUID\n}",
+      "file:///a.stm": "schema customers {\n  id UUID\n}\nschema orders {\n  id UUID\n}",
     });
     const edit = computeRename(
       trees["file:///a.stm"],
@@ -223,14 +186,7 @@ schema customers {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",
     });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "customers",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "customers");
     assert.equal(edit, null);
   });
 
@@ -244,14 +200,7 @@ schema customers {
       "file:///a.stm": "schema customers {\n  id UUID\n}",
       "file:///b.stm": bSource,
     });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "clients");
     assert.ok(edit);
     const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
     assert.ok(
@@ -270,14 +219,7 @@ schema customers {
       "file:///a.stm": "schema customers {\n  id UUID\n}",
       "file:///b.stm": bSource,
     });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "clients");
     assert.ok(edit);
     const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
     assert.ok(
@@ -296,19 +238,12 @@ schema customers {
     // @customers }` kept the old name after a rename while the quoted form
     // was rewritten.
     const bSource =
-      'mapping `m` {\n  source { customers }\n  target { dim }\n  a -> b { derived from @customers }\n}';
+      "mapping `m` {\n  source { customers }\n  target { dim }\n  a -> b { derived from @customers }\n}";
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",
       "file:///b.stm": bSource,
     });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "clients");
     assert.ok(edit);
     const renamed = applyEdits(bSource, edit.changes["file:///b.stm"]);
     assert.ok(
@@ -327,14 +262,7 @@ schema customers {
     const source =
       "schema address {\n  street VARCHAR\n}\nmapping `m` {\n  source { src }\n  target { dim }\n  address.street -> s\n}";
     const { index, trees } = buildIndex({ "file:///a.stm": source });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "location",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "location");
     assert.ok(edit);
     const renamed = applyEdits(source, edit.changes["file:///a.stm"]);
     assert.ok(
@@ -351,14 +279,7 @@ schema customers {
     const source =
       'schema customers {\n  id UUID\n}\nmapping `m` {\n  source { customers (note "refreshed daily") }\n  target { dim }\n  id -> id\n}';
     const { index, trees } = buildIndex({ "file:///a.stm": source });
-    const edit = computeRename(
-      trees["file:///a.stm"],
-      0,
-      8,
-      "file:///a.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///a.stm"], 0, 8, "file:///a.stm", index, "clients");
     assert.ok(edit);
     const renamed = applyEdits(source, edit.changes["file:///a.stm"]);
     assert.ok(
@@ -394,17 +315,9 @@ schema customers {
   it("renames from a reference site", () => {
     const { index, trees } = buildIndex({
       "file:///a.stm": "schema customers {\n  id UUID\n}",
-      "file:///b.stm":
-        "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
+      "file:///b.stm": "mapping `test` {\n  source { customers }\n  target { dim }\n  id -> id\n}",
     });
-    const edit = computeRename(
-      trees["file:///b.stm"],
-      1,
-      12,
-      "file:///b.stm",
-      index,
-      "clients",
-    );
+    const edit = computeRename(trees["file:///b.stm"], 1, 12, "file:///b.stm", index, "clients");
     assert.ok(edit);
     // Should still rename in both files
     assert.ok(edit.changes["file:///a.stm"]);

--- a/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/semantic-diagnostics.test.js
@@ -13,7 +13,9 @@ const {
   computeScopedSemanticDiagnostics,
 } = require("../dist/semantic-diagnostics");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Build an index from a map of { uri: source }. */
 function buildIndex(files) {
@@ -331,7 +333,10 @@ mapping m {
     const scoped = createScopedIndex(idx, getImportReachableUris("file:///c%3A/ws/a.stm", idx));
     const diags = computeCoreSemanticDiagnostics("file:///c%3A/ws/b.stm", scoped);
     const dupDiag = diags.find((d) => d.code === "duplicate-definition");
-    assert.ok(dupDiag, "expected the genuine duplicate to be reported under the alternate spelling");
+    assert.ok(
+      dupDiag,
+      "expected the genuine duplicate to be reported under the alternate spelling",
+    );
   });
 
   it("returns no diagnostics for a valid single-file workspace", () => {

--- a/tooling/satsuma-lsp/test/semantic-tokens.test.js
+++ b/tooling/satsuma-lsp/test/semantic-tokens.test.js
@@ -10,14 +10,8 @@ const {
   semanticTokensLegend,
 } = require("../dist/semantic-tokens");
 
-const WASM_PATH = path.resolve(
-  __dirname,
-  "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm",
-);
-const HIGHLIGHTS_PATH = path.resolve(
-  __dirname,
-  "../../tree-sitter-satsuma/queries/highlights.scm",
-);
+const WASM_PATH = path.resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+const HIGHLIGHTS_PATH = path.resolve(__dirname, "../../tree-sitter-satsuma/queries/highlights.scm");
 
 before(async () => {
   await initTestParser();
@@ -90,9 +84,7 @@ describe("computeSemanticTokens", () => {
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     // Find the field name token
-    const fieldToken = tokens.find(
-      (t) => t.type === "property" && t.line === 1,
-    );
+    const fieldToken = tokens.find((t) => t.type === "property" && t.line === 1);
     assert.ok(fieldToken, "should have a property token for field name");
     assert.equal(fieldToken.length, 2); // "id"
 
@@ -103,9 +95,7 @@ describe("computeSemanticTokens", () => {
   });
 
   it("tokenizes mapping keyword and label as function definition", () => {
-    const tree = parse(
-      "mapping migrate {\n  source { `s` }\n  target { `t` }\n  a -> b\n}",
-    );
+    const tree = parse("mapping migrate {\n  source { `s` }\n  target { `t` }\n  a -> b\n}");
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     const keyword = tokens.find((t) => t.type === "keyword");
@@ -145,9 +135,7 @@ describe("computeSemanticTokens", () => {
   // After Feature 28, pipe chain bare tokens are NL text, not function calls.
   // They should receive string tokens, while the block label stays function.definition.
   it("tokenizes pipe chain bare tokens as strings, not function calls", () => {
-    const tree = parse(
-      "transform clean {\n  trim | lowercase | validate_email\n}",
-    );
+    const tree = parse("transform clean {\n  trim | lowercase | validate_email\n}");
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     // 'clean' is still function.definition (block label)
@@ -164,10 +152,7 @@ describe("computeSemanticTokens", () => {
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     const keywords = tokens.filter((t) => t.type === "keyword");
-    assert.ok(
-      keywords.length >= 2,
-      "should have keyword tokens for import and from",
-    );
+    assert.ok(keywords.length >= 2, "should have keyword tokens for import and from");
   });
 
   it("tokenizes operators and punctuation", () => {
@@ -186,11 +171,7 @@ describe("computeSemanticTokens", () => {
     // Check no two tokens share the same position
     const positions = tokens.map((t) => `${t.line}:${t.col}`);
     const unique = new Set(positions);
-    assert.equal(
-      positions.length,
-      unique.size,
-      "no duplicate token positions",
-    );
+    assert.equal(positions.length, unique.size, "no duplicate token positions");
   });
 
   it("does not emit variable tokens for strings without @refs", () => {
@@ -212,9 +193,7 @@ describe("computeSemanticTokens", () => {
   });
 
   it("applies nlRef modifier to @refs in nl_string", () => {
-    const tree = parse(
-      'note { "Check @balance field." }',
-    );
+    const tree = parse('note { "Check @balance field." }');
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     const varTokens = tokens.filter((t) => t.type === "variable");
@@ -223,9 +202,7 @@ describe("computeSemanticTokens", () => {
     assert.equal(varTokens[0].mods & 16, 16, "should have nlRef modifier set");
 
     // String parts should NOT have the nlRef modifier
-    const stringTokens = tokens.filter(
-      (t) => t.type === "string" && t.line === 0 && t.col >= 7,
-    );
+    const stringTokens = tokens.filter((t) => t.type === "string" && t.line === 0 && t.col >= 7);
     for (const st of stringTokens) {
       assert.equal(st.mods & 16, 0, "string segments should not have nlRef modifier");
     }
@@ -239,9 +216,7 @@ describe("computeSemanticTokens", () => {
   });
 
   it("tokenizes @ref references inside nl_string as variable", () => {
-    const tree = parse(
-      'note { "Check @balance and @customers.email field." }',
-    );
+    const tree = parse('note { "Check @balance and @customers.email field." }');
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     const varTokens = tokens.filter((t) => t.type === "variable");
@@ -255,9 +230,7 @@ describe("computeSemanticTokens", () => {
   });
 
   it("tokenizes @ref references inside multiline_string as variable", () => {
-    const tree = parse(
-      'note {\n  """\n  Sum @orders.total and @tax fields.\n  """\n}',
-    );
+    const tree = parse('note {\n  """\n  Sum @orders.total and @tax fields.\n  """\n}');
     const tokens = decodeTokens(computeSemanticTokens(tree).data);
 
     const varTokens = tokens.filter((t) => t.type === "variable");

--- a/tooling/satsuma-lsp/test/source-scan.test.js
+++ b/tooling/satsuma-lsp/test/source-scan.test.js
@@ -37,7 +37,9 @@ describe("findSatsumaSourceFiles", () => {
   });
 
   it("finds .stm and .satsuma files at any depth (sl-v215)", () => {
-    const found = findSatsumaSourceFiles(root).map((p) => path.relative(root, p)).sort();
+    const found = findSatsumaSourceFiles(root)
+      .map((p) => path.relative(root, p))
+      .sort();
     assert.deepEqual(found, ["crm/orders.satsuma", "ingest.satsuma", "pipeline.stm"]);
   });
 
@@ -45,7 +47,10 @@ describe("findSatsumaSourceFiles", () => {
     // Dependency and VCS trees can contain .stm fixtures; indexing them would
     // pollute cross-file navigation with definitions outside the workspace.
     const found = findSatsumaSourceFiles(root);
-    assert.equal(found.some((p) => p.includes("node_modules") || p.includes(".git")), false);
+    assert.equal(
+      found.some((p) => p.includes("node_modules") || p.includes(".git")),
+      false,
+    );
   });
 
   it("returns an empty list for an unreadable or missing directory", () => {

--- a/tooling/satsuma-lsp/test/symbols.test.js
+++ b/tooling/satsuma-lsp/test/symbols.test.js
@@ -3,7 +3,9 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { computeDocumentSymbols } = require("../dist/symbols");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 // SymbolKind constants from LSP spec
 const SymbolKind = {

--- a/tooling/satsuma-lsp/test/validate-diagnostics.test.js
+++ b/tooling/satsuma-lsp/test/validate-diagnostics.test.js
@@ -30,11 +30,7 @@ describe("reconcileValidateCache", () => {
     ]);
     // The fixing save: the new run reports nothing for B any more.
     const results = new Map([["file:///a.stm", diag("new A")]]);
-    const cleared = reconcileValidateCache(
-      cache,
-      ["file:///a.stm", "file:///b.stm"],
-      results,
-    );
+    const cleared = reconcileValidateCache(cache, ["file:///a.stm", "file:///b.stm"], results);
     assert.deepEqual(cleared, ["file:///b.stm"]);
     assert.equal(cache.has("file:///b.stm"), false, "stale entry must be removed");
     assert.deepEqual(cache.get("file:///a.stm"), diag("new A"), "fresh results replace old");
@@ -91,7 +87,17 @@ describe("parseValidateFindings", () => {
 
   it("extracts findings from the {findings, summary} envelope the CLI emits today", () => {
     const raw = JSON.stringify({
-      findings: [{ file: "/a.stm", line: 3, column: 1, severity: "warning", rule: "r", message: "m", fixable: false }],
+      findings: [
+        {
+          file: "/a.stm",
+          line: 3,
+          column: 1,
+          severity: "warning",
+          rule: "r",
+          message: "m",
+          fixable: false,
+        },
+      ],
       summary: { files: 1, errors: 0, warnings: 1 },
     });
     const entries = parseValidateFindings(raw);
@@ -121,20 +127,14 @@ describe("parseValidateFindings", () => {
 describe("runValidate", () => {
   it("returns empty map when CLI produces no output", async () => {
     // Use a non-existent CLI to exercise the error/empty path
-    const result = await runValidate(
-      "file:///tmp/nonexistent.stm",
-      "/nonexistent/satsuma-cli",
-    );
+    const result = await runValidate("file:///tmp/nonexistent.stm", "/nonexistent/satsuma-cli");
     assert.ok(result instanceof Map);
     assert.equal(result.size, 0);
   });
 
   it("returns empty map when CLI produces invalid JSON", async () => {
     // echo outputs non-JSON text
-    const result = await runValidate(
-      "file:///tmp/test.stm",
-      "echo",
-    );
+    const result = await runValidate("file:///tmp/test.stm", "echo");
     assert.ok(result instanceof Map);
     assert.equal(result.size, 0);
   });
@@ -146,27 +146,33 @@ describe("runValidate", () => {
   // warehouse::conformed_store in the 'daily sales pipeline' mapping), so a
   // non-empty result is a hard requirement, not an if-guarded hope.
   it("surfaces the namespaces example's four field-not-in-schema warnings from the real CLI", async () => {
-    const fixturePath = path.resolve(
-      __dirname,
-      "../../../examples/namespaces/namespaces.stm",
-    );
+    const fixturePath = path.resolve(__dirname, "../../../examples/namespaces/namespaces.stm");
     const fixtureUri = pathToFileURL(fixturePath).toString();
 
     const result = await runValidate(fixtureUri, CLI_PATH);
 
-    assert.ok(result.size > 0, "real CLI output must produce diagnostics — empty means the JSON shapes have drifted (sl-rngq)");
+    assert.ok(
+      result.size > 0,
+      "real CLI output must produce diagnostics — empty means the JSON shapes have drifted (sl-rngq)",
+    );
 
     const all = [...result.values()].flat();
     const fieldWarnings = all.filter((d) => d.code === "field-not-in-schema");
-    assert.equal(fieldWarnings.length, 4, "the four bogus source fields must each surface as a diagnostic");
+    assert.equal(
+      fieldWarnings.length,
+      4,
+      "the four bogus source fields must each surface as a diagnostic",
+    );
     for (const d of fieldWarnings) {
       assert.equal(d.source, "satsuma-validate");
       // DiagnosticSeverity.Warning === 2
       assert.equal(d.severity, 2, "field-not-in-schema is warning severity");
       assert.match(d.message, /not declared in schema 'warehouse::conformed_store'/);
       // CLI reports lines 105-108 (1-based); LSP must convert to 0-based.
-      assert.ok(d.range.start.line >= 104 && d.range.start.line <= 107,
-        `expected 0-based line in [104,107], got ${d.range.start.line}`);
+      assert.ok(
+        d.range.start.line >= 104 && d.range.start.line <= 107,
+        `expected 0-based line in [104,107], got ${d.range.start.line}`,
+      );
     }
 
     // Diagnostics must be keyed by canonical file:// URIs so they attach to

--- a/tooling/satsuma-lsp/test/viz-full-lineage.test.js
+++ b/tooling/satsuma-lsp/test/viz-full-lineage.test.js
@@ -13,12 +13,11 @@ const { describe, it, before } = require("node:test");
 const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { computeFullLineage } = require("../dist/full-lineage");
-const {
-  createWorkspaceIndex,
-  indexFile,
-} = require("@satsuma/viz-backend");
+const { createWorkspaceIndex, indexFile } = require("@satsuma/viz-backend");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /**
  * Run computeFullLineage over an in-memory workspace. Every file's tree is
@@ -60,7 +59,10 @@ describe("satsuma/vizFullLineage — import graph traversal", () => {
   it("includes schemas from import-reachable files", () => {
     const { model } = fullLineage(FILES, "file:///entry.stm");
     const ids = model.namespaces.flatMap((g) => g.schemas.map((s) => s.id));
-    assert.ok(ids.includes("customers"), "imported schema 'customers' should appear in merged model");
+    assert.ok(
+      ids.includes("customers"),
+      "imported schema 'customers' should appear in merged model",
+    );
     assert.ok(ids.includes("orders"), "local schema 'orders' should still appear");
   });
 

--- a/tooling/satsuma-lsp/test/viz-linked-files.test.js
+++ b/tooling/satsuma-lsp/test/viz-linked-files.test.js
@@ -16,7 +16,9 @@ const {
   resolveDefinition,
 } = require("@satsuma/viz-backend");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Mirror the satsuma/vizLinkedFiles handler logic. */
 function linkedFiles(files, schemaId, currentUri) {

--- a/tooling/satsuma-lsp/test/viz-model.test.js
+++ b/tooling/satsuma-lsp/test/viz-model.test.js
@@ -18,7 +18,9 @@ const {
   buildVizModel,
 } = require("@satsuma/viz-backend");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Build a workspace from `{uri: source}` and return {index, trees}. */
 function workspace(files) {
@@ -41,10 +43,7 @@ function vizModel(files, primaryUri) {
 
 describe("satsuma/vizModel — single file", () => {
   it("returns a model whose uri matches the requested document", () => {
-    const model = vizModel(
-      { "file:///a.stm": "schema customers { id UUID }" },
-      "file:///a.stm",
-    );
+    const model = vizModel({ "file:///a.stm": "schema customers { id UUID }" }, "file:///a.stm");
     assert.equal(model.uri, "file:///a.stm");
   });
 

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -13,7 +13,9 @@ const {
   createScopedIndex,
 } = require("../dist/workspace-index");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Build an index from a map of { uri: source }. */
 function buildIndex(files) {
@@ -49,7 +51,8 @@ describe("indexFile", () => {
 
   it("indexes fragment definitions", () => {
     const idx = buildIndex({
-      "file:///a.stm": "fragment `audit fields` {\n  created_at TIMESTAMP\n  updated_at TIMESTAMP\n}",
+      "file:///a.stm":
+        "fragment `audit fields` {\n  created_at TIMESTAMP\n  updated_at TIMESTAMP\n}",
     });
     const defs = idx.definitions.get("audit fields");
     assert.ok(defs);
@@ -180,7 +183,8 @@ describe("indexFile", () => {
 
   it("indexes backtick source references", () => {
     const idx = buildIndex({
-      "file:///a.stm": "mapping `test` {\n  source { `raw_customers` }\n  target { dim_customers }\n  id -> id\n}",
+      "file:///a.stm":
+        "mapping `test` {\n  source { `raw_customers` }\n  target { dim_customers }\n  id -> id\n}",
     });
     const refs = idx.references.get("raw_customers");
     assert.ok(refs);
@@ -189,7 +193,8 @@ describe("indexFile", () => {
 
   it("indexes qualified name source references", () => {
     const idx = buildIndex({
-      "file:///a.stm": "mapping `test` {\n  source { crm::customers }\n  target { dim_customers }\n  id -> id\n}",
+      "file:///a.stm":
+        "mapping `test` {\n  source { crm::customers }\n  target { dim_customers }\n  id -> id\n}",
     });
     const refs = idx.references.get("crm::customers");
     assert.ok(refs);
@@ -376,7 +381,9 @@ describe("findReferences", () => {
   it("does not return bare refs that resolve in a different namespace (sl-p256)", () => {
     const idx = buildIndex({ "file:///a.stm": TWO_NAMESPACES });
     // b's source { foo } binds to b::foo, so a::foo has no references.
-    const aRefs = findReferences(idx, "a::foo").filter((r) => r.context === "source" || r.context === "target");
+    const aRefs = findReferences(idx, "a::foo").filter(
+      (r) => r.context === "source" || r.context === "target",
+    );
     assert.equal(aRefs.length, 0, "a::foo must not inherit namespace b's refs");
     const bRefs = findReferences(idx, "b::foo").filter((r) => r.context === "source");
     assert.equal(bRefs.length, 1, "b::foo keeps its own bare source ref");
@@ -390,7 +397,9 @@ describe("findReferences", () => {
     });
     // namespace b declares its own foo, so b's refs bind there — the global
     // schema foo is unreferenced.
-    const refs = findReferences(idx, "foo").filter((r) => r.context === "source" || r.context === "target");
+    const refs = findReferences(idx, "foo").filter(
+      (r) => r.context === "source" || r.context === "target",
+    );
     assert.equal(refs.length, 0, "shadowed bare refs must not count against the global name");
   });
 
@@ -413,7 +422,9 @@ describe("findReferences", () => {
     });
     // source { x::foo } binds to x::foo; only the bare target ref binds to
     // the global foo.
-    const refs = findReferences(idx, "foo").filter((r) => r.context === "source" || r.context === "target");
+    const refs = findReferences(idx, "foo").filter(
+      (r) => r.context === "source" || r.context === "target",
+    );
     assert.equal(refs.length, 1);
     assert.equal(refs[0].context, "target");
     const qualified = findReferences(idx, "x::foo").filter((r) => r.context === "source");
@@ -455,7 +466,8 @@ describe("getFields", () => {
 
   it("returns nested fields", () => {
     const idx = buildIndex({
-      "file:///a.stm": "schema customers {\n  address record {\n    street VARCHAR\n    city VARCHAR\n  }\n}",
+      "file:///a.stm":
+        "schema customers {\n  address record {\n    street VARCHAR\n    city VARCHAR\n  }\n}",
     });
     const fields = getFields(idx, "customers", null);
     assert.equal(fields[0].name, "address");
@@ -613,7 +625,9 @@ describe("reference range precision (sl-xf3f)", () => {
     assert.equal(textAt(source, bareRefs[0].range), "address");
     // Full-path entry is keyed without the ns:: prefix, so its range must
     // exclude the prefix too.
-    const pathRefs = (idx.references.get("address.street") || []).filter((r) => r.context === "arrow");
+    const pathRefs = (idx.references.get("address.street") || []).filter(
+      (r) => r.context === "arrow",
+    );
     assert.equal(pathRefs.length, 1);
     assert.equal(textAt(source, pathRefs[0].range), "address.street");
   });
@@ -703,7 +717,8 @@ describe("NL string reference indexing", () => {
 
   it("indexes @refs with backtick-delimited names", () => {
     const idx = buildIndex({
-      "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  -> name { \"Use @`first name` here\" }\n}",
+      "file:///a.stm":
+        'mapping test {\n  source { customers }\n  target { dim }\n  -> name { "Use @`first name` here" }\n}',
     });
     const refs = (idx.references.get("first name") || []).filter((r) => r.context === "nl");
     assert.ok(refs.length >= 1, "expected nl ref for @`first name`");
@@ -797,7 +812,7 @@ describe("NL string reference indexing", () => {
   // find-references/rename skipped bare-text refs entirely.
 
   it("indexes a bare @ref in unquoted pipe text, range excluding the @ sigil", () => {
-    const line = '  a -> b { derived from @customers }';
+    const line = "  a -> b { derived from @customers }";
     const source = `mapping test {\n  source { customers }\n  target { dim }\n${line}\n}`;
     const idx = buildIndex({ "file:///a.stm": source });
     const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
@@ -813,7 +828,8 @@ describe("NL string reference indexing", () => {
     // Backtick delimiters are stripped from the keyed name, mirroring the
     // quoted-string regex path, so lookups by the plain name find it.
     const idx = buildIndex({
-      "file:///a.stm": "mapping test {\n  source { customers }\n  target { dim }\n  a -> b { lookup @`order id` }\n}",
+      "file:///a.stm":
+        "mapping test {\n  source { customers }\n  target { dim }\n  a -> b { lookup @`order id` }\n}",
     });
     const refs = (idx.references.get("order id") || []).filter((r) => r.context === "nl");
     assert.equal(refs.length, 1);
@@ -823,7 +839,8 @@ describe("NL string reference indexing", () => {
 describe("transform spread indexing in arrows", () => {
   it("indexes transform spread references in arrows", () => {
     const idx = buildIndex({
-      "file:///a.stm": "transform `clean email` {\n  trim | lowercase\n}\nmapping test {\n  source { customers }\n  target { dim }\n  email -> email { ...`clean email` }\n}",
+      "file:///a.stm":
+        "transform `clean email` {\n  trim | lowercase\n}\nmapping test {\n  source { customers }\n  target { dim }\n  email -> email { ...`clean email` }\n}",
     });
     const refs = idx.references.get("clean email");
     assert.ok(refs);

--- a/tooling/satsuma-viz-backend/src/parser-utils.ts
+++ b/tooling/satsuma-viz-backend/src/parser-utils.ts
@@ -11,17 +11,8 @@
 // than the top-level vscode-languageserver, whose JSON-RPC server pulls in
 // Node-only modules. This keeps the package bundleable for --platform=browser
 // (feature 33: the playground runs this code in the browser).
-import {
-  Position,
-  Range,
-} from "vscode-languageserver-types";
-import {
-  child,
-  children,
-  labelText,
-  stringText,
-  walkDescendants,
-} from "@satsuma/core";
+import { Position, Range } from "vscode-languageserver-types";
+import { child, children, labelText, stringText, walkDescendants } from "@satsuma/core";
 import type { SyntaxNode } from "@satsuma/core";
 
 export type { SyntaxNode, Tree } from "@satsuma/core";

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -78,11 +78,7 @@ import { CONSTRAINT_TAGS } from "@satsuma/viz-model";
 
 // ---------- VizModel builder ----------
 
-export function buildVizModel(
-  uri: string,
-  tree: Tree,
-  wsIndex: WorkspaceIndex,
-): VizModel {
+export function buildVizModel(uri: string, tree: Tree, wsIndex: WorkspaceIndex): VizModel {
   const root = tree.rootNode;
   const fileNotes: NoteBlock[] = [];
   const globalNs: NamespaceGroup = {
@@ -342,10 +338,7 @@ function expandedFieldToEntry(decl: FieldDecl): FieldEntry {
 
 // ---------- Top-level processing ----------
 
-function getOrCreateNamespace(
-  map: Map<string, NamespaceGroup>,
-  name: string,
-): NamespaceGroup {
+function getOrCreateNamespace(map: Map<string, NamespaceGroup>, name: string): NamespaceGroup {
   let ns = map.get(name);
   if (!ns) {
     ns = { name, schemas: [], mappings: [], metrics: [], fragments: [] };
@@ -422,11 +415,7 @@ function collectTopLevelComments(
 
 /** Attach each standalone //! and //? among `siblings` to the nearest
  *  preceding block found in `group`. */
-function collectSiblingComments(
-  uri: string,
-  siblings: SyntaxNode[],
-  group: NamespaceGroup,
-): void {
+function collectSiblingComments(uri: string, siblings: SyntaxNode[], group: NamespaceGroup): void {
   for (let i = 0; i < siblings.length; i++) {
     const node = siblings[i]!;
     if (node.type !== "warning_comment" && node.type !== "question_comment") {
@@ -637,11 +626,7 @@ function extractFieldEntries(uri: string, body: SyntaxNode): FieldEntry[] {
  * Convert a core FieldDecl to a viz FieldEntry, enriching with CST-derived
  * notes, comments, constraints, and location from the parallel CST node.
  */
-function fieldDeclToEntry(
-  decl: FieldDecl,
-  uri: string,
-  cstNode: SyntaxNode | null,
-): FieldEntry {
+function fieldDeclToEntry(decl: FieldDecl, uri: string, cstNode: SyntaxNode | null): FieldEntry {
   // Derive constraints from core's metadata entries
   const constraints = extractConstraintsFromMeta(decl.metadata ?? []);
 
@@ -694,31 +679,43 @@ function extractConstraintsFromMeta(entries: MetaEntry[]): string[] {
   return constraints;
 }
 
-
 // ---------- Mapping extraction ----------
 
 /** Build a DefinitionLookup from the LSP WorkspaceIndex for NL @-ref resolution. */
 function makeVizLookup(wsIndex: WorkspaceIndex): DefinitionLookup {
   return {
-    hasSchema: (key) => (wsIndex.definitions.get(key)?.some((d) => d.kind === "schema") ?? false),
+    hasSchema: (key) => wsIndex.definitions.get(key)?.some((d) => d.kind === "schema") ?? false,
     getSchema: (key) => {
       const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "schema");
       if (!def) return null;
-      return { fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })), hasSpreads: false };
+      return {
+        fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+        hasSpreads: false,
+      };
     },
-    hasFragment: (key) => (wsIndex.definitions.get(key)?.some((d) => d.kind === "fragment") ?? false),
+    hasFragment: (key) => wsIndex.definitions.get(key)?.some((d) => d.kind === "fragment") ?? false,
     getFragment: (key) => {
       const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "fragment");
       if (!def) return null;
-      return { fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })), hasSpreads: false };
+      return {
+        fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+        hasSpreads: false,
+      };
     },
-    hasTransform: (key) => (wsIndex.definitions.get(key)?.some((d) => d.kind === "transform") ?? false),
+    hasTransform: (key) =>
+      wsIndex.definitions.get(key)?.some((d) => d.kind === "transform") ?? false,
     getMapping: () => null,
     iterateSchemas: function* () {
       for (const [key, defs] of wsIndex.definitions) {
         const schemaDef = defs.find((d) => d.kind === "schema");
         if (schemaDef) {
-          yield [key, { fields: schemaDef.fields.map((f) => ({ name: f.name, type: f.type ?? "" })), hasSpreads: false }] as [string, { fields: { name: string; type: string }[]; hasSpreads: boolean }];
+          yield [
+            key,
+            {
+              fields: schemaDef.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+              hasSpreads: false,
+            },
+          ] as [string, { fields: { name: string; type: string }[]; hasSpreads: boolean }];
         }
       }
     },
@@ -768,9 +765,7 @@ function resolveMappingRef(
   if (!schemaDef) return refName;
 
   // Qualify with the definition's namespace if it has one
-  return schemaDef.namespace
-    ? `${schemaDef.namespace}::${refName}`
-    : refName;
+  return schemaDef.namespace ? `${schemaDef.namespace}::${refName}` : refName;
 }
 
 /**
@@ -820,7 +815,7 @@ function extractMapping(
           sourceBlock = extractSourceBlock(ch);
           if (sourceBlock.schemas.length > 0) {
             const resolvedSchemas = sourceBlock.schemas.map((ref) =>
-              resolveMappingRef(ref, namespace, wsIndex)
+              resolveMappingRef(ref, namespace, wsIndex),
             );
             sourceBlock = { ...sourceBlock, schemas: resolvedSchemas };
             sourceRefs.push(...resolvedSchemas);
@@ -865,7 +860,13 @@ function extractMapping(
   const targets = targetRef ? [targetRef] : [];
   for (const arrow of arrows) {
     if (arrow.transform && arrow.transform.kind === "nl") {
-      const atRefs = resolveTransformAtRefs(arrow.transform, sourceRefs, targets, namespace, wsIndex);
+      const atRefs = resolveTransformAtRefs(
+        arrow.transform,
+        sourceRefs,
+        targets,
+        namespace,
+        wsIndex,
+      );
       if (atRefs.length > 0) arrow.transform.atRefs = atRefs;
     }
   }
@@ -910,7 +911,12 @@ function extractSourceBlock(node: SyntaxNode): SourceBlockInfo {
     if (ch.type === "source_ref") {
       // An NL string inside a source_ref is a join description, not a schema name
       const nlChild = child(ch, "nl_string") ?? child(ch, "multiline_string");
-      if (nlChild && !child(ch, "identifier") && !child(ch, "backtick_name") && !child(ch, "qualified_name")) {
+      if (
+        nlChild &&
+        !child(ch, "identifier") &&
+        !child(ch, "backtick_name") &&
+        !child(ch, "qualified_name")
+      ) {
         joinDescription = stringText(nlChild);
       } else {
         const name = sourceRefText(ch);
@@ -1023,7 +1029,12 @@ interface NestedBlockContents {
 }
 
 function extractNestedBlockContents(uri: string, node: SyntaxNode): NestedBlockContents {
-  const contents: NestedBlockContents = { arrows: [], nestedEach: [], nestedFlatten: [], nestedArrows: [] };
+  const contents: NestedBlockContents = {
+    arrows: [],
+    nestedEach: [],
+    nestedFlatten: [],
+    nestedArrows: [],
+  };
 
   for (const ch of node.namedChildren) {
     if (ch.type === "map_arrow") {
@@ -1120,11 +1131,7 @@ function extractNestedArrowBlock(uri: string, node: SyntaxNode): NestedArrowBloc
  * which is why metric fields go through `extractMetricFields` instead of the
  * normal `extractFieldEntries` path.
  */
-function extractMetric(
-  uri: string,
-  node: SyntaxNode,
-  namespace: string | null,
-): MetricCard {
+function extractMetric(uri: string, node: SyntaxNode, namespace: string | null): MetricCard {
   const name = labelText(node) ?? "unknown";
   const qualifiedId = namespace ? `${namespace}::${name}` : name;
   const meta = child(node, "metadata_block");
@@ -1136,10 +1143,7 @@ function extractMetric(
   let label: string | null = null;
   if (meta) {
     for (const ch of meta.namedChildren) {
-      if (
-        ch.type === "tag_with_value" &&
-        ch.namedChildren[0]?.text === "metric_name"
-      ) {
+      if (ch.type === "tag_with_value" && ch.namedChildren[0]?.text === "metric_name") {
         const val = ch.namedChildren[1];
         const strNode = val?.namedChildren.find(
           (c) => c.type === "nl_string" || c.type === "multiline_string",
@@ -1156,7 +1160,13 @@ function extractMetric(
   let filter: string | null = null;
 
   if (meta) {
-    extractMetricMetadata(meta, source, slices, (g) => (grain = g), (f) => (filter = f));
+    extractMetricMetadata(
+      meta,
+      source,
+      slices,
+      (g) => (grain = g),
+      (f) => (filter = f),
+    );
   }
 
   return {
@@ -1284,9 +1294,7 @@ function extractMetricFields(uri: string, body: SyntaxNode): MetricFieldEntry[] 
  * is still treated as a measure; `null` is reserved for fields that have no
  * `measure` tag at all (i.e. dimension fields).
  */
-function extractMeasure(
-  meta: SyntaxNode,
-): MetricFieldEntry["measure"] {
+function extractMeasure(meta: SyntaxNode): MetricFieldEntry["measure"] {
   for (const ch of meta.namedChildren) {
     // Bare "measure" tag appears as tag_token in the CST
     if (ch.type === "tag_token") {
@@ -1299,10 +1307,13 @@ function extractMeasure(
         const val = ch.namedChildren[1];
         if (val) {
           // value_text wraps the actual value identifier
-          const valueText = val.type === "value_text"
-            ? (val.namedChildren[0]?.text ?? val.text)
-            : val.text;
-          if (valueText === "additive" || valueText === "non_additive" || valueText === "semi_additive") {
+          const valueText =
+            val.type === "value_text" ? (val.namedChildren[0]?.text ?? val.text) : val.text;
+          if (
+            valueText === "additive" ||
+            valueText === "non_additive" ||
+            valueText === "semi_additive"
+          ) {
             return valueText;
           }
         }
@@ -1414,7 +1425,10 @@ function extractComments(uri: string, node: SyntaxNode): CommentEntry[] {
             text: extractCommentText(sib),
             location: nodeLocation(uri, sib),
           });
-        } else if (sib.type === "question_comment" && sib.startPosition.row === node.endPosition.row) {
+        } else if (
+          sib.type === "question_comment" &&
+          sib.startPosition.row === node.endPosition.row
+        ) {
           comments.push({
             kind: "question",
             text: extractCommentText(sib),
@@ -1509,8 +1523,10 @@ function pathText(node: SyntaxNode): string {
  * (e.g. from value_text nodes), strips quotes manually.
  */
 function stripQuotes(text: string): string {
-  if ((text.startsWith('"') && text.endsWith('"')) ||
-      (text.startsWith("'") && text.endsWith("'"))) {
+  if (
+    (text.startsWith('"') && text.endsWith('"')) ||
+    (text.startsWith("'") && text.endsWith("'"))
+  ) {
     return text.slice(1, -1);
   }
   return text;
@@ -1548,10 +1564,7 @@ function nodeLocation(uri: string, node: SyntaxNode): SourceLocation {
  * @param primaryUri - The file URI that anchors the lineage view.
  * @param models     - One VizModel per import-reachable file (including the primary).
  */
-export function mergeVizModels(
-  primaryUri: string,
-  models: VizModel[],
-): VizModel {
+export function mergeVizModels(primaryUri: string, models: VizModel[]): VizModel {
   if (models.length === 0) {
     return { uri: primaryUri, fileNotes: [], namespaces: [] };
   }
@@ -1631,13 +1644,23 @@ export function mergeVizModels(
   // Build ordered namespace list: global first (if present), then named.
   const namespaces: NamespaceGroup[] = [];
   const globalNs = nsMap.get(null);
-  if (globalNs && (globalNs.schemas.length > 0 || globalNs.mappings.length > 0 ||
-      globalNs.metrics.length > 0 || globalNs.fragments.length > 0)) {
+  if (
+    globalNs &&
+    (globalNs.schemas.length > 0 ||
+      globalNs.mappings.length > 0 ||
+      globalNs.metrics.length > 0 ||
+      globalNs.fragments.length > 0)
+  ) {
     namespaces.push(globalNs);
   }
   for (const [name, ns] of nsMap) {
-    if (name !== null && (ns.schemas.length > 0 || ns.mappings.length > 0 ||
-        ns.metrics.length > 0 || ns.fragments.length > 0)) {
+    if (
+      name !== null &&
+      (ns.schemas.length > 0 ||
+        ns.mappings.length > 0 ||
+        ns.metrics.length > 0 ||
+        ns.fragments.length > 0)
+    ) {
       namespaces.push(ns);
     }
   }

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -21,9 +21,7 @@
 // Range is a runtime value (Range.create) from vscode-languageserver-types, the
 // zero-dependency types package — not the top-level vscode-languageserver, which
 // would drag Node-only JSON-RPC server code into the browser bundle (feature 33).
-import {
-  Range,
-} from "vscode-languageserver-types";
+import { Range } from "vscode-languageserver-types";
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { nodeRange, child, children, labelText, walkDescendants } from "./parser-utils";
 import {
@@ -212,10 +210,7 @@ function walkImportGraph(
  * Import path strings are resolved relative to the importing file's directory.
  * Files not present in `index.indexedFiles` are silently skipped.
  */
-export function getImportReachableUris(
-  entryUri: string,
-  index: WorkspaceIndex,
-): Set<string> {
+export function getImportReachableUris(entryUri: string, index: WorkspaceIndex): Set<string> {
   return walkImportGraph(entryUri, index).reachable;
 }
 
@@ -227,10 +222,7 @@ export function getImportReachableUris(
  * consumer that needs missing-import diagnostics. Order follows the graph walk;
  * duplicates are preserved (one entry per failing import declaration).
  */
-export function getUnresolvedImportPaths(
-  entryUri: string,
-  index: WorkspaceIndex,
-): string[] {
+export function getUnresolvedImportPaths(entryUri: string, index: WorkspaceIndex): string[] {
   return walkImportGraph(entryUri, index).unresolved;
 }
 
@@ -284,11 +276,7 @@ export function createScopedIndex(
  * pathname diff (no Node `path.relative`), keeping this module browser-safe.
  * Falls back to a placeholder path when either URI is unparseable.
  */
-export function buildImportSuggestion(
-  currentUri: string,
-  name: string,
-  defUri: string,
-): string {
+export function buildImportSuggestion(currentUri: string, name: string, defUri: string): string {
   const rel = relativeUriPath(currentUri, defUri);
   if (rel === null) return `import { ${name} } from "..."`;
   // Import paths must be explicitly relative; bare paths read as bare-name imports.
@@ -453,10 +441,7 @@ export function resolveReferenceKey(
  * query), so renaming a::foo also rewrote `source { foo }` inside namespace
  * b — a reference that binds to b::foo (sl-p256).
  */
-export function findReferences(
-  index: WorkspaceIndex,
-  name: string,
-): ReferenceEntry[] {
+export function findReferences(index: WorkspaceIndex, name: string): ReferenceEntry[] {
   const results: ReferenceEntry[] = [];
 
   if (name.includes("::")) {
@@ -526,14 +511,9 @@ export function countReferences(
 }
 
 /** Find distinct mapping names that reference a given schema as source or target. */
-export function findMappingsUsing(
-  index: WorkspaceIndex,
-  schemaName: string,
-): string[] {
+export function findMappingsUsing(index: WorkspaceIndex, schemaName: string): string[] {
   const refs = findReferences(index, schemaName);
-  const mappingRefs = refs.filter(
-    (r) => r.context === "source" || r.context === "target",
-  );
+  const mappingRefs = refs.filter((r) => r.context === "source" || r.context === "target");
   // Deduplicate by the containing mapping, not by reference site — a mapping
   // that names the schema in both its source and target blocks is still one
   // mapping (sl-0tgo). The uri:line fallback covers entries indexed before
@@ -600,9 +580,7 @@ function indexTopLevel(
   // Metric schemas are schema_block nodes decorated with (metric, ...) metadata.
   // Upgrade the kind from "schema" to "metric" so the index correctly classifies them.
   const effectiveKind: DefinitionEntry["kind"] =
-    kind === "schema" && isMetricSchema(child(node, "metadata_block"))
-      ? "metric"
-      : kind;
+    kind === "schema" && isMetricSchema(child(node, "metadata_block")) ? "metric" : kind;
 
   const name = labelText(node);
   if (!name) return;
@@ -612,9 +590,10 @@ function indexTopLevel(
   const selectionRange = lblNode ? nodeRange(lblNode) : nodeRange(node);
 
   // Extract fields for schema/fragment blocks (metric schemas also have schema_body)
-  const fields = (effectiveKind === "schema" || effectiveKind === "metric" || effectiveKind === "fragment")
-    ? extractFields(child(node, "schema_body"))
-    : [];
+  const fields =
+    effectiveKind === "schema" || effectiveKind === "metric" || effectiveKind === "fragment"
+      ? extractFields(child(node, "schema_body"))
+      : [];
 
   addDefinition(index, qualifiedName, {
     uri,
@@ -702,7 +681,9 @@ function indexMappingRefs(
   // unique per mapping.
   const mappingName = labelText(mappingNode);
   const container = mappingName
-    ? (namespace ? `${namespace}::${mappingName}` : mappingName)
+    ? namespace
+      ? `${namespace}::${mappingName}`
+      : mappingName
     : `<anon>@${uri}:${mappingNode.startPosition.row}`;
 
   for (const ch of body.namedChildren) {
@@ -756,10 +737,7 @@ function indexMappingRefs(
  */
 function sourceRefNameRange(ref: SyntaxNode): Range {
   const nameNode = ref.namedChildren.find(
-    (c) =>
-      c.type === "qualified_name" ||
-      c.type === "backtick_name" ||
-      c.type === "identifier",
+    (c) => c.type === "qualified_name" || c.type === "backtick_name" || c.type === "identifier",
   );
   return nameNode ? nodeRange(nameNode) : nodeRange(ref);
 }
@@ -805,8 +783,8 @@ function indexArrowFieldRefs(
     const isSrc = n.type === "src_path";
     const schemas = isSrc ? sourceSchemas : targetSchemas;
 
-    const fieldName = extractArrowFieldName(n);    // first segment / bare name
-    const fullPath = extractArrowFullPath(n);       // full dotted path, namespace-stripped
+    const fieldName = extractArrowFieldName(n); // first segment / bare name
+    const fullPath = extractArrowFullPath(n); // full dotted path, namespace-stripped
 
     if (!fieldName) return;
 
@@ -868,10 +846,7 @@ function arrowFirstSegmentNode(pathNode: SyntaxNode): SyntaxNode | null {
   // is the namespace, so the field's first segment is the second. Every other
   // path form (field_path, backtick_path, relative_field_path) starts
   // directly with its first segment.
-  const seg =
-    inner.type === "namespaced_path"
-      ? inner.namedChildren[1]
-      : inner.namedChildren[0];
+  const seg = inner.type === "namespaced_path" ? inner.namedChildren[1] : inner.namedChildren[0];
   return seg ?? null;
 }
 
@@ -995,11 +970,7 @@ function enclosingNamespace(node: SyntaxNode): string | null {
  * pipe text — `a -> b { derived from @b }` has no nl_string at all, so a
  * string-only walk missed it entirely (bptar-l6n8).
  */
-function indexNlRefs(
-  index: WorkspaceIndex,
-  uri: string,
-  node: SyntaxNode,
-): void {
+function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void {
   walkDescendants(node, (n) => {
     if (n.type === "at_ref") {
       // Strip the leading @ and any backtick delimiters, mirroring the
@@ -1050,7 +1021,6 @@ function indexNlRefs(
         namespace: enclosingNamespace(n),
       });
     }
-
   });
 }
 
@@ -1088,7 +1058,14 @@ function offsetToRange(
     }
   }
   const endLine = nodeStartRow + endRow;
-  const endChar = endRow === 0 ? nodeStartCol + endCol : (endRow === row ? (row === 0 ? nodeStartCol + endCol : endCol) : endCol);
+  const endChar =
+    endRow === 0
+      ? nodeStartCol + endCol
+      : endRow === row
+        ? row === 0
+          ? nodeStartCol + endCol
+          : endCol
+        : endCol;
 
   return Range.create(startLine, startChar, endLine, endChar);
 }
@@ -1130,7 +1107,9 @@ function indexMetricRefs(
   // every metric_source ref in the file (sl-ei1e).
   const metricName = labelText(metricNode);
   const container = metricName
-    ? (namespace ? `${namespace}::${metricName}` : metricName)
+    ? namespace
+      ? `${namespace}::${metricName}`
+      : metricName
     : `<anon>@${uri}:${metricNode.startPosition.row}`;
 
   walkDescendants(meta, (n) => {
@@ -1169,9 +1148,7 @@ function extractFields(body: SyntaxNode | null): FieldInfo[] {
   if (!body) return [];
   const fieldTree = extractFieldTree(body);
   const fieldNodes = children(body, "field_decl");
-  return fieldTree.fields.map((decl, i) =>
-    fieldDeclToInfo(decl, fieldNodes[i] ?? null),
-  );
+  return fieldTree.fields.map((decl, i) => fieldDeclToInfo(decl, fieldNodes[i] ?? null));
 }
 
 /**
@@ -1190,7 +1167,12 @@ function fieldDeclToInfo(decl: FieldDecl, cstNode: SyntaxNode | null): FieldInfo
   const nameNode = cstNode ? child(cstNode, "field_name") : null;
   const range = nameNode
     ? nodeRange(nameNode)
-    : Range.create(decl.startRow ?? 0, decl.startColumn ?? 0, decl.startRow ?? 0, (decl.startColumn ?? 0) + decl.name.length);
+    : Range.create(
+        decl.startRow ?? 0,
+        decl.startColumn ?? 0,
+        decl.startRow ?? 0,
+        (decl.startColumn ?? 0) + decl.name.length,
+      );
 
   // Recurse for nested fields
   const nestedBody = cstNode ? child(cstNode, "schema_body") : null;
@@ -1242,28 +1224,22 @@ function spreadLabelText(node: SyntaxNode): string | null {
   if (qn) return coreQualifiedNameText(qn);
   const quoted = child(node, "backtick_name");
   if (quoted) return quoted.text.slice(1, -1);
-  const ids = node.namedChildren.filter((c: SyntaxNode) => c.type === "identifier" || c.type === "continuation_word");
+  const ids = node.namedChildren.filter(
+    (c: SyntaxNode) => c.type === "identifier" || c.type === "continuation_word",
+  );
   if (ids.length > 0) return ids.map((i: SyntaxNode) => i.text).join(" ");
   return node.text;
 }
 
 // ---------- Internal helpers ----------
 
-function addDefinition(
-  index: WorkspaceIndex,
-  name: string,
-  entry: DefinitionEntry,
-): void {
+function addDefinition(index: WorkspaceIndex, name: string, entry: DefinitionEntry): void {
   const existing = index.definitions.get(name) ?? [];
   existing.push(entry);
   index.definitions.set(name, existing);
 }
 
-function addReference(
-  index: WorkspaceIndex,
-  name: string,
-  entry: ReferenceEntry,
-): void {
+function addReference(index: WorkspaceIndex, name: string, entry: ReferenceEntry): void {
   const existing = index.references.get(name) ?? [];
   existing.push(entry);
   index.references.set(name, existing);

--- a/tooling/satsuma-viz-backend/test/helper.js
+++ b/tooling/satsuma-viz-backend/test/helper.js
@@ -10,10 +10,7 @@
 const path = require("path");
 const { initParser, getParser, getLanguage } = require("@satsuma/core");
 
-const WASM_PATH = path.resolve(
-  __dirname,
-  "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm",
-);
+const WASM_PATH = path.resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
 
 /** Initialise the WASM parser.  Must be awaited once before parse() is called. */
 async function initTestParser() {

--- a/tooling/satsuma-viz-backend/test/import-resolver.test.js
+++ b/tooling/satsuma-viz-backend/test/import-resolver.test.js
@@ -73,10 +73,7 @@ describe("resolveImportUri parity with the legacy path-based resolver", () => {
   // URL constructor must yield the same encoded form so indexedFiles keys match.
   it("matches the legacy output when the path contains a space", () => {
     const pathText = "./order items.stm";
-    assert.equal(
-      resolveImportUri(importer, pathText),
-      legacyResolveImportUri(importer, pathText),
-    );
+    assert.equal(resolveImportUri(importer, pathText), legacyResolveImportUri(importer, pathText));
   });
 
   // A malformed importer URI must degrade to null rather than throw, so a
@@ -98,20 +95,13 @@ describe("getImportReachableUris with virtual file:/// URIs (browser form)", () 
     const importeeUri = `${base}crm/customers.stm`;
 
     const index = createWorkspaceIndex();
-    indexFile(
-      index,
-      entryUri,
-      parse('import { customers } from "./customers.stm"\n'),
-    );
+    indexFile(index, entryUri, parse('import { customers } from "./customers.stm"\n'));
     indexFile(index, importeeUri, parse("schema customers { id INT }\n"));
 
     const reachable = getImportReachableUris(entryUri, index);
 
     assert.ok(reachable.has(entryUri), "entry file is always reachable");
-    assert.ok(
-      reachable.has(importeeUri),
-      "imported sibling resolves to the library-keyed URI",
-    );
+    assert.ok(reachable.has(importeeUri), "imported sibling resolves to the library-keyed URI");
   });
 
   // An import to a path with no matching indexed document must be skipped, not
@@ -121,11 +111,7 @@ describe("getImportReachableUris with virtual file:/// URIs (browser form)", () 
     await initTestParser();
     const entryUri = "file:///library/solo.stm";
     const index = createWorkspaceIndex();
-    indexFile(
-      index,
-      entryUri,
-      parse('import { missing } from "./nowhere.stm"\n'),
-    );
+    indexFile(index, entryUri, parse('import { missing } from "./nowhere.stm"\n'));
 
     const reachable = getImportReachableUris(entryUri, index);
 
@@ -137,11 +123,7 @@ describe("buildImportSuggestion relative-path computation", () => {
   // The quick-fix must emit an explicitly-relative path. A sibling file is the
   // common case and must gain a leading ./ so it is not read as a bare-name import.
   it("emits a ./-prefixed path for a sibling file", () => {
-    const suggestion = buildImportSuggestion(
-      "file:///ws/a.stm",
-      "Customer",
-      "file:///ws/b.stm",
-    );
+    const suggestion = buildImportSuggestion("file:///ws/a.stm", "Customer", "file:///ws/b.stm");
     assert.equal(suggestion, 'import { Customer } from "./b.stm"');
   });
 

--- a/tooling/satsuma-viz-backend/test/model-from-sources.test.js
+++ b/tooling/satsuma-viz-backend/test/model-from-sources.test.js
@@ -111,9 +111,7 @@ describe("buildModelFromSources — cross-file lineage from in-memory documents"
     // The merged model carries the importee's location for its contributed
     // schema, which the single-file model does not.
     const lineageUris = new Set(
-      lineage.namespaces.flatMap((ns) =>
-        ns.schemas.map((s) => s.location?.uri).filter(Boolean),
-      ),
+      lineage.namespaces.flatMap((ns) => ns.schemas.map((s) => s.location?.uri).filter(Boolean)),
     );
     assert.ok(
       lineageUris.has(importeeUri),
@@ -204,9 +202,7 @@ describe("buildModelResultFromSources — unresolved-import diagnostics", () => 
   // model — consumers picking either entry point see the same VizModel.
   it("buildModelFromSources returns the same model as the result form", () => {
     const uri = `${base}buffer.stm`;
-    const documents = [
-      { uri, source: "schema users { id INT }\nschema customers { id INT }" },
-    ];
+    const documents = [{ uri, source: "schema users { id INT }\nschema customers { id INT }" }];
     assert.deepEqual(
       buildModelFromSources(uri, documents),
       buildModelResultFromSources(uri, documents).model,

--- a/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
@@ -36,7 +36,9 @@ const {
   extractMetadataEntries,
 } = _testInternals;
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 const URI = "file:///b.stm";
 
@@ -178,7 +180,8 @@ describe("extractMapping (direct)", () => {
   // Pins the MappingBlock defaults (empty each/flatten/note/comments arrays
   // and structured sourceBlock) for the simplest possible mapping shape.
   it("returns the canonical MappingBlock shape for a one-arrow mapping", () => {
-    const src = "schema s { a INT }\nschema t { b INT }\n" +
+    const src =
+      "schema s { a INT }\nschema t { b INT }\n" +
       "mapping m {\n  source { s }\n  target { t }\n  a -> b\n}";
     const { ws, tree } = singleFileIndex(src);
     const node = findNode(tree.rootNode, "mapping_block");
@@ -213,7 +216,8 @@ describe("extractMapping (direct)", () => {
   // tags like `airflow` and the note text — was dropped at extraction, so the
   // detail view's header could never show it.
   it("extracts the mapping's own metadata block (bare tags and note)", () => {
-    const src = "schema s { a INT }\nschema t { b INT }\n" +
+    const src =
+      "schema s { a INT }\nschema t { b INT }\n" +
       'mapping export_to_csv (airflow, note "All fields to CSV") {\n' +
       "  source { s }\n  target { t }\n  a -> b\n}";
     const { ws, tree } = singleFileIndex(src);
@@ -237,16 +241,16 @@ describe("extractMetric (direct)", () => {
   // (extractMetricFields → extractMeasure).
   it("returns the canonical MetricCard shape for a basic metric", () => {
     const src =
-      'schema mrr (\n' +
-      '  metric,\n' +
+      "schema mrr (\n" +
+      "  metric,\n" +
       '  metric_name "MRR",\n' +
-      '  source subs,\n' +
-      '  grain monthly,\n' +
-      '  slice {region, plan},\n' +
+      "  source subs,\n" +
+      "  grain monthly,\n" +
+      "  slice {region, plan},\n" +
       '  filter "active"\n' +
-      ') {\n' +
-      '  value DECIMAL (measure additive)\n' +
-      '}';
+      ") {\n" +
+      "  value DECIMAL (measure additive)\n" +
+      "}";
     const node = findNode(root(src), "schema_block");
     const card = extractMetric(URI, node, null);
 
@@ -280,19 +284,25 @@ describe("extractMetricMetadata (direct)", () => {
   // correct out-parameter.
   it("populates source / grain / slices / filter from metadata_block", () => {
     const src =
-      'schema m (\n' +
-      '  metric,\n' +
-      '  source orders,\n' +
-      '  grain daily,\n' +
-      '  slice {country},\n' +
+      "schema m (\n" +
+      "  metric,\n" +
+      "  source orders,\n" +
+      "  grain daily,\n" +
+      "  slice {country},\n" +
       '  filter "paid = true"\n' +
-      ') { v INT (measure) }';
+      ") { v INT (measure) }";
     const meta = findNode(root(src), "metadata_block");
     const source = [];
     const slices = [];
     let grain = null;
     let filter = null;
-    extractMetricMetadata(meta, source, slices, (g) => (grain = g), (f) => (filter = f));
+    extractMetricMetadata(
+      meta,
+      source,
+      slices,
+      (g) => (grain = g),
+      (f) => (filter = f),
+    );
     assert.deepStrictEqual(source, ["orders"]);
     assert.deepStrictEqual(slices, ["country"]);
     assert.equal(grain, "daily");
@@ -306,13 +316,13 @@ describe("extractMetricFields (direct)", () => {
   // a non-measure field that yields measure: null.
   it("returns one MetricFieldEntry per field with the correct measure value", () => {
     const src =
-      'schema m (metric, source s) {\n' +
-      '  add_v DECIMAL (measure additive)\n' +
-      '  na_v  DECIMAL (measure non_additive)\n' +
-      '  sa_v  DECIMAL (measure semi_additive)\n' +
-      '  bare  INT (measure)\n' +
-      '  none  INT\n' +
-      '}';
+      "schema m (metric, source s) {\n" +
+      "  add_v DECIMAL (measure additive)\n" +
+      "  na_v  DECIMAL (measure non_additive)\n" +
+      "  sa_v  DECIMAL (measure semi_additive)\n" +
+      "  bare  INT (measure)\n" +
+      "  none  INT\n" +
+      "}";
     const body = findNode(root(src), "schema_body");
     const fields = extractMetricFields(URI, body);
     assert.equal(fields.length, 5);
@@ -333,22 +343,16 @@ describe("extractMeasure (direct)", () => {
   // The bare `measure` tag (no value) defaults to "additive" — this rule is
   // codified in extractMeasure and checked here in isolation.
   it("returns 'additive' for a bare measure tag", () => {
-    const src = 'schema m (metric, source s) { v INT (measure) }';
-    const fieldMeta = findNode(
-      findNode(root(src), "field_decl"),
-      "metadata_block",
-    );
+    const src = "schema m (metric, source s) { v INT (measure) }";
+    const fieldMeta = findNode(findNode(root(src), "field_decl"), "metadata_block");
     assert.equal(extractMeasure(fieldMeta), "additive");
   });
 
   // A field whose metadata block has no measure tag yields null — separate
   // from the "additive default" path above.
   it("returns null when no measure tag is present", () => {
-    const src = 'schema s { v INT (pk) }';
-    const fieldMeta = findNode(
-      findNode(root(src), "field_decl"),
-      "metadata_block",
-    );
+    const src = "schema s { v INT (pk) }";
+    const fieldMeta = findNode(findNode(root(src), "field_decl"), "metadata_block");
     assert.equal(extractMeasure(fieldMeta), null);
   });
 });
@@ -363,13 +367,13 @@ describe("extractFieldEntries (direct)", () => {
   // common field flavours in one canonical assertion.
   it("returns the canonical FieldEntry shape for nested + list + constraint fields", () => {
     const src =
-      'schema events {\n' +
-      '  id UUID (pk)\n' +
-      '  data record {\n' +
-      '    name STRING\n' +
-      '  }\n' +
-      '  tags list_of STRING\n' +
-      '}';
+      "schema events {\n" +
+      "  id UUID (pk)\n" +
+      "  data record {\n" +
+      "    name STRING\n" +
+      "  }\n" +
+      "  tags list_of STRING\n" +
+      "}";
     const body = findNode(root(src), "schema_body");
     const fields = extractFieldEntries(URI, body);
 
@@ -445,11 +449,7 @@ describe("extractSpreads (direct)", () => {
   // module exposes is "return the spread names in declaration order".
   it("returns spread names in declaration order", () => {
     const src =
-      'schema s {\n' +
-      '  ...common::base\n' +
-      '  ...common::audit\n' +
-      '  id INT\n' +
-      '}';
+      "schema s {\n" + "  ...common::base\n" + "  ...common::audit\n" + "  id INT\n" + "}";
     const body = findNode(root(src), "schema_body");
     assert.deepStrictEqual(extractSpreads(body), ["common::base", "common::audit"]);
   });
@@ -457,7 +457,7 @@ describe("extractSpreads (direct)", () => {
   // Empty schema bodies must return [] (not undefined) so the SchemaCard
   // shape is uniform.
   it("returns an empty array for a schema body with no spreads", () => {
-    const src = 'schema s { id INT }';
+    const src = "schema s { id INT }";
     const body = findNode(root(src), "schema_body");
     assert.deepStrictEqual(extractSpreads(body), []);
   });
@@ -483,7 +483,7 @@ describe("extractSchemaLabel (direct)", () => {
 
   // Metadata block exists but contains no note tag → null.
   it("returns null when no note tag is present", () => {
-    const src = 'schema foo (key) { id INT }';
+    const src = "schema foo (key) { id INT }";
     const meta = findNode(root(src), "metadata_block");
     assert.equal(extractSchemaLabel(meta), null);
   });
@@ -518,8 +518,8 @@ describe("extractArrow (direct)", () => {
   // A bare-copy arrow with no transform pins the ArrowEntry default shape:
   // empty metadata, empty comments, transform: null.
   it("returns the canonical ArrowEntry shape for a bare-copy arrow", () => {
-    const src = "schema s { a INT }\nschema t { b INT }\n" +
-      "mapping m { source { s } target { t } a -> b }";
+    const src =
+      "schema s { a INT }\nschema t { b INT }\n" + "mapping m { source { s } target { t } a -> b }";
     const node = findNode(root(src), "map_arrow");
     const arrow = extractArrow(URI, node);
     assert.deepStrictEqual(arrow, {
@@ -535,7 +535,8 @@ describe("extractArrow (direct)", () => {
 
   // Multi-source arrows produce sourceFields with one entry per src_path.
   it("captures every src_path in sourceFields for a multi-source arrow", () => {
-    const src = "schema s { a STRING\n b STRING }\nschema t { c STRING }\n" +
+    const src =
+      "schema s { a STRING\n b STRING }\nschema t { c STRING }\n" +
       'mapping m { source { s } target { t } a, b -> c { "concat" } }';
     const node = findNode(root(src), "map_arrow");
     const arrow = extractArrow(URI, node);
@@ -550,7 +551,8 @@ describe("extractComputedArrow (direct)", () => {
   // Computed arrows have no source fields but still carry the same
   // ArrowEntry shape (sourceFields: []).
   it("returns sourceFields: [] and a non-null transform for a computed arrow", () => {
-    const src = "schema s { a INT }\nschema t { b INT }\n" +
+    const src =
+      "schema s { a INT }\nschema t { b INT }\n" +
       'mapping m { source { s } target { t } -> b { "compute" } }';
     const node = findNode(root(src), "computed_arrow");
     const arrow = extractComputedArrow(URI, node);
@@ -571,7 +573,8 @@ describe("extractTransform (direct)", () => {
   // A pipe chain with bare-token steps yields kind "nl" and one entry per
   // pipe_text in steps. text is the raw source of the pipe_chain.
   it("returns kind 'nl' with one step per pipe_text", () => {
-    const src = "schema s { a INT }\nschema t { b INT }\n" +
+    const src =
+      "schema s { a INT }\nschema t { b INT }\n" +
       "mapping m { source { s } target { t } a -> b { trim | lowercase } }";
     const pipeChain = findNode(root(src), "pipe_chain");
     const tf = extractTransform(pipeChain);
@@ -582,7 +585,8 @@ describe("extractTransform (direct)", () => {
 
   // A standalone map literal flips kind to "map" — the only non-nl variant.
   it("returns kind 'map' when the chain contains a map_literal", () => {
-    const src = "schema s { a STRING }\nschema t { b STRING }\n" +
+    const src =
+      "schema s { a STRING }\nschema t { b STRING }\n" +
       'mapping m { source { s } target { t } a -> b { map { A: "x" } } }';
     const pipeChain = findNode(root(src), "pipe_chain");
     const tf = extractTransform(pipeChain);
@@ -652,7 +656,8 @@ describe("each and flatten nesting (sl-vu22)", () => {
   // a flatten inside an each (examples/nested-iteration/pipeline.stm:100) was
   // dropped from the model entirely, taking its arrows with it.
 
-  const NESTED = "schema s { orders list_of record {\n" +
+  const NESTED =
+    "schema s { orders list_of record {\n" +
     "  parcels list_of record { contents list_of record { sku STRING } }\n" +
     "} }\n" +
     "schema t { orders list_of record { packed_items list_of record { sku STRING } } }\n" +
@@ -789,10 +794,9 @@ describe("extractNotes (direct)", () => {
     assert.equal(notes[0].text, "Tag note");
   });
 
-
   // No notes at all yields the empty array, not undefined.
   it("returns an empty array when there are no notes", () => {
-    const src = 'schema s { id INT }';
+    const src = "schema s { id INT }";
     const node = findNode(root(src), "schema_block");
     assert.deepStrictEqual(extractNotes(URI, node), []);
   });

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -9,7 +9,9 @@ const {
 } = require("../dist/workspace-index");
 const { buildVizModel, mergeVizModels } = require("../dist/viz-model");
 
-before(async () => { await initTestParser(); });
+before(async () => {
+  await initTestParser();
+});
 
 /** Build a VizModel from source text. */
 function vizModel(source, uri = "file:///test.stm") {
@@ -134,9 +136,7 @@ describe("schemas", () => {
   });
 
   it("extracts schema with note metadata", () => {
-    const model = vizModel(
-      'schema foo (note "My description") {\n  id INT\n}',
-    );
+    const model = vizModel('schema foo (note "My description") {\n  id INT\n}');
     const schema = model.namespaces[0].schemas[0];
     assert.equal(schema.label, "My description");
   });
@@ -191,8 +191,8 @@ describe("mappings", () => {
   it("extracts a basic mapping with source, target, and arrows", () => {
     const model = vizModel(
       "schema src { id INT\n name STRING }\n" +
-      "schema tgt { id INT\n name STRING }\n" +
-      "mapping m1 {\n  source { src }\n  target { tgt }\n  id -> id\n  name -> name\n}",
+        "schema tgt { id INT\n name STRING }\n" +
+        "mapping m1 {\n  source { src }\n  target { tgt }\n  id -> id\n  name -> name\n}",
     );
     const mapping = model.namespaces[0].mappings[0];
     assert.equal(mapping.id, "m1");
@@ -204,7 +204,7 @@ describe("mappings", () => {
   it("extracts arrow source and target fields", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      "mapping m {\n  source { s }\n  target { t }\n  a -> b\n}",
+        "mapping m {\n  source { s }\n  target { t }\n  a -> b\n}",
     );
     const arrow = model.namespaces[0].mappings[0].arrows[0];
     assert.deepEqual(arrow.sourceFields, ["a"]);
@@ -218,7 +218,7 @@ describe("mappings", () => {
   it("extracts bare-token transforms as NL kind", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      "mapping m {\n  source { s }\n  target { t }\n  a -> b { trim | lowercase }\n}",
+        "mapping m {\n  source { s }\n  target { t }\n  a -> b { trim | lowercase }\n}",
     );
     const tf = model.namespaces[0].mappings[0].arrows[0].transform;
     assert.ok(tf);
@@ -229,7 +229,7 @@ describe("mappings", () => {
   it("extracts quoted NL transforms as NL kind", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      'mapping m {\n  source { s }\n  target { t }\n  a -> b { "Convert to uppercase" }\n}',
+        'mapping m {\n  source { s }\n  target { t }\n  a -> b { "Convert to uppercase" }\n}',
     );
     const tf = model.namespaces[0].mappings[0].arrows[0].transform;
     assert.ok(tf);
@@ -239,7 +239,7 @@ describe("mappings", () => {
   it("extracts mixed bare + quoted transforms as NL kind", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      'mapping m {\n  source { s }\n  target { t }\n  a -> b {\n    "Do something"\n    | round(2)\n  }\n}',
+        'mapping m {\n  source { s }\n  target { t }\n  a -> b {\n    "Do something"\n    | round(2)\n  }\n}',
     );
     const tf = model.namespaces[0].mappings[0].arrows[0].transform;
     assert.ok(tf);
@@ -250,7 +250,7 @@ describe("mappings", () => {
   it("extracts map block transforms", () => {
     const model = vizModel(
       "schema s { status STRING }\nschema t { stage STRING }\n" +
-      'mapping m {\n  source { s }\n  target { t }\n  status -> stage {\n    map {\n      A: "alpha"\n      B: "beta"\n    }\n  }\n}',
+        'mapping m {\n  source { s }\n  target { t }\n  status -> stage {\n    map {\n      A: "alpha"\n      B: "beta"\n    }\n  }\n}',
     );
     const tf = model.namespaces[0].mappings[0].arrows[0].transform;
     assert.ok(tf);
@@ -260,7 +260,7 @@ describe("mappings", () => {
   it("extracts computed arrows (no source)", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      'mapping m {\n  source { s }\n  target { t }\n  -> b { "Compute something" }\n}',
+        'mapping m {\n  source { s }\n  target { t }\n  -> b { "Compute something" }\n}',
     );
     const arrow = model.namespaces[0].mappings[0].arrows[0];
     assert.deepEqual(arrow.sourceFields, []);
@@ -270,7 +270,7 @@ describe("mappings", () => {
   it("extracts multi-source arrows", () => {
     const model = vizModel(
       "schema s { a STRING\n  b STRING }\nschema t { c STRING }\n" +
-      'mapping m {\n  source { s }\n  target { t }\n  a, b -> c { "Concat" }\n}',
+        'mapping m {\n  source { s }\n  target { t }\n  a, b -> c { "Concat" }\n}',
     );
     const arrow = model.namespaces[0].mappings[0].arrows[0];
     assert.equal(arrow.sourceFields.length, 2);
@@ -281,7 +281,7 @@ describe("mappings", () => {
   it("extracts source block with join description", () => {
     const model = vizModel(
       "schema a { id INT }\nschema b { id INT }\nschema t { id INT }\n" +
-      'mapping m {\n  source {\n    a\n    b\n    "Join on a.id = b.id"\n  }\n  target { t }\n  a.id -> id\n}',
+        'mapping m {\n  source {\n    a\n    b\n    "Join on a.id = b.id"\n  }\n  target { t }\n  a.id -> id\n}',
     );
     const sb = model.namespaces[0].mappings[0].sourceBlock;
     assert.ok(sb);
@@ -292,14 +292,14 @@ describe("mappings", () => {
   it("resolves local namespaced mapping refs to qualified schema ids", () => {
     const model = vizModel(
       "namespace warehouse {\n" +
-      "  schema src { id INT }\n" +
-      "  schema tgt { id INT }\n" +
-      "  mapping m {\n" +
-      "    source { src }\n" +
-      "    target { tgt }\n" +
-      "    id -> id\n" +
-      "  }\n" +
-      "}",
+        "  schema src { id INT }\n" +
+        "  schema tgt { id INT }\n" +
+        "  mapping m {\n" +
+        "    source { src }\n" +
+        "    target { tgt }\n" +
+        "    id -> id\n" +
+        "  }\n" +
+        "}",
     );
     const mapping = model.namespaces.find((ns) => ns.name === "warehouse").mappings[0];
     assert.deepEqual(mapping.sourceRefs, ["warehouse::src"]);
@@ -310,14 +310,14 @@ describe("mappings", () => {
   it("falls back to global schema refs from inside namespaces", () => {
     const model = vizModel(
       "schema global_src { id INT }\n" +
-      "namespace warehouse {\n" +
-      "  schema tgt { id INT }\n" +
-      "  mapping m {\n" +
-      "    source { global_src }\n" +
-      "    target { tgt }\n" +
-      "    id -> id\n" +
-      "  }\n" +
-      "}",
+        "namespace warehouse {\n" +
+        "  schema tgt { id INT }\n" +
+        "  mapping m {\n" +
+        "    source { global_src }\n" +
+        "    target { tgt }\n" +
+        "    id -> id\n" +
+        "  }\n" +
+        "}",
     );
     const mapping = model.namespaces.find((ns) => ns.name === "warehouse").mappings[0];
     assert.deepEqual(mapping.sourceRefs, ["global_src"]);
@@ -327,7 +327,7 @@ describe("mappings", () => {
   it("does not treat source join descriptions as source refs", () => {
     const model = vizModel(
       "schema a { id INT }\nschema b { id INT }\nschema t { id INT }\n" +
-      'mapping m {\n  source {\n    a\n    b\n    "Join on a.id = b.id"\n  }\n  target { t }\n  a.id -> id\n}',
+        'mapping m {\n  source {\n    a\n    b\n    "Join on a.id = b.id"\n  }\n  target { t }\n  a.id -> id\n}',
     );
     const mapping = model.namespaces[0].mappings[0];
     assert.deepEqual(mapping.sourceRefs, ["a", "b"]);
@@ -336,8 +336,8 @@ describe("mappings", () => {
   it("extracts flatten blocks", () => {
     const model = vizModel(
       "schema s { items list_of record { sku STRING } }\n" +
-      "schema t { sku STRING }\n" +
-      "mapping m {\n  source { s }\n  target { t }\n  flatten items -> t {\n    .sku -> sku\n  }\n}",
+        "schema t { sku STRING }\n" +
+        "mapping m {\n  source { s }\n  target { t }\n  flatten items -> t {\n    .sku -> sku\n  }\n}",
     );
     const mapping = model.namespaces[0].mappings[0];
     assert.equal(mapping.flattenBlocks.length, 1);
@@ -348,7 +348,7 @@ describe("mappings", () => {
   it("extracts mapping-level notes", () => {
     const model = vizModel(
       "schema s { a INT }\nschema t { b INT }\n" +
-      'mapping m {\n  note { "Mapping note" }\n  source { s }\n  target { t }\n  a -> b\n}',
+        'mapping m {\n  note { "Mapping note" }\n  source { s }\n  target { t }\n  a -> b\n}',
     );
     const mapping = model.namespaces[0].mappings[0];
     assert.equal(mapping.notes.length, 1);
@@ -376,10 +376,10 @@ describe("metrics", () => {
   it("extracts metric fields with measure types", () => {
     const model = vizModel(
       "schema m1 (metric, source s) {\n" +
-      "  val DECIMAL (measure additive)\n" +
-      "  avg DECIMAL (measure non_additive)\n" +
-      "  half DECIMAL (measure semi_additive)\n" +
-      "}",
+        "  val DECIMAL (measure additive)\n" +
+        "  avg DECIMAL (measure non_additive)\n" +
+        "  half DECIMAL (measure semi_additive)\n" +
+        "}",
     );
     const fields = model.namespaces[0].metrics[0].fields;
     assert.equal(fields.length, 3);
@@ -405,9 +405,7 @@ describe("metrics", () => {
   });
 
   it("extracts bare measure tag as additive", () => {
-    const model = vizModel(
-      "schema m1 (metric, source s) {\n  count INT (measure)\n}",
-    );
+    const model = vizModel("schema m1 (metric, source s) {\n  count INT (measure)\n}");
     const fields = model.namespaces[0].metrics[0].fields;
     assert.equal(fields[0].measure, "additive");
   });
@@ -429,8 +427,7 @@ describe("namespaces", () => {
 
   it("separates global and namespaced blocks", () => {
     const model = vizModel(
-      "schema global_s { id INT }\n" +
-      "namespace ns1 {\n  schema ns_s { id INT }\n}",
+      "schema global_s { id INT }\n" + "namespace ns1 {\n  schema ns_s { id INT }\n}",
     );
     assert.equal(model.namespaces.length, 2);
     const global = model.namespaces.find((n) => n.name === null);
@@ -445,10 +442,10 @@ describe("namespaces", () => {
   it("handles mappings inside namespaces", () => {
     const model = vizModel(
       "namespace wh {\n" +
-      "  schema src { id INT }\n" +
-      "  schema tgt { id INT }\n" +
-      "  mapping load {\n    source { src }\n    target { tgt }\n    id -> id\n  }\n" +
-      "}",
+        "  schema src { id INT }\n" +
+        "  schema tgt { id INT }\n" +
+        "  mapping load {\n    source { src }\n    target { tgt }\n    id -> id\n  }\n" +
+        "}",
     );
     const ns = model.namespaces.find((n) => n.name === "wh");
     assert.ok(ns);
@@ -461,36 +458,24 @@ describe("namespaces", () => {
 
 describe("comments", () => {
   it("extracts warning comments from fields", () => {
-    const model = vizModel(
-      "schema s {\n  email STRING //! PII risk\n}",
-    );
+    const model = vizModel("schema s {\n  email STRING //! PII risk\n}");
     const schema = model.namespaces[0].schemas[0];
     // Warning comments appear on the schema or the field
-    const allComments = [
-      ...schema.comments,
-      ...schema.fields.flatMap((f) => f.comments),
-    ];
+    const allComments = [...schema.comments, ...schema.fields.flatMap((f) => f.comments)];
     assert.ok(allComments.some((c) => c.kind === "warning"));
   });
 
   it("extracts question comments", () => {
-    const model = vizModel(
-      "schema s {\n  status STRING //? Should this be an enum?\n}",
-    );
+    const model = vizModel("schema s {\n  status STRING //? Should this be an enum?\n}");
     const schema = model.namespaces[0].schemas[0];
-    const allComments = [
-      ...schema.comments,
-      ...schema.fields.flatMap((f) => f.comments),
-    ];
+    const allComments = [...schema.comments, ...schema.fields.flatMap((f) => f.comments)];
     assert.ok(allComments.some((c) => c.kind === "question"));
   });
 
   it("attaches a standalone comment between top-level blocks to the preceding block", () => {
     // Control case for the namespaced fix below: standalone //! siblings of
     // global blocks attach to the nearest preceding schema.
-    const model = vizModel(
-      "schema s {\n  id INT\n}\n//! needs review\nschema t {\n  id INT\n}",
-    );
+    const model = vizModel("schema s {\n  id INT\n}\n//! needs review\nschema t {\n  id INT\n}");
     const s = model.namespaces[0].schemas.find((x) => x.id === "s");
     assert.equal(s.comments.length, 1);
     assert.equal(s.comments[0].kind, "warning");
@@ -517,7 +502,8 @@ describe("external lineage", () => {
     const model = vizModelMulti(
       {
         "file:///a.stm": "schema customers { id INT }",
-        "file:///b.stm": "schema tgt { id INT }\nmapping m {\n  source { customers }\n  target { tgt }\n  id -> id\n}",
+        "file:///b.stm":
+          "schema tgt { id INT }\nmapping m {\n  source { customers }\n  target { tgt }\n  id -> id\n}",
       },
       "file:///a.stm",
     );
@@ -764,20 +750,14 @@ mapping enrich {
 }`;
 
   it("injects a stub schema card for an imported source schema", () => {
-    const model = vizModelScoped(
-      { [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC },
-      MAIN_URI,
-    );
+    const model = vizModelScoped({ [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC }, MAIN_URI);
     const ns = model.namespaces[0];
     const ids = ns.schemas.map((s) => s.qualifiedId);
     assert.ok(ids.includes("fx_spot_rates"), `expected fx_spot_rates in ${ids}`);
   });
 
   it("stub schema has hasExternalLineage = true", () => {
-    const model = vizModelScoped(
-      { [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC },
-      MAIN_URI,
-    );
+    const model = vizModelScoped({ [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC }, MAIN_URI);
     const ns = model.namespaces[0];
     const stub = ns.schemas.find((s) => s.qualifiedId === "fx_spot_rates");
     assert.ok(stub);
@@ -785,10 +765,7 @@ mapping enrich {
   });
 
   it("stub schema preserves fields from the imported definition", () => {
-    const model = vizModelScoped(
-      { [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC },
-      MAIN_URI,
-    );
+    const model = vizModelScoped({ [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC }, MAIN_URI);
     const ns = model.namespaces[0];
     const stub = ns.schemas.find((s) => s.qualifiedId === "fx_spot_rates");
     assert.ok(stub);
@@ -797,10 +774,7 @@ mapping enrich {
   });
 
   it("does not inject a stub when the schema is defined locally", () => {
-    const model = vizModelScoped(
-      { [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC },
-      MAIN_URI,
-    );
+    const model = vizModelScoped({ [LOOKUP_URI]: LOOKUP_SRC, [MAIN_URI]: MAIN_SRC }, MAIN_URI);
     const ns = model.namespaces[0];
     const localIds = ["transactions", "transactions_usd"];
     for (const id of localIds) {
@@ -839,7 +813,7 @@ mapping convert_amount {
     assert.equal(arrow.transform.kind, "nl");
     assert.ok(Array.isArray(arrow.transform.atRefs), "expected atRefs array");
     assert.ok(arrow.transform.atRefs.length >= 1, "expected at least one atRef");
-    const spotRef = arrow.transform.atRefs.find(r => r.ref === "exchange_rates.spot");
+    const spotRef = arrow.transform.atRefs.find((r) => r.ref === "exchange_rates.spot");
     assert.ok(spotRef, "expected atRef for exchange_rates.spot");
     assert.equal(spotRef.resolved, true);
     assert.ok(spotRef.resolvedTo, "expected resolvedTo to be set");
@@ -858,7 +832,7 @@ mapping m {
     const model = vizModel(source);
     const arrow = model.namespaces[0].mappings[0].arrows[0];
     assert.ok(arrow.transform);
-    const ref = arrow.transform.atRefs?.find(r => r.ref === "bogus_unknown_field");
+    const ref = arrow.transform.atRefs?.find((r) => r.ref === "bogus_unknown_field");
     assert.ok(ref, "expected atRef entry for unknown ref");
     assert.equal(ref.resolved, false);
   });
@@ -876,8 +850,10 @@ mapping m {
     const arrow = model.namespaces[0].mappings[0].arrows[0];
     assert.ok(arrow.transform);
     assert.equal(arrow.transform.kind, "nl");
-    assert.ok(!arrow.transform.atRefs || arrow.transform.atRefs.length === 0,
-      "expected no atRefs for bare-token NL transform");
+    assert.ok(
+      !arrow.transform.atRefs || arrow.transform.atRefs.length === 0,
+      "expected no atRefs for bare-token NL transform",
+    );
   });
 
   // After Feature 28, bare tokens + NL strings in the same pipe chain are all
@@ -896,7 +872,7 @@ mapping m {
     assert.ok(arrow.transform);
     assert.equal(arrow.transform.kind, "nl");
     assert.ok(Array.isArray(arrow.transform.atRefs));
-    const rateRef = arrow.transform.atRefs.find(r => r.ref === "rate");
+    const rateRef = arrow.transform.atRefs.find((r) => r.ref === "rate");
     assert.ok(rateRef, "expected atRef for rate");
     assert.equal(rateRef.classification, "bare");
   });
@@ -922,49 +898,61 @@ describe("mergeVizModels", () => {
     const m2 = vizModel("schema foo { id INT\nname VARCHAR }", "file:///b.stm");
     // Primary model's schema wins the dedup.
     const result = mergeVizModels("file:///a.stm", [m1, m2]);
-    const schemas = result.namespaces.flatMap(ns => ns.schemas);
+    const schemas = result.namespaces.flatMap((ns) => ns.schemas);
     assert.equal(schemas.length, 1, "duplicate schema should be deduped");
     assert.equal(schemas[0].fields.length, 1, "primary model schema should win");
   });
 
   it("includes mappings from upstream files", () => {
     // Model A has a schema and mapping; model B has a different mapping.
-    const modelA = vizModel(`
+    const modelA = vizModel(
+      `
 schema src { id INT }
 schema tgt { id INT }
 mapping m1 {
   source { src }
   target { tgt }
   src.id -> id
-}`, "file:///a.stm");
+}`,
+      "file:///a.stm",
+    );
 
-    const modelB = vizModel(`
+    const modelB = vizModel(
+      `
 schema upstream { code VARCHAR }
 schema src { id INT }
 mapping m_upstream {
   source { upstream }
   target { src }
   upstream.code -> id
-}`, "file:///b.stm");
+}`,
+      "file:///b.stm",
+    );
 
     const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
-    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
+    const allMappings = result.namespaces.flatMap((ns) => ns.mappings);
     assert.equal(allMappings.length, 2, "both mappings should be present");
-    const mappingIds = allMappings.map(m => m.id);
+    const mappingIds = allMappings.map((m) => m.id);
     assert.ok(mappingIds.includes("m1"), "primary mapping present");
     assert.ok(mappingIds.includes("m_upstream"), "upstream mapping present");
   });
 
   it("preserves only primary file's fileNotes", () => {
-    const modelA = vizModel(`
+    const modelA = vizModel(
+      `
 note { "File A note" }
 schema foo { id INT }
-`, "file:///a.stm");
+`,
+      "file:///a.stm",
+    );
 
-    const modelB = vizModel(`
+    const modelB = vizModel(
+      `
 note { "File B note" }
 schema bar { id INT }
-`, "file:///b.stm");
+`,
+      "file:///b.stm",
+    );
 
     const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
     assert.equal(result.fileNotes.length, 1);
@@ -972,19 +960,25 @@ schema bar { id INT }
   });
 
   it("merges entities from different namespaces correctly", () => {
-    const modelA = vizModel(`
+    const modelA = vizModel(
+      `
 namespace crm {
   schema customers { id INT }
-}`, "file:///a.stm");
+}`,
+      "file:///a.stm",
+    );
 
-    const modelB = vizModel(`
+    const modelB = vizModel(
+      `
 namespace billing {
   schema invoices { id INT }
-}`, "file:///b.stm");
+}`,
+      "file:///b.stm",
+    );
 
     const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
     assert.equal(result.namespaces.length, 2, "two namespace groups");
-    const nsNames = result.namespaces.map(ns => ns.name).sort();
+    const nsNames = result.namespaces.map((ns) => ns.name).sort();
     assert.deepStrictEqual(nsNames, ["billing", "crm"]);
   });
 
@@ -992,7 +986,8 @@ namespace billing {
     // Bug sl-aeae: the mapping dedup key was id@uri, omitting the namespace.
     // Two mappings named "load" in namespaces a and b of the same file
     // collided and the second was dropped from the merged model.
-    const modelA = vizModel(`
+    const modelA = vizModel(
+      `
 namespace a {
   schema s1 { id INT }
   schema t1 { id INT }
@@ -1002,7 +997,9 @@ namespace b {
   schema s2 { id INT }
   schema t2 { id INT }
   mapping load { source { s2 } target { t2 } id -> id }
-}`, "file:///a.stm");
+}`,
+      "file:///a.stm",
+    );
     const modelB = vizModel("schema unrelated { id INT }", "file:///b.stm");
 
     const result = mergeVizModels("file:///a.stm", [modelA, modelB]);
@@ -1107,15 +1104,15 @@ mapping m_a {
     const result = vizModelFullLineage(files, "file:///a.stm");
 
     // All three schemas should be present.
-    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
-    const schemaIds = allSchemas.map(s => s.qualifiedId).sort();
+    const allSchemas = result.namespaces.flatMap((ns) => ns.schemas);
+    const schemaIds = allSchemas.map((s) => s.qualifiedId).sort();
     assert.ok(schemaIds.includes("upstream"), "upstream schema from file C");
     assert.ok(schemaIds.includes("intermediate"), "intermediate schema from file B");
     assert.ok(schemaIds.includes("target"), "target schema from file A");
 
     // Both mappings should be present (one from A, one from B).
-    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
-    const mappingIds = allMappings.map(m => m.id).sort();
+    const allMappings = result.namespaces.flatMap((ns) => ns.mappings);
+    const mappingIds = allMappings.map((m) => m.id).sort();
     assert.ok(mappingIds.includes("m_a"), "mapping from file A");
     assert.ok(mappingIds.includes("m_b"), "mapping from file B");
   });
@@ -1145,19 +1142,21 @@ import { cleaned_orders } from "./pipeline.stm"`,
     const result = vizModelFullLineage(files, "file:///platform.stm");
 
     // Both schemas and the mapping from imported files should be present.
-    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
-    const schemaIds = allSchemas.map(s => s.qualifiedId).sort();
+    const allSchemas = result.namespaces.flatMap((ns) => ns.schemas);
+    const schemaIds = allSchemas.map((s) => s.qualifiedId).sort();
     assert.ok(schemaIds.includes("raw_orders"), "upstream schema present");
     assert.ok(schemaIds.includes("cleaned_orders"), "downstream schema present");
 
-    const allMappings = result.namespaces.flatMap(ns => ns.mappings);
+    const allMappings = result.namespaces.flatMap((ns) => ns.mappings);
     assert.equal(allMappings.length, 1, "mapping from pipeline file present");
     assert.equal(allMappings[0].id, "clean");
 
     // Namespaces should not be empty — the import-only file contributes nothing
     // locally, but the merged model has content from imported files.
-    assert.ok(result.namespaces.length > 0,
-      "merged model has non-empty namespaces despite import-only entry point");
+    assert.ok(
+      result.namespaces.length > 0,
+      "merged model has non-empty namespaces despite import-only entry point",
+    );
   });
 
   it("location.uri tracks which file each entity came from", () => {
@@ -1176,14 +1175,20 @@ mapping m {
     };
 
     const result = vizModelFullLineage(files, "file:///main.stm");
-    const allSchemas = result.namespaces.flatMap(ns => ns.schemas);
+    const allSchemas = result.namespaces.flatMap((ns) => ns.schemas);
 
-    const resultSchema = allSchemas.find(s => s.qualifiedId === "result");
-    assert.equal(resultSchema.location.uri, "file:///main.stm",
-      "result schema should come from main.stm");
+    const resultSchema = allSchemas.find((s) => s.qualifiedId === "result");
+    assert.equal(
+      resultSchema.location.uri,
+      "file:///main.stm",
+      "result schema should come from main.stm",
+    );
 
-    const sourceSchema = allSchemas.find(s => s.qualifiedId === "source_data");
-    assert.equal(sourceSchema.location.uri, "file:///src.stm",
-      "source_data schema should come from src.stm");
+    const sourceSchema = allSchemas.find((s) => s.qualifiedId === "source_data");
+    assert.equal(
+      sourceSchema.location.uri,
+      "file:///src.stm",
+      "source_data schema should come from src.stm",
+    );
   });
 });

--- a/tooling/satsuma-viz-harness/scripts/build-playground.mjs
+++ b/tooling/satsuma-viz-harness/scripts/build-playground.mjs
@@ -66,9 +66,7 @@ const ROOT_ABSOLUTE_ASSET = /(?:src|href)="\/(?!\/)/;
 export function buildPlaygroundBundle(files, outDir) {
   for (const file of files) {
     if (!existsSync(file)) {
-      throw new Error(
-        `[playground] missing build artifact: ${file} — run "npm run build" first`,
-      );
+      throw new Error(`[playground] missing build artifact: ${file} — run "npm run build" first`);
     }
   }
 
@@ -77,7 +75,7 @@ export function buildPlaygroundBundle(files, outDir) {
     const html = readFileSync(indexHtml, "utf-8");
     if (ROOT_ABSOLUTE_ASSET.test(html)) {
       throw new Error(
-        "[playground] index.html references a root-absolute asset (src/href=\"/…\"); " +
+        '[playground] index.html references a root-absolute asset (src/href="/…"); ' +
           "all assets must be page-relative (./…) so the bundle works under a " +
           "non-root base path such as GitHub Pages",
       );

--- a/tooling/satsuma-viz-harness/scripts/generate-examples-manifest.test.mjs
+++ b/tooling/satsuma-viz-harness/scripts/generate-examples-manifest.test.mjs
@@ -63,10 +63,8 @@ describe("buildExamplesManifest", () => {
   // resolver produces, so indexedFiles.has(resolved) matches in the browser.
   it("derives file:/// virtual URIs consistent with the resolver", () => {
     const { examples } = buildExamplesManifest(corpusDir);
-    const uri = new URL(
-      examples.find((e) => e.path === "group/pipeline.stm").path,
-      LIBRARY_BASE,
-    ).href;
+    const uri = new URL(examples.find((e) => e.path === "group/pipeline.stm").path, LIBRARY_BASE)
+      .href;
     assert.equal(uri, "file:///library/group/pipeline.stm");
   });
 

--- a/tooling/satsuma-viz-harness/src/client/app.ts
+++ b/tooling/satsuma-viz-harness/src/client/app.ts
@@ -139,7 +139,9 @@ const harness: SatsumaHarness = {
   unresolvedImports: [],
   events: [],
   ready: false,
-  clearEvents() { this.events = []; },
+  clearEvents() {
+    this.events = [];
+  },
 };
 
 window.__satsumaHarness = harness;
@@ -170,26 +172,26 @@ function getRequired(id: string): HTMLElement {
   return el;
 }
 
-const layoutEl          = getRequired("layout");
-const fixtureListEl     = getRequired("fixture-list");
-const fixturePickerBtn  = getRequired("fixture-picker-btn");
+const layoutEl = getRequired("layout");
+const fixtureListEl = getRequired("fixture-list");
+const fixturePickerBtn = getRequired("fixture-picker-btn");
 const fixturePickerName = getRequired("fixture-picker-name");
-const fixtureDropdown   = getRequired("fixture-picker-dropdown");
-const libraryNewBtn     = getRequired("library-new-btn");
-const libraryResetBtn   = getRequired("library-reset-btn");
-const sourceEditorHost  = getRequired("source-editor");
-const parseStatusEl     = getRequired("parse-status");
+const fixtureDropdown = getRequired("fixture-picker-dropdown");
+const libraryNewBtn = getRequired("library-new-btn");
+const libraryResetBtn = getRequired("library-reset-btn");
+const sourceEditorHost = getRequired("source-editor");
+const parseStatusEl = getRequired("parse-status");
 const parseStatusDismiss = getRequired("parse-status-dismiss");
-const unresolvedNoteEl  = getRequired("unresolved-imports");
-const storageWarningEl  = getRequired("storage-warning");
+const unresolvedNoteEl = getRequired("unresolved-imports");
+const storageWarningEl = getRequired("storage-warning");
 const storageWarningDismiss = getRequired("storage-warning-dismiss");
-const fileOpenBtn       = getRequired("file-open-btn");
-const fileOpenInput     = getRequired("file-open-input") as HTMLInputElement;
-const fileSaveBtn       = getRequired("file-save-btn");
+const fileOpenBtn = getRequired("file-open-btn");
+const fileOpenInput = getRequired("file-open-input") as HTMLInputElement;
+const fileSaveBtn = getRequired("file-save-btn");
 const editorCollapseBtn = getRequired("editor-collapse-btn");
-const editorExpandRail  = getRequired("editor-expand-rail");
-const vizContainer      = getRequired("viz-container");
-const themeToggle       = getRequired("theme-toggle");
+const editorExpandRail = getRequired("editor-expand-rail");
+const vizContainer = getRequired("viz-container");
+const themeToggle = getRequired("theme-toggle");
 
 // ---------- Storage warning ----------
 
@@ -281,9 +283,10 @@ function normalizeNavigateEvent(event: Event): HarnessSourceLocation | null {
  * CustomEvent.detail for compatibility with legacy synthetic recorder tests.
  */
 function normalizeFieldEvent(event: Event): HarnessFieldPayload | null {
-  const source = ("schemaId" in event || "fieldName" in event)
-    ? event as Event & { schemaId?: unknown; fieldName?: unknown }
-    : customEventDetail(event);
+  const source =
+    "schemaId" in event || "fieldName" in event
+      ? (event as Event & { schemaId?: unknown; fieldName?: unknown })
+      : customEventDetail(event);
   if (!isRecord(source)) return null;
   const schemaId = source["schemaId"];
   const fieldName = source["fieldName"];
@@ -298,11 +301,12 @@ function normalizeFieldEvent(event: Event): HarnessFieldPayload | null {
  */
 function normalizeOpenMappingEvent(event: Event): HarnessMappingPayload | null {
   const detail = customEventDetail(event);
-  const source = "mapping" in event
-    ? (event as Event & { mapping?: unknown }).mapping
-    : isRecord(detail) && "mapping" in detail
-      ? detail["mapping"]
-      : detail;
+  const source =
+    "mapping" in event
+      ? (event as Event & { mapping?: unknown }).mapping
+      : isRecord(detail) && "mapping" in detail
+        ? detail["mapping"]
+        : detail;
   if (!isRecord(source)) return null;
   const id = source["id"];
   const sourceRefs = source["sourceRefs"];
@@ -310,7 +314,9 @@ function normalizeOpenMappingEvent(event: Event): HarnessMappingPayload | null {
   if (typeof id !== "string" || !Array.isArray(sourceRefs) || typeof targetRef !== "string") {
     return null;
   }
-  const normalizedSourceRefs = sourceRefs.filter((value): value is string => typeof value === "string");
+  const normalizedSourceRefs = sourceRefs.filter(
+    (value): value is string => typeof value === "string",
+  );
   if (normalizedSourceRefs.length !== sourceRefs.length) return null;
   return { id, sourceRefs: normalizedSourceRefs, targetRef };
 }
@@ -320,9 +326,8 @@ function normalizeOpenMappingEvent(event: Event): HarnessMappingPayload | null {
  * while preserving the legacy detail object shape.
  */
 function normalizeExpandLineageEvent(event: Event): { schemaId: string } | null {
-  const source = "schemaId" in event
-    ? event as Event & { schemaId?: unknown }
-    : customEventDetail(event);
+  const source =
+    "schemaId" in event ? (event as Event & { schemaId?: unknown }) : customEventDetail(event);
   if (!isRecord(source)) return null;
   const schemaId = source["schemaId"];
   return typeof schemaId === "string" ? { schemaId } : null;
@@ -354,7 +359,11 @@ function recordEvent(type: string, detail: unknown): void {
  * A null payload is retained when an event shape is invalid so test failures
  * expose the recorder mismatch instead of silently dropping the interaction.
  */
-function recordNormalizedEvent(type: string, event: Event, normalize: (event: Event) => unknown): unknown {
+function recordNormalizedEvent(
+  type: string,
+  event: Event,
+  normalize: (event: Event) => unknown,
+): unknown {
   const detail = normalize(event);
   recordEvent(type, detail);
   return detail;
@@ -418,9 +427,11 @@ function ensureVizElement(): HTMLElement {
     recordNormalizedEvent("open-mapping", e, normalizeOpenMappingEvent);
   });
   el.addEventListener("export", (e) => {
-    const payload = recordNormalizedEvent("export", e, normalizeExportEvent) as
-      | HarnessExportPayload
-      | null;
+    const payload = recordNormalizedEvent(
+      "export",
+      e,
+      normalizeExportEvent,
+    ) as HarnessExportPayload | null;
     // Export SVG must produce an artifact, not just an event: download it
     // client-side like Save does — nothing leaves the browser (sl-7pdf).
     if (payload?.format === "svg") {
@@ -619,7 +630,10 @@ document.addEventListener("click", () => {
 function renderLibraryList(): void {
   fixtureListEl.innerHTML = "";
   const docs = library.list();
-  renderLibrarySection("Examples", docs.filter((d) => d.kind === "builtin"));
+  renderLibrarySection(
+    "Examples",
+    docs.filter((d) => d.kind === "builtin"),
+  );
   const userDocs = docs.filter((d) => d.kind === "user");
   if (userDocs.length > 0) renderLibrarySection("Your documents", userDocs);
 }

--- a/tooling/satsuma-viz-harness/src/client/highlight.ts
+++ b/tooling/satsuma-viz-harness/src/client/highlight.ts
@@ -109,21 +109,21 @@ export function highlightSatsuma(source: string): string {
     const g = m.groups ?? {};
     const text = m[0];
 
-    if (g.triple)        html += wrap("tok-string-triple", text);
-    else if (g.string)   html += highlightStringContents(text);
+    if (g.triple) html += wrap("tok-string-triple", text);
+    else if (g.string) html += highlightStringContents(text);
     else if (g.comment_warn) html += wrap("tok-comment-warn", text);
-    else if (g.comment_q)    html += wrap("tok-comment-q",    text);
-    else if (g.comment)      html += wrap("tok-comment",       text);
-    else if (g.arrow)    html += wrap("tok-arrow",    text);
-    else if (g.spread)   html += wrap("tok-spread",   text);
-    else if (g.pipe)     html += wrap("tok-pipe",     text);
+    else if (g.comment_q) html += wrap("tok-comment-q", text);
+    else if (g.comment) html += wrap("tok-comment", text);
+    else if (g.arrow) html += wrap("tok-arrow", text);
+    else if (g.spread) html += wrap("tok-spread", text);
+    else if (g.pipe) html += wrap("tok-pipe", text);
     else if (g.backtick) html += wrap("tok-backtick", text);
-    else if (g.kw)       html += wrap("tok-kw",       text);
-    else if (g.type)     html += wrap("tok-type",     text);
+    else if (g.kw) html += wrap("tok-kw", text);
+    else if (g.type) html += wrap("tok-type", text);
     else if (g.pipeline) html += wrap("tok-pipeline", text);
-    else if (g.boolean)  html += wrap("tok-boolean",  text);
-    else if (g.number)   html += wrap("tok-number",   text);
-    else                 html += esc(text);
+    else if (g.boolean) html += wrap("tok-boolean", text);
+    else if (g.number) html += wrap("tok-number", text);
+    else html += esc(text);
 
     last = (m.index ?? 0) + text.length;
   }

--- a/tooling/satsuma-viz-harness/src/client/library.ts
+++ b/tooling/satsuma-viz-harness/src/client/library.ts
@@ -297,7 +297,11 @@ export class DocumentLibrary {
 
   /** Derive a user-document name that no existing user document already uses. */
   private uniqueUserName(name: string): string {
-    const taken = new Set(this.list().filter((d) => d.kind === "user").map((d) => d.name));
+    const taken = new Set(
+      this.list()
+        .filter((d) => d.kind === "user")
+        .map((d) => d.name),
+    );
     if (!taken.has(name)) return name;
     // Split "pipeline.stm" into "pipeline" + ".stm" so the counter lands before
     // the extension; a name with no dot gets the counter appended directly.

--- a/tooling/satsuma-viz-harness/src/server.ts
+++ b/tooling/satsuma-viz-harness/src/server.ts
@@ -219,15 +219,25 @@ function makeHandler(
     // ── API routes ─────────────────────────────────────────────────────────
 
     if (rawPath === "/api/fixtures") {
-      sendJson(res, 200, fixtures.map((f) => ({ name: f.name, path: f.path, uri: f.uri })));
+      sendJson(
+        res,
+        200,
+        fixtures.map((f) => ({ name: f.name, path: f.path, uri: f.uri })),
+      );
       return;
     }
 
     if (rawPath === "/api/source") {
       const uri = query.get("uri");
-      if (!uri) { sendError(res, 400, "Missing ?uri="); return; }
+      if (!uri) {
+        sendError(res, 400, "Missing ?uri=");
+        return;
+      }
       const fixture = fixturesByUri.get(uri);
-      if (!fixture) { sendError(res, 404, `Unknown fixture URI: ${uri}`); return; }
+      if (!fixture) {
+        sendError(res, 404, `Unknown fixture URI: ${uri}`);
+        return;
+      }
       try {
         const source = fs.readFileSync(fixture.path, "utf-8");
         sendJson(res, 200, { source, uri });

--- a/tooling/satsuma-viz-harness/test/chrome.test.ts
+++ b/tooling/satsuma-viz-harness/test/chrome.test.ts
@@ -24,17 +24,13 @@ async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
 }
 
 test.describe("Branded header (sl-ohxn)", () => {
-  test("the header is the Satsuma logo + wordmark, with no internal chrome", async ({
-    page,
-  }) => {
+  test("the header is the Satsuma logo + wordmark, with no internal chrome", async ({ page }) => {
     await page.goto("/");
 
     // Logo must actually load (a broken image still occupies layout space).
     const logo = page.locator("#header-logo");
     await expect(logo).toBeVisible();
-    expect(
-      await logo.evaluate((img) => (img as HTMLImageElement).naturalWidth),
-    ).toBeGreaterThan(0);
+    expect(await logo.evaluate((img) => (img as HTMLImageElement).naturalWidth)).toBeGreaterThan(0);
 
     // Wordmark is exactly "Satsuma" — no "viz harness" suffix.
     await expect(page.locator("#header h1")).toHaveText(/^\s*Satsuma\s*$/);
@@ -49,9 +45,7 @@ test.describe("Branded header (sl-ohxn)", () => {
 
   test("lineage is the default view mode without a visible toggle", async ({ page }) => {
     await page.goto("/");
-    await expect
-      .poll(() => page.evaluate(() => window.__satsumaHarness?.viewMode))
-      .toBe("lineage");
+    await expect.poll(() => page.evaluate(() => window.__satsumaHarness?.viewMode)).toBe("lineage");
   });
 });
 
@@ -87,19 +81,18 @@ test.describe("Brand typography (sl-ga3c)", () => {
   // (header, panel labels, toolbar buttons) must render in the self-hosted
   // Lexend; code surfaces keep JetBrains Mono. The component's --sz-font-sans
   // deliberately stays on its Inter/system stack — see the sl-ga3c notes.
-  test("chrome text renders in Lexend; the source editor stays monospace", async ({
-    page,
-  }) => {
+  test("chrome text renders in Lexend; the source editor stays monospace", async ({ page }) => {
     await page.goto("/");
 
     // The self-hosted face must actually have loaded — a bad @font-face URL
     // silently falls back to system-ui and font-family alone wouldn't catch it.
-    await expect
-      .poll(() => page.evaluate(() => document.fonts.check("12px Lexend")))
-      .toBe(true);
+    await expect.poll(() => page.evaluate(() => document.fonts.check("12px Lexend"))).toBe(true);
 
     const familyOf = (selector: string) =>
-      page.locator(selector).first().evaluate((el) => getComputedStyle(el).fontFamily);
+      page
+        .locator(selector)
+        .first()
+        .evaluate((el) => getComputedStyle(el).fontFamily);
 
     for (const selector of ["#header h1", ".panel-label", ".toolbar-action"]) {
       expect(await familyOf(selector), `${selector} must use Lexend`).toContain("Lexend");
@@ -120,9 +113,7 @@ test.describe("Brand typography (sl-ga3c)", () => {
     });
 
     await page.goto("/");
-    await expect
-      .poll(() => page.evaluate(() => document.fonts.check("12px Lexend")))
-      .toBe(true);
+    await expect.poll(() => page.evaluate(() => document.fonts.check("12px Lexend"))).toBe(true);
 
     expect(fontRequests.length).toBeGreaterThan(0);
     const origin = new URL(page.url()).origin;

--- a/tooling/satsuma-viz-harness/test/collapse.test.ts
+++ b/tooling/satsuma-viz-harness/test/collapse.test.ts
@@ -58,9 +58,7 @@ test.describe("Collapsible source pane", () => {
     expect(await vizWidth(page)).toBeGreaterThan(expandedWidth + MIN_RECLAIMED_WIDTH);
 
     // The automation contract mirrors the state and records the toggle.
-    expect(
-      await page.evaluate(() => window.__satsumaHarness.editorCollapsed),
-    ).toBe(true);
+    expect(await page.evaluate(() => window.__satsumaHarness.editorCollapsed)).toBe(true);
     expect(
       await page.evaluate(() =>
         window.__satsumaHarness.events.filter((e) => e.type === "editor-collapse"),
@@ -72,9 +70,7 @@ test.describe("Collapsible source pane", () => {
     await expect(page.locator("#source-editor")).toBeVisible();
     await expect(page.locator("#editor-expand-rail")).toBeHidden();
     expect(await vizWidth(page)).toBeCloseTo(expandedWidth, 0);
-    expect(
-      await page.evaluate(() => window.__satsumaHarness.editorCollapsed),
-    ).toBe(false);
+    expect(await page.evaluate(() => window.__satsumaHarness.editorCollapsed)).toBe(false);
   });
 
   test("the collapsed state survives a reload via localStorage", async ({ page }) => {
@@ -87,17 +83,13 @@ test.describe("Collapsible source pane", () => {
     await page.reload();
     await expect(page.locator("#editor-expand-rail")).toBeVisible();
     await expect(page.locator("#source-editor")).toBeHidden();
-    expect(
-      await page.evaluate(() => window.__satsumaHarness.editorCollapsed),
-    ).toBe(true);
+    expect(await page.evaluate(() => window.__satsumaHarness.editorCollapsed)).toBe(true);
 
     // And it is symmetric: expanding then reloading comes back expanded.
     await page.locator("#editor-expand-rail").click();
     await page.reload();
     await expect(page.locator("#source-editor")).toBeVisible();
-    expect(
-      await page.evaluate(() => window.__satsumaHarness.editorCollapsed),
-    ).toBe(false);
+    expect(await page.evaluate(() => window.__satsumaHarness.editorCollapsed)).toBe(false);
   });
 });
 
@@ -105,9 +97,7 @@ test.describe("Collapse affordance discoverability (sl-i0db)", () => {
   // The Feature 34 review flagged the original bare ◀ glyph as "useless —
   // more obvious hint needed". Both directions must now say what they do in
   // words, and stay keyboard-operable with accessible names.
-  test("both directions are labelled in words and carry accessible names", async ({
-    page,
-  }) => {
+  test("both directions are labelled in words and carry accessible names", async ({ page }) => {
     await openWithFixture(page);
 
     const collapseBtn = page.locator("#editor-collapse-btn");

--- a/tooling/satsuma-viz-harness/test/edge-anchors.test.ts
+++ b/tooling/satsuma-viz-harness/test/edge-anchors.test.ts
@@ -128,9 +128,7 @@ async function assertDotsOnCards(page: Page): Promise<void> {
 
 for (const theme of ["light", "dark"] as const) {
   test.describe(`Overview edge anchors — ${theme} theme`, () => {
-    test(`dots sit on non-namespaced cards at the header midpoint (${theme})`, async ({
-      page,
-    }) => {
+    test(`dots sit on non-namespaced cards at the header midpoint (${theme})`, async ({ page }) => {
       await loadFixture(page, buyToOmUri);
       await page.locator(`#theme-toggle .toggle-btn[data-theme='${theme}']`).click();
       await assertDotsOnCards(page);
@@ -144,9 +142,7 @@ for (const theme of ["light", "dark"] as const) {
   });
 }
 
-test("card chrome matches the geometry contract: no filler bar, 40px header", async ({
-  page,
-}) => {
+test("card chrome matches the geometry contract: no filler bar, 40px header", async ({ page }) => {
   // Anchor math measures from the card top: header midpoint is at
   // top + (pill ? 24 : 0) + 20. The old 24px filler bar shifted the visible
   // header down without the layout knowing. Assert the actual chrome: the

--- a/tooling/satsuma-viz-harness/test/editor.test.ts
+++ b/tooling/satsuma-viz-harness/test/editor.test.ts
@@ -79,16 +79,14 @@ test.describe("Live editor — editing and highlighting", () => {
     const input = page.locator("#source-input");
     await input.fill(SINGLE_SCHEMA_DOC);
 
-    await expect.poll(async () =>
-      page.locator("#source-highlight").evaluate((el) => el.textContent),
-    ).toBe(SINGLE_SCHEMA_DOC);
+    await expect
+      .poll(async () => page.locator("#source-highlight").evaluate((el) => el.textContent))
+      .toBe(SINGLE_SCHEMA_DOC);
 
     // `schema` is a keyword; `ID` and `STRING` are data types — all must be
     // tokenized into their respective token classes (not left as plain text).
     await expect(page.locator("#source-highlight .tok-kw").first()).toHaveText("schema");
-    await expect(
-      page.locator("#source-highlight .tok-type", { hasText: "STRING" }),
-    ).toHaveCount(1);
+    await expect(page.locator("#source-highlight .tok-type", { hasText: "STRING" })).toHaveCount(1);
   });
 
   test("wide lines scroll horizontally with the highlight layer locked to the caret", async ({
@@ -107,11 +105,7 @@ test.describe("Live editor — editing and highlighting", () => {
     // setting scrollLeft before layout has grown the scrollable overflow
     // silently clamps it (observed flake: 120 requested, 10 applied).
     await expect
-      .poll(() =>
-        page.locator("#source-input").evaluate(
-          (el) => el.scrollWidth - el.clientWidth,
-        ),
-      )
+      .poll(() => page.locator("#source-input").evaluate((el) => el.scrollWidth - el.clientWidth))
       .toBeGreaterThan(SCROLL_BY);
 
     const token = page.locator("#source-highlight .tok-comment").first();

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -116,11 +116,11 @@ test.describe("Overview view — sfdc-to-snowflake fixture", () => {
     await page.goto("/");
     // Lineage mode is active by default; load the single-file fixture first
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
   });
 
@@ -145,11 +145,11 @@ test.describe("Detail view — clicking a mapping", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
   });
 
@@ -171,11 +171,11 @@ test.describe("Hover and highlight interaction", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
   });
 
@@ -196,11 +196,13 @@ test.describe("Hover and highlight interaction", () => {
       .first()
       .hover();
 
-    await expect.poll(async () => recordedEvents(page, "field-hover")).toContainEqual(
-      expect.objectContaining({
-        detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
-      }),
-    );
+    await expect
+      .poll(async () => recordedEvents(page, "field-hover"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
+        }),
+      );
   });
 });
 
@@ -235,11 +237,11 @@ test.describe("Cross-file lineage expansion", () => {
     // an expand-lineage control exists in the UI.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, metricsUri);
 
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
@@ -253,9 +255,9 @@ test.describe("Cross-file lineage expansion", () => {
       }
     });
 
-    await expect.poll(async () => recordedEvents(page, "expand-lineage")).toContainEqual(
-      expect.objectContaining({ detail: { schemaId: "test::schema" } }),
-    );
+    await expect
+      .poll(async () => recordedEvents(page, "expand-lineage"))
+      .toContainEqual(expect.objectContaining({ detail: { schemaId: "test::schema" } }));
   });
 });
 
@@ -263,32 +265,32 @@ test.describe("Navigation intent", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
   });
 
-  test("navigate events from the viz are captured in the harness event log", async ({
-    page,
-  }) => {
+  test("navigate events from the viz are captured in the harness event log", async ({ page }) => {
     // A real overview schema-header click dispatches SzNavigateEvent with a
     // SourceLocation property; the harness must normalize it to stable JSON.
     await page.evaluate(() => window.__satsumaHarness.clearEvents());
 
     await page.locator("[data-testid='overview-schema-card-sfdc-opportunity']").click();
 
-    await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
-      expect.objectContaining({
-        detail: expect.objectContaining({
-          uri: expect.stringContaining("sfdc-to-snowflake/pipeline.stm"),
-          line: expect.any(Number),
-          character: expect.any(Number),
+    await expect
+      .poll(async () => recordedEvents(page, "navigate"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            uri: expect.stringContaining("sfdc-to-snowflake/pipeline.stm"),
+            line: expect.any(Number),
+            character: expect.any(Number),
+          }),
         }),
-      }),
-    );
+      );
   });
 
   test("field-lineage events from the viz are captured in the harness event log", async ({
@@ -307,16 +309,16 @@ test.describe("Navigation intent", () => {
     await fieldRow.hover();
     await fieldRow.locator("[data-testid$='-field-id-lineage']").click();
 
-    await expect.poll(async () => recordedEvents(page, "field-lineage")).toContainEqual(
-      expect.objectContaining({
-        detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
-      }),
-    );
+    await expect
+      .poll(async () => recordedEvents(page, "field-lineage"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: { schemaId: "sfdc_opportunity", fieldName: "Id" },
+        }),
+      );
   });
 
-  test("clicking an arrow row in the mapping detail records a navigate event", async ({
-    page,
-  }) => {
+  test("clicking an arrow row in the mapping detail records a navigate event", async ({ page }) => {
     // Each arrow row in the mapping detail table is wired to _navigate(arrow.location)
     // (sz-mapping-detail.ts:645). A real click must therefore round-trip through
     // SzNavigateEvent and surface as a `navigate` event in the harness recorder
@@ -331,15 +333,17 @@ test.describe("Navigation intent", () => {
       .first()
       .click();
 
-    await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
-      expect.objectContaining({
-        detail: expect.objectContaining({
-          uri: expect.stringContaining("sfdc-to-snowflake/pipeline.stm"),
-          line: expect.any(Number),
-          character: expect.any(Number),
+    await expect
+      .poll(async () => recordedEvents(page, "navigate"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            uri: expect.stringContaining("sfdc-to-snowflake/pipeline.stm"),
+            line: expect.any(Number),
+            character: expect.any(Number),
+          }),
         }),
-      }),
-    );
+      );
   });
 
   test("export events from the viz are captured in the harness event log", async ({ page }) => {
@@ -349,14 +353,16 @@ test.describe("Navigation intent", () => {
 
     await page.locator("[data-testid='toolbar-export']").click();
 
-    await expect.poll(async () => recordedEvents(page, "export")).toContainEqual(
-      expect.objectContaining({
-        detail: expect.objectContaining({
-          format: "svg",
-          content: expect.stringContaining("<svg"),
+    await expect
+      .poll(async () => recordedEvents(page, "export"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            format: "svg",
+            content: expect.stringContaining("<svg"),
+          }),
         }),
-      }),
-    );
+      );
   });
 });
 
@@ -379,11 +385,11 @@ test.describe("Overview view — sfdc-to-snowflake single-file mode", () => {
     // namespaced fixture against.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
 
     const schemaCards = page.locator("[data-testid^='overview-schema-card-']");
@@ -391,13 +397,9 @@ test.describe("Overview view — sfdc-to-snowflake single-file mode", () => {
 
     // None of the sfdc schemas live inside a namespace, so the namespace pill
     // hook (sl-3c2w) must not appear anywhere in the overview.
-    await expect(
-      page.locator("[data-testid$='-namespace-pill']"),
-    ).toHaveCount(0);
+    await expect(page.locator("[data-testid$='-namespace-pill']")).toHaveCount(0);
 
-    await expect(
-      page.locator("[data-testid^='overview-mapping-card-']"),
-    ).toHaveCount(1);
+    await expect(page.locator("[data-testid^='overview-mapping-card-']")).toHaveCount(1);
   });
 });
 
@@ -439,9 +441,7 @@ test.describe("Overview view — namespaces/ns-platform lineage mode", () => {
     // mapping becomes a test id starting with `overview-mapping-node-mapping-vault-`.
     // The vault layer is the densest mapping zone in this fixture.
     await expect(
-      page
-        .locator("[data-testid^='overview-mapping-node-mapping-vault-']")
-        .first(),
+      page.locator("[data-testid^='overview-mapping-node-mapping-vault-']").first(),
     ).toBeVisible();
   });
 });
@@ -461,14 +461,8 @@ test.describe("Overview view — metrics-platform lineage mode", () => {
     // look for the metric-card test id.  sanitizeTestIdSegment turns
     // underscores into dashes, so `monthly_recurring_revenue` →
     // `monthly-recurring-revenue`.
-    for (const metric of [
-      "monthly-recurring-revenue",
-      "churn-rate",
-      "customer-lifetime-value",
-    ]) {
-      await expect(
-        page.locator(`[data-testid='overview-metric-card-${metric}']`),
-      ).toBeVisible();
+    for (const metric of ["monthly-recurring-revenue", "churn-rate", "customer-lifetime-value"]) {
+      await expect(page.locator(`[data-testid='overview-metric-card-${metric}']`)).toBeVisible();
     }
 
     // Imported source from metric_sources.stm — proves the lineage merge
@@ -488,11 +482,11 @@ test.describe("Overview view — reports-and-models", () => {
     // report/model targets the same way they navigate to ordinary schemas.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, reportsUri);
 
     // sanitizeTestIdSegment lowercases and turns each underscore into `-`.
@@ -504,9 +498,7 @@ test.describe("Overview view — reports-and-models", () => {
       "customer-risk-report",
       "daily-order-summary",
     ]) {
-      await expect(
-        page.locator(`[data-testid='overview-schema-card-${id}']`),
-      ).toBeVisible();
+      await expect(page.locator(`[data-testid='overview-schema-card-${id}']`)).toBeVisible();
     }
   });
 });
@@ -520,11 +512,11 @@ test.describe("Overview view — sap-po-to-mfcs layout stability", () => {
     // ready" regression where layout completes but emits no cards.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sapUri);
 
     const vizRoot = page.locator("[data-testid='viz-root']");
@@ -567,11 +559,11 @@ test.describe("Mapping detail — sfdc opportunity ingestion", () => {
     // view must render its core elements correctly.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
     const detail = await openMappingByName(page, "opportunity-ingestion");
 
@@ -666,11 +658,11 @@ test.describe("Mapping detail — completed orders (multi-source join)", () => {
     // correctly.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, ffgUri);
     const detail = await openMappingByName(page, "completed-orders");
 
@@ -721,11 +713,11 @@ test.describe("Mapping detail — order line facts (flatten)", () => {
     // marker, readers cannot tell flatten arrows from top-level arrows.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, ffgUri);
     const detail = await openMappingByName(page, "order-line-facts");
 
@@ -733,9 +725,7 @@ test.describe("Mapping detail — order line facts (flatten)", () => {
     //   {prefix}-{sectionPrefix}
     // where sectionPrefix = `flatten-{sourceField}` sanitized.
     await expect(
-      detail.locator(
-        "[data-testid='mapping-detail-order-line-facts-flatten-line-items']",
-      ),
+      detail.locator("[data-testid='mapping-detail-order-line-facts-flatten-line-items']"),
     ).toBeVisible();
 
     // Per-element arrow rows nested inside the flatten section have test ids
@@ -770,11 +760,11 @@ test.describe("Field coverage indicators", () => {
     // makes coverage circles meaningful in the UI.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
     const detail = await openMappingByName(page, "opportunity-ingestion");
 
@@ -802,20 +792,21 @@ test.describe("Field coverage indicators", () => {
     // collide with any other top-level sku in the same schema.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, ffgUri);
     const detail = await openMappingByName(page, "order-line-facts");
 
     const targetCardPrefix =
       "mapping-detail-order-line-facts-target-schema-card-order-line-facts-parquet";
 
-    await expect(
-      detail.locator(`[data-testid='${targetCardPrefix}-field-sku']`),
-    ).toHaveAttribute("data-coverage", "mapped");
+    await expect(detail.locator(`[data-testid='${targetCardPrefix}-field-sku']`)).toHaveAttribute(
+      "data-coverage",
+      "mapped",
+    );
     await expect(
       detail.locator(`[data-testid='${targetCardPrefix}-field-line-number']`),
     ).toHaveAttribute("data-coverage", "mapped");
@@ -832,11 +823,11 @@ test.describe("Hover highlighting between arrows and field rows", () => {
     // reader sees which fields participate in this arrow.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
     const detail = await openMappingByName(page, "opportunity-ingestion");
 
@@ -862,11 +853,11 @@ test.describe("Hover highlighting between arrows and field rows", () => {
     // bidirectional and not arrow-row-only.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
     const detail = await openMappingByName(page, "opportunity-ingestion");
 
@@ -910,38 +901,26 @@ test.describe("Toolbar namespace filter — ns-platform", () => {
     await loadFixture(page, nsPlatformUri);
 
     // Baseline: all namespaces show their cards.
-    await expect(
-      page.locator("[data-testid^='overview-schema-card-raw-']").first(),
-    ).toBeVisible();
-    await expect(
-      page.locator("[data-testid^='overview-schema-card-mart-']").first(),
-    ).toBeVisible();
+    await expect(page.locator("[data-testid^='overview-schema-card-raw-']").first()).toBeVisible();
+    await expect(page.locator("[data-testid^='overview-schema-card-mart-']").first()).toBeVisible();
 
     // Select `mart` only.
     await page.locator("[data-testid='toolbar-namespace-filter']").selectOption("mart");
     await waitForViewReady(page);
 
     // mart cards remain; raw cards must be gone.
-    await expect(
-      page.locator("[data-testid^='overview-schema-card-mart-']").first(),
-    ).toBeVisible();
-    expect(
-      await page.locator("[data-testid^='overview-schema-card-raw-']").count(),
-    ).toBe(0);
+    await expect(page.locator("[data-testid^='overview-schema-card-mart-']").first()).toBeVisible();
+    expect(await page.locator("[data-testid^='overview-schema-card-raw-']").count()).toBe(0);
 
     // Reset to all namespaces.
     await page.locator("[data-testid='toolbar-namespace-filter']").selectOption("");
     await waitForViewReady(page);
-    await expect(
-      page.locator("[data-testid^='overview-schema-card-raw-']").first(),
-    ).toBeVisible();
+    await expect(page.locator("[data-testid^='overview-schema-card-raw-']").first()).toBeVisible();
   });
 });
 
 test.describe("Toolbar file filter — metrics-platform lineage mode", () => {
-  test("selecting a source file restricts cards to that file's declarations", async ({
-    page,
-  }) => {
+  test("selecting a source file restricts cards to that file's declarations", async ({ page }) => {
     // metrics.stm imports from metric_sources.stm, so lineage mode shows
     // cards declared across both files.  Filtering to metrics.stm only must
     // drop the imported source cards (e.g. fact_subscriptions).  Filtering
@@ -965,7 +944,9 @@ test.describe("Toolbar file filter — metrics-platform lineage mode", () => {
       .evaluateAll((opts) =>
         (opts as HTMLOptionElement[]).map((o) => ({ value: o.value, label: o.textContent })),
       );
-    const metricsOption = options.find((o) => o.label?.includes("metrics.stm") && !o.label.includes("metric_sources"));
+    const metricsOption = options.find(
+      (o) => o.label?.includes("metrics.stm") && !o.label.includes("metric_sources"),
+    );
     const sourcesOption = options.find((o) => o.label?.includes("metric_sources.stm"));
     if (!metricsOption || !sourcesOption) {
       throw new Error(`expected both file filter options; got ${JSON.stringify(options)}`);
@@ -1027,20 +1008,18 @@ async function readOverviewCardBoxes(page: Page): Promise<CardBox[]> {
     .locator("[data-testid^='overview-schema-card-']")
     .first()
     .waitFor({ state: "attached", timeout: 10_000 });
-  const boxes = await page
-    .locator("[data-testid^='overview-schema-card-']")
-    .evaluateAll((els) =>
-      (els as HTMLElement[]).map((el) => {
-        const r = el.getBoundingClientRect();
-        return {
-          testId: el.getAttribute("data-testid") ?? "",
-          x: r.x,
-          y: r.y,
-          width: r.width,
-          height: r.height,
-        };
-      }),
-    );
+  const boxes = await page.locator("[data-testid^='overview-schema-card-']").evaluateAll((els) =>
+    (els as HTMLElement[]).map((el) => {
+      const r = el.getBoundingClientRect();
+      return {
+        testId: el.getAttribute("data-testid") ?? "",
+        x: r.x,
+        y: r.y,
+        width: r.width,
+        height: r.height,
+      };
+    }),
+  );
   return boxes.sort((a, b) => a.testId.localeCompare(b.testId));
 }
 
@@ -1069,10 +1048,8 @@ function assertBoxesDoNotOverlap(boxes: CardBox[], tolerance = 1): void {
       // Indices are loop-bounded, so this never skips; the guard only
       // narrows the noUncheckedIndexedAccess types without an assertion.
       if (!a || !b) continue;
-      const overlapX =
-        Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
-      const overlapY =
-        Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
+      const overlapX = Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x);
+      const overlapY = Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y);
       const overlapping = overlapX > tolerance && overlapY > tolerance;
       expect(
         overlapping,
@@ -1089,11 +1066,11 @@ test.describe("Geometry sanity — overview layout invariants", () => {
     // regression in the non-namespaced card-height path.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
     const boxes = await readOverviewCardBoxes(page);
     assertBoxesAreSane(boxes);
@@ -1121,20 +1098,18 @@ test.describe("Geometry sanity — overview layout invariants", () => {
     // every pill is contained within at least one card's box — proves the
     // pill height is included in the card-height calculation rather than
     // being clipped or rendered outside its host card.
-    const pillBoxes = await page
-      .locator("[data-testid$='-namespace-pill']")
-      .evaluateAll((els) =>
-        (els as HTMLElement[]).map((el) => {
-          const r = el.getBoundingClientRect();
-          return {
-            testId: el.getAttribute("data-testid") ?? "",
-            x: r.x,
-            y: r.y,
-            w: r.width,
-            h: r.height,
-          };
-        }),
-      );
+    const pillBoxes = await page.locator("[data-testid$='-namespace-pill']").evaluateAll((els) =>
+      (els as HTMLElement[]).map((el) => {
+        const r = el.getBoundingClientRect();
+        return {
+          testId: el.getAttribute("data-testid") ?? "",
+          x: r.x,
+          y: r.y,
+          w: r.width,
+          h: r.height,
+        };
+      }),
+    );
     expect(pillBoxes.length).toBeGreaterThan(0);
     for (const pill of pillBoxes) {
       expect(pill.w, `${pill.testId} width not positive`).toBeGreaterThan(0);
@@ -1166,11 +1141,11 @@ test.describe("Geometry sanity — overview layout invariants", () => {
     // per-mapping geometry expectations rather than a global rule.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
 
     const sourceBox = await page
@@ -1212,11 +1187,11 @@ test.describe("Geometry sanity — overview layout invariants", () => {
     // original kind would push every dot well outside the tolerance.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sfdcUri);
 
     // Tolerance budget = anchor-dot radius (3.5px) + edge stroke width
@@ -1279,11 +1254,11 @@ test.describe("Geometry sanity — overview layout invariants", () => {
     // schemas or denser arrows than the small canonical fixtures expose.
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, sapUri);
     const boxes = await readOverviewCardBoxes(page);
     assertBoxesAreSane(boxes);
@@ -1306,11 +1281,11 @@ test.describe("Compact card expansion in overview", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, buyToOmUri);
   });
 
@@ -1345,7 +1320,9 @@ test.describe("Compact card expansion in overview", () => {
 
     await header.click();
     // Fields visible after first click.
-    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({
+      timeout: 5_000,
+    });
 
     await header.click();
     // Fields gone after second click.
@@ -1364,7 +1341,9 @@ test.describe("Compact card expansion in overview", () => {
 
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
     await card.locator(".header-toggle").click();
-    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({
+      timeout: 5_000,
+    });
     await expect
       .poll(async () => canvas.evaluate((el) => el.getBoundingClientRect().height))
       .toBeGreaterThan(heightBefore);
@@ -1413,7 +1392,9 @@ test.describe("Compact card expansion in overview", () => {
     assertBoxesDoNotOverlap(boxes);
   });
 
-  test("the toggle arrow expands without navigating; the header name navigates", async ({ page }) => {
+  test("the toggle arrow expands without navigating; the header name navigates", async ({
+    page,
+  }) => {
     // Regression for sl-tw0r: the old combined handler made every expansion
     // also dispatch SzNavigateEvent, so hosts that open documents on navigate
     // (VS Code) yanked the editor to the source file whenever a card was
@@ -1423,18 +1404,22 @@ test.describe("Compact card expansion in overview", () => {
 
     const card = page.locator("[data-testid^='overview-schema-card-buy-order']");
     await card.locator(".header-toggle").click();
-    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({ timeout: 5_000 });
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({
+      timeout: 5_000,
+    });
     expect(await recordedEvents(page, "navigate")).toEqual([]);
 
     await card.locator(".header-name").click();
-    await expect.poll(async () => recordedEvents(page, "navigate")).toContainEqual(
-      expect.objectContaining({
-        detail: expect.objectContaining({
-          uri: expect.stringContaining("buy-to-om-order.stm"),
-          line: expect.any(Number),
+    await expect
+      .poll(async () => recordedEvents(page, "navigate"))
+      .toContainEqual(
+        expect.objectContaining({
+          detail: expect.objectContaining({
+            uri: expect.stringContaining("buy-to-om-order.stm"),
+            line: expect.any(Number),
+          }),
         }),
-      }),
-    );
+      );
   });
 });
 
@@ -1450,24 +1435,15 @@ test.describe("Compact card expansion in overview", () => {
 
 /** Computed background-color of the <satsuma-viz> host (drives off --sz-bg). */
 async function vizHostBackground(page: Page): Promise<string> {
-  return page
-    .locator("satsuma-viz")
-    .evaluate((el) => getComputedStyle(el).backgroundColor);
+  return page.locator("satsuma-viz").evaluate((el) => getComputedStyle(el).backgroundColor);
 }
 
 /** Read a computed style property of the first element matching a selector. */
-async function computedStyle(
-  page: Page,
-  selector: string,
-  property: string,
-): Promise<string> {
+async function computedStyle(page: Page, selector: string, property: string): Promise<string> {
   return page
     .locator(selector)
     .first()
-    .evaluate(
-      (el, prop) => getComputedStyle(el).getPropertyValue(prop),
-      property,
-    );
+    .evaluate((el, prop) => getComputedStyle(el).getPropertyValue(prop), property);
 }
 
 test.describe("Theme switching — URL parameter", () => {
@@ -1500,9 +1476,7 @@ test.describe("Theme switching — prefers-color-scheme fallback", () => {
   // colorScheme. Playwright drives the media query via test.use({ colorScheme }).
   test.describe("emulated light scheme", () => {
     test.use({ colorScheme: "light" });
-    test("adopts light when the OS prefers light and no parameter is set", async ({
-      page,
-    }) => {
+    test("adopts light when the OS prefers light and no parameter is set", async ({ page }) => {
       await page.goto("/");
       await loadFixture(page, sfdcUri);
       expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("light");
@@ -1512,9 +1486,7 @@ test.describe("Theme switching — prefers-color-scheme fallback", () => {
 
   test.describe("emulated dark scheme", () => {
     test.use({ colorScheme: "dark" });
-    test("adopts dark when the OS prefers dark and no parameter is set", async ({
-      page,
-    }) => {
+    test("adopts dark when the OS prefers dark and no parameter is set", async ({ page }) => {
       await page.goto("/");
       await loadFixture(page, sfdcUri);
       expect(await page.evaluate(() => window.__satsumaHarness.theme)).toBe("dark");
@@ -1554,16 +1526,14 @@ test.describe("Theme switching — header toggle", () => {
     expect(bodyBgAfter).toBe("rgb(255, 250, 245)");
 
     // The switch is observable in the automation event log.
-    await expect.poll(async () => recordedEvents(page, "theme-change")).toContainEqual(
-      expect.objectContaining({ detail: { theme: "light" } }),
-    );
+    await expect
+      .poll(async () => recordedEvents(page, "theme-change"))
+      .toContainEqual(expect.objectContaining({ detail: { theme: "light" } }));
   });
 });
 
 test.describe("Theme switching — representative audit tokens", () => {
-  test("report header and overview edge stroke change colour between themes", async ({
-    page,
-  }) => {
+  test("report header and overview edge stroke change colour between themes", async ({ page }) => {
     // --sz-bg flipping is necessary but not sufficient: the audit promoted many
     // other tokens. This asserts two representative ones — the report-card
     // header (--sz-report) and the overview edge stroke (--sz-edge-default) —
@@ -1579,11 +1549,11 @@ test.describe("Theme switching — representative audit tokens", () => {
 
     await page.goto("/?theme=light");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, reportsUri);
     const reportHeaderLight = await computedStyle(page, reportHeader, "background-color");
     const edgeStrokeLight = await computedStyle(page, overviewEdge, "stroke");
@@ -1596,11 +1566,11 @@ test.describe("Theme switching — representative audit tokens", () => {
 
     await page.goto("/?theme=dark");
     await page.waitForFunction(() => {
-    const harness = window.__satsumaHarness;
-    if (!harness?.setViewMode) return false; // app.js not evaluated yet
-    harness.setViewMode("single");
-    return true;
-  });
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
     await loadFixture(page, reportsUri);
     const reportHeaderDark = await computedStyle(page, reportHeader, "background-color");
     const edgeStrokeDark = await computedStyle(page, overviewEdge, "stroke");

--- a/tooling/satsuma-viz-harness/test/mapping-field-meta.test.ts
+++ b/tooling/satsuma-viz-harness/test/mapping-field-meta.test.ts
@@ -39,9 +39,9 @@ async function openMappingDetail(
   await page
     .locator(`[data-testid='overview-mapping-card-${mappingTestId}']`)
     .dispatchEvent("click");
-  await expect(
-    page.locator(`[data-testid='mapping-detail-${mappingTestId}']`).first(),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(`[data-testid='mapping-detail-${mappingTestId}']`).first()).toBeVisible(
+    { timeout: 10_000 },
+  );
 }
 
 test("mapping-level metadata renders in the detail header", async ({ page }) => {
@@ -65,9 +65,7 @@ test("non-constraint field metadata renders as pills on the field row", async ({
   // appear as key+value pills instead of being silently dropped.
   await openMappingDetail(page, governanceUri, "customer-360-assembly");
 
-  const fieldRow = page
-    .locator("[data-testid$='-field-first-name']")
-    .first();
+  const fieldRow = page.locator("[data-testid$='-field-first-name']").first();
   await expect(fieldRow).toBeVisible();
 
   const pills = fieldRow.locator(".badge.field-meta");

--- a/tooling/satsuma-viz-harness/test/meta-pills.test.ts
+++ b/tooling/satsuma-viz-harness/test/meta-pills.test.ts
@@ -34,12 +34,10 @@ async function openOrderLinesDetail(page: Page): Promise<void> {
     { timeout: 20_000 },
   );
   // dispatchEvent: overview cards can sit under the minimap overlay.
-  await page
-    .locator("[data-testid='overview-mapping-card-order-lines']")
-    .dispatchEvent("click");
-  await expect(
-    page.locator("[data-testid='mapping-detail-order-lines']").first(),
-  ).toBeVisible({ timeout: 10_000 });
+  await page.locator("[data-testid='overview-mapping-card-order-lines']").dispatchEvent("click");
+  await expect(page.locator("[data-testid='mapping-detail-order-lines']").first()).toBeVisible({
+    timeout: 10_000,
+  });
 }
 
 function sourceCard(page: Page) {

--- a/tooling/satsuma-viz-harness/test/metric-endpoints.test.ts
+++ b/tooling/satsuma-viz-harness/test/metric-endpoints.test.ts
@@ -43,16 +43,16 @@ test("a mapping targeting a metric renders the metric card in the TARGET column"
   await page
     .locator("[data-testid='overview-mapping-card-conversion-rate-pipeline']")
     .dispatchEvent("click");
-  const detail = page
-    .locator("[data-testid='mapping-detail-conversion-rate-pipeline']")
-    .first();
+  const detail = page.locator("[data-testid='mapping-detail-conversion-rate-pipeline']").first();
   await expect(detail).toBeVisible({ timeout: 10_000 });
 
   // The target column must contain the conversion_rate metric card — not be
   // empty — with its measure fields and metric metadata pills visible.
-  const targetCard = page.locator(
-    "[data-testid^='mapping-detail-conversion-rate-pipeline-target-schema-card-conversion-rate']",
-  ).first();
+  const targetCard = page
+    .locator(
+      "[data-testid^='mapping-detail-conversion-rate-pipeline-target-schema-card-conversion-rate']",
+    )
+    .first();
   await expect(targetCard).toBeVisible();
   await expect(targetCard).toContainText("pipeline_stage");
   await expect(targetCard).toContainText("value");
@@ -92,9 +92,7 @@ test("a mapping sourcing from a metric renders the metric card in the SOURCES co
   // overview card to appear (proves the model rebuilt with the new mapping).
   const buffer = await page.locator("#source-input").inputValue();
   await page.locator("#source-input").fill(buffer + METRIC_SOURCE_MAPPING);
-  const mappingCard = page.locator(
-    "[data-testid='overview-mapping-card-win-rate-report-load']",
-  );
+  const mappingCard = page.locator("[data-testid='overview-mapping-card-win-rate-report-load']");
   await expect(mappingCard).toBeVisible({ timeout: 10_000 });
 
   // The appended mapping lays out at the canvas edge — under the minimap.
@@ -102,9 +100,11 @@ test("a mapping sourcing from a metric renders the metric card in the SOURCES co
   const detail = page.locator("[data-testid='mapping-detail-win-rate-report-load']").first();
   await expect(detail).toBeVisible({ timeout: 10_000 });
 
-  const sourceCard = page.locator(
-    "[data-testid^='mapping-detail-win-rate-report-load-source-schema-card-conversion-rate']",
-  ).first();
+  const sourceCard = page
+    .locator(
+      "[data-testid^='mapping-detail-win-rate-report-load-source-schema-card-conversion-rate']",
+    )
+    .first();
   await expect(sourceCard).toBeVisible();
   await expect(sourceCard).toContainText("pipeline_stage");
   await expect(sourceCard).toContainText("value");

--- a/tooling/satsuma-viz-harness/test/minimap.test.ts
+++ b/tooling/satsuma-viz-harness/test/minimap.test.ts
@@ -64,9 +64,9 @@ async function openWithBuffer(page: Page, text: string): Promise<void> {
     { timeout: 20_000 },
   );
   await page.locator("#source-input").fill(text);
-  await expect(
-    page.locator("[data-testid='overview-mapping-card-load-1']"),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("[data-testid='overview-mapping-card-load-1']")).toBeVisible({
+    timeout: 10_000,
+  });
 }
 
 test.describe("Minimap visibility and contents", () => {
@@ -83,19 +83,15 @@ test.describe("Minimap visibility and contents", () => {
     await expect(minimap).toBeInViewport();
   });
 
-  test("mapping detail minimap shows the detail content, not the file canvas", async ({
-    page,
-  }) => {
+  test("mapping detail minimap shows the detail content, not the file canvas", async ({ page }) => {
     await openWithBuffer(page, tallDoc(1));
 
     // dispatchEvent rather than a pointer click: opening the mapping is the
     // precondition here, not the subject (see view-persistence.test.ts).
-    await page
-      .locator("[data-testid='overview-mapping-card-load-1']")
-      .dispatchEvent("click");
-    await expect(
-      page.locator("[data-testid='mapping-detail-load-1']").first(),
-    ).toBeVisible({ timeout: 10_000 });
+    await page.locator("[data-testid='overview-mapping-card-load-1']").dispatchEvent("click");
+    await expect(page.locator("[data-testid='mapping-detail-load-1']").first()).toBeVisible({
+      timeout: 10_000,
+    });
 
     const minimap = page.locator("[data-testid='viz-minimap']");
     await expect(minimap).toBeVisible({ timeout: 10_000 });

--- a/tooling/satsuma-viz-harness/test/open-save.test.ts
+++ b/tooling/satsuma-viz-harness/test/open-save.test.ts
@@ -85,9 +85,7 @@ test.describe("Open a local file (client-only)", () => {
     await page.locator("#fixture-picker-btn").click();
     const userSection = page.locator(".fixture-section-header", { hasText: "Your documents" });
     await expect(userSection).toBeVisible();
-    await expect(
-      page.locator(".fixture-item", { hasText: OPENED_FILENAME }),
-    ).toBeVisible();
+    await expect(page.locator(".fixture-item", { hasText: OPENED_FILENAME })).toBeVisible();
   });
 });
 

--- a/tooling/satsuma-viz-harness/test/playground-static.test.ts
+++ b/tooling/satsuma-viz-harness/test/playground-static.test.ts
@@ -53,9 +53,7 @@ test.describe("Static playground bundle (non-root base path)", () => {
 
     // The viz rendered a seeded example — the library came from the bundled
     // examples.json, because this server has no fixture API to fall back to.
-    await expect(
-      page.locator("[data-testid^='overview-schema-card-']").first(),
-    ).toBeVisible();
+    await expect(page.locator("[data-testid^='overview-schema-card-']").first()).toBeVisible();
 
     // The picker is populated from the seeded localStorage library.
     await page.locator("#fixture-picker-btn").click();
@@ -63,9 +61,7 @@ test.describe("Static playground bundle (non-root base path)", () => {
 
     expect(requests.length).toBeGreaterThan(0);
     for (const url of requests) {
-      expect(url, `request escaped the base path: ${url}`).toContain(
-        "/satsuma-lang/playground/",
-      );
+      expect(url, `request escaped the base path: ${url}`).toContain("/satsuma-lang/playground/");
     }
   });
 

--- a/tooling/satsuma-viz-harness/test/screenshots.spec.ts
+++ b/tooling/satsuma-viz-harness/test/screenshots.spec.ts
@@ -95,13 +95,13 @@ async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
   await page.locator("#fixture-picker-btn").click();
   await page.locator(`.fixture-item[data-uri="${fixtureUri}"]`).click();
   await page.locator("[data-testid='viz-root']").waitFor({ state: "visible" });
-  await page
-    .locator("[data-testid='viz-root']")
-    .waitFor({ state: "visible", timeout: 20_000 });
+  await page.locator("[data-testid='viz-root']").waitFor({ state: "visible", timeout: 20_000 });
   // Wait for the layout pipeline to finish before screenshotting — otherwise
   // we capture the loading state instead of the rendered viz.
   await page.waitForFunction(
-    () => document.querySelector("[data-testid='viz-root']")?.getAttribute("data-ready-state") === "ready",
+    () =>
+      document.querySelector("[data-testid='viz-root']")?.getAttribute("data-ready-state") ===
+      "ready",
     null,
     { timeout: 20_000 },
   );
@@ -126,7 +126,9 @@ async function openMapping(page: Page, mappingId: string): Promise<void> {
 
 async function waitForReady(page: Page): Promise<void> {
   await page.waitForFunction(
-    () => document.querySelector("[data-testid='viz-root']")?.getAttribute("data-ready-state") === "ready",
+    () =>
+      document.querySelector("[data-testid='viz-root']")?.getAttribute("data-ready-state") ===
+      "ready",
     null,
     { timeout: 15_000 },
   );
@@ -252,14 +254,12 @@ for (const theme of THEMES) {
       // Drive the file filter to the metric_sources.stm option, mirroring the
       // approach used in the toolbar file-filter test in harness.test.ts.
       const fileFilter = page.locator("[data-testid='toolbar-file-filter']");
-      const options = await fileFilter
-        .locator("option")
-        .evaluateAll((opts) =>
-          (opts as HTMLOptionElement[]).map((o) => ({
-            value: o.value,
-            label: o.textContent,
-          })),
-        );
+      const options = await fileFilter.locator("option").evaluateAll((opts) =>
+        (opts as HTMLOptionElement[]).map((o) => ({
+          value: o.value,
+          label: o.textContent,
+        })),
+      );
       const sourcesOption = options.find((o) => o.label?.includes("metric_sources.stm"));
       if (!sourcesOption) {
         throw new Error(`metric_sources.stm option not found; got ${JSON.stringify(options)}`);

--- a/tooling/satsuma-viz-harness/test/unit/library.test.mjs
+++ b/tooling/satsuma-viz-harness/test/unit/library.test.mjs
@@ -120,10 +120,10 @@ describe("first-load seeding", () => {
       assert.equal(doc.kind, "builtin");
       assert.equal(doc.edited, false);
     }
-    assert.deepEqual(
-      docs.map((d) => d.uri).sort(),
-      ["file:///examples/demo/customers.stm", "file:///examples/demo/pipeline.stm"],
-    );
+    assert.deepEqual(docs.map((d) => d.uri).sort(), [
+      "file:///examples/demo/customers.stm",
+      "file:///examples/demo/pipeline.stm",
+    ]);
   });
 
   // The URI contract that makes cross-file lineage work: a sibling-relative

--- a/tooling/satsuma-viz-harness/test/view-persistence.test.ts
+++ b/tooling/satsuma-viz-harness/test/view-persistence.test.ts
@@ -61,23 +61,19 @@ async function openWithBuffer(page: Page, text: string): Promise<void> {
   );
   await page.locator("#source-input").fill(text);
   // The one-mapping overview card proves the buffer replaced the fixture model.
-  await expect(
-    page.locator("[data-testid='overview-mapping-card-orders-load']"),
-  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("[data-testid='overview-mapping-card-orders-load']")).toBeVisible({
+    timeout: 10_000,
+  });
 }
 
 test.describe("Detail view persistence across live edits", () => {
-  test("an edit that keeps the mapping re-renders the detail view in place", async ({
-    page,
-  }) => {
+  test("an edit that keeps the mapping re-renders the detail view in place", async ({ page }) => {
     await openWithBuffer(page, doc("orders_load"));
 
     // dispatchEvent rather than a pointer click: the tiny two-schema graph
     // sits partly under the minimap overlay, which intercepts real pointer
     // events. Opening the mapping is the precondition here, not the subject.
-    await page
-      .locator("[data-testid='overview-mapping-card-orders-load']")
-      .dispatchEvent("click");
+    await page.locator("[data-testid='overview-mapping-card-orders-load']").dispatchEvent("click");
     const detail = page.locator("[data-testid='mapping-detail-orders-load']").first();
     await expect(detail).toBeVisible({ timeout: 10_000 });
 
@@ -99,20 +95,18 @@ test.describe("Detail view persistence across live edits", () => {
     await openWithBuffer(page, doc("orders_load"));
 
     // See above: dispatchEvent avoids minimap pointer interception.
-    await page
-      .locator("[data-testid='overview-mapping-card-orders-load']")
-      .dispatchEvent("click");
-    await expect(
-      page.locator("[data-testid='mapping-detail-orders-load']").first(),
-    ).toBeVisible({ timeout: 10_000 });
+    await page.locator("[data-testid='overview-mapping-card-orders-load']").dispatchEvent("click");
+    await expect(page.locator("[data-testid='mapping-detail-orders-load']").first()).toBeVisible({
+      timeout: 10_000,
+    });
 
     // Renaming the mapping deletes the selected one; the only sensible place
     // for the user is back at the overview, now showing the renamed mapping.
     await page.locator("#source-input").fill(doc("orders_load_v2"));
 
-    await expect(
-      page.locator("[data-testid='overview-mapping-card-orders-load-v2']"),
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("[data-testid='overview-mapping-card-orders-load-v2']")).toBeVisible({
+      timeout: 10_000,
+    });
     await expect(page.locator("[data-testid^='mapping-detail-']")).toHaveCount(0);
     await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
       "data-view-mode",

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -336,6 +336,4 @@ export interface SourceLocation {
  * Constraints are rendered as badges in the viz component; arbitrary tags are not.
  * Source: Satsuma v2 spec §4.2 (field metadata).
  */
-export const CONSTRAINT_TAGS = new Set([
-  "pk", "required", "pii", "indexed", "unique", "encrypt",
-]);
+export const CONSTRAINT_TAGS = new Set(["pk", "required", "pii", "indexed", "unique", "encrypt"]);

--- a/tooling/satsuma-viz-model/test/model.test.js
+++ b/tooling/satsuma-viz-model/test/model.test.js
@@ -183,7 +183,12 @@ describe("VizModel fixture validation", () => {
       text: "copy @customers.email",
       steps: ["copy @customers.email"],
       atRefs: [
-        { ref: "@customers", classification: "schema_ref", resolved: true, resolvedTo: { kind: "schema", name: "customers" } },
+        {
+          ref: "@customers",
+          classification: "schema_ref",
+          resolved: true,
+          resolvedTo: { kind: "schema", name: "customers" },
+        },
       ],
     };
     /** @type {import("@satsuma/viz-model").TransformInfo} */

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -196,9 +196,14 @@ export class SzFragmentCard extends LitElement {
     // edge anchors missed the header — sl-wixe.) The row is pinned to the
     // shared NAMESPACE_PILL_HEIGHT the layout reserves for it.
     if (!this.namespaceLabel) return html``;
-    return html`<div style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-green);">
-        <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);">${this.namespaceLabel}</span>
-      </div>`;
+    return html`<div
+      style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-green);"
+    >
+      <span
+        style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
+        >${this.namespaceLabel}</span
+      >
+    </div>`;
   }
 
   override render() {
@@ -227,11 +232,14 @@ export class SzFragmentCard extends LitElement {
           <span class="header-icon">&#9674;</span>
           <span class="header-name">${fr.id}</span>
           <span class="header-count">${fr.fields.length} fields</span>
-          <span class="header-toggle" ?data-collapsed=${this._collapsed} @click=${this._onToggleClick}>&#9660;</span>
+          <span
+            class="header-toggle"
+            ?data-collapsed=${this._collapsed}
+            @click=${this._onToggleClick}
+            >&#9660;</span
+          >
         </div>
-        <div class="fields">
-          ${fr.fields.map((f) => this._renderField(f))}
-        </div>
+        <div class="fields">${fr.fields.map((f) => this._renderField(f))}</div>
         ${hasNotes ? this._renderNotes(fr.notes) : ""}
       </div>
     `;
@@ -244,9 +252,11 @@ export class SzFragmentCard extends LitElement {
           <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
           <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
         </div>
-        ${this._notesExpanded
-          ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
-          : ""}
+        ${
+          this._notesExpanded
+            ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
+            : ""
+        }
       </div>
     `;
   }
@@ -263,9 +273,7 @@ export class SzFragmentCard extends LitElement {
         <span class="field-name">${f.name}</span>
         <span class="field-type">${f.type}</span>
         <span class="badges">
-          ${f.constraints.map(
-            (c) => html`<span class="badge">${c}</span>`
-          )}
+          ${f.constraints.map((c) => html`<span class="badge">${c}</span>`)}
         </span>
       </div>
     `;

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -179,7 +179,9 @@ export class SzMappingDetail extends LitElement {
 
     .arrow-table tr {
       cursor: pointer;
-      transition: opacity 0.15s ease, background 0.15s ease;
+      transition:
+        opacity 0.15s ease,
+        background 0.15s ease;
     }
 
     .arrow-table tr:hover {
@@ -397,10 +399,7 @@ export class SzMappingDetail extends LitElement {
       if (this._hoveredCardSchema === m.targetRef) {
         return this._findSourceFieldsForTarget(this._hoveredCardField, m);
       } else if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-        result.set(
-          this._hoveredCardSchema,
-          new Set([this._hoveredCardField])
-        );
+        result.set(this._hoveredCardSchema, new Set([this._hoveredCardField]));
       }
     }
 
@@ -415,21 +414,15 @@ export class SzMappingDetail extends LitElement {
 
     if (this._hoveredArrow) {
       if (!targetSchema) return new Set();
-      const localPath = resolveSchemaLocalFieldPath(
-        this._hoveredArrow.targetField,
-        targetSchema,
-        [m.targetRef],
-      );
+      const localPath = resolveSchemaLocalFieldPath(this._hoveredArrow.targetField, targetSchema, [
+        m.targetRef,
+      ]);
       return localPath ? new Set([localPath]) : new Set();
     }
 
     if (this._hoveredCardField && this._hoveredCardSchema) {
       if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-        return this._findTargetFieldsForSource(
-          this._hoveredCardField,
-          this._hoveredCardSchema,
-          m,
-        );
+        return this._findTargetFieldsForSource(this._hoveredCardField, this._hoveredCardSchema, m);
       } else if (this._hoveredCardSchema === m.targetRef) {
         return new Set([this._hoveredCardField]);
       }
@@ -439,7 +432,10 @@ export class SzMappingDetail extends LitElement {
   }
 
   /** Find source fields that map to a given target field, grouped by schema id. */
-  private _findSourceFieldsForTarget(targetField: string, m: MappingBlock): Map<string, Set<string>> {
+  private _findSourceFieldsForTarget(
+    targetField: string,
+    m: MappingBlock,
+  ): Map<string, Set<string>> {
     const result = new Map<string, Set<string>>();
     // forEachMappingArrow recurses into every nested each/flatten combination —
     // hand-rolled loops over the top-level collections missed nested-each arrows
@@ -455,7 +451,8 @@ export class SzMappingDetail extends LitElement {
           for (const sf of a.sourceFields) {
             const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
             if (!localSourcePath) continue;
-            if (!result.has(sourceSchema.qualifiedId)) result.set(sourceSchema.qualifiedId, new Set());
+            if (!result.has(sourceSchema.qualifiedId))
+              result.set(sourceSchema.qualifiedId, new Set());
             result.get(sourceSchema.qualifiedId)!.add(localSourcePath);
           }
         }
@@ -465,7 +462,11 @@ export class SzMappingDetail extends LitElement {
   }
 
   /** Find target fields that a given source field maps to. */
-  private _findTargetFieldsForSource(sourceField: string, sourceSchemaId: string, m: MappingBlock): Set<string> {
+  private _findTargetFieldsForSource(
+    sourceField: string,
+    sourceSchemaId: string,
+    m: MappingBlock,
+  ): Set<string> {
     const result = new Set<string>();
     const sourceSchema = this.sourceSchemas.find((schema) => schema.qualifiedId === sourceSchemaId);
     const targetSchema = this.targetSchema;
@@ -480,7 +481,9 @@ export class SzMappingDetail extends LitElement {
         return localSourcePath === sourceField;
       });
       if (sourceMatches) {
-        const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef]);
+        const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [
+          m.targetRef,
+        ]);
         if (localTargetPath) result.add(localTargetPath);
       }
     });
@@ -494,15 +497,22 @@ export class SzMappingDetail extends LitElement {
 
     const m = this.mapping!;
     if (m.sourceRefs.includes(this._hoveredCardSchema)) {
-      const sourceSchema = this.sourceSchemas.find((schema) => schema.qualifiedId === this._hoveredCardSchema);
-      return !!sourceSchema && a.sourceFields.some((sf) => {
-        const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
-        return localSourcePath === this._hoveredCardField;
-      });
+      const sourceSchema = this.sourceSchemas.find(
+        (schema) => schema.qualifiedId === this._hoveredCardSchema,
+      );
+      return (
+        !!sourceSchema &&
+        a.sourceFields.some((sf) => {
+          const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
+          return localSourcePath === this._hoveredCardField;
+        })
+      );
     } else if (this._hoveredCardSchema === m.targetRef) {
       const targetSchema = this.targetSchema;
       if (!targetSchema) return false;
-      const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef]);
+      const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [
+        m.targetRef,
+      ]);
       return localTargetPath === this._hoveredCardField;
     }
     return false;
@@ -525,36 +535,39 @@ export class SzMappingDetail extends LitElement {
       <div class="layout" data-testid=${this.testIdPrefix}>
         <div class="column" data-testid=${`${this.testIdPrefix}-source-column`}>
           <div class="column-header">Sources</div>
-          ${this.sourceSchemas.map((s) => html`
-            <sz-schema-card
-              .schema=${s}
-              .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
-              .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
-              highlightColor="source"
-              test-id-prefix=${`${sourcePrefix}-${sanitizeTestIdSegment(s.qualifiedId)}`}
-              content-width
-            ></sz-schema-card>
-          `)}
+          ${this.sourceSchemas.map(
+            (s) => html`
+              <sz-schema-card
+                .schema=${s}
+                .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
+                .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
+                highlightColor="source"
+                test-id-prefix=${`${sourcePrefix}-${sanitizeTestIdSegment(s.qualifiedId)}`}
+                content-width
+              ></sz-schema-card>
+            `,
+          )}
         </div>
 
         <div class="column" data-testid=${`${this.testIdPrefix}-mapping-column`}>
           <div class="column-header">Mapping</div>
-          ${this._renderMappingHeader(m)}
-          ${this._renderArrowTable(m)}
+          ${this._renderMappingHeader(m)} ${this._renderArrowTable(m)}
         </div>
 
         <div class="column" data-testid=${`${this.testIdPrefix}-target-column`}>
           <div class="column-header">Target</div>
-          ${this.targetSchema
-            ? html`<sz-schema-card
-                .schema=${this.targetSchema}
-                .mappedFields=${this.targetMappedFields}
-                .highlightFields=${targetHL}
-                highlightColor="target"
-                test-id-prefix=${`${targetPrefix}-${sanitizeTestIdSegment(this.targetSchema.qualifiedId)}`}
-                content-width
-              ></sz-schema-card>`
-            : nothing}
+          ${
+            this.targetSchema
+              ? html`<sz-schema-card
+                  .schema=${this.targetSchema}
+                  .mappedFields=${this.targetMappedFields}
+                  .highlightFields=${targetHL}
+                  highlightColor="target"
+                  test-id-prefix=${`${targetPrefix}-${sanitizeTestIdSegment(this.targetSchema.qualifiedId)}`}
+                  content-width
+                ></sz-schema-card>`
+              : nothing
+          }
         </div>
       </div>
     `;
@@ -565,47 +578,65 @@ export class SzMappingDetail extends LitElement {
 
     return html`
       <div class="mapping-header" data-testid=${`${this.testIdPrefix}-header`}>
-        ${this.namespaceLabel
-          ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange);">
-              <span
-                class="meta-tag"
-                data-testid=${`${this.testIdPrefix}-namespace-label`}
-                style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
-              >${this.namespaceLabel}</span>
-            </div>`
-          : nothing}
+        ${
+          this.namespaceLabel
+            ? html`<div style="padding: 8px 12px 0; background: var(--sz-orange);">
+                <span
+                  class="meta-tag"
+                  data-testid=${`${this.testIdPrefix}-namespace-label`}
+                  style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
+                  >${this.namespaceLabel}</span
+                >
+              </div>`
+            : nothing
+        }
         <div class="mapping-title" @click=${() => this._navigate(m.location)}>
           <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M2 4h5l2 2h5v8H2V4z" opacity="0.9"/>
+            <path d="M2 4h5l2 2h5v8H2V4z" opacity="0.9" />
           </svg>
           ${m.id}
         </div>
         <div class="mapping-meta">
-          ${m.sourceRefs.map((s) => html`
-            <div class="mapping-meta-row">
-              <span class="meta-tag"><span class="label">source</span> ${s}</span>
-            </div>
-          `)}
+          ${m.sourceRefs.map(
+            (s) => html`
+              <div class="mapping-meta-row">
+                <span class="meta-tag"><span class="label">source</span> ${s}</span>
+              </div>
+            `,
+          )}
           <div class="mapping-meta-row">
             <span class="meta-tag"><span class="label">target</span> ${m.targetRef}</span>
           </div>
-          ${sb?.joinDescription
-            ? html`
-                <div class="mapping-meta-row">
-                  <span class="meta-tag wrap"><span class="label">join</span> ${sb.joinDescription}</span>
-                </div>
-              `
-            : nothing}
-          ${(sb?.filters ?? []).map((f) => html`
-            <div class="mapping-meta-row">
-              <span class="meta-tag wrap"><span class="label">filter</span> ${f}</span>
-            </div>
-          `)}
-          ${m.metadata.map((entry) => html`
-            <div class="mapping-meta-row" data-testid=${`${this.testIdPrefix}-meta-${sanitizeTestIdSegment(entry.key)}`}>
-              <span class="meta-tag wrap"><span class="label">${entry.key}</span> ${entry.value}</span>
-            </div>
-          `)}
+          ${
+            sb?.joinDescription
+              ? html`
+                  <div class="mapping-meta-row">
+                    <span class="meta-tag wrap"
+                      ><span class="label">join</span> ${sb.joinDescription}</span
+                    >
+                  </div>
+                `
+              : nothing
+          }
+          ${(sb?.filters ?? []).map(
+            (f) => html`
+              <div class="mapping-meta-row">
+                <span class="meta-tag wrap"><span class="label">filter</span> ${f}</span>
+              </div>
+            `,
+          )}
+          ${m.metadata.map(
+            (entry) => html`
+              <div
+                class="mapping-meta-row"
+                data-testid=${`${this.testIdPrefix}-meta-${sanitizeTestIdSegment(entry.key)}`}
+              >
+                <span class="meta-tag wrap"
+                  ><span class="label">${entry.key}</span> ${entry.value}</span
+                >
+              </div>
+            `,
+          )}
         </div>
       </div>
     `;
@@ -649,26 +680,36 @@ export class SzMappingDetail extends LitElement {
         class="arrow-row ${hl}"
         data-testid=${rowTestId}
         @click=${() => this._navigate(a.location)}
-        @mouseenter=${() => { this._hoveredArrow = a; this._hoveredCardField = null; }}
-        @mouseleave=${() => { this._hoveredArrow = null; }}
+        @mouseenter=${() => {
+          this._hoveredArrow = a;
+          this._hoveredCardField = null;
+        }}
+        @mouseleave=${() => {
+          this._hoveredArrow = null;
+        }}
       >
         <td>
           <div class="source-ref-list">
-            ${a.sourceFields.map((sourceField) => html`
-              <span class="field-ref source-ref-item">${sourceField}</span>
-            `)}
+            ${a.sourceFields.map(
+              (sourceField) => html`
+                <span class="field-ref source-ref-item">${sourceField}</span>
+              `,
+            )}
           </div>
         </td>
         <td><span class="arrow-icon">&#x2192;</span></td>
         <td class="transform-cell">${this._renderTransform(a)}</td>
         <td><span class="field-ref">${a.targetField}</span></td>
       </tr>
-      ${noteEntry
-        ? html`<tr
-            class="arrow-note-row"
-            data-testid=${`${rowTestId}-note`}
-          ><td colspan="4"><span class="arrow-note">${unsafeHTML(highlightAtRefs(noteEntry.value))}</span></td></tr>`
-        : ""}
+      ${
+        noteEntry
+          ? html`<tr class="arrow-note-row" data-testid=${`${rowTestId}-note`}>
+              <td colspan="4">
+                <span class="arrow-note">${unsafeHTML(highlightAtRefs(noteEntry.value))}</span>
+              </td>
+            </tr>`
+          : ""
+      }
     `;
   }
 
@@ -687,10 +728,7 @@ export class SzMappingDetail extends LitElement {
     const sectionId = sanitizeTestIdSegment(`each-${eb.targetField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
     return html`
-      <tr
-        class="scope-section"
-        data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}
-      >
+      <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
           <div class="scope-label">
             <span class="scope-tag">each</span>
@@ -709,10 +747,7 @@ export class SzMappingDetail extends LitElement {
     const sectionId = sanitizeTestIdSegment(`flatten-${fb.sourceField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
     return html`
-      <tr
-        class="scope-section"
-        data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}
-      >
+      <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
           <div class="scope-label">
             <span class="scope-tag">flatten</span>
@@ -737,10 +772,7 @@ export class SzMappingDetail extends LitElement {
     const sectionId = sanitizeTestIdSegment(`nested-${na.targetField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
     return html`
-      <tr
-        class="scope-section"
-        data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}
-      >
+      <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
           <div class="scope-label">
             <span class="scope-tag">nested</span>

--- a/tooling/satsuma-viz/src/components/sz-metric-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-metric-card.ts
@@ -5,9 +5,9 @@ import { SzNavigateEvent } from "../satsuma-viz.js";
 import { HEADER_HEIGHT, NAMESPACE_PILL_HEIGHT } from "../layout/geometry.js";
 
 const MEASURE_ICONS: Record<string, string> = {
-  additive: "\u03A3",        // Σ
-  non_additive: "\u2248",    // ≈
-  semi_additive: "\u00BD",   // ½
+  additive: "\u03A3", // Σ
+  non_additive: "\u2248", // ≈
+  semi_additive: "\u00BD", // ½
 };
 
 @customElement("sz-metric-card")
@@ -200,9 +200,14 @@ export class SzMetricCard extends LitElement {
     // edge anchors missed the header — sl-wixe.) The row is pinned to the
     // shared NAMESPACE_PILL_HEIGHT the layout reserves for it.
     if (!this.namespaceLabel) return html``;
-    return html`<div style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-violet);">
-        <span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);">${this.namespaceLabel}</span>
-      </div>`;
+    return html`<div
+      style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-violet);"
+    >
+      <span
+        style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
+        >${this.namespaceLabel}</span
+      >
+    </div>`;
   }
 
   override render() {
@@ -231,22 +236,31 @@ export class SzMetricCard extends LitElement {
         <div class="header" @click=${this._onHeaderClick}>
           <span class="header-icon">&#9670;</span>
           <span class="header-name">${m.id}</span>
-          <span class="header-toggle" ?data-collapsed=${this._collapsed} @click=${this._onToggleClick}>&#9660;</span>
+          <span
+            class="header-toggle"
+            ?data-collapsed=${this._collapsed}
+            @click=${this._onToggleClick}
+            >&#9660;</span
+          >
         </div>
-        ${hasMeta
-          ? html`
-              <div class="meta">
-                ${m.label ? html`<div class="meta-row">"${m.label}"${m.grain ? html` &middot; grain: ${m.grain}` : ""}</div>` : ""}
-                ${!m.label && m.grain ? html`<div class="meta-row"><span class="meta-label">grain:</span> ${m.grain}</div>` : ""}
-                ${m.slices.length > 0
-                  ? html`<div class="meta-row"><span class="meta-label">slice:</span> ${m.slices.join(", ")}</div>`
-                  : ""}
-              </div>
-            `
-          : ""}
-        <div class="fields">
-          ${m.fields.map((f) => this._renderField(f))}
-        </div>
+        ${
+          hasMeta
+            ? html`
+                <div class="meta">
+                  ${m.label ? html`<div class="meta-row">"${m.label}"${m.grain ? html` &middot; grain: ${m.grain}` : ""}</div>` : ""}
+                  ${!m.label && m.grain ? html`<div class="meta-row"><span class="meta-label">grain:</span> ${m.grain}</div>` : ""}
+                  ${
+                    m.slices.length > 0
+                      ? html`<div class="meta-row">
+                          <span class="meta-label">slice:</span> ${m.slices.join(", ")}
+                        </div>`
+                      : ""
+                  }
+                </div>
+              `
+            : ""
+        }
+        <div class="fields">${m.fields.map((f) => this._renderField(f))}</div>
         ${hasNotes ? this._renderNotes(m.notes) : ""}
       </div>
     `;
@@ -259,9 +273,11 @@ export class SzMetricCard extends LitElement {
           <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
           <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
         </div>
-        ${this._notesExpanded
-          ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
-          : ""}
+        ${
+          this._notesExpanded
+            ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
+            : ""
+        }
       </div>
     `;
   }
@@ -272,7 +288,7 @@ export class SzMetricCard extends LitElement {
   }
 
   private _renderField(f: MetricFieldEntry) {
-    const icon = f.measure ? MEASURE_ICONS[f.measure] ?? "" : "";
+    const icon = f.measure ? (MEASURE_ICONS[f.measure] ?? "") : "";
     return html`
       <div class="field-row" @click=${() => this._navigate(f.location)}>
         <span class="measure-icon">${icon}</span>

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -5,7 +5,12 @@ import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
 import { isCoveredFieldPath } from "@satsuma/core/coverage-paths";
-import { HEADER_HEIGHT, META_PILL_ROW_GAP, META_PILL_ROW_HEIGHT, NAMESPACE_PILL_HEIGHT } from "../layout/geometry.js";
+import {
+  HEADER_HEIGHT,
+  META_PILL_ROW_GAP,
+  META_PILL_ROW_HEIGHT,
+  NAMESPACE_PILL_HEIGHT,
+} from "../layout/geometry.js";
 
 /**
  * Detail of the `sz-compact-toggled` CustomEvent a compact card dispatches
@@ -271,7 +276,7 @@ export class SzSchemaCard extends LitElement {
       display: none;
     }
 
-.metadata-pills {
+    .metadata-pills {
       /* Pills stack one per row and are EXCLUDED from the card's intrinsic
          width (contain: inline-size) — a long metadata value such as a
          namespace URI must never widen the card beyond what its field rows
@@ -417,7 +422,9 @@ export class SzSchemaCard extends LitElement {
       flex-shrink: 0;
       padding: 0;
       opacity: 0;
-      transition: opacity 0.1s, background 0.1s;
+      transition:
+        opacity 0.1s,
+        background 0.1s;
     }
 
     .field-row:hover .lineage-btn {
@@ -556,30 +563,31 @@ export class SzSchemaCard extends LitElement {
     // without text matching against a positioned <span>. The row is pinned
     // to the shared NAMESPACE_PILL_HEIGHT the layout reserves for it.
     return html`<div
-        style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-orange);"
-        data-testid=${`${this.testIdPrefix}-namespace-pill`}
+      style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-orange);"
+      data-testid=${`${this.testIdPrefix}-namespace-pill`}
+    >
+      <span
+        data-testid=${`${this.testIdPrefix}-namespace-label`}
+        style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
+        >${this.namespaceLabel}</span
       >
-        <span
-          data-testid=${`${this.testIdPrefix}-namespace-label`}
-          style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
-        >${this.namespaceLabel}</span>
-      </div>`;
+    </div>`;
   }
 
   private _headerIcon(isReport: boolean) {
     if (isReport) {
       // Chart/report icon
       return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
-        <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-        <rect x="4" y="8" width="2" height="4" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
-        <rect x="7" y="5" width="2" height="7" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
-        <rect x="10" y="7" width="2" height="5" rx="0.5" fill="var(--sz-icon-overlay-soft)"/>
+        <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9" />
+        <rect x="4" y="8" width="2" height="4" rx="0.5" fill="var(--sz-icon-overlay-soft)" />
+        <rect x="7" y="5" width="2" height="7" rx="0.5" fill="var(--sz-icon-overlay-soft)" />
+        <rect x="10" y="7" width="2" height="5" rx="0.5" fill="var(--sz-icon-overlay-soft)" />
       </svg>`;
     }
     // Table/schema icon
     return html`<svg class="header-icon" viewBox="0 0 16 16" fill="currentColor">
-      <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9"/>
-      <line x1="1" y1="6" x2="15" y2="6" stroke="var(--sz-icon-divider)" stroke-width="1"/>
+      <rect x="1" y="2" width="14" height="12" rx="2" opacity="0.9" />
+      <line x1="1" y1="6" x2="15" y2="6" stroke="var(--sz-icon-divider)" stroke-width="1" />
     </svg>`;
   }
 
@@ -598,28 +606,47 @@ export class SzSchemaCard extends LitElement {
     return html`
       <div class=${this._collapsed ? "collapsed" : ""} data-testid=${this.testIdPrefix}>
         ${this._renderNamespacePill()}
-        <div class="header ${isReport ? "report" : ""}" data-testid=${`${this.testIdPrefix}-header`} @click=${this._onHeaderClick}>
+        <div
+          class="header ${isReport ? "report" : ""}"
+          data-testid=${`${this.testIdPrefix}-header`}
+          @click=${this._onHeaderClick}
+        >
           ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
           <span class="header-count">${mappedCount}/${totalFields}</span>
-          <span class="header-toggle" ?data-collapsed=${this._collapsed} @click=${this._onToggleClick}>&#9660;</span>
+          <span
+            class="header-toggle"
+            ?data-collapsed=${this._collapsed}
+            @click=${this._onToggleClick}
+            >&#9660;</span
+          >
         </div>
         ${s.label ? html`<div class="label">${s.label}</div>` : ""}
-        ${metaPills.length > 0
-          ? html`<div class="metadata-pills">
-              ${metaPills.map(
-                (m) => html`<span class="meta-pill" title=${`${m.key} ${m.value}`}><span class="meta-key">${m.key}</span> ${m.value}</span>`
-              )}
-            </div>`
-          : ""}
+        ${
+          metaPills.length > 0
+            ? html`<div class="metadata-pills">
+                ${metaPills.map(
+                  (m) =>
+                    html`<span class="meta-pill" title=${`${m.key} ${m.value}`}
+                      ><span class="meta-key">${m.key}</span> ${m.value}</span
+                    >`,
+                )}
+              </div>`
+            : ""
+        }
         <div class="fields" data-testid=${`${this.testIdPrefix}-fields`}>
           ${s.fields.map((f) => this._renderField(f, 0))}
         </div>
-        ${s.spreads.length > 0
-          ? s.spreads.map(
-              (sp) => html`<div class="spread-indicator"><span class="spread-icon">&#8230;</span> spreads ${sp}</div>`
-            )
-          : ""}
+        ${
+          s.spreads.length > 0
+            ? s.spreads.map(
+                (sp) =>
+                  html`<div class="spread-indicator">
+                    <span class="spread-icon">&#8230;</span> spreads ${sp}
+                  </div>`,
+              )
+            : ""
+        }
         ${hasNotes ? this._renderNotes(s.notes) : ""}
       </div>
     `;
@@ -641,9 +668,13 @@ export class SzSchemaCard extends LitElement {
           <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
           <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
         </div>
-        ${this._notesExpanded
-          ? notes.map((n) => html`<div class="note-content">${unsafeHTML(renderMarkdown(n.text))}</div>`)
-          : ""}
+        ${
+          this._notesExpanded
+            ? notes.map(
+                (n) => html`<div class="note-content">${unsafeHTML(renderMarkdown(n.text))}</div>`,
+              )
+            : ""
+        }
       </div>
     `;
   }
@@ -685,36 +716,66 @@ export class SzSchemaCard extends LitElement {
         <span class="badges">
           ${f.constraints
             .filter((c) => c !== "pii")
-            .map(
-              (c) => html`<span class="badge">${c}</span>`
-            )}
+            .map((c) => html`<span class="badge">${c}</span>`)}
           ${hasPii ? html`<span class="badge pii" title="PII">&#128737; pii</span>` : ""}
           ${this._fieldMetaPills(f).map(
-            (m) => html`<span class="badge field-meta" title=${`${m.key} ${m.value}`.trim()}><span class="badge-key">${m.key}</span>${m.value ? ` ${m.value}` : ""}</span>`
+            (m) =>
+              html`<span class="badge field-meta" title=${`${m.key} ${m.value}`.trim()}
+                ><span class="badge-key">${m.key}</span>${m.value ? ` ${m.value}` : ""}</span
+              >`,
           )}
         </span>
-        ${hasWarning
-          ? html`<span class="comment-badge warning" title=${this._commentText(f, "warning")}>&#9888;</span>`
-          : ""}
-        ${hasQuestion
-          ? html`<span class="comment-badge question" title=${this._commentText(f, "question")}>?</span>`
-          : ""}
+        ${
+          hasWarning
+            ? html`<span class="comment-badge warning" title=${this._commentText(f, "warning")}
+                >&#9888;</span
+              >`
+            : ""
+        }
+        ${
+          hasQuestion
+            ? html`<span class="comment-badge question" title=${this._commentText(f, "question")}
+                >?</span
+              >`
+            : ""
+        }
         <button
           class="lineage-btn"
           data-testid=${`${fieldTestId}-lineage`}
           title="Show field lineage"
-          @click=${(e: Event) => { e.stopPropagation(); this._onFieldLineage(fieldPath); }}
-        ><svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="2" cy="6" r="1.5" fill="currentColor"/>
-          <circle cx="10" cy="3" r="1.5" fill="currentColor"/>
-          <circle cx="10" cy="9" r="1.5" fill="currentColor"/>
-          <line x1="3.5" y1="5.3" x2="8.5" y2="3.7" stroke="currentColor" stroke-width="1.2"/>
-          <line x1="3.5" y1="6.7" x2="8.5" y2="8.3" stroke="currentColor" stroke-width="1.2"/>
-        </svg></button>
+          @click=${(e: Event) => {
+            e.stopPropagation();
+            this._onFieldLineage(fieldPath);
+          }}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle cx="2" cy="6" r="1.5" fill="currentColor" />
+            <circle cx="10" cy="3" r="1.5" fill="currentColor" />
+            <circle cx="10" cy="9" r="1.5" fill="currentColor" />
+            <line x1="3.5" y1="5.3" x2="8.5" y2="3.7" stroke="currentColor" stroke-width="1.2" />
+            <line x1="3.5" y1="6.7" x2="8.5" y2="8.3" stroke="currentColor" stroke-width="1.2" />
+          </svg>
+        </button>
       </div>
-      ${f.notes.length > 0
-        ? f.notes.map((n) => html`<div class="field-note" style=${depth > 0 ? `padding-left: ${38 + depth * 20}px` : ""}>${n.text}</div>`)
-        : ""}
+      ${
+        f.notes.length > 0
+          ? f.notes.map(
+              (n) =>
+                html`<div
+                  class="field-note"
+                  style=${depth > 0 ? `padding-left: ${38 + depth * 20}px` : ""}
+                >
+                  ${n.text}
+                </div>`,
+            )
+          : ""
+      }
       ${f.children.map((child) => this._renderField(child, depth + 1, fieldPath))}
     `;
   }
@@ -776,21 +837,31 @@ export class SzSchemaCard extends LitElement {
         <div class="header ${isReport ? "report" : ""}" @click=${this._onHeaderClick}>
           ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>
-          <span class="header-toggle" ?data-collapsed=${!this.compactExpanded} @click=${this._onToggleClick}>&#9660;</span>
+          <span
+            class="header-toggle"
+            ?data-collapsed=${!this.compactExpanded}
+            @click=${this._onToggleClick}
+            >&#9660;</span
+          >
           <span class="header-count">${totalFields} fields</span>
         </div>
-        ${metaPills.length > 0
-          ? html`<div class="metadata-pills">
-              ${metaPills.map(
-                (m) => html`<span class="meta-pill" title=${`${m.key} ${m.value}`}><span class="meta-key">${m.key}</span> ${m.value}</span>`
-              )}
-            </div>`
-          : ""}
-        ${this.compactExpanded
-          ? html`<div class="fields">
-              ${s.fields.map((f) => this._renderField(f, 0))}
-            </div>`
-          : ""}
+        ${
+          metaPills.length > 0
+            ? html`<div class="metadata-pills">
+                ${metaPills.map(
+                  (m) =>
+                    html`<span class="meta-pill" title=${`${m.key} ${m.value}`}
+                      ><span class="meta-key">${m.key}</span> ${m.value}</span
+                    >`,
+                )}
+              </div>`
+            : ""
+        }
+        ${
+          this.compactExpanded
+            ? html`<div class="fields">${s.fields.map((f) => this._renderField(f, 0))}</div>`
+            : ""
+        }
       </div>
     `;
   }

--- a/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
@@ -152,7 +152,9 @@ export class SzEdgeLayer extends LitElement {
     /* Dimmed edges when highlighting a field */
     :host([has-highlight]) .edge-path {
       opacity: 0.15;
-      transition: opacity 0.15s ease, stroke-width 0.15s ease;
+      transition:
+        opacity 0.15s ease,
+        stroke-width 0.15s ease;
     }
 
     :host([has-highlight]) .edge-path.highlighted {
@@ -215,19 +217,14 @@ export class SzEdgeLayer extends LitElement {
       edge.sourceNode === this.highlightSchema &&
       edge.arrow.sourceFields.includes(this.highlightField);
     const matchesTarget =
-      edge.targetNode === this.highlightSchema &&
-      edge.arrow.targetField === this.highlightField;
+      edge.targetNode === this.highlightSchema && edge.arrow.targetField === this.highlightField;
 
     return matchesSource || matchesTarget;
   }
 
   override render() {
     return html`
-      <svg
-        width=${this.width}
-        height=${this.height}
-        viewBox="0 0 ${this.width} ${this.height}"
-      >
+      <svg width=${this.width} height=${this.height} viewBox="0 0 ${this.width} ${this.height}">
         ${this.edges.map((e) => this._renderEdge(e))}
       </svg>
       ${this._expandedEdge ? this._renderTransformCard() : ""}
@@ -252,27 +249,34 @@ export class SzEdgeLayer extends LitElement {
         d=${d}
         @click=${() => this._onEdgeClick(edge)}
       />
-      ${hasTransform
-        ? svg`
+      ${
+        hasTransform
+          ? svg`
           <g
             class="gear-group ${hl}"
             transform="translate(${mid.x}, ${mid.y})"
-            @click=${(ev: Event) => { ev.stopPropagation(); this._toggleGear(edge.id); }}
+            @click=${(ev: Event) => {
+              ev.stopPropagation();
+              this._toggleGear(edge.id);
+            }}
           >
             <circle class="gear-circle" r="9" />
             <text class="gear-icon" dy="0.5">&#9881;</text>
           </g>
         `
-        : svg``}
-      ${edge.scopeLabel
-        ? svg`
+          : svg``
+      }
+      ${
+        edge.scopeLabel
+          ? svg`
           <text
             class="scope-label ${edge.scopeLabel} ${hl}"
             x=${mid.x}
             y=${mid.y + (hasTransform ? 18 : 0)}
           >${edge.scopeLabel === "each" ? "⟲ each" : "⤵ flatten"}</text>
         `
-        : svg``}
+          : svg``
+      }
     `;
   }
 
@@ -290,16 +294,12 @@ export class SzEdgeLayer extends LitElement {
       const prev = points[i - 1];
       const curr = points[i];
       const dx = (curr.x - prev.x) * 0.4;
-      parts.push(
-        `C ${prev.x + dx} ${prev.y}, ${curr.x - dx} ${curr.y}, ${curr.x} ${curr.y}`
-      );
+      parts.push(`C ${prev.x + dx} ${prev.y}, ${curr.x - dx} ${curr.y}, ${curr.x} ${curr.y}`);
     }
     return parts.join(" ");
   }
 
-  private _midpoint(
-    points: Array<{ x: number; y: number }>
-  ): { x: number; y: number } {
+  private _midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
     const mid = Math.floor(points.length / 2);
     if (points.length % 2 === 0) {
       return {
@@ -333,19 +333,19 @@ export class SzEdgeLayer extends LitElement {
         style="left: ${mid.x + 16}px; top: ${mid.y - 12}px"
         @click=${(ev: Event) => ev.stopPropagation()}
       >
-        <div class="label">
-          ${t.kind === "map" ? "Map" : "Transform"}
-        </div>
-        ${t.steps.length > 0
-          ? html`${t.steps.map(
-              (step, i) => html`
-                <div class="step">
-                  ${i > 0 ? html`<span class="step-sep">|</span>` : ""}
-                  <span class="step-text">${unsafeHTML(highlightAtRefs(step))}</span>
-                </div>
-              `
-            )}`
-          : html`<div class="step-text">${unsafeHTML(highlightAtRefs(t.text))}</div>`}
+        <div class="label">${t.kind === "map" ? "Map" : "Transform"}</div>
+        ${
+          t.steps.length > 0
+            ? html`${t.steps.map(
+                (step, i) => html`
+                  <div class="step">
+                    ${i > 0 ? html`<span class="step-sep">|</span>` : ""}
+                    <span class="step-text">${unsafeHTML(highlightAtRefs(step))}</span>
+                  </div>
+                `,
+              )}`
+            : html`<div class="step-text">${unsafeHTML(highlightAtRefs(t.text))}</div>`
+        }
       </div>
     `;
   }

--- a/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-overview-edge-layer.ts
@@ -50,7 +50,11 @@ export class SzOverviewEdgeLayer extends LitElement {
       stroke: var(--sz-edge-default);
       pointer-events: stroke;
       cursor: pointer;
-      transition: stroke-width 0.15s ease, stroke 0.15s ease, opacity 0.15s ease, filter 0.15s ease;
+      transition:
+        stroke-width 0.15s ease,
+        stroke 0.15s ease,
+        opacity 0.15s ease,
+        filter 0.15s ease;
       opacity: 0.55;
     }
 
@@ -79,7 +83,9 @@ export class SzOverviewEdgeLayer extends LitElement {
       pointer-events: none;
       fill: var(--sz-edge-default);
       opacity: 0.55;
-      transition: fill 0.15s ease, opacity 0.15s ease;
+      transition:
+        fill 0.15s ease,
+        opacity 0.15s ease;
     }
 
     .anchor-dot.highlighted {
@@ -146,11 +152,7 @@ export class SzOverviewEdgeLayer extends LitElement {
       : null;
 
     return html`
-      <svg
-        width=${this.width}
-        height=${this.height}
-        viewBox="0 0 ${this.width} ${this.height}"
-      >
+      <svg width=${this.width} height=${this.height} viewBox="0 0 ${this.width} ${this.height}">
         ${this.edges.map((e) => this._renderOverviewEdge(e))}
       </svg>
       ${hoveredEdge ? this._renderTooltip(hoveredEdge) : ""}
@@ -165,9 +167,9 @@ export class SzOverviewEdgeLayer extends LitElement {
     const last = edge.points[edge.points.length - 1];
 
     const hasHighlight = this.highlightNodes.size > 0;
-    const connected = hasHighlight && (
-      this.highlightNodes.has(edge.sourceNode) || this.highlightNodes.has(edge.targetNode)
-    );
+    const connected =
+      hasHighlight &&
+      (this.highlightNodes.has(edge.sourceNode) || this.highlightNodes.has(edge.targetNode));
     const cls = hasHighlight ? (connected ? "highlighted" : "dimmed") : "";
 
     return svg`
@@ -235,9 +237,7 @@ export class SzOverviewEdgeLayer extends LitElement {
     return html`
       <div class="tooltip" style="left: ${this._hoverPos.x}px; top: ${this._hoverPos.y}px;">
         <div class="tooltip-name">${m.id}</div>
-        <div class="tooltip-detail">
-          ${m.sourceRefs.join(", ")} &#x2192; ${m.targetRef}
-        </div>
+        <div class="tooltip-detail">${m.sourceRefs.join(", ")} &#x2192; ${m.targetRef}</div>
         <div class="tooltip-count">${arrowCount} arrow${arrowCount !== 1 ? "s" : ""}</div>
       </div>
     `;

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -152,7 +152,9 @@ export function buildMappingCoveredFields(
 
   forEachMappingArrow(mapping, (arrow) => {
     if (targetSchema) {
-      const targetPath = resolveSchemaLocalFieldPath(arrow.targetField, targetSchema, [mapping.targetRef]);
+      const targetPath = resolveSchemaLocalFieldPath(arrow.targetField, targetSchema, [
+        mapping.targetRef,
+      ]);
       if (targetPath) targetFieldRefs.push(targetPath);
     }
 
@@ -181,7 +183,9 @@ export function buildMappingCoveredFields(
 export function buildMappedFieldsIndex(model: VizModel): Map<string, Set<string>> {
   const index = new Map<string, Set<string>>();
   const allSchemas = new Map(
-    model.namespaces.flatMap((ns) => ns.schemas.map((schema) => [schema.qualifiedId, schema] as const)),
+    model.namespaces.flatMap((ns) =>
+      ns.schemas.map((schema) => [schema.qualifiedId, schema] as const),
+    ),
   );
 
   for (const ns of model.namespaces) {
@@ -190,7 +194,11 @@ export function buildMappedFieldsIndex(model: VizModel): Map<string, Set<string>
         .map((schemaId) => allSchemas.get(schemaId))
         .filter((schema): schema is SchemaCard => schema != null);
       const targetSchema = allSchemas.get(mapping.targetRef) ?? null;
-      const { sourceMapped, targetMapped } = buildMappingCoveredFields(mapping, sourceSchemas, targetSchema);
+      const { sourceMapped, targetMapped } = buildMappingCoveredFields(
+        mapping,
+        sourceSchemas,
+        targetSchema,
+      );
 
       for (const [schemaId, covered] of sourceMapped) {
         if (!index.has(schemaId)) index.set(schemaId, new Set());

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -101,7 +101,7 @@ export interface OverviewLayoutResult {
 // Header and namespace-pill heights are a hard contract with the card
 // components (edge anchors are computed from them), so they are imported
 // from the shared geometry module (see top of file) instead of re-declared.
-const LABEL_HEIGHT = 24;  // .label padding (4+6) + font ~14px
+const LABEL_HEIGHT = 24; // .label padding (4+6) + font ~14px
 const FIELD_HEIGHT = 28;
 const FIELDS_PADDING_TOP = 4; // .fields { padding: 4px 0; }
 const FIELDS_PADDING_BOTTOM = 4;
@@ -141,9 +141,10 @@ function preambleHeight(
   // in the card CSS to the shared geometry constants used here.
   const pillCount = schema.metadata.filter((m) => m.key !== "note").length;
   if (pillCount > 0) {
-    h += METADATA_PILLS_CHROME
-      + pillCount * META_PILL_ROW_HEIGHT
-      + (pillCount - 1) * META_PILL_ROW_GAP;
+    h +=
+      METADATA_PILLS_CHROME +
+      pillCount * META_PILL_ROW_HEIGHT +
+      (pillCount - 1) * META_PILL_ROW_GAP;
   }
   return h;
 }
@@ -181,16 +182,17 @@ function estimateTextWidth(text: string, charWidth: number): number {
 }
 
 function estimateOverviewLabelWidth(mappingId: string, namespaceName?: string | null): number {
-  const labelWidth = Math.ceil(estimateTextWidth(mappingId, OVERVIEW_LABEL_CHAR_WIDTH) + OVERVIEW_LABEL_PADDING);
+  const labelWidth = Math.ceil(
+    estimateTextWidth(mappingId, OVERVIEW_LABEL_CHAR_WIDTH) + OVERVIEW_LABEL_PADDING,
+  );
   // Namespace pill sits in its own row; take the wider of the two
   const pillWidth = namespaceName
-    ? Math.ceil(estimateTextWidth(namespaceName, OVERVIEW_PILL_CHAR_WIDTH) + OVERVIEW_NAMESPACE_PILL_PADDING)
+    ? Math.ceil(
+        estimateTextWidth(namespaceName, OVERVIEW_PILL_CHAR_WIDTH) +
+          OVERVIEW_NAMESPACE_PILL_PADDING,
+      )
     : 0;
-  return clamp(
-    Math.max(labelWidth, pillWidth),
-    CARD_MIN_WIDTH,
-    OVERVIEW_LABEL_MAX_WIDTH,
-  );
+  return clamp(Math.max(labelWidth, pillWidth), CARD_MIN_WIDTH, OVERVIEW_LABEL_MAX_WIDTH);
 }
 
 function overviewMappingNodeId(namespaceName: string | null, mappingId: string): string {
@@ -233,7 +235,10 @@ function estimateLines(text: string, charsPerLine: number): number {
   const segments = text
     .split("\n")
     .map((line) => Math.max(1, Math.ceil(line.trim().length / charsPerLine)));
-  return Math.max(1, segments.reduce((sum, lines) => sum + lines, 0));
+  return Math.max(
+    1,
+    segments.reduce((sum, lines) => sum + lines, 0),
+  );
 }
 
 function estimateNoteBlockHeight(text: string, expanded: boolean): number {
@@ -248,20 +253,26 @@ function estimateSchemaWidth(schema: SchemaCard): number {
   const titleWidth =
     FULL_HEADER_BASE_WIDTH +
     estimateTextWidth(schema.id, FULL_TITLE_CHAR_WIDTH) +
-    estimateTextWidth(`${countFields(schema.fields)}/${countFields(schema.fields)}`, OVERVIEW_COUNT_CHAR_WIDTH);
+    estimateTextWidth(
+      `${countFields(schema.fields)}/${countFields(schema.fields)}`,
+      OVERVIEW_COUNT_CHAR_WIDTH,
+    );
 
-  const labelWidth = schema.label
-    ? estimateTextWidth(schema.label, FULL_META_CHAR_WIDTH) + 48
-    : 0;
+  const labelWidth = schema.label ? estimateTextWidth(schema.label, FULL_META_CHAR_WIDTH) + 48 : 0;
 
   // Metadata pills are width-contained (see estimateCompactSchemaWidth).
   const fieldWidth = measureFieldWidth(schema.fields);
   const spreadWidth = spreads.reduce(
-    (max, spread) => Math.max(max, estimateTextWidth(`spreads ${spread}`, FULL_META_CHAR_WIDTH) + 48),
+    (max, spread) =>
+      Math.max(max, estimateTextWidth(`spreads ${spread}`, FULL_META_CHAR_WIDTH) + 48),
     0,
   );
   const noteWidth = notes.reduce(
-    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    (max, note) =>
+      Math.max(
+        max,
+        estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56,
+      ),
     0,
   );
 
@@ -285,21 +296,30 @@ function estimateMetricWidth(metric: MetricCard): number {
     0,
   );
   const fieldWidth = metric.fields.reduce(
-    (max, field) => Math.max(
-      max,
-      FULL_FIELD_BASE_WIDTH +
-        16 +
-        estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
-        estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
-    ),
+    (max, field) =>
+      Math.max(
+        max,
+        FULL_FIELD_BASE_WIDTH +
+          16 +
+          estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
+          estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
+      ),
     0,
   );
   const noteWidth = notes.reduce(
-    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    (max, note) =>
+      Math.max(
+        max,
+        estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56,
+      ),
     0,
   );
 
-  return clamp(Math.ceil(Math.max(titleWidth, metaWidth, fieldWidth, noteWidth)), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
+  return clamp(
+    Math.ceil(Math.max(titleWidth, metaWidth, fieldWidth, noteWidth)),
+    CARD_MIN_WIDTH,
+    CARD_MAX_WIDTH,
+  );
 }
 
 function estimateFragmentWidth(fragment: FragmentCard): number {
@@ -309,20 +329,29 @@ function estimateFragmentWidth(fragment: FragmentCard): number {
     estimateTextWidth(fragment.id, FULL_TITLE_CHAR_WIDTH) +
     estimateTextWidth(`${fragment.fields.length} fields`, OVERVIEW_COUNT_CHAR_WIDTH);
   const fieldWidth = fragment.fields.reduce(
-    (max, field) => Math.max(
-      max,
-      FULL_FIELD_BASE_WIDTH +
-        estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
-        estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
-    ),
+    (max, field) =>
+      Math.max(
+        max,
+        FULL_FIELD_BASE_WIDTH +
+          estimateTextWidth(field.name, FULL_FIELD_CHAR_WIDTH) +
+          estimateTextWidth(field.type, FULL_TYPE_CHAR_WIDTH),
+      ),
     0,
   );
   const noteWidth = notes.reduce(
-    (max, note) => Math.max(max, estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56),
+    (max, note) =>
+      Math.max(
+        max,
+        estimateTextWidth(note.text.replace(/\s+/g, " ").trim(), FULL_NOTE_CHAR_WIDTH) + 56,
+      ),
     0,
   );
 
-  return clamp(Math.ceil(Math.max(titleWidth, fieldWidth, noteWidth)), CARD_MIN_WIDTH, CARD_MAX_WIDTH);
+  return clamp(
+    Math.ceil(Math.max(titleWidth, fieldWidth, noteWidth)),
+    CARD_MIN_WIDTH,
+    CARD_MAX_WIDTH,
+  );
 }
 
 function estimateMetricHeight(metric: MetricCard, hasNamespace = false): number {
@@ -332,21 +361,45 @@ function estimateMetricHeight(metric: MetricCard, hasNamespace = false): number 
     (!metric.label && metric.grain ? 1 : 0) +
     (metric.slices.length > 0 ? 1 : 0);
   const metaHeight = metaRows > 0 ? FULL_META_BASE_HEIGHT + metaRows * FULL_META_ROW_HEIGHT : 0;
-  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
+  const notesHeight = notes.reduce(
+    (sum, note) => sum + estimateNoteBlockHeight(note.text, false),
+    0,
+  );
 
-  return (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + metaHeight + FIELDS_PADDING_TOP + metric.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+  return (
+    (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) +
+    HEADER_HEIGHT +
+    metaHeight +
+    FIELDS_PADDING_TOP +
+    metric.fields.length * FIELD_HEIGHT +
+    FIELDS_PADDING_BOTTOM +
+    notesHeight
+  );
 }
 
 function estimateFragmentHeight(fragment: FragmentCard, hasNamespace = false): number {
   const notes = fragment.notes ?? [];
-  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, false), 0);
-  return (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) + HEADER_HEIGHT + FIELDS_PADDING_TOP + fragment.fields.length * FIELD_HEIGHT + FIELDS_PADDING_BOTTOM + notesHeight;
+  const notesHeight = notes.reduce(
+    (sum, note) => sum + estimateNoteBlockHeight(note.text, false),
+    0,
+  );
+  return (
+    (hasNamespace ? NAMESPACE_PILL_HEIGHT : 0) +
+    HEADER_HEIGHT +
+    FIELDS_PADDING_TOP +
+    fragment.fields.length * FIELD_HEIGHT +
+    FIELDS_PADDING_BOTTOM +
+    notesHeight
+  );
 }
 
 function estimateSchemaHeight(schema: SchemaCard, hasNamespace = false): number {
   const notes = schema.notes ?? [];
   const spreads = schema.spreads ?? [];
-  const notesHeight = notes.reduce((sum, note) => sum + estimateNoteBlockHeight(note.text, true), 0);
+  const notesHeight = notes.reduce(
+    (sum, note) => sum + estimateNoteBlockHeight(note.text, true),
+    0,
+  );
   const spreadsHeight = spreads.length * FULL_SPREAD_HEIGHT;
   return (
     preambleHeight(schema, hasNamespace) +
@@ -642,7 +695,12 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
    * path ("customer.email") — while ports are keyed by schema-local path, so
    * the ref must be resolved against the card's declared fields first (sl-l7u0).
    */
-  const findPort = (nodeId: string, fieldRef: string, side: "src" | "tgt", scopeRefs: string[]): string | null => {
+  const findPort = (
+    nodeId: string,
+    fieldRef: string,
+    side: "src" | "tgt",
+    scopeRefs: string[],
+  ): string | null => {
     const card = ctx.cardsByNode.get(nodeId);
     if (!card) return null;
     const localPath = resolveSchemaLocalFieldPath(fieldRef, card, scopeRefs);
@@ -712,9 +770,7 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
           [
             ...block.nestedEach.map((b): [EachBlock, EdgeScope] => [b, "each"]),
             ...block.nestedFlatten.map((b): [FlattenBlock, EdgeScope] => [b, "flatten"]),
-            ...block.nestedArrows.map(
-              (b): [NestedArrowBlock, EdgeScope | undefined] => [b, scope],
-            ),
+            ...block.nestedArrows.map((b): [NestedArrowBlock, EdgeScope | undefined] => [b, scope]),
           ],
           `${prefix}:${j}:nested`,
         );
@@ -735,11 +791,7 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
   }
 }
 
-function extractLayout(
-  result: ElkLayoutResult,
-  _model: VizModel,
-  ctx: GraphContext,
-): LayoutResult {
+function extractLayout(result: ElkLayoutResult, _model: VizModel, ctx: GraphContext): LayoutResult {
   const nodes = new Map<string, LayoutNode>();
   const edges: LayoutEdge[] = [];
 
@@ -857,11 +909,14 @@ export async function computeOverviewLayout(
   const edges: ElkEdge[] = [];
   const overviewNodeKinds = new Map<string, LayoutNode["kind"]>();
   const overviewNodeHasNamespace = new Set<string>();
-  const overviewEdgeMeta = new Map<string, {
-    sourceNode: string;
-    targetNode: string;
-    mapping: MappingBlock;
-  }>();
+  const overviewEdgeMeta = new Map<
+    string,
+    {
+      sourceNode: string;
+      targetNode: string;
+      mapping: MappingBlock;
+    }
+  >();
   const nodeIds = new Set<string>();
 
   // Pass 1: build all nodes and populate nodeIds before creating any edges.
@@ -994,7 +1049,7 @@ export async function computeOverviewLayout(
     edges,
   };
 
-  const result = await elk.layout(elkGraph) as unknown as ElkLayoutResult;
+  const result = (await elk.layout(elkGraph)) as unknown as ElkLayoutResult;
 
   // Extract positioned nodes
   const nodes: LayoutNode[] = [];
@@ -1008,13 +1063,10 @@ export async function computeOverviewLayout(
         x,
         y,
         width: n.width ?? CARD_MIN_WIDTH,
-        height: n.height ?? (HEADER_HEIGHT + FIELDS_PADDING_BOTTOM),
-        kind: overviewNodeKinds.get(n.id)
-          ?? (n.id.startsWith("mapping:")
-            ? "mapping"
-            : nodeIds.has(n.id)
-              ? "schema"
-              : undefined),
+        height: n.height ?? HEADER_HEIGHT + FIELDS_PADDING_BOTTOM,
+        kind:
+          overviewNodeKinds.get(n.id) ??
+          (n.id.startsWith("mapping:") ? "mapping" : nodeIds.has(n.id) ? "schema" : undefined),
         hasNamespace: overviewNodeHasNamespace.has(n.id),
         ports: new Map(),
       });
@@ -1045,12 +1097,7 @@ export async function computeOverviewLayout(
         const src = overviewVisualAnchor(sourceNode, "source");
         const tgt = overviewVisualAnchor(targetNode, "target");
         const midX = (src.x + tgt.x) / 2;
-        const cleanPoints = [
-          src,
-          { x: midX, y: src.y },
-          { x: midX, y: tgt.y },
-          tgt,
-        ];
+        const cleanPoints = [src, { x: midX, y: src.y }, { x: midX, y: tgt.y }, tgt];
         overviewEdges.push({
           id: e.id,
           sourceNode: meta.sourceNode,
@@ -1079,7 +1126,10 @@ export async function computeOverviewLayout(
   };
 }
 
-function overviewVisualAnchor(node: LayoutNode, side: "source" | "target"): { x: number; y: number } {
+function overviewVisualAnchor(
+  node: LayoutNode,
+  side: "source" | "target",
+): { x: number; y: number } {
   const x = side === "source" ? node.x + node.width : node.x;
   const namespaceOffset = node.hasNamespace ? NAMESPACE_PILL_HEIGHT : 0;
 

--- a/tooling/satsuma-viz/src/markdown.ts
+++ b/tooling/satsuma-viz/src/markdown.ts
@@ -27,8 +27,7 @@ export function highlightAtRefs(text: string): string {
  */
 export function renderMarkdown(text: string): string {
   // Escape HTML special chars
-  const esc = (s: string) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
   // Apply inline formatting to an already-escaped string
   const inline = (s: string) =>

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -1,8 +1,20 @@
 import { LitElement, html, svg, css, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import type { VizModel, SourceLocation, NamespaceGroup, MappingBlock, SchemaCard } from "./model.js";
-import { computeLayout, computeOverviewLayout, type LayoutResult, type OverviewLayoutResult, type SourceBlockLayout } from "./layout/elk-layout.js";
+import type {
+  VizModel,
+  SourceLocation,
+  NamespaceGroup,
+  MappingBlock,
+  SchemaCard,
+} from "./model.js";
+import {
+  computeLayout,
+  computeOverviewLayout,
+  type LayoutResult,
+  type OverviewLayoutResult,
+  type SourceBlockLayout,
+} from "./layout/elk-layout.js";
 import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 import { renderMarkdown } from "./markdown.js";
@@ -31,9 +43,22 @@ export {
   NAMESPACE_PILL_HEIGHT,
 } from "./layout/geometry.js";
 import { countMappingArrows } from "./field-coverage.js";
-export { buildMappingCoveredFields, buildMappedFieldsIndex, countMappingArrows, resolveSchemaLocalFieldPath, schemaHasFieldPath } from "./field-coverage.js";
+export {
+  buildMappingCoveredFields,
+  buildMappedFieldsIndex,
+  countMappingArrows,
+  resolveSchemaLocalFieldPath,
+  schemaHasFieldPath,
+} from "./field-coverage.js";
 export { metricAsSchemaCard, metricFieldEntries } from "./metric-adapter.js";
-export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout, OverviewLayoutResult, OverviewEdge } from "./layout/elk-layout.js";
+export type {
+  LayoutResult,
+  LayoutNode,
+  LayoutEdge,
+  SourceBlockLayout,
+  OverviewLayoutResult,
+  OverviewEdge,
+} from "./layout/elk-layout.js";
 
 /**
  * Replace every `var(--*)` reference in an exported SVG with the literal
@@ -43,10 +68,7 @@ export type { LayoutResult, LayoutNode, LayoutEdge, SourceBlockLayout, OverviewL
  * component (sl-7pdf). References that resolve to nothing are left intact
  * rather than silently emptied.
  */
-export function inlineCssVariables(
-  svg: string,
-  resolve: (name: string) => string,
-): string {
+export function inlineCssVariables(svg: string, resolve: (name: string) => string): string {
   return svg.replace(/var\((--[\w-]+)\)/g, (whole, name: string) => {
     const value = resolve(name).trim();
     return value === "" ? whole : value;
@@ -102,13 +124,17 @@ export function buildExportSvg(layout: LayoutResult, edgeSvgContent: string): st
   </style>
   <rect width="${w}" height="${h}" fill="var(--sz-bg)"/>
   ${edgeSvgContent}
-  ${[...layout.nodes.values()].map((n) => `
+  ${[...layout.nodes.values()]
+    .map(
+      (n) => `
   <g transform="translate(${n.x},${n.y})">
     <rect class="card" width="${n.width}" height="${n.height}" fill="var(--sz-card-bg)" stroke="var(--sz-card-border)" rx="8"/>
     <rect class="header" width="${n.width}" height="40" fill="var(--sz-orange)" rx="8"/>
     <rect x="0" y="32" width="${n.width}" height="8" fill="var(--sz-orange)"/>
     <text class="card-name" x="12" y="26">${escapeXml(n.id)}</text>
-  </g>`).join("")}
+  </g>`,
+    )
+    .join("")}
 </svg>`;
 }
 
@@ -341,8 +367,12 @@ export class SatsumaViz extends LitElement {
     }
 
     @keyframes fadeIn {
-      from { opacity: 0; }
-      to { opacity: 1; }
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
     }
 
     /* Flexbox fallback when no layout computed yet */
@@ -623,13 +653,25 @@ export class SatsumaViz extends LitElement {
 
     /* Slide-in animation for expanded cards */
     @keyframes slideInLeft {
-      from { opacity: 0; transform: translateX(-40px); }
-      to { opacity: 1; transform: translateX(0); }
+      from {
+        opacity: 0;
+        transform: translateX(-40px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0);
+      }
     }
 
     @keyframes slideInRight {
-      from { opacity: 0; transform: translateX(40px); }
-      to { opacity: 1; transform: translateX(0); }
+      from {
+        opacity: 0;
+        transform: translateX(40px);
+      }
+      to {
+        opacity: 1;
+        transform: translateX(0);
+      }
     }
 
     .positioned-card.expanded {
@@ -932,7 +974,13 @@ export class SatsumaViz extends LitElement {
   private _mappedFieldsBySchema = new Map<string, Set<string>>();
 
   @state()
-  private _renderedNamespaceBoxes: Array<{ name: string; x: number; y: number; w: number; h: number }> = [];
+  private _renderedNamespaceBoxes: Array<{
+    name: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  }> = [];
 
   /**
    * Minimap input for the mapping detail view, measured from the rendered
@@ -1012,14 +1060,14 @@ export class SatsumaViz extends LitElement {
     }
 
     if (
-      changed.has("_layout")
-      || changed.has("_overviewLayout")
-      || changed.has("_viewMode")
-      || changed.has("model")
-      || changed.has("_nsFilter")
-      || changed.has("_fileFilter")
-      || changed.has("_showNotes")
-      || changed.has("_selectedMapping")
+      changed.has("_layout") ||
+      changed.has("_overviewLayout") ||
+      changed.has("_viewMode") ||
+      changed.has("model") ||
+      changed.has("_nsFilter") ||
+      changed.has("_fileFilter") ||
+      changed.has("_showNotes") ||
+      changed.has("_selectedMapping")
     ) {
       requestAnimationFrame(() => {
         this._measureNamespaceBoxes();
@@ -1028,11 +1076,11 @@ export class SatsumaViz extends LitElement {
     }
 
     if (
-      changed.has("model")
-      || changed.has("_layout")
-      || changed.has("_overviewLayout")
-      || changed.has("_layoutError")
-      || changed.has("_viewMode")
+      changed.has("model") ||
+      changed.has("_layout") ||
+      changed.has("_overviewLayout") ||
+      changed.has("_layoutError") ||
+      changed.has("_viewMode")
     ) {
       this._publishAutomationState();
     }
@@ -1205,12 +1253,24 @@ export class SatsumaViz extends LitElement {
     });
 
     if (!this.model) {
-      return html`<div class="empty" data-testid="viz-empty" data-ready-state=${automationState.readyState}>No mapping file loaded</div>`;
+      return html`<div
+        class="empty"
+        data-testid="viz-empty"
+        data-ready-state=${automationState.readyState}
+      >
+        No mapping file loaded
+      </div>`;
     }
 
     const { namespaces } = this.model;
     if (namespaces.length === 0) {
-      return html`<div class="empty" data-testid="viz-empty" data-ready-state=${automationState.readyState}>No schemas found in this file</div>`;
+      return html`<div
+        class="empty"
+        data-testid="viz-empty"
+        data-ready-state=${automationState.readyState}
+      >
+        No schemas found in this file
+      </div>`;
     }
 
     const filtered = this._filterNamespaces(namespaces);
@@ -1220,7 +1280,13 @@ export class SatsumaViz extends LitElement {
     if (!this._layout && !this._overviewLayout && !this._layoutError) {
       return html`
         ${this._renderToolbar(namespaces)}
-        <div class="loading" data-testid="viz-loading" data-ready-state=${automationState.readyState}>Computing layout...</div>
+        <div
+          class="loading"
+          data-testid="viz-loading"
+          data-ready-state=${automationState.readyState}
+        >
+          Computing layout...
+        </div>
       `;
     }
 
@@ -1229,8 +1295,7 @@ export class SatsumaViz extends LitElement {
       return html`
         ${this._renderToolbar(namespaces)}
         <div class=${toggleClasses}>
-          ${this._renderFileNotes()}
-          ${this._renderFlexFallback(filtered)}
+          ${this._renderFileNotes()} ${this._renderFlexFallback(filtered)}
         </div>
       `;
     }
@@ -1242,7 +1307,8 @@ export class SatsumaViz extends LitElement {
         <div class="${toggleClasses} view-content">
           ${this._renderFileNotes()}
           <div class="notes-pane-wrapper">
-            <div class="viewport"
+            <div
+              class="viewport"
               data-testid="viz-viewport"
               @wheel=${this._onWheel}
               @mousedown=${this._onMouseDown}
@@ -1250,7 +1316,8 @@ export class SatsumaViz extends LitElement {
               @mouseup=${this._onMouseUp}
               @mouseleave=${this._onMouseUp}
             >
-              <div class="viewport-inner"
+              <div
+                class="viewport-inner"
                 style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
               >
                 <div class="detail-inner" style="padding: 16px;">
@@ -1270,12 +1337,12 @@ export class SatsumaViz extends LitElement {
     // Overview mode: compact schema cards with thick mapping arrows
     if (this._overviewLayout) {
       return html`
-        ${this._renderToolbar(namespaces)}
-        ${this._renderBreadcrumbs()}
+        ${this._renderToolbar(namespaces)} ${this._renderBreadcrumbs()}
         <div class="${toggleClasses} view-content">
           ${this._renderFileNotes()}
           <div class="notes-pane-wrapper">
-            <div class="viewport"
+            <div
+              class="viewport"
               data-testid="viz-viewport"
               @wheel=${this._onWheel}
               @mousedown=${this._onMouseDown}
@@ -1283,7 +1350,8 @@ export class SatsumaViz extends LitElement {
               @mouseup=${this._onMouseUp}
               @mouseleave=${this._onMouseUp}
             >
-              <div class="viewport-inner"
+              <div
+                class="viewport-inner"
                 style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
               >
                 ${this._renderOverview(this._overviewLayout, filtered)}
@@ -1305,12 +1373,12 @@ export class SatsumaViz extends LitElement {
     const showPane = this._showNotes && (hasComments || hasFileNotes);
 
     return html`
-      ${this._renderToolbar(namespaces)}
-      ${this._renderBreadcrumbs()}
+      ${this._renderToolbar(namespaces)} ${this._renderBreadcrumbs()}
       <div class=${toggleClasses}>
         ${this._renderFileNotes()}
         <div class="notes-pane-wrapper">
-          <div class="viewport"
+          <div
+            class="viewport"
             data-testid="viz-viewport"
             @wheel=${this._onWheel}
             @mousedown=${this._onMouseDown}
@@ -1318,7 +1386,8 @@ export class SatsumaViz extends LitElement {
             @mouseup=${this._onMouseUp}
             @mouseleave=${this._onMouseUp}
           >
-            <div class="viewport-inner"
+            <div
+              class="viewport-inner"
               style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
             >
               ${this._renderPositioned(this._layout!, filtered)}
@@ -1341,67 +1410,106 @@ export class SatsumaViz extends LitElement {
 
     return html`
       <div class="toolbar">
-        ${inDetail
-          ? html`
-              <button class="toolbar-btn" @click=${this._backToOverview}
-                title="Back to overview">&#9664; Overview</button>
-              <div class="toolbar-sep"></div>
-              <span class="toolbar-title">${this._selectedMapping?.id ?? "Mapping Detail"}</span>
-            `
-          : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`}
+        ${
+          inDetail
+            ? html`
+                <button class="toolbar-btn" @click=${this._backToOverview} title="Back to overview">
+                  &#9664; Overview
+                </button>
+                <div class="toolbar-sep"></div>
+                <span class="toolbar-title">${this._selectedMapping?.id ?? "Mapping Detail"}</span>
+              `
+            : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`
+        }
         <div class="toolbar-sep"></div>
         <button
           class="toolbar-btn"
           data-testid="toolbar-toggle-file-notes"
           ?data-active=${this._showNotes}
-          @click=${() => { this._showNotes = !this._showNotes; }}
+          @click=${() => {
+            this._showNotes = !this._showNotes;
+          }}
           title="Show or hide file notes"
-        >Show File Notes</button>
+        >
+          Show File Notes
+        </button>
         <div class="toolbar-sep"></div>
-        ${!inDetail
-          ? html`<button class="toolbar-btn" data-testid="toolbar-fit" @click=${this._fit} title="Fit all content in viewport">Fit</button>`
-          : ""}
-        <button class="toolbar-btn" data-testid="toolbar-refresh" @click=${this._refresh} title="Re-fetch visualization data">&#8635; Refresh</button>
-        ${!inDetail
-          ? html`<button class="toolbar-btn" data-testid="toolbar-export" @click=${this._exportSvg} title="Export the overview as an SVG file">&#x21E9; Export SVG</button>`
-          : ""}
-        ${hasNamespaces && !inDetail
-          ? html`
-              <div class="toolbar-sep"></div>
-              <select
-                class="toolbar-select"
-                data-testid="toolbar-namespace-filter"
-                @change=${this._onNsFilterChange}
-                title="Filter by namespace"
+        ${
+          !inDetail
+            ? html`<button
+                class="toolbar-btn"
+                data-testid="toolbar-fit"
+                @click=${this._fit}
+                title="Fit all content in viewport"
               >
-                <option value="" ?selected=${this._nsFilter === null}>All namespaces</option>
-                ${namedNs.map(
-                  (ns) => html`<option value=${ns.name!} ?selected=${this._nsFilter === ns.name}>${ns.name}</option>`
-                )}
-              </select>
-            `
-          : ""}
-        ${this._getSourceFiles().length > 1 && !inDetail
-          ? html`
-              <div class="toolbar-sep"></div>
-              <select
-                class="toolbar-select"
-                data-testid="toolbar-file-filter"
-                @change=${this._onFileFilterChange}
-                title="Filter by source file"
+                Fit
+              </button>`
+            : ""
+        }
+        <button
+          class="toolbar-btn"
+          data-testid="toolbar-refresh"
+          @click=${this._refresh}
+          title="Re-fetch visualization data"
+        >
+          &#8635; Refresh
+        </button>
+        ${
+          !inDetail
+            ? html`<button
+                class="toolbar-btn"
+                data-testid="toolbar-export"
+                @click=${this._exportSvg}
+                title="Export the overview as an SVG file"
               >
-                <option value="" ?selected=${this._fileFilter === null}>All files</option>
-                ${this._getSourceFiles().map(
-                  (uri) => {
+                &#x21E9; Export SVG
+              </button>`
+            : ""
+        }
+        ${
+          hasNamespaces && !inDetail
+            ? html`
+                <div class="toolbar-sep"></div>
+                <select
+                  class="toolbar-select"
+                  data-testid="toolbar-namespace-filter"
+                  @change=${this._onNsFilterChange}
+                  title="Filter by namespace"
+                >
+                  <option value="" ?selected=${this._nsFilter === null}>All namespaces</option>
+                  ${namedNs.map(
+                    (ns) =>
+                      html`<option value=${ns.name!} ?selected=${this._nsFilter === ns.name}>
+                        ${ns.name}
+                      </option>`,
+                  )}
+                </select>
+              `
+            : ""
+        }
+        ${
+          this._getSourceFiles().length > 1 && !inDetail
+            ? html`
+                <div class="toolbar-sep"></div>
+                <select
+                  class="toolbar-select"
+                  data-testid="toolbar-file-filter"
+                  @change=${this._onFileFilterChange}
+                  title="Filter by source file"
+                >
+                  <option value="" ?selected=${this._fileFilter === null}>All files</option>
+                  ${this._getSourceFiles().map((uri) => {
                     const name = uri.split("/").pop() ?? uri;
                     const isCurrent = uri === this.model?.uri;
                     const label = isCurrent ? `${name} (current)` : name;
-                    return html`<option value=${uri} ?selected=${this._fileFilter === uri}>${label}</option>`;
-                  }
-                )}
-              </select>
-            `
-          : ""}
+                    return html`<option value=${uri} ?selected=${this._fileFilter === uri}>
+                      ${label}
+                    </option>`;
+                  })}
+                </select>
+              `
+            : ""
+        }
         <div class="toolbar-spacer"></div>
       </div>
     `;
@@ -1583,14 +1691,20 @@ export class SatsumaViz extends LitElement {
             const name = m.uri.split("/").pop() ?? m.uri;
             return html`
               <span class="breadcrumb-sep">&#9654;</span>
-              <span class="breadcrumb-item" title="${m.uri} (via ${schemaId})"
+              <span
+                class="breadcrumb-item"
+                title="${m.uri} (via ${schemaId})"
                 @click=${() => this.addExpandedModels(schemaId, models)}
-              >${name}</span>
+                >${name}</span
+              >
             `;
-          })
+          }),
         )}
-        <button class="breadcrumb-collapse" @click=${this._collapseAll}
-          title="Collapse back to single-file view">
+        <button
+          class="breadcrumb-collapse"
+          @click=${this._collapseAll}
+          title="Collapse back to single-file view"
+        >
           &#10005; Collapse all
         </button>
       </div>
@@ -1600,8 +1714,11 @@ export class SatsumaViz extends LitElement {
   /** Render the overview: compact schema cards + thick overview edges. */
   private _renderOverview(overview: OverviewLayoutResult, namespaces: NamespaceGroup[]) {
     return html`
-      <div class="canvas" style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;"
-        @sz-compact-toggled=${this._onCompactToggled}>
+      <div
+        class="canvas"
+        style="width: ${overview.width + 48}px; height: ${overview.height + 48}px; padding: 24px;"
+        @sz-compact-toggled=${this._onCompactToggled}
+      >
         <!-- Cards and edges share .card-layer so both use the same coordinate
              origin by construction — a sibling edge layer anchored to the
              canvas padding box renders 24px above the in-flow cards (sl-wixe). -->
@@ -1619,9 +1736,13 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === s.qualifiedId);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                <div
+                  class="positioned-card"
+                  data-node-id=${s.qualifiedId}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
                   @mouseenter=${() => this._onOverviewNodeHover(s.qualifiedId)}
-                  @mouseleave=${() => this._onOverviewNodeLeave()}>
+                  @mouseleave=${() => this._onOverviewNodeLeave()}
+                >
                   <sz-schema-card
                     data-testid=${`overview-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
                     .testIdPrefix=${`overview-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
@@ -1637,10 +1758,18 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === f.id);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                <div
+                  class="positioned-card"
+                  data-node-id=${f.id}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
                   @mouseenter=${() => this._onOverviewNodeHover(f.id)}
-                  @mouseleave=${() => this._onOverviewNodeLeave()}>
-                  <sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name} compact></sz-fragment-card>
+                  @mouseleave=${() => this._onOverviewNodeLeave()}
+                >
+                  <sz-fragment-card
+                    .fragment=${f}
+                    .namespaceLabel=${ns.name}
+                    compact
+                  ></sz-fragment-card>
                 </div>
               `;
             }),
@@ -1648,9 +1777,13 @@ export class SatsumaViz extends LitElement {
               const node = overview.nodes.find((n) => n.id === m.qualifiedId);
               if (!node) return html``;
               return html`
-                <div class="positioned-card" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                <div
+                  class="positioned-card"
+                  data-node-id=${m.qualifiedId}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
                   @mouseenter=${() => this._onOverviewNodeHover(m.qualifiedId)}
-                  @mouseleave=${() => this._onOverviewNodeLeave()}>
+                  @mouseleave=${() => this._onOverviewNodeLeave()}
+                >
                   <sz-metric-card
                     data-testid=${`overview-metric-card-${sanitizeTestIdSegment(m.qualifiedId)}`}
                     .metric=${m}
@@ -1674,11 +1807,22 @@ export class SatsumaViz extends LitElement {
                   @mouseenter=${() => this._onOverviewNodeHover(mappingNodeId)}
                   @mouseleave=${() => this._onOverviewNodeLeave()}
                 >
-                  <div class="overview-mapping-card" data-testid=${`overview-mapping-card-${sanitizeTestIdSegment(m.id)}`} title=${m.id}>
-                    <div style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0;">
-                      ${ns.name
-                        ? html`<span style="display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:999px;background:var(--sz-namespace-pill-bg);color:var(--sz-namespace-pill-text);">${ns.name}</span>`
-                        : ""}
+                  <div
+                    class="overview-mapping-card"
+                    data-testid=${`overview-mapping-card-${sanitizeTestIdSegment(m.id)}`}
+                    title=${m.id}
+                  >
+                    <div
+                      style="display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0;"
+                    >
+                      ${
+                        ns.name
+                          ? html`<span
+                              style="display:inline-block;font-size:10px;font-weight:700;padding:1px 6px;border-radius:999px;background:var(--sz-namespace-pill-bg);color:var(--sz-namespace-pill-text);"
+                              >${ns.name}</span
+                            >`
+                          : ""
+                      }
                       <div style="display:flex;align-items:center;gap:8px;min-width:0;">
                         <svg class="overview-mapping-icon" viewBox="0 0 16 16" fill="currentColor">
                           <path d="M2 3h3v2H2v2l-2-3 2-3v2z" opacity="0.95"></path>
@@ -1687,7 +1831,9 @@ export class SatsumaViz extends LitElement {
                           <path d="M4.5 9h7v1.5h-7z" opacity="0.78"></path>
                         </svg>
                         <span class="overview-mapping-name">${m.id}</span>
-                        <span style="opacity:0.6;font-size:11px;font-weight:400;">${countMappingArrows(m)} &#8594;s</span>
+                        <span style="opacity:0.6;font-size:11px;font-weight:400;"
+                          >${countMappingArrows(m)} &#8594;s</span
+                        >
                       </div>
                     </div>
                   </div>
@@ -1703,7 +1849,7 @@ export class SatsumaViz extends LitElement {
   /** Compute namespace bounding boxes from the overview layout. */
   private _computeOverviewNamespaceBoxes(
     overview: OverviewLayoutResult,
-    namespaces: NamespaceGroup[]
+    namespaces: NamespaceGroup[],
   ): Array<{ name: string; x: number; y: number; w: number; h: number }> {
     if (this._renderedNamespaceBoxes.length > 0) {
       return this._renderedNamespaceBoxes;
@@ -1720,7 +1866,10 @@ export class SatsumaViz extends LitElement {
         ...ns.mappings.map((m) => this._overviewMappingNodeId(ns.name, m.id)),
       ];
 
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
       let found = false;
 
       for (const id of ids) {
@@ -1919,40 +2068,54 @@ export class SatsumaViz extends LitElement {
     return html`
       <div class="notes-pane">
         <div class="notes-pane-header">Notes &amp; Comments</div>
-        ${fileNotes.length > 0
-          ? html`
-              <div class="notes-pane-section">File Notes</div>
-              ${fileNotes.map((n) => html`<div class="note-card">${unsafeHTML(renderMarkdown(n.text))}</div>`)}
-            `
-          : ""}
-        ${allComments.warnings.length > 0
-          ? html`
-              <div class="notes-pane-section">&#9888; Warnings (${allComments.warnings.length})</div>
-              ${allComments.warnings.map(
-                (w) => html`
-                  <div class="comment-card warning" @click=${() => this._navigateTo(w.location)}
-                    title="Click to navigate">
-                    ${w.text}
-                    <div class="comment-card-source">${w.source}</div>
-                  </div>
-                `
-              )}
-            `
-          : ""}
-        ${allComments.questions.length > 0
-          ? html`
-              <div class="notes-pane-section">? Questions (${allComments.questions.length})</div>
-              ${allComments.questions.map(
-                (q) => html`
-                  <div class="comment-card question" @click=${() => this._navigateTo(q.location)}
-                    title="Click to navigate">
-                    ${q.text}
-                    <div class="comment-card-source">${q.source}</div>
-                  </div>
-                `
-              )}
-            `
-          : ""}
+        ${
+          fileNotes.length > 0
+            ? html`
+                <div class="notes-pane-section">File Notes</div>
+                ${fileNotes.map((n) => html`<div class="note-card">${unsafeHTML(renderMarkdown(n.text))}</div>`)}
+              `
+            : ""
+        }
+        ${
+          allComments.warnings.length > 0
+            ? html`
+                <div class="notes-pane-section">
+                  &#9888; Warnings (${allComments.warnings.length})
+                </div>
+                ${allComments.warnings.map(
+                  (w) => html`
+                    <div
+                      class="comment-card warning"
+                      @click=${() => this._navigateTo(w.location)}
+                      title="Click to navigate"
+                    >
+                      ${w.text}
+                      <div class="comment-card-source">${w.source}</div>
+                    </div>
+                  `,
+                )}
+              `
+            : ""
+        }
+        ${
+          allComments.questions.length > 0
+            ? html`
+                <div class="notes-pane-section">? Questions (${allComments.questions.length})</div>
+                ${allComments.questions.map(
+                  (q) => html`
+                    <div
+                      class="comment-card question"
+                      @click=${() => this._navigateTo(q.location)}
+                      title="Click to navigate"
+                    >
+                      ${q.text}
+                      <div class="comment-card-source">${q.source}</div>
+                    </div>
+                  `,
+                )}
+              `
+            : ""
+        }
       </div>
     `;
   }
@@ -1972,7 +2135,11 @@ export class SatsumaViz extends LitElement {
     const vh = (vpH / this._zoom) * scale;
 
     return html`
-      <div class="minimap" data-testid="viz-minimap" @click=${(e: MouseEvent) => this._onMinimapClick(e, scale)}>
+      <div
+        class="minimap"
+        data-testid="viz-minimap"
+        @click=${(e: MouseEvent) => this._onMinimapClick(e, scale)}
+      >
         <svg width=${mmW} height=${mmH} viewBox="0 0 ${mmW} ${mmH}">
           ${map.rects.map(
             (n) => svg`
@@ -1982,10 +2149,11 @@ export class SatsumaViz extends LitElement {
                 fill="var(--sz-card-border-strong)"
                 rx="1"
               />
-            `
+            `,
           )}
         </svg>
-        <div class="minimap-viewport"
+        <div
+          class="minimap-viewport"
           style="left: ${vx}px; top: ${vy}px; width: ${vw}px; height: ${vh}px;"
         ></div>
       </div>
@@ -2029,9 +2197,7 @@ export class SatsumaViz extends LitElement {
 
     for (const f of sb.filters) {
       results.push(html`
-        <div class="source-block-filter" style="left: ${x}px; top: ${y}px;">
-          &#x25B7; ${f}
-        </div>
+        <div class="source-block-filter" style="left: ${x}px; top: ${y}px;">&#x25B7; ${f}</div>
       `);
       y += 20;
     }
@@ -2083,22 +2249,28 @@ export class SatsumaViz extends LitElement {
     // Namespace filter
     if (this._nsFilter) {
       result = result.filter(
-        (ns) => ns.name === this._nsFilter || (!ns.name && result.some((n) => n.name === this._nsFilter))
+        (ns) =>
+          ns.name === this._nsFilter || (!ns.name && result.some((n) => n.name === this._nsFilter)),
       );
     }
 
     // File filter — narrow schemas/mappings/metrics/fragments to those from the selected file.
     if (this._fileFilter) {
-      result = result.map(ns => ({
-        ...ns,
-        schemas: ns.schemas.filter(s => s.location.uri === this._fileFilter),
-        mappings: ns.mappings.filter(m => m.location.uri === this._fileFilter),
-        metrics: ns.metrics.filter(m => m.location.uri === this._fileFilter),
-        fragments: ns.fragments.filter(f => f.location.uri === this._fileFilter),
-      })).filter(ns =>
-        ns.schemas.length > 0 || ns.mappings.length > 0 ||
-        ns.metrics.length > 0 || ns.fragments.length > 0
-      );
+      result = result
+        .map((ns) => ({
+          ...ns,
+          schemas: ns.schemas.filter((s) => s.location.uri === this._fileFilter),
+          mappings: ns.mappings.filter((m) => m.location.uri === this._fileFilter),
+          metrics: ns.metrics.filter((m) => m.location.uri === this._fileFilter),
+          fragments: ns.fragments.filter((f) => f.location.uri === this._fileFilter),
+        }))
+        .filter(
+          (ns) =>
+            ns.schemas.length > 0 ||
+            ns.mappings.length > 0 ||
+            ns.metrics.length > 0 ||
+            ns.fragments.length > 0,
+        );
     }
 
     return result;
@@ -2126,13 +2298,22 @@ export class SatsumaViz extends LitElement {
     const notes = this.model.fileNotes;
     return html`
       <div class="file-notes">
-        <div class="file-notes-toggle" data-testid="file-notes-toggle" @click=${this._toggleFileNotes}>
+        <div
+          class="file-notes-toggle"
+          data-testid="file-notes-toggle"
+          @click=${this._toggleFileNotes}
+        >
           <span class="arrow" ?data-expanded=${this._fileNotesExpanded}>&#9654;</span>
           <span>&#128221; File Notes (${notes.length})</span>
         </div>
-        ${this._fileNotesExpanded
-          ? notes.map((n) => html`<div class="file-note-item">${unsafeHTML(renderMarkdown(n.text))}</div>`)
-          : ""}
+        ${
+          this._fileNotesExpanded
+            ? notes.map(
+                (n) =>
+                  html`<div class="file-note-item">${unsafeHTML(renderMarkdown(n.text))}</div>`,
+              )
+            : ""
+        }
       </div>
     `;
   }
@@ -2155,7 +2336,10 @@ export class SatsumaViz extends LitElement {
     }
 
     return html`
-      <div class="canvas" style="width: ${layout.width + 48}px; height: ${layout.height + 48}px; padding: 24px;">
+      <div
+        class="canvas"
+        style="width: ${layout.width + 48}px; height: ${layout.height + 48}px; padding: 24px;"
+      >
         <!-- Everything positioned from layout coordinates lives inside
              .card-layer so cards, edges, and labels share one coordinate
              origin by construction — siblings anchored to the canvas padding
@@ -2179,26 +2363,35 @@ export class SatsumaViz extends LitElement {
               if (!node) return [html``];
               const mapped = this._mappedFieldsBySchema.get(s.qualifiedId) ?? new Set();
               const isExpanded = expandedIds.has(s.qualifiedId);
-              const results = [html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${s.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
-                  <sz-schema-card
-                    data-testid=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
-                    .testIdPrefix=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
-                    .schema=${s}
-                    .mappedFields=${mapped}
-                    .namespaceLabel=${ns.name}
-                  ></sz-schema-card>
-                </div>
-              `];
+              const results = [
+                html`
+                  <div
+                    class="positioned-card ${isExpanded ? "expanded" : ""}"
+                    data-node-id=${s.qualifiedId}
+                    style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                  >
+                    <sz-schema-card
+                      data-testid=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
+                      .testIdPrefix=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
+                      .schema=${s}
+                      .mappedFields=${mapped}
+                      .namespaceLabel=${ns.name}
+                    ></sz-schema-card>
+                  </div>
+                `,
+              ];
               // Block-level comment badges
               let badgeOffset = 0;
               for (const c of s.comments) {
                 results.push(html`
-                  <div class="block-comment-badge ${c.kind}"
+                  <div
+                    class="block-comment-badge ${c.kind}"
                     style="left: ${node.x + node.width + 8}px; top: ${node.y + badgeOffset}px;"
                     title=${c.text}
                     @click=${() => this._navigateTo(c.location)}
-                  >${c.kind === "warning" ? "⚠" : "?"} ${c.text}</div>
+                  >
+                    ${c.kind === "warning" ? "⚠" : "?"} ${c.text}
+                  </div>
                 `);
                 badgeOffset += 24;
               }
@@ -2209,7 +2402,11 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               const isExpanded = expandedIds.has(f.id);
               return html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${f.id} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div
+                  class="positioned-card ${isExpanded ? "expanded" : ""}"
+                  data-node-id=${f.id}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                >
                   <sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name}></sz-fragment-card>
                 </div>
               `;
@@ -2219,7 +2416,11 @@ export class SatsumaViz extends LitElement {
               if (!node) return html``;
               const isExpanded = expandedIds.has(m.qualifiedId);
               return html`
-                <div class="positioned-card ${isExpanded ? "expanded" : ""}" data-node-id=${m.qualifiedId} style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;">
+                <div
+                  class="positioned-card ${isExpanded ? "expanded" : ""}"
+                  data-node-id=${m.qualifiedId}
+                  style="left: ${node.x}px; top: ${node.y}px; width: ${node.width}px;"
+                >
                   <sz-metric-card .metric=${m} .namespaceLabel=${ns.name}></sz-metric-card>
                 </div>
               `;
@@ -2241,7 +2442,7 @@ export class SatsumaViz extends LitElement {
                   ${this._renderFlexCards(ns)}
                 </div>
               `
-            : this._renderFlexCards(ns)
+            : this._renderFlexCards(ns),
         )}
       </div>
     `;
@@ -2260,17 +2461,18 @@ export class SatsumaViz extends LitElement {
         ></sz-schema-card>`;
       })}
       ${ns.fragments.map(
-        (f) => html`<sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name}></sz-fragment-card>`
+        (f) =>
+          html`<sz-fragment-card .fragment=${f} .namespaceLabel=${ns.name}></sz-fragment-card>`,
       )}
       ${ns.metrics.map(
-        (m) => html`<sz-metric-card .metric=${m} .namespaceLabel=${ns.name}></sz-metric-card>`
+        (m) => html`<sz-metric-card .metric=${m} .namespaceLabel=${ns.name}></sz-metric-card>`,
       )}
     `;
   }
 
   private _computeNamespaceBoxes(
     layout: LayoutResult,
-    namespaces: NamespaceGroup[]
+    namespaces: NamespaceGroup[],
   ): Array<{ name: string; x: number; y: number; w: number; h: number }> {
     if (this._renderedNamespaceBoxes.length > 0) {
       return this._renderedNamespaceBoxes;
@@ -2287,7 +2489,10 @@ export class SatsumaViz extends LitElement {
         ...ns.mappings.map((m) => this._overviewMappingNodeId(ns.name, m.id)),
       ];
 
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      let minX = Infinity,
+        minY = Infinity,
+        maxX = -Infinity,
+        maxY = -Infinity;
       let found = false;
 
       for (const id of ids) {
@@ -2346,7 +2551,9 @@ export class SatsumaViz extends LitElement {
       let found = false;
 
       for (const id of ids) {
-        const el = canvas.querySelector(`.positioned-card[data-node-id="${CSS.escape(id)}"]`) as HTMLElement | null;
+        const el = canvas.querySelector(
+          `.positioned-card[data-node-id="${CSS.escape(id)}"]`,
+        ) as HTMLElement | null;
         if (!el) continue;
         found = true;
         minX = Math.min(minX, el.offsetLeft);
@@ -2434,8 +2641,8 @@ export class SatsumaViz extends LitElement {
       ".source-block-label",
       ".source-block-filter",
     ];
-    const elements = selectors.flatMap((selector) =>
-      Array.from(canvas.querySelectorAll(selector)) as HTMLElement[]
+    const elements = selectors.flatMap(
+      (selector) => Array.from(canvas.querySelectorAll(selector)) as HTMLElement[],
     );
 
     if (elements.length === 0) {

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -118,14 +118,22 @@ describe("viz automation helpers", () => {
         { key: "note", value: "Unique key across ORDERS tables" },
         { key: "sensitivity", value: "internal" },
       ],
-      notes: [{ text: "Unique key across ORDERS tables", isMultiline: false,
-        location: { uri: "file:///t.stm", line: 1, character: 0 } }],
+      notes: [
+        {
+          text: "Unique key across ORDERS tables",
+          isMultiline: false,
+          location: { uri: "file:///t.stm", line: 1, character: 0 },
+        },
+      ],
       comments: [],
       children: [],
       location: { uri: "file:///t.stm", line: 1, character: 0 },
     };
     const pills = card._fieldMetaPills(field);
-    assert.deepEqual(pills.map((p) => p.key), ["sensitivity"]);
+    assert.deepEqual(
+      pills.map((p) => p.key),
+      ["sensitivity"],
+    );
 
     // The note text must still reach the rendered output via the field-note row.
     const serialize = (t) => {
@@ -199,16 +207,18 @@ describe("viz automation helpers", () => {
       qualifiedId: "customers",
       kind: "schema",
       label: null,
-      fields: [{
-        name: "customer_id",
-        type: "UUID",
-        constraints: [],
-        metadata: [],
-        notes: [],
-        comments: [],
-        children: [],
-        location: { uri: "file:///test.stm", line: 1, character: 0 },
-      }],
+      fields: [
+        {
+          name: "customer_id",
+          type: "UUID",
+          constraints: [],
+          metadata: [],
+          notes: [],
+          comments: [],
+          children: [],
+          location: { uri: "file:///test.stm", line: 1, character: 0 },
+        },
+      ],
       notes: [],
       comments: [],
       metadata: [],

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -40,9 +40,7 @@ describe("field-coverage helpers", () => {
   });
 
   it("resolves unqualified nested source paths against the owning schema", () => {
-    const src = schema("order_events", [
-      field("customer", [field("email"), field("tier")]),
-    ]);
+    const src = schema("order_events", [field("customer", [field("email"), field("tier")])]);
     assert.equal(mod.schemaHasFieldPath(src, "customer.email"), true);
     assert.equal(
       mod.resolveSchemaLocalFieldPath("customer.email", src, ["order_events", "customer_profiles"]),
@@ -53,7 +51,10 @@ describe("field-coverage helpers", () => {
   it("strips explicit schema qualifiers when resolving local paths", () => {
     const profiles = schema("customer_profiles", [field("region")]);
     assert.equal(
-      mod.resolveSchemaLocalFieldPath("customer_profiles.region", profiles, ["order_events", "customer_profiles"]),
+      mod.resolveSchemaLocalFieldPath("customer_profiles.region", profiles, [
+        "order_events",
+        "customer_profiles",
+      ]),
       "region",
     );
   });
@@ -62,9 +63,7 @@ describe("field-coverage helpers", () => {
     const orderEvents = schema("order_events", [
       field("customer", [field("email"), field("tier")]),
     ]);
-    const target = schema("completed_orders", [
-      field("customer_email"),
-    ]);
+    const target = schema("completed_orders", [field("customer_email")]);
     const mapping = {
       id: "completed orders",
       sourceRefs: ["order_events", "customer_profiles"],
@@ -114,7 +113,10 @@ describe("field-coverage helpers", () => {
     // The qualified form must keep working too — cross-namespace refs are
     // authored fully qualified.
     assert.equal(
-      mod.resolveSchemaLocalFieldPath("crm::customers.id", customers, ["crm::customers", "crm::orders"]),
+      mod.resolveSchemaLocalFieldPath("crm::customers.id", customers, [
+        "crm::customers",
+        "crm::orders",
+      ]),
       "id",
     );
   });
@@ -134,7 +136,11 @@ describe("field-coverage helpers", () => {
     // with bare-prefixed arrow refs left sourceMapped empty for both schemas.
     const customers = schema("customers", [field("id"), field("email")], "crm::customers");
     const orders = schema("orders", [field("customer_id"), field("total")], "crm::orders");
-    const target = schema("customer_orders", [field("email"), field("total")], "crm::customer_orders");
+    const target = schema(
+      "customer_orders",
+      [field("email"), field("total")],
+      "crm::customer_orders",
+    );
     const mapping = {
       id: "join_orders",
       sourceRefs: ["crm::customers", "crm::orders"],
@@ -191,7 +197,12 @@ describe("field-coverage helpers", () => {
 
 /** One arrow, for building nesting fixtures compactly. */
 const arrow = (src, tgt) => ({
-  sourceFields: [src], targetField: tgt, transform: null, metadata: [], comments: [], location: loc,
+  sourceFields: [src],
+  targetField: tgt,
+  transform: null,
+  metadata: [],
+  comments: [],
+  location: loc,
 });
 
 /** A mapping with one arrow at each level: top, each, nested-each, flatten. */
@@ -200,32 +211,38 @@ const arrowAtEveryLevel = () => ({
   sourceRefs: ["order"],
   targetRef: "invoice",
   arrows: [arrow("id", "id")],
-  eachBlocks: [{
-    sourceField: "items",
-    targetField: "lines",
-    arrows: [arrow("items.sku", "lines.sku")],
-    nestedEach: [{
-      sourceField: "items.discounts",
-      targetField: "lines.discounts",
-      arrows: [arrow("items.discounts.code", "lines.discounts.code")],
+  eachBlocks: [
+    {
+      sourceField: "items",
+      targetField: "lines",
+      arrows: [arrow("items.sku", "lines.sku")],
+      nestedEach: [
+        {
+          sourceField: "items.discounts",
+          targetField: "lines.discounts",
+          arrows: [arrow("items.discounts.code", "lines.discounts.code")],
+          nestedEach: [],
+          nestedFlatten: [],
+          nestedArrows: [],
+          location: loc,
+        },
+      ],
+      nestedFlatten: [],
+      nestedArrows: [],
+      location: loc,
+    },
+  ],
+  flattenBlocks: [
+    {
+      sourceField: "tags",
+      targetField: "invoice",
+      arrows: [arrow("tags.label", "tag_label")],
       nestedEach: [],
       nestedFlatten: [],
       nestedArrows: [],
       location: loc,
-    }],
-    nestedFlatten: [],
-    nestedArrows: [],
-    location: loc,
-  }],
-  flattenBlocks: [{
-    sourceField: "tags",
-    targetField: "invoice",
-    arrows: [arrow("tags.label", "tag_label")],
-    nestedEach: [],
-    nestedFlatten: [],
-    nestedArrows: [],
-    location: loc,
-  }],
+    },
+  ],
   nestedArrows: [],
   sourceBlock: null,
   notes: [],
@@ -252,23 +269,27 @@ describe("countMappingArrows (sl-fm0q)", () => {
       arrows: [],
       flattenBlocks: [],
       nestedArrows: [],
-      eachBlocks: [{
-        sourceField: "orders",
-        targetField: "orders",
-        arrows: [arrow("orders.id", "orders.id")],
-        nestedEach: [],
-        nestedFlatten: [{
-          sourceField: "orders.parcels.contents",
-          targetField: "orders.packed_items",
-          arrows: [arrow("orders.parcels.contents.sku", "orders.packed_items.sku")],
+      eachBlocks: [
+        {
+          sourceField: "orders",
+          targetField: "orders",
+          arrows: [arrow("orders.id", "orders.id")],
           nestedEach: [],
-          nestedFlatten: [],
+          nestedFlatten: [
+            {
+              sourceField: "orders.parcels.contents",
+              targetField: "orders.packed_items",
+              arrows: [arrow("orders.parcels.contents.sku", "orders.packed_items.sku")],
+              nestedEach: [],
+              nestedFlatten: [],
+              nestedArrows: [],
+              location: loc,
+            },
+          ],
           nestedArrows: [],
           location: loc,
-        }],
-        nestedArrows: [],
-        location: loc,
-      }],
+        },
+      ],
     };
     assert.equal(countMappingArrows(mapping), 2);
   });
@@ -283,23 +304,30 @@ describe("countMappingArrows (sl-fm0q)", () => {
     // arrow each for a mapping-level nested_arrow and one inside an each.
     const { countMappingArrows } = await import("../dist/satsuma-viz.js");
     const nestedArrowBlock = (src, tgt, arrows) => ({
-      sourceField: src, targetField: tgt, arrows,
-      nestedEach: [], nestedFlatten: [], nestedArrows: [], location: loc,
+      sourceField: src,
+      targetField: tgt,
+      arrows,
+      nestedEach: [],
+      nestedFlatten: [],
+      nestedArrows: [],
+      location: loc,
     });
     const mapping = {
       ...arrowAtEveryLevel(),
       arrows: [arrow("id", "id")],
       flattenBlocks: [],
       nestedArrows: [nestedArrowBlock("addr", "address", [arrow(".line1", ".line1")])],
-      eachBlocks: [{
-        sourceField: "items",
-        targetField: "lines",
-        arrows: [],
-        nestedEach: [],
-        nestedFlatten: [],
-        nestedArrows: [nestedArrowBlock(".dims", ".dims", [arrow(".h", ".h")])],
-        location: loc,
-      }],
+      eachBlocks: [
+        {
+          sourceField: "items",
+          targetField: "lines",
+          arrows: [],
+          nestedEach: [],
+          nestedFlatten: [],
+          nestedArrows: [nestedArrowBlock(".dims", ".dims", [arrow(".h", ".h")])],
+          location: loc,
+        },
+      ],
     };
     assert.equal(countMappingArrows(mapping), 5);
   });
@@ -338,7 +366,11 @@ describe("sz-mapping-detail hover lookups recurse into nestedEach (sl-fm0q)", ()
 
   it("hovering a nested-each source field highlights its target counterpart", async () => {
     const detail = await makeDetail();
-    const targets = detail._findTargetFieldsForSource("items.discounts.code", "order", detail.mapping);
+    const targets = detail._findTargetFieldsForSource(
+      "items.discounts.code",
+      "order",
+      detail.mapping,
+    );
     assert.deepEqual([...targets], ["lines.discounts.code"]);
   });
 });

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -176,10 +176,7 @@ describe("computeLayout", () => {
     const tgt = result.nodes.get("target");
 
     // ELK layered layout with RIGHT direction: source should be left of target
-    assert.ok(
-      src.x < tgt.x,
-      `Source x (${src.x}) should be less than target x (${tgt.x})`
-    );
+    assert.ok(src.x < tgt.x, `Source x (${src.x}) should be less than target x (${tgt.x})`);
 
     // Should produce edges
     assert.ok(result.edges.length >= 0, "Should have edges array");
@@ -388,13 +385,10 @@ describe("computeLayout", () => {
 
     const result = await computeLayout(model);
 
-    assert.ok(
-      result.nodes.has("crm::customers"),
-      "Should have namespaced schema node"
-    );
+    assert.ok(result.nodes.has("crm::customers"), "Should have namespaced schema node");
     assert.ok(
       !result.nodes.has("ns:crm"),
-      "Namespace layout container should not exist in result nodes"
+      "Namespace layout container should not exist in result nodes",
     );
   });
 
@@ -452,21 +446,35 @@ describe("computeLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [{
-          ...schema(
-            "branch_product_daily_as_is",
-            [field("branch_id"), field("branch_name"), field("effective_from", "DATE")],
-          ),
-          metadata: [{ key: "report", value: "" }, { key: "tool", value: "powerbi" }],
-          notes: [{ text: "Long report note that should reserve extra card height in the detailed lineage view.", isMultiline: false, location: loc }],
-          spreads: ["audit_fields"],
-        }],
-        mappings: [],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [
+            {
+              ...schema("branch_product_daily_as_is", [
+                field("branch_id"),
+                field("branch_name"),
+                field("effective_from", "DATE"),
+              ]),
+              metadata: [
+                { key: "report", value: "" },
+                { key: "tool", value: "powerbi" },
+              ],
+              notes: [
+                {
+                  text: "Long report note that should reserve extra card height in the detailed lineage view.",
+                  isMultiline: false,
+                  location: loc,
+                },
+              ],
+              spreads: ["audit_fields"],
+            },
+          ],
+          mappings: [],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeLayout(model);
@@ -487,36 +495,64 @@ describe("computeLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [],
-        mappings: [],
-        metrics: [{
-          id: "branch_product_revenue_variance",
-          qualifiedId: "branch_product_revenue_variance",
-          label: "Revenue Variance",
-          source: ["orders"],
-          grain: "daily",
-          slices: ["region", "branch", "product"],
-          filter: null,
-          fields: [
-            { name: "variance_amount", type: "DECIMAL(14,2)", measure: "additive", notes: [], location: loc },
-            { name: "variance_pct", type: "DECIMAL(9,4)", measure: "non_additive", notes: [], location: loc },
+      namespaces: [
+        {
+          name: null,
+          schemas: [],
+          mappings: [],
+          metrics: [
+            {
+              id: "branch_product_revenue_variance",
+              qualifiedId: "branch_product_revenue_variance",
+              label: "Revenue Variance",
+              source: ["orders"],
+              grain: "daily",
+              slices: ["region", "branch", "product"],
+              filter: null,
+              fields: [
+                {
+                  name: "variance_amount",
+                  type: "DECIMAL(14,2)",
+                  measure: "additive",
+                  notes: [],
+                  location: loc,
+                },
+                {
+                  name: "variance_pct",
+                  type: "DECIMAL(9,4)",
+                  measure: "non_additive",
+                  notes: [],
+                  location: loc,
+                },
+              ],
+              notes: [
+                {
+                  text: "Used by operational reporting and downstream dashboards.",
+                  isMultiline: false,
+                  location: loc,
+                },
+              ],
+              comments: [],
+              location: loc,
+            },
           ],
-          notes: [{ text: "Used by operational reporting and downstream dashboards.", isMultiline: false, location: loc }],
-          comments: [],
-          location: loc,
-        }],
-        fragments: [],
-      }],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeLayout(model);
     const node = result.nodes.get("branch_product_revenue_variance");
 
     assert.ok(node, "Should have metric node");
-    assert.ok(node.height > 120, `Metric node height (${node.height}) should include meta and notes`);
-    assert.ok(node.width > 240, `Metric node width (${node.width}) should expand for long names/content`);
+    assert.ok(
+      node.height > 120,
+      `Metric node height (${node.height}) should include meta and notes`,
+    );
+    assert.ok(
+      node.width > 240,
+      `Metric node width (${node.width}) should expand for long names/content`,
+    );
   });
 
   it("produces positive dimensions for the overall layout", async () => {
@@ -578,20 +614,34 @@ describe("computeLayout edge metadata survives namespaces and concurrency (sl-i8
     // sl-i8mo: edge bookkeeping was module-level and cleared once per
     // namespace, so ANY later namespace group — even one without mappings —
     // erased every earlier edge's source/target/arrow metadata.
-    const result = await computeLayout(model(
-      ns(null, {
-        schemas: [schema("src", [field("email")]), schema("tgt", [field("email")])],
-        mappings: [mapping("m1", ["src"], "tgt", [arrow("email", "email")])],
-      }),
-      ns("crm", { schemas: [schema("customers", [field("id")], "crm::customers")] }),
-    ));
+    const result = await computeLayout(
+      model(
+        ns(null, {
+          schemas: [schema("src", [field("email")]), schema("tgt", [field("email")])],
+          mappings: [mapping("m1", ["src"], "tgt", [arrow("email", "email")])],
+        }),
+        ns("crm", { schemas: [schema("customers", [field("id")], "crm::customers")] }),
+      ),
+    );
 
     assert.equal(result.edges.length, 1, "the global mapping should produce one edge");
     const edge = result.edges[0];
-    assert.equal(edge.sourceNode, "src", "edge must keep its source node after a later namespace is processed");
-    assert.equal(edge.targetNode, "tgt", "edge must keep its target node after a later namespace is processed");
+    assert.equal(
+      edge.sourceNode,
+      "src",
+      "edge must keep its source node after a later namespace is processed",
+    );
+    assert.equal(
+      edge.targetNode,
+      "tgt",
+      "edge must keep its target node after a later namespace is processed",
+    );
     assert.equal(edge.sourceField, "email");
-    assert.equal(edge.arrow.targetField, "email", "edge must keep its real arrow, not the dummy fallback");
+    assert.equal(
+      edge.arrow.targetField,
+      "email",
+      "edge must keep its real arrow, not the dummy fallback",
+    );
   });
 
   it("returns each call's own edge metadata when layouts run concurrently", async () => {
@@ -599,10 +649,13 @@ describe("computeLayout edge metadata survives namespaces and concurrency (sl-i8
     // could repopulate state between another call's graph build and its
     // post-await extraction. Identical mapping ids make a stale read visible:
     // model A's edge would pick up model B's metadata.
-    const modelFor = (suffix) => model(ns(null, {
-      schemas: [schema(`src_${suffix}`, [field("id")]), schema(`tgt_${suffix}`, [field("id")])],
-      mappings: [mapping("m1", [`src_${suffix}`], `tgt_${suffix}`, [arrow("id", "id")])],
-    }));
+    const modelFor = (suffix) =>
+      model(
+        ns(null, {
+          schemas: [schema(`src_${suffix}`, [field("id")]), schema(`tgt_${suffix}`, [field("id")])],
+          mappings: [mapping("m1", [`src_${suffix}`], `tgt_${suffix}`, [arrow("id", "id")])],
+        }),
+      );
 
     const [a, b] = await Promise.all([computeLayout(modelFor("a")), computeLayout(modelFor("b"))]);
 
@@ -629,44 +682,67 @@ describe("computeLayout field ports for dotted, prefixed, and namespaced paths (
     // sl-l7u0: ports were keyed by bare field name while the edge lookup used
     // the authored ref verbatim, so "src.email" found no port and the edge
     // was silently dropped.
-    const result = await computeLayout(model(
-      [schema("src", [field("email")]), schema("tgt", [field("email")])],
-      [mapping("m1", ["src"], "tgt", [arrow("src.email", "email")])],
-    ));
+    const result = await computeLayout(
+      model(
+        [schema("src", [field("email")]), schema("tgt", [field("email")])],
+        [mapping("m1", ["src"], "tgt", [arrow("src.email", "email")])],
+      ),
+    );
 
-    assert.equal(result.edges.length, 1, "prefixed source ref must resolve to the declared field's port");
+    assert.equal(
+      result.edges.length,
+      1,
+      "prefixed source ref must resolve to the declared field's port",
+    );
     assert.equal(result.edges[0].sourceNode, "src");
   });
 
   it("renders an edge whose target is a nested dotted field path", async () => {
     const tgt = schema("tgt", [{ ...field("customer", "record"), children: [field("email")] }]);
-    const result = await computeLayout(model(
-      [schema("src", [field("email")]), tgt],
-      [mapping("m1", ["src"], "tgt", [arrow("email", "customer.email")])],
-    ));
+    const result = await computeLayout(
+      model(
+        [schema("src", [field("email")]), tgt],
+        [mapping("m1", ["src"], "tgt", [arrow("email", "customer.email")])],
+      ),
+    );
 
-    assert.equal(result.edges.length, 1, "nested dotted target path must resolve to the child field's port");
+    assert.equal(
+      result.edges.length,
+      1,
+      "nested dotted target path must resolve to the child field's port",
+    );
     assert.equal(result.edges[0].targetField, "customer.email");
   });
 
   it("attaches a multi-source arrow to the source schema that declares the field", async () => {
     // Pre-fix the edge was always pinned to sourceRefs[0]; a ref like "b.id"
     // then looked up a non-existent port on schema a and the edge vanished.
-    const result = await computeLayout(model(
-      [schema("a", [field("x")]), schema("b", [field("id")]), schema("tgt", [field("id")])],
-      [mapping("m1", ["a", "b"], "tgt", [arrow("b.id", "id")])],
-    ));
+    const result = await computeLayout(
+      model(
+        [schema("a", [field("x")]), schema("b", [field("id")]), schema("tgt", [field("id")])],
+        [mapping("m1", ["a", "b"], "tgt", [arrow("b.id", "id")])],
+      ),
+    );
 
     assert.equal(result.edges.length, 1);
-    assert.equal(result.edges[0].sourceNode, "b", "the edge must start at the schema declaring the field");
+    assert.equal(
+      result.edges[0].sourceNode,
+      "b",
+      "the edge must start at the schema declaring the field",
+    );
   });
 
   it("keeps ports distinct for same-named fields at different nesting levels", async () => {
     // Pre-fix both rows produced the id "node:email:src" and the later port
     // silently overwrote the earlier one in LayoutNode.ports.
-    const result = await computeLayout(model(
-      [schema("s", [field("email"), { ...field("customer", "record"), children: [field("email")] }])],
-    ));
+    const result = await computeLayout(
+      model([
+        schema("s", [
+          field("email"),
+          { ...field("customer", "record"), children: [field("email")] },
+        ]),
+      ]),
+    );
 
     const ports = result.nodes.get("s").ports;
     const top = ports.get("email:src");
@@ -682,17 +758,22 @@ describe("computeLayout field ports for dotted, prefixed, and namespaced paths (
     const result = await computeLayout({
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: "crm",
-        schemas: [schema("customers", [field("id")], "crm::customers")],
-        mappings: [],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: "crm",
+          schemas: [schema("customers", [field("id")], "crm::customers")],
+          mappings: [],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     });
 
     const ports = result.nodes.get("crm::customers").ports;
-    assert.ok(ports.get("id:src"), "field key must be the local path, undamaged by '::' in the node id");
+    assert.ok(
+      ports.get("id:src"),
+      "field key must be the local path, undamaged by '::' in the node id",
+    );
     assert.ok(ports.get("id:tgt"));
   });
 });
@@ -711,21 +792,23 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [schema("src"), schema("tgt")],
-        mappings: [mapping("m1", ["src"], "tgt", [arrow("id", "id")])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [schema("src"), schema("tgt")],
+          mappings: [mapping("m1", ["src"], "tgt", [arrow("id", "id")])],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
 
     assert.ok(result.nodes.length >= 3, "Should include schema nodes plus a mapping node");
-    const srcNode = result.nodes.find(n => n.id === "src");
-    const tgtNode = result.nodes.find(n => n.id === "tgt");
-    const mappingNode = result.nodes.find(n => n.id === "mapping:_:m1");
+    const srcNode = result.nodes.find((n) => n.id === "src");
+    const tgtNode = result.nodes.find((n) => n.id === "tgt");
+    const mappingNode = result.nodes.find((n) => n.id === "mapping:_:m1");
     assert.ok(srcNode, "Should have src node");
     assert.ok(tgtNode, "Should have tgt node");
     assert.ok(mappingNode, "Should have a mapping node");
@@ -740,20 +823,20 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [
-          schema("src", [field("a"), field("b"), field("c")]),
-          schema("tgt", [field("x"), field("y"), field("z")]),
-        ],
-        mappings: [mapping("m1", ["src"], "tgt", [
-          arrow("a", "x"),
-          arrow("b", "y"),
-          arrow("c", "z"),
-        ])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [
+            schema("src", [field("a"), field("b"), field("c")]),
+            schema("tgt", [field("x"), field("y"), field("z")]),
+          ],
+          mappings: [
+            mapping("m1", ["src"], "tgt", [arrow("a", "x"), arrow("b", "y"), arrow("c", "z")]),
+          ],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
@@ -768,13 +851,15 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [schema("s1"), schema("s2"), schema("tgt")],
-        mappings: [mapping("m1", ["s1", "s2"], "tgt", [arrow("id", "id")])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [schema("s1"), schema("s2"), schema("tgt")],
+          mappings: [mapping("m1", ["s1", "s2"], "tgt", [arrow("id", "id")])],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
@@ -782,7 +867,7 @@ describe("computeOverviewLayout", () => {
     assert.equal(result.edges.length, 3, "Two source inputs plus one target edge");
     const inboundSources = result.edges
       .filter((e) => e.targetNode === "mapping:_:m1")
-      .map(e => e.sourceNode)
+      .map((e) => e.sourceNode)
       .sort();
     assert.deepEqual(inboundSources, ["s1", "s2"]);
     assert.ok(result.edges.some((e) => e.sourceNode === "mapping:_:m1" && e.targetNode === "tgt"));
@@ -797,17 +882,19 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [
-          schema("s1", [field("a"), field("b"), field("c"), field("d")]),
-          schema("s2"),
-          schema("tgt"),
-        ],
-        mappings: [mapping("m1", ["s1", "s2"], "tgt", [arrow("a", "id")])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [
+            schema("s1", [field("a"), field("b"), field("c"), field("d")]),
+            schema("s2"),
+            schema("tgt"),
+          ],
+          mappings: [mapping("m1", ["s1", "s2"], "tgt", [arrow("a", "id")])],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const compact = await computeOverviewLayout(model);
@@ -838,33 +925,37 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: "crm",
-        schemas: [schema("customers", [field("id")], "crm::customers")],
-        mappings: [],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: "crm",
+          schemas: [schema("customers", [field("id")], "crm::customers")],
+          mappings: [],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
 
-    const node = result.nodes.find(n => n.id === "crm::customers");
+    const node = result.nodes.find((n) => n.id === "crm::customers");
     assert.ok(node, "Should have namespaced schema node");
-    assert.ok(!result.nodes.find(n => n.id === "ns:crm"), "No namespace node in output");
+    assert.ok(!result.nodes.find((n) => n.id === "ns:crm"), "No namespace node in output");
   });
 
   it("produces positive overall dimensions", async () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [schema("a")],
-        mappings: [],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [schema("a")],
+          mappings: [],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
@@ -876,22 +967,25 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [
-          schema("src"),
-          {
-            ...schema(
-              "order_headers_parquet_with_a_long_name",
-              [field("id"), field("customer_id"), field("created_at")],
-            ),
-            metadata: [{ key: "format", value: "parquet" }],
-          },
-        ],
-        mappings: [],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [
+            schema("src"),
+            {
+              ...schema("order_headers_parquet_with_a_long_name", [
+                field("id"),
+                field("customer_id"),
+                field("created_at"),
+              ]),
+              metadata: [{ key: "format", value: "parquet" }],
+            },
+          ],
+          mappings: [],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
@@ -911,13 +1005,15 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [schema("src"), schema("tgt")],
-        mappings: [mapping(longMappingId, ["src"], "tgt", [arrow("id", "id")])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [schema("src"), schema("tgt")],
+          mappings: [mapping(longMappingId, ["src"], "tgt", [arrow("id", "id")])],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
@@ -942,17 +1038,25 @@ describe("computeOverviewLayout", () => {
     const model = {
       uri: "file:///test.stm",
       fileNotes: [],
-      namespaces: [{
-        name: null,
-        schemas: [schema("src"), schema("tgt")],
-        mappings: [mapping("m1", ["src", "Join text that is not a schema"], "tgt", [arrow("id", "id")])],
-        metrics: [],
-        fragments: [],
-      }],
+      namespaces: [
+        {
+          name: null,
+          schemas: [schema("src"), schema("tgt")],
+          mappings: [
+            mapping("m1", ["src", "Join text that is not a schema"], "tgt", [arrow("id", "id")]),
+          ],
+          metrics: [],
+          fragments: [],
+        },
+      ],
     };
 
     const result = await computeOverviewLayout(model);
-    assert.equal(result.edges.length, 2, "Should keep the valid inbound edge plus the mapping-to-target edge");
+    assert.equal(
+      result.edges.length,
+      2,
+      "Should keep the valid inbound edge plus the mapping-to-target edge",
+    );
     assert.ok(result.edges.some((e) => e.sourceNode === "src" && e.targetNode === "mapping:_:m1"));
     assert.ok(result.edges.some((e) => e.sourceNode === "mapping:_:m1" && e.targetNode === "tgt"));
   });

--- a/tooling/satsuma-viz/test/meta-pills-layout.test.js
+++ b/tooling/satsuma-viz/test/meta-pills-layout.test.js
@@ -41,10 +41,7 @@ describe("metadata pill geometry in the overview layout", () => {
     const { computeOverviewLayout } = await import("../dist/satsuma-viz.js");
     const longUri = "namespace http://example.com/commerce/order/v2/with/a/really/long/path";
     const layout = await computeOverviewLayout(
-      model(
-        schema("plain"),
-        schema("pilled", [{ key: "namespace", value: longUri }]),
-      ),
+      model(schema("plain"), schema("pilled", [{ key: "namespace", value: longUri }])),
     );
 
     // Same id-length headers → identical widths; the URI pill must not
@@ -60,8 +57,7 @@ describe("metadata pill geometry in the overview layout", () => {
       METADATA_PILLS_CHROME,
     } = await import("../dist/satsuma-viz.js");
 
-    const pills = (n) =>
-      Array.from({ length: n }, (_, i) => ({ key: `k${i}`, value: `v${i}` }));
+    const pills = (n) => Array.from({ length: n }, (_, i) => ({ key: `k${i}`, value: `v${i}` }));
     const layout = await computeOverviewLayout(
       model(schema("none"), schema("one", pills(1)), schema("three", pills(3))),
     );
@@ -71,9 +67,6 @@ describe("metadata pill geometry in the overview layout", () => {
     assert.equal(h("one") - h("none"), METADATA_PILLS_CHROME + META_PILL_ROW_HEIGHT);
     // …each further pill exactly one row + one gap. The card CSS pins these
     // same constants, so renderer and layout cannot drift.
-    assert.equal(
-      h("three") - h("one"),
-      2 * (META_PILL_ROW_HEIGHT + META_PILL_ROW_GAP),
-    );
+    assert.equal(h("three") - h("one"), 2 * (META_PILL_ROW_HEIGHT + META_PILL_ROW_GAP));
   });
 });

--- a/tooling/satsuma-viz/test/metric-adapter.test.js
+++ b/tooling/satsuma-viz/test/metric-adapter.test.js
@@ -48,7 +48,10 @@ describe("metric → schema-card adaptation", () => {
     assert.equal(fields.length, 2);
     assert.deepEqual(
       fields.map((f) => [f.name, f.type]),
-      [["won_count", "INT64"], ["win_rate", "DECIMAL(5,2)"]],
+      [
+        ["won_count", "INT64"],
+        ["win_rate", "DECIMAL(5,2)"],
+      ],
     );
     // Lean MetricFieldEntry has no constraints/comments/children — the
     // adaptation must supply the empty collections schema consumers expect.

--- a/tooling/satsuma-viz/test/metric-card.test.js
+++ b/tooling/satsuma-viz/test/metric-card.test.js
@@ -42,7 +42,11 @@ describe("sz-metric-card collapse vs navigate intent (sl-37f3)", () => {
     const { card, navigations } = await makeCard();
 
     let propagationStopped = false;
-    card._onToggleClick({ stopPropagation: () => { propagationStopped = true; } });
+    card._onToggleClick({
+      stopPropagation: () => {
+        propagationStopped = true;
+      },
+    });
 
     assert.equal(card._collapsed, true, "arrow click must flip the collapsed state");
     assert.equal(navigations.length, 0, "arrow click must never navigate");

--- a/tooling/satsuma-viz/test/minimap.test.js
+++ b/tooling/satsuma-viz/test/minimap.test.js
@@ -14,22 +14,71 @@ import { describe, it, before } from "node:test";
 import * as assert from "node:assert/strict";
 
 const loc = { uri: "file:///test.stm", line: 1, character: 0 };
-const field = (name, type = "STRING") => ({ name, type, constraints: [], notes: [], comments: [], children: [], location: loc });
-const arrow = (source, target) => ({ sourceFields: [source], targetField: target, transform: null, metadata: [], comments: [], location: loc });
-const schema = (id, fields) => ({ id, qualifiedId: id, kind: "schema", label: null, fields, notes: [], comments: [], metadata: [], location: loc, hasExternalLineage: false, spreads: [] });
-const mapping = (id, sourceRefs, targetRef, arrows) => ({ id, sourceRefs, targetRef, arrows, eachBlocks: [], flattenBlocks: [], nestedArrows: [], sourceBlock: null, notes: [], comments: [], location: loc });
+const field = (name, type = "STRING") => ({
+  name,
+  type,
+  constraints: [],
+  notes: [],
+  comments: [],
+  children: [],
+  location: loc,
+});
+const arrow = (source, target) => ({
+  sourceFields: [source],
+  targetField: target,
+  transform: null,
+  metadata: [],
+  comments: [],
+  location: loc,
+});
+const schema = (id, fields) => ({
+  id,
+  qualifiedId: id,
+  kind: "schema",
+  label: null,
+  fields,
+  notes: [],
+  comments: [],
+  metadata: [],
+  location: loc,
+  hasExternalLineage: false,
+  spreads: [],
+});
+const mapping = (id, sourceRefs, targetRef, arrows) => ({
+  id,
+  sourceRefs,
+  targetRef,
+  arrows,
+  eachBlocks: [],
+  flattenBlocks: [],
+  nestedArrows: [],
+  sourceBlock: null,
+  notes: [],
+  comments: [],
+  location: loc,
+});
 
 const model = {
   uri: "file:///test.stm",
   fileNotes: [],
-  namespaces: [{
-    name: null,
-    notes: [],
-    schemas: [schema("src_users", [field("id"), field("email")]), schema("tgt_users", [field("user_id"), field("email")])],
-    fragments: [],
-    metrics: [],
-    mappings: [mapping("users_map", ["src_users"], "tgt_users", [arrow("id", "user_id"), arrow("email", "email")])],
-  }],
+  namespaces: [
+    {
+      name: null,
+      notes: [],
+      schemas: [
+        schema("src_users", [field("id"), field("email")]),
+        schema("tgt_users", [field("user_id"), field("email")]),
+      ],
+      fragments: [],
+      metrics: [],
+      mappings: [
+        mapping("users_map", ["src_users"], "tgt_users", [
+          arrow("id", "user_id"),
+          arrow("email", "email"),
+        ]),
+      ],
+    },
+  ],
 };
 
 /** Flatten a lit TemplateResult tree to a string for structural assertions. */

--- a/tooling/satsuma-viz/test/overview-anchors.test.js
+++ b/tooling/satsuma-viz/test/overview-anchors.test.js
@@ -91,9 +91,8 @@ describe("overview edge anchor geometry", () => {
   });
 
   it("shifts anchors below the namespace pill row for namespaced cards", async () => {
-    const { computeOverviewLayout, HEADER_HEIGHT, NAMESPACE_PILL_HEIGHT } = await import(
-      "../dist/satsuma-viz.js"
-    );
+    const { computeOverviewLayout, HEADER_HEIGHT, NAMESPACE_PILL_HEIGHT } =
+      await import("../dist/satsuma-viz.js");
     const result = await computeOverviewLayout(
       model("crm", ["src", "tgt"], [mapping("m1", ["crm::src"], "crm::tgt")]),
     );
@@ -118,9 +117,7 @@ describe("overview edge anchor geometry", () => {
   });
 
   it("reserves pill-row height in node heights only for namespaced nodes", async () => {
-    const { computeOverviewLayout, NAMESPACE_PILL_HEIGHT } = await import(
-      "../dist/satsuma-viz.js"
-    );
+    const { computeOverviewLayout, NAMESPACE_PILL_HEIGHT } = await import("../dist/satsuma-viz.js");
     const globalScope = await computeOverviewLayout(
       model(null, ["src", "tgt"], [mapping("m1", ["src"], "tgt")]),
     );
@@ -132,10 +129,7 @@ describe("overview edge anchor geometry", () => {
     // cards AND mapping pills. The renderer pins cards to these node heights,
     // so any other delta means the chrome and the layout have diverged.
     const h = (layout, id) => layout.nodes.find((n) => n.id === id).height;
-    assert.equal(
-      h(namespaced, "crm::src") - h(globalScope, "src"),
-      NAMESPACE_PILL_HEIGHT,
-    );
+    assert.equal(h(namespaced, "crm::src") - h(globalScope, "src"), NAMESPACE_PILL_HEIGHT);
     assert.equal(
       h(namespaced, "mapping:crm:m1") - h(globalScope, "mapping:_:m1"),
       NAMESPACE_PILL_HEIGHT,

--- a/tooling/satsuma-viz/test/overview-edge-layer.test.js
+++ b/tooling/satsuma-viz/test/overview-edge-layer.test.js
@@ -32,7 +32,10 @@ const edge = {
   id: "overview:mapping:_:orders_load:in:orders_raw",
   sourceNode: "orders_raw",
   targetNode: "mapping:_:orders_load",
-  points: [{ x: 0, y: 0 }, { x: 50, y: 50 }],
+  points: [
+    { x: 0, y: 0 },
+    { x: 50, y: 50 },
+  ],
   mapping,
 };
 
@@ -46,7 +49,11 @@ describe("sz-overview-edge-layer click contract (sl-sewl)", () => {
     layer._onEdgeClick(edge);
 
     assert.equal(opened.length, 1, "edge click must dispatch the open-mapping event");
-    assert.equal(opened[0].mapping.id, "orders_load", "the event must carry the clicked edge's mapping");
+    assert.equal(
+      opened[0].mapping.id,
+      "orders_load",
+      "the event must carry the clicked edge's mapping",
+    );
     assert.ok(opened[0] instanceof mod.SzOpenMappingEvent);
   });
 

--- a/tooling/satsuma-viz/test/svg-export.test.js
+++ b/tooling/satsuma-viz/test/svg-export.test.js
@@ -14,20 +14,18 @@ describe("inlineCssVariables", () => {
     const { inlineCssVariables } = await import("../dist/satsuma-viz.js");
     const palette = { "--sz-orange": "#F2913D", "--sz-card-bg": "rgb(255, 250, 245)" };
 
-    const svg = '<rect fill="var(--sz-card-bg)" stroke="var(--sz-orange)"/>'
-      + ".cls { color: var(--sz-orange); }";
+    const svg =
+      '<rect fill="var(--sz-card-bg)" stroke="var(--sz-orange)"/>' +
+      ".cls { color: var(--sz-orange); }";
     const out = inlineCssVariables(svg, (name) => palette[name] ?? "");
 
-    assert.equal(
-      out,
-      '<rect fill="rgb(255, 250, 245)" stroke="#F2913D"/>.cls { color: #F2913D; }',
-    );
+    assert.equal(out, '<rect fill="rgb(255, 250, 245)" stroke="#F2913D"/>.cls { color: #F2913D; }');
     assert.ok(!out.includes("var("), "no unresolved references remain");
   });
 
   it("resolves values with surrounding whitespace (getComputedStyle returns ' #fff')", async () => {
     const { inlineCssVariables } = await import("../dist/satsuma-viz.js");
-    const out = inlineCssVariables("<rect fill=\"var(--sz-bg)\"/>", () => "  #0f1117  ");
+    const out = inlineCssVariables('<rect fill="var(--sz-bg)"/>', () => "  #0f1117  ");
     assert.equal(out, '<rect fill="#0f1117"/>');
   });
 
@@ -63,7 +61,10 @@ function assertWellFormedXml(doc) {
   while ((m = tagRe.exec(body)) !== null) {
     const [whole, closing, name, attrs, text] = m;
     if (text !== undefined) {
-      assert.ok(!/&(?![A-Za-z]+;|#\d+;)/.test(text), `dangling & in text: ${JSON.stringify(text.trim())}`);
+      assert.ok(
+        !/&(?![A-Za-z]+;|#\d+;)/.test(text),
+        `dangling & in text: ${JSON.stringify(text.trim())}`,
+      );
       continue;
     }
     assert.ok(name, `unparseable markup at: ${whole.slice(0, 40)}`);
@@ -82,7 +83,10 @@ describe("buildExportSvg", () => {
     width: 200,
     height: 100,
     nodes: new Map([
-      ["P&L <quarterly>", { id: "P&L <quarterly>", x: 0, y: 0, width: 100, height: 40, ports: new Map() }],
+      [
+        "P&L <quarterly>",
+        { id: "P&L <quarterly>", x: 0, y: 0, width: 100, height: 40, ports: new Map() },
+      ],
     ]),
     edges: [],
     sourceBlocks: [],
@@ -106,7 +110,7 @@ describe("buildExportSvg", () => {
   it("sanity: the well-formedness checker rejects the pre-fix breakage", () => {
     // Guards the guard: if assertWellFormedXml accepted raw interpolation,
     // the two tests above would prove nothing.
-    assert.throws(() => assertWellFormedXml('<svg><text>P&L <quarterly></text></svg>'));
+    assert.throws(() => assertWellFormedXml("<svg><text>P&L <quarterly></text></svg>"));
   });
 });
 

--- a/tooling/satsuma-viz/test/theme.test.js
+++ b/tooling/satsuma-viz/test/theme.test.js
@@ -25,7 +25,7 @@ function getTokensByBlock() {
   const lightMatch = css.match(/:host\s*\{([\s\S]*?)\n\}/);
   const darkMatch = css.match(/:host\(\[theme="dark"\]\)\s*\{([\s\S]*?)\n\}/);
   assert.ok(lightMatch, "Expected to find :host token block in tokens.css");
-  assert.ok(darkMatch, "Expected to find :host([theme=\"dark\"]) token block in tokens.css");
+  assert.ok(darkMatch, 'Expected to find :host([theme="dark"]) token block in tokens.css');
 
   return {
     light: parseTokenBlockTokens(lightMatch[1]),
@@ -69,11 +69,7 @@ describe("theme token parity", () => {
 
     const missing = requiredDarkTokens.filter((tokenName) => !dark.has(tokenName));
 
-    assert.deepEqual(
-      missing,
-      [],
-      `Missing dark token overrides: ${missing.join(", ")}`,
-    );
+    assert.deepEqual(missing, [], `Missing dark token overrides: ${missing.join(", ")}`);
   });
 });
 
@@ -87,7 +83,7 @@ describe("satsuma-viz theme property", () => {
     assert.equal(el.theme, "light");
   });
 
-  it("reflects theme to the `theme` attribute so :host([theme=\"dark\"]) engages", async () => {
+  it('reflects theme to the `theme` attribute so :host([theme="dark"]) engages', async () => {
     // Reflection is the ONLY palette-switching mechanism: assigning theme must
     // write the `theme` attribute on the host so the tokens.css
     // `:host([theme="dark"])` override block applies. If reflect were dropped,

--- a/tooling/satsuma-viz/test/view-state.test.js
+++ b/tooling/satsuma-viz/test/view-state.test.js
@@ -75,7 +75,11 @@ describe("view-state reconciliation across model updates", () => {
     viz._reconcileViewState(model(namespace(null, { mappings: [newMapping] })));
 
     assert.equal(viz._viewMode, "detail");
-    assert.equal(viz._selectedMapping, newMapping, "selection must point at the NEW model's object");
+    assert.equal(
+      viz._selectedMapping,
+      newMapping,
+      "selection must point at the NEW model's object",
+    );
   });
 
   it("falls back to the overview when the selected mapping was renamed or deleted", async () => {

--- a/tooling/tree-sitter-satsuma/grammar.js
+++ b/tooling/tree-sitter-satsuma/grammar.js
@@ -28,12 +28,7 @@
 module.exports = grammar({
   name: "satsuma",
 
-  extras: ($) => [
-    /[ \t\f\r\n]+/,
-    $.warning_comment,
-    $.question_comment,
-    $.comment,
-  ],
+  extras: ($) => [/[ \t\f\r\n]+/, $.warning_comment, $.question_comment, $.comment],
 
   word: ($) => $.identifier,
 
@@ -104,13 +99,7 @@ module.exports = grammar({
       ),
 
     _namespace_item: ($) =>
-      choice(
-        $.note_block,
-        $.schema_block,
-        $.fragment_block,
-        $.transform_block,
-        $.mapping_block,
-      ),
+      choice($.note_block, $.schema_block, $.fragment_block, $.transform_block, $.mapping_block),
 
     // ── Import ────────────────────────────────────────────────────────────
 
@@ -137,40 +126,19 @@ module.exports = grammar({
     // ── Schema block ──────────────────────────────────────────────────────
 
     schema_block: ($) =>
-      seq(
-        "schema",
-        $.block_label,
-        optional($.metadata_block),
-        "{",
-        optional($.schema_body),
-        "}",
-      ),
+      seq("schema", $.block_label, optional($.metadata_block), "{", optional($.schema_body), "}"),
 
     // ── Fragment block ────────────────────────────────────────────────────
     // Metadata is accepted on every definition block (spec 2.1 describes
     // metadata generically); fragment/transform parity with schema/mapping.
 
     fragment_block: ($) =>
-      seq(
-        "fragment",
-        $.block_label,
-        optional($.metadata_block),
-        "{",
-        optional($.schema_body),
-        "}",
-      ),
+      seq("fragment", $.block_label, optional($.metadata_block), "{", optional($.schema_body), "}"),
 
     // ── Transform block ───────────────────────────────────────────────────
 
     transform_block: ($) =>
-      seq(
-        "transform",
-        $.block_label,
-        optional($.metadata_block),
-        "{",
-        optional($.pipe_chain),
-        "}",
-      ),
+      seq("transform", $.block_label, optional($.metadata_block), "{", optional($.pipe_chain), "}"),
 
     // ── Mapping block ───────────────────────────────────────────────────
 
@@ -186,8 +154,7 @@ module.exports = grammar({
         "}",
       ),
 
-    mapping_body: ($) =>
-      repeat1($._mapping_body_item),
+    mapping_body: ($) => repeat1($._mapping_body_item),
 
     _mapping_body_item: ($) =>
       choice(
@@ -200,13 +167,7 @@ module.exports = grammar({
       ),
 
     // source { ref1, ref2 } or source { ref1 ref2 } or source { "join ..." }
-    source_block: ($) =>
-      seq(
-        "source",
-        "{",
-        repeat1(seq($._source_entry, optional(","))),
-        "}",
-      ),
+    source_block: ($) => seq("source", "{", repeat1(seq($._source_entry, optional(","))), "}"),
 
     _source_entry: ($) => $.source_ref,
 
@@ -218,14 +179,7 @@ module.exports = grammar({
 
     // target { ref } — single entry; trailing comma allowed for consistency
     // with source blocks (see "Comma policy" in the spec, sl-0nvt).
-    target_block: ($) =>
-      seq(
-        "target",
-        "{",
-        $._source_entry,
-        optional(","),
-        "}",
-      ),
+    target_block: ($) => seq("target", "{", $._source_entry, optional(","), "}"),
 
     // ── each/flatten blocks ─────────────────────────────────────────────
     // each src_path -> tgt_path (metadata)? { nested_block_item* }
@@ -262,33 +216,17 @@ module.exports = grammar({
     // Shared body item for each/flatten blocks: arrow declarations plus nested
     // each/flatten sub-blocks. Does not include source/target/note, which are
     // mapping-level constructs.
-    _nested_block_item: ($) =>
-      choice(
-        $._arrow_decl,
-        $.each_block,
-        $.flatten_block,
-      ),
+    _nested_block_item: ($) => choice($._arrow_decl, $.each_block, $.flatten_block),
 
     // ── Note block ────────────────────────────────────────────────────────
 
-    note_block: ($) =>
-      seq(
-        "note",
-        "{",
-        choice($.multiline_string, repeat1($.nl_string)),
-        "}",
-      ),
+    note_block: ($) => seq("note", "{", choice($.multiline_string, repeat1($.nl_string)), "}"),
 
     // ── Schema body ───────────────────────────────────────────────────────
 
     schema_body: ($) => repeat1($._schema_body_item),
 
-    _schema_body_item: ($) =>
-      choice(
-        $.field_decl,
-        $.fragment_spread,
-        $.note_block,
-      ),
+    _schema_body_item: ($) => choice($.field_decl, $.fragment_spread, $.note_block),
 
     // ── Field declaration (unified syntax) ──────────────────────────────
     // All fields follow: NAME [TYPE] [(metadata)] [{schema_body}]
@@ -322,21 +260,10 @@ module.exports = grammar({
         optional($.metadata_block),
       ),
 
-    _typeless_field: ($) =>
-      seq(
-        $.field_name,
-        $.metadata_block,
-      ),
+    _typeless_field: ($) => seq($.field_name, $.metadata_block),
 
     _record_field: ($) =>
-      seq(
-        $.field_name,
-        "record",
-        optional($.metadata_block),
-        "{",
-        optional($.schema_body),
-        "}",
-      ),
+      seq($.field_name, "record", optional($.metadata_block), "{", optional($.schema_body), "}"),
 
     _list_of_record_field: ($) =>
       seq(
@@ -350,12 +277,7 @@ module.exports = grammar({
       ),
 
     _list_of_scalar_field: ($) =>
-      seq(
-        $.field_name,
-        "list_of",
-        alias($.inline_type, $.type_expr),
-        optional($.metadata_block),
-      ),
+      seq($.field_name, "list_of", alias($.inline_type, $.type_expr), optional($.metadata_block)),
 
     field_name: ($) => choice($.identifier, $.backtick_name),
 
@@ -375,8 +297,7 @@ module.exports = grammar({
     // continuation_word is an external token that only matches when no newline
     // appears between the previous token and the candidate identifier, so
     // `...f\nextra x` correctly parses as spread "f" + field "extra x".
-    spread_label: ($) =>
-      choice($.qualified_name, $.backtick_name, $._spread_words),
+    spread_label: ($) => choice($.qualified_name, $.backtick_name, $._spread_words),
 
     _spread_words: ($) => seq($.identifier, repeat($.continuation_word)),
 
@@ -385,21 +306,11 @@ module.exports = grammar({
     // computed_arrow omits src_path (starts directly with ->).
     // nested_arrow body contains arrow_decls; map_arrow body contains pipe_chain.
 
-    _arrow_decl: ($) =>
-      choice(
-        $.computed_arrow,
-        $.nested_arrow,
-        $.map_arrow,
-      ),
+    _arrow_decl: ($) => choice($.computed_arrow, $.nested_arrow, $.map_arrow),
 
     // -> tgt_path (metadata)? { pipe_chain }?
     computed_arrow: ($) =>
-      seq(
-        "->",
-        $.tgt_path,
-        optional($.metadata_block),
-        optional($._arrow_transform_body),
-      ),
+      seq("->", $.tgt_path, optional($.metadata_block), optional($._arrow_transform_body)),
 
     // src_path -> tgt_path (metadata)? { arrow_decl* }
     nested_arrow: ($) =>
@@ -434,45 +345,27 @@ module.exports = grammar({
     tgt_path: ($) => $._path_expr,
 
     _path_expr: ($) =>
-      choice(
-        $.namespaced_path,
-        $.backtick_path,
-        $.relative_field_path,
-        $.field_path,
-      ),
+      choice($.namespaced_path, $.backtick_path, $.relative_field_path, $.field_path),
 
     // ns::identifier or ns::identifier.field...
     // token.immediate(".") ensures continuation dots must be adjacent (no
     // newlines) so multi-line bare arrows are not merged into one path.
     namespaced_path: ($) =>
-      prec.right(seq(
-        $.identifier,
-        "::",
-        $._path_seg,
-        repeat(seq(token.immediate("."), $._path_seg)),
-      )),
+      prec.right(
+        seq($.identifier, "::", $._path_seg, repeat(seq(token.immediate("."), $._path_seg))),
+      ),
 
     // `BacktickRef` or `BacktickRef`.field...
     backtick_path: ($) =>
-      prec.right(seq(
-        $.backtick_name,
-        repeat(seq(token.immediate("."), $._path_seg)),
-      )),
+      prec.right(seq($.backtick_name, repeat(seq(token.immediate("."), $._path_seg)))),
 
     // .field or .field.nested...
     relative_field_path: ($) =>
-      prec.right(seq(
-        ".",
-        $._path_seg,
-        repeat(seq(token.immediate("."), $._path_seg)),
-      )),
+      prec.right(seq(".", $._path_seg, repeat(seq(token.immediate("."), $._path_seg)))),
 
     // field or field.nested...
     field_path: ($) =>
-      prec.right(seq(
-        $.identifier,
-        repeat(seq(token.immediate("."), $._path_seg)),
-      )),
+      prec.right(seq($.identifier, repeat(seq(token.immediate("."), $._path_seg)))),
 
     _path_seg: ($) => choice($.identifier, $.backtick_name),
 
@@ -480,12 +373,7 @@ module.exports = grammar({
 
     pipe_chain: ($) => seq($.pipe_step, repeat(seq("|", $.pipe_step))),
 
-    pipe_step: ($) =>
-      choice(
-        $.fragment_spread,
-        $.map_literal,
-        $.pipe_text,
-      ),
+    pipe_step: ($) => choice($.fragment_spread, $.map_literal, $.pipe_text),
 
     // pipe_text: greedy repeat of NL-compatible tokens.
     //
@@ -497,13 +385,7 @@ module.exports = grammar({
     // value maps (`map { ... }`), which are parsed by sibling rules above.
     //
     // | and } naturally terminate it (not in the choice set).
-    pipe_text: ($) =>
-      repeat1(
-        choice(
-          $._pipe_text_atom,
-          $._parenthesized_pipe_text,
-        ),
-      ),
+    pipe_text: ($) => repeat1(choice($._pipe_text_atom, $._parenthesized_pipe_text)),
 
     _pipe_text_atom: ($) =>
       choice(
@@ -519,22 +401,11 @@ module.exports = grammar({
       ),
 
     _parenthesized_pipe_text: ($) =>
-      seq(
-        "(",
-        repeat(
-          choice(
-            $._pipe_text_atom,
-            $._parenthesized_pipe_text,
-            ",",
-          ),
-        ),
-        ")",
-      ),
+      seq("(", repeat(choice($._pipe_text_atom, $._parenthesized_pipe_text, ",")), ")"),
 
     // ── Map literal ───────────────────────────────────────────────────────
 
-    map_literal: ($) =>
-      seq("map", "{", repeat(seq($.map_entry, optional(","))), "}"),
+    map_literal: ($) => seq("map", "{", repeat(seq($.map_entry, optional(","))), "}"),
 
     map_entry: ($) => seq($.map_key, ":", $.map_value),
 
@@ -557,8 +428,7 @@ module.exports = grammar({
 
     // `=` is included so NL pipe text like `rate = 0.5` lexes; `==` wins by
     // maximal munch where both could match.
-    _comparison_op: (_) =>
-      token(choice(">=", "<=", ">", "<", "!=", "==", "=")),
+    _comparison_op: (_) => token(choice(">=", "<=", ">", "<", "!=", "==", "=")),
 
     // Each operator is its own anonymous token (no combined token() wrapper)
     // so the minus can be the external scanner's token, which refuses to lex
@@ -572,13 +442,7 @@ module.exports = grammar({
     // `R: retail B: x` is a loud error, not two entries.
     map_value: ($) =>
       seq(
-        choice(
-          $.nl_string,
-          $.multiline_string,
-          $.identifier,
-          $.number_literal,
-          "null",
-        ),
+        choice($.nl_string, $.multiline_string, $.identifier, $.number_literal, "null"),
         repeat(alias($.map_value_word, $.identifier)),
       ),
 
@@ -591,20 +455,10 @@ module.exports = grammar({
     // `()` (empty) is allowed; a trailing comma is allowed only after at
     // least one entry, so `(,)` is a parse error rather than silently empty.
     metadata_block: ($) =>
-      seq(
-        "(",
-        optional(seq(commaSep1($._metadata_entry), optional(","))),
-        ")",
-      ),
+      seq("(", optional(seq(commaSep1($._metadata_entry), optional(","))), ")"),
 
     _metadata_entry: ($) =>
-      choice(
-        $.enum_body,
-        $.slice_body,
-        $.note_tag,
-        $.tag_with_value,
-        $.tag_token,
-      ),
+      choice($.enum_body, $.slice_body, $.note_tag, $.tag_with_value, $.tag_token),
 
     enum_body: ($) =>
       seq(
@@ -615,21 +469,9 @@ module.exports = grammar({
         "}",
       ),
 
-    slice_body: ($) =>
-      seq(
-        "slice",
-        "{",
-        commaSep1($.identifier),
-        optional(","),
-        "}",
-      ),
+    slice_body: ($) => seq("slice", "{", commaSep1($.identifier), optional(","), "}"),
 
-
-    note_tag: ($) =>
-      seq(
-        "note",
-        choice($.multiline_string, $.nl_string),
-      ),
+    note_tag: ($) => seq("note", choice($.multiline_string, $.nl_string)),
 
     // tag_with_value: identifier followed by greedy value tokens
     tag_with_value: ($) => seq($.identifier, $.value_text),
@@ -657,18 +499,12 @@ module.exports = grammar({
           $.boolean_literal,
           alias($.value_word, $.identifier),
           $._comparison_op,
-          seq(
-            "{",
-            commaSep1(choice($.qualified_name, $.identifier)),
-            optional(","),
-            "}",
-          ),
+          seq("{", commaSep1(choice($.qualified_name, $.identifier)), optional(","), "}"),
         ),
       ),
 
     // ns::identifier.field... — namespace-qualified dotted ref path
-    qualified_dotted_name: ($) =>
-      seq($.qualified_name, repeat1(seq(".", $.identifier))),
+    qualified_dotted_name: ($) => seq($.qualified_name, repeat1(seq(".", $.identifier))),
 
     dotted_name: ($) =>
       prec.left(seq($.identifier, repeat1(seq(".", choice($.identifier, $.number_literal))))),

--- a/tooling/tree-sitter-satsuma/scripts/cst_summary.py
+++ b/tooling/tree-sitter-satsuma/scripts/cst_summary.py
@@ -15,7 +15,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[3]
 # Prefer the npm-local tree-sitter binary (always has --wasm support) over the
 # system one (e.g. Homebrew on macOS may not be compiled with the wasm feature).
-_LOCAL_BIN = Path(__file__).resolve().parents[1] / "node_modules" / ".bin" / "tree-sitter"
+_LOCAL_BIN = (
+    Path(__file__).resolve().parents[1] / "node_modules" / ".bin" / "tree-sitter"
+)
 TREE_SITTER_BIN = str(_LOCAL_BIN) if _LOCAL_BIN.exists() else "tree-sitter"
 DEFAULT_GLOBS = (
     "examples/*.stm",
@@ -176,7 +178,9 @@ def block_label(node: Node, source: SourceText) -> str:
     if node.type in ("schema_block", "fragment_block", "transform_block"):
         keyword = node.type.replace("_block", "")
         label_node = _find_child_by_type(node, "block_label")
-        name = clean_scalar(node_text(label_node, source)) if label_node else "<anonymous>"
+        name = (
+            clean_scalar(node_text(label_node, source)) if label_node else "<anonymous>"
+        )
         return f"{keyword} {name}"
     if node.type == "mapping_block":
         label_node = _find_child_by_type(node, "block_label")
@@ -258,7 +262,9 @@ def summarize_tree(source: SourceText, root: Node) -> dict[str, t.Any]:
     return {
         "parse_ok": counts["ERROR"] == 0 and counts["MISSING"] == 0,
         "counts": dict(sorted(counts.items())),
-        "blocks": [summarize_block(node, source) for node in nodes if node.type in BLOCK_TYPES],
+        "blocks": [
+            summarize_block(node, source) for node in nodes if node.type in BLOCK_TYPES
+        ],
         "schema_members": [
             summarize_schema_member(node, source)
             for node in nodes
@@ -267,7 +273,14 @@ def summarize_tree(source: SourceText, root: Node) -> dict[str, t.Any]:
         "map_items": [
             summarize_map_item(node, source)
             for node in nodes
-            if node.type in {"map_arrow", "computed_arrow", "nested_arrow", "each_block", "flatten_block"}
+            if node.type
+            in {
+                "map_arrow",
+                "computed_arrow",
+                "nested_arrow",
+                "each_block",
+                "flatten_block",
+            }
         ],
         "paths": [
             {
@@ -338,6 +351,7 @@ def parse_with_cli(path: Path) -> Node:
     ]
 
     import os
+
     env = os.environ.copy()
     env["XDG_CACHE_HOME"] = str(ROOT / ".cache")
     result = subprocess.run(
@@ -373,7 +387,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Emit JSON summaries from Satsuma CSTs using the repo-local tree-sitter wrapper."
     )
-    parser.add_argument("files", nargs="*", type=Path, help="Specific Satsuma files to summarize.")
+    parser.add_argument(
+        "files", nargs="*", type=Path, help="Specific Satsuma files to summarize."
+    )
     parser.add_argument(
         "--pretty",
         action="store_true",
@@ -381,7 +397,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    files = [resolve_input_path(path) for path in args.files] if args.files else discover_files(DEFAULT_GLOBS)
+    files = (
+        [resolve_input_path(path) for path in args.files]
+        if args.files
+        else discover_files(DEFAULT_GLOBS)
+    )
     if not files:
         parser.error("no Satsuma files found")
 

--- a/tooling/tree-sitter-satsuma/scripts/smoke-check.js
+++ b/tooling/tree-sitter-satsuma/scripts/smoke-check.js
@@ -18,7 +18,7 @@
 "use strict";
 
 const Parser = require("tree-sitter");
-const STM = require("../");          // tree-sitter-satsuma binding (built from grammar.js)
+const STM = require("../"); // tree-sitter-satsuma binding (built from grammar.js)
 const fs = require("fs");
 const path = require("path");
 
@@ -63,8 +63,8 @@ function isMetricSchema(schemaNode) {
   const meta = schemaNode.namedChildren.find((n) => n.type === "metadata_block");
   if (!meta) return false;
   return meta.namedChildren.some(
-    (n) => n.type === "tag_token" && n.namedChildren[0]?.type === "identifier" &&
-           n.text === "metric",
+    (n) =>
+      n.type === "tag_token" && n.namedChildren[0]?.type === "identifier" && n.text === "metric",
   );
 }
 
@@ -112,16 +112,14 @@ function parseFile(filePath) {
       name: blockLabel(n, src),
     })),
     // In v2, metrics are schema_block nodes with the bare `metric` tag in metadata.
-    metrics: collectNodes(root, "schema_block").filter(isMetricSchema).map((n) => ({
-      name: blockLabel(n, src),
-      display: metricDisplayName(n, src),
-    })),
-    warnings: collectNodes(root, "warning_comment").map((n) =>
-      text(n, src).slice(3).trim(),
-    ),
-    questions: collectNodes(root, "question_comment").map((n) =>
-      text(n, src).slice(3).trim(),
-    ),
+    metrics: collectNodes(root, "schema_block")
+      .filter(isMetricSchema)
+      .map((n) => ({
+        name: blockLabel(n, src),
+        display: metricDisplayName(n, src),
+      })),
+    warnings: collectNodes(root, "warning_comment").map((n) => text(n, src).slice(3).trim()),
+    questions: collectNodes(root, "question_comment").map((n) => text(n, src).slice(3).trim()),
   };
 
   return { summary, errors };
@@ -132,9 +130,7 @@ function parseFile(filePath) {
 const args = process.argv.slice(2);
 
 if (args.length === 0) {
-  console.error(
-    "Usage: node scripts/smoke-check.js <file.stm | directory> [...]",
-  );
+  console.error("Usage: node scripts/smoke-check.js <file.stm | directory> [...]");
   process.exit(1);
 }
 
@@ -178,8 +174,6 @@ if (results.length === 1) {
 }
 
 if (totalErrors > 0) {
-  process.stderr.write(
-    `\n${totalErrors} total parse error(s) across ${files.length} file(s)\n`,
-  );
+  process.stderr.write(`\n${totalErrors} total parse error(s) across ${files.length} file(s)\n`);
   process.exit(1);
 }

--- a/tooling/tree-sitter-satsuma/scripts/test_fixtures.py
+++ b/tooling/tree-sitter-satsuma/scripts/test_fixtures.py
@@ -57,10 +57,16 @@ def load_fixtures() -> list[Fixture]:
 
 def validate_example_coverage(fixtures: list[Fixture]) -> None:
     expected = {path.resolve() for path in sorted(EXAMPLES_ROOT.glob("*.stm"))}
-    covered = {fixture.source for fixture in fixtures if fixture.source.parent == EXAMPLES_ROOT}
+    covered = {
+        fixture.source for fixture in fixtures if fixture.source.parent == EXAMPLES_ROOT
+    }
 
-    missing = sorted(path.relative_to(REPO_ROOT).as_posix() for path in expected - covered)
-    extra = sorted(path.relative_to(REPO_ROOT).as_posix() for path in covered - expected)
+    missing = sorted(
+        path.relative_to(REPO_ROOT).as_posix() for path in expected - covered
+    )
+    extra = sorted(
+        path.relative_to(REPO_ROOT).as_posix() for path in covered - expected
+    )
 
     if missing or extra:
         details: list[str] = []
@@ -98,6 +104,7 @@ def parse_fixture(fixture: Fixture) -> tuple[bool, str]:
         str(fixture.source),
     ]
     import os
+
     env = os.environ.copy()
     env["XDG_CACHE_HOME"] = str(REPO_ROOT / ".cache")
     result = subprocess.run(
@@ -110,14 +117,20 @@ def parse_fixture(fixture: Fixture) -> tuple[bool, str]:
     )
 
     # Filter out wrapper script info lines (Using ROOT_DIR, Using XDG_CACHE_HOME)
-    tree_lines = [line for line in result.stdout.splitlines() if not line.startswith("Using ")]
+    tree_lines = [
+        line for line in result.stdout.splitlines() if not line.startswith("Using ")
+    ]
     tree = "\n".join(tree_lines).strip()
-    diag_lines = [line for line in result.stderr.splitlines() if not line.startswith("Using ")]
+    diag_lines = [
+        line for line in result.stderr.splitlines() if not line.startswith("Using ")
+    ]
     diagnostics = "\n".join(diag_lines).strip()
     combined = "\n".join(part for part in (tree, diagnostics) if part)
 
     if result.returncode != 0 and not (fixture.allow_error or fixture.allow_missing):
-        return False, failure_message("parse command exited non-zero", fixture, combined)
+        return False, failure_message(
+            "parse command exited non-zero", fixture, combined
+        )
 
     if fixture.expect_root and not tree.startswith(f"({fixture.expect_root} "):
         return False, failure_message(
@@ -127,16 +140,24 @@ def parse_fixture(fixture: Fixture) -> tuple[bool, str]:
         )
 
     if not fixture.allow_error and "(ERROR " in tree:
-        return False, failure_message("parse tree contains ERROR nodes", fixture, combined, "(ERROR ")
+        return False, failure_message(
+            "parse tree contains ERROR nodes", fixture, combined, "(ERROR "
+        )
 
     if not fixture.allow_missing and "(MISSING " in tree:
-        return False, failure_message("parse tree contains MISSING nodes", fixture, combined, "(MISSING ")
+        return False, failure_message(
+            "parse tree contains MISSING nodes", fixture, combined, "(MISSING "
+        )
 
     if fixture.require_error and "(ERROR " not in combined:
-        return False, failure_message("expected ERROR nodes in recovered parse", fixture, combined)
+        return False, failure_message(
+            "expected ERROR nodes in recovered parse", fixture, combined
+        )
 
     if fixture.require_missing and "(MISSING " not in combined:
-        return False, failure_message("expected MISSING nodes in recovered parse", fixture, combined)
+        return False, failure_message(
+            "expected MISSING nodes in recovered parse", fixture, combined
+        )
 
     for expected in fixture.expect_contains:
         if expected not in combined:
@@ -149,7 +170,9 @@ def parse_fixture(fixture: Fixture) -> tuple[bool, str]:
     return True, combined
 
 
-def failure_message(reason: str, fixture: Fixture, output: str, needle: str | None = None) -> str:
+def failure_message(
+    reason: str, fixture: Fixture, output: str, needle: str | None = None
+) -> str:
     excerpt = excerpt_output(output, needle)
     rel_source = fixture.source.relative_to(REPO_ROOT).as_posix()
     return "\n".join(

--- a/tooling/tree-sitter-satsuma/scripts/test_smoke_summary.py
+++ b/tooling/tree-sitter-satsuma/scripts/test_smoke_summary.py
@@ -225,7 +225,7 @@ class SmokeSummaryTests(unittest.TestCase):
                 self.assertEqual(
                     summary["parse_ok"],
                     expect["parse_ok"],
-                    f'{relpath}: expected parse_ok={expect["parse_ok"]}',
+                    f"{relpath}: expected parse_ok={expect['parse_ok']}",
                 )
 
     def test_section_minimum_counts(self) -> None:
@@ -279,7 +279,13 @@ class SmokeSummaryTests(unittest.TestCase):
 
     def test_map_items_have_kind(self) -> None:
         """Every map item must have a recognised kind."""
-        valid_kinds = {"map_arrow", "computed_arrow", "nested_arrow", "each_block", "flatten_block"}
+        valid_kinds = {
+            "map_arrow",
+            "computed_arrow",
+            "nested_arrow",
+            "each_block",
+            "flatten_block",
+        }
         for relpath in EXPECTATIONS:
             if relpath in self._errors:
                 continue

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -24,9 +24,7 @@ const serverConfig = {
   outfile: "server/dist/server.js",
   format: "cjs",
   sourcemap: true,
-  nodePaths: [
-    path.resolve(__dirname, "../satsuma-lsp/node_modules"),
-  ],
+  nodePaths: [path.resolve(__dirname, "../satsuma-lsp/node_modules")],
   alias: {
     "@satsuma/viz-backend": path.resolve(__dirname, "../satsuma-viz-backend/src/index.ts"),
     "@satsuma/viz-backend/workspace-index": path.resolve(
@@ -43,9 +41,7 @@ const serverConfig = {
   // making import.meta.url → undefined and crashing at runtime. The banner
   // injects a CJS-compatible shim so the bundled code gets a real URL.
   banner: {
-    js: [
-      `var __import_meta_url = require("url").pathToFileURL(__filename).href;`,
-    ].join("\n"),
+    js: [`var __import_meta_url = require("url").pathToFileURL(__filename).href;`].join("\n"),
   },
   define: {
     "import.meta.url": "__import_meta_url",
@@ -123,7 +119,10 @@ function copyAssets() {
     ["src/webview/lineage/lineage.css", "dist/webview/lineage/lineage.css"],
     ["src/webview/viz/viz.css", "dist/webview/viz/viz.css"],
     ["src/webview/field-lineage/field-lineage.css", "dist/webview/field-lineage/field-lineage.css"],
-    ["src/webview/schema-lineage/schema-lineage.css", "dist/webview/schema-lineage/schema-lineage.css"],
+    [
+      "src/webview/schema-lineage/schema-lineage.css",
+      "dist/webview/schema-lineage/schema-lineage.css",
+    ],
   ];
 
   // Copy WASM and highlights.scm into server/dist/ so the server can load them
@@ -136,7 +135,10 @@ function copyAssets() {
     // web-tree-sitter 0.26+ renamed tree-sitter.wasm → web-tree-sitter.wasm.
     // The WASM file lives in satsuma-lsp's node_modules since the server was
     // extracted into its own package (ADR-021).
-    ["../satsuma-lsp/node_modules/web-tree-sitter/web-tree-sitter.wasm", "server/dist/tree-sitter.wasm"],
+    [
+      "../satsuma-lsp/node_modules/web-tree-sitter/web-tree-sitter.wasm",
+      "server/dist/tree-sitter.wasm",
+    ],
   );
 
   for (const [src, dst] of pairs) {

--- a/tooling/vscode-satsuma/src/commands/action-context.ts
+++ b/tooling/vscode-satsuma/src/commands/action-context.ts
@@ -8,9 +8,7 @@ export interface EditorActionContext {
   targetSchema: string | null;
 }
 
-export async function getEditorActionContext(
-  client: LanguageClient,
-): Promise<EditorActionContext> {
+export async function getEditorActionContext(client: LanguageClient): Promise<EditorActionContext> {
   const editor = vscode.window.activeTextEditor;
   if (!editor || editor.document.languageId !== "satsuma") {
     return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };

--- a/tooling/vscode-satsuma/src/commands/cli-runner-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/cli-runner-logic.ts
@@ -33,10 +33,7 @@ export function exitCodeFrom(error: SpawnError | null): number {
  * gets a specific install hint; callers surface this text directly in their
  * warning toasts.
  */
-export function spawnFailureMessage(
-  error: SpawnError | null,
-  cliPath: string,
-): string | null {
+export function spawnFailureMessage(error: SpawnError | null, cliPath: string): string | null {
   if (!error || typeof error.code !== "string") return null;
   if (error.code === "ENOENT") {
     return `Satsuma CLI not found at "${cliPath}". Install it (npm install -g satsuma-cli) or point the satsuma.cliPath setting at the executable.`;

--- a/tooling/vscode-satsuma/src/commands/cli-runner.ts
+++ b/tooling/vscode-satsuma/src/commands/cli-runner.ts
@@ -12,13 +12,8 @@ export interface CliResult {
  * Run a satsuma CLI command and return the result.
  * Resolves even on non-zero exit (caller checks exitCode).
  */
-export function runCli(
-  cliPath: string,
-  args: string[],
-  cwd?: string,
-): Promise<CliResult> {
-  const workDir =
-    cwd ?? workspace.workspaceFolders?.[0]?.uri.fsPath ?? ".";
+export function runCli(cliPath: string, args: string[], cwd?: string): Promise<CliResult> {
+  const workDir = cwd ?? workspace.workspaceFolders?.[0]?.uri.fsPath ?? ".";
 
   return new Promise((resolve) => {
     execFile(

--- a/tooling/vscode-satsuma/src/commands/coverage-logic.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage-logic.ts
@@ -54,14 +54,11 @@ export interface FileCoverageMarkers {
  * hover labels (source fields are "used / not used as source"; target
  * fields are "mapped / unmapped"). Keys are the URIs reported by the LSP.
  */
-export function groupCoverageByUri(
-  schemas: CoverageSchema[],
-): Map<string, FileCoverageMarkers> {
+export function groupCoverageByUri(schemas: CoverageSchema[]): Map<string, FileCoverageMarkers> {
   const byUri = new Map<string, FileCoverageMarkers>();
   for (const schema of schemas) {
     const mappedLabel = schema.role === "source" ? "used as source" : "mapped";
-    const unmappedLabel =
-      schema.role === "source" ? "not used as source" : "unmapped";
+    const unmappedLabel = schema.role === "source" ? "not used as source" : "unmapped";
     for (const f of schema.fields) {
       let bucket = byUri.get(f.uri);
       if (!bucket) {

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -102,10 +102,7 @@ export function registerCoverageCommand(
   _cliPath: string,
   client: LanguageClient,
 ): void {
-  coverageBar = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Right,
-    100,
-  );
+  coverageBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   // The bar doubles as the overlay's dismiss affordance.
   coverageBar.command = "satsuma.clearCoverage";
   context.subscriptions.push(coverageBar);
@@ -138,9 +135,7 @@ export function registerCoverageCommand(
       }
 
       if (coverageResult.schemas.length === 0) {
-        vscode.window.showInformationMessage(
-          `No schemas found for mapping '${mappingName}'.`,
-        );
+        vscode.window.showInformationMessage(`No schemas found for mapping '${mappingName}'.`);
         return;
       }
 
@@ -150,9 +145,7 @@ export function registerCoverageCommand(
       createDecorationTypes(context.extensionPath);
 
       const grouped = groupCoverageByUri(coverageResult.schemas);
-      activeMarkers = new Map(
-        [...grouped].map(([uri, markers]) => [normalizeUri(uri), markers]),
-      );
+      activeMarkers = new Map([...grouped].map(([uri, markers]) => [normalizeUri(uri), markers]));
 
       // Decorate only what is already on screen; other affected files get
       // their icons when they become visible. Never open files here — one

--- a/tooling/vscode-satsuma/src/commands/entry-file.ts
+++ b/tooling/vscode-satsuma/src/commands/entry-file.ts
@@ -34,8 +34,7 @@ let lastPickedEntryFile: string | undefined;
  */
 export async function resolveEntryFile(): Promise<string | undefined> {
   const activeDoc = vscode.window.activeTextEditor?.document;
-  const activeFsPath =
-    activeDoc && !activeDoc.isUntitled ? activeDoc.uri.fsPath : undefined;
+  const activeFsPath = activeDoc && !activeDoc.isUntitled ? activeDoc.uri.fsPath : undefined;
 
   const found = await vscode.workspace.findFiles(
     SATSUMA_FILE_GLOB,
@@ -70,8 +69,7 @@ export async function resolveEntryFile(): Promise<string | undefined> {
           fsPath,
         })),
         {
-          placeHolder:
-            "Select the Satsuma entry file (the workspace is its transitive imports)",
+          placeHolder: "Select the Satsuma entry file (the workspace is its transitive imports)",
         },
       );
       if (picked) lastPickedEntryFile = picked.fsPath;

--- a/tooling/vscode-satsuma/src/commands/lineage.ts
+++ b/tooling/vscode-satsuma/src/commands/lineage.ts
@@ -32,9 +32,7 @@ export function registerLineageCommand(
         names = [];
       }
 
-      const schemaNames = names
-        .filter((n) => n.kind === "schema")
-        .map((n) => n.name);
+      const schemaNames = names.filter((n) => n.kind === "schema").map((n) => n.name);
 
       if (schemaNames.length === 0) {
         vscode.window.showInformationMessage("No schemas found in workspace.");

--- a/tooling/vscode-satsuma/src/commands/summary.ts
+++ b/tooling/vscode-satsuma/src/commands/summary.ts
@@ -44,9 +44,7 @@ export function registerSummaryCommand(
             label: "Schemas",
             format: (s) => {
               const fields =
-                s.fieldCount === 1
-                  ? `[${s.fieldCount} field]`
-                  : `[${s.fieldCount} fields]`;
+                s.fieldCount === 1 ? `[${s.fieldCount} field]` : `[${s.fieldCount} fields]`;
               const note = s.note ? ` — ${s.note}` : "";
               return `  ${s.name}  ${fields}${note}`;
             },
@@ -98,9 +96,7 @@ export function registerSummaryCommand(
         for (const section of sections) {
           const items = data[section.key];
           if (Array.isArray(items) && items.length > 0) {
-            outputChannel.appendLine(
-              `${section.label} (${items.length}):`,
-            );
+            outputChannel.appendLine(`${section.label} (${items.length}):`);
             for (const item of items) {
               outputChannel.appendLine(section.format(item));
             }

--- a/tooling/vscode-satsuma/src/commands/validate.ts
+++ b/tooling/vscode-satsuma/src/commands/validate.ts
@@ -2,10 +2,7 @@ import * as vscode from "vscode";
 import { runCli } from "./cli-runner";
 import { resolveEntryFile } from "./entry-file";
 
-export function registerValidateCommand(
-  context: vscode.ExtensionContext,
-  cliPath: string,
-): void {
+export function registerValidateCommand(context: vscode.ExtensionContext, cliPath: string): void {
   const diagnostics = vscode.languages.createDiagnosticCollection("satsuma-validate-cmd");
   context.subscriptions.push(diagnostics);
 
@@ -63,9 +60,7 @@ export function registerValidateCommand(
         diagnostics.set(vscode.Uri.parse(uriStr), diags);
       }
 
-      vscode.window.showInformationMessage(
-        `Satsuma: ${entries.length} diagnostic(s) found.`,
-      );
+      vscode.window.showInformationMessage(`Satsuma: ${entries.length} diagnostic(s) found.`);
     }),
   );
 }

--- a/tooling/vscode-satsuma/src/commands/warnings.ts
+++ b/tooling/vscode-satsuma/src/commands/warnings.ts
@@ -2,10 +2,7 @@ import * as vscode from "vscode";
 import { runCli } from "./cli-runner";
 import { resolveEntryFile } from "./entry-file";
 
-export function registerWarningsCommand(
-  context: vscode.ExtensionContext,
-  cliPath: string,
-): void {
+export function registerWarningsCommand(context: vscode.ExtensionContext, cliPath: string): void {
   const diagnostics = vscode.languages.createDiagnosticCollection("satsuma-warnings-cmd");
   context.subscriptions.push(diagnostics);
 
@@ -43,9 +40,7 @@ export function registerWarningsCommand(
           diagnostics.set(vscode.Uri.parse(uriStr), diags);
         }
 
-        vscode.window.showInformationMessage(
-          `Satsuma: ${data.count} warning(s) found.`,
-        );
+        vscode.window.showInformationMessage(`Satsuma: ${data.count} warning(s) found.`);
       } catch {
         if (result.stderr) {
           vscode.window.showWarningMessage(result.stderr.trim());

--- a/tooling/vscode-satsuma/src/extension.ts
+++ b/tooling/vscode-satsuma/src/extension.ts
@@ -21,9 +21,7 @@ import { FieldLineagePanel } from "./webview/field-lineage/panel";
 let client: LanguageClient | undefined;
 
 export function activate(context: ExtensionContext): void {
-  const serverModule = context.asAbsolutePath(
-    join("server", "dist", "server.js"),
-  );
+  const serverModule = context.asAbsolutePath(join("server", "dist", "server.js"));
 
   const serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.ipc },
@@ -82,42 +80,40 @@ export function activate(context: ExtensionContext): void {
 
   // Field Lineage webview (Phase 1 — ELK panel)
   context.subscriptions.push(
-    vscode.commands.registerCommand("satsuma.traceFieldLineage", async (args?: { fieldPath?: string }) => {
-      // The CLI scopes the workspace via the entry file's imports and rejects
-      // directories (ADR-022) — never fall back to a folder path (sl-1ycv).
-      const entryFilePath = await resolveEntryFile();
-      if (!entryFilePath) return;
+    vscode.commands.registerCommand(
+      "satsuma.traceFieldLineage",
+      async (args?: { fieldPath?: string }) => {
+        // The CLI scopes the workspace via the entry file's imports and rejects
+        // directories (ADR-022) — never fall back to a folder path (sl-1ycv).
+        const entryFilePath = await resolveEntryFile();
+        if (!entryFilePath) return;
 
-      // Prefer: explicit arg > LSP actionContext > user input
-      let fieldPath: string | undefined = args?.fieldPath;
+        // Prefer: explicit arg > LSP actionContext > user input
+        let fieldPath: string | undefined = args?.fieldPath;
 
-      if (!fieldPath && client) {
-        const actionContext = await getEditorActionContext(client);
-        fieldPath = actionContext.fieldPath ?? undefined;
-      }
+        if (!fieldPath && client) {
+          const actionContext = await getEditorActionContext(client);
+          fieldPath = actionContext.fieldPath ?? undefined;
+        }
 
-      if (!fieldPath) {
-        // Command-palette fallback: prompt for the field
-        const editor = vscode.window.activeTextEditor;
-        const word = editor?.document.getText(
-          editor.document.getWordRangeAtPosition(editor.selection.active),
-        );
-        fieldPath = await vscode.window.showInputBox({
-          prompt: "Enter field reference (schema.field)",
-          value: word?.includes(".") ? word : `${word ?? ""}.`,
-          placeHolder: "customers.email",
-        });
-      }
+        if (!fieldPath) {
+          // Command-palette fallback: prompt for the field
+          const editor = vscode.window.activeTextEditor;
+          const word = editor?.document.getText(
+            editor.document.getWordRangeAtPosition(editor.selection.active),
+          );
+          fieldPath = await vscode.window.showInputBox({
+            prompt: "Enter field reference (schema.field)",
+            value: word?.includes(".") ? word : `${word ?? ""}.`,
+            placeHolder: "customers.email",
+          });
+        }
 
-      if (!fieldPath) return;
+        if (!fieldPath) return;
 
-      FieldLineagePanel.createOrShow(
-        context.extensionUri,
-        cliPath,
-        entryFilePath,
-        fieldPath,
-      );
-    }),
+        FieldLineagePanel.createOrShow(context.extensionUri, cliPath, entryFilePath, fieldPath);
+      },
+    ),
   );
 }
 

--- a/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/field-lineage/field-lineage.ts
@@ -18,9 +18,9 @@ const elk = new ELK();
 // ── Layout constants ───────────────────────────────────────────────────────
 
 const NODE_W = 200;
-const NODE_H = 80;   // header 30 + field 26 + via 24
+const NODE_H = 80; // header 30 + field 26 + via 24
 const FOCAL_W = 220;
-const FOCAL_H = 68;  // header 30 + field 38 (larger, no via label)
+const FOCAL_H = 68; // header 30 + field 38 (larger, no via label)
 const CANVAS_PADDING = 40;
 
 // ── Type declarations ──────────────────────────────────────────────────────
@@ -170,8 +170,8 @@ function buildElkGraph(payload: Payload): ElkNode {
 // ── Canvas ─────────────────────────────────────────────────────────────────
 
 function buildCanvas(laid: ElkNode, payload: Payload): HTMLDivElement {
-  const w = (laid.width ?? 800);
-  const h = (laid.height ?? 400);
+  const w = laid.width ?? 800;
+  const h = laid.height ?? 400;
 
   const wrap = document.createElement("div");
   wrap.className = "canvas-wrap";
@@ -184,7 +184,12 @@ function buildCanvas(laid: ElkNode, payload: Payload): HTMLDivElement {
   // Build node position lookup
   const nodePos = new Map<string, NodePos>();
   for (const n of (laid.children ?? []) as ElkNode[]) {
-    nodePos.set(n.id!, { x: n.x ?? 0, y: n.y ?? 0, width: n.width ?? NODE_W, height: n.height ?? NODE_H });
+    nodePos.set(n.id!, {
+      x: n.x ?? 0,
+      y: n.y ?? 0,
+      width: n.width ?? NODE_W,
+      height: n.height ?? NODE_H,
+    });
   }
 
   // Upstream cards
@@ -428,9 +433,17 @@ function buildToolbar(breadcrumb: string[]): HTMLDivElement {
   dirWrap.className = "toolbar-control dir-toggle";
 
   const dirOptions: Array<{ value: Direction; label: string; title: string }> = [
-    { value: "upstream",   label: "← Upstream",   title: "Show only upstream (where this field's data comes from)" },
-    { value: "both",       label: "↔ Both",        title: "Show both upstream and downstream" },
-    { value: "downstream", label: "Downstream →",  title: "Show only downstream (where this field's data goes to)" },
+    {
+      value: "upstream",
+      label: "← Upstream",
+      title: "Show only upstream (where this field's data comes from)",
+    },
+    { value: "both", label: "↔ Both", title: "Show both upstream and downstream" },
+    {
+      value: "downstream",
+      label: "Downstream →",
+      title: "Show only downstream (where this field's data goes to)",
+    },
   ];
 
   for (const opt of dirOptions) {
@@ -442,7 +455,10 @@ function buildToolbar(breadcrumb: string[]): HTMLDivElement {
     btn.addEventListener("click", () => {
       sessionDirection = opt.value as Direction;
       dirWrap.querySelectorAll(".dir-btn").forEach((b) => {
-        (b as HTMLElement).classList.toggle("active", (b as HTMLElement).dataset["dir"] === opt.value);
+        (b as HTMLElement).classList.toggle(
+          "active",
+          (b as HTMLElement).dataset["dir"] === opt.value,
+        );
       });
       if (lastPayload) {
         render(applyFilters(lastPayload));
@@ -524,7 +540,6 @@ function formatMappingKey(key: string): string {
   }
   return key.startsWith("::") ? key.slice(2) : key;
 }
-
 
 // Minimal ELK type stubs for the @ts-nocheck context
 interface ElkNode {

--- a/tooling/vscode-satsuma/src/webview/field-lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/field-lineage/panel.ts
@@ -44,9 +44,7 @@ export class FieldLineagePanel {
       {
         enableScripts: true,
         retainContextWhenHidden: true,
-        localResourceRoots: [
-          vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview")),
-        ],
+        localResourceRoots: [vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview"))],
       },
     );
 
@@ -231,8 +229,7 @@ export class FieldLineagePanel {
   private isDarkTheme(): boolean {
     const themeKind = vscode.window.activeColorTheme.kind;
     return (
-      themeKind === vscode.ColorThemeKind.Dark ||
-      themeKind === vscode.ColorThemeKind.HighContrast
+      themeKind === vscode.ColorThemeKind.Dark || themeKind === vscode.ColorThemeKind.HighContrast
     );
   }
 
@@ -248,24 +245,12 @@ export class FieldLineagePanel {
   private getHtml(): string {
     const scriptUri = this.panel.webview.asWebviewUri(
       vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "field-lineage",
-          "field-lineage.js",
-        ),
+        join(this.extensionUri.fsPath, "dist", "webview", "field-lineage", "field-lineage.js"),
       ),
     );
     const styleUri = this.panel.webview.asWebviewUri(
       vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "field-lineage",
-          "field-lineage.css",
-        ),
+        join(this.extensionUri.fsPath, "dist", "webview", "field-lineage", "field-lineage.css"),
       ),
     );
     const nonce = getNonce();
@@ -291,8 +276,7 @@ export class FieldLineagePanel {
 
 function getNonce(): string {
   let text = "";
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   for (let i = 0; i < 32; i++) {
     text += chars.charAt(Math.floor(Math.random() * chars.length));
   }

--- a/tooling/vscode-satsuma/src/webview/lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/lineage/panel.ts
@@ -9,11 +9,7 @@ export class LineagePanel {
   private readonly cliPath: string;
   private disposables: vscode.Disposable[] = [];
 
-  static createOrShow(
-    extensionUri: vscode.Uri,
-    cliPath: string,
-    fieldPath: string,
-  ): void {
+  static createOrShow(extensionUri: vscode.Uri, cliPath: string, fieldPath: string): void {
     if (LineagePanel.currentPanel) {
       LineagePanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
       LineagePanel.currentPanel.refresh(fieldPath);
@@ -69,9 +65,25 @@ export class LineagePanel {
   private async traceLineage(
     fieldPath: string,
     maxHops: number,
-  ): Promise<Array<{ source: string; target: string; classification: string; transform: string; file: string; line: number }>> {
+  ): Promise<
+    Array<{
+      source: string;
+      target: string;
+      classification: string;
+      transform: string;
+      file: string;
+      line: number;
+    }>
+  > {
     const visited = new Set<string>();
-    const allArrows: Array<{ source: string; target: string; classification: string; transform: string; file: string; line: number }> = [];
+    const allArrows: Array<{
+      source: string;
+      target: string;
+      classification: string;
+      transform: string;
+      file: string;
+      line: number;
+    }> = [];
     const queue = [fieldPath];
 
     for (let hop = 0; hop < maxHops && queue.length > 0; hop++) {
@@ -79,12 +91,7 @@ export class LineagePanel {
       if (visited.has(current)) continue;
       visited.add(current);
 
-      const result = await runCli(this.cliPath, [
-        "arrows",
-        current,
-        "--as-source",
-        "--json",
-      ]);
+      const result = await runCli(this.cliPath, ["arrows", current, "--as-source", "--json"]);
 
       if (result.exitCode !== 0 || !result.stdout.trim()) continue;
 

--- a/tooling/vscode-satsuma/src/webview/schema-lineage/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/schema-lineage/panel.ts
@@ -60,9 +60,7 @@ export class SchemaLineagePanel {
       {
         enableScripts: true,
         retainContextWhenHidden: true,
-        localResourceRoots: [
-          vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview")),
-        ],
+        localResourceRoots: [vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview"))],
       },
     );
 
@@ -162,8 +160,7 @@ export class SchemaLineagePanel {
   private isDarkTheme(): boolean {
     const themeKind = vscode.window.activeColorTheme.kind;
     return (
-      themeKind === vscode.ColorThemeKind.Dark ||
-      themeKind === vscode.ColorThemeKind.HighContrast
+      themeKind === vscode.ColorThemeKind.Dark || themeKind === vscode.ColorThemeKind.HighContrast
     );
   }
 
@@ -179,24 +176,12 @@ export class SchemaLineagePanel {
   private getHtml(): string {
     const scriptUri = this.panel.webview.asWebviewUri(
       vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "schema-lineage",
-          "schema-lineage.js",
-        ),
+        join(this.extensionUri.fsPath, "dist", "webview", "schema-lineage", "schema-lineage.js"),
       ),
     );
     const styleUri = this.panel.webview.asWebviewUri(
       vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "schema-lineage",
-          "schema-lineage.css",
-        ),
+        join(this.extensionUri.fsPath, "dist", "webview", "schema-lineage", "schema-lineage.css"),
       ),
     );
     const nonce = getNonce();

--- a/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
+++ b/tooling/vscode-satsuma/src/webview/schema-lineage/schema-lineage.ts
@@ -152,7 +152,10 @@ function buildHeader(payload: Payload): HTMLDivElement {
 
   const legend = document.createElement("div");
   legend.className = "legend";
-  for (const [cls, label] of [["schema", "schema"], ["mapping", "mapping"]] as const) {
+  for (const [cls, label] of [
+    ["schema", "schema"],
+    ["mapping", "mapping"],
+  ] as const) {
     const pill = document.createElement("span");
     pill.className = `legend-pill ${cls}`;
     pill.textContent = label;
@@ -184,7 +187,12 @@ function buildCanvas(
   // Build ELK id → position lookup
   const nodePos = new Map<string, NodePos>();
   for (const n of (laid.children ?? []) as ElkNode[]) {
-    nodePos.set(n.id!, { x: n.x ?? 0, y: n.y ?? 0, width: n.width ?? PILL_W, height: n.height ?? PILL_H });
+    nodePos.set(n.id!, {
+      x: n.x ?? 0,
+      y: n.y ?? 0,
+      width: n.width ?? PILL_W,
+      height: n.height ?? PILL_H,
+    });
   }
 
   // Reverse lookup: elk id → LineageNode
@@ -300,7 +308,6 @@ function buildArrowMarker(): SVGMarkerElement {
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
 
 // Minimal ELK type stubs for the @ts-nocheck context
 interface ElkNode {

--- a/tooling/vscode-satsuma/src/webview/viz/panel.ts
+++ b/tooling/vscode-satsuma/src/webview/viz/panel.ts
@@ -4,11 +4,7 @@ import { isSatsumaFilePath } from "@satsuma/core/source-files";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { FieldLineagePanel } from "../field-lineage/panel";
 import { resolveEntryFile } from "../../commands/entry-file";
-import {
-  loadExpandedModels,
-  loadFullLineageModel,
-  vizThemeForKind,
-} from "./integration";
+import { loadExpandedModels, loadFullLineageModel, vizThemeForKind } from "./integration";
 import { RefreshGate } from "./refresh-gate";
 
 export class VizPanel {
@@ -27,11 +23,7 @@ export class VizPanel {
    */
   private readonly refreshGate = new RefreshGate();
 
-  static createOrShow(
-    extensionUri: vscode.Uri,
-    client: LanguageClient,
-    cliPath: string,
-  ): void {
+  static createOrShow(extensionUri: vscode.Uri, client: LanguageClient, cliPath: string): void {
     if (VizPanel.currentPanel) {
       VizPanel.currentPanel.panel.reveal(vscode.ViewColumn.Beside);
       VizPanel.currentPanel.refresh();
@@ -45,9 +37,7 @@ export class VizPanel {
       {
         enableScripts: true,
         retainContextWhenHidden: true,
-        localResourceRoots: [
-          vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview")),
-        ],
+        localResourceRoots: [vscode.Uri.file(join(extensionUri.fsPath, "dist", "webview"))],
       },
     );
 
@@ -83,13 +73,11 @@ export class VizPanel {
     this.disposables.push(saveWatcher);
 
     // Refresh when active editor changes to an .stm file
-    const editorWatcher = vscode.window.onDidChangeActiveTextEditor(
-      (editor) => {
-        if (editor?.document.languageId === "satsuma") {
-          this.refresh();
-        }
-      },
-    );
+    const editorWatcher = vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor?.document.languageId === "satsuma") {
+        this.refresh();
+      }
+    });
     this.disposables.push(editorWatcher);
 
     // Live theme switching: when the user changes their VS Code colour theme
@@ -115,9 +103,7 @@ export class VizPanel {
     // and the .stm editor is no longer the active editor.
     const editor = vscode.window.activeTextEditor;
     const activeUri =
-      editor?.document.languageId === "satsuma"
-        ? editor.document.uri.toString()
-        : undefined;
+      editor?.document.languageId === "satsuma" ? editor.document.uri.toString() : undefined;
     const uri = activeUri ?? this._lastUri;
 
     if (!uri) {
@@ -209,9 +195,7 @@ export class VizPanel {
     // no workspace open, let the dialog choose its own starting location.
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
     const uri = await vscode.window.showSaveDialog({
-      defaultUri: workspaceRoot
-        ? vscode.Uri.joinPath(workspaceRoot, "mapping-viz.svg")
-        : undefined,
+      defaultUri: workspaceRoot ? vscode.Uri.joinPath(workspaceRoot, "mapping-viz.svg") : undefined,
       filters: { "SVG files": ["svg"] },
     });
     if (uri) {
@@ -223,9 +207,9 @@ export class VizPanel {
   private async expandLineage(schemaId: string): Promise<void> {
     const editor = vscode.window.activeTextEditor;
     const currentUri =
-      (editor?.document.languageId === "satsuma"
-        ? editor.document.uri.toString()
-        : undefined) ?? this._lastUri ?? "";
+      (editor?.document.languageId === "satsuma" ? editor.document.uri.toString() : undefined) ??
+      this._lastUri ??
+      "";
 
     // An expansion is computed against the model currently in the webview.
     // If a refresh starts while the request is in flight, the expansion
@@ -272,26 +256,10 @@ export class VizPanel {
 
   private getHtml(): string {
     const vizScriptUri = this.panel.webview.asWebviewUri(
-      vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "viz",
-          "viz.js",
-        ),
-      ),
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "viz", "viz.js")),
     );
     const styleUri = this.panel.webview.asWebviewUri(
-      vscode.Uri.file(
-        join(
-          this.extensionUri.fsPath,
-          "dist",
-          "webview",
-          "viz",
-          "viz.css",
-        ),
-      ),
+      vscode.Uri.file(join(this.extensionUri.fsPath, "dist", "webview", "viz", "viz.css")),
     );
     const nonce = getNonce();
 
@@ -313,8 +281,7 @@ export class VizPanel {
 
 function getNonce(): string {
   let text = "";
-  const chars =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   for (let i = 0; i < 32; i++) {
     text += chars.charAt(Math.floor(Math.random() * chars.length));
   }

--- a/tooling/vscode-satsuma/test/cli-runner-logic.test.js
+++ b/tooling/vscode-satsuma/test/cli-runner-logic.test.js
@@ -44,7 +44,10 @@ describe("spawnFailureMessage", () => {
   });
 
   it("reports other spawn errnos with their code", () => {
-    const msg = spawnFailureMessage({ code: "EACCES", message: "permission denied" }, "/opt/satsuma");
+    const msg = spawnFailureMessage(
+      { code: "EACCES", message: "permission denied" },
+      "/opt/satsuma",
+    );
     assert.match(msg, /EACCES/);
     assert.match(msg, /permission denied/);
   });

--- a/tooling/vscode-satsuma/test/coverage-logic.test.js
+++ b/tooling/vscode-satsuma/test/coverage-logic.test.js
@@ -45,10 +45,7 @@ describe("groupCoverageByUri", () => {
     // Fields from different schemas land in different files; an icon in the
     // wrong file would mislabel a different schema's field entirely.
     const byUri = groupCoverageByUri(sampleSchemas());
-    assert.deepEqual([...byUri.keys()].sort(), [
-      "file:///ws/src.stm",
-      "file:///ws/tgt.stm",
-    ]);
+    assert.deepEqual([...byUri.keys()].sort(), ["file:///ws/src.stm", "file:///ws/tgt.stm"]);
     assert.equal(byUri.get("file:///ws/src.stm").mapped.length, 1);
     assert.equal(byUri.get("file:///ws/src.stm").unmapped.length, 1);
     // Three mapped entries in tgt.stm: customer_id, the `address` record and
@@ -61,10 +58,7 @@ describe("groupCoverageByUri", () => {
     // A source field is "used", a target field is "mapped" — swapping the
     // vocabulary makes the hover claim the opposite data-flow direction.
     const byUri = groupCoverageByUri(sampleSchemas());
-    assert.equal(
-      byUri.get("file:///ws/src.stm").mapped[0].hoverMessage,
-      "**id** — used as source",
-    );
+    assert.equal(byUri.get("file:///ws/src.stm").mapped[0].hoverMessage, "**id** — used as source");
     assert.equal(
       byUri.get("file:///ws/src.stm").unmapped[0].hoverMessage,
       "**internal_note** — not used as source",
@@ -93,14 +87,17 @@ describe("computeTargetCoverageStats", () => {
     // the tier split so a reviewer can tell declared coverage from an @ref.
     const declaredOnly = [
       {
-        schemaId: "t", role: "target",
+        schemaId: "t",
+        role: "target",
         fields: [{ path: "a", uri: "file:///t.stm", line: 1, mapped: true, tier: "declared" }],
       },
     ];
-    assert.deepEqual(
-      computeTargetCoverageStats(declaredOnly),
-      { mapped: 1, total: 1, pct: 100, mappedNl: 0 },
-    );
+    assert.deepEqual(computeTargetCoverageStats(declaredOnly), {
+      mapped: 1,
+      total: 1,
+      pct: 100,
+      mappedNl: 0,
+    });
   });
 
   it("returns undefined when the result has no target schema", () => {
@@ -111,9 +108,7 @@ describe("computeTargetCoverageStats", () => {
   });
 
   it("reports 0% for an empty target schema instead of dividing by zero", () => {
-    const stats = computeTargetCoverageStats([
-      { schemaId: "empty", role: "target", fields: [] },
-    ]);
+    const stats = computeTargetCoverageStats([{ schemaId: "empty", role: "target", fields: [] }]);
     assert.deepEqual(stats, { mapped: 0, total: 0, pct: 0, mappedNl: 0 });
   });
 });


### PR DESCRIPTION
## Summary

Implements pfg-9dk8 in three commits so the churn is isolated exactly as the ticket demands:

1. **`eedb8e4` — config only.** prettier pinned as a root devDependency; `.prettierrc` sets printWidth 100 with a comment explaining the measured rationale (80 fights the prevailing style, 120 is too wide for this repo's comment-dense lines); `.prettierignore` mirrors eslint's ignores (generated parser artifacts, dist/build, minified site assets, worktrees).
2. **`4041154` — the pure repo-wide reformat.** 230 files, `prettier --write` over all JS/TS + `ruff format` over the Python script dirs, nothing else. Recorded in the new `.git-blame-ignore-revs`. Note: three lit `html`-template files (sz-metric-card, sz-schema-card, satsuma-viz) needed a second prettier pass to reach the formatter's fixed point — a known Prettier embedded-template quirk; the committed state is stable.
3. **`883bc6d` — the gates.** `lint:js` gains `prettier --check`, `lint:python` gains `ruff format --check` — both flow into the Lint CI job and the pre-commit hook with no new CI job. `npm run format` fixes everything in one shot. A Claude Code `PostToolUse` hook in `.claude/settings.json` runs prettier/ruff format on each edited file, so agents get format-on-edit and the commit gate should rarely fire. `blame.ignoreRevsFile` setup documented in AGENT-CONTRIBUTIONS.md (worktree checklist + new Formatting section).

Also carries `.tickets/sl-1wtv.md` (Semgrep CI bug ticket raised separately this morning, swept in per the tickets-in-every-commit rule).

**Stacked on #416** (needs its `tmp/` markdownlint exclusion for the hook to pass) — merge #416 first, then this rebases clean.

## Test plan

- Full pre-commit suite (repo lint incl. the new gates, all package tests, tree-sitter corpus, Python tests, smoke tests) green on commits 1 and 3; the reformat commit is behaviour-neutral by that same run.
- Gate verified negatively: a deliberately misformatted TS file makes `npm run lint` fail; restoring it goes green. Same for the Python side via `ruff format --check`.
- Format-on-edit hook verified live: an Edit introducing bad spacing came back prettier-formatted with clean git status.

Closes pfg-9dk8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)