### PR TITLE
Feature 38: viz coverage parity — leaf counting, relative-path resolution, fragment spreads (sl-hcan, 3cdd-yavi, sl-5nsv)

### DIFF
--- a/.tickets/3cdd-yavi.md
+++ b/.tickets/3cdd-yavi.md
@@ -1,6 +1,6 @@
 ---
 id: 3cdd-yavi
-status: open
+status: closed
 deps: []
 links: [svdfe-s6we, sc-xnxp]
 created: 2026-08-01T21:19:06Z
@@ -17,3 +17,12 @@ Arrows inside nested_arrow, each and flatten bodies are authored with element-re
 
 Child arrows inside nested_arrow/each/flatten reach the model with container-qualified absolute paths (or the resolution layer qualifies them equivalently), reusing core's qualification rule rather than a viz-local copy; buildMappingCoveredFields marks .line1 -> .line1 under 'addr -> address' as covering address.line1 on both sides; elk-layout produces edges for relative-path arrows, including flatten-inside-each (the sl-vu22 shape) and nested_arrow bodies; hover cross-highlighting resolves them; a layout test with populated eachBlocks/flattenBlocks/nestedArrows pins edge collection; viz + viz-backend suites pass and the Playwright harness run is green.
 
+
+## Notes
+
+**2026-08-02T21:06:38Z**
+
+**2026-08-02T21:06:38Z**
+
+Cause: the viz model stores arrow paths as authored, and nothing qualified an element-relative path (.line1) against its container before matching it against declared fields — resolveSchemaLocalFieldPath split it to ['', 'line1'] and returned null, so every arrow inside nested_arrow/each/flatten was dropped from mapping-detail coverage, hover cross-highlighting and overview edges (elk skipped the edge on the missing port silently).
+Fix: exported core's prefixing rule as qualifyChildArrowPath (extraction now calls it too, so there is one copy) and applied it at resolution time — forEachMappingArrow hands visitors the arrow plus its absolute paths, and elk-layout and the detail highlight check thread the same ContainerScope. Model keeps authored text so the detail table still renders what the author wrote (ADR-038). Layout/hover fixtures moved to the canonical relative form; Playwright harness green at 99 passed (commit 5c3e6d9).

--- a/.tickets/sl-5nsv.md
+++ b/.tickets/sl-5nsv.md
@@ -1,6 +1,6 @@
 ---
 id: sl-5nsv
-status: open
+status: closed
 deps: [sl-0pun, sl-hcan, sl-vu22]
 links: []
 created: 2026-07-31T14:44:00Z
@@ -20,3 +20,12 @@ This is also the test that catches spread-expansion divergence. The three consum
 
 Parity test over one nested fixture asserts identical leaf verdicts, container states and percentages across the CLI and viz-backend paths. Spread-materialised nested fields are counted in every consumer, using tooling/satsuma-cli/test/fixtures/nested-record-spread.stm where a record body contains only '...address_fields' — address.street and address.city appear as coverage entries with correct states in all paths. A new fixture covers a spread into a list_of record body, which exists nowhere in the repo today. A test covers one fragment spread into two sibling record bodies (examples/lib/sfdc_fragments.stm shape) asserting that mapping BillingAddress.Street leaves ShippingAddress.Street uncovered.
 
+
+## Notes
+
+**2026-08-02T20:54:55Z**
+
+**2026-08-02T20:54:55Z**
+
+Cause: the three consumers expanded fragment spreads at three different points — the CLI ran both the nested and schema-level passes, the viz ran only the schema-level one, and the LSP ran neither — so one file produced three coverage figures (2/5 vs 1/3 vs a childless 'address' record). The shared workspace index and the viz model both dropped spread declarations when projecting fields, so the two could not have expanded them even if they tried.
+Fix: added core expandDeclaredFields (both passes, fixed order, on a copy) and routed the CLI, LSP adapter and viz model builder through it; the shared index's FieldInfo/DefinitionEntry and the viz FieldEntry now carry unresolved spread names so expansion can happen once the workspace is complete. Added a list_of-record-spread fixture and parity tests asserting identical leaves, states and percentages from the CLI, LSP, viz-backend and viz-component suites, plus the sibling-records case (commit a9e5b77).

--- a/.tickets/sl-hcan.md
+++ b/.tickets/sl-hcan.md
@@ -1,6 +1,6 @@
 ---
 id: sl-hcan
-status: open
+status: closed
 deps: [sl-0pun]
 links: []
 created: 2026-07-31T14:44:00Z
@@ -25,3 +25,12 @@ The three conventions shipping today:
 
 The viz card's _countFields/_countMapped stop computing their own figures and delegate to core summarizeFieldCoverage/leafFieldEntries per ADR-034; container states reported alongside as counts (records: {covered, partial, uncovered}) — useful review information but not a percentage; the depth-invariance invariant documented: a schema's percentage is unchanged by re-nesting, same leaves and same arrows give the same number; test asserting two schemas with the same four leaves, one flat and one nested three deep, report identical percentages; test asserting the same fixture reports the same number from the core rollup and the viz card (today 25% and 40%); once 3cc-t6uo also lands, all three surfaces agree; containers excluded from the denominator — 'amount' plus 'address record {city,line1,postcode}' with only address.city mapped reports 25%, not 40%; vscode and viz suites pass.
 
+
+## Notes
+
+**2026-08-02T20:22:35Z**
+
+**2026-08-02T20:22:35Z**
+
+Cause: sz-schema-card computed its own coverage figures with _countFields/_countMapped, counting every node including records in both halves of the ratio, so one covered leaf lifted the numerator once per ancestor level (2/5 where satsuma coverage reported 1/4) — the third of the three conventions ADR-034 forbids.
+Fix: added core fieldCoverageFromCoveredPaths (set-based entry building, asserted equal to computeMappingCoverage for the same arrows) and countContainerStates; the card now delegates to summarizeFieldCoverage/countContainerStates for both the expanded ratio and the compact field count, and names partly mapped records in the header tooltip (commit 6bb3fe1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,27 @@ leaves as consumed even though `out` is a scalar — a whole record was read.
 Coverage figures on schemas using whole-record arrows will rise; figures that
 were resting on an `each` header or a computed arrow to a record will fall.
 
+### Viz resolves element-relative arrow paths against their container (`3cdd-yavi`)
+
+Arrows inside `nested_arrow`, `each` and `flatten` bodies are authored relative
+to the container — `.line1 -> .line1` under `addr -> address` (spec §4.6) — and
+the viz model stores that text as written. Nothing made it absolute before
+matching it against a declared field, so `.line1` split to `["", "line1"]`,
+matched nothing, and **every relative-path arrow was invisible** to three
+surfaces at once: mapping-detail coverage highlighting, hover
+cross-highlighting, and overview edges (the missing port was skipped silently,
+so a nested-iteration mapping simply drew no lines). Arrow counts and the detail
+table were already correct and are unchanged.
+
+All three now qualify paths through core's `qualifyChildArrowPath`, the same rule
+`extractArrowRecords` applies, accumulating one container level per nesting step
+so a `flatten` inside an `each` resolves to `orders.parcels.sku`. The rule is
+applied at _resolution_ time, not in the model: the mapping-detail table still
+shows `.line1 -> .line1` under its scope heading, because that is what the author
+wrote and the heading already supplies the context. Coverage figures on
+workspaces using nested iteration will rise — they were understated by every
+arrow inside a container.
+
 ### The viz schema card counts coverage in leaves, like every other surface (`sl-hcan`)
 
 The card computed its own coverage figures and counted every node — records

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,8 @@ applied at _resolution_ time, not in the model: the mapping-detail table still
 shows `.line1 -> .line1` under its scope heading, because that is what the author
 wrote and the heading already supplies the context. Coverage figures on
 workspaces using nested iteration will rise — they were understated by every
-arrow inside a container.
+arrow inside a container. See **ADR-039** for the convention this and the spread
+fix share.
 
 ### The viz schema card counts coverage in leaves, like every other surface (`sl-hcan`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,33 @@ leaves as consumed even though `out` is a scalar — a whole record was read.
 Coverage figures on schemas using whole-record arrows will rise; figures that
 were resting on an `each` header or a computed arrow to a record will fall.
 
+### Fragment spreads count towards coverage in every consumer (`sl-5nsv`)
+
+A spread is an authoring shorthand — `...address_fields` inside a record body
+declares that record's fields as surely as writing them out — but the three
+consumers expanded them at three different points, so one file produced three
+answers. For `customer { id, name, address record { ...address_fields } }` with
+two address leaves mapped, `satsuma coverage` reported **2/5 (40%)**, the VS Code
+gutter and status bar reported **1/3** with `address` a single fully covered
+leaf, and the viz card counted `address` as a childless record. The flattering
+number was the wrong one: fields a schema acquires via a spread were in neither
+numerator nor denominator.
+
+All three now materialise fields through core's new `expandDeclaredFields`, which
+owns both passes and their order — nested record-body spreads first, then
+schema-level ones appended — on a copy, so an index shared across commands is
+never mutated. The shared workspace index (LSP and viz) records spreads
+unresolved, since a spread may name a fragment in a file that is not indexed
+yet, and they are expanded once the whole workspace is available. Coverage
+figures on schemas using spreads will move, in both directions.
+
+Two things follow. Records that spread the same fragment stay independent —
+mapping `BillingAddress.Street` leaves `ShippingAddress.Street` uncovered, since
+coverage matches by path and not by name. And the parity itself is now tested:
+one fixture pair is asserted leaf for leaf, state for state, and percentage for
+percentage by the CLI, LSP, viz-backend and viz-component suites, so a future
+divergence fails a test instead of appearing as two numbers on one screen.
+
 ### Viz resolves element-relative arrow paths against their container (`3cdd-yavi`)
 
 Arrows inside `nested_arrow`, `each` and `flatten` bodies are authored relative

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,30 @@ leaves as consumed even though `out` is a scalar — a whole record was read.
 Coverage figures on schemas using whole-record arrows will rise; figures that
 were resting on an `each` header or a computed arrow to a record will fall.
 
+### The viz schema card counts coverage in leaves, like every other surface (`sl-hcan`)
+
+The card computed its own coverage figures and counted every node — records
+included — in both halves of the ratio, so one covered leaf lifted the numerator
+once per ancestor level. A schema of `amount` plus `address record { city, line1,
+postcode }` with only `address.city` mapped read as **2/5 (40%)** on the card
+while `satsuma coverage` reported **1/4 (25%)** for the same file. The card now
+delegates to core's `summarizeFieldCoverage`, which counts leaves only on each
+leaf's own flag (ADR-034), so the two agree. A card's percentage is now
+depth-invariant: re-nesting a schema without changing its leaves or the arrows
+into it cannot move the number.
+
+Records stay out of the ratio but are no longer silent — the header count's
+tooltip reads `1/4 leaf fields mapped (25%) — 1 record partly mapped`, so a
+reviewer can see which records need attention without a number that
+double-counts their children. Compact cards count leaves too, so one card no
+longer answers "how many fields?" two ways depending on its form.
+
+Consumers holding a covered-path set rather than a mapping's CST — the viz card
+is the first — build their entries through core's new
+`fieldCoverageFromCoveredPaths`, which applies the same container tri-state and
+leaf rules as `computeMappingCoverage`. `countContainerStates` reports the
+per-state container tally that sits beside a percentage.
+
 ### Prettier and `ruff format` are now formatting gates (`pfg-9dk8`)
 
 JS/TS had no formatting gate at all (ESLint 10 ships no formatting rules) and

--- a/adrs/adr-039-authored-form-in-models-resolution-at-point-of-use.md
+++ b/adrs/adr-039-authored-form-in-models-resolution-at-point-of-use.md
@@ -1,0 +1,123 @@
+# ADR-039 — Consumer Models Keep the Authored Form; Core's Rules Resolve It at the Point of Use
+
+**Status:** Accepted
+**Date:** 2026-08-02 (3cdd-yavi, sl-5nsv; feature 38)
+
+## Context
+
+Satsuma lets an author write two things in shorthand, and both have to be
+expanded before anything can be matched against a declared field.
+
+The first is the **element-relative path**. Inside a `nested_arrow`, `each` or
+`flatten` body, arrows are authored relative to the container: `.line1 ->
+.line1` under `addr -> address` means `addr.line1 -> address.line1` (spec §4.6,
+`examples/nested-iteration/pipeline.stm`). The second is the **fragment
+spread**. `address record { ...address_fields }` declares that record's fields
+as surely as writing them out (ADR-008), and the spread may name a fragment in
+another file.
+
+Core normalises both as it extracts: `extractArrowRecords` makes a container's
+children absolute by accumulating the enclosing paths, and the CLI's coverage
+resolver expanded spreads before handing core a field tree. The two consumers
+built on the shared workspace index did neither, and in both cases the authored
+form was not merely left unresolved but *discarded*: `viz-model.ts` stored
+`.line1` verbatim with nothing that could later qualify it, and the index's
+`FieldInfo` projection dropped `spreads` entirely, so no later pass could have
+expanded it even if one had wanted to.
+
+The result was three answers to one question. `resolveSchemaLocalFieldPath(".line1",
+…)` split to `["", "line1"]`, matched no declared field, and returned null — so
+every relative-path arrow contributed nothing to mapping-detail coverage, hover
+cross-highlighting, or overview edges, where ELK's missing-port `continue`
+dropped the edge without a word (`3cdd-yavi`). On the spread side, for
+`customer { id, name, address record { ...address_fields } }` with two address
+leaves mapped, `satsuma coverage` reported 2/5, the editor gutter reported 1/3
+with `address` a single fully covered leaf, and the viz card had `address` with
+no children at all (`sl-5nsv`). Every disagreement flattered the number.
+
+The obvious repair is to normalise into the model and the index at build time,
+as core does at extraction. One obstacle stands in front of each form. The viz
+model is a *rendering* contract (ADR-018): the mapping-detail table prints an
+arrow's paths verbatim beneath the scope heading that gives them their meaning,
+so absolute paths would print `parcels.line1 -> packed.line1` under `each
+parcels -> packed` — the author's own text replaced by a redundant expansion,
+and every row's test id changed with it. Spreads have a timing obstacle rather
+than a presentational one: `indexFile` runs per file, and a spread may name a
+fragment in a file that has not been indexed yet, so at index time the
+information needed to resolve it does not exist.
+
+## Decision
+
+**A consumer's index or model records authored shorthand as written — leading
+dot and fragment name intact — and resolution happens at the point where a value
+is matched against a declared field, through core's rule and never a local
+copy.** Two functions are that rule, and core's own extraction calls the first
+of them so there is exactly one implementation of each:
+
+- `qualifyChildArrowPath(path, containerPath)` in
+  `satsuma-core/src/extract.ts` — makes one container child's path absolute,
+  stripping the authored dot; a null container returns the path untouched, dot
+  and all, so a malformed mapping-level path stays unresolvable instead of being
+  matched to a top-level field.
+- `expandDeclaredFields(entity, ns, resolveRef, lookupFragment)` in
+  `satsuma-core/src/spread-expand.ts` — materialises both spread forms in one
+  fixed order (nested record-body spreads, then schema-level ones appended), on
+  a deep copy, since the nested pass mutates and index records are shared across
+  commands.
+
+Where "the point of use" falls is decided by one question: **does this consumer
+render the authored text?** Arrow paths in the viz model are rendered, so they
+stay authored and are qualified per lookup — `forEachMappingArrow` hands each
+visitor the model's own `ArrowEntry` alongside its absolute paths, and the two
+walks that cannot go through it (`elk-layout`'s edge collection, which needs
+per-block ids and scope badges, and the detail view's highlight check) thread the
+same `ContainerScope`. Declared fields are not rendered in authored form —
+ADR-008 makes a spread's fields the consuming schema's own — so they are
+expanded as early as the workspace allows: in the LSP's `resolveSchema` adapter
+and in the viz's `resolveAndStripSpreads`, both of which run after the index is
+complete. The index itself, being a per-file record built before the workspace
+exists, always stores the authored form: `FieldInfo.spreads` and
+`DefinitionEntry.spreads` now carry it.
+
+The corollary is the one ADR-034 states for denominators, applied to the field
+tree and the path: a consumer must not re-derive either rule locally, and a new
+resolution site must resolve before it matches.
+
+## Consequences
+
+**Positive:**
+
+- One implementation of each rule, so a spec or grammar change lands in core
+  and reaches every consumer (ADR-020). The relative-path rule in particular had
+  already been fixed twice in two packages under two ticket numbers (`sc-xnxp`,
+  then `3cdd-yavi`) before it was shared.
+- Cross-file spreads resolve by construction, because expansion is deferred to a
+  point where the whole workspace is indexed.
+- The mapping-detail table still shows what the author wrote, and its test ids
+  are unchanged.
+- An unresolvable spread survives expansion and stays visible on the schema card
+  as a dangling-reference indicator, rather than silently becoming an empty
+  record.
+- The parity this enables is now pinned rather than asserted: one fixture pair is
+  checked leaf for leaf, state for state and percentage for percentage by the
+  CLI, LSP, viz-backend and viz-component suites.
+
+**Negative:**
+
+- Every resolution site has to remember to resolve, and forgetting fails
+  silently — an unmatched path yields no coverage, no edge and no highlight,
+  which is exactly how `3cdd-yavi` stayed hidden through two rounds of work on
+  the same file. Funnelling viz's arrow walks through `forEachMappingArrow`
+  narrows this, but does not close it: `elk-layout` still applies the rule
+  itself.
+- Two representations of one path are in flight at once. A reader of the viz
+  model must know that its arrow paths are not comparable to declared field
+  paths, which is a thing to know rather than a thing the types enforce.
+- The viz model now mixes conventions in one object graph — materialised field
+  trees beside authored arrow paths — and stays legible only as long as the doc
+  comments saying so remain accurate.
+- `FieldInfo` and `FieldEntry` carry a `spreads` field that is meaningful only
+  before expansion and that most consumers never read.
+- Expansion deep-copies a schema's field tree per resolution rather than once per
+  index, so coverage over a workspace pays the copy for every (mapping, schema)
+  pair it reports on.

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -26,7 +26,7 @@ import type {
   ResolvedNLRef,
 } from "@satsuma/core";
 import { resolveScopedEntityRef } from "./index-builder.js";
-import { expandEntityFields, expandNestedSpreads } from "./spread-expand.js";
+import { expandDeclaredFields } from "./spread-expand.js";
 import { toCoverageFields } from "./field-positions.js";
 import type { ExtractedWorkspace, ParsedFile, SchemaRecord } from "./types.js";
 
@@ -87,23 +87,16 @@ export function makeSchemaResolver(
 }
 
 /**
- * A schema's fields with fragment spreads inlined.
+ * A schema's fields with fragment spreads inlined, nested and schema-level
+ * alike.
  *
- * Copies the field list before expanding: `expandNestedSpreads` mutates in
- * place, and the index's records are shared with every other command in the
- * process.
+ * Both passes and the defensive copy are core's `expandDeclaredFields`, shared
+ * with the LSP and viz adapters: this module ran its own sequence of the two
+ * until sl-5nsv, and the consumers that ran a different sequence reported
+ * different totals for the same schema.
  */
 function expandedFields(schema: SchemaRecord, index: ExtractedWorkspace) {
-  const fields = deepCopyFields(schema.fields);
-  expandNestedSpreads(fields, schema.namespace ?? null, index);
-  return [...fields, ...expandEntityFields(schema, schema.namespace ?? null, index)];
-}
-
-/** Recursive copy so in-place spread expansion cannot touch the shared index. */
-function deepCopyFields<T extends { children?: T[] }>(fields: T[]): T[] {
-  return fields.map((f) =>
-    f.children ? { ...f, children: deepCopyFields(f.children) } : { ...f },
-  );
+  return expandDeclaredFields(schema, schema.namespace ?? null, index);
 }
 
 /**

--- a/tooling/satsuma-cli/src/spread-expand.ts
+++ b/tooling/satsuma-cli/src/spread-expand.ts
@@ -14,6 +14,7 @@
 import {
   collectFieldPaths as _collectFieldPaths,
   expandSpreads as _expandSpreads,
+  expandDeclaredFields as _expandDeclaredFields,
   expandEntityFields as _expandEntityFields,
   expandNestedSpreads as _expandNestedSpreads,
 } from "@satsuma/core";
@@ -68,6 +69,23 @@ export function expandEntityFields(
   const resolveRef = makeIndexRefResolver(currentNs, index.fragments);
   const lookupFragment = (key: string) => index.fragments.get(key);
   return _expandEntityFields(entity, currentNs, resolveRef, lookupFragment);
+}
+
+/**
+ * Every field a schema declares with its fragment spreads inlined — nested
+ * record-body spreads and schema-level ones alike, on a copy. Wraps
+ * satsuma-core's callback-based expandDeclaredFields, which owns the ordering
+ * of the two passes so every consumer materialises the same field tree
+ * (sl-5nsv).
+ */
+export function expandDeclaredFields(
+  entity: SpreadEntity | null | undefined,
+  currentNs: string | null,
+  index: ExtractedWorkspace,
+): FieldDecl[] {
+  const resolveRef = makeIndexRefResolver(currentNs, index.fragments);
+  const lookupFragment = (key: string) => index.fragments.get(key);
+  return _expandDeclaredFields(entity, currentNs, resolveRef, lookupFragment);
 }
 
 /**

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -868,3 +868,59 @@ describe("satsuma coverage — key spelling", () => {
     assert.equal(parseJson(json.stdout).mappings[0].mapping, "crm::load contacts");
   });
 });
+
+// ── Fragment spreads (sl-5nsv) ──────────────────────────────────────────────
+//
+// A spread is an authoring shorthand: `...address_fields` inside a record body
+// declares that record's fields as surely as writing them out, so coverage must
+// count them. These two fixtures are the cross-consumer parity cases — the LSP
+// suite (satsuma-lsp/test/coverage.test.js) and the viz-backend suite read the
+// same two files and must produce the same leaves, states and totals stated
+// here. If you change a figure in one place, the other two are wrong.
+
+describe("satsuma coverage — fragment spreads", () => {
+  const NESTED_SPREAD = resolve(__dirname, "fixtures/nested-record-spread.stm");
+  const LIST_OF_SPREAD = resolve(__dirname, "fixtures/list-of-record-spread.stm");
+
+  it("counts the leaves a spread materialises inside a record body", async () => {
+    // `address record { ...address_fields }` declares three leaves. Counting the
+    // record as one opaque field instead reports the schema 1/3 covered where it
+    // is 2/5 — and reports a mapped record where two of its leaves are gaps.
+    const { stdout } = await run("coverage", NESTED_SPREAD, "--json");
+    const target = schemaEntry(parseJson(stdout), "::customer_map", "target", "::customer");
+    assert.deepEqual(
+      target.fields.map((f: any) => [f.path, f.mapped]),
+      [
+        ["id", false],
+        ["name", false],
+        ["address.street", true],
+        ["address.city", true],
+        ["address.zip", false],
+      ],
+    );
+    assert.equal(target.covered, 2);
+    assert.equal(target.total, 5);
+    assert.equal(target.pct, 40);
+  });
+
+  it("counts them the same way inside a list_of record body", async () => {
+    // A list_of record is a container like any other, and a spread inside one
+    // must materialise leaves the same way — the shape that existed nowhere in
+    // the repo before this fixture. One of three line fields is mapped, so the
+    // schema is 2/4 with `lines` partly covered.
+    const { stdout } = await run("coverage", LIST_OF_SPREAD, "--json");
+    const target = schemaEntry(parseJson(stdout), "::invoice_load", "target", "::invoice");
+    assert.deepEqual(
+      target.fields.map((f: any) => [f.path, f.mapped]),
+      [
+        ["invoice_no", true],
+        ["lines.sku", true],
+        ["lines.qty", false],
+        ["lines.unit_price", false],
+      ],
+    );
+    assert.equal(target.covered, 2);
+    assert.equal(target.total, 4);
+    assert.equal(target.pct, 50);
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/list-of-record-spread.stm
+++ b/tooling/satsuma-cli/test/fixtures/list-of-record-spread.stm
@@ -1,0 +1,29 @@
+// Fixture for sl-5nsv: fragment spread inside a `list_of record` body.
+//
+// The nested-spread shape that existed nowhere in the repo. It matters because
+// every consumer treats a list_of record as a container like any other record,
+// so a spread inside one must materialise leaves the same way — and a mapping
+// that populates one of them must leave the rest visibly uncovered.
+fragment line_fields {
+  sku STRING(64)
+  qty INT
+  unit_price DECIMAL(12,2)
+}
+
+schema invoice {
+  invoice_no STRING
+  lines list_of record {
+    ...line_fields
+  }
+}
+
+mapping invoice_load {
+  source { raw_invoice }
+  target { invoice }
+
+  raw_no -> invoice_no
+
+  each raw_lines -> lines {
+    .item_code -> .sku
+  }
+}

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -77,6 +77,23 @@ export interface CoverageTotals {
 }
 
 /**
+ * How many of a schema's containers sit in each coverage state (PRD 38 R2).
+ *
+ * Reported *alongside* a percentage, never inside one: a record is structure,
+ * so it is excluded from the ratio by ADR-034, but "two records are only partly
+ * mapped" is exactly what a reviewer wants next to "9/12". The three counts sum
+ * to the number of record and `list_of record` fields declared.
+ */
+export interface ContainerStateCounts {
+  /** Containers every one of whose descendant leaves is covered. */
+  covered: number;
+  /** Containers with at least one covered and at least one uncovered leaf. */
+  partial: number;
+  /** Containers no leaf of which is covered. */
+  uncovered: number;
+}
+
+/**
  * Aggregate coverage for one schema in one role, unioned across every mapping
  * that references it.
  *
@@ -165,6 +182,28 @@ export function summarizeFieldCoverage(fields: FieldCoverageEntry[]): CoverageTo
 export function leafFieldEntries(fields: FieldCoverageEntry[]): FieldCoverageEntry[] {
   const paths = new Set(fields.map((f) => f.path));
   return fields.filter((f) => !hasDescendant(f.path, paths));
+}
+
+/**
+ * The container entries of a schema's coverage list, tallied by state.
+ *
+ * The counterpart to {@link summarizeFieldCoverage}, and deliberately not part
+ * of it: containers are excluded from the percentage (ADR-034) and this is the
+ * shape that lets a consumer say so out loud. "9/12 leaves, 2 records partly
+ * mapped" is review information a percentage cannot carry — a reviewer can see
+ * that two records need attention without a number that double-counts their
+ * children.
+ *
+ * Containers and leaves partition the list, so a schema with no records reports
+ * three zeroes.
+ */
+export function countContainerStates(fields: FieldCoverageEntry[]): ContainerStateCounts {
+  const paths = new Set(fields.map((f) => f.path));
+  const counts: ContainerStateCounts = { covered: 0, partial: 0, uncovered: 0 };
+  for (const field of fields) {
+    if (hasDescendant(field.path, paths)) counts[field.state]++;
+  }
+  return counts;
 }
 
 /** True when any entry's path sits below `path`, i.e. `path` is a record. */

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -657,6 +657,45 @@ interface TieredCoveredPaths {
 }
 
 /**
+ * Coverage entries for a declared field tree, judged against the flat
+ * covered-path set view (`buildCoveredFieldSet`).
+ *
+ * The entry point for a consumer that holds a *set* of covered paths rather
+ * than a mapping's CST — the viz card, which builds its set in the browser from
+ * the viz model. Without it that consumer has to re-derive the tri-state and
+ * leaf rules itself, and ADR-034 requires the opposite: `satsuma coverage`, the
+ * VS Code status bar and the viz card must report one number for one workspace,
+ * so every one of them counts through the shapes this module emits.
+ *
+ * Re-deriving the model from the flat set changes no answer. The set is defined
+ * as the union of the model's `direct` and `ancestors` sets, and
+ * {@link isCoveredPath} asks for membership of either, so a path is covered here
+ * exactly when it was covered in the model the set came from. Containers are
+ * judged from their leaves regardless of how their own path was registered.
+ *
+ * **Tier:** a flat set records no tier, so every covered leaf is reported as
+ * `declared`. That is accurate for the only caller today — the viz builds its
+ * set from declared arrows alone — but a consumer that starts folding resolved
+ * NL `@ref` coverage into its set must move to {@link computeMappingCoverage}
+ * rather than have it mislabelled here (ADR-036).
+ *
+ * **Whole-structure arrows are not expanded** (ADR-037): the expansion needs the
+ * arrow's declaration kind, which a set of paths has thrown away. A caller whose
+ * set may contain a whole-record arrow's target must expand it into that
+ * record's leaves before building the set, or the record will read as uncovered.
+ */
+export function fieldCoverageFromCoveredPaths(
+  fields: CoverageField[],
+  uri: string,
+  coveredPaths: Iterable<string>,
+): FieldCoverageEntry[] {
+  return buildFieldCoverage(fields, uri, "", {
+    declared: buildCoveredFieldPaths(coveredPaths),
+    nl: buildCoveredFieldPaths([]),
+  });
+}
+
+/**
  * Recursively build the FieldCoverageEntry list for a schema's fields.
  * `prefix` is the path from the schema root to the current level; record
  * fields emit an entry of their own *and* entries for every descendant, the

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -950,6 +950,34 @@ export function extractMappingArrowRecords(
 }
 
 /**
+ * Make one arrow path absolute against the container it was authored inside.
+ *
+ * Inside a `nested_arrow`, `each` or `flatten` body, paths are authored
+ * *element-relative* — `.line1 -> .line1` under `each parcels -> packed` means
+ * `parcels.line1 -> packed.line1` (spec §4.6). The leading dot is the authored
+ * marker of that relativity and is stripped as the container prefix goes on;
+ * a path written without one inside a container is treated identically, since
+ * the container is the only frame it can be read in.
+ *
+ * Exported because every consumer that resolves an arrow against a declared
+ * field must apply this rule, and the copies drift when they don't share it:
+ * coverage reported nested leaves as gaps until sc-xnxp, and the viz dropped
+ * every relative-path arrow from its coverage lookups, hover highlighting and
+ * overview edges until 3cdd-yavi.
+ *
+ * @param path        Path as authored, with or without a leading dot.
+ * @param containerPath Absolute path of the enclosing container, or null at
+ *                    mapping-body level, where a path is already absolute and
+ *                    is returned untouched — dot and all, since a stray leading
+ *                    dot there matches no declared field and must not be made
+ *                    to look as though it does.
+ */
+export function qualifyChildArrowPath(path: string, containerPath: string | null): string {
+  if (!containerPath || !path) return path;
+  return `${containerPath}.${path.replace(/^\./, "")}`;
+}
+
+/**
  * Recursively collect arrow records from a list of sibling CST nodes,
  * appending to `records` in document order.
  *
@@ -1021,16 +1049,8 @@ function extractSingleArrow(
   const derived = classifyArrow(arrow);
   const steps = decomposePipeSteps(pipeSteps);
 
-  if (parentSrc && sources.length > 0) {
-    sources = sources.map((s) => {
-      const cleanSrc = s.replace(/^\./, "");
-      return `${parentSrc}.${cleanSrc}`;
-    });
-  }
-  if (parentTgt && target) {
-    const cleanTgt = target.replace(/^\./, "");
-    target = `${parentTgt}.${cleanTgt}`;
-  }
+  sources = sources.map((s) => qualifyChildArrowPath(s, parentSrc));
+  target = target === null ? null : qualifyChildArrowPath(target, parentTgt);
 
   // Canonical (layout-independent) so two arrows that differ only in how
   // the formatter laid out the chain or a map literal compare equal — diff

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -118,6 +118,7 @@ export {
 export {
   collectFieldPaths,
   expandSpreads,
+  expandDeclaredFields,
   expandEntityFields,
   expandNestedSpreads,
   makeEntityRefResolver,

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -23,7 +23,11 @@ export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";
 export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
-export { computeMappingCoverage, declaredFieldKind } from "./coverage.js";
+export {
+  computeMappingCoverage,
+  declaredFieldKind,
+  fieldCoverageFromCoveredPaths,
+} from "./coverage.js";
 export type {
   CoverageTier,
   FieldCoverageState,
@@ -43,10 +47,16 @@ export {
   schemaRefPrefixes,
 } from "./coverage-paths.js";
 export type { CoveredFieldPaths } from "./coverage-paths.js";
-export { aggregateCoverage, summarizeFieldCoverage, leafFieldEntries } from "./coverage-rollup.js";
+export {
+  aggregateCoverage,
+  summarizeFieldCoverage,
+  leafFieldEntries,
+  countContainerStates,
+} from "./coverage-rollup.js";
 export type {
   MappingCoverageInput,
   CoverageTotals,
+  ContainerStateCounts,
   AggregateSchemaCoverage,
   RoleTotals,
   NamespaceCoverage,

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -112,6 +112,7 @@ export {
   extractImports,
   extractArrowRecords,
   extractMappingArrowRecords,
+  qualifyChildArrowPath,
   canonicalPipeChainText,
 } from "./extract.js";
 export {

--- a/tooling/satsuma-core/src/spread-expand.ts
+++ b/tooling/satsuma-core/src/spread-expand.ts
@@ -251,6 +251,50 @@ export function expandNestedSpreads(
 }
 
 /**
+ * Every field a schema declares once its fragment spreads are inlined —
+ * the complete answer to "what fields does this schema have?".
+ *
+ * Spreads are an authoring shorthand: `...address_fields` inside a record body
+ * declares that record's fields as surely as writing them out. Any consumer
+ * reporting on declared fields — coverage, the editor gutter, the viz card —
+ * must therefore see through them, and must see through *both* forms:
+ *
+ *  - **nested**, inside a record body (`address record { ...address_fields }`),
+ *    which contributes `address.street`;
+ *  - **schema-level**, in the schema body itself, which contributes top-level
+ *    fields appended after the ones written out.
+ *
+ * Doing one and not the other is the failure this function exists to prevent
+ * (sl-5nsv): the CLI expanded both and reported `customer` at 2/5, the LSP
+ * expanded neither and reported the same schema at 1/3 with `address` as a
+ * childless leaf, and the viz expanded only the schema-level form. Three
+ * numbers, one file. Consumers now call this rather than sequencing the two
+ * passes themselves.
+ *
+ * The input is never mutated — `expandNestedSpreads` works in place, and index
+ * records are shared with every other command in the process, so the field tree
+ * is deep-copied first.
+ */
+export function expandDeclaredFields(
+  entity: SpreadEntity | null | undefined,
+  currentNs: string | null,
+  resolveRef: EntityRefResolver,
+  lookupFragment: SpreadEntityLookup,
+): FieldDecl[] {
+  if (!entity) return [];
+  const fields = deepCopyFields(entity.fields);
+  expandNestedSpreads(fields, currentNs, resolveRef, lookupFragment);
+  return [...fields, ...expandEntityFields(entity, currentNs, resolveRef, lookupFragment)];
+}
+
+/** Recursive copy, so in-place nested expansion cannot touch a shared index. */
+function deepCopyFields<T extends { children?: T[] }>(fields: T[]): T[] {
+  return fields.map((f) =>
+    f.children ? { ...f, children: deepCopyFields(f.children) } : { ...f },
+  );
+}
+
+/**
  * Namespace-aware entity reference resolver. This is the standard
  * implementation suitable for use with any `Map<string, unknown>` entity index.
  *

--- a/tooling/satsuma-core/test/arrow-records.test.js
+++ b/tooling/satsuma-core/test/arrow-records.test.js
@@ -14,7 +14,13 @@ import assert from "node:assert/strict";
 import { describe, it, before } from "node:test";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { initParser, getParser, extractArrowRecords, extractMappings } from "@satsuma/core";
+import {
+  initParser,
+  getParser,
+  extractArrowRecords,
+  extractMappings,
+  qualifyChildArrowPath,
+} from "@satsuma/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
@@ -143,5 +149,36 @@ describe("extractArrowRecords — nested arrow recursion (sl-zl55)", () => {
     const [mapping] = extractMappings(root);
     const EACH_FLATTEN_BLOCKS = 2;
     assert.equal(records.length, mapping.arrowCount + EACH_FLATTEN_BLOCKS);
+  });
+});
+
+// ── The qualification rule on its own (3cdd-yavi) ────────────────────────────
+//
+// The prefixing above is now an exported function, because the viz has to apply
+// the identical rule to the paths *its* model stores. These cases pin the two
+// boundaries a caller outside extraction can hit and the CST path cannot,
+// since the parser never hands extraction a container with no path.
+
+describe("qualifyChildArrowPath()", () => {
+  it("returns the path untouched when there is no container, dot and all", () => {
+    // Mapping-body level. A stray leading dot there names no declared field and
+    // must stay unresolvable: stripping it would make a malformed path match a
+    // top-level field and raise coverage on a broken spec.
+    assert.equal(qualifyChildArrowPath(".orders", null), ".orders");
+    assert.equal(qualifyChildArrowPath("orders.id", null), "orders.id");
+  });
+
+  it("leaves an empty path empty rather than producing a dangling dot", () => {
+    // A malformed block can reach a consumer with no path on one side; joining
+    // it would yield "parcels." — a path that matches nothing but looks like a
+    // real one in any output that prints it.
+    assert.equal(qualifyChildArrowPath("", "parcels"), "");
+  });
+
+  it("prefixes with or without the authored dot, since the container is the only frame", () => {
+    // `each lines -> .lines` in examples/nested-iteration/pipeline.stm writes
+    // one side dotted and the other not; both mean the same thing.
+    assert.equal(qualifyChildArrowPath(".sku", "parcels"), "parcels.sku");
+    assert.equal(qualifyChildArrowPath("sku", "parcels"), "parcels.sku");
   });
 });

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -24,6 +24,7 @@ import {
   extractMappings,
   aggregateCoverage,
   summarizeFieldCoverage,
+  countContainerStates,
 } from "@satsuma/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -139,6 +140,43 @@ describe("summarizeFieldCoverage()", () => {
       { path: "c", uri: "u", mapped: false },
     ]);
     assert.equal(totals.pct, 33);
+  });
+});
+
+describe("countContainerStates()", () => {
+  // The counts reviewers read beside the ratio. Containers are excluded from
+  // the percentage (ADR-034), so this is the only surface that reports them —
+  // and it must report the tri-state, not a boolean, or "one of twelve address
+  // fields is mapped" is indistinguishable from "all twelve are".
+  const ENTRIES = [
+    { path: "address", uri: "u", mapped: true, state: "partial" },
+    { path: "address.city", uri: "u", mapped: true, state: "covered" },
+    { path: "address.line1", uri: "u", mapped: false, state: "uncovered" },
+    { path: "billing", uri: "u", mapped: true, state: "covered" },
+    { path: "billing.city", uri: "u", mapped: true, state: "covered" },
+    { path: "shipping", uri: "u", mapped: false, state: "uncovered" },
+    { path: "shipping.city", uri: "u", mapped: false, state: "uncovered" },
+    { path: "amount", uri: "u", mapped: true, state: "covered" },
+  ];
+
+  it("tallies containers by state and counts no leaf among them", () => {
+    // `amount` and every `.city` are leaves: were any of them counted the
+    // totals would exceed the three records declared.
+    assert.deepEqual(countContainerStates(ENTRIES), {
+      covered: 1,
+      partial: 1,
+      uncovered: 1,
+    });
+  });
+
+  it("reports three zeroes for a schema declaring no records", () => {
+    // A flat schema has no container state to report, and must not borrow its
+    // leaves' states to manufacture one.
+    assert.deepEqual(countContainerStates([{ path: "id", uri: "u", mapped: true }]), {
+      covered: 0,
+      partial: 0,
+      uncovered: 0,
+    });
   });
 });
 

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -19,8 +19,11 @@ import { fileURLToPath } from "node:url";
 import {
   initParser,
   getParser,
+  buildCoveredFieldSet,
   computeMappingCoverage,
+  countContainerStates,
   extractSchemas,
+  fieldCoverageFromCoveredPaths,
   extractMappings,
   extractNLRefData,
   leafFieldEntries,
@@ -1580,5 +1583,101 @@ mapping load {
 }`;
     const s = forRole(coverage(BRACKETS, "load"), "source");
     assertMapped(s, "items.id", false);
+  });
+});
+
+// ── Set-based entry building (sl-hcan) ───────────────────────────────────────
+//
+// The path a consumer takes when it holds a covered-path *set* rather than a
+// mapping's CST — the viz card, which builds its set in the browser. ADR-034
+// requires one number per workspace across `satsuma coverage`, the VS Code
+// status bar and the viz card, so what matters here is that this entry point
+// answers exactly as the CST path does.
+
+describe("fieldCoverageFromCoveredPaths()", () => {
+  const NESTED = `
+schema src { city STRING }
+schema tgt {
+  amount DECIMAL
+  address record { city STRING line1 STRING postcode STRING }
+}
+mapping load {
+  source { src }
+  target { tgt }
+  city -> address.city
+}`;
+
+  /** The declared field tree of `tgt`, in core's minimal coverage shape. */
+  function targetFields(source = NESTED, schemaName = "tgt") {
+    const tree = getParser().parse(source);
+    const schema = extractSchemas(tree.rootNode).find((s) => s.name === schemaName);
+    return toCoverageFields(schema.fields);
+  }
+
+  it("reports the same entries as computeMappingCoverage for the same arrows", () => {
+    // The parity property sl-hcan exists for. If the two paths can disagree,
+    // the viz card and the CLI can print different numbers for one file, which
+    // is exactly what they did before this entry point existed.
+    const viaCst = forRole(coverage(NESTED, "load"), "target");
+    const viaSet = fieldCoverageFromCoveredPaths(
+      targetFields(),
+      TEST_URI,
+      buildCoveredFieldSet(["address.city"]),
+    );
+    assert.deepEqual(viaSet, viaCst.fields);
+  });
+
+  it("counts leaves only, so nesting depth alone cannot move the percentage", () => {
+    // The concrete figure sl-hcan cites: `amount` plus a three-leaf `address`
+    // with only `address.city` covered is 1/4 — 25%. Counting the record too
+    // (the viz card's old rule) gave 2/5 — 40%.
+    const entries = fieldCoverageFromCoveredPaths(
+      targetFields(),
+      TEST_URI,
+      buildCoveredFieldSet(["address.city"]),
+    );
+    assert.deepEqual(summarizeFieldCoverage(entries), {
+      covered: 1,
+      coveredDeclared: 1,
+      coveredNl: 0,
+      total: 4,
+      pct: 25,
+    });
+    assert.deepEqual(countContainerStates(entries), { covered: 0, partial: 1, uncovered: 0 });
+  });
+
+  it("gives a flat and a deeply nested schema with the same leaves the same percentage", () => {
+    // Depth invariance, stated as a property rather than a figure: re-nesting a
+    // schema without changing its leaves or the arrows into it must not move the
+    // number. This is what makes a coverage percentage comparable between two
+    // schemas, and what counting containers destroyed.
+    const FLAT = `schema tgt { a STRING b STRING c STRING d STRING }`;
+    const DEEP = `schema tgt { a STRING outer record { b STRING mid record { c STRING inner record { d STRING } } } }`;
+    const COVERED = new Set(["a"]);
+
+    const flat = summarizeFieldCoverage(
+      fieldCoverageFromCoveredPaths(targetFields(FLAT), TEST_URI, COVERED),
+    );
+    const deep = summarizeFieldCoverage(
+      fieldCoverageFromCoveredPaths(targetFields(DEEP), TEST_URI, COVERED),
+    );
+    assert.deepEqual(flat, deep);
+    assert.equal(flat.total, 4);
+    assert.equal(flat.pct, 25);
+  });
+
+  it("judges a container from its leaves even when the set names the container itself", () => {
+    // A set built from `each parcels -> .packed { }` contains "packed" with no
+    // leaf beneath it covered. A container reference must not manufacture leaf
+    // coverage (PRD 38 R2) — the same rule the CST path applies, reached here
+    // through a set that has forgotten which arrow put the path there.
+    const SCHEMA = `schema tgt { packed record { weight DECIMAL sku STRING } }`;
+    const entries = fieldCoverageFromCoveredPaths(
+      targetFields(SCHEMA),
+      TEST_URI,
+      buildCoveredFieldSet(["packed"]),
+    );
+    assert.equal(entries.find((f) => f.path === "packed").state, "uncovered");
+    assert.equal(summarizeFieldCoverage(entries).covered, 0);
   });
 });

--- a/tooling/satsuma-core/test/spread-expand.test.js
+++ b/tooling/satsuma-core/test/spread-expand.test.js
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   collectFieldPaths,
+  expandDeclaredFields,
   expandEntityFields,
   expandNestedSpreads,
   makeEntityRefResolver,
@@ -138,5 +139,95 @@ describe("expandNestedSpreads()", () => {
     assert.equal(fields[0].children.length, 2);
     assert.equal(fields[0].children[0].name, "city");
     assert.equal(fields[0].hasSpreads, undefined);
+  });
+});
+
+// ── expandDeclaredFields ─────────────────────────────────────────────────────
+//
+// The whole answer to "what fields does this schema declare?", and the reason
+// it exists is that its two halves used to be sequenced by each consumer: the
+// CLI ran both, the viz ran only the schema-level pass, the LSP ran neither,
+// and the three reported different totals for one file (sl-5nsv).
+
+describe("expandDeclaredFields()", () => {
+  const addressFields = fragment("address_fields", [field("street"), field("city")]);
+  const entities = new Map([["address_fields", addressFields]]);
+  const resolveRef = makeEntityRefResolver(entities);
+  const lookup = (key) => entities.get(key) ?? null;
+
+  /** Every dotted leaf path of a field tree, the unit coverage counts in. */
+  const leaves = (fields, prefix = "") =>
+    fields.flatMap((f) =>
+      f.children?.length ? leaves(f.children, `${prefix}${f.name}.`) : [`${prefix}${f.name}`],
+    );
+
+  it("inlines a spread declared inside a record body", () => {
+    // The nested form. Expanding only the schema-level one leaves `address` a
+    // childless record, which every consumer then counts as a single leaf.
+    const schema = {
+      fields: [
+        field("id"),
+        { ...field("address", "record", []), hasSpreads: true, spreads: ["address_fields"] },
+      ],
+      hasSpreads: false,
+      spreads: [],
+    };
+    assert.deepEqual(expandDeclaredFields(schema, null, resolveRef, lookup), [
+      field("id"),
+      {
+        ...field("address", "record", [
+          { ...field("street"), fromFragment: "address_fields" },
+          { ...field("city"), fromFragment: "address_fields" },
+        ]),
+      },
+    ]);
+  });
+
+  it("appends a schema-level spread's fields after the ones written out", () => {
+    // Declaration order is part of the contract: consumers zip the expanded
+    // list against their own field entries by position.
+    const schema = { fields: [field("id")], hasSpreads: true, spreads: ["address_fields"] };
+    assert.deepEqual(leaves(expandDeclaredFields(schema, null, resolveRef, lookup)), [
+      "id",
+      "street",
+      "city",
+    ]);
+  });
+
+  it("expands both forms in one call", () => {
+    const schema = {
+      fields: [
+        { ...field("address", "record", []), hasSpreads: true, spreads: ["address_fields"] },
+      ],
+      hasSpreads: true,
+      spreads: ["address_fields"],
+    };
+    assert.deepEqual(leaves(expandDeclaredFields(schema, null, resolveRef, lookup)), [
+      "address.street",
+      "address.city",
+      "street",
+      "city",
+    ]);
+  });
+
+  it("never mutates the entity it was given", () => {
+    // Nested expansion works in place, and index records are shared with every
+    // other command in the process — expanding for coverage must not leave the
+    // index holding fields the author did not write there.
+    const address = {
+      ...field("address", "record", []),
+      hasSpreads: true,
+      spreads: ["address_fields"],
+    };
+    const schema = { fields: [address], hasSpreads: false, spreads: [] };
+    expandDeclaredFields(schema, null, resolveRef, lookup);
+    assert.deepEqual(address.children, [], "the caller's field tree is untouched");
+    assert.deepEqual(address.spreads, ["address_fields"], "and still records its spread");
+  });
+
+  it("returns nothing for an absent entity rather than throwing", () => {
+    // Resolvers hand back null for a reference they cannot resolve; coverage is
+    // not a validation pass and must carry on reporting the schemas it did find.
+    assert.deepEqual(expandDeclaredFields(null, null, resolveRef, lookup), []);
   });
 });

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -21,10 +21,11 @@
  */
 
 import type { Tree } from "./parser-utils";
-import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
+import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
 import {
   computeMappingCoverage as computeCoverage,
+  expandDeclaredFields,
   extractMappings,
   extractNLRefData,
   resolveAllNLRefs,
@@ -33,7 +34,9 @@ import type {
   CoverageField,
   CoverageSchemaDefinition,
   DefinitionLookup,
+  FieldDecl,
   ResolvedNLRef,
+  SpreadEntity,
 } from "@satsuma/core";
 
 // Re-export shared types from core so existing LSP code that imports from
@@ -140,19 +143,73 @@ type DefinitionEntryKind = "schema" | "fragment" | "transform";
  * Only `kind === "schema"` definitions participate: a mapping's source/target
  * blocks may name something the index also knows as another kind, and coverage
  * is defined over declared schema fields.
+ *
+ * Fragment spreads are expanded first. The index records them unresolved — a
+ * spread may name a fragment in a file that was not indexed yet when the schema
+ * was — so this is the first point at which the whole workspace is available to
+ * resolve them against. Skipping it reported `address record { ...address_fields
+ * }` to the gutter as a single childless leaf, while `satsuma coverage` reported
+ * the three leaves the fragment materialises (sl-5nsv).
  */
 function resolveSchema(wsIndex: WorkspaceIndex, schemaId: string): CoverageSchemaDefinition | null {
   const defs = resolveDefinition(wsIndex, schemaId, null);
   const def = defs.find((d) => d.kind === "schema");
   if (!def) return null;
-  return { uri: def.uri, fields: def.fields.map(toCoverageField) };
+  return { uri: def.uri, fields: expandedFields(wsIndex, def).map(toCoverageField) };
 }
 
-/** Project an LSP `FieldInfo` onto core's minimal field shape. */
-function toCoverageField(field: FieldInfo): CoverageField {
+/**
+ * A definition's declared fields with every fragment spread inlined, nested
+ * and block-level alike, applying core's rule so the gutter's field tree is the
+ * one `satsuma coverage` reports on.
+ */
+function expandedFields(wsIndex: WorkspaceIndex, def: DefinitionEntry): FieldDecl[] {
+  const spreadEntity = toSpreadEntity(def);
+  const lookupFragment = (key: string): SpreadEntity | null => {
+    const entry = resolveDefinition(wsIndex, key, null).find(
+      (d) => d.kind === "fragment" || d.kind === "schema",
+    );
+    return entry ? toSpreadEntity(entry) : null;
+  };
+  const resolveRef = (ref: string, currentNs: string | null): string | null => {
+    for (const candidate of currentNs && !ref.includes("::")
+      ? [`${currentNs}::${ref}`, ref]
+      : [ref])
+      if (lookupFragment(candidate)) return candidate;
+    return null;
+  };
+  return expandDeclaredFields(spreadEntity, def.namespace, resolveRef, lookupFragment);
+}
+
+/** Project a `DefinitionEntry` onto core's spread-expansion input shape. */
+function toSpreadEntity(def: DefinitionEntry): SpreadEntity {
+  return {
+    fields: def.fields.map(toFieldDecl),
+    hasSpreads: (def.spreads?.length ?? 0) > 0,
+    spreads: def.spreads ?? [],
+  };
+}
+
+/**
+ * Project an LSP `FieldInfo` onto core's `FieldDecl`, carrying the field's own
+ * unresolved spreads so nested expansion can see them.
+ */
+function toFieldDecl(field: FieldInfo): FieldDecl {
   return {
     name: field.name,
-    line: field.range.start.line,
-    children: field.children.map(toCoverageField),
+    type: field.type ?? "",
+    startRow: field.range.start.line,
+    children: field.children.map(toFieldDecl),
+    hasSpreads: (field.spreads?.length ?? 0) > 0,
+    spreads: field.spreads ?? [],
+  };
+}
+
+/** Project a core `FieldDecl` onto core's minimal coverage field shape. */
+function toCoverageField(field: FieldDecl): CoverageField {
+  return {
+    name: field.name,
+    ...(field.startRow !== undefined ? { line: field.startRow } : {}),
+    children: (field.children ?? []).map(toCoverageField),
   };
 }

--- a/tooling/satsuma-lsp/test/coverage.test.js
+++ b/tooling/satsuma-lsp/test/coverage.test.js
@@ -93,3 +93,93 @@ mapping load {
     );
   });
 });
+
+// ── Fragment spreads (sl-5nsv) ──────────────────────────────────────────────
+//
+// The gutter and the status bar must show what `satsuma coverage` shows, and a
+// spread is the case where they did not: the index records spreads unresolved
+// (a spread may name a fragment in a file not indexed yet), and the adapter
+// used to hand core the unexpanded tree — so `address record {
+// ...address_fields }` reached the gutter as one childless leaf.
+//
+// The two fixtures are shared, deliberately, with the CLI suite
+// (satsuma-cli/test/coverage.test.ts) and the viz-backend suite: same file,
+// same expected leaves and totals in all three, so a divergence fails a test
+// rather than showing up as two numbers on one reviewer's screen.
+
+describe("LSP coverage adapter — fragment spreads", () => {
+  const { readFileSync } = require("node:fs");
+  const { resolve } = require("node:path");
+
+  /** Fixtures live in the CLI package because the CLI suite asserts on them too. */
+  const fixture = (name) =>
+    readFileSync(resolve(__dirname, "../../satsuma-cli/test/fixtures", name), "utf8");
+
+  it("reports the leaves a spread materialises inside a record body", () => {
+    // The CLI reports 2/5 for this file with `address` partly covered; before
+    // the adapter expanded spreads the gutter reported 1/3 with `address` fully
+    // covered — the same file, two numbers, and the more flattering one wrong.
+    const target = coverage(fixture("nested-record-spread.stm"), "customer_map").schemas.find(
+      (s) => s.role === "target",
+    );
+    assert.deepEqual(
+      target.fields.map((f) => [f.path, f.state]),
+      [
+        ["id", "uncovered"],
+        ["name", "uncovered"],
+        ["address", "partial"],
+        ["address.street", "covered"],
+        ["address.city", "covered"],
+        ["address.zip", "uncovered"],
+      ],
+    );
+  });
+
+  it("reports them the same way inside a list_of record body", () => {
+    // A list_of record is a container like any other. The CLI reports 2/4 here.
+    const target = coverage(fixture("list-of-record-spread.stm"), "invoice_load").schemas.find(
+      (s) => s.role === "target",
+    );
+    assert.deepEqual(
+      target.fields.map((f) => [f.path, f.state]),
+      [
+        ["invoice_no", "covered"],
+        ["lines", "partial"],
+        ["lines.sku", "covered"],
+        ["lines.qty", "uncovered"],
+        ["lines.unit_price", "uncovered"],
+      ],
+    );
+  });
+
+  it("keeps two records spread from one fragment independently covered", () => {
+    // The examples/lib/sfdc_fragments.stm shape. Both records materialise a
+    // field named `Street` from the same fragment, so a coverage model keyed by
+    // field *name* — or one that credited the fragment rather than the record
+    // that spreads it — would report ShippingAddress.Street as mapped because
+    // BillingAddress.Street is. Only the billing arrow exists (sl-joeq).
+    const src = `fragment address_fields { Street STRING City STRING }
+schema account {
+  BillingAddress record { ...address_fields }
+  ShippingAddress record { ...address_fields }
+}
+schema src { billing_street STRING }
+mapping load {
+  source { src }
+  target { account }
+  billing_street -> BillingAddress.Street
+}`;
+    const target = coverage(src, "load").schemas.find((s) => s.role === "target");
+    assert.deepEqual(
+      target.fields.map((f) => [f.path, f.state]),
+      [
+        ["BillingAddress", "partial"],
+        ["BillingAddress.Street", "covered"],
+        ["BillingAddress.City", "uncovered"],
+        ["ShippingAddress", "uncovered"],
+        ["ShippingAddress.Street", "uncovered"],
+        ["ShippingAddress.City", "uncovered"],
+      ],
+    );
+  });
+});

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -18,7 +18,7 @@ import {
   sourceRefText as coreSourceRefText,
   fieldNameText as coreFieldNameText,
   extractMetadata,
-  expandEntityFields,
+  expandDeclaredFields,
   makeEntityRefResolver,
   extractFieldTree,
   isMetricSchema,
@@ -276,16 +276,25 @@ function resolveAndStripSpreads(namespaces: NamespaceGroup[]): void {
   const resolveRef = makeEntityRefResolver(entityMap);
   const lookupFragment = (key: string) => entityMap.get(key) ?? null;
 
-  // Expand schema spreads using core and append resulting fields. The schema's
-  // own namespace is the resolution context, so a bare `...audit` inside
-  // `namespace crm` finds the fragment keyed `crm::audit` (sl-22ym).
+  // Expand both spread forms using core, which owns the ordering: nested
+  // record-body spreads first, then the schema-level ones appended. The
+  // schema's own namespace is the resolution context, so a bare `...audit`
+  // inside `namespace crm` finds the fragment keyed `crm::audit` (sl-22ym).
+  //
+  // Expanding only the schema-level form left `address record {
+  // ...address_fields }` as a childless record on the card, so the card
+  // counted it as one leaf where `satsuma coverage` counted the three the
+  // fragment materialises (sl-5nsv).
   for (const ns of namespaces) {
     for (const s of ns.schemas) {
-      if (s.spreads.length === 0) continue;
-      const spreadEntity = schemaToSpreadEntity(s);
-      const expanded = expandEntityFields(spreadEntity, ns.name, resolveRef, lookupFragment);
-      const extraFields: FieldEntry[] = expanded.map((ef) => expandedFieldToEntry(ef));
-      s.fields = [...s.fields, ...extraFields];
+      if (s.spreads.length === 0 && !declaresNestedSpread(s.fields)) continue;
+      const expanded = expandDeclaredFields(
+        schemaToSpreadEntity(s),
+        ns.name,
+        resolveRef,
+        lookupFragment,
+      );
+      s.fields = expanded.map((decl, i) => mergeExpandedField(decl, s.fields[i]));
       // Keep spreads that could not be resolved: the schema card renders them
       // as a "… spreads X" indicator, which beats silently losing the reference.
       s.spreads = s.spreads.filter((name) => resolveRef(name, ns.name) === null);
@@ -319,7 +328,45 @@ function fieldEntryToDecl(fe: FieldEntry): FieldDecl {
     name: fe.name,
     type: fe.type,
     children: fe.children.map(fieldEntryToDecl),
+    hasSpreads: (fe.spreads?.length ?? 0) > 0,
+    spreads: fe.spreads ?? [],
   };
+}
+
+/**
+ * True when any field anywhere in the tree declares a spread in its record
+ * body — the cheap test for "does this schema need the nested pass at all?".
+ */
+function declaresNestedSpread(fields: FieldEntry[]): boolean {
+  return fields.some((f) => (f.spreads?.length ?? 0) > 0 || declaresNestedSpread(f.children));
+}
+
+/**
+ * Reunite one expanded field with the viz data core's expansion does not carry.
+ *
+ * Expansion runs over core's `FieldDecl`, which has no constraints, notes,
+ * comments or source location — so a field that was already declared keeps its
+ * original entry and takes only its (possibly newly materialised) children from
+ * the expansion. Fields with no original are ones a spread introduced, and get
+ * the empty display data {@link expandedFieldToEntry} supplies.
+ *
+ * Positional matching is safe because expansion preserves declaration order and
+ * appends: index i of the result is the original field i for as long as
+ * originals last.
+ */
+function mergeExpandedField(decl: FieldDecl, original: FieldEntry | undefined): FieldEntry {
+  if (!original) return expandedFieldToEntry(decl);
+  const merged: FieldEntry = {
+    ...original,
+    children: (decl.children ?? []).map((child, i) =>
+      mergeExpandedField(child, original.children[i]),
+    ),
+  };
+  // A spread that resolved is gone from the decl; one that did not survives and
+  // stays visible on the card rather than being silently dropped.
+  if (decl.spreads && decl.spreads.length > 0) merged.spreads = decl.spreads;
+  else delete merged.spreads;
+  return merged;
 }
 
 /** Convert a core ExpandedField (FieldDecl) back to a viz FieldEntry for display. */
@@ -650,7 +697,7 @@ function fieldDeclToEntry(decl: FieldDecl, uri: string, cstNode: SyntaxNode | nu
     ? nodeLocation(uri, nameNode)
     : { uri, line: decl.startRow ?? 0, character: decl.startColumn ?? 0 };
 
-  return {
+  const entry: FieldEntry = {
     name: decl.name,
     type,
     constraints,
@@ -660,6 +707,10 @@ function fieldDeclToEntry(decl: FieldDecl, uri: string, cstNode: SyntaxNode | nu
     children: fieldChildren,
     location,
   };
+  // Carried only so resolveAndStripSpreads can expand it; a field whose body
+  // declares no spread carries no key at all.
+  if (decl.spreads && decl.spreads.length > 0) entry.spreads = decl.spreads;
+  return entry;
 }
 
 /**

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -45,6 +45,19 @@ export interface FieldInfo {
   range: Range;
   /** Nested child fields for record/list_of record structures. */
   children: FieldInfo[];
+  /**
+   * Fragments spread into this field's record body (`address record {
+   * ...address_fields }`), as authored — unresolved.
+   *
+   * Recorded rather than resolved because a spread may name a fragment in
+   * another file, which is not indexed yet when this field is. Consumers expand
+   * it once the whole workspace is indexed, through core's
+   * `expandDeclaredFields`. Dropping it here is what left the editor gutter
+   * reporting `address` as one childless leaf while `satsuma coverage` reported
+   * its three spread-materialised leaves (sl-5nsv). Absent when the body
+   * declares no spread.
+   */
+  spreads?: string[];
 }
 
 export interface DefinitionEntry {
@@ -60,6 +73,12 @@ export interface DefinitionEntry {
   namespace: string | null;
   /** Declared fields for schema/fragment definitions. */
   fields: FieldInfo[];
+  /**
+   * Fragments spread into the block body itself, as authored — the
+   * schema-level counterpart of {@link FieldInfo.spreads}, and unresolved for
+   * the same reason. Absent when the block declares no spread.
+   */
+  spreads?: string[];
 }
 
 export interface ReferenceEntry {
@@ -595,6 +614,8 @@ function indexTopLevel(
       ? extractFields(child(node, "schema_body"))
       : [];
 
+  const spreads = fields.length > 0 ? extractBodySpreads(child(node, "schema_body")) : [];
+
   addDefinition(index, qualifiedName, {
     uri,
     range: nodeRange(node),
@@ -602,6 +623,7 @@ function indexTopLevel(
     kind: effectiveKind,
     namespace,
     fields,
+    ...(spreads.length > 0 ? { spreads } : {}),
   });
 
   // Extract references from mapping bodies
@@ -1151,6 +1173,11 @@ function extractFields(body: SyntaxNode | null): FieldInfo[] {
   return fieldTree.fields.map((decl, i) => fieldDeclToInfo(decl, fieldNodes[i] ?? null));
 }
 
+/** Fragments spread directly into a block body, as authored. */
+function extractBodySpreads(body: SyntaxNode | null): string[] {
+  return body ? extractFieldTree(body).spreads : [];
+}
+
 /**
  * Convert a core FieldDecl to an LSP FieldInfo, deriving the Range from
  * the parallel CST field_name node when available, otherwise from the
@@ -1181,7 +1208,12 @@ function fieldDeclToInfo(decl: FieldDecl, cstNode: SyntaxNode | null): FieldInfo
     fieldDeclToInfo(childDecl, nestedNodes[j] ?? null),
   );
 
-  return { name: decl.name, type, range, children: fieldChildren };
+  const info: FieldInfo = { name: decl.name, type, range, children: fieldChildren };
+  // Only present when authored, so a field with no spread carries no key —
+  // the index is compared structurally in places, and an empty array would
+  // read as a declaration that is not there.
+  if (decl.spreads && decl.spreads.length > 0) info.spreads = decl.spreads;
+  return info;
 }
 
 // ---------- Text extraction helpers ----------

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -1192,3 +1192,84 @@ mapping m {
     );
   });
 });
+
+// ---------- Nested (record-body) fragment spreads (sl-5nsv) ----------
+//
+// The model is what the viz card counts coverage from, so a spread it fails to
+// materialise is a field the card cannot count. It expanded schema-level
+// spreads only, leaving `address record { ...address_fields }` a childless
+// record — one leaf where `satsuma coverage` sees three.
+//
+// The fixtures are shared with the CLI suite (satsuma-cli/test/coverage.test.ts)
+// and the LSP suite: the leaf lists below are exactly the paths those two
+// report on the same files, which is the parity claim under test.
+
+describe("nested fragment spreads (sl-5nsv)", () => {
+  const { readFileSync } = require("node:fs");
+  const { resolve } = require("node:path");
+
+  /** Fixtures live in the CLI package because its suite asserts on them too. */
+  const fixture = (name) =>
+    readFileSync(resolve(__dirname, "../../satsuma-cli/test/fixtures", name), "utf8");
+
+  /** Dotted paths of the schema's leaves, the unit coverage is counted in. */
+  const leafPaths = (fields, prefix = "") =>
+    fields.flatMap((f) =>
+      f.children.length > 0 ? leafPaths(f.children, `${prefix}${f.name}.`) : [`${prefix}${f.name}`],
+    );
+
+  const schemaNamed = (source, id) =>
+    vizModel(source)
+      .namespaces.flatMap((ns) => ns.schemas)
+      .find((s) => s.id === id);
+
+  it("materialises a spread inside a record body as that record's children", () => {
+    const customer = schemaNamed(fixture("nested-record-spread.stm"), "customer");
+    assert.deepEqual(leafPaths(customer.fields), [
+      "id",
+      "name",
+      "address.street",
+      "address.city",
+      "address.zip",
+    ]);
+  });
+
+  it("materialises a spread inside a list_of record body the same way", () => {
+    const invoice = schemaNamed(fixture("list-of-record-spread.stm"), "invoice");
+    assert.deepEqual(leafPaths(invoice.fields), [
+      "invoice_no",
+      "lines.sku",
+      "lines.qty",
+      "lines.unit_price",
+    ]);
+  });
+
+  it("keeps the declaring field's own display data when it gains children", () => {
+    // Expansion runs over core's FieldDecl, which carries no constraints, notes
+    // or source location. A record that merely acquires children must keep the
+    // entry the CST gave it, or the card loses its jump link and badges.
+    const src = `fragment address_fields { street STRING }
+schema customer {
+  address record (pii) {
+    ...address_fields
+  }
+}`;
+    const address = schemaNamed(src, "customer").fields[0];
+    assert.deepEqual(address.constraints, ["pii"]);
+    assert.equal(address.location.line, 2, "record keeps its declared position");
+    assert.deepEqual(
+      address.children.map((c) => c.name),
+      ["street"],
+    );
+  });
+
+  it("leaves an unresolvable nested spread visible rather than dropping the field", () => {
+    // A dangling reference must not silently become an empty record: the card
+    // renders what it is given, and a record with no children reads as a
+    // declared leaf.
+    const src = `schema customer { address record { ...nowhere } }`;
+    const address = schemaNamed(src, "customer").fields[0];
+    assert.deepEqual(address.children, []);
+    assert.equal(address.name, "address");
+  });
+});

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -80,6 +80,19 @@ export interface FieldEntry {
   comments: CommentEntry[];
   /** Non-empty when the field has record type; contains the nested field declarations. */
   children: FieldEntry[];
+  /**
+   * Fragments spread into this field's record body (`address record {
+   * ...address_fields }`), as authored.
+   *
+   * Present only while the model is being built: `buildVizModel` resolves
+   * spreads and replaces them with the fields they materialise, so a model
+   * handed to the component has this only for spreads that could not be
+   * resolved. A consumer rendering fields should not need it — it exists so the
+   * expansion pass can see a nested spread at all, which it could not before
+   * sl-5nsv, leaving `address` as a childless record on the card while the CLI
+   * reported its three leaves.
+   */
+  spreads?: string[];
   location: SourceLocation;
 }
 

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@lit-labs/ssr-dom-shim": "^1.6.0",
+        "@satsuma/viz-backend": "file:../satsuma-viz-backend",
         "@types/node": "^22.0.0",
         "c8": "^11.0.0",
         "esbuild": "^0.28.1",
@@ -32,6 +33,22 @@
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
+      }
+    },
+    "../satsuma-viz-backend": {
+      "name": "@satsuma/viz-backend",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core",
+        "@satsuma/viz-model": "file:../satsuma-viz-model",
+        "vscode-languageserver-types": "^3.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
+        "typescript": "^5.9.3"
       }
     },
     "../satsuma-viz-model": {
@@ -551,6 +568,10 @@
     },
     "node_modules/@satsuma/core": {
       "resolved": "../satsuma-core",
+      "link": true
+    },
+    "node_modules/@satsuma/viz-backend": {
+      "resolved": "../satsuma-viz-backend",
       "link": true
     },
     "node_modules/@satsuma/viz-model": {

--- a/tooling/satsuma-viz/package.json
+++ b/tooling/satsuma-viz/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@lit-labs/ssr-dom-shim": "^1.6.0",
+    "@satsuma/viz-backend": "file:../satsuma-viz-backend",
     "@types/node": "^22.0.0",
     "c8": "^11.0.0",
     "esbuild": "^0.28.1",

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -10,8 +10,15 @@ import type {
   NestedArrowBlock,
 } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
-import { forEachMappingArrow, resolveSchemaLocalFieldPath } from "../field-coverage.js";
+import {
+  MAPPING_BODY_SCOPE,
+  forEachMappingArrow,
+  resolveSchemaLocalFieldPath,
+  scopeWithin,
+} from "../field-coverage.js";
+import type { ContainerScope } from "../field-coverage.js";
 import { highlightAtRefs } from "../markdown.js";
+import { qualifyChildArrowPath } from "@satsuma/core/extract";
 
 function sanitizeTestIdSegment(value: string): string {
   const lowered = value.toLowerCase();
@@ -441,14 +448,14 @@ export class SzMappingDetail extends LitElement {
     // hand-rolled loops over the top-level collections missed nested-each arrows
     // (sl-fm0q), and nestedEach-only recursion missed flatten-inside-each
     // (sl-vu22).
-    forEachMappingArrow(m, (a) => {
+    forEachMappingArrow(m, ({ sourceFields, targetField: arrowTarget }) => {
       const targetSchema = this.targetSchema;
       const localTargetPath = targetSchema
-        ? resolveSchemaLocalFieldPath(a.targetField, targetSchema, [m.targetRef])
+        ? resolveSchemaLocalFieldPath(arrowTarget, targetSchema, [m.targetRef])
         : null;
       if (localTargetPath === targetField) {
         for (const sourceSchema of this.sourceSchemas) {
-          for (const sf of a.sourceFields) {
+          for (const sf of sourceFields) {
             const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
             if (!localSourcePath) continue;
             if (!result.has(sourceSchema.qualifiedId))
@@ -475,13 +482,13 @@ export class SzMappingDetail extends LitElement {
     // hand-rolled loops over the top-level collections missed nested-each arrows
     // (sl-fm0q), and nestedEach-only recursion missed flatten-inside-each
     // (sl-vu22).
-    forEachMappingArrow(m, (a) => {
-      const sourceMatches = a.sourceFields.some((sf) => {
+    forEachMappingArrow(m, ({ sourceFields, targetField }) => {
+      const sourceMatches = sourceFields.some((sf) => {
         const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
         return localSourcePath === sourceField;
       });
       if (sourceMatches) {
-        const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [
+        const localTargetPath = resolveSchemaLocalFieldPath(targetField, targetSchema, [
           m.targetRef,
         ]);
         if (localTargetPath) result.add(localTargetPath);
@@ -491,11 +498,15 @@ export class SzMappingDetail extends LitElement {
   }
 
   /** Check if an arrow row should be highlighted. */
-  private _isArrowHighlighted(a: ArrowEntry): boolean {
+  private _isArrowHighlighted(a: ArrowEntry, scope: ContainerScope): boolean {
     if (this._hoveredArrow === a) return true;
     if (!this._hoveredCardField || !this._hoveredCardSchema) return false;
 
     const m = this.mapping!;
+    // Card fields are declared paths, so the arrow's authored path has to be
+    // qualified against its container before the two can be compared — without
+    // it, hovering `parcels.line1` never lit the `.line1 -> .line1` row that
+    // populates it (3cdd-yavi).
     if (m.sourceRefs.includes(this._hoveredCardSchema)) {
       const sourceSchema = this.sourceSchemas.find(
         (schema) => schema.qualifiedId === this._hoveredCardSchema,
@@ -503,16 +514,23 @@ export class SzMappingDetail extends LitElement {
       return (
         !!sourceSchema &&
         a.sourceFields.some((sf) => {
-          const localSourcePath = resolveSchemaLocalFieldPath(sf, sourceSchema, m.sourceRefs);
+          const qualified = qualifyChildArrowPath(sf, scope.source);
+          const localSourcePath = resolveSchemaLocalFieldPath(
+            qualified,
+            sourceSchema,
+            m.sourceRefs,
+          );
           return localSourcePath === this._hoveredCardField;
         })
       );
     } else if (this._hoveredCardSchema === m.targetRef) {
       const targetSchema = this.targetSchema;
       if (!targetSchema) return false;
-      const localTargetPath = resolveSchemaLocalFieldPath(a.targetField, targetSchema, [
-        m.targetRef,
-      ]);
+      const localTargetPath = resolveSchemaLocalFieldPath(
+        qualifyChildArrowPath(a.targetField, scope.target),
+        targetSchema,
+        [m.targetRef],
+      );
       return localTargetPath === this._hoveredCardField;
     }
     return false;
@@ -655,10 +673,12 @@ export class SzMappingDetail extends LitElement {
             </tr>
           </thead>
           <tbody>
-            ${m.arrows.map((a) => this._renderArrowRow(a, ""))}
-            ${m.eachBlocks.map((eb) => this._renderEachSection(eb, ""))}
-            ${m.flattenBlocks.map((fb) => this._renderFlattenSection(fb, ""))}
-            ${m.nestedArrows.map((na) => this._renderNestedArrowSection(na, ""))}
+            ${m.arrows.map((a) => this._renderArrowRow(a, "", MAPPING_BODY_SCOPE))}
+            ${m.eachBlocks.map((eb) => this._renderEachSection(eb, "", MAPPING_BODY_SCOPE))}
+            ${m.flattenBlocks.map((fb) => this._renderFlattenSection(fb, "", MAPPING_BODY_SCOPE))}
+            ${m.nestedArrows.map((na) =>
+              this._renderNestedArrowSection(na, "", MAPPING_BODY_SCOPE),
+            )}
           </tbody>
         </table>
       </div>
@@ -667,8 +687,17 @@ export class SzMappingDetail extends LitElement {
 
   // sectionPrefix disambiguates arrow rows that share a target field across
   // nested each/flatten sections (sl-eikr). Empty string for top-level rows.
-  private _renderArrowRow(a: ArrowEntry, sectionPrefix: string): TemplateResult {
-    const hl = this._isArrowHighlighted(a) ? "hl" : "";
+  //
+  // `scope` is the container the row sits in. The row *renders* the paths as
+  // authored — `.line1` under its `each` heading is what the author wrote — but
+  // deciding whether it lights up when a card field is hovered is a resolution
+  // question, and resolution needs the absolute path (3cdd-yavi).
+  private _renderArrowRow(
+    a: ArrowEntry,
+    sectionPrefix: string,
+    scope: ContainerScope,
+  ): TemplateResult {
+    const hl = this._isArrowHighlighted(a, scope) ? "hl" : "";
     const noteEntry = a.metadata.find((m) => m.key === "note");
     const targetId = sanitizeTestIdSegment(a.targetField);
     const rowTestId = sectionPrefix
@@ -724,9 +753,14 @@ export class SzMappingDetail extends LitElement {
     return html`<span class="transform-nl">${unsafeHTML(highlightAtRefs(t.text))}</span>`;
   }
 
-  private _renderEachSection(eb: EachBlock, parentPrefix: string): TemplateResult {
+  private _renderEachSection(
+    eb: EachBlock,
+    parentPrefix: string,
+    parentScope: ContainerScope,
+  ): TemplateResult {
     const sectionId = sanitizeTestIdSegment(`each-${eb.targetField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
+    const scope = scopeWithin(parentScope, eb);
     return html`
       <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
@@ -736,16 +770,21 @@ export class SzMappingDetail extends LitElement {
           </div>
         </td>
       </tr>
-      ${eb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix))}
-      ${eb.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix))}
-      ${eb.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix))}
-      ${eb.nestedArrows.map((na) => this._renderNestedArrowSection(na, sectionPrefix))}
+      ${eb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix, scope))}
+      ${eb.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix, scope))}
+      ${eb.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix, scope))}
+      ${eb.nestedArrows.map((na) => this._renderNestedArrowSection(na, sectionPrefix, scope))}
     `;
   }
 
-  private _renderFlattenSection(fb: FlattenBlock, parentPrefix: string): TemplateResult {
+  private _renderFlattenSection(
+    fb: FlattenBlock,
+    parentPrefix: string,
+    parentScope: ContainerScope,
+  ): TemplateResult {
     const sectionId = sanitizeTestIdSegment(`flatten-${fb.sourceField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
+    const scope = scopeWithin(parentScope, fb);
     return html`
       <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
@@ -757,10 +796,10 @@ export class SzMappingDetail extends LitElement {
           </div>
         </td>
       </tr>
-      ${fb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix))}
-      ${fb.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix))}
-      ${fb.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix))}
-      ${fb.nestedArrows.map((na) => this._renderNestedArrowSection(na, sectionPrefix))}
+      ${fb.arrows.map((a) => this._renderArrowRow(a, sectionPrefix, scope))}
+      ${fb.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix, scope))}
+      ${fb.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix, scope))}
+      ${fb.nestedArrows.map((na) => this._renderNestedArrowSection(na, sectionPrefix, scope))}
     `;
   }
 
@@ -768,9 +807,14 @@ export class SzMappingDetail extends LitElement {
   // arrows the way each/flatten group a list's, so it renders as the same kind
   // of scope section. Before svdfe-s6we these blocks were absent from the model
   // and their arrows simply missing from this table.
-  private _renderNestedArrowSection(na: NestedArrowBlock, parentPrefix: string): TemplateResult {
+  private _renderNestedArrowSection(
+    na: NestedArrowBlock,
+    parentPrefix: string,
+    parentScope: ContainerScope,
+  ): TemplateResult {
     const sectionId = sanitizeTestIdSegment(`nested-${na.targetField}`);
     const sectionPrefix = parentPrefix ? `${parentPrefix}-${sectionId}` : sectionId;
+    const scope = scopeWithin(parentScope, na);
     return html`
       <tr class="scope-section" data-testid=${`${this.testIdPrefix}-${sectionPrefix}`}>
         <td colspan="4">
@@ -780,10 +824,10 @@ export class SzMappingDetail extends LitElement {
           </div>
         </td>
       </tr>
-      ${na.arrows.map((a) => this._renderArrowRow(a, sectionPrefix))}
-      ${na.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix))}
-      ${na.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix))}
-      ${na.nestedArrows.map((nn) => this._renderNestedArrowSection(nn, sectionPrefix))}
+      ${na.arrows.map((a) => this._renderArrowRow(a, sectionPrefix, scope))}
+      ${na.nestedEach.map((ne) => this._renderEachSection(ne, sectionPrefix, scope))}
+      ${na.nestedFlatten.map((nf) => this._renderFlattenSection(nf, sectionPrefix, scope))}
+      ${na.nestedArrows.map((nn) => this._renderNestedArrowSection(nn, sectionPrefix, scope))}
     `;
   }
 

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -5,6 +5,9 @@ import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
 import { isCoveredFieldPath } from "@satsuma/core/coverage-paths";
+import { fieldCoverageFromCoveredPaths } from "@satsuma/core/coverage";
+import { summarizeFieldCoverage, countContainerStates } from "@satsuma/core/coverage-rollup";
+import type { CoverageTotals, ContainerStateCounts } from "@satsuma/core/coverage-rollup";
 import {
   HEADER_HEIGHT,
   META_PILL_ROW_GAP,
@@ -597,8 +600,7 @@ export class SzSchemaCard extends LitElement {
 
     if (this.compact) return this._renderCompact(s);
 
-    const totalFields = this._countFields(s.fields);
-    const mappedCount = this._countMapped(s.fields);
+    const { totals, containers } = this._coverage(s);
     const hasNotes = s.notes.length > 0;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
@@ -613,7 +615,12 @@ export class SzSchemaCard extends LitElement {
         >
           ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
-          <span class="header-count">${mappedCount}/${totalFields}</span>
+          <span
+            class="header-count"
+            data-testid=${`${this.testIdPrefix}-header-count`}
+            title=${this._coverageTitle(totals, containers)}
+            >${totals.covered}/${totals.total}</span
+          >
           <span
             class="header-toggle"
             ?data-collapsed=${this._collapsed}
@@ -806,28 +813,55 @@ export class SzSchemaCard extends LitElement {
       .join("\n");
   }
 
-  private _countFields(fields: FieldEntry[]): number {
-    let count = 0;
-    for (const f of fields) {
-      count++;
-      count += this._countFields(f.children);
-    }
-    return count;
+  /**
+   * The card's coverage figures, counted by core.
+   *
+   * **The card does not compute its own denominator** (ADR-034). It used to:
+   * `_countFields`/`_countMapped` counted every node, records included, so one
+   * covered leaf lifted the numerator once per ancestor level and a schema of
+   * `amount` plus `address record { city, line1, postcode }` with only
+   * `address.city` mapped read as 2/5 — 40% — where `satsuma coverage` reported
+   * 25% and the VS Code status bar reported something different again (sl-hcan).
+   * Coverage is counted in *leaves* because a record is structure, not data:
+   * counting it alongside its children counts the same data twice and lets
+   * nesting depth move the percentage on its own.
+   *
+   * Container states come back beside the ratio rather than inside it — a
+   * reviewer wants to know two records are partly mapped, but that fact must not
+   * enter the number.
+   */
+  private _coverage(s: SchemaCard): {
+    totals: CoverageTotals;
+    containers: ContainerStateCounts;
+  } {
+    const entries = fieldCoverageFromCoveredPaths(s.fields, s.location.uri, this.mappedFields);
+    return {
+      totals: summarizeFieldCoverage(entries),
+      containers: countContainerStates(entries),
+    };
   }
 
-  private _countMapped(fields: FieldEntry[], prefix = ""): number {
-    let count = 0;
-    for (const f of fields) {
-      const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
-      if (isCoveredFieldPath(fieldPath, this.mappedFields)) count++;
-      count += this._countMapped(f.children, fieldPath);
-    }
-    return count;
+  /**
+   * Tooltip spelling out what the `covered/total` header count means, since the
+   * bare ratio cannot say that records are excluded from it, nor that some of
+   * them are partly mapped. Partly-mapped records are the reviewable state — a
+   * record every leaf of which is covered needs no attention, and one with no
+   * covered leaf is already visible as uncovered rows — so only that count is
+   * worth a phrase of its own.
+   */
+  private _coverageTitle(totals: CoverageTotals, containers: ContainerStateCounts): string {
+    const ratio = `${totals.covered}/${totals.total} leaf fields mapped (${totals.pct}%)`;
+    if (containers.partial === 0) return ratio;
+    const noun = containers.partial === 1 ? "record" : "records";
+    return `${ratio} — ${containers.partial} ${noun} partly mapped`;
   }
 
   private _renderCompact(s: SchemaCard) {
     const displayName = s.id;
-    const totalFields = this._countFields(s.fields);
+    // Leaf count, the same unit the expanded card's ratio is denominated in
+    // (ADR-034). One card must not answer "how many fields?" two ways depending
+    // on whether it happens to be compact.
+    const totalFields = this._coverage(s).totals.total;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
 

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -6,6 +6,7 @@
  */
 
 import { buildCoveredFieldSet, schemaLocalFieldPath } from "@satsuma/core/coverage-paths";
+import { qualifyChildArrowPath } from "@satsuma/core/extract";
 import type {
   ArrowEntry,
   EachBlock,
@@ -80,8 +81,33 @@ export function resolveSchemaLocalFieldPath(
 }
 
 /**
+ * One arrow as the walk hands it to a visitor: the model's entry, plus the
+ * paths it references resolved against the containers it sits inside.
+ *
+ * The two are separate because the model and the resolvers want different
+ * things from the same arrow. The model deliberately stores paths **as
+ * authored** — `.line1 -> .line1` renders in the mapping-detail table under the
+ * `each parcels -> packed` heading that gives it its meaning, and a row showing
+ * the expanded `parcels.line1` there would be noise the author did not write.
+ * Anything matching an arrow against a *declared field*, on the other hand,
+ * needs the absolute path, because that is the only form a schema declares.
+ */
+export interface MappingArrowVisit {
+  /**
+   * The arrow exactly as the model holds it — authored paths, and the same
+   * object identity the renderer uses for hover and highlight comparisons.
+   */
+  arrow: ArrowEntry;
+  /** `arrow.sourceFields`, each made absolute against the enclosing containers. */
+  sourceFields: string[];
+  /** `arrow.targetField`, made absolute against the enclosing containers. */
+  targetField: string;
+}
+
+/**
  * Walk every arrow in a mapping, including those nested arbitrarily deep inside
- * `each`, `flatten` and `nested_arrow` blocks in any combination.
+ * `each`, `flatten` and `nested_arrow` blocks in any combination, resolving each
+ * one's paths against the containers it is authored inside.
  *
  * All three container kinds carry the same nesting collections, so one
  * recursion handles them rather than each block type getting its own
@@ -95,10 +121,17 @@ export function resolveSchemaLocalFieldPath(
  * opens an iteration scope and is NOT an arrow, but a `nested_arrow` header
  * genuinely maps record to record (`addr -> address`) and IS one — it is
  * visited as a synthesized {@link ArrowEntry} before the block's body.
+ *
+ * **Path qualification** is core's rule ({@link qualifyChildArrowPath}), applied
+ * with the container's own already-qualified paths as the prefix so it
+ * accumulates through arbitrary nesting — the same recursion core's
+ * `collectArrowRecords` performs over the CST. Every resolution-dependent
+ * surface reaches its arrows through this walk, so applying the rule once here
+ * is what keeps them all agreeing with the CLI (3cdd-yavi).
  */
 export function forEachMappingArrow(
   mapping: MappingBlock,
-  visit: (arrow: ArrowEntry) => void,
+  visit: (entry: MappingArrowVisit) => void,
 ): void {
   // The model stores a nested_arrow's own record→record mapping as header
   // fields on the block; reconstitute it as the arrow core counts it as.
@@ -111,17 +144,74 @@ export function forEachMappingArrow(
     location: block.location,
   });
 
-  const visitBlocks = (blocks: Array<EachBlock | FlattenBlock | NestedArrowBlock>): void => {
+  /** Visit one arrow, qualified against the container scope it was found in. */
+  const visitArrow = (arrow: ArrowEntry, scope: ContainerScope): void => {
+    visit({
+      arrow,
+      sourceFields: arrow.sourceFields.map((f) => qualifyChildArrowPath(f, scope.source)),
+      targetField: qualifyChildArrowPath(arrow.targetField, scope.target),
+    });
+  };
+
+  const visitBlocks = (
+    blocks: Array<EachBlock | FlattenBlock | NestedArrowBlock>,
+    outer: ContainerScope,
+  ): void => {
     for (const block of blocks) {
-      for (const arrow of block.arrows) visit(arrow);
-      for (const nested of block.nestedArrows) visit(headerArrowOf(nested));
-      visitBlocks([...block.nestedEach, ...block.nestedFlatten, ...block.nestedArrows]);
+      // The block's own header is relative to the block enclosing it, and its
+      // qualified form is the prefix everything inside it resolves against.
+      const scope = scopeWithin(outer, block);
+      for (const arrow of block.arrows) visitArrow(arrow, scope);
+      for (const nested of block.nestedArrows) {
+        visitArrow(headerArrowOf(nested), scope);
+      }
+      visitBlocks([...block.nestedEach, ...block.nestedFlatten, ...block.nestedArrows], scope);
     }
   };
 
-  for (const arrow of mapping.arrows) visit(arrow);
-  for (const nested of mapping.nestedArrows) visit(headerArrowOf(nested));
-  visitBlocks([...mapping.eachBlocks, ...mapping.flattenBlocks, ...mapping.nestedArrows]);
+  for (const arrow of mapping.arrows) visitArrow(arrow, MAPPING_BODY_SCOPE);
+  for (const nested of mapping.nestedArrows) {
+    visitArrow(headerArrowOf(nested), MAPPING_BODY_SCOPE);
+  }
+  visitBlocks(
+    [...mapping.eachBlocks, ...mapping.flattenBlocks, ...mapping.nestedArrows],
+    MAPPING_BODY_SCOPE,
+  );
+}
+
+/**
+ * The absolute source and target paths that child arrows inside a container
+ * resolve against. Null on a side means "no container" — at mapping-body level,
+ * or when a malformed block declares no path on that side.
+ */
+export interface ContainerScope {
+  /** Absolute source path of the enclosing container chain. */
+  source: string | null;
+  /** Absolute target path of the enclosing container chain. */
+  target: string | null;
+}
+
+/** Mapping-body level: arrows there are already absolute. */
+export const MAPPING_BODY_SCOPE: ContainerScope = { source: null, target: null };
+
+/**
+ * The scope inside `block`, given the scope the block itself sits in.
+ *
+ * A block's header is authored relative to its own container (`each .parcels ->
+ * .packed` inside another `each`), so the header is qualified first and the
+ * result becomes the prefix for everything the block contains — which is how
+ * one rule covers nesting of any depth. An empty path on either side (a
+ * malformed block) leaves that side unprefixed rather than producing a path
+ * with a dangling dot.
+ */
+export function scopeWithin(
+  outer: ContainerScope,
+  block: EachBlock | FlattenBlock | NestedArrowBlock,
+): ContainerScope {
+  return {
+    source: qualifyChildArrowPath(block.sourceField, outer.source) || null,
+    target: qualifyChildArrowPath(block.targetField, outer.target) || null,
+  };
 }
 
 /**
@@ -150,15 +240,18 @@ export function buildMappingCoveredFields(
 
   const targetFieldRefs: string[] = [];
 
-  forEachMappingArrow(mapping, (arrow) => {
+  // Resolution reads the *qualified* paths: `.line1` under `each parcels ->
+  // packed` declares no field on its own, and matching it as authored resolved
+  // to nothing, so every relative-path arrow contributed no coverage (3cdd-yavi).
+  forEachMappingArrow(mapping, ({ sourceFields, targetField }) => {
     if (targetSchema) {
-      const targetPath = resolveSchemaLocalFieldPath(arrow.targetField, targetSchema, [
+      const targetPath = resolveSchemaLocalFieldPath(targetField, targetSchema, [
         mapping.targetRef,
       ]);
       if (targetPath) targetFieldRefs.push(targetPath);
     }
 
-    for (const sourceField of arrow.sourceFields) {
+    for (const sourceField of sourceFields) {
       for (const schema of sourceSchemas) {
         const localPath = resolveSchemaLocalFieldPath(sourceField, schema, mapping.sourceRefs);
         if (localPath) sourceFieldRefs.get(schema.qualifiedId)!.push(localPath);

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -18,7 +18,14 @@ import type {
   FlattenBlock,
   NestedArrowBlock,
 } from "../model.js";
-import { resolveSchemaLocalFieldPath, type FieldPathCard } from "../field-coverage.js";
+import {
+  MAPPING_BODY_SCOPE,
+  resolveSchemaLocalFieldPath,
+  scopeWithin,
+  type ContainerScope,
+  type FieldPathCard,
+} from "../field-coverage.js";
+import { qualifyChildArrowPath } from "@satsuma/core/extract";
 import { metricFieldEntries } from "../metric-adapter.js";
 import {
   HEADER_HEIGHT,
@@ -710,10 +717,23 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
   };
 
   for (const m of mappings) {
-    const addArrowEdges = (arrows: ArrowEntry[], prefix: string, scope?: EdgeScope) => {
+    const addArrowEdges = (
+      arrows: ArrowEntry[],
+      prefix: string,
+      container: ContainerScope,
+      scope?: EdgeScope,
+    ) => {
       for (let i = 0; i < arrows.length; i++) {
         const a = arrows[i];
-        const sourceField = a.sourceFields[0] ?? a.targetField;
+        // Ports are keyed by declared field path, so an arrow authored
+        // element-relative inside a container (`.line1 -> .line1`) has to be
+        // qualified against that container before findPort can match it. Until
+        // 3cdd-yavi every such arrow resolved to no port and its edge was
+        // silently skipped, so nested-iteration mappings drew no lines at all.
+        const targetField = qualifyChildArrowPath(a.targetField, container.target);
+        const sourceField = a.sourceFields[0]
+          ? qualifyChildArrowPath(a.sourceFields[0], container.source)
+          : targetField;
         const edgeId = `${prefix}:${i}`;
 
         // Attach the edge to the first source ref whose card actually
@@ -728,7 +748,7 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
             break;
           }
         }
-        const tgtPort = findPort(m.targetRef, a.targetField, "tgt", [m.targetRef]);
+        const tgtPort = findPort(m.targetRef, targetField, "tgt", [m.targetRef]);
 
         // Skip edges with missing ports — ELK throws if a port doesn't exist
         if (!sourceNode || !srcPort || !tgtPort) continue;
@@ -743,14 +763,14 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
           sourceNode,
           targetNode: m.targetRef,
           sourceField,
-          targetField: a.targetField,
+          targetField,
           arrow: a,
           scope,
         });
       }
     };
 
-    addArrowEdges(m.arrows, `${m.id}:arrow`);
+    addArrowEdges(m.arrows, `${m.id}:arrow`, MAPPING_BODY_SCOPE);
 
     // One recursion over all three container kinds, mirroring
     // forEachMappingArrow. Separate per-kind loops here walked nestedEach only,
@@ -762,10 +782,15 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
     const collectBlockEdges = (
       blocks: Array<[EachBlock | FlattenBlock | NestedArrowBlock, EdgeScope | undefined]>,
       prefix: string,
+      outer: ContainerScope,
     ) => {
       for (let j = 0; j < blocks.length; j++) {
         const [block, scope] = blocks[j];
-        addArrowEdges(block.arrows, `${prefix}:${j}`, scope);
+        // The block header is itself relative to the block enclosing it, so its
+        // qualified form — not its authored text — is what its children resolve
+        // against. This is core's accumulation rule, one level per recursion.
+        const container = scopeWithin(outer, block);
+        addArrowEdges(block.arrows, `${prefix}:${j}`, container, scope);
         collectBlockEdges(
           [
             ...block.nestedEach.map((b): [EachBlock, EdgeScope] => [b, "each"]),
@@ -773,20 +798,24 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
             ...block.nestedArrows.map((b): [NestedArrowBlock, EdgeScope | undefined] => [b, scope]),
           ],
           `${prefix}:${j}:nested`,
+          container,
         );
       }
     };
     collectBlockEdges(
       m.eachBlocks.map((b): [EachBlock, EdgeScope] => [b, "each"]),
       `${m.id}:eb`,
+      MAPPING_BODY_SCOPE,
     );
     collectBlockEdges(
       m.flattenBlocks.map((b): [FlattenBlock, EdgeScope] => [b, "flatten"]),
       `${m.id}:flat`,
+      MAPPING_BODY_SCOPE,
     );
     collectBlockEdges(
       m.nestedArrows.map((b): [NestedArrowBlock, EdgeScope | undefined] => [b, undefined]),
       `${m.id}:na`,
+      MAPPING_BODY_SCOPE,
     );
   }
 }

--- a/tooling/satsuma-viz/test/coverage-parity.test.js
+++ b/tooling/satsuma-viz/test/coverage-parity.test.js
@@ -1,0 +1,110 @@
+/**
+ * coverage-parity.test.js — The viz card and `satsuma coverage` report one number.
+ *
+ * Feature 36's overlay is only worth building if its figures equal the CLI's,
+ * and that guarantee had no test that would fail if it broke (sl-5nsv). This
+ * file supplies it end to end on the viz side: parse a fixture, build the model
+ * through `@satsuma/viz-backend` exactly as the VS Code host does, derive the
+ * covered-field set the card is given, and count it the way the card counts.
+ *
+ * The expected figures are the ones `satsuma coverage --json` prints for the
+ * same files, asserted in satsuma-cli/test/coverage.test.ts, and the same leaves
+ * the editor gutter reports, asserted in satsuma-lsp/test/coverage.test.js. One
+ * fixture, three suites, one set of numbers — change one and the others fail.
+ *
+ * `@satsuma/viz-backend` is a devDependency here for exactly this: the runtime
+ * dependency still runs component → core only, and nothing in the bundle
+ * changes.
+ */
+import "./dom-shim.js";
+import { before, describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  countContainerStates,
+  fieldCoverageFromCoveredPaths,
+  getParser,
+  initParser,
+  summarizeFieldCoverage,
+} from "@satsuma/core";
+import { createWorkspaceIndex, indexFile } from "@satsuma/viz-backend/workspace-index";
+import { buildVizModel } from "@satsuma/viz-backend/viz-model";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+/** Fixtures live in the CLI package because its suite asserts on them too. */
+const FIXTURES = resolve(__dirname, "../../satsuma-cli/test/fixtures");
+
+/** @type {typeof import("../dist/satsuma-viz.js")} */
+let viz;
+
+before(async () => {
+  await initParser(WASM_PATH);
+  viz = await import("../dist/satsuma-viz.js");
+});
+
+/**
+ * Coverage of one target schema as the card computes it: model from the
+ * backend, covered set from the mapping's arrows, counting from core.
+ */
+function targetCoverage(fixtureName, schemaId) {
+  const uri = `file://${resolve(FIXTURES, fixtureName)}`;
+  const tree = getParser().parse(readFileSync(resolve(FIXTURES, fixtureName), "utf8"));
+  const index = createWorkspaceIndex();
+  indexFile(index, uri, tree);
+  const model = buildVizModel(uri, tree, index);
+
+  const schemas = model.namespaces.flatMap((ns) => ns.schemas);
+  const schema = schemas.find((s) => s.id === schemaId);
+  const mapping = model.namespaces.flatMap((ns) => ns.mappings)[0];
+  const { targetMapped } = viz.buildMappingCoveredFields(mapping, [], schema);
+
+  const entries = fieldCoverageFromCoveredPaths(schema.fields, uri, targetMapped);
+  return {
+    leaves: entries.map((f) => [f.path, f.state]),
+    totals: summarizeFieldCoverage(entries),
+    containers: countContainerStates(entries),
+  };
+}
+
+describe("viz coverage equals satsuma coverage (sl-5nsv)", () => {
+  it("agrees leaf for leaf on a record body materialised by a fragment spread", () => {
+    // The CLI reports 2/5 (40%) here with address.street and address.city
+    // covered. Every part of that has to match: the leaf list (the model must
+    // materialise the spread), the verdicts, the container state, and the
+    // percentage.
+    const { leaves, totals, containers } = targetCoverage("nested-record-spread.stm", "customer");
+    assert.deepEqual(leaves, [
+      ["id", "uncovered"],
+      ["name", "uncovered"],
+      ["address", "partial"],
+      ["address.street", "covered"],
+      ["address.city", "covered"],
+      ["address.zip", "uncovered"],
+    ]);
+    assert.equal(totals.covered, 2);
+    assert.equal(totals.total, 5);
+    assert.equal(totals.pct, 40);
+    assert.deepEqual(containers, { covered: 0, partial: 1, uncovered: 0 });
+  });
+
+  it("agrees on a list_of record body whose arrows are element-relative", () => {
+    // Two fixes meeting on one file: the spread has to materialise `lines`'
+    // leaves (sl-5nsv) and `.item_code -> .sku` inside the `each` has to
+    // resolve against its container (3cdd-yavi). Miss either and the card reads
+    // 0 covered where the CLI reads 2/4.
+    const { leaves, totals } = targetCoverage("list-of-record-spread.stm", "invoice");
+    assert.deepEqual(leaves, [
+      ["invoice_no", "covered"],
+      ["lines", "partial"],
+      ["lines.sku", "covered"],
+      ["lines.qty", "uncovered"],
+      ["lines.unit_price", "uncovered"],
+    ]);
+    assert.equal(totals.covered, 2);
+    assert.equal(totals.total, 4);
+    assert.equal(totals.pct, 50);
+  });
+});

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -1,5 +1,5 @@
 import "./dom-shim.js";
-import { describe, it } from "node:test";
+import { before, describe, it } from "node:test";
 import * as assert from "node:assert/strict";
 
 const loc = { uri: "file:///test.stm", line: 1, character: 0 };
@@ -215,12 +215,12 @@ const arrowAtEveryLevel = () => ({
     {
       sourceField: "items",
       targetField: "lines",
-      arrows: [arrow("items.sku", "lines.sku")],
+      arrows: [arrow(".sku", ".sku")],
       nestedEach: [
         {
-          sourceField: "items.discounts",
-          targetField: "lines.discounts",
-          arrows: [arrow("items.discounts.code", "lines.discounts.code")],
+          sourceField: ".discounts",
+          targetField: ".discounts",
+          arrows: [arrow(".code", ".code")],
           nestedEach: [],
           nestedFlatten: [],
           nestedArrows: [],
@@ -236,7 +236,7 @@ const arrowAtEveryLevel = () => ({
     {
       sourceField: "tags",
       targetField: "invoice",
-      arrows: [arrow("tags.label", "tag_label")],
+      arrows: [arrow(".label", "tag_label")],
       nestedEach: [],
       nestedFlatten: [],
       nestedArrows: [],
@@ -273,13 +273,13 @@ describe("countMappingArrows (sl-fm0q)", () => {
         {
           sourceField: "orders",
           targetField: "orders",
-          arrows: [arrow("orders.id", "orders.id")],
+          arrows: [arrow(".id", ".id")],
           nestedEach: [],
           nestedFlatten: [
             {
-              sourceField: "orders.parcels.contents",
-              targetField: "orders.packed_items",
-              arrows: [arrow("orders.parcels.contents.sku", "orders.packed_items.sku")],
+              sourceField: ".parcels.contents",
+              targetField: ".packed_items",
+              arrows: [arrow(".sku", ".sku")],
               nestedEach: [],
               nestedFlatten: [],
               nestedArrows: [],
@@ -372,5 +372,103 @@ describe("sz-mapping-detail hover lookups recurse into nestedEach (sl-fm0q)", ()
       detail.mapping,
     );
     assert.deepEqual([...targets], ["lines.discounts.code"]);
+  });
+});
+
+// ── Element-relative paths inside containers (3cdd-yavi) ─────────────────────
+//
+// Arrows inside `nested_arrow`, `each` and `flatten` bodies are authored
+// relative to the container (`.line1 -> .line1`, spec §4.6) and the model keeps
+// them that way, because that is what the mapping-detail table shows. Anything
+// matching an arrow against a *declared field* has to qualify first — and until
+// this ticket nothing did, so `resolveSchemaLocalFieldPath(".line1", …)` split
+// to ["", "line1"], matched no field, and every relative-path arrow silently
+// contributed nothing to coverage, hover highlighting or overview edges.
+
+describe("relative arrow paths resolve against their container (3cdd-yavi)", () => {
+  /** @type {typeof import("../dist/satsuma-viz.js")} */
+  let mod;
+
+  const src = schema("s", [field("addr", [field("line1")]), field("orders", [field("id")])]);
+  const tgt = schema("t", [field("address", [field("line1")]), field("orders", [field("id")])]);
+
+  /** A mapping whose only arrow sits inside `blocks`, authored relatively. */
+  const mappingWith = (over) => ({
+    id: "m",
+    sourceRefs: ["s"],
+    targetRef: "t",
+    arrows: [],
+    eachBlocks: [],
+    flattenBlocks: [],
+    nestedArrows: [],
+    sourceBlock: null,
+    notes: [],
+    comments: [],
+    location: loc,
+    ...over,
+  });
+
+  const block = (sourceField, targetField, over = {}) => ({
+    sourceField,
+    targetField,
+    arrows: [],
+    nestedEach: [],
+    nestedFlatten: [],
+    nestedArrows: [],
+    location: loc,
+    ...over,
+  });
+
+  before(async () => {
+    mod = await import("../dist/satsuma-viz.js");
+  });
+
+  it("counts a nested_arrow body's relative arrow as covering the qualified leaf", () => {
+    // The ticket's headline case: `.line1 -> .line1` under `addr -> address`
+    // covers addr.line1 and address.line1 on their respective cards.
+    const mapping = mappingWith({
+      nestedArrows: [block("addr", "address", { arrows: [arrow(".line1", ".line1")] })],
+    });
+    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(mapping, [src], tgt);
+
+    assert.equal(sourceMapped.get("s").has("addr.line1"), true);
+    assert.equal(targetMapped.has("address.line1"), true);
+    // The containers come along as ancestors of a covered leaf, which is what
+    // makes the record row render as touched rather than as a gap.
+    assert.equal(targetMapped.has("address"), true);
+  });
+
+  it("accumulates prefixes through a flatten nested inside an each", () => {
+    // The sl-vu22 shape. Each container level contributes one segment, so the
+    // rule has to compose — a single level of qualification would resolve
+    // `.sku` to `parcels.sku` and still match nothing.
+    const deepSrc = schema("s", [field("orders", [field("parcels", [field("sku")])])]);
+    const deepTgt = schema("t", [field("orders", [field("packed", [field("sku")])])]);
+    const mapping = mappingWith({
+      eachBlocks: [
+        block("orders", "orders", {
+          nestedFlatten: [block(".parcels", ".packed", { arrows: [arrow(".sku", ".sku")] })],
+        }),
+      ],
+    });
+
+    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
+      mapping,
+      [deepSrc],
+      deepTgt,
+    );
+    assert.equal(sourceMapped.get("s").has("orders.parcels.sku"), true);
+    assert.equal(targetMapped.has("orders.packed.sku"), true);
+  });
+
+  it("leaves a mapping-level arrow untouched, dot and all", () => {
+    // At mapping-body level there is no container to resolve against, so a
+    // stray leading dot must stay unresolvable rather than be quietly matched
+    // to a top-level field — coverage must never rise on a malformed path.
+    const mapping = mappingWith({ arrows: [arrow(".orders", ".orders")] });
+    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(mapping, [src], tgt);
+
+    assert.equal(sourceMapped.get("s").has("orders"), false);
+    assert.equal(targetMapped.has("orders"), false);
   });
 });

--- a/tooling/satsuma-viz/test/layout.test.js
+++ b/tooling/satsuma-viz/test/layout.test.js
@@ -186,10 +186,10 @@ describe("computeLayout", () => {
     // Pins collectBlockEdges' unified recursion: the previous per-kind loops
     // walked nestedEach only, so arrows under a flatten nested in an each (the
     // sl-vu22 shape) got no edges, and nested_arrow blocks were absent from the
-    // model entirely. Absolute authored paths are used because relative-path
-    // arrows (.sku -> .sku) do not resolve to ports yet — that is 3cdd-yavi,
-    // and when it lands this fixture's paths can switch to the canonical
-    // relative form.
+    // model entirely. Paths are authored element-relative, as spec §4.6 has
+    // them inside all three container kinds and as the model stores them — the
+    // form that resolved to no port at all, and so drew no edge, until
+    // 3cdd-yavi qualified them against their container.
     const nested = (name, children) => ({ ...field(name, "record"), children });
     const model = {
       uri: "file:///test.stm",
@@ -214,13 +214,13 @@ describe("computeLayout", () => {
                 {
                   sourceField: "orders",
                   targetField: "orders",
-                  arrows: [arrow("orders.id", "orders.id")],
+                  arrows: [arrow(".id", ".id")],
                   nestedEach: [],
                   nestedFlatten: [
                     {
-                      sourceField: "orders.parcels",
+                      sourceField: ".parcels",
                       targetField: ".packed",
-                      arrows: [arrow("orders.parcels.sku", "orders.packed.sku")],
+                      arrows: [arrow(".sku", ".sku")],
                       nestedEach: [],
                       nestedFlatten: [],
                       nestedArrows: [],
@@ -235,7 +235,7 @@ describe("computeLayout", () => {
                 {
                   sourceField: "addr",
                   targetField: "address",
-                  arrows: [arrow("addr.line1", "address.line1")],
+                  arrows: [arrow(".line1", ".line1")],
                   nestedEach: [],
                   nestedFlatten: [],
                   nestedArrows: [],
@@ -309,19 +309,19 @@ describe("computeLayout", () => {
               ...mapping("m", ["s"], "t", [arrow("plain", "plain")]),
               eachBlocks: [
                 eachBlock({
-                  arrows: [arrow("orders.id", "orders.id")],
+                  arrows: [arrow(".id", ".id")],
                   nestedFlatten: [
                     eachBlock({
-                      sourceField: "orders.parcels",
+                      sourceField: ".parcels",
                       targetField: ".packed",
-                      arrows: [arrow("orders.parcels.sku", "orders.packed.sku")],
+                      arrows: [arrow(".sku", ".sku")],
                     }),
                   ],
                   nestedArrows: [
                     eachBlock({
                       sourceField: ".ship",
                       targetField: ".shipping",
-                      arrows: [arrow("orders.ship.carrier", "orders.shipping.carrier")],
+                      arrows: [arrow(".carrier", ".carrier")],
                     }),
                   ],
                 }),
@@ -330,7 +330,7 @@ describe("computeLayout", () => {
                 eachBlock({
                   sourceField: "addr",
                   targetField: "address",
-                  arrows: [arrow("addr.line1", "address.line1")],
+                  arrows: [arrow(".line1", ".line1")],
                 }),
               ],
             },

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -1,0 +1,147 @@
+/**
+ * schema-card-coverage.test.js — What the schema card's header ratio counts.
+ *
+ * The card used to compute its own coverage figures, counting every node —
+ * records included — in both numerator and denominator, so one covered leaf
+ * lifted the numerator once per ancestor level. `satsuma coverage`, the VS Code
+ * status bar and this card then reported three different percentages for one
+ * mapping (sl-hcan). ADR-034 settles the rule — leaves only, on each leaf's own
+ * flag — and states that consumers must not compute their own denominators.
+ *
+ * These cases pin the card's end of that: the figures it renders, and the
+ * depth-invariance property that makes them comparable between schemas. The
+ * counting rule itself is core's, and is tested there.
+ */
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import { buildCoveredFieldSet } from "@satsuma/core/coverage-paths";
+
+const LOC = { uri: "file:///test.stm", line: 0, character: 0 };
+
+/** A leaf field declaration in the viz model's shape. */
+function leaf(name, type = "STRING") {
+  return {
+    name,
+    type,
+    constraints: [],
+    metadata: [],
+    notes: [],
+    comments: [],
+    children: [],
+    location: LOC,
+  };
+}
+
+/** A record field declaration wrapping the given children. */
+function record(name, children) {
+  return { ...leaf(name, "record"), children };
+}
+
+/** A schema card payload carrying nothing but the fields under test. */
+function schemaCard(fields) {
+  return {
+    id: "tgt",
+    qualifiedId: "tgt",
+    kind: "schema",
+    label: null,
+    fields,
+    notes: [],
+    comments: [],
+    metadata: [],
+    location: LOC,
+    hasExternalLineage: false,
+    spreads: [],
+  };
+}
+
+/**
+ * Render a card and return its markup as text, with template values
+ * interleaved in source order — the ratio is `${covered}/${total}`, so only an
+ * interleaved serialization can tell "1/4" from "4/1".
+ */
+function renderText(card) {
+  const serialize = (value) => {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.map(serialize).join("");
+    if (typeof value === "object" && value.strings && "values" in value) {
+      return value.strings
+        .map((s, i) => s + (i < value.values.length ? serialize(value.values[i]) : ""))
+        .join("");
+    }
+    return String(value);
+  };
+  return serialize(card.render());
+}
+
+/** A card bound to `fields`, with `covered` schema-local paths marked mapped. */
+async function makeCard(fields, covered = [], { compact = false } = {}) {
+  const mod = await import("../dist/satsuma-viz.js");
+  const card = new mod.SzSchemaCard();
+  card.schema = schemaCard(fields);
+  card.mappedFields = buildCoveredFieldSet(covered);
+  card.compact = compact;
+  return card;
+}
+
+// The figure named in sl-hcan: one scalar beside a three-leaf record, with a
+// single leaf of that record covered.
+const AMOUNT_AND_ADDRESS = [
+  leaf("amount", "DECIMAL"),
+  record("address", [leaf("city"), leaf("line1"), leaf("postcode")]),
+];
+
+describe("sz-schema-card header ratio (sl-hcan)", () => {
+  it("counts leaves only, excluding the record that contains them", async () => {
+    // 1 of 4 leaves — not 2 of 5, which is what counting `address` itself in
+    // both halves produced. The old figure claimed 40% coverage of a schema
+    // `satsuma coverage` reports as 25%.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, ["address.city"]);
+    assert.match(renderText(card), /header-count[^>]*>1\/4</);
+  });
+
+  it("reports the same ratio however deeply the same leaves are nested", async () => {
+    // Depth invariance is what makes one card's percentage comparable with
+    // another's. Counting containers broke it: re-nesting four leaves three
+    // levels deep moved the denominator without a field being added.
+    const flat = await makeCard([leaf("a"), leaf("b"), leaf("c"), leaf("d")], ["a"]);
+    const deep = await makeCard(
+      [
+        leaf("a"),
+        record("outer", [leaf("b"), record("mid", [leaf("c"), record("in", [leaf("d")])])]),
+      ],
+      ["a"],
+    );
+    assert.match(renderText(flat), /header-count[^>]*>1\/4</);
+    assert.match(renderText(deep), /header-count[^>]*>1\/4</);
+  });
+
+  it("names partly mapped records in the tooltip, keeping them out of the ratio", async () => {
+    // Containers are excluded from the percentage, so the count beside it is
+    // the only place a reviewer learns that a record needs attention. A record
+    // with one covered and two uncovered leaves is the reviewable state.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, ["address.city"]);
+    assert.match(renderText(card), /1\/4 leaf fields mapped \(25%\) — 1 record partly mapped/);
+  });
+
+  it("says nothing about records when none is partly mapped", async () => {
+    // A fully covered or wholly uncovered record is already legible from the
+    // field rows; only the partial state is worth a phrase.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, [
+      "address.city",
+      "address.line1",
+      "address.postcode",
+    ]);
+    const text = renderText(card);
+    assert.match(text, /3\/4 leaf fields mapped \(75%\)/);
+    assert.doesNotMatch(text, /partly mapped/);
+  });
+
+  it("counts fields the same way on a compact card as on an expanded one", async () => {
+    // One card must not answer "how many fields?" two ways depending on which
+    // form it is rendered in — the compact header showed 5 for the schema the
+    // expanded header denominated in 4.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, [], { compact: true });
+    assert.match(renderText(card), /header-count[^>]*>4 fields</);
+  });
+});


### PR DESCRIPTION
Three coverage defects of one class: a consumer answering a question core
already answers, and answering it differently. Together they close feature 38's
cross-consumer requirement (epic `sl-j6g9`, PRD R3/R6) — `satsuma coverage`, the
VS Code gutter and status bar, and the viz card now report one number for one
workspace, and a test fails if that stops being true.

## `sl-hcan` — the viz card counts leaves, via core

`_countFields`/`_countMapped` counted every node, records included, in both
halves of the ratio, so one covered leaf lifted the numerator once per ancestor
level. `amount` plus `address record { city, line1, postcode }` with only
`address.city` mapped read as **2/5 (40%)** where `satsuma coverage` reported
**1/4 (25%)**. ADR-034 had already settled the rule and said consumers must not
compute their own denominators.

Core gains `fieldCoverageFromCoveredPaths` — the entry-building path for a
consumer holding a covered-path *set* rather than a mapping's CST — asserted
equal to `computeMappingCoverage` for the same arrows, plus `countContainerStates`
for the container tally that belongs beside a percentage rather than inside it.
The card's percentage is now depth-invariant, and partly-mapped records are named
in the header tooltip.

## `3cdd-yavi` — element-relative arrow paths resolve against their container

`.line1 -> .line1` under `addr -> address` (spec §4.6) reached
`resolveSchemaLocalFieldPath` as authored, split to `["", "line1"]`, and matched
nothing — so **every arrow inside a `nested_arrow`, `each` or `flatten` body**
was invisible to mapping-detail coverage, hover cross-highlighting and overview
edges. ELK skipped the edge on the missing port with no diagnostic, so
nested-iteration mappings simply drew no lines.

Core's inline prefixing rule is now the exported `qualifyChildArrowPath`, called
by extraction too, so there is one implementation. `forEachMappingArrow`
qualifies as it recurses and hands each visitor the model's arrow plus its
absolute paths; `elk-layout` and the detail view's highlight check thread the
same `ContainerScope`.

## `sl-5nsv` — fragment spreads count in every consumer, and parity is pinned

Found while writing the parity test the ticket asks for. For
`customer { id, name, address record { ...address_fields } }` with two address
leaves mapped: the CLI reported **2/5**, the gutter **1/3** with `address` a
single covered leaf, and the viz model had `address` with **no children at all**.
Every disagreement flattered the number.

Core gains `expandDeclaredFields`, owning both expansion passes and their order
on a copy; the CLI's hand-rolled sequence, the LSP adapter and the viz model
builder all call it. Both consumers needed the declaration to survive indexing
to do so — the shared index dropped `spreads` when projecting fields, and the viz
model dropped nested ones — so both now record them unresolved and expand once
the workspace is complete.

Parity is now tested rather than asserted: two fixtures (the existing
`nested-record-spread.stm`, plus a new `list_of record` one — a shape that
existed nowhere in the repo) checked leaf for leaf, state for state and
percentage for percentage by the CLI, LSP, viz-backend and viz-component suites,
the last of which runs the whole chain: parse → model → covered set → count.
Records spreading one fragment stay independent — mapping `BillingAddress.Street`
leaves `ShippingAddress.Street` uncovered.

## ADR-039

`3cdd-yavi` and `sl-5nsv` are the same defect twice, and the repair is a
convention worth recording: **a consumer's index or model keeps authored
shorthand as written, and resolution happens at the point of use, through core's
rule.** Where that point falls is decided by one question — does the consumer
render the authored text? The detail table renders arrow paths, so they stay
authored; declared fields are not rendered in authored form (ADR-008), so spreads
expand as early as the workspace allows. No existing ADR is superseded. (Numbered 039 — ADR-038 was taken by the whole-structure container-source decision, `3ct-cs4y`, which landed on main while this branch was open; the branch is rebased onto it.)

## Testing

All suites run locally and green:

| package | tests |
| --- | --- |
| satsuma-core | 552 |
| satsuma-cli | 974 |
| satsuma-lsp | 295 |
| satsuma-viz | 111 |
| satsuma-viz-backend | 174 |
| satsuma-viz-model | 6 |
| vscode-satsuma | 34 |
| viz harness (Playwright, firefox + screenshots) | 99 |

`npm audit` clean. The one dependency change is `@satsuma/viz-backend` as a
**devDependency** of `satsuma-viz`, so the end-to-end parity test can build a
model the way the VS Code host does; the runtime graph still runs component →
core only and the bundle grew 1.7 KB (from the core coverage import, tree-shaken).

## Behaviour changes to expect

- Coverage figures on schemas using fragment spreads move, in both directions.
- Coverage on workspaces using nested iteration rises — every arrow inside a
  container was previously uncounted by the viz.
- The viz card's ratio changes on any nested schema (it now excludes records).
- Compact cards count leaves too, so one card no longer answers "how many
  fields?" two ways depending on its form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)