### PR TITLE
Whole-structure expansion requires a container source, plus the lint rule that explains it (3ct-cs4y)

### DIFF
--- a/.tickets/3ct-cs4y.md
+++ b/.tickets/3ct-cs4y.md
@@ -1,6 +1,6 @@
 ---
 id: 3ct-cs4y
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-02T18:39:46Z
@@ -32,3 +32,21 @@ Check the example corpus and any real workspaces for scalar-to-record arrows bef
 
 A decision recorded in ADR-037 (amendment or successor ADR, per the immutability rule). If the behaviour changes: target-side expansion requires a container source, source-side expansion is unchanged, the scalar-to-record test in coverage.test.js flips with a comment saying why, and CHANGELOG plus SATSUMA-CLI.md state the final rule. If it does not change: the ADR records the reasoning and this ticket closes as won't-do.
 
+
+## Notes
+
+**2026-08-02T20:16:25Z**
+
+Cause: ADR-037 gated whole-structure expansion on the arrow's declaration kind alone, never checking the field opposite the arrow — coverageForSchema reports on one schema at a time and held no field tree but its own. On the source side that reads correctly (a map arrow off a record consumes the whole record whatever receives it); on the target side it credited every leaf of a record to a single scalar, an overstatement on the number --fail-under gates and in the direction ADR-034 explicitly refused to risk.
+
+Evidence gathered before choosing: a scan of all 270 expansion-eligible arrows in examples/ found every one is scalar-to-scalar — no arrow touches a container on either side, so neither the risk nor ADR-037's feature is visible in the corpus. That made every option free of measurable consequence today, which is the argument for picking the safe one now rather than after someone builds a threshold on the generous reading. (Detector validated against a synthetic positive control classifying all four shapes.)
+
+Fix: option (b) plus option (e) from the PR #421 review.
+
+(b) Target-side expansion now additionally requires that at least one source path names a declared container. Source-side expansion is unchanged. Sub-rules: any one container source suffices for a multi-source arrow; it fails closed, so a source naming nothing declared (or a schema the resolver cannot resolve) confers nothing; resolved NL @refs are untouched. computeMappingCoverage resolves participating schemas up front so the target-side test has the source field trees in hand.
+
+(e) New CLI lint rule unenumerated-record-target (warning, not fixable): flags an arrow that targets a record while neither carrying a record nor listing child arrows. It is the explanation for the gap coverage now reports — otherwise the author sees twelve uncovered fields with no clue one arrow was nearly responsible.
+
+The shared question 'what does this path name in this schema?' is answered once, by declaredFieldKind in satsuma-core/src/coverage.ts, called by both coverage and the lint rule so the number and its explanation cannot drift. ArrowRecord gained kind/enumeratesChildren (already flowing at runtime, only the type was narrow) and the index gained a flat arrows list.
+
+Verified: corpus coverage fingerprint byte-identical to main across every example; the new rule reports 0 findings on the corpus; end-to-end run on a four-arrow file flags exactly the scalar-to-record arrow while record-to-record, enumerated and scalar-to-scalar stay silent and correctly counted. Recorded as ADR-038, amending ADR-037.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### A whole-record arrow must carry a record to cover one (`3ct-cs4y`)
+
+Tightens the change below, before anyone sets a `--fail-under` threshold against
+it. **No percentage in the example corpus moves** — verified by diffing
+`coverage --json` across every example — and the new lint rule is silent on all
+of them.
+
+`addr -> address` between two records still covers `address` and every leaf
+beneath it. `full_name -> address`, where a single scalar targets a twelve-leaf
+record, no longer does: one scalar cannot fill twelve leaves, and the arrow does
+not say which one it would fill, so crediting all twelve inflated the very number
+`--fail-under` gates. Those leaves now report as gaps.
+
+The **source** side is deliberately unchanged. `addr -> out` still credits
+`addr`'s leaves as consumed even though `out` is a scalar — a whole record was
+read, whatever received it. Requiring records at both ends would have turned
+every record-to-scalar arrow into a false "unconsumed source field".
+
+Two details: any one container source is enough for a multi-source arrow
+(`addr, tag -> address` still confers), and a source path that resolves to
+nothing confers nothing — the safe direction, and `validate` already reports the
+broken reference.
+
+New lint rule **`unenumerated-record-target`** (warning, not fixable) explains
+the gap: it flags an arrow that targets a record while neither carrying a record
+nor listing child arrows, so you are not left with twelve uncovered fields and no
+clue which arrow was nearly responsible for them. Close it by enumerating
+(`address { .line1 -> ... }`) or by mapping from a record. See **ADR-038**.
+
 ### Container coverage is a tri-state, and a whole-record arrow covers its subtree (`sl-0pun`, `sl-r6b0`, closes `3cc-iedv`)
 
 Two changes to what "covered" means for a `record` or `list_of record` field.
@@ -36,11 +65,8 @@ reference to it, not a claim that everything beneath it maps.
 
 Only the side being reported on is examined, so the rule is about the record the
 arrow names rather than about both ends of it. `addr -> out` credits `addr`'s
-leaves as consumed even though `out` is a scalar — a whole record was read — and,
-in the other direction, `full_name -> address` credits every leaf of `address`
-even though only one field feeds it. If you have arrows of that second shape,
-expect their targets to read as fully covered; `3ct-cs4y` tracks whether to
-tighten it.
+leaves as consumed even though `out` is a scalar — a whole record was read.
+(The target side gained a second condition before release; see `3ct-cs4y` above.)
 
 Coverage figures on schemas using whole-record arrows will rise; figures that
 were resting on an `each` header or a computed arrow to a record will fall.

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -109,6 +109,7 @@ Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rule
 | `hidden-source-in-nl`  | error    | yes     | NL text references a schema not in the mapping's source/target list |
 | `unresolved-nl-ref`    | warning  | no      | `@ref` in NL does not resolve to any known identifier               |
 | `duplicate-definition` | error    | no      | Named definition is declared more than once in a namespace          |
+| `unenumerated-record-target` | warning | no | Arrow targets a record without a record source or child arrows |
 
 ### coverage
 
@@ -141,7 +142,9 @@ Counting a resolved `@ref` is **resolution, not interpretation**: the author wro
 
 **A whole-record arrow covers the whole record.** `addr -> address` onto a record-typed field asserts the structure maps across, so every leaf beneath `address` counts as covered. Two conditions gate it. The arrow must state a correspondence: an `each`/`flatten` header opens an iteration and a computed arrow (`-> containers { "..." }`) has no source, so neither one counts. And its body must enumerate nothing — once a header lists child arrows it is claiming those and no others, so `addr -> address { .street -> .line }` covers `street` and leaves `zip` a gap. A record that is merely the _ancestor_ of a covered leaf confers nothing downward either: with `address` copied wholesale and `billing` covered only by an arrow to `billing.city`, `billing.line1` is still a gap.
 
-Only the record the arrow names is examined — not the field opposite it. `addr -> out` credits `addr`'s leaves as consumed even though `out` is a scalar, which is the right reading of a whole record being read; `full_name -> address` credits every leaf of `address` even though one field feeds it, which is the generous one. Both ship deliberately (ADR-037); `3ct-cs4y` carries the question of tightening the second.
+**On the target side the arrow must also carry a record** (ADR-038). `addr -> address` covers `address` wholesale because a record arrives; `full_name -> address` does not, because one scalar cannot fill twelve leaves and the arrow does not say which one it would fill — so those leaves stay gaps, and `lint`'s `unenumerated-record-target` tells you which arrow left them that way. Any one container source is enough for a multi-source arrow, and a source path that resolves to nothing confers nothing.
+
+The **source** side has no such condition, deliberately: `addr -> out` credits `addr`'s leaves as consumed even though `out` is a scalar, because a whole record was read whatever received it.
 
 #### Per-mapping vs aggregate
 

--- a/adrs/adr-037-container-coverage-and-whole-structure-arrows.md
+++ b/adrs/adr-037-container-coverage-and-whole-structure-arrows.md
@@ -1,6 +1,6 @@
 # ADR-037 — Container Coverage Is Derived From Leaves, and a Whole-Structure Arrow Covers Its Subtree
 
-**Status:** Accepted
+**Status:** Accepted — amended by ADR-038
 **Date:** 2026-08-02 (sl-0pun, sl-r6b0; feature 38, closes 3cc-iedv)
 
 ## Context

--- a/adrs/adr-038-whole-structure-expansion-requires-a-container-source.md
+++ b/adrs/adr-038-whole-structure-expansion-requires-a-container-source.md
@@ -1,0 +1,122 @@
+# ADR-038 — Target-Side Whole-Structure Expansion Requires a Container Source
+
+**Status:** Accepted
+**Date:** 2026-08-02 (3ct-cs4y; feature 38)
+
+## Context
+
+ADR-037 gave a whole-structure arrow the power to cover its entire declared
+subtree, gated on two properties of the declaration: its kind is `map` or
+`nested`, and its body enumerates no child arrows. Its Decision text also said
+the arrow must be a "record-to-record correspondence" — but the shipped code
+never checked the field on the other side of the arrow, and could not:
+`coverageForSchema` reports on one schema at a time and holds no field tree but
+its own. The PR #421 review caught the mismatch and corrected the documentation
+to describe what shipped, deferring the behavioural question to this ADR.
+
+What shipped therefore expands whichever endpoint resolves to a container in the
+schema being reported on, with no view of the other end. That produces two
+readings of very different quality:
+
+- **Source side.** `addr -> out`, a record into a scalar, credits every leaf of
+  `addr` as consumed. This is correct. Source coverage asks "was this field
+  read?", and a whole record was read whatever happens downstream.
+- **Target side.** `full_name -> address`, a scalar into a twelve-leaf record,
+  credits all twelve as populated. One scalar cannot fill twelve leaves, and the
+  declaration says nothing about which one it would fill.
+
+The second is an overstatement on the number `coverage --fail-under` gates, in
+precisely the direction ADR-034 refused to risk when it chose to under-count the
+whole-record arrow rather than over-count an ambiguous one. A spec with twelve
+unmapped fields could pass a gate set at 100%.
+
+A scan of the example corpus found the shape does not occur: of 270 arrows
+eligible for expansion, every one is scalar-to-scalar — no arrow touches a
+container on either side. So neither the risk nor ADR-037's feature is visible in
+the corpus today, and any choice here is free of measurable consequence. That
+cuts both ways, and it is why the decision is worth making now rather than after
+someone has built a threshold on top of the generous reading.
+
+The exposure is latent rather than hypothetical. Flat-source-into-nested-target
+is a first-class use case for this language — `cobol-to-avro` and `edi-to-json`
+are both that shape. Those examples avoid the problem by writing the enumerated
+form, which coverage already reads correctly. The author who takes the shortcut
+and writes the bare arrow is the exposed one, so the failure mode is *the author
+skipped the detail and coverage rewarded them with 100%*.
+
+## Decision
+
+**Target-side whole-structure expansion additionally requires that at least one
+of the arrow's source paths names a declared container.** Source-side expansion
+is unchanged and keeps its own two conditions only.
+
+Three sub-rules, each a decision rather than an implementation detail:
+
+1. **Any one container source suffices.** A multi-source arrow
+   (`addr, tag -> address`) asserts a single correspondence assembled from
+   several inputs; a record among them makes the whole-structure reading
+   plausible. Requiring every source to be a container would turn a mixed arrow
+   into a gap.
+2. **It fails closed.** A source path naming nothing declared, or naming a schema
+   the resolver could not resolve, is not evidence of a record and does not
+   confer. Under-counting is the safe direction (ADR-034), and a source path that
+   resolves to nothing is already reported by `validate`'s `field-not-in-schema`.
+3. **Resolved NL `@refs` are untouched.** They never expanded (ADR-036) and still
+   do not.
+
+This is **not a new kind of judgement.** The code already refuses to expand
+unless the path resolves to a declared container — that is what makes
+`descendantPathsOf` return nothing for a leaf. This decision applies the same
+structural question to the other endpoint. Coverage still interprets no prose,
+checks no types, and asks nothing it was not already asking.
+
+**The arrow is not wrong, merely under-specified, and saying so is `lint`'s
+job.** A new rule, `unenumerated-record-target`, warns when a `map`/`nested`
+arrow with no enumerated children targets a container but carries no container.
+It is the explanation for the gap coverage now reports: without it the author
+sees twelve uncovered fields and no indication that one arrow is nearly
+responsible for them. That split is the one SATSUMA-CLI.md already draws when it
+says policy judgements about which gaps are acceptable remain `lint`'s.
+
+The shared question — "what does this authored path name in this schema?" — is
+answered once, by `declaredFieldKind` in `satsuma-core/src/coverage.ts`, which
+both coverage and the lint rule call. Two implementations would let the number
+and the explanation for it drift apart.
+
+This **amends ADR-037**. Its two conditions still hold; this adds a third that
+applies to the target side only, and replaces the "record-to-record
+correspondence" wording its Decision used with a rule the code actually
+implements.
+
+## Consequences
+
+**Positive:**
+
+- The gated number can no longer be inflated by an under-specified arrow. The one
+  remaining way to reach 100% is to declare what maps.
+- The source side keeps the reading that is correct for it. Requiring containers
+  on both ends would have made every `record -> scalar` arrow report its source
+  leaves as unconsumed — false gaps in the review queue.
+- The author gets told. The coverage drop and the lint warning arrive together
+  and name the same arrow.
+- Coverage and lint cannot disagree about what a path names, because they share
+  `declaredFieldKind`.
+
+**Negative:**
+
+- Coverage now depends on the *source* schema resolving, so an unresolvable
+  source silently costs a target record its subtree credit. That is the
+  fail-closed direction, but it means a broken import can move a percentage
+  without any arrow changing. `validate` reports the broken reference; coverage
+  does not explain the interaction.
+- A third condition is a third thing to explain, on a rule that already needed
+  two. The asymmetry between the sides is principled but not obvious, and the
+  ADR is now the only place it is set out in full.
+- `computeMappingCoverage` resolves participating schemas before building its
+  reference lists rather than inside the report loops. Equivalent work, but the
+  ordering is now load-bearing and a future refactor could break the target-side
+  test by moving it.
+- Every percentage in the example corpus is unchanged (verified by diffing
+  `coverage --json` across every example before and after), so the corpus again
+  neither demonstrates the change nor regression-tests it. The acceptance tests
+  in `coverage.test.js` carry that load, as they did for ADR-037.

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -228,6 +228,14 @@ Examples:
                   ? nlRef.mapping.slice(nlRef.namespace.length + 2)
                   : nlRef.mapping,
               namespace: nlRef.namespace,
+              // An inferred arrow has no declaration to read a kind off, so it
+              // takes the one that asserts least. Prose naming a record is a
+              // reference to it, never a claim that everything beneath it maps
+              // (ADR-036), and `computed` is the kind that carries exactly that
+              // — the same conservative default `arrowDeclarationKind` falls back
+              // to for an unrecognised shape.
+              kind: "computed",
+              enumeratesChildren: false,
               sources: [resolvedTo],
               target: nlRef.targetField,
               transform_raw: `(NL ref)`,

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -452,6 +452,7 @@ export function buildIndex(parsedFiles: (ParsedFile | FileData)[]): ExtractedWor
     warnings,
     questions,
     fieldArrows,
+    arrows: allArrowRecords,
     referenceGraph,
     namespaceNames,
     nlRefData: allNLRefData,

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -7,7 +7,13 @@
  * whose `apply` function rewrites source text deterministically.
  */
 
-import { capitalize, stripNLRefScopePrefix } from "@satsuma/core";
+import {
+  capitalize,
+  declaredFieldKind,
+  schemaLocalFieldPath,
+  stripNLRefScopePrefix,
+} from "@satsuma/core";
+import type { ArrowDeclarationKind } from "@satsuma/core";
 import {
   extractAtRefs,
   computeNLRefPosition,
@@ -35,6 +41,11 @@ export const RULES: LintRule[] = [
     id: "duplicate-definition",
     description: "Named definition is declared more than once in a namespace",
     check: checkDuplicateDefinition,
+  },
+  {
+    id: "unenumerated-record-target",
+    description: "Arrow targets a record without a record source or child arrows",
+    check: checkUnenumeratedRecordTarget,
   },
 ];
 
@@ -484,6 +495,110 @@ function checkDuplicateDefinition(index: ExtractedWorkspace): LintDiagnostic[] {
   }
 
   return diagnostics;
+}
+
+// ── unenumerated-record-target ─────────────────────────────────────────────
+
+/**
+ * Report an arrow that names a record as its target but neither carries a record
+ * nor says which of the record's fields it fills.
+ *
+ * `full_name -> address`, where `address` is a twelve-leaf record, is legal
+ * Satsuma and may well be what the author meant — but it is the one shape that
+ * leaves a reader unable to tell *which* of the twelve the arrow populates. The
+ * two shapes that do answer that are `addr -> address` (a record arrives, so the
+ * structure corresponds) and `full_name -> address { .line1 -> ... }` (the body
+ * lists what maps).
+ *
+ * **Why this rule exists at all.** Coverage refuses to credit the record's leaves
+ * for this arrow (ADR-038), which is the safe reading but a silent one: the
+ * author sees a coverage gap on twelve fields with no indication that one arrow
+ * is nearly responsible for them. This rule is the explanation for that gap.
+ * Coverage reports the number; `lint` says what to change — the split
+ * SATSUMA-CLI.md already draws when it puts policy judgements about gaps here.
+ *
+ * Not fixable: closing it means either enumerating the children or changing the
+ * source, and only the author knows which was intended.
+ */
+function checkUnenumeratedRecordTarget(index: ExtractedWorkspace): LintDiagnostic[] {
+  const diagnostics: LintDiagnostic[] = [];
+
+  for (const arrow of index.arrows) {
+    // Only declarations that would otherwise assert a whole-structure
+    // correspondence are candidates — the same first condition coverage applies
+    // (ADR-037). An `each`/`flatten` header opens an iteration and a body that
+    // lists child arrows has already said what maps, so neither is under-specified.
+    if (!WHOLE_STRUCTURE_KINDS.has(arrow.kind) || arrow.enumeratesChildren) continue;
+    if (!arrow.target || arrow.sources.length === 0) continue;
+
+    const mapping = index.mappings.get(qualifiedMappingKey(arrow));
+    if (!mapping) continue;
+
+    // A record target is the precondition; a record source is the excuse.
+    if (endpointKind(arrow.target, mapping.targets, index) !== "container") continue;
+    if (arrow.sources.some((s) => endpointKind(s, mapping.sources, index) === "container"))
+      continue;
+
+    const sources = arrow.sources.join(", ");
+    diagnostics.push({
+      file: arrow.file,
+      line: arrow.line + 1,
+      column: 1,
+      severity: "warning",
+      rule: "unenumerated-record-target",
+      message:
+        `Arrow '${sources} -> ${arrow.target}' targets a record, but ${arrow.sources.length > 1 ? "no source is" : "its source is not"} ` +
+        `a record and the body lists no child arrows — so which fields of '${arrow.target}' it populates is unstated, ` +
+        `and coverage counts them as gaps. Enumerate them (${arrow.target} { ... }) or map from a record.`,
+      fixable: false,
+    });
+  }
+
+  return diagnostics;
+}
+
+/**
+ * The declaration kinds that state a correspondence over a whole structure —
+ * kept in step with `WHOLE_STRUCTURE_KINDS` in core's coverage.ts, which gates
+ * the coverage behaviour this rule explains.
+ */
+const WHOLE_STRUCTURE_KINDS = new Set<ArrowDeclarationKind>(["map", "nested"]);
+
+/** Index key for the mapping an arrow belongs to (`ns::name`, or the bare name). */
+function qualifiedMappingKey(arrow: { mapping: string | null; namespace: string | null }): string {
+  return arrow.namespace ? `${arrow.namespace}::${arrow.mapping}` : (arrow.mapping ?? "");
+}
+
+/**
+ * What an authored arrow path names across the schemas on one side of its
+ * mapping: a container, a leaf, or null when nothing declares it.
+ *
+ * Delegates the two hard parts to core — stripping a schema prefix
+ * (`schemaLocalFieldPath`) and walking the field tree (`declaredFieldKind`) — so
+ * this rule and coverage cannot disagree about what a path names. A schema with
+ * unresolved spreads is skipped: its field list is incomplete, and reporting an
+ * arrow as under-specified because a spread has not been expanded would be a
+ * false positive.
+ */
+function endpointKind(
+  path: string,
+  schemaRefs: readonly string[],
+  index: ExtractedWorkspace,
+): "container" | "leaf" | null {
+  for (const ref of schemaRefs) {
+    const schema = index.schemas.get(resolveCanonicalKey(ref));
+    if (!schema || schema.hasSpreads) continue;
+    const local = schemaLocalFieldPath(
+      path,
+      [ref],
+      schemaRefs.filter((r) => r !== ref),
+      (name) => schema.fields.some((f) => f.name === name),
+    );
+    if (local === null) continue;
+    const kind = declaredFieldKind(local, schema.fields);
+    if (kind) return kind;
+  }
+  return null;
 }
 
 // ── Engine ─────────────────────────────────────────────────────────────────

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -130,6 +130,17 @@ export type Classification = "none" | "nl" | "nl-derived";
 export interface ArrowRecord {
   mapping: string | null;
   namespace: string | null;
+  /**
+   * Which declaration shape produced this record, straight from core's
+   * `ExtractedArrow`. Consumers asking what an arrow *asserts* about a container
+   * — rather than merely which paths it names — branch on this.
+   */
+  kind: import("@satsuma/core").ArrowDeclarationKind;
+  /**
+   * True when this declaration's braces enumerate further arrows, so its claim
+   * is narrowed to the children it lists. See `ExtractedArrow` for the contract.
+   */
+  enumeratesChildren: boolean;
   sources: string[];
   target: string | null;
   transform_raw: string;
@@ -203,6 +214,14 @@ export interface ExtractedWorkspace {
   warnings: WarningRecord[];
   questions: QuestionRecord[];
   fieldArrows: Map<string, ArrowRecord[]>;
+  /**
+   * Every arrow in the workspace, once each, in file order.
+   *
+   * {@link fieldArrows} indexes the same records under many keys for lookup by
+   * field, so a rule that must visit each arrow exactly once — rather than each
+   * *reference* to one — reads this instead of de-duplicating that map.
+   */
+  arrows: ArrowRecord[];
   referenceGraph: ReferenceGraph;
   namespaceNames: Set<string>;
   nlRefData: NLRefData[];

--- a/tooling/satsuma-cli/test/lint-engine.test.ts
+++ b/tooling/satsuma-cli/test/lint-engine.test.ts
@@ -11,6 +11,8 @@ import type { ExtractedWorkspace } from "#src/types.js";
 interface MockSchema {
   name: string;
   fields: Array<{ name: string; children?: Array<{ name: string }> }>;
+  /** Set when the schema spreads a fragment that has not been expanded — its field list is then incomplete. */
+  hasSpreads?: boolean;
   file?: string;
   row?: number;
 }
@@ -36,15 +38,35 @@ interface MockNLRef {
   column: number;
 }
 
+/**
+ * Shape of a mock arrow passed to makeIndex.
+ *
+ * `kind` and `enumeratesChildren` default to the plain-arrow reading (`map`,
+ * nothing enumerated), which is the shape `unenumerated-record-target` judges;
+ * a case that needs another declaration shape states it.
+ */
+interface MockArrow {
+  mapping: string;
+  namespace?: string | null;
+  sources: string[];
+  target: string | null;
+  kind?: "map" | "computed" | "nested" | "each" | "flatten";
+  enumeratesChildren?: boolean;
+  file?: string;
+  line?: number;
+}
+
 /** Build a minimal ExtractedWorkspace for lint testing. */
 function makeIndex({
   schemas = [],
   mappings = [],
   nlRefData = [],
+  arrows = [],
 }: {
   schemas?: MockSchema[];
   mappings?: MockMapping[];
   nlRefData?: MockNLRef[];
+  arrows?: MockArrow[];
 } = {}): ExtractedWorkspace {
   const schemaMap = new Map<string, any>();
   for (const s of schemas) {
@@ -64,6 +86,18 @@ function makeIndex({
     warnings: [],
     questions: [],
     fieldArrows: new Map(),
+    arrows: arrows.map((a) => ({
+      kind: "map",
+      enumeratesChildren: false,
+      namespace: null,
+      transform_raw: "",
+      steps: [],
+      classification: "none",
+      derived: false,
+      file: "test.stm",
+      line: 0,
+      ...a,
+    })),
     referenceGraph: {
       usedByMappings: new Map(),
       fragmentsUsedIn: new Map(),
@@ -689,5 +723,112 @@ describe("lint diagnostic shape", () => {
     assert.equal(typeof d.rule, "string");
     assert.equal(typeof d.message, "string");
     assert.equal(typeof d.fixable, "boolean");
+  });
+});
+
+// ── unenumerated-record-target ─────────────────────────────────────────────
+
+describe("lint: unenumerated-record-target", () => {
+  /** src has a scalar and a record; tgt has a record. Each case varies only the arrow. */
+  const twoShapes = (arrows: MockArrow[]) =>
+    makeIndex({
+      schemas: [
+        {
+          name: "src",
+          fields: [
+            { name: "full_name" },
+            { name: "addr", children: [{ name: "line1" }, { name: "city" }] },
+          ],
+        },
+        {
+          name: "tgt",
+          fields: [{ name: "address", children: [{ name: "line1" }, { name: "city" }] }],
+        },
+      ],
+      mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
+      arrows,
+    });
+
+  const run = (index: ExtractedWorkspace) =>
+    runLint(index, { select: ["unenumerated-record-target"] });
+
+  it("flags an arrow from a scalar into a record that enumerates nothing", () => {
+    // The shape the rule exists for, and the one coverage refuses to credit
+    // (ADR-038): a reader cannot tell which of the record's fields the arrow
+    // fills, so the leaves report as gaps with no indication why.
+    const diags = run(twoShapes([{ mapping: "load", sources: ["full_name"], target: "address" }]));
+    assert.equal(diags.length, 1);
+    assert.equal(diags[0].severity, "warning");
+    assert.match(diags[0].message, /targets a record/);
+    assert.match(diags[0].message, /Enumerate them/);
+    assert.equal(diags[0].fixable, false);
+  });
+
+  it("stays silent when the source is itself a record", () => {
+    // `addr -> address` is the correspondence whole-structure coverage credits,
+    // so there is nothing under-specified to report.
+    assert.deepEqual(
+      run(twoShapes([{ mapping: "load", sources: ["addr"], target: "address" }])),
+      [],
+    );
+  });
+
+  it("stays silent when the body enumerates the record's children", () => {
+    // The author has said which fields map, which is the other way to answer the
+    // question the rule asks. Enumerating must not be penalised.
+    const diags = run(
+      twoShapes([
+        {
+          mapping: "load",
+          sources: ["full_name"],
+          target: "address",
+          kind: "nested",
+          enumeratesChildren: true,
+        },
+      ]),
+    );
+    assert.deepEqual(diags, []);
+  });
+
+  it("stays silent for an each header, which opens an iteration rather than a correspondence", () => {
+    // Iteration kinds assert nothing about a subtree either way, so they are
+    // outside this rule — flagging them would fire on every well-formed each block.
+    const diags = run(
+      twoShapes([{ mapping: "load", sources: ["full_name"], target: "address", kind: "each" }]),
+    );
+    assert.deepEqual(diags, []);
+  });
+
+  it("stays silent when the target is a leaf rather than a record", () => {
+    // A record target is the precondition — an ordinary scalar-to-scalar arrow
+    // has nothing unstated about it. This is the bulk of every real workspace,
+    // so a false positive here would make the rule unusable.
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "full_name" }] },
+        { name: "tgt", fields: [{ name: "name" }] },
+      ],
+      mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
+      arrows: [{ mapping: "load", sources: ["full_name"], target: "name" }],
+    });
+    assert.deepEqual(run(index), []);
+  });
+
+  it("stays silent when the target schema has unresolved spreads", () => {
+    // The field list is incomplete, so "targets a record" cannot be established
+    // — reporting on it would blame the author for an unexpanded fragment.
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "full_name" }] },
+        {
+          name: "tgt",
+          fields: [{ name: "address", children: [{ name: "line1" }] }],
+          hasSpreads: true,
+        },
+      ],
+      mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
+      arrows: [{ mapping: "load", sources: ["full_name"], target: "address" }],
+    });
+    assert.deepEqual(run(index), []);
   });
 });

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -257,31 +257,76 @@ export function computeMappingCoverage(
   // list consumes it, and writing into one populates it. Whether that reference
   // reaches the container's *leaves* depends on the declaration kind — see
   // {@link ArrowFieldReference}.
+  // Schemas are resolved once, up front, rather than inside the two report loops
+  // below. The target side's whole-structure test has to ask what the *source*
+  // path names (ADR-038), so the source field trees must be in hand before
+  // `declaredTgt` is built.
+  const sources = resolveParticipants(sourceIds, resolveSchema);
+  const targets = resolveParticipants(targetIds, resolveSchema);
+
   const arrows = extractMappingArrowRecords(found.node);
-  const declaredSrc = arrows.flatMap((a) => a.sources.map((path) => arrowReference(path, a)));
+  const declaredSrc = arrows.flatMap((a) =>
+    a.sources.map((path) => ({ path, wholeStructure: declaresCorrespondence(a) })),
+  );
   const declaredTgt = arrows
     .filter((a) => a.target !== null)
-    .map((a) => arrowReference(a.target as string, a));
+    .map((a) => ({
+      path: a.target as string,
+      // Target-side only: a record is populated wholesale by an arrow that
+      // carries a record, not by one carrying a single scalar (ADR-038).
+      wholeStructure: declaresCorrespondence(a) && namesAContainer(a.sources, sources),
+    }));
 
   const nl = nlRefFieldPaths(nlRefs, found.mappingKey);
 
   const schemas: SchemaCoverageResult[] = [];
 
-  for (const schemaId of sourceIds) {
-    const def = resolveSchema(schemaId);
-    if (!def) continue;
-    schemas.push(coverageForSchema(def, schemaId, "source", sourceIds, declaredSrc, nl.anyContext));
+  for (const participant of sources) {
+    schemas.push(coverageForSchema(participant, "source", sourceIds, declaredSrc, nl.anyContext));
   }
 
-  for (const schemaId of targetIds) {
-    const def = resolveSchema(schemaId);
-    if (!def) continue;
+  for (const participant of targets) {
     schemas.push(
-      coverageForSchema(def, schemaId, "target", targetIds, declaredTgt, nl.arrowBodyOnly),
+      coverageForSchema(participant, "target", targetIds, declaredTgt, nl.arrowBodyOnly),
     );
   }
 
   return { schemas };
+}
+
+/**
+ * One schema a mapping names, paired with the definition the resolver returned.
+ *
+ * `writtenRef` is the form the mapping used; `def.schemaId` may canonicalise it,
+ * and a reference can legitimately use either — so both are kept and both are
+ * matched when a path's schema prefix is stripped.
+ */
+interface ParticipatingSchema {
+  /** Schema id exactly as written in the mapping's `source{}`/`target{}` block. */
+  writtenRef: string;
+  /** The resolved field tree and its uri. */
+  def: CoverageSchemaDefinition;
+}
+
+/**
+ * Resolve the schemas on one side of a mapping, dropping any the resolver cannot
+ * find.
+ *
+ * An unresolvable schema is omitted rather than reported: coverage is not a
+ * validation pass, and `validate` owns missing-reference diagnostics. The
+ * omission is also what makes an unresolvable *source* fail closed for
+ * whole-structure expansion — see {@link namesAContainer}.
+ */
+function resolveParticipants(
+  schemaIds: readonly string[],
+  resolveSchema: CoverageSchemaResolver,
+): ParticipatingSchema[] {
+  const resolved: ParticipatingSchema[] = [];
+  for (const writtenRef of schemaIds) {
+    const def = resolveSchema(writtenRef);
+    if (def) resolved.push({ writtenRef, def });
+  }
+  return resolved;
 }
 
 // ── Whole-structure arrows (PRD 38 R5, 3cc-iedv) ────────────────────────────
@@ -346,12 +391,51 @@ interface ArrowFieldReference {
  */
 const WHOLE_STRUCTURE_KINDS: readonly ArrowDeclarationKind[] = ["map", "nested"];
 
-/** Tag an authored path with what its declaration asserts about it. */
-function arrowReference(path: string, arrow: ExtractedArrow): ArrowFieldReference {
-  return {
-    path,
-    wholeStructure: WHOLE_STRUCTURE_KINDS.includes(arrow.kind) && !arrow.enumeratesChildren,
-  };
+/**
+ * True when the declaration states a correspondence over the whole structure it
+ * names, rather than over the parts its body lists — condition 1 AND condition 2
+ * of ADR-037, which are properties of the declaration alone.
+ *
+ * This is the whole test on the **source** side. The target side adds
+ * {@link namesAContainer} on top of it (ADR-038).
+ */
+function declaresCorrespondence(arrow: ExtractedArrow): boolean {
+  return WHOLE_STRUCTURE_KINDS.includes(arrow.kind) && !arrow.enumeratesChildren;
+}
+
+/**
+ * True when at least one of these authored paths names a declared container in
+ * one of the schemas on that side of the mapping.
+ *
+ * This is ADR-038's target-side condition: `addr -> address` populates the whole
+ * of `address` because a record arrives; `full_name -> address` does not,
+ * because one scalar cannot fill twelve leaves and the declaration says nothing
+ * about which leaf it would fill. Without the test, coverage credits all twelve
+ * — an overstatement in exactly the direction ADR-034 refused to risk, since it
+ * is `covered` that `--fail-under` gates.
+ *
+ * **Any one container source is enough.** A multi-source arrow
+ * (`addr, meta -> address`) asserts one correspondence built from several
+ * inputs, and a record among them makes the whole-structure reading plausible.
+ * Requiring all of them would turn a mixed arrow into a gap.
+ *
+ * **Fails closed.** A path naming nothing declared, or naming a schema the
+ * resolver could not resolve (so absent from `schemas` entirely), is not
+ * evidence of a record — so it does not confer. Under-counting is the safe
+ * direction (ADR-034), and a source path that resolves to nothing is already
+ * reported by `validate`'s `field-not-in-schema`.
+ */
+function namesAContainer(
+  paths: readonly string[],
+  schemas: readonly ParticipatingSchema[],
+): boolean {
+  const participatingRefs = schemas.map((s) => s.writtenRef);
+  return paths.some((path) =>
+    schemas.some((schema) => {
+      const local = schemaLocalPath(path, schema, participatingRefs);
+      return local !== null && declaredFieldKind(local, schema.def.fields) === "container";
+    }),
+  );
 }
 
 /**
@@ -392,13 +476,8 @@ function expandWholeStructureRefs(
  * consistent with the model for consumers that only hold the set.
  */
 function descendantPathsOf(path: string, fields: CoverageField[]): string[] {
-  let level: CoverageField[] | undefined = fields;
-  let found: CoverageField | undefined;
-  for (const segment of path.split(".")) {
-    found = level?.find((f) => f.name === segment);
-    if (!found) return [];
-    level = found.children;
-  }
+  const found = findDeclaredField(path, fields);
+  if (!found) return [];
 
   const paths: string[] = [];
   const collect = (children: CoverageField[], prefix: string): void => {
@@ -408,8 +487,77 @@ function descendantPathsOf(path: string, fields: CoverageField[]): string[] {
       if (child.children) collect(child.children, childPath);
     }
   };
-  collect(found?.children ?? [], path);
+  collect(found.children ?? [], path);
   return paths;
+}
+
+/**
+ * The declared field a schema-local dotted path names, or null when the schema
+ * declares no such path.
+ *
+ * The single walk of a {@link CoverageField} tree — {@link descendantPathsOf}
+ * and {@link declaredFieldKind} both go through it, so "what does this path
+ * name?" has one answer rather than one per caller.
+ */
+function findDeclaredField(path: string, fields: CoverageField[]): CoverageField | null {
+  let level: CoverageField[] | undefined = fields;
+  let found: CoverageField | undefined;
+  for (const segment of path.split(".")) {
+    found = level?.find((f) => f.name === segment);
+    if (!found) return null;
+    level = found.children;
+  }
+  return found ?? null;
+}
+
+/**
+ * What a schema-local dotted path names in a declared field tree: a `container`
+ * (a field with declared children — `record` or `list_of record`), a `leaf`, or
+ * `null` when this schema declares no such path.
+ *
+ * Exported because "is this arrow endpoint a record?" is asked in two places
+ * that must agree: coverage gates target-side subtree expansion on it
+ * (ADR-038), and the CLI's `unenumerated-record-target` lint rule reports the
+ * arrows that gate turns away. A second implementation would let the number and
+ * the explanation for it drift apart.
+ *
+ * A container with no declared children reads as a `leaf`, matching the rule
+ * `coverageForField` and `leafFieldEntries` apply when counting: as far as
+ * coverage is concerned a record nothing is declared inside carries data of its
+ * own.
+ */
+export function declaredFieldKind(
+  path: string,
+  fields: CoverageField[],
+): "container" | "leaf" | null {
+  const found = findDeclaredField(path, fields);
+  if (!found) return null;
+  return found.children && found.children.length > 0 ? "container" : "leaf";
+}
+
+/**
+ * Reduce an authored arrow path to one local to `schema`, or null when it names
+ * a different participating schema.
+ *
+ * Wraps {@link schemaLocalFieldPath} with the three inputs every caller has to
+ * assemble the same way: the schema's two legitimate spellings (as written in
+ * the mapping, and the id the resolver canonicalised it to), the other schemas
+ * on that side, and whether the schema shadows a prefix with a top-level field
+ * of the same name. Sharing it keeps `coverageForSchema` and
+ * {@link namesAContainer} resolving prefixes identically — if they diverged, a
+ * qualified arrow could confer a subtree in one and not the other.
+ */
+function schemaLocalPath(
+  ref: string,
+  schema: ParticipatingSchema,
+  participatingRefs: readonly string[],
+): string | null {
+  const canonicalRef = schema.def.schemaId ?? schema.writtenRef;
+  const ownRefs =
+    canonicalRef === schema.writtenRef ? [schema.writtenRef] : [schema.writtenRef, canonicalRef];
+  const otherRefs = participatingRefs.filter((r) => r !== schema.writtenRef);
+  const topLevelNames = new Set(schema.def.fields.map((f) => f.name));
+  return schemaLocalFieldPath(ref, ownRefs, otherRefs, (name) => topLevelNames.has(name));
 }
 
 // ── Resolved NL @ref paths (ADR-036) ────────────────────────────────────────
@@ -459,23 +607,17 @@ function nlRefFieldPaths(nlRefs: readonly ResolvedNLRef[], mappingKey: string): 
  * because the tier a field is reported under depends on which set matched.
  */
 function coverageForSchema(
-  def: CoverageSchemaDefinition,
-  writtenRef: string,
+  schema: ParticipatingSchema,
   role: "source" | "target",
   participatingRefs: readonly string[],
   declaredRefs: readonly ArrowFieldReference[],
   nlRefPaths: readonly string[],
 ): SchemaCoverageResult {
+  const { def } = schema;
   // A reference may name this schema by the form written in the mapping or by the
   // id the resolver canonicalised it to, so both must resolve.
-  const canonicalRef = def.schemaId ?? writtenRef;
-  const ownRefs = canonicalRef === writtenRef ? [writtenRef] : [writtenRef, canonicalRef];
-  const otherRefs = participatingRefs.filter((ref) => ref !== writtenRef);
-
-  const topLevelNames = new Set(def.fields.map((f) => f.name));
-  const declaresTopLevel = (name: string): boolean => topLevelNames.has(name);
-  const toLocal = (ref: string): string | null =>
-    schemaLocalFieldPath(ref, ownRefs, otherRefs, declaresTopLevel);
+  const canonicalRef = def.schemaId ?? schema.writtenRef;
+  const toLocal = (ref: string): string | null => schemaLocalPath(ref, schema, participatingRefs);
 
   const declaredLocal: ArrowFieldReference[] = [];
   for (const ref of declaredRefs) {

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -23,7 +23,7 @@ export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";
 export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
-export { computeMappingCoverage } from "./coverage.js";
+export { computeMappingCoverage, declaredFieldKind } from "./coverage.js";
 export type {
   CoverageTier,
   FieldCoverageState,

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -368,7 +368,10 @@ mapping copy {
     // conferred coverage, `billing.line1` would read covered — turning "one of
     // twelve address fields is mapped" into "all twelve are".
     const MIXED = `
-schema src { a STRING b STRING }
+schema src {
+  a record { line1 STRING city STRING }
+  b STRING
+}
 schema tgt {
   address record { line1 STRING city STRING }
   billing record { line1 STRING city STRING }
@@ -409,7 +412,7 @@ mapping copy {
     // A subtree is a subtree. Stopping at direct children would leave the deepest
     // leaves — the ones hardest to notice missing — reported as gaps.
     const DEEP = `
-schema src { v STRING }
+schema src { v record { b record { x STRING y STRING } z STRING } }
 schema tgt { a record { b record { x STRING y STRING } z STRING } }
 mapping copy {
   source { src }
@@ -428,7 +431,7 @@ mapping copy {
     // covered set is a set, so the leaf is counted once and the percentage
     // cannot exceed 100%.
     const OVERLAP = `
-schema src { a STRING b STRING }
+schema src { a record { line1 STRING city STRING } b STRING }
 schema tgt { address record { line1 STRING city STRING } }
 mapping copy {
   source { src }
@@ -587,19 +590,19 @@ mapping load {
     assertState(src, "work.city", "covered");
   });
 
-  it("confers onto a record target even when the source is a scalar", () => {
-    // The deliberate limit of condition 1, pinned here so it is a decision
-    // rather than an accident of two tests written for other purposes.
+  it("does not confer onto a record target when the source is a scalar", () => {
+    // ADR-038, and the flip this test was written for: it previously asserted
+    // `covered` here, pinning the generous reading ADR-037 shipped, with a
+    // comment saying it would flip if 3ct-cs4y tightened the target side. It did.
     //
-    // ADR-037 gates expansion on the arrow's KIND, not on both sides being
-    // records: `coverageForSchema` reports on one schema at a time and does not
-    // hold the counterpart's field tree. On the source side that reads correctly
-    // (`addr -> out` consumes the whole of `addr` whatever receives it); here, on
-    // the target side, it is generous — one scalar credits every leaf of a
-    // record, and that is the direction ADR-034 called a silent overstatement.
+    // One scalar cannot populate two leaves, and the declaration says nothing
+    // about which leaf it would fill — so crediting both is an overstatement in
+    // the direction ADR-034 refused to risk, on the very number `--fail-under`
+    // gates. `address` still reports uncovered rather than partial: nothing
+    // beneath it is written at all.
     //
-    // Shipped knowingly. If `3ct-cs4y` decides to tighten the target side, this
-    // test flips to `uncovered` and its comment becomes the record of why.
+    // The arrow is not wrong, merely under-specified, and saying so is the
+    // CLI's `unenumerated-record-target` lint rule — not coverage's job.
     const SCALAR_INTO_RECORD = `
 schema src { full_name STRING }
 schema tgt { address record { line1 STRING city STRING } }
@@ -609,9 +612,81 @@ mapping load {
   full_name -> address
 }`;
     const tgt = forRole(coverage(SCALAR_INTO_RECORD, "load"), "target");
+    assertState(tgt, "address", "uncovered");
+    assertState(tgt, "address.line1", "uncovered");
+    assertState(tgt, "address.city", "uncovered");
+  });
+
+  it("still confers onto a record target when the source is a record", () => {
+    // The complement, and the case ADR-038 must not break: 3cc-iedv's original
+    // defect. A record arriving at a record is exactly the correspondence
+    // whole-structure expansion exists for, so tightening the scalar case must
+    // leave this one crediting every leaf.
+    const RECORD_INTO_RECORD = `
+schema src { addr record { line1 STRING city STRING } }
+schema tgt { address record { line1 STRING city STRING } }
+mapping load {
+  source { src }
+  target { tgt }
+  addr -> address
+}`;
+    const tgt = forRole(coverage(RECORD_INTO_RECORD, "load"), "target");
     assertState(tgt, "address", "covered");
     assertState(tgt, "address.line1", "covered");
+  });
+
+  it("keeps crediting a record source consumed by a scalar target", () => {
+    // ADR-038 tightens the TARGET side only. `addr -> out` reads the whole of
+    // `addr` whatever receives it, so source coverage must be unaffected —
+    // requiring records on both sides would turn every record-to-scalar arrow
+    // into a false "unconsumed source field" in the review queue.
+    const RECORD_INTO_SCALAR = `
+schema src { addr record { line1 STRING city STRING } }
+schema tgt { out STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  addr -> out
+}`;
+    const src = forRole(coverage(RECORD_INTO_SCALAR, "load"), "source");
+    assertState(src, "addr", "covered");
+    assertState(src, "addr.line1", "covered");
+    assertState(src, "addr.city", "covered");
+  });
+
+  it("confers when any one source of a multi-source arrow is a record", () => {
+    // ADR-038's any-one rule. A multi-source arrow asserts a single
+    // correspondence assembled from several inputs; a record among them makes
+    // the whole-structure reading plausible, and requiring every source to be
+    // one would turn a mixed arrow into a gap.
+    const MIXED_SOURCES = `
+schema src { addr record { line1 STRING city STRING } tag STRING }
+schema tgt { address record { line1 STRING city STRING } }
+mapping load {
+  source { src }
+  target { tgt }
+  addr, tag -> address
+}`;
+    const tgt = forRole(coverage(MIXED_SOURCES, "load"), "target");
+    assertState(tgt, "address", "covered");
     assertState(tgt, "address.city", "covered");
+  });
+
+  it("does not confer when the source path names nothing the schema declares", () => {
+    // Fails closed (ADR-038). A typo'd or unresolvable source is not evidence of
+    // a record, and under-counting is the safe direction — the alternative is a
+    // gate passing because a source name was misspelled. `validate` reports the
+    // bad reference itself, via field-not-in-schema.
+    const UNKNOWN_SOURCE = `
+schema src { addr record { line1 STRING } }
+schema tgt { address record { line1 STRING city STRING } }
+mapping load {
+  source { src }
+  target { tgt }
+  nonexistent -> address
+}`;
+    const tgt = forRole(coverage(UNKNOWN_SOURCE, "load"), "target");
+    assertState(tgt, "address", "uncovered");
   });
 });
 


### PR DESCRIPTION
Closes `3ct-cs4y` — the question PR #421's review deferred rather than answered. Options **(b)** and **(e)** from that review, per your call.

## The defect

ADR-037 gated whole-structure expansion on the arrow's declaration kind alone, never checking the field opposite the arrow — `coverageForSchema` reports on one schema at a time and holds no field tree but its own. So `full_name -> address`, one scalar into a twelve-leaf record, credited all twelve. That is an overstatement on the number `--fail-under` gates, in exactly the direction ADR-034 refused to risk when it chose to under-count instead.

## Decided on evidence

I scanned every expansion-eligible arrow in `examples/` before choosing:

| shape | count |
|---|---|
| record → record | 0 |
| **scalar → record** | **0** |
| record → scalar | 0 |
| scalar → scalar | 270 |

Not one arrow in the corpus touches a container on either side — so neither the risk nor ADR-037's feature is visible there, and every option was free of measurable consequence. That is the argument for taking the safe one *now*, before a threshold gets built on the generous reading. (Detector validated against a synthetic positive control that classifies all four shapes.)

The exposure is latent, not hypothetical: flat-into-nested is a first-class use case here (`cobol-to-avro`, `edi-to-json`). Those examples are safe because they write the enumerated form. The author who takes the shortcut is the exposed one — so the failure mode is *skipped the detail, got rewarded with 100%*.

## (b) The target side must carry a record

`addr -> address` still covers the subtree. `full_name -> address` no longer does.

**The source side is deliberately unchanged.** `addr -> out` still credits `addr`'s leaves as consumed — a whole record was read, whatever received it. Requiring records at both ends would turn every record-to-scalar arrow into a false "unconsumed source field" in the review queue.

Three sub-rules, each a decision: any one container source suffices for a multi-source arrow; it **fails closed**, so a source naming nothing declared confers nothing; resolved NL `@refs` are untouched.

This is **not a new kind of judgement** — the code already refused to expand unless the path resolved to a declared container. It asks the same structural question of the other endpoint.

## (e) `unenumerated-record-target`

A warning (not fixable) when an arrow targets a record while neither carrying a record nor listing child arrows. It is the *explanation* for the gap coverage now reports — otherwise the author sees twelve uncovered fields and no clue that one arrow was nearly responsible. That split is the one `SATSUMA-CLI.md` already draws when it says policy judgements about gaps remain `lint`'s.

## Shared, not duplicated

`declaredFieldKind` in `satsuma-core/src/coverage.ts` answers "what does this path name in this schema?" once, for both coverage and the lint rule — two implementations would let the number and its explanation drift apart. `ArrowRecord` gained `kind`/`enumeratesChildren` (already flowing at runtime; only the type was narrow) and the workspace index a flat `arrows` list.

## Verification

- **Corpus coverage fingerprint byte-identical to `main`** across every example, and the new rule reports **0** findings on the corpus.
- End-to-end on a four-arrow file: flags exactly the scalar→record arrow; record→record, enumerated, and scalar→scalar stay silent and correctly counted (4/7, with `address.line1`/`address.city` now gaps).
- Core 542, CLI 978, LSP 292, viz 101, viz-backend 170, viz-model 6, vscode 34. `npm run lint` clean.

## Note on the tests

Three tests in the whole-subtree suite used a scalar source *incidentally* — their subject was ancestor non-inheritance, depth, and overlap. Those were given record sources so they keep testing what they were written for. The fourth, `confers onto a record target even when the source is a scalar`, was added in #421 specifically to pin the generous reading, with a comment saying it would flip if this ticket tightened it. It has flipped, and its comment now records why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)