### PR TITLE
chore(tickets): close sl-1wtv with closing notes

### DIFF
--- a/.tickets/sl-1wtv.md
+++ b/.tickets/sl-1wtv.md
@@ -1,6 +1,6 @@
 ---
 id: sl-1wtv
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-02T06:23:57Z
@@ -23,3 +23,9 @@ The 'Semgrep OSS' code-scanning check on every PR reports neutral ('skipping', '
 **2026-08-02T06:25:46Z**
 
 Confirmed via the code scanning API: refs/heads/main carries two Semgrep analyses per push — analysis_key '.github/workflows/security.yml:semgrep' (from the push trigger) and '.github/workflows/release.yml:semgrep' (from release.yml's workflow_call), both 19 results at the same commit. PR check run 91464141061 is conclusion=neutral, output.title '1 configuration not found', naming '.github/workflows/release.yml:semgrep'. Semgrep itself was always running and passing; only the code-scanning diff was broken.
+
+**2026-08-02T08:02:39Z**
+
+Cause: release.yml invokes security.yml via workflow_call on pushes to main, and github/codeql-action/upload-sarif keys a code scanning configuration on the CALLING workflow file plus job id. Main's baseline therefore carried '.github/workflows/release.yml:semgrep' alongside '.github/workflows/security.yml:semgrep', while a PR (which runs security.yml directly) could only ever produce the latter — so code scanning could not diff and the 'Semgrep OSS' check resolved neutral ('1 configuration not found'), gating nothing. Semgrep itself always ran and passed.
+Fix: added a skip_sarif_upload workflow_call input to security.yml, guarding both SARIF steps with `always() && !inputs.skip_sarif_upload`; release.yml passes true and uses the workflow purely as a gate (commit 795dfbb, PR #417). Verified on the merge commit: the Release-invoked job shows Generate SARIF=skipped / Upload SARIF=skipped with Run Semgrep=success, and 795dfbb has exactly one analysis on main.
+Baseline cleanup: deleted all 345 pre-existing '.github/workflows/release.yml:semgrep' analyses from refs/heads/main via the code scanning API (user-approved). Two API constraints mattered — only the newest analysis in a set is deletable, and next_analysis_url chains only within one set, so each boundary needs a re-scan of ALL pages (the newest stale survivor migrates to later pages as recent ones are removed). Open alerts verified identical before and after: 7, unchanged.


### PR DESCRIPTION
Closing notes for sl-1wtv, fixed in #417.

Records the root cause (code scanning keys a configuration on the *calling* workflow, so `release.yml`'s `workflow_call` into `security.yml` wrote a second configuration that only ever existed on `main`), the fix, and the manual baseline cleanup.

Post-merge verification of #417:
- Release-invoked job: `Run Semgrep=success`, `Generate SARIF=skipped`, `Upload SARIF=skipped`
- Merge commit `795dfbb` has exactly one analysis on `main`

Baseline cleanup (approved by @thorbenlouw): all 345 stale `.github/workflows/release.yml:semgrep` analyses deleted from `refs/heads/main`. Open alerts verified identical before and after — 7, unchanged; the duplicates held no unique findings. `security.yml:semgrep` (339) and the CodeQL sets (755 + 15) untouched.

Two API constraints are documented in the note for anyone who has to repeat this: only the newest analysis in a set is `deletable`, and `next_analysis_url` chains only within one set — so each set boundary needs a re-scan across *all* pages, because the newest stale survivor migrates to later pages as recent ones are removed.

The proof that the check is healthy is this PR itself: **Semgrep OSS** should now report a conclusion rather than `skipping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)