### PR TITLE
chore(lint): record the on-main SHA of the Prettier reformat commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,4 +6,4 @@
 # (documented as a setup step in docs/developer/AGENT-CONTRIBUTIONS.md)
 
 # Repo-wide Prettier (printWidth 100) + ruff format adoption reformat (pfg-9dk8)
-9605b252268cc35741d55205433b0840f707fdfb
+bd12dc16fa4bd65f652d938b4d4a7459c6d01d67


### PR DESCRIPTION
One-line follow-up to #418: GitHub's rebase merge rewrites commit SHAs, so `.git-blame-ignore-revs` recorded a pre-merge SHA that no longer exists on main. This points it at the reformat commit that actually landed (`bd12dc1`), so `git config blame.ignoreRevsFile .git-blame-ignore-revs` works as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)