### PR TITLE
docs: nested/repeated data guide, and the Features 35 & 38 exploratory test pass

### DIFF
--- a/.tickets/sl-3de8.md
+++ b/.tickets/sl-3de8.md
@@ -2,7 +2,7 @@
 id: sl-3de8
 status: open
 deps: [sl-ce11]
-links: [sl-9p2t]
+links: [sl-9p2t, sl-46wr, sl-csrs]
 created: 2026-07-31T13:13:41Z
 type: epic
 priority: 1

--- a/.tickets/sl-3fou.md
+++ b/.tickets/sl-3fou.md
@@ -1,0 +1,36 @@
+---
+id: sl-3fou
+status: open
+deps: []
+links: [sl-lnbt]
+created: 2026-08-02T21:41:28Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# lint: unenumerated-record-target proposes a fix that is a parse error for multi-source arrows
+
+The rule's message ends: "Enumerate them (observations { ... }) or map from a record."
+
+For a multi-source arrow neither remedy exists. Spec §4.4 makes a multi-source arrow's body a transform pipeline, not a nesting scope, so
+
+  species_codes, counts -> observations {
+    .species -> .species
+  }
+
+is a parse error ('unexpected {'). And when the sources are scalar lists (list_of STRING), there is no record to map from either. The only working form is one arrow per target leaf:
+
+  species_codes -> observations.species
+  counts -> observations.birds
+
+which coverage reads correctly (3/3). So the author is told to do two things they cannot do, and not told the one they can.
+
+Reproduced against tooling/satsuma-cli 0.11.0.
+
+## Acceptance Criteria
+
+- The message branches on arrow kind: for a multi-source arrow it recommends one arrow per target leaf, not enumeration.
+- The single-source wording is unchanged.
+- A test covers the multi-source case and asserts the recommended remedy actually parses.
+- docs/nested-data/README.md §5 quotes whatever wording ships.
+

--- a/.tickets/sl-46wr.md
+++ b/.tickets/sl-46wr.md
@@ -1,0 +1,43 @@
+---
+id: sl-46wr
+status: open
+deps: []
+links: [sl-csrs, sl-3de8, sl-5nsv]
+created: 2026-08-02T21:40:23Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, coverage, viz, core]
+---
+# viz: coverage ignores the NL @ref tier, so the schema card disagrees with satsuma coverage
+
+The viz derives its own covered-path set in satsuma-viz/src/field-coverage.ts (buildMappingCoveredFields), walking the viz model's arrows. It counts declared arrows only. ADR-036 added a second coverage tier — a leaf named by a *resolved* NL @ref counts as covered — and that rule lives in core's computeMappingCoverage(), which the viz path does not call. So every field covered only by an @ref reads as uncovered on the schema card while satsuma coverage and the VS Code gutter report it covered.
+
+Reproduced across the shipped corpus by computing both paths over every examples/**.stm. Twelve files disagree; the divergence is NL-tier in every case checked:
+
+  examples/db-to-db/pipeline.stm         source legacy_sqlserver   viz 15/21   cli 21/21
+  examples/contracts/buy-to-om-order.stm source buy_order          viz  7/8    cli  8/8
+  examples/edi-to-json/pipeline.stm      source edi_desadv         viz  6/16   cli  7/16
+  examples/multi-source/multi-source-join.stm source order_transactions  viz 0/10  cli 6/10
+  examples/multi-source/multi-source-join.stm source support_tickets     viz 0/8   cli 5/8
+  examples/filter-flatten-governance/governance.stm source finance_transactions  viz 0/16  cli 3/16
+  (also: filter-flatten-governance.stm, json-api-to-parquet, merge-strategies,
+   multi-source-hub, protobuf-to-parquet, sap-po-to-mfcs, xml-to-parquet)
+
+On buy-to-om-order the single differing leaf is tax_amount, which the CLI tags tier=nl and the viz reports uncovered.
+
+This is the failure PRD 38 P3 exists to remove ('one workspace, three completeness figures') and it breaks the epic's acceptance criterion that the CLI, the VS Code status bar and the viz card report identical figures. It also blocks Feature 36 (sl-3de8), whose R2 requires the overlay's numbers to equal coverage --json.
+
+## Design
+
+Root cause is structural: sl-vu22 deleted the duplicate CST walker in core, but the viz kept a third derivation of covered paths over the viz model. Every coverage rule added since — the NL tier (ADR-036), whole-structure conferral (ADR-037) — has to be implemented twice or the viz drifts.
+
+Preferred fix is to stop deriving in the viz: have the host (viz-backend / the VS Code extension) call core's computeMappingCoverage and pass the resulting FieldCoverageEntry list, tiers and all, to the card, which already counts through core's summarizeFieldCoverage/countContainerStates. That subsumes this ticket and 3ct-nlv2's sibling (whole-structure conferral) and prevents the next rule from drifting. If the model-only derivation must stay for the standalone harness, the NL tier must be added to buildMappingCoveredFields and the parity test extended to a fixture that has one.
+
+Note the viz card renders a tier-blind boolean today; ADR-036 requires consumers not to compute their own declared/NL split, so whatever is passed in must carry the tier.
+
+## Acceptance Criteria
+
+The viz path and satsuma coverage --json report identical covered counts, totals and percentages for every file under examples/ — asserted by a sweep-style test or at minimum by extending tooling/satsuma-viz/test/coverage-parity.test.js with a fixture whose coverage includes an nl-tier leaf. examples/contracts/buy-to-om-order.stm reports 8/8 on the source side from the viz path. The parity test fails if the NL tier is removed from either side.
+

--- a/.tickets/sl-5nsv.md
+++ b/.tickets/sl-5nsv.md
@@ -2,7 +2,7 @@
 id: sl-5nsv
 status: closed
 deps: [sl-0pun, sl-hcan, sl-vu22]
-links: []
+links: [sl-46wr]
 created: 2026-07-31T14:44:00Z
 type: task
 priority: 2

--- a/.tickets/sl-8ba4.md
+++ b/.tickets/sl-8ba4.md
@@ -1,0 +1,46 @@
+---
+id: sl-8ba4
+status: open
+deps: []
+links: []
+created: 2026-08-02T21:40:55Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [feature-35, coverage, cli]
+---
+# coverage: --fail-under gates a rounded percentage, so 200/201 passes --fail-under 100
+
+CoverageTotals.pct is Math.round((covered/total)*100) (satsuma-core/src/coverage-rollup.ts:220) and evaluateGate compares that rounded figure (satsuma-cli/src/commands/coverage.ts:499). Any schema large enough for one leaf to be worth less than half a percent therefore passes a 100% gate while a field is unmapped.
+
+Reproduced with a 201-leaf schema, 200 leaves mapped:
+
+  $ satsuma coverage rounding.stm --uncovered
+    source  big_s  200/201  100%
+    target  big_t  200/201  100%
+      uncovered in big_t (target): 1 field
+        f200
+  $ satsuma coverage rounding.stm --fail-under 100 ; echo $?
+  0
+
+The report prints '100%' next to '200/201' and the gate agrees. --fail-under exists so a spec gap blocks a merge; this is the one direction that must not fail open. The threshold 100 is the case a team actually writes for a finished spec, and it is exactly where the rounding bites.
+
+The report itself is also wrong independently of the gate: '200/201  100%' claims completeness. The symmetric case rounds the other way — 1/201 prints '0%' — which is misleading but errs safe.
+
+Verified on the 8/9 case too: --fail-under 89 passes on examples/nested-iteration/pipeline.stm at 88.9%. That direction is defensible if documented; the 100% one is not.
+
+## Design
+
+Two candidate rules, and the choice belongs to the user:
+
+(a) Floor the displayed percentage, except that covered === total reports 100 and covered === 0 reports 0. 200/201 then prints 99% and fails --fail-under 100, and 1/201 prints 0% only when nothing is covered — matching how coverage tools conventionally report.
+(b) Keep Math.round for display but gate on the exact ratio: met = covered/total*100 >= threshold. Fixes the gate, leaves the display claiming 100% for an incomplete spec.
+
+(a) is preferred: the number a reviewer reads and the number CI gates should be the same number, which is why the gate reads pct in the first place. Whichever is chosen, state the rounding rule in the command's help text next to the exit codes — it is part of the gate contract — and note the change in CHANGELOG.md, since existing percentages will move by a point.
+
+The rule belongs in core's percentage() so the CLI, the LSP status bar and the viz card cannot disagree about it.
+
+## Acceptance Criteria
+
+A 201-leaf fixture with 200 leaves mapped reports below 100% and exits 3 under --fail-under 100. A fully-mapped schema reports 100% and exits 0. A schema with no covered leaf reports 0%. The rounding rule is documented in coverage --help and in SATSUMA-CLI.md, and tested at the boundary in core (percentage()) rather than only through the CLI.
+

--- a/.tickets/sl-8vqk.md
+++ b/.tickets/sl-8vqk.md
@@ -1,0 +1,30 @@
+---
+id: sl-8vqk
+status: open
+deps: []
+links: [sl-kezo]
+created: 2026-08-02T21:42:17Z
+type: feature
+priority: 3
+assignee: Thorben Louw
+---
+# grammar: no notation to reference an ancestor field from inside an each/flatten block
+
+Every path inside a container is prefixed with the container's path, so a parent field referenced from inside a block resolves to a path that does not exist:
+
+  flatten transects.sightings -> rows {
+    transects.transect_ref -> transect_ref   // becomes transects.sightings.transects.transect_ref
+  }
+
+  warning [field-not-in-schema] Arrow source 'transects.sightings.transects.transect_ref' not declared in schema 'colony_survey'
+
+For flatten there is a clean workaround: write the arrow outside the block, where fields are row context repeated on every output row. For a *nested each* there is none — "the parent transect's ref populates a field on each child element" cannot be stated structurally and has to go in a note, which lineage and coverage cannot follow.
+
+Candidate notations to weigh: a '^.' parent prefix, a '$.' root prefix, or an explicit binding on the each header (each t in transects). Any of them must keep the existing dot semantics untouched — the prefixing rule is relied on by extraction, coverage, viz and the LSP.
+
+## Acceptance Criteria
+
+- Decide whether an escape notation is wanted; ADR if adopted (the prefixing rule is currently an implicit contract across four consumers).
+- If adopted: grammar, corpus fixture with a parent-to-child-element arrow, extraction, coverage and lineage all resolve it.
+- docs/nested-data/README.md sections 2 and 9 updated.
+

--- a/.tickets/sl-csrs.md
+++ b/.tickets/sl-csrs.md
@@ -1,0 +1,33 @@
+---
+id: sl-csrs
+status: open
+deps: []
+links: [sl-46wr, sl-3de8]
+created: 2026-08-02T21:40:38Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, coverage, viz, core]
+---
+# viz: coverage ignores whole-structure arrow conferral, so a record-to-record arrow reads as a gap
+
+ADR-037 (R5, closes 3cc-iedv) rules that an arrow whose path resolves to a record or list_of record covers that node's entire declared subtree, when the arrow states a correspondence (kind map or nested) and enumerates no child arrows. Core implements it; the viz's own covered-path derivation (satsuma-viz/src/field-coverage.ts, buildMappingCoveredFields) does not, so the leaves under a whole-structure arrow read as uncovered on the schema card.
+
+Reproduced on a minimal fixture with addr -> address (3 leaves), rows -> lines (list_of record, 2 leaves), bill.city -> billing.city and a leaf-into-record arrow:
+
+  source  cli 7/8  88%   viz 2/8  25%
+  target  cli 6/9  67%   viz 1/9  11%
+
+Same divergence for the two conferring forms ADR-037 names explicitly — an empty body (p -> p { }) and a pipe-chain transform body (r -> r { trim }) — while the enumerating form (q -> q { .x -> .x }) agrees, because only the explicit child arrow is counted either way.
+
+Second half of the same root cause as sl-46wr: the viz maintains a third derivation of covered paths, so each coverage rule added to core has to be re-implemented there or the number drifts. The existing parity test (sl-5nsv) only exercises fragment-spread fixtures, which is why both gaps survived.
+
+## Design
+
+Fix with sl-46wr, by having the host pass core's computed FieldCoverageEntry list to the card instead of deriving covered paths from the viz model. If the derivation stays, buildMappingCoveredFields needs the ADR-037 conferral rule — including its two conditions (ExtractedArrow.kind in {map, nested}; enumeratesChildren false) — which requires the viz model to carry the same kind/enumeration signal, and that is itself an argument for deleting the derivation.
+
+## Acceptance Criteria
+
+A viz-path/CLI parity test over a fixture containing a whole-record arrow, a whole-list_of-record arrow, an empty-body arrow and a pipe-chain-body arrow asserts identical leaf verdicts, container states and percentages. The enumerating form still confers only its enumerated children.
+

--- a/.tickets/sl-j6g9.md
+++ b/.tickets/sl-j6g9.md
@@ -27,3 +27,13 @@ Root cause of most of it: the covered set is a flat bag of strings mixing 'an ar
 
 All PRD requirements R1-R7 delivered; the 31 acceptance tests in the PRD pass, including the nine that must fail before the work starts; coverage figures reported by the CLI, the VS Code status bar and the viz card are identical for the same workspace; features/38 PRD open questions resolved and recorded.
 
+
+## Notes
+
+**2026-08-02T21:43:08Z**
+
+Exploratory test pass over the merged feature-35 + feature-38 work (main @ e831be3). All package suites green: core 556, cli 980, lsp 295, viz-backend 174, viz 111, vscode golden 7. Note satsuma-viz needs 'npm install' after b7ff50f — the @satsuma/viz-backend devDependency added by sl-5nsv is absent in stale trees and the parity test then fails to load rather than to assert.
+
+Verified passing against the PRD's acceptance tests: name-shadowing at every depth (AT1-4, AT6 on deep-nested-bugs.stm), nested_arrow (AT7), flatten-in-each on examples/nested-iteration/pipeline.stm reporting 8/9 and 8/8 with orders.parcels.barcode the single gap (AT8, AT29), empty each body and computed-arrow-into-container both uncovered (AT16, AT17, per ADR-037), leaf-only percentages and depth invariance (AT18, AT19), whole-structure conferral including the empty-body and pipe-chain-body forms and the direct-vs-derived distinction (AT22-25, ADR-037/038). CLI, LSP and VS Code paths agree everywhere tested. fields --unmapped-by matches coverage --uncovered leaf for leaf across every mapping in examples/ and the CLI fixtures, with one exception (sl-ymxs).
+
+The epic stays open on its own acceptance criterion — 'coverage figures reported by the CLI, the VS Code status bar and the viz card are identical for the same workspace'. The viz card is not identical: it keeps a third derivation of covered paths (satsuma-viz/src/field-coverage.ts) that implements neither the NL @ref tier (sl-46wr, twelve shipped examples disagree) nor whole-structure conferral (sl-csrs). Also raised: sl-qead (a spread redeclaring an explicit field counts it twice, in the shipped corpus) and sl-lctd (R3/AT21 container state counts never reported by the CLI). Outside this epic: sl-8ba4 (--fail-under gates a rounded percentage, so 200/201 passes --fail-under 100), sl-ymxs, sl-v6rt.

--- a/.tickets/sl-kezo.md
+++ b/.tickets/sl-kezo.md
@@ -1,0 +1,24 @@
+---
+id: sl-kezo
+status: open
+deps: []
+links: [sl-8vqk]
+created: 2026-08-02T21:41:28Z
+type: feature
+priority: 3
+assignee: Thorben Louw
+---
+# grammar: no way to bind the current element of a scalar list inside each
+
+each iterates a list, and arrows inside address the element's *fields* with a leading dot. A list_of TYPE element has no fields, and there is no notation for the element itself — 'each species_codes -> observations { . -> .species }' is a parse error ('unexpected .').
+
+So a scalar list can only be mapped as a whole (species_codes -> observations.species), which is expressive enough for coverage but says nothing about per-element transforms: 'trim and uppercase each tag' has nowhere structural to live and must be prose.
+
+Candidate notations to weigh (none chosen): a bare 'value'/'element' keyword, '.' as an element reference where a path is expected, or 'each tag in tags -> ...' naming the binding. Any of these would also give the zip case (see the linked ticket) something to iterate over.
+
+## Acceptance Criteria
+
+- Decide whether scalar-list iteration is in scope for the language at all, and record the outcome (ADR if yes, roadmap note if no).
+- If yes: grammar rule, corpus fixtures, extraction paths, and coverage semantics for the bound element.
+- docs/nested-data/README.md §9 'known sharp edges' updated either way.
+

--- a/.tickets/sl-lctd.md
+++ b/.tickets/sl-lctd.md
@@ -1,0 +1,32 @@
+---
+id: sl-lctd
+status: open
+deps: []
+links: []
+created: 2026-08-02T21:41:45Z
+type: task
+priority: 3
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, coverage, cli, docs]
+---
+# coverage: container state counts (records covered/partial/uncovered) are never reported by the CLI
+
+PRD 38 R3 requires container states to be reported alongside the percentage — 'records: {covered, partial, uncovered}' — and acceptance test 21 states it as a case. Core implements it (countContainerStates, ContainerStateCounts in satsuma-core/src/coverage-rollup.ts) and the viz card surfaces it in the card's tooltip, but satsuma coverage never does: tooling/satsuma-cli/src/commands/coverage.ts contains no reference to containers in either the human output or --json, and the --json shape documented in its help text has no field for them.
+
+So the reviewer who most needs the signal — the one reading the terminal or gating CI — cannot see that two records are half-mapped, and a JSON consumer cannot reconstruct it, because fields[] lists leaves only.
+
+Everything else in R3 shipped: leaf-only counting, and both former consumer-local denominators (VS Code status bar, viz card) now delegate to core.
+
+## Design
+
+Human output: one line per schema beside the ratio, printed only when there is something to say — the viz card's precedent is to mention partly-mapped records only when partial > 0, and the same restraint suits a terminal report. A record with every leaf covered needs no attention and one with none is already visible in the uncovered list.
+
+--json: add the counts to each schema entry, under both 'mappings' and 'aggregate', and document the key in the help text's JSON shape block alongside covered/total/pct. The counts must come from core's countContainerStates, never recomputed here (ADR-034).
+
+Also state in the help text what the counts are not: they are reported beside the percentage and are excluded from it, since a record is structure rather than data.
+
+## Acceptance Criteria
+
+coverage --json carries container state counts for every schema in both sections, sourced from core. Human output names partly-mapped records when there are any and stays silent when there are none. The PRD 38 acceptance-test-21 fixture (amount + address record {city, line1, postcode}, only address.city mapped) reports 25% with records {covered: 0, partial: 1, uncovered: 0}. The JSON shape in coverage --help and in SATSUMA-CLI.md documents the new key.
+

--- a/.tickets/sl-lnbt.md
+++ b/.tickets/sl-lnbt.md
@@ -1,0 +1,28 @@
+---
+id: sl-lnbt
+status: open
+deps: []
+links: [sl-3fou]
+created: 2026-08-02T21:42:31Z
+type: feature
+priority: 3
+assignee: Thorben Louw
+---
+# lint: an NL @ref naming a record confers no coverage on its leaves, and nothing says so
+
+ADR-036 counts a resolved @ref toward coverage; ADR-037/038 expand a whole-structure *arrow* onto a record. The two do not meet: an @ref that names a record confers nothing on that record's leaves.
+
+  -> geohash { "Encode @station.lat and @station.lon to a geohash" }   =>  3/4, 75% (1 declared, 2 nl)
+  -> geohash { "Encode @station to a geohash" }                        =>  1/4, 25%
+
+The 25% reading is deliberate — prose is not interpreted (ADR-038 rule 3). The problem is that it is silent. The equivalent declared arrow gets unenumerated-record-target explaining the gap; the prose form gets nothing, so the author sees three uncovered leaves with no indication that one @ref is responsible for them.
+
+Symmetry with the existing rule argues for a warning along the lines of: this @ref names a record, so coverage counts its leaves as gaps — reference the leaves you actually use.
+
+## Acceptance Criteria
+
+- New rule (or an extension of unenumerated-record-target) fires when a resolved @ref names a declared container whose leaves are otherwise uncovered.
+- No finding when those leaves are covered by other arrows — the point is to explain a gap, not to ban the reference.
+- Shares declaredFieldKind with coverage so the explanation and the number cannot drift (ADR-038).
+- docs/nested-data/README.md sections 7 and 9 updated.
+

--- a/.tickets/sl-pn00.md
+++ b/.tickets/sl-pn00.md
@@ -1,0 +1,33 @@
+---
+id: sl-pn00
+status: open
+deps: []
+links: [sl-ttw0]
+created: 2026-08-02T21:41:13Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# spec: the §4.4 nested-each example does not validate — a sibling list gets the container prefix
+
+SATSUMA-V2-SPEC.md §4.4 (and the same code repeated in §8.2) shows:
+
+  each POReferences -> ShipmentHeader.asnDetails {
+    each LineItems -> .items {
+      .ITEMNO -> .item
+      Quantities.QUANTITY -> .unitQuantity
+    }
+  }
+
+Every path inside a container is prefixed with the container's path (qualifyChildArrowPath in satsuma-core/src/extract.ts), unconditionally. With LineItems and Quantities declared as siblings at schema root — which is how examples/edi-to-json/pipeline.stm declares them — the example resolves to POReferences.LineItems, POReferences.LineItems.ITEMNO and POReferences.LineItems.Quantities.QUANTITY, and satsuma validate reports three field-not-in-schema warnings.
+
+The corpus example was already rewritten to the correct form (three sibling each blocks, correlated by a note with an @ref). The spec text was not, so the normative document still teaches a shape the tooling rejects.
+
+## Acceptance Criteria
+
+- Reproduced: the §4.4 snippet, given a schema with sibling root-level lists, emits field-not-in-schema warnings.
+- §4.4 either nests the source lists to match the example, or is rewritten to the sibling-each + positional-note form used by examples/edi-to-json.
+- §8.2's copy of the same code is updated in step.
+- §4.4 states the prefixing rule explicitly: a path inside each/flatten is always relative to the container, dot or no dot, and there is no notation to reach an ancestor.
+- docs/nested-data/README.md §2 stays consistent with whatever the spec settles on.
+

--- a/.tickets/sl-qead.md
+++ b/.tickets/sl-qead.md
@@ -1,0 +1,45 @@
+---
+id: sl-qead
+status: open
+deps: []
+links: []
+created: 2026-08-02T21:41:14Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, coverage, core, cli]
+---
+# coverage: a fragment spread that redeclares an explicit field counts the field twice
+
+When a schema declares a field explicitly and also spreads a fragment declaring the same name, expansion emits two FieldCoverageEntry rows with the identical path. Both land in the denominator, and if the field is covered both land in the numerator, so the percentage depends on how many times a name is declared.
+
+Minimal repro — three distinct leaves (id, load_ts, batch_id), two of them mapped:
+
+  fragment meta { load_ts TIMESTAMPTZ  batch_id STRING(36) }
+  schema s_d { id STRING(10)  load_ts TIMESTAMPTZ  ...meta }
+  mapping ... { id -> id   load_ts -> load_ts }
+
+  $ satsuma coverage dupspread.stm
+    source  s_d  3/4  75%        <- should be 2/3, 67%
+
+satsuma validate reports no issue. The duplicate is overstated coverage — the dangerous direction for --fail-under.
+
+Present in the shipped corpus, not just contrived input: examples/namespaces/ns-platform.stm's vault::sat_contact_details declares load_ts at line 85 and spreads ...standard_metadata, which declares load_ts again. coverage --json lists load_ts twice in fields[] and reports 11 leaves where the schema has 10. Same in tooling/satsuma-cli/test/fixtures/platform.stm. A sweep of examples/ found no other case.
+
+ADR-035 makes the qualified path a coverage entry's identity, so two entries sharing a path is a contract violation on its own terms: any consumer keying fields[] by path silently collapses them and then disagrees with the printed counts.
+
+## Design
+
+Two questions, and the second is the user's:
+
+1. Coverage counting. expandDeclaredFields (satsuma-core/src/spread-expand.ts) should not emit a path already declared at that level. Explicit declaration wins over the spread, matching the intuition that a spread fills in what the body did not say. Dedupe there rather than in each consumer, so the CLI, LSP and viz all see one entry.
+
+2. Language semantics. The v2 spec says nothing about a spread colliding with an explicit field — grep for 'duplicate'/'collision' in docs/developer/SATSUMA-V2-SPEC.md finds nothing on point. It could be an override (as above), an error, or a warning. Whatever is decided must be written into the spec, and a lint or validate diagnostic for a redeclared field is the natural companion, since today the author gets no signal at all. Note the corpus relies on the permissive reading: ns-platform.stm would emit a diagnostic on day one.
+
+Coverage should be fixed to dedupe regardless of how the spec question lands — a duplicated path cannot be right under any reading.
+
+## Acceptance Criteria
+
+The minimal fixture above reports 2/3 (67%) from the CLI, the LSP path and the viz path. coverage --json never emits two fields[] entries with the same path, pinned by a test. examples/namespaces/ns-platform.stm reports vault::sat_contact_details with 10 leaves. The spec question is resolved and recorded in docs/developer/SATSUMA-V2-SPEC.md; if the ruling is that a redeclaration is a diagnostic, it is raised as a separate lint ticket rather than folded in here.
+

--- a/.tickets/sl-ttw0.md
+++ b/.tickets/sl-ttw0.md
@@ -1,0 +1,25 @@
+---
+id: sl-ttw0
+status: open
+deps: []
+links: [sl-pn00]
+created: 2026-08-02T21:42:32Z
+type: task
+priority: 3
+assignee: Thorben Louw
+---
+# docs: verify fenced satsuma blocks in guides run, as part of repo checks
+
+Repo checks run `satsuma fmt --check` over the example corpus, but nothing checks the Satsuma shown in docs/**/*.md. Guides drift from the tooling silently — sl-kood was one instance, and the spec section 4.4 example (sl-pn00) is another that has been wrong long enough for the corpus to be fixed around it.
+
+Writing docs/nested-data/README.md needed an ad-hoc harness: extract every fenced satsuma block, assemble fragments into a complete file with the context they need, run validate + lint, and allow specific expected findings for blocks that exist to demonstrate a warning. That harness is the shape of the check.
+
+The hard part is fragments — a block showing three arrows is not a file. Options: a fenced-info convention (satsuma fragment schema=colony_survey), a per-doc fixture preamble, or checking only blocks that are complete files and requiring guides to keep one.
+
+## Acceptance Criteria
+
+- A script validates every fenced satsuma block in docs/ (and SATSUMA-V2-SPEC.md), with a documented mechanism for fragments and for blocks whose point is a warning.
+- Wired into scripts/run-repo-checks.sh.
+- Failing on a deliberately broken block is covered by a test.
+- Existing docs are made to pass, or the exceptions are listed with ticket references.
+

--- a/.tickets/sl-v6rt.md
+++ b/.tickets/sl-v6rt.md
@@ -1,0 +1,33 @@
+---
+id: sl-v6rt
+status: open
+deps: []
+links: []
+created: 2026-08-02T21:41:57Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [cli, docs]
+---
+# fields --json: documented shape omits children, isList, startRow and metadata
+
+satsuma fields --help documents the JSON shape as an array of {"name": str, "type": str | null}. The command actually emits nested objects:
+
+  $ satsuma fields warehouse_dispatch_events examples/nested-iteration/pipeline.stm --unmapped-by 'dispatch manifest' --json
+  [ { "name": "orders", "type": "record", "isList": true,
+      "children": [ { "name": "parcels", ..., "children": [ { "name": "barcode", "type": "STRING(40)",
+        "startRow": 39, "startColumn": 6, "metadata": [ {"kind": "tag", "tag": "required"} ] } ] } ],
+      "startRow": 29, "startColumn": 2 } ]
+
+The nesting matters most: a consumer written against the documented shape reads only top-level names and silently misses every nested field, which for --unmapped-by means missing most of the gaps. Found while cross-checking fields --unmapped-by against coverage --uncovered, where a flat reading of the JSON produced 14 false divergences.
+
+Compare coverage --json, whose help documents every key and its meaning. Note also that startRow/startColumn are 0-indexed here while coverage --json's 'line' is 1-indexed and documented as such — the same inconsistency cbh-7rvo and cbh-gz2v fixed elsewhere in the CLI.
+
+## Design
+
+Document the real shape in the help text: the recursive children array, isList, the position keys and their indexing base, and metadata. Decide whether startRow/startColumn should join the rest of the CLI on 1-indexed lines under a 'line' key — if so that is a contract change worth its own note in CHANGELOG.md, and it should be settled together with sl-9p2t (display key form in --json), which is already open against the same surface.
+
+## Acceptance Criteria
+
+fields --help documents every key the command emits, including the recursive children array and the indexing base of any position key. A test asserts the documented keys match the emitted ones for a nested schema, so the two cannot drift again.
+

--- a/.tickets/sl-ymxs.md
+++ b/.tickets/sl-ymxs.md
@@ -1,0 +1,42 @@
+---
+id: sl-ymxs
+status: open
+deps: []
+links: []
+created: 2026-08-02T21:41:30Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [feature-35, coverage, cli]
+---
+# fields --unmapped-by is role-blind, contradicting coverage when one schema is both source and target
+
+satsuma coverage separates a schema's source-side and target-side coverage; fields --unmapped-by unions the two. When a mapping names the same schema on both sides, the two commands disagree, and fields is the one that under-reports.
+
+tooling/satsuma-cli/test/fixtures/ambiguous-scope.stm — schema customers is both source and target, id -> id plus a computed arrow -> name { "Look up the customer name from CRM" }:
+
+  $ satsuma coverage ambiguous-scope.stm --mapping customers
+    source  customers  1/2   50%
+    target  customers  2/2  100%
+      uncovered in customers (source): 1 field
+        name
+  $ satsuma fields customers ambiguous-scope.stm --unmapped-by customers
+  All fields in 'customers' are mapped by 'customers'.
+
+name is written by the mapping and never read by it. Coverage says so; fields says the review queue is empty.
+
+Feature 35's sl-oqsj committed to the two commands reporting the identical field set, and PRD 38 R6 re-states it. A sweep of every mapping in examples/ plus tooling/satsuma-cli/test/fixtures/ found this as the only divergence — 64 other files agree leaf for leaf — so the invariant holds except for the both-roles case, which no test covers.
+
+## Design
+
+fields --unmapped-by takes no role, and for a schema on one side of a mapping there is nothing to choose. Options:
+
+(a) Report the union of the two roles' gaps (a field is unmapped if it is unmapped in either role it plays). Keeps a single answer, makes the queue conservative, and is the reading that matches 'show me what still needs work'.
+(b) Add --role source|target mirroring coverage, and default to (a).
+
+Either way the parity invariant needs restating in terms both commands can satisfy, and a test with a both-roles fixture — ambiguous-scope.stm is already in the repo — must pin it. The logic is core's; put the role handling wherever filterUnmappedFields now reads its covered set, not in the command.
+
+## Acceptance Criteria
+
+fields --unmapped-by and coverage --uncovered --mapping report the same leaf set for ambiguous-scope.stm. A test asserts the invariant on a fixture where one schema is both source and target, and it fails if either command reverts to the other's convention. The chosen semantics are documented in fields --help.
+

--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -48,6 +48,28 @@ Both example sets model the same RetailCo company. See the [comparison overview]
 
 ---
 
+## Nested and Repeated Data
+
+**How do I declare a nested structure or a repeated one?**
+Use `record { }` for a single nested structure, `list_of record { }` for a repeated one, and `list_of TYPE` for a list of primitives. Full guide: [Nested and Repeated Data](docs/nested-data/README.md#1-three-shapes-one-declaration-syntax)
+
+**How do I map a list of records without losing the hierarchy?**
+Use `each src -> tgt { }` and address element fields with a leading `.`. Nest `each` blocks for deeper hierarchies. Guide: [`each`](docs/nested-data/README.md#3-each--iterate-a-list-keep-the-hierarchy)
+
+**How do I turn a nested list into one row per element?**
+Use `flatten src -> tgt { }`. Arrows outside the block repeat on every output row. Guide: [`flatten`](docs/nested-data/README.md#4-flatten--one-output-row-per-element)
+
+**How do I reference a parent field from inside an `each` or `flatten` block?**
+You can't — every path inside a block is prefixed with the block's path. Put the arrow outside the block. Guide: [The resolution rule](docs/nested-data/README.md#the-resolution-rule)
+
+**How do I map two parallel lists that are correlated by position (a "zip")?**
+There is no `zip` operator. Use sibling `each` blocks over one target list, or map each scalar list onto its target leaf — and state the correlation in a `note`. Guide: [Two parallel lists](docs/nested-data/README.md#5-two-parallel-lists--the-zip-question)
+
+**How does nesting affect my coverage percentage?**
+Only leaf fields are counted; a record's state is derived from its leaves; and a whole-structure arrow (`addr -> address`) covers its entire subtree. Guide: [What coverage counts](docs/nested-data/README.md#7-what-coverage-counts)
+
+---
+
 ## Load Strategy
 
 **How do I declare an upsert/merge strategy on a mapping?**
@@ -194,4 +216,4 @@ Run `satsuma where-used <metric-name>` or `satsuma metric <name>` for extraction
 
 ---
 
-*All convention guides are complete. See [features/21-convention-docs/PRD.md](features/21-convention-docs/PRD.md) for the documentation plan.*
+_All convention guides are complete. See [features/21-convention-docs/PRD.md](features/21-convention-docs/PRD.md) for the documentation plan._

--- a/docs/nested-data/README.md
+++ b/docs/nested-data/README.md
@@ -1,0 +1,807 @@
+# Nested and Repeated Data in Satsuma
+
+Hierarchy is where mapping specifications usually go vague. A spreadsheet row can
+say `order.customer.email → customer_email`, but it has nowhere to say _what
+happens to the list of line items_, _which list the target rows come from_, or
+_whether the two arrays that arrived side by side line up_. Those are exactly the
+questions that break a pipeline in production.
+
+Satsuma answers them with a small vocabulary:
+
+| Concern                                    | Construct                |
+| ------------------------------------------ | ------------------------ |
+| A single nested structure                  | `record { }`             |
+| A repeated structure                       | `list_of record { }`     |
+| A repeated primitive                       | `list_of TYPE`           |
+| Map a list, keeping the hierarchy          | `each src -> tgt { }`    |
+| Map a list, one output row per element     | `flatten src -> tgt { }` |
+| Address a field inside the current element | `.field`                 |
+
+This guide walks that vocabulary from a two-field record up to a three-level XML
+hierarchy, then explains **how nesting changes what `satsuma coverage` counts** —
+the part that decides whether a partially mapped record shows up as a gap or
+silently passes a CI gate.
+
+Every Satsuma block in this guide is a real file that parses, validates,
+formats, and (where it contains a mapping) produces the coverage output quoted
+beneath it.
+
+**Running scenario.** Rangers at the Puffin Point seabird colony walk fixed
+_transects_, recording _sightings_ of each species, and read the _rings_ on
+birds they catch. A field tablet emits the survey; a science portal wants a
+nested JSON document; the analytics lake wants one flat row per sighting.
+
+---
+
+## 1. Three shapes, one declaration syntax
+
+Every field — scalar, record, or list — is declared the same way:
+
+```
+NAME [TYPE] [(metadata)] [{ body }]
+```
+
+`record` and `list_of record` occupy the TYPE slot, so nesting needs no new
+syntax:
+
+```satsuma
+schema colony_survey (format json) {
+  survey_id     UUID            (pk, required)
+  surveyed_at   TIMESTAMPTZ     (required)
+
+  observer record {
+    ranger_id  STRING(12)  (required)
+    email      STRING      (pii)
+  }
+
+  weather_tags  list_of STRING
+
+  sightings list_of record {
+    species_code  STRING(6)  (required)
+    adults        INT
+    chicks        INT
+  }
+}
+```
+
+Three things about this are worth stating explicitly, because each one is a
+mistake people make on their first nested schema:
+
+- **`list_of STRING` needs no braces.** A list of primitives has no subfields to
+  declare. `weather_tags` is one field, whether it holds zero tags or nine.
+- **A braced body always needs `record` or `list_of record` in front of it.**
+  `observer { ... }` without the keyword is a parse error — Satsuma will not
+  guess that you meant a record.
+- **The type stays on the field's line.** A name on one line and `record` on the
+  next is two invalid fields, not one wrapped field.
+
+Metadata goes between the type and the body, so a list can carry governance,
+format, or filter tokens of its own:
+
+```satsuma
+sightings list_of record (filter species_code != "UNK", note "Confirmed identifications only") {
+  species_code  STRING(6)  (required)
+}
+```
+
+Records nest to any depth. The full survey schema used for the rest of this
+guide is four levels deep — survey → transects → sightings → rings:
+
+```satsuma
+schema colony_survey (format json) {
+  survey_id     UUID            (pk, required)
+  surveyed_at   TIMESTAMPTZ     (required)
+
+  observer record {
+    ranger_id  STRING(12)  (required)
+    email      STRING      (pii)
+  }
+
+  weather_tags  list_of STRING
+
+  transects list_of record {
+    transect_ref  STRING(8)  (required)
+    length_m      INT
+
+    sightings list_of record {
+      species_code  STRING(6)  (required)
+      adults        INT
+      chicks        INT
+
+      rings list_of record {
+        ring_id    STRING(16)  (required)
+        condition  STRING
+      }
+    }
+  }
+}
+```
+
+---
+
+## 2. Addressing a nested field
+
+A field's path is its ancestors joined with dots:
+`transects.sightings.species_code`.
+
+**Paths never contain indices.** `transects[0].sightings` is a parse error, and
+so is `transects[*]`. Repetition is expressed by the iteration keywords, never by
+the path — which is why a single path can describe every element of every transect
+at once. (Format-specific addresses such as JSONPath's `[*]` do appear, but only
+inside quoted metadata — see [section 6](#6-hierarchies-anchored-to-xml-or-json).)
+
+Inside an `each` or `flatten` block, a leading `.` marks a path as relative to
+the element currently being iterated:
+
+```satsuma
+each transects -> transects {
+  .transect_ref -> .ref        // transects.transect_ref -> transects.ref
+}
+```
+
+### The resolution rule
+
+Every path written inside a block is prefixed with that block's own path. This
+applies whether or not you wrote the leading dot — the dot documents the intent,
+it does not change the result:
+
+| Inside                                         | Written                  | Resolves to                                     |
+| ---------------------------------------------- | ------------------------ | ----------------------------------------------- |
+| `each transects -> transects`                  | `.transect_ref`          | `transects.transect_ref`                        |
+| `each transects` → `each sightings -> .counts` | `.adults`                | `transects.sightings.adults`                    |
+| `flatten transects.sightings -> rows`          | `.species_code`          | `transects.sightings.species_code`              |
+| `flatten transects.sightings -> rows`          | `transects.transect_ref` | `transects.sightings.transects.transect_ref` ❌ |
+
+That last row is the trap. **There is no notation for escaping outward to an
+ancestor.** A parent field referenced from inside a block gets the block's prefix
+like everything else, producing a path that does not exist:
+
+```
+warning [field-not-in-schema] Arrow source
+'transects.sightings.transects.transect_ref' not declared in schema 'colony_survey'
+```
+
+Write the arrow _outside_ the block instead — where its path is already absolute:
+
+```satsuma
+transects.transect_ref -> transect_ref     // ✅ outside the block
+
+flatten transects.sightings -> sighting_rows_parquet {
+  .species_code -> species_code
+}
+```
+
+For `flatten` this reads naturally: fields outside the block are the row's
+context and repeat on every output row. For a nested `each` it is a real
+limitation — you cannot state "the parent's transect ref populates a field on
+each child element". Say it in a `note` until the grammar grows an escape.
+
+---
+
+## 3. `each` — iterate a list, keep the hierarchy
+
+`each` maps one list onto another: one target element per source element,
+structure preserved. The science portal wants exactly that.
+
+```satsuma
+// --- Target: science portal document ---
+schema colony_report_json (format json) {
+  report_id   UUID         (required)
+  counted_at  TIMESTAMPTZ  (required)
+
+  recorder record {
+    code  STRING(12)  (required)
+  }
+
+  transects list_of record {
+    ref  STRING(8)
+
+    counts list_of record {
+      species  STRING(6)
+      birds    INT
+    }
+
+    ringed_birds list_of record {
+      ring       STRING(16)
+      condition  STRING
+    }
+  }
+}
+
+mapping `colony report` {
+  source { colony_survey }
+  target { colony_report_json }
+
+  survey_id -> report_id
+  surveyed_at -> counted_at
+  observer.ranger_id -> recorder.code
+
+  each transects -> transects (note "One report transect per surveyed transect.") {
+    .transect_ref -> .ref
+
+    each sightings -> .counts {
+      .species_code -> .species
+      .adults, .chicks -> .birds { "Sum adults and chicks" }
+    }
+
+    flatten sightings.rings -> .ringed_birds {
+      .ring_id -> .ring
+      .condition -> .condition
+    }
+  }
+}
+```
+
+Three levels of nesting in nine lines of mapping, and each construct is doing
+something the others cannot:
+
+- **`each transects -> transects`** — one report transect per surveyed transect.
+- **`each sightings -> .counts`** (nested) — the second level of hierarchy is
+  preserved; each transect keeps its own list of species counts.
+- **`flatten sightings.rings -> .ringed_birds`** (nested) — `rings` is _doubly_
+  nested under a transect (one list per sighting). Flattening lifts every ring
+  from every sighting into a single per-transect list.
+
+A record on both sides needs no iteration at all: `observer.ranger_id ->
+recorder.code` addresses the leaf directly. Reach for `each` when a _list_ is
+involved, not merely because something is nested.
+
+```
+$ satsuma coverage colony-report.stm
+
+  source  colony_survey          9/12   75%
+  target  colony_report_json      8/8  100%
+    uncovered in colony_survey (source): 3 fields
+      observer.email, weather_tags, transects.length_m
+```
+
+Every target field is populated; three source fields were not consumed. That
+asymmetry is normal and is the reason coverage reports the two roles separately.
+
+---
+
+## 4. `flatten` — one output row per element
+
+The analytics lake wants a table, not a document: one row per sighting, with the
+survey and transect identifiers repeated on every row.
+
+```satsuma
+// --- Target: analytics lake, one row per sighting ---
+schema sighting_rows_parquet (format parquet) {
+  survey_id     UUID
+  transect_ref  STRING(8)
+  species_code  STRING(6)
+  total_birds   INT
+}
+
+mapping `sighting rows` {
+  source { colony_survey }
+  target { sighting_rows_parquet }
+
+  survey_id -> survey_id
+  transects.transect_ref -> transect_ref
+
+  flatten transects.sightings -> sighting_rows_parquet {
+    .species_code -> species_code
+    .adults, .chicks -> total_birds { "Sum adults and chicks" }
+  }
+}
+```
+
+- The `flatten` header names the list that determines **row cardinality** — one
+  output row per sighting, across all transects.
+- Arrows **inside** the block address the current element (`.species_code`).
+- Arrows **outside** the block are context and are **repeated on every row**.
+  `survey_id` is constant for the file; `transects.transect_ref` varies per row,
+  because the flattened path runs through `transects`.
+
+```
+$ satsuma coverage sighting-rows.stm
+
+  source  colony_survey             5/12   42%
+  target  sighting_rows_parquet      4/4  100%
+    uncovered in colony_survey (source): 7 fields
+      surveyed_at, observer.ranger_id, observer.email, weather_tags,
+      transects.length_m, transects.sightings.rings.ring_id,
+      transects.sightings.rings.condition
+```
+
+A flattening mapping consumes a _slice_ of a hierarchy, so a low source
+percentage here is expected — the same schema reaches 75% under the document
+mapping in section 3, and the fields neither one touches are the real gaps. That
+is what the **aggregate** section of a multi-mapping report exists to tell you.
+
+### Choosing between them
+
+|                                  | `each`                                 | `flatten`                                    |
+| -------------------------------- | -------------------------------------- | -------------------------------------------- |
+| Target shape                     | a list, nested where the source was    | rows (or a flat list)                        |
+| Cardinality                      | one target element per source element  | one output row per element of the named list |
+| Typical use                      | JSON/XML document to JSON/XML document | hierarchy to warehouse table                 |
+| Sibling arrows outside the block | populate the enclosing level           | repeat on every output row                   |
+
+Both can nest inside each other, in any combination — `flatten` inside `each` (as
+in section 3) lifts a deep list into a shallower one without abandoning the
+hierarchy above it.
+
+---
+
+## 5. Two parallel lists — the "zip" question
+
+Legacy exports love to send data as parallel arrays: a list of birds and a list
+of weights, correlated only by position. Satsuma has **no `zip` operator**, and
+no way to bind the current element of a _scalar_ list — `each species_codes ->
+observations { . -> .species }` is a parse error (`unexpected '.'`). Positional
+correlation is expressed by arrows plus a stated rule.
+
+### Lists of records — two `each` blocks over one target list
+
+```satsuma
+// Ringing station tablet: two parallel lists, correlated by position
+schema ringing_tablet (format json) {
+  session_id  STRING  (pk)
+
+  birds list_of record (jsonpath "$.birds[*]") {
+    ring_id  STRING  (jsonpath ".ring")
+  }
+
+  weights list_of record (jsonpath "$.weights[*]") {
+    mass_g  DECIMAL(6,1)  (jsonpath ".mass")
+  }
+}
+
+schema ringing_records (format parquet) {
+  session_id  STRING
+
+  captures list_of record {
+    ring    STRING
+    mass_g  DECIMAL(6,1)
+  }
+}
+
+mapping `ringing capture records` {
+  note {
+    "The tablet emits birds and weights as two positionally-correlated lists:
+     weights[i] is the mass of birds[i]. Reject the batch if the two lists
+     differ in length — there is no key to re-align them on."
+  }
+
+  source { ringing_tablet }
+  target { ringing_records }
+
+  session_id -> session_id
+
+  each birds -> captures (note "One capture per ringed bird, in tablet order.") {
+    .ring_id -> .ring
+  }
+
+  each weights -> captures (
+    note "Positional join to @birds — weights[i] belongs to birds[i]."
+  ) {
+    .mass_g -> .mass_g
+  }
+}
+```
+
+Two `each` blocks write into the same target list, each contributing its own
+columns. The correlation rule lives in a `note` on the second block — and the
+`@birds` reference makes it traceable, not merely readable. Coverage: **3/3
+source, 3/3 target**.
+
+### Scalar lists — address the target leaves directly
+
+With `list_of STRING` there is no element to bind, so map each list onto the
+target leaf it fills:
+
+```satsuma
+// Older tablet firmware: two parallel *scalar* lists
+schema tablet_v1_export (format json) {
+  transect_ref   STRING(8)       (pk)
+  species_codes  list_of STRING
+  counts         list_of INT
+}
+
+schema portal_transect (format json) {
+  ref  STRING(8)
+
+  observations list_of record {
+    species  STRING
+    birds    INT
+  }
+}
+
+mapping `v1 transect observations` {
+  note {
+    "Firmware 1.x emits species_codes and counts as positionally-correlated
+     scalar lists: counts[i] is the tally for species_codes[i]. There is no
+     element key, so the two arrows below are the only way to state the
+     correspondence — reject the file if the lengths differ."
+  }
+
+  source { tablet_v1_export }
+  target { portal_transect }
+
+  transect_ref -> ref
+  species_codes -> observations.species
+  counts -> observations.birds
+}
+```
+
+Coverage: **3/3 source, 3/3 target**. Note that `species_codes` counts as _one_
+field however many elements it holds — a scalar list is a leaf.
+
+### What not to write
+
+The tempting shorthand is a multi-source arrow onto the list itself:
+
+```satsuma
+species_codes, counts -> observations {
+  "Zip the two parallel lists by position."
+}
+```
+
+It parses, but it costs you the coverage and earns a lint warning:
+
+```
+  source  tablet_v1_export      3/3  100%
+  target  portal_transect       1/3   33%
+    uncovered in portal_transect (target): 2 fields
+      observations.species, observations.birds
+
+warning [unenumerated-record-target] Arrow 'species_codes, counts -> observations'
+targets a record, but no source is a record and the body lists no child arrows —
+so which fields of 'observations' it populates is unstated, and coverage counts
+them as gaps. Enumerate them (observations { ... }) or map from a record.
+```
+
+Which field receives the species and which receives the count is genuinely
+unstated, so coverage is right to withhold it. Use one of the two forms above
+instead. (You cannot fix this arrow by enumerating children: a multi-source
+arrow's body is a transform pipeline, not a nesting scope, so an arrow written
+inside it is a parse error.)
+
+---
+
+## 6. Hierarchies anchored to XML or JSON
+
+When the source is XML or JSON, two addressing systems coexist, and keeping them
+in their own lanes is what makes the spec readable:
+
+- **The Satsuma path** — declared by the `record` / `list_of record` nesting,
+  index-free, and what every tool (lineage, coverage, arrows) uses.
+- **The extraction address** — the format's own idiom (`srv:Transect`, `@id`,
+  `$.data.transects[*]`), living entirely inside quoted metadata.
+
+### XML with namespaces and XPath
+
+```satsuma
+// Partner NGO submits the same survey as XML
+schema colony_submission_xml (
+  format xml,
+  namespace srv "http://seabirds.example.org/survey/v3",
+  namespace geo "http://seabirds.example.org/geo/v1"
+) {
+  Survey record (xpath "/srv:ColonySubmission/srv:Survey") {
+    SurveyId  STRING  (xpath "@id", required)
+
+    Colony record (xpath "srv:Colony") {
+      Name     STRING  (xpath "srv:Name")
+      GridRef  STRING  (xpath "geo:GridRef")
+    }
+
+    Transects list_of record (xpath "srv:Transects/srv:Transect") {
+      Ref  STRING  (xpath "@ref")
+
+      Sightings list_of record (xpath "srv:Sighting") {
+        Species  STRING  (xpath "srv:Species/@code")
+        Adults   INT     (xpath "srv:Count[@stage='adult']")
+        Chicks   INT     (xpath "srv:Count[@stage='chick']")
+      }
+    }
+  }
+}
+
+// The colony name lives above the flattened list, so it is a row-context field
+schema colony_sighting_rows_parquet (format parquet) {
+  survey_id     STRING
+  colony_name   STRING
+  transect_ref  STRING
+  species_code  STRING
+  total_birds   INT
+}
+
+mapping `xml sighting rows` {
+  source { colony_submission_xml }
+  target { colony_sighting_rows_parquet }
+
+  Survey.SurveyId -> survey_id
+  Survey.Colony.Name -> colony_name
+  Survey.Transects.Ref -> transect_ref
+
+  flatten Survey.Transects.Sightings -> colony_sighting_rows_parquet {
+    .Species -> species_code { trim | uppercase }
+    .Adults, .Chicks -> total_birds {
+      "Sum adults and chicks; treat missing as 0"
+    }
+  }
+}
+```
+
+The XPath on a record is the **context node** for its children, so child paths
+stay relative (`srv:Name`, `@ref`) — the same containment the Satsuma nesting
+expresses. A `flatten` header takes a full path of any depth
+(`Survey.Transects.Sightings`), so an XML document three elements deep still
+flattens in one block.
+
+```
+  source  colony_submission_xml             6/7   86%
+  target  colony_sighting_rows_parquet      5/5  100%
+    uncovered in colony_submission_xml (source): 1 field
+      Survey.Colony.GridRef
+```
+
+### JSON with JSONPath
+
+```satsuma
+// Same hierarchy, arriving from a REST API instead of a tablet
+schema colony_api_page (format json) {
+  page record (jsonpath "$.meta") {
+    number      INT     (jsonpath "$.meta.page")
+    next_token  STRING  (jsonpath "$.meta.next")
+  }
+
+  transects list_of record (jsonpath "$.data.transects[*]") {
+    ref          STRING  (jsonpath ".ref")
+
+    sightings list_of record (jsonpath ".sightings[*]") {
+      species  STRING  (jsonpath ".species.code")
+      adults   INT     (jsonpath ".counts.adult")
+      chicks   INT     (jsonpath ".counts.chick")
+    }
+
+    raw_payload  JSON    (jsonpath ".", note "Whole element kept for replay")
+  }
+}
+```
+
+Convention (see the [JSON path guide](../conventions-for-schema-formats/json/conventions.md)):
+absolute `$.` paths on top-level and `record` fields, relative `.field` paths
+inside a `list_of record` whose parent already declares the `[*]` iteration. A
+subtree you want to keep intact is a `JSON`-typed leaf, not a record — and it
+counts as one field.
+
+---
+
+## 7. What coverage counts
+
+`satsuma coverage` answers "which declared fields is nothing mapping yet?".
+Nesting changes the answer in four specific ways. All of them exist to stop a
+percentage from either hiding real work or manufacturing false completeness.
+
+### Only leaves are counted
+
+A record and its children describe the same data, so counting both would count
+it twice and let _nesting depth alone_ move a percentage. Records are therefore
+excluded from the numerator and denominator ([ADR-034](../../adrs/adr-034-leaf-only-coverage-counting.md)).
+
+In the survey schema, `observer` and `transects` are structure; the twelve
+counted fields are the leaves beneath them (`weather_tags`, a scalar list,
+included — it is a leaf).
+
+Re-nesting a schema without changing a single arrow leaves every percentage
+unchanged. That is the property the rule buys.
+
+### A record's own state is derived from its leaves
+
+Records still _have_ a coverage state, but it is computed bottom-up and has
+three values ([ADR-037](../../adrs/adr-037-container-coverage-and-whole-structure-arrows.md)):
+
+| State       | Meaning                          |
+| ----------- | -------------------------------- |
+| `covered`   | every descendant leaf is covered |
+| `partial`   | at least one, but not all        |
+| `uncovered` | none                             |
+
+This is what the editor gutter and the viz overlay paint, and what the CLI shows
+as a tree when you ask which fields a mapping missed:
+
+```
+$ satsuma fields colony_survey --unmapped-by "colony report" colony-report.stm
+
+  observer      record
+    email  STRING
+  weather_tags  list_of STRING
+  transects     list_of record
+    length_m  INT
+```
+
+`observer` appears because one of its two leaves is a gap — a _partial_ record.
+It contributes nothing to the count itself; the leaf beneath it does.
+
+`satsuma coverage` does not yet print the states themselves (no
+`records: {covered, partial, uncovered}` line, and `--json` lists leaves only) —
+read the tree above, the editor gutter, or the viz card until `sl-lctd` lands.
+
+### A whole-structure arrow covers its whole subtree
+
+Copying a record wholesale is a legitimate mapping, and enumerating twelve
+identical child arrows to prove it would be busywork. So an arrow onto a record
+confers coverage on everything beneath it, provided:
+
+1. **it states a correspondence, not an iteration** — a `map` or nested arrow;
+   an `each`/`flatten` header asserts no field-by-field correspondence, and a
+   computed arrow has no source at all; and
+2. **its body enumerates no child arrows** — listing one child means you are
+   claiming that child _and no others_.
+
+For a **target-side** record there is a third condition: at least one source
+path must itself name a declared record
+([ADR-038](../../adrs/adr-038-whole-structure-expansion-requires-a-container-source.md)).
+One scalar cannot fill twelve leaves, and a gate must not be passable by writing
+a vaguer arrow.
+
+Each row below is a real file; the numbers are its actual coverage. The record
+`station`/`site` has three leaves, plus one scalar field each side, so 4 is a
+full house.
+
+| Arrow written                        | Source  | Target  | Why                                                                       |
+| ------------------------------------ | ------- | ------- | ------------------------------------------------------------------------- |
+| `station -> site`                    | **4/4** | **4/4** | whole-structure copy, both ends are records                               |
+| `station -> site { }`                | **4/4** | **4/4** | an empty body enumerates nothing — still a whole-structure copy           |
+| `station -> site { .code -> .code }` | 2/4     | 2/4     | enumerating one child claims that child only; `lat`/`lon` are gaps        |
+| `each hops -> relays { }`            | 1/3     | 1/3     | an iteration header asserts nothing about fields; empty body maps nothing |
+| `station -> id` (record → scalar)    | **4/4** | 1/4     | the whole record was _read_; one scalar target field was written          |
+| `ping_id -> site` (scalar → record)  | 1/4     | 1/4     | + `lint` warns `unenumerated-record-target`                               |
+
+Two of these are worth internalising because they look alike and behave
+oppositely:
+
+```satsuma
+station -> site { }        // covers code, lat, lon  — "the whole record goes across"
+each hops -> relays { }    // covers nothing         — "iterate, and map… nothing"
+```
+
+And adding the first child arrow to a whole-structure arrow **reduces** its
+coverage, from the subtree to that one field. That is the correct reading of
+what you wrote — but it surprises people, so it is worth knowing before you see
+a percentage drop after adding a line.
+
+### Natural-language `@refs` count — for leaves
+
+A resolved `@ref` inside a transform is structural, not prose interpretation, so
+it counts toward coverage as a distinct **NL tier**
+([ADR-036](../../adrs/adr-036-nl-ref-coverage-tier.md)). Nested paths resolve
+just as leaf paths do:
+
+```satsuma
+-> geohash { "Encode @station.lat and @station.lon to a 9-character geohash" }
+```
+
+```
+  source  tablet_ping      3/4   75%  (1 declared, 2 nl)
+    uncovered in tablet_ping (source): 1 field
+      station.code
+```
+
+But an `@ref` to a _record_ confers nothing on its leaves — whole-structure
+expansion applies to declared arrows only:
+
+```satsuma
+-> geohash { "Encode @station to a 9-character geohash" }
+```
+
+```
+  source  tablet_ping      1/4   25%
+    uncovered in tablet_ping (source): 3 fields
+      station.code, station.lat, station.lon
+```
+
+If prose consumes a whole record, name the leaves you actually use, or state the
+correspondence with an arrow.
+
+### Worked example: one hierarchy, two mappings
+
+Put the document mapping (section 3) and the flattening mapping (section 4) in
+one workspace and the two sections of the report say different things — by
+design:
+
+```
+$ satsuma coverage puffin-point.stm
+
+mapping sighting rows
+  source  colony_survey             5/12   42%
+  target  sighting_rows_parquet      4/4  100%
+    uncovered in colony_survey (source): 7 fields
+      surveyed_at, observer.ranger_id, observer.email, weather_tags,
+      transects.length_m, transects.sightings.rings.ring_id,
+      transects.sightings.rings.condition
+
+Aggregate — a field is uncovered here only when NO mapping in scope covers it
+  source  colony_survey             9/12   75%
+  target  colony_report_json         8/8  100%
+  target  sighting_rows_parquet      4/4  100%
+    covered by no mapping — colony_survey (source): 3 fields
+      observer.email, weather_tags, transects.length_m
+
+  workspace  source    9/12   75%   target   12/12  100%
+```
+
+Five of the seven fields the flattening mapping "misses" are read by the
+document mapping — `rings.ring_id` among them. Only three fields are genuinely
+untouched by anything, and those three are the review queue. Deleting a field on
+the strength of the per-mapping section alone is how live data gets dropped.
+
+### Gating nested specs in CI
+
+```bash
+satsuma coverage pipeline.stm --fail-under 90              # gates TARGET coverage
+satsuma coverage pipeline.stm --fail-under 80 --role source
+```
+
+`--fail-under` gates the **target** role unless `--role` says otherwise, and
+exits **3** when the threshold is missed (distinct from 1 for a bad
+`--mapping`/`--schema` name, so CI can tell an incomplete spec from a broken
+invocation).
+
+For nested work specifically:
+
+- Gate the target role first. An unfilled target leaf is a bug; an unconsumed
+  source leaf is often a deliberate decision.
+- Read the **aggregate** section, not the per-mapping one, before calling a
+  field unmapped — a second mapping may populate it. In a nested workspace this
+  is common: one mapping builds the document, another flattens it.
+- Investigate a _drop_ after a purely additive change. Adding the first child
+  arrow under a whole-structure arrow narrows its claim, as above.
+
+---
+
+## 8. Checklist
+
+Before you commit a nested mapping:
+
+- [ ] Every braced body has `record` or `list_of record` in front of it.
+- [ ] Lists of primitives use `list_of TYPE` with no braces.
+- [ ] `each` where the target keeps the hierarchy; `flatten` where the target is
+      rows.
+- [ ] No path inside a block reaches for an ancestor — those arrows live outside
+      the block.
+- [ ] Parallel lists carry a `note` stating the correlation rule and what
+      happens when lengths differ.
+- [ ] Format addresses (`xpath`, `jsonpath`) are in metadata; Satsuma paths carry
+      no indices.
+- [ ] `satsuma lint` is clean — `unenumerated-record-target` means a record whose
+      contents nobody has stated.
+- [ ] `satsuma coverage --uncovered` shows only gaps you can defend.
+
+## 9. Known sharp edges
+
+Honest limits of the current language and tooling, so you can recognise them
+rather than debug them. Where a limit is tracked, the ticket is named.
+
+| Limitation                                                                                            | Workaround                                                              | Tracked   |
+| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------- |
+| No way to reference an ancestor field from inside an `each`/`flatten` block                           | Put the arrow outside the block, or describe it in a `note`             | `sl-8vqk` |
+| No way to bind the current element of a _scalar_ list (`each tags -> t { . -> .x }` is a parse error) | Map the list onto the target leaf directly (section 5)                  | `sl-kezo` |
+| No `zip` construct for positionally-correlated lists                                                  | Sibling `each` blocks, or per-leaf arrows, plus a `note`                | `sl-kezo` |
+| A multi-source arrow onto a record cannot enumerate children (its body is a pipeline)                 | Write one arrow per target leaf                                         | `sl-3fou` |
+| A scalar-to-record arrow reports the record's leaves as gaps                                          | Enumerate the leaves; `lint` flags this as `unenumerated-record-target` | by design |
+| An `@ref` to a record in prose confers no coverage on its leaves, and nothing warns                   | Reference the leaves, or add declared arrows                            | `sl-lnbt` |
+
+---
+
+## See also
+
+- [Language specification §3.3, §4.4, §4.6](../developer/SATSUMA-V2-SPEC.md) — the
+  normative rules for `record`, `list_of`, `each`, and `flatten`
+- [`satsuma coverage` reference](../../SATSUMA-CLI.md#coverage) — flags, JSON
+  contract, exit codes
+- [JSON path conventions](../conventions-for-schema-formats/json/conventions.md)
+  and the [schema format guides](../conventions-for-schema-formats/README.md)
+- [`examples/nested-iteration/`](../../examples/nested-iteration/) and
+  [`examples/edi-to-json/`](../../examples/edi-to-json/) — nested iteration and
+  positional correlation in the canonical corpus
+- ADRs [034](../../adrs/adr-034-leaf-only-coverage-counting.md),
+  [036](../../adrs/adr-036-nl-ref-coverage-tier.md),
+  [037](../../adrs/adr-037-container-coverage-and-whole-structure-arrows.md),
+  [038](../../adrs/adr-038-whole-structure-expansion-requires-a-container-source.md)
+  — why coverage counts nested data the way it does


### PR DESCRIPTION
Two independent pieces of work that were both sitting uncommitted in the same tree, kept as one commit each.

## 1. `chore(tickets)`: exploratory test pass — Features 35 & 38

An exploratory pass over the merged feature-35 and feature-38 coverage work, driven beyond the package suites: the CLI, the LSP adapter and the viz model-building path, over purpose-built fixtures and the whole example corpus.

**The epic is not closed and the PRD is not archived.** Feature 38's own acceptance criterion — *coverage figures reported by the CLI, the VS Code status bar and the viz card are identical for the same workspace* — does not hold. A note on `sl-j6g9` records the pass and why it stays open. Feature 35's epic was already closed and its PRD archived before the session, so its three findings are tagged `feature-35` rather than reopening it.

### What was run

All suites green on `main` @ `e831be3`: core 556, cli 980, lsp 295, viz-backend 174, viz 111, vscode golden 7.

One caveat worth knowing: `tooling/satsuma-viz` needs `npm install` after `b7ff50f` — the `@satsuma/viz-backend` devDependency `sl-5nsv` added is missing in stale trees, and the parity test then fails *to load* rather than to assert. It passes once installed.

### What holds up

Name shadowing at every depth (AT1–4, AT6 on `deep-nested-bugs.stm`), `nested_arrow` (AT7), flatten-in-each on `nested-iteration/pipeline.stm` — 8/9 and 8/8 with `orders.parcels.barcode` the single gap (AT8, AT29), empty `each` bodies and computed-arrows-into-containers both uncovered per ADR-037 (AT16–17), leaf-only percentages and depth invariance (AT18–19), and whole-structure conferral in all three forms ADR-037 names, including direct-vs-derived (AT22–25). `fields --unmapped-by` matches `coverage --uncovered` leaf for leaf across every mapping in `examples/` and the CLI fixtures, with one exception below. CLI ≡ LSP ≡ VS Code everywhere probed.

### Findings

| | Ticket | Finding |
|---|---|---|
| P1 | `sl-46wr` | viz ignores the NL `@ref` tier. It keeps a third derivation of covered paths (`satsuma-viz/src/field-coverage.ts`) counting declared arrows only. Twelve shipped examples disagree — db-to-db source reads 15/21 in the card, 21/21 in the terminal. |
| P1 | `sl-csrs` | viz ignores whole-structure conferral (ADR-037/R5). `addr -> address` fixture: CLI 7/8, viz 2/8. Same root cause as above. |
| P1 | `sl-8ba4` | `--fail-under` gates a **rounded** percentage. 200 of 201 leaves mapped prints `200/201 100%` and `--fail-under 100` exits 0 — the gate fails open in the one direction it must not. |
| P2 | `sl-qead` | A spread redeclaring an explicit field counts it twice, in numerator *and* denominator, so coverage is overstated (3/4 where it should read 2/3). Live in `examples/namespaces/ns-platform.stm`; violates ADR-035. Carries an open spec question. |
| P2 | `sl-ymxs` | `fields --unmapped-by` is role-blind. Where one schema is both source and target it reports the queue empty while `coverage` reports a source-side gap. |
| P3 | `sl-lctd` | R3/AT21 container state counts are never reported by the CLI — core computes them, the viz tooltip shows them, `satsuma coverage` references them in neither text nor JSON. |
| P3 | `sl-v6rt` | `fields --json` help documents a flat `{name, type}` array; output is a recursive tree with `children`/`isList`/`startRow`. A consumer written to the docs misses every nested gap. |

`sl-46wr`, `sl-csrs`, `sl-qead` and `sl-lctd` are parented under `sl-j6g9`; the two viz findings are linked to `sl-3de8` (Feature 36), which they block.

## 2. `docs`: nested and repeated data guide

`docs/nested-data/README.md` — the rules for hierarchy were spread across spec §3.3/§4.4/§4.6, four ADRs and a lint rule message. This collects them onto one worked scenario: a seabird colony survey, four levels deep, mapped both hierarchy-preserving and flattened, arriving as a tablet export, an XML submission and a REST page.

Sections: the three shapes; the container-prefix resolution rule and the ancestor-reference trap it creates; `each` vs `flatten` and their nesting; positional correlation of parallel lists (there is no `zip`); XPath/JSONPath hierarchies; and how nesting changes coverage — leaf-only counting (ADR-034), container tri-state (ADR-037), whole-structure conferral and its target-side container condition (ADR-038), the NL `@ref` tier (ADR-036), a two-mapping aggregate worked example, and CI gating. Indexed from `HOW-DO-I.md` under a new *Nested and Repeated Data* section.

**Verification.** Every fenced `satsuma` block was extracted, assembled (fragments get the context they need) and run through `validate` + `lint` — 15/15 clean, with the single expected lint finding allow-listed. Every quoted coverage figure is a real run, not written by hand.

### Issues surfaced while writing it — raised, not fixed

| Ticket | Finding |
|---|---|
| `sl-pn00` | **Spec §4.4's own example does not validate.** `each LineItems` nested inside `each POReferences` resolves to `POReferences.LineItems.…` → three `field-not-in-schema` warnings. The corpus was already rewritten to sibling `each` blocks; the normative spec (and its §8.2 copy) still teaches the broken shape. |
| `sl-3fou` | `unenumerated-record-target` recommends enumeration — a parse error for the multi-source arrows that most often trigger it, whose body is a pipeline, not a nesting scope. The one form that works isn't mentioned. |
| `sl-kezo` | No way to bind the current element of a scalar list (`each tags -> t { . -> .x }` → `unexpected '.'`), which is also why positional correlation has no notation. |
| `sl-8vqk` | No notation to reach an ancestor field from inside `each`/`flatten`. Workable for `flatten`; unexpressible for a nested `each`. |
| `sl-lnbt` | An `@ref` naming a record confers no coverage on its leaves (correct per ADR-038) but warns about nothing, unlike the equivalent declared arrow. |
| `sl-ttw0` | Nothing checks that fenced `satsuma` blocks in docs actually run. The ad-hoc harness this guide needed is the shape of the check. |

## Notes for the reviewer

- **No ADR.** Neither commit makes an architectural decision — the guide documents ADR-034/036/037/038 as shipped, and the tickets defer every decision they raise (`sl-kezo` and `sl-8vqk` both call for an ADR *if* adopted).
- `docs/product-owner/ROADMAP.md:19` is now stale: it says the canonical nested example "reports 75% when it is 100% mapped", but it reports 89% with one genuine gap. Left alone — it belongs with whoever next revises Feature 38's roadmap entry.
- Pre-commit hook ran on both commits; repo checks and the 50 smoke tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
