### PR TITLE
fix(coverage): --fail-under cannot pass an incomplete spec (sl-8ba4), and §4.4's example validates (sl-pn00)

### DIFF
--- a/.tickets/sl-8ba4.md
+++ b/.tickets/sl-8ba4.md
@@ -1,6 +1,6 @@
 ---
 id: sl-8ba4
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-02T21:40:55Z
@@ -44,3 +44,10 @@ The rule belongs in core's percentage() so the CLI, the LSP status bar and the v
 
 A 201-leaf fixture with 200 leaves mapped reports below 100% and exits 3 under --fail-under 100. A fully-mapped schema reports 100% and exits 0. A schema with no covered leaf reports 0%. The rounding rule is documented in coverage --help and in SATSUMA-CLI.md, and tested at the boundary in core (percentage()) rather than only through the CLI.
 
+## Notes
+
+**2026-08-03T06:35:00Z**
+
+Cause: CoverageTotals.pct was Math.round((covered/total)*100), and evaluateGate compared that rounded figure, so any population large enough for one leaf to be worth under half a percent reported 100% while a field was unmapped — 200/201 printed "200/201 100%" and --fail-under 100 exited 0.
+Fix: replaced percentage() with an exported coveragePercentage() in satsuma-core/src/coverage-rollup.ts implementing rule (a) from the ticket's design — 100 only when covered === total, 0 only when covered === 0 or total === 0, otherwise floor clamped up to 1 so partial work never reports as none. Every consumer reads totals.pct, so the CLI table, --json, the VS Code status bar, the viz card and the gate all moved together. Rounding rule documented in coverage --help and SATSUMA-CLI.md next to the exit codes, with a CHANGELOG entry for the percentages that drop by a point (8/9 now 88%, 2/3 now 66%).
+Tests: four boundary cases on coveragePercentage() in core (201/201, 200/201, 2000/2001, 1/201, 1/100000, 8/9, 0/0), and three CLI tests over a generated 201-leaf workspace asserting exit 3 with "200/201 99%" under --fail-under 100, exit 0 at 201/201, and 1% rather than 0% at 1/201. Stale expectations updated in core (three), CLI (two) and vscode (one).

--- a/.tickets/sl-pn00.md
+++ b/.tickets/sl-pn00.md
@@ -1,6 +1,6 @@
 ---
 id: sl-pn00
-status: open
+status: closed
 deps: []
 links: [sl-ttw0]
 created: 2026-08-02T21:41:13Z
@@ -31,3 +31,10 @@ The corpus example was already rewritten to the correct form (three sibling each
 - §4.4 states the prefixing rule explicitly: a path inside each/flatten is always relative to the container, dot or no dot, and there is no notation to reach an ancestor.
 - docs/nested-data/README.md §2 stays consistent with whatever the spec settles on.
 
+## Notes
+
+**2026-08-03T06:35:00Z**
+
+Cause: §4.4's example nested `each LineItems` inside `each POReferences` while the EDI schema it was drawn from declares POReferences, LineItems and Quantities as siblings at the schema root. Because qualifyChildArrowPath prefixes every path inside a container unconditionally, the example resolved to POReferences.LineItems.* and produced three field-not-in-schema warnings. The corpus example had already been rewritten to sibling each blocks; the spec had not.
+Fix: rewrote §4.4 around a source whose `lines` list is genuinely declared inside its `orders` list, so nested `each` is demonstrated by a shape that validates; added an explicit statement of the prefixing rule with a resolution table (including the ancestor case that resolves to nothing) and the fact that there is no notation for reaching an ancestor; added the sibling-each + positional-note form for lists declared side by side, pointing at §8.2. §8.2's copy of the code now matches examples/edi-to-json/pipeline.stm — three sibling each blocks with @ref notes — with a comment explaining why it is not nested. Both rewritten snippets verified with validate, coverage and lint (100%/100%, no findings).
+docs/nested-data/README.md §2 already taught the same rule and stays consistent; §9 continues to track the missing ancestor notation as sl-8vqk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+### `--fail-under` no longer passes an incomplete spec (`sl-8ba4`)
+
+**Some percentages move by a point.** `coverage` reported a percentage rounded to
+nearest, and the gate compared it, so 200 of 201 mapped leaves printed
+`200/201 100%` and `--fail-under 100` exited 0 — a merge gate failing open on the
+one thing it exists to catch.
+
+100% and 0% are now reserved for the exact endpoints: only a fully covered
+population reports 100%, only an entirely uncovered one reports 0%, and
+everything between them floors into 1–99%. 200/201 reports 99% and fails
+`--fail-under 100`; 1/201 reports 1% rather than a 0% that reads as nothing
+mapped.
+
+Existing figures that were rounded up drop by a point — `8/9` now reports 88%
+instead of 89%, so a threshold set just under a rounded-up figure (`--fail-under 89`
+on that schema) will start failing. It was passing on a number that overstated
+the spec. Thresholds at or below the true percentage are unaffected.
+
+The rule lives in core's `coveragePercentage()`, exported for consumers, so the
+CLI table, `--json`, the VS Code status bar, the viz card and the gate cannot
+disagree about it (ADR-034's single-definition rule).
+
 ### A whole-record arrow must carry a record to cover one (`3ct-cs4y`)
 
 Tightens the change below, before anyone sets a `--fail-under` threshold against

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -104,12 +104,12 @@ Operations that check or compare workspace structure.
 
 Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rules>` / `--ignore <rules>` (filter rules), `--quiet` (exit code only), `--rules` (list available rules).
 
-| Rule                   | Severity | Fixable | Description                                                         |
-| ---------------------- | -------- | ------- | ------------------------------------------------------------------- |
-| `hidden-source-in-nl`  | error    | yes     | NL text references a schema not in the mapping's source/target list |
-| `unresolved-nl-ref`    | warning  | no      | `@ref` in NL does not resolve to any known identifier               |
-| `duplicate-definition` | error    | no      | Named definition is declared more than once in a namespace          |
-| `unenumerated-record-target` | warning | no | Arrow targets a record without a record source or child arrows |
+| Rule                         | Severity | Fixable | Description                                                         |
+| ---------------------------- | -------- | ------- | ------------------------------------------------------------------- |
+| `hidden-source-in-nl`        | error    | yes     | NL text references a schema not in the mapping's source/target list |
+| `unresolved-nl-ref`          | warning  | no      | `@ref` in NL does not resolve to any known identifier               |
+| `duplicate-definition`       | error    | no      | Named definition is declared more than once in a namespace          |
+| `unenumerated-record-target` | warning  | no      | Arrow targets a record without a record source or child arrows      |
 
 ### coverage
 
@@ -137,6 +137,8 @@ Flags: `--mapping <name>`, `--schema <name>`, `--role source|target`, `--uncover
 Counting a resolved `@ref` is **resolution, not interpretation**: the author wrote `@` to mark a reference, and resolving it against the index reads no surrounding prose. Two things still do not count — a field prose merely _describes_ without an `@ref` (use `nl-refs` to find those), and an `@ref` that resolves to nothing (that is `lint`'s `unresolved-nl-ref`; letting it count would make coverage rise when a spec breaks). Policy judgements about which gaps are acceptable remain `lint`'s. See **ADR-036**, and **ADR-013** for why an `@ref` carries the same lineage weight as a declared source field.
 
 **Coverage matches whole paths, never bare field names.** `home_address.city` covers exactly that path — not a top-level `city`, and not `work_address.city`. Repeated leaf names across depths (`id`, `sku`, `code`, `BIC`) are normal in nested schemas, so name matching would report unmapped fields as mapped. In a multi-source mapping, an arrow's schema prefix resolves to the schema it names: `crm.consent.email_marketing` covers `consent.email_marketing` in `crm` and contributes nothing to any other source.
+
+**100% and 0% are reserved for the exact endpoints.** A percentage is a whole number, and only a fully covered population reports 100% — everything below it floors into 1–99%. So 200 of 201 leaves reports 99% and fails `--fail-under 100`, where rounding to nearest reported 100% and let the gate pass a spec with an unmapped field; and 1 of 201 reports 1% rather than a 0% that reads as nothing mapped. The number printed is the number gated: `--fail-under` compares the same figure the report shows.
 
 **Percentages count leaf fields only.** A `record` is structure, not data; counting it alongside its children would count the same data twice and let a schema's nesting depth move the number on its own. A record's own coverage is _derived_ from its leaves and has three states — covered (every leaf), partial (some), uncovered (none) — which is what the editor gutter and the viz overlay render; the percentage still counts the leaves it was derived from.
 

--- a/adrs/adr-034-leaf-only-coverage-counting.md
+++ b/adrs/adr-034-leaf-only-coverage-counting.md
@@ -1,6 +1,6 @@
 # ADR-034 — Leaf-Only Coverage Counting on a Field's Own Flag
 
-**Status:** Accepted — amended by ADR-037
+**Status:** Accepted — amended by ADR-037 and ADR-040
 **Date:** 2026-07-31 (sl-4qvp, feature 35)
 
 ## Context

--- a/adrs/adr-040-coverage-percentage-reserves-the-endpoints.md
+++ b/adrs/adr-040-coverage-percentage-reserves-the-endpoints.md
@@ -1,0 +1,118 @@
+# ADR-040 — A Coverage Percentage Reserves 100% and 0% for the Exact Endpoints
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-8ba4)
+
+## Context
+
+ADR-034 settled _what_ a coverage percentage counts: leaf fields only, on each
+leaf's own flag, computed in one place so that a CLI table, a `--fail-under`
+verdict, a VS Code status bar and a viz overlay cannot disagree. It did not
+address how the resulting ratio becomes the whole number every one of those
+surfaces prints, and the answer inherited from the original implementation was
+`Math.round`.
+
+Rounding to nearest is the one reduction a merge gate cannot survive. Any
+population large enough for a single leaf to be worth under half a percent
+rounds up to 100:
+
+    $ satsuma coverage rounding.stm --uncovered
+      source  big_s  200/201  100%
+      target  big_t  200/201  100%
+        uncovered in big_t (target): 1 field
+          f200
+    $ satsuma coverage rounding.stm --fail-under 100 ; echo $?
+    0
+
+`--fail-under` exists so an incomplete spec blocks a merge, and 100 is precisely
+the threshold a team writes once a spec is meant to be finished — so the defect
+sat on the most-used setting, in the only direction that matters. The report was
+independently wrong: `200/201 100%` claims completeness beside the field list
+that contradicts it.
+
+The failure is not in the gate. `evaluateGate` compares `totals.pct` deliberately,
+because ADR-034's whole point is that the number a reviewer reads is the number CI
+enforces. The failure is that `pct` was a figure no longer supported by the counts
+it came from.
+
+Nested schemas are where this bites, which is why it surfaced with feature 38: a
+flat schema rarely has 200 leaves, and a four-level one reaches that easily.
+
+## Decision
+
+**The two endpoints are decided by the counts, not by arithmetic on them, and
+everything between them floors.** `coveragePercentage(covered, total)` in
+`satsuma-core/src/coverage-rollup.ts`:
+
+- `covered === total` → **100**. The only way to print 100.
+- `covered === 0`, or `total === 0` → **0**. The only way to print 0.
+- otherwise → `floor(covered / total * 100)`, **clamped up to 1**.
+
+Each clause answers a distinct failure. Reserving 100 is the fix: a gate at 100
+now means every leaf. Flooring in between keeps every printed figure a claim the
+counts support, so a threshold can be read as a floor rather than as a rounding
+target. The clamp to 1 exists because flooring alone introduces the mirror-image
+lie at the bottom — 1 of 201 floors to 0, and 0% is the review queue's strongest
+claim, the one that reads as "nothing here is mapped". Partial work must stay
+visible. `total === 0` reports 0 rather than 100 because a schema with no leaves
+has nothing to cover, and calling that complete would let an empty schema satisfy
+any threshold.
+
+The rule is **exported**, not private, so a consumer that needs a percentage from
+counts it holds shares this definition instead of reimplementing it — the same
+reasoning that made `leafFieldEntries()` public in ADR-034. Every current
+consumer reads `totals.pct` and therefore inherited the change without knowing
+about it.
+
+**The rejected alternative was to keep `Math.round` for display and gate on the
+exact ratio** (`covered / total * 100 >= threshold`). It fixes the fail-open bug
+without moving a single existing percentage, which is a real advantage. It was
+rejected because it makes the report and the verdict disagree by construction:
+`200/201 100%` printed directly above `--fail-under: target coverage 100% vs
+threshold 100% — NOT met`. A reviewer investigating that has to know which of two
+numbers to trust, and ADR-034 exists specifically so that question never arises.
+Preserving a figure that overstates the spec is not worth the contradiction.
+
+**Plain flooring with no special cases** was also considered and rejected for the
+1/201 → 0% case above.
+
+This **amends ADR-034**, whose counting rule is unchanged: leaves only, each on
+its own flag, one implementation. This ADR fixes how that count is reduced to a
+whole number and what its extreme values assert.
+
+## Consequences
+
+**Positive:**
+
+- `--fail-under 100` means every leaf, and no threshold can be satisfied by a
+  figure the counts do not support. The gate can only be passed by declaring what
+  maps.
+- The reviewer and CI still read one number. The alternative would have bought
+  stability at the cost of that property.
+- 0% and 100% become meaningful claims rather than buckets: seeing either tells
+  you something exact about the schema.
+- The rule is stated where the contract is read — `coverage --help` beside the
+  exit codes, and SATSUMA-CLI.md — rather than only in code.
+
+**Negative:**
+
+- **Percentages move.** Any figure that was rounded up drops a point: `8/9` now
+  reports 88% instead of 89%, `2/3` reports 66% instead of 67%. A threshold set
+  just under a rounded-up figure (`--fail-under 89` against an 8/9 schema) starts
+  failing. It was passing on an overstatement, but the break lands on the user,
+  not on the author of the arrow, and no `.stm` diff explains it. The CHANGELOG
+  entry carries the warning.
+- Six test expectations across core, the CLI and the VS Code extension moved with
+  the rule. Each carries a comment naming this decision, because a bare `66`
+  where a reader expects `67` looks like a bug.
+- The rule is three clauses where it was one expression, and two of them exist to
+  prevent a misreading rather than to compute anything. A future reader may
+  simplify it back to a floor without knowing what the clamp is for; the
+  doc-comment and the boundary tests are the defence.
+- Asymmetry remains between the endpoints: 100 requires exactness, while 1 is
+  reachable by clamping from below. That is deliberate — overstatement and
+  understatement are not symmetric risks for a gate — but it means the function
+  is not a pure rounding rule and cannot be described as one.
+- A percentage still cannot distinguish 200/201 from 198/201; both print 99%. The
+  ratio beside it can, and every surface prints both, so the loss is confined to
+  the number gated.

--- a/docs/developer/SATSUMA-V2-SPEC.md
+++ b/docs/developer/SATSUMA-V2-SPEC.md
@@ -23,11 +23,11 @@ Satsuma is a concise notation for describing data schemas, mappings, and transfo
 
 ### 2.1 Delimiters
 
-| Delimiter | Role | Contains |
-|-----------|------|----------|
-| `( )` | Metadata / annotations | Key-value pairs, flags, notes about the preceding element |
-| `{ }` | Structural content | Fields, arrows, map entries, pipe chains, child blocks |
-| `" "` | Natural language | Human-readable descriptions, transform logic, documentation |
+| Delimiter | Role                   | Contains                                                    |
+| --------- | ---------------------- | ----------------------------------------------------------- |
+| `( )`     | Metadata / annotations | Key-value pairs, flags, notes about the preceding element   |
+| `{ }`     | Structural content     | Fields, arrows, map entries, pipe chains, child blocks      |
+| `" "`     | Natural language       | Human-readable descriptions, transform logic, documentation |
 
 These roles are **mutually exclusive**. Metadata never appears in `{ }`. Structural children never appear in `( )`. Natural language always uses `" "`.
 
@@ -40,12 +40,13 @@ All comma-separated list constructs follow one rule: **a trailing comma after th
 ### 2.2 Strings and Quoting
 
 - **Double quotes** `" "` — natural language strings. Always double quotes. Escape inner double quotes with `\"`.
-- **Triple double quotes** `""" """` — multiline natural language with Markdown support. No escaping needed for inner `"`, including at the end of the content (`"""He said "hi""""` is valid). The one limitation: content cannot *end* with three or more consecutive quotes, since that run is indistinguishable from the closing delimiter. Use for notes with headings, bold, lists, or multi-paragraph content. Leading indentation from the content is preserved as-is.
+- **Triple double quotes** `""" """` — multiline natural language with Markdown support. No escaping needed for inner `"`, including at the end of the content (`"""He said "hi""""` is valid). The one limitation: content cannot _end_ with three or more consecutive quotes, since that run is indistinguishable from the closing delimiter. Use for notes with headings, bold, lists, or multi-paragraph content. Leading indentation from the content is preserved as-is.
 - **Backticks** `` ` ` `` — identifiers and names that aren't bare-safe. Used for block labels containing special characters (spaces, dots, hyphens) and for field identifiers with special characters.
 - **`@` prefix** — structural cross-references in NL text. `@customers.email` references a schema field. Required inside NL strings for tooling to detect refs; optional but allowed everywhere else.
 
 **Two quoting rules:**
-- Backticks for names: bare names work when matching `[a-zA-Z_][a-zA-Z0-9_-]*`, except that a bare name may not *end* with a hyphen (so `a->b` always reads as an arrow, never as the name `a-` followed by `>`). Everything else gets backticks.
+
+- Backticks for names: bare names work when matching `[a-zA-Z_][a-zA-Z0-9_-]*`, except that a bare name may not _end_ with a hyphen (so `a->b` always reads as an arrow, never as the name `a-` followed by `>`). Everything else gets backticks.
 - Double quotes for prose: NL content uses `"..."` or `"""..."""`.
 
 ```
@@ -73,11 +74,11 @@ fragment `US Address` { ... }
 
 ### 2.4 Comments
 
-| Syntax | Meaning | Behaviour |
-|--------|---------|-----------|
-| `//` | Comment | Author-side. Stripped by tooling. Not exported. |
-| `//!` | Warning | Flags a known issue or risk. May be surfaced by tooling. |
-| `//?` | Question/TODO | Open question. May be surfaced by tooling. |
+| Syntax | Meaning       | Behaviour                                                |
+| ------ | ------------- | -------------------------------------------------------- |
+| `//`   | Comment       | Author-side. Stripped by tooling. Not exported.          |
+| `//!`  | Warning       | Flags a known issue or risk. May be surfaced by tooling. |
+| `//?`  | Question/TODO | Open question. May be surfaced by tooling.               |
 
 Comments run to end of line. There are no block comments.
 
@@ -85,13 +86,13 @@ Comments run to end of line. There are no block comments.
 
 Whitespace around `->` is optional: `a->b`, `a-> b`, `a ->b`, and `a -> b` are all the same arrow.
 
-| Operator | Meaning |
-|----------|---------|
-| `->` | Maps source to target |
-| `->` (no left side) | Computed/derived target field |
-| `\|` | Pipeline step separator |
-| `...` | Spread/expand a fragment or named transform |
-| `:` | Separator in map entries |
+| Operator            | Meaning                                     |
+| ------------------- | ------------------------------------------- |
+| `->`                | Maps source to target                       |
+| `->` (no left side) | Computed/derived target field               |
+| `\|`                | Pipeline step separator                     |
+| `...`               | Spread/expand a fragment or named transform |
+| `:`                 | Separator in map entries                    |
 
 ### 2.6 Reserved Keywords
 
@@ -162,9 +163,9 @@ A field is declared as:
 - **Type** — a vocabulary token (interpreted by the LLM, not formally validated). Common types: `STRING`, `VARCHAR(n)`, `INT`, `DECIMAL(p,s)`, `BOOLEAN`, `DATE`, `TIMESTAMPTZ`, `UUID`, `JSON`, `TEXT`.
 - **Metadata** — optional `( )` block with flags and key-value pairs.
 
-**Type arguments vs metadata.** Parentheses attached *directly* to the type name (no whitespace) are type arguments and belong to the type: `DECIMAL(12,2)`, `VARCHAR(MAX)`. Parentheses separated from the type by whitespace are the field's metadata block: `UUID (pk)`. The two are easy to mix up:
+**Type arguments vs metadata.** Parentheses attached _directly_ to the type name (no whitespace) are type arguments and belong to the type: `DECIMAL(12,2)`, `VARCHAR(MAX)`. Parentheses separated from the type by whitespace are the field's metadata block: `UUID (pk)`. The two are easy to mix up:
 
-- `customer_id UUID(pk)` parses cleanly but means "a type called `UUID(pk)`" — the `pk` constraint is *not* metadata. Tooling flags known constraint tokens inside type arguments (`constraint-in-type-args` warning).
+- `customer_id UUID(pk)` parses cleanly but means "a type called `UUID(pk)`" — the `pk` constraint is _not_ metadata. Tooling flags known constraint tokens inside type arguments (`constraint-in-type-args` warning).
 - `amount DECIMAL (12,2)` is a parse error — numeric type arguments must attach to the type with no space.
 
 ### 3.3 Nested Structures: `record` and `list_of`
@@ -176,6 +177,7 @@ NAME [TYPE] [(metadata)] [{body}]
 ```
 
 Where TYPE can be:
+
 - A scalar type: `STRING`, `DECIMAL(12,2)`, etc.
 - `record` — single nested structure
 - `list_of record` — list of structured elements
@@ -254,7 +256,7 @@ note {
 }
 ```
 
-This distinction follows the three-delimiter rule: `( )` for metadata *about* an element, `{ }` for standalone structural content.
+This distinction follows the three-delimiter rule: `( )` for metadata _about_ an element, `{ }` for standalone structural content.
 
 ### 3.5 Format-Specific Metadata
 
@@ -393,7 +395,7 @@ CUST_ID -> customer_id (note "Deterministic UUID from legacy ID") {
 
 ### 4.3 Value Maps
 
-Use `map { }` for discrete value mappings. The `:` separates input from output. Output values are usually quoted; a bare (unquoted) value extends to the end of its line, so entries can be newline-separated without commas. Two entries on the *same* line must be comma-separated — `R: retail B: biz` without a comma is an error.
+Use `map { }` for discrete value mappings. The `:` separates input from output. Output values are usually quoted; a bare (unquoted) value extends to the end of its line, so entries can be newline-separated without commas. Two entries on the _same_ line must be comma-separated — `R: retail B: biz` without a comma is an error.
 
 ```
 CUST_TYPE -> customer_type {
@@ -438,27 +440,65 @@ StageName -> pipeline_stage {
 
 ### 4.4 Nested Mappings
 
-When source and target have nested/repeated structures, use `each` blocks to iterate lists and nest the arrows:
+When source and target have nested/repeated structures, use `each` blocks to iterate lists and nest the arrows. Blocks nest where the _source_ nests — here `lines` is declared inside `orders`:
 
 ```
-each POReferences -> ShipmentHeader.asnDetails (
-  note "Each PO reference generates one asnDetails entry.
-        Line items and quantities correlated by position."
-) {
-  .REFNUM -> .orderNo { split("/") | first | to_number }
+schema dispatch {
+  orders list_of record {
+    order_no  STRING
+    lines list_of record {
+      sku  STRING
+      qty  INT
+    }
+  }
+}
 
-  each LineItems -> .items {
-    .ITEMNO -> .item { trim | "Resolve via MFCS supplier item cross-reference" }
-    Quantities.QUANTITY -> .unitQuantity {
-      "Divide by 10000 (4 implied decimals), multiply by PO pack size from MFCS"
+mapping `dispatch manifest` {
+  source { dispatch }
+  target { manifest }
+
+  each orders -> shipments (note "One shipment per dispatched order.") {
+    .order_no -> .reference { trim | uppercase }
+
+    each lines -> .items {
+      .sku -> .code { trim | uppercase }
+      .qty -> .quantity
     }
   }
 }
 ```
 
-The `.` prefix indicates a field relative to the current nesting context. The `each` keyword introduces an iteration over a source list, producing elements in the target list.
+The `each` keyword introduces an iteration over a source list, producing elements in the target list.
 
-**Where nested arrows are valid.** Arrows nest inside `each`/`flatten` blocks and inside the braced body of a plain `src -> tgt` arrow. The bodies of *computed* arrows (`-> tgt { ... }`) and *multi-source* arrows (`a, b -> tgt { ... }`) are transform pipelines, not nesting scopes — an arrow written there is a parse error, never silently treated as pipeline prose (it would otherwise vanish from lineage).
+**Every path inside a block is relative to that block.** A leading `.` documents the relativity, but it does not decide it: `sku` and `.sku` inside `each lines` both mean `orders.lines.sku`. The block's own path is prefixed to whatever is written, accumulating through every level of nesting.
+
+| Written inside                                     | Resolves to                                           |
+| -------------------------------------------------- | ----------------------------------------------------- |
+| `.order_no` in `each orders`                       | `orders.order_no`                                     |
+| `.sku` in `each lines` in `each orders`            | `orders.lines.sku`                                    |
+| `orders.order_no` in `each lines` in `each orders` | `orders.lines.orders.order_no` — not a declared field |
+
+**There is no notation for reaching an ancestor**, as that last row shows. A field from an enclosing level cannot be referenced from inside a block; write the arrow _outside_ the block, where its path is already absolute. In a `flatten` block that reads naturally, since fields outside the block repeat on every output row (section 4.6).
+
+**Correlating two lists declared side by side.** A list is only nested if it is _declared_ nested. Two lists at the schema root are iterated by two sibling `each` blocks, which may write into the same target list; state the correspondence in a `note`, using an `@ref` so it is traceable:
+
+```
+each LineItems -> ShipmentHeader.asnDetails.items (
+  note "Correlate to @POReferences by position within the EDI message group."
+) {
+  .ITEMNO -> .item { trim }
+}
+
+each Quantities -> ShipmentHeader.asnDetails.items (
+  note "Match to @LineItems by position — each quantity corresponds to one line item."
+) {
+  .QUANTITY -> .unitQuantity { "Divide by 10000 (4 implied decimals)" }
+}
+```
+
+Nesting `each Quantities` inside `each LineItems` would instead resolve to `LineItems.Quantities`, which such a schema does not declare. Section 8.2 shows this pattern in full.
+
+**Where nested arrows are valid.** Arrows nest inside `each`/`flatten` blocks and inside the braced body of a plain `src -> tgt` arrow. The bodies of _computed_ arrows (`-> tgt { ... }`) and _multi-source_ arrows (`a, b -> tgt { ... }`) are transform pipelines, not nesting scopes — an arrow written there is a parse error, never silently treated as pipeline prose (it would otherwise vanish from lineage).
 
 ### 4.5 Fallback Sources
 
@@ -589,6 +629,7 @@ Import syntax follows the pattern `import { <names> } from "<path>"`. Paths are 
 Satsuma uses **explicit import scoping**: a symbol is only in scope within a file if it appears in that file's import graph (directly imported or transitively reachable via imported symbols' own dependencies). Symbols that exist in the same workspace directory but are not reachable via imports are **not** in scope. Importing one symbol from a file does **not** bring every other definition from that file into scope.
 
 Tooling must respect this boundary:
+
 - Navigation features (go-to-definition, find-references, completions, rename) resolve symbols only within the import-reachable file set of the active file.
 - Editor diagnostics and semantic analysis use the same import-reachable file set; they do not treat the surrounding directory or workspace folder as an implicit merged scope.
 - A reference to a symbol that exists in the workspace but is not reachable via imports is a semantic error. Tooling should suggest the exact `import` statement needed to bring the symbol into scope.
@@ -602,7 +643,7 @@ The entry file for platform-wide lineage analysis is the file that imports from 
 
 A metric schema declares a business metric: what it measures, where the data comes from, and how it can be sliced. Metrics are consumers of schemas — they appear at the end of a lineage graph, not in the middle.
 
-Metrics are `schema` blocks decorated with the `metric` vocabulary token in the metadata block. This is consistent with how `report` and `ml_model` schemas are declared — there is no separate `metric` keyword. Data flow *into* a metric is expressed via `mapping` blocks, not embedded in the schema declaration.
+Metrics are `schema` blocks decorated with the `metric` vocabulary token in the metadata block. This is consistent with how `report` and `ml_model` schemas are declared — there is no separate `metric` keyword. Data flow _into_ a metric is expressed via `mapping` blocks, not embedded in the schema declaration.
 
 ### 6.1 Basic Structure
 
@@ -629,23 +670,23 @@ The data pipeline that populates the metric is expressed as a separate `mapping`
 
 These vocabulary tokens go in the `( )` metadata block alongside `metric`:
 
-| Token | Meaning | Example |
-|-------|---------|---------|
-| `metric` | Marks this schema as a business metric | `metric` |
-| `metric_name` | Short business display label | `metric_name "MRR"` |
-| `source` | Schema(s) the metric is derived from | `source fact_orders` or `source {fact_orders, dim_customer}` |
-| `grain` | The time or dimensional grain | `grain monthly`, `grain daily` |
-| `slice` | Dimensions the metric can be cut by | `slice {region, product_line, segment}` |
-| `filter` | Row-level filter applied before aggregation | `filter "status = 'active'"` |
+| Token         | Meaning                                     | Example                                                      |
+| ------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| `metric`      | Marks this schema as a business metric      | `metric`                                                     |
+| `metric_name` | Short business display label                | `metric_name "MRR"`                                          |
+| `source`      | Schema(s) the metric is derived from        | `source fact_orders` or `source {fact_orders, dim_customer}` |
+| `grain`       | The time or dimensional grain               | `grain monthly`, `grain daily`                               |
+| `slice`       | Dimensions the metric can be cut by         | `slice {region, product_line, segment}`                      |
+| `filter`      | Row-level filter applied before aggregation | `filter "status = 'active'"`                                 |
 
 ### 6.3 Measure Fields
 
 Fields inside a metric body declare the numeric values the metric produces. The `measure` vocabulary token describes aggregation behaviour:
 
-| Token | Meaning |
-|-------|---------|
-| `measure additive` | Can be summed across all dimensions |
-| `measure non_additive` | Cannot be summed (e.g. ratios, averages) |
+| Token                   | Meaning                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| `measure additive`      | Can be summed across all dimensions                                                   |
+| `measure non_additive`  | Cannot be summed (e.g. ratios, averages)                                              |
 | `measure semi_additive` | Can be summed across some dimensions but not others (e.g. balance at a point in time) |
 
 ### 6.4 Examples
@@ -716,7 +757,7 @@ schema churn_rate (
 ### 6.5 Metric Schemas vs Regular Schemas
 
 - Metric schemas **are schemas** — they share the definition namespace with all other schemas and can appear as `target` in mapping blocks.
-- Metric schemas are **not valid sources** — mapping blocks should not use a metric schema as a `source`. By convention, data flows *into* metrics; nothing flows *out*.
+- Metric schemas are **not valid sources** — mapping blocks should not use a metric schema as a `source`. By convention, data flows _into_ metrics; nothing flows _out_.
 - The `source`, `grain`, `slice`, and `filter` tokens are vocabulary tokens interpreted by the LLM or downstream tooling — the parser captures them structurally but does not enforce them.
 - The `satsuma metric <name>` command identifies schemas decorated with the `metric` metadata token. It is not a distinct block type.
 
@@ -728,56 +769,56 @@ Vocabulary tokens are **not keywords** — they are interpreted by the LLM based
 
 ### 7.1 Field Metadata Tokens (used in `( )`)
 
-| Token | Meaning | Example |
-|-------|---------|---------|
-| `pk` | Primary key | `(pk)` |
-| `required` | Must not be null | `(required)` |
-| `unique` | Values must be unique | `(unique)` |
-| `indexed` | Should have an index | `(indexed)` |
-| `pii` | Personally identifiable information | `(pii)` |
-| `encrypt` | Must be encrypted | `(encrypt AES-256-GCM)` |
-| `enum` | Restricted value set | `(enum {a, b, c})` |
-| `default` | Default value | `(default 0)` |
-| `format` | Data format constraint | `(format email)` |
-| `ref` | Foreign key reference | `(ref addresses.id)` |
-| `xpath` | XML path expression | `(xpath "ord:OrderId")` |
-| `namespace` | XML namespace declaration | `(namespace ord "http://...")` |
-| `filter` | Row-level filter condition | `(filter QUAL == "ON")` |
-| `note` | Persistent documentation | `(note "Converted at daily spot rate")` |
+| Token       | Meaning                             | Example                                 |
+| ----------- | ----------------------------------- | --------------------------------------- |
+| `pk`        | Primary key                         | `(pk)`                                  |
+| `required`  | Must not be null                    | `(required)`                            |
+| `unique`    | Values must be unique               | `(unique)`                              |
+| `indexed`   | Should have an index                | `(indexed)`                             |
+| `pii`       | Personally identifiable information | `(pii)`                                 |
+| `encrypt`   | Must be encrypted                   | `(encrypt AES-256-GCM)`                 |
+| `enum`      | Restricted value set                | `(enum {a, b, c})`                      |
+| `default`   | Default value                       | `(default 0)`                           |
+| `format`    | Data format constraint              | `(format email)`                        |
+| `ref`       | Foreign key reference               | `(ref addresses.id)`                    |
+| `xpath`     | XML path expression                 | `(xpath "ord:OrderId")`                 |
+| `namespace` | XML namespace declaration           | `(namespace ord "http://...")`          |
+| `filter`    | Row-level filter condition          | `(filter QUAL == "ON")`                 |
+| `note`      | Persistent documentation            | `(note "Converted at daily spot rate")` |
 
-**Tag value boundaries.** A bare (unquoted) tag value extends along the tag's line only, and never includes the structural entry keywords (`note`, `enum`, `slice`) or the constraint flag tokens (`pk`, `required`, `unique`, `indexed`, `pii`, `encrypt`). This makes a forgotten comma a parse error rather than a silent misread: `(pk note "x")`, `(required pii)`, and a flag starting the next line all fail loudly instead of folding the flag into the previous value. To use a constraint flag word *as* a value, quote it: `(classification "pii")`.
+**Tag value boundaries.** A bare (unquoted) tag value extends along the tag's line only, and never includes the structural entry keywords (`note`, `enum`, `slice`) or the constraint flag tokens (`pk`, `required`, `unique`, `indexed`, `pii`, `encrypt`). This makes a forgotten comma a parse error rather than a silent misread: `(pk note "x")`, `(required pii)`, and a flag starting the next line all fail loudly instead of folding the flag into the previous value. To use a constraint flag word _as_ a value, quote it: `(classification "pii")`.
 
 ### 7.2 Vocabulary Conventions (pipe step shorthand)
 
 All pipe step content — bare tokens, quoted strings, and map literals — is natural language interpreted by a human or LLM. The following table lists **vocabulary conventions**: commonly used bare tokens that teams adopt as shorthand for well-understood operations. They are not keywords or reserved words; the parser treats them identically to any other bare token. Their meaning is defined by convention and by the implementing system, not by the Satsuma grammar.
 
-| Token | Conventional meaning |
-|-------|---------------------|
-| `trim` | Strip whitespace |
-| `lowercase` / `uppercase` | Case conversion |
-| `coalesce(val)` | Replace null with val |
-| `round(n)` | Round to n decimal places |
-| `split(sep)` | Split string on separator |
-| `first` / `last` | Take first/last element |
-| `to_utc` | Convert to UTC |
-| `to_iso8601` | Format as ISO 8601 |
-| `parse(fmt)` | Parse string with format |
-| `null_if_empty` | Convert empty string to null |
-| `null_if_invalid` | Convert invalid value to null |
-| `drop_if_invalid` | Drop the record if value is invalid |
-| `drop_if_null` | Drop the record if value is null |
-| `warn_if_invalid` | Log a warning if value is invalid |
-| `warn_if_null` | Log a warning if value is null |
-| `error_if_invalid` | Fail the pipeline if value is invalid |
-| `error_if_null` | Fail the pipeline if value is null |
-| `validate_email` | Validate email format |
-| `now_utc()` | Current UTC timestamp |
-| `title_case` | Convert to title case |
-| `escape_html` | Escape HTML entities |
-| `truncate(n)` | Truncate to n characters |
-| `to_number` | Convert to numeric type |
-| `prepend(str)` | Prefix a string |
-| `max_length(n)` | Enforce maximum length |
+| Token                     | Conventional meaning                  |
+| ------------------------- | ------------------------------------- |
+| `trim`                    | Strip whitespace                      |
+| `lowercase` / `uppercase` | Case conversion                       |
+| `coalesce(val)`           | Replace null with val                 |
+| `round(n)`                | Round to n decimal places             |
+| `split(sep)`              | Split string on separator             |
+| `first` / `last`          | Take first/last element               |
+| `to_utc`                  | Convert to UTC                        |
+| `to_iso8601`              | Format as ISO 8601                    |
+| `parse(fmt)`              | Parse string with format              |
+| `null_if_empty`           | Convert empty string to null          |
+| `null_if_invalid`         | Convert invalid value to null         |
+| `drop_if_invalid`         | Drop the record if value is invalid   |
+| `drop_if_null`            | Drop the record if value is null      |
+| `warn_if_invalid`         | Log a warning if value is invalid     |
+| `warn_if_null`            | Log a warning if value is null        |
+| `error_if_invalid`        | Fail the pipeline if value is invalid |
+| `error_if_null`           | Fail the pipeline if value is null    |
+| `validate_email`          | Validate email format                 |
+| `now_utc()`               | Current UTC timestamp                 |
+| `title_case`              | Convert to title case                 |
+| `escape_html`             | Escape HTML entities                  |
+| `truncate(n)`             | Truncate to n characters              |
+| `to_number`               | Convert to numeric type               |
+| `prepend(str)`            | Prefix a string                       |
+| `max_length(n)`           | Enforce maximum length                |
 
 #### Error-handling convention
 
@@ -1140,24 +1181,33 @@ mapping `edi to mfcs` {
   ShipmentRefs.SHIPREF -> ShipmentHeader.comments { prepend("Shipment reference number: ") }
 
   // --- Detail lines grouped by PO ---
+  // POReferences, LineItems and Quantities are all declared at the schema root,
+  // so each is iterated by its own block. Nesting `each LineItems` inside
+  // `each POReferences` would resolve to POReferences.LineItems, which the EDI
+  // schema does not declare — see the path rule in section 4.4.
   each POReferences -> ShipmentHeader.asnDetails (
-    note "Each PO reference generates one asnDetails entry.
-          Line items and quantities are correlated by position."
+    note "Each PO reference generates one asnDetails entry."
   ) {
     .REFNUM -> .orderNo { split("/") | first | to_number }
+  }
 
-    each LineItems -> .items {
-      .ITEMNO -> .item {
-        trim
-        | "Retrieve MFCS item number using the supplier's traded code
-           from the MFCS supplier item cross-reference."
-      }
+  each LineItems -> ShipmentHeader.asnDetails.items (
+    note "Correlate to @POReferences by position within the EDI message group."
+  ) {
+    .ITEMNO -> .item {
+      trim
+      | "Retrieve MFCS item number using the supplier's traded code
+         from the MFCS supplier item cross-reference."
+    }
+  }
 
-      Quantities.QUANTITY -> .unitQuantity {
-        "Divide by 10000 to account for 4 implied decimal places.
-         Then multiply by PO pack size from MFCS (Action A-504).
-         Pack size retrieved from MFCS PO line matching this item."
-      }
+  each Quantities -> ShipmentHeader.asnDetails.items (
+    note "Match to @LineItems by position — each quantity corresponds to one line item."
+  ) {
+    .QUANTITY -> .unitQuantity {
+      "Divide by 10000 to account for 4 implied decimal places.
+       Then multiply by PO pack size from MFCS (Action A-504).
+       Pack size retrieved from MFCS PO line matching this item."
     }
   }
 
@@ -1473,17 +1523,17 @@ mapping `opportunity ingestion` {
 
 ## 8. Summary of Changes from v1
 
-| v1 | v2 | Rationale |
-|----|-----|-----------|
-| `[pk, required]` bracket tags | `(pk, required)` parentheses | `()` = metadata, `[]` freed |
-| `@xpath(...)`, `@format(...)` annotations | `(xpath ..., format ...)` in metadata | Unified in `()` |
-| `table`, `message`, `source`, `target` keywords | Single `schema` keyword | Simpler — role is contextual |
-| `STRUCT { }` / `ARRAY { }` | `Name record { }` / `Name list_of record { }` | Unified field syntax: `NAME TYPE (meta) {body}` |
-| `nl("...")` function | Bare `"..."` in `{ }` | NL is first-class |
-| `: transform` after arrow | `{ transform }` after arrow | Consistent — `{}` holds content |
-| `when/else` clauses | `map { }` with conditions or NL | Simpler, more flexible |
-| `fallback` keyword | NL fallback description | Let the LLM interpret |
-| `[enum: {a, b}]` | `(enum {a, b})` | Braces for value sets, parens for metadata |
-| `note '''...`''` triple-quoted | `(note "...")` or `(note """...""")` | Notes are metadata; `"""` for Markdown |
-| `integration { }` block | `note { """...""" }` block | Structured, consistent with delimiter rules |
-| `=> target` computed fields | `-> target` (no left side) | Consistent arrow syntax |
+| v1                                              | v2                                            | Rationale                                       |
+| ----------------------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+| `[pk, required]` bracket tags                   | `(pk, required)` parentheses                  | `()` = metadata, `[]` freed                     |
+| `@xpath(...)`, `@format(...)` annotations       | `(xpath ..., format ...)` in metadata         | Unified in `()`                                 |
+| `table`, `message`, `source`, `target` keywords | Single `schema` keyword                       | Simpler — role is contextual                    |
+| `STRUCT { }` / `ARRAY { }`                      | `Name record { }` / `Name list_of record { }` | Unified field syntax: `NAME TYPE (meta) {body}` |
+| `nl("...")` function                            | Bare `"..."` in `{ }`                         | NL is first-class                               |
+| `: transform` after arrow                       | `{ transform }` after arrow                   | Consistent — `{}` holds content                 |
+| `when/else` clauses                             | `map { }` with conditions or NL               | Simpler, more flexible                          |
+| `fallback` keyword                              | NL fallback description                       | Let the LLM interpret                           |
+| `[enum: {a, b}]`                                | `(enum {a, b})`                               | Braces for value sets, parens for metadata      |
+| `note '''...`''` triple-quoted                  | `(note "...")` or `(note """...""")`          | Notes are metadata; `"""` for Markdown          |
+| `integration { }` block                         | `note { """...""" }` block                    | Structured, consistent with delimiter rules     |
+| `=> target` computed fields                     | `-> target` (no left side)                    | Consistent arrow syntax                         |

--- a/docs/nested-data/README.md
+++ b/docs/nested-data/README.md
@@ -298,7 +298,7 @@ mapping `sighting rows` {
 ```
 $ satsuma coverage sighting-rows.stm
 
-  source  colony_survey             5/12   42%
+  source  colony_survey             5/12   41%
   target  sighting_rows_parquet      4/4  100%
     uncovered in colony_survey (source): 7 fields
       surveyed_at, observer.ranger_id, observer.email, weather_tags,
@@ -534,7 +534,7 @@ expresses. A `flatten` header takes a full path of any depth
 flattens in one block.
 
 ```
-  source  colony_submission_xml             6/7   86%
+  source  colony_submission_xml             6/7   85%
   target  colony_sighting_rows_parquet      5/5  100%
     uncovered in colony_submission_xml (source): 1 field
       Survey.Colony.GridRef
@@ -709,7 +709,7 @@ design:
 $ satsuma coverage puffin-point.stm
 
 mapping sighting rows
-  source  colony_survey             5/12   42%
+  source  colony_survey             5/12   41%
   target  sighting_rows_parquet      4/4  100%
     uncovered in colony_survey (source): 7 fields
       surveyed_at, observer.ranger_id, observer.email, weather_tags,
@@ -742,6 +742,12 @@ satsuma coverage pipeline.stm --fail-under 80 --role source
 exits **3** when the threshold is missed (distinct from 1 for a bad
 `--mapping`/`--schema` name, so CI can tell an incomplete spec from a broken
 invocation).
+
+**`--fail-under 100` means every leaf.** Percentages reserve 100% and 0% for the
+exact endpoints and floor everything between, so a single unmapped leaf in a
+201-leaf schema reports 99% and fails the gate rather than rounding up to a pass.
+This matters most on nested schemas, because they are where leaf counts get large
+enough for one field to disappear into a rounding.
 
 For nested work specifically:
 

--- a/tooling/satsuma-cli/src/commands/coverage.ts
+++ b/tooling/satsuma-cli/src/commands/coverage.ts
@@ -146,6 +146,12 @@ pipeline can gate one mapping or one schema rather than the whole workspace.
 The figure gated is the COMBINED one, both tiers together: the gate asks "is this
 spec complete", and an @ref is a declaration of intent, not a hint.
 
+Percentages are whole numbers, and the two endpoints are reserved: 100% means
+every leaf is covered and 0% means none is. Anything in between floors into
+1-99%, so 200 of 201 leaves reports 99% and fails --fail-under 100 rather than
+rounding up to a pass, and 1 of 201 reports 1% rather than flooring to a 0% that
+reads as nothing mapped. The number printed is the number gated.
+
 Exit codes:
   0  report produced (and the --fail-under threshold met, if given)
   1  --mapping/--schema named something that does not exist, nothing matched, or
@@ -477,6 +483,11 @@ interface CoverageGate {
  * 0% coverage, it is nothing to measure: `--schema customers --fail-under 90`
  * where `customers` is only ever a source would otherwise report a spec failure
  * caused entirely by the invocation.
+ *
+ * Compares `totals.pct` rather than re-deriving a ratio, deliberately: core's
+ * `coveragePercentage` reserves 100 for a complete spec and floors everything
+ * below it, so the figure a reviewer reads is the figure gated. Gating a
+ * separately-computed ratio is how the two came apart in `sl-8ba4`.
  */
 function evaluateGate(
   aggregate: AggregateCoverage,

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -15,7 +15,9 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { resolve, dirname } from "node:path";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { run as _run } from "./helpers.js";
 
@@ -34,6 +36,29 @@ const NESTED_ARROW = resolve(__dirname, "fixtures/nested-arrow-lookup.stm");
 const MULTI_SOURCE = resolve(__dirname, "fixtures/coverage-multi-source.stm");
 
 const run = (...args: string[]) => _run(CLI, ...args);
+
+/**
+ * Write a throwaway workspace of `total` leaves with `mapped` of them mapped.
+ *
+ * Generated rather than committed as a fixture because the percentage rule's
+ * boundary needs a schema large enough that one leaf is worth under half a
+ * percent (sl-8ba4), and a 200-field file adds nothing a reader could not infer
+ * from this loop. Returns the file path and a cleanup that removes the temp dir.
+ */
+function writeLeafFixture(total: number, mapped: number): { file: string; cleanup: () => void } {
+  const fields = Array.from({ length: total }, (_, i) => `  f${i}  STRING`).join("\n");
+  const arrows = Array.from({ length: mapped }, (_, i) => `  f${i} -> f${i}`).join("\n");
+  const source = [
+    `schema big_s {\n${fields}\n}`,
+    `schema big_t {\n${fields}\n}`,
+    `mapping \`wide\` {\n  source { big_s }\n  target { big_t }\n\n${arrows}\n}`,
+  ].join("\n\n");
+
+  const dir = mkdtempSync(join(tmpdir(), "coverage-pct-"));
+  const file = join(dir, "wide.stm");
+  writeFileSync(file, `${source}\n`);
+  return { file, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
 
 /** Parse `--json` output, failing with the raw text when it is not JSON. */
 function parseJson(stdout: string): any {
@@ -694,10 +719,12 @@ describe("satsuma coverage --fail-under", () => {
       "--json",
     );
     assert.equal(code, 3);
+    // 2 of 3 leaves is 66%, not 67% — percentages floor between the endpoints
+    // so a figure never overstates what the counts support (sl-8ba4).
     assert.deepEqual(parseJson(stdout).gate, {
       role: "target",
       threshold: 100,
-      pct: 67,
+      pct: 66,
       met: false,
     });
   });
@@ -746,6 +773,47 @@ describe("satsuma coverage --fail-under", () => {
     const { code } = await run("coverage", WORKSPACE, "--fail-under", "0");
     assert.equal(code, 0);
   });
+
+  it("fails --fail-under 100 on a schema one leaf short of complete (sl-8ba4)", async () => {
+    // The gate's fail-open case. With the percentage rounded to nearest, 200 of
+    // 201 leaves reported 100% and this exited 0 — a merge gate passing a spec
+    // with an unmapped field. The report and the verdict must both refuse to
+    // call it complete, and they are the same number.
+    const { file, cleanup } = writeLeafFixture(201, 200);
+    try {
+      const { stdout, code } = await run("coverage", file, "--fail-under", "100");
+      assert.equal(code, 3, "one unmapped leaf must not satisfy a 100% gate");
+      assert.match(stdout, /200\/201\s+99%/, "the printed figure must not claim 100%");
+      assert.match(stdout, /--fail-under: target coverage 99% vs threshold 100% — NOT met/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("passes --fail-under 100 once the last leaf is mapped", async () => {
+    // The other side of the boundary: 100% is reachable, so the stricter rule
+    // cannot be satisfied only by lowering the threshold.
+    const { file, cleanup } = writeLeafFixture(201, 201);
+    try {
+      const { stdout, code } = await run("coverage", file, "--fail-under", "100");
+      assert.equal(code, 0);
+      assert.match(stdout, /201\/201\s+100%/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("reports 1%, not 0%, when a single leaf of many is mapped", async () => {
+    // Flooring alone would print 0% here, indistinguishable from a spec nothing
+    // touches — the review queue's strongest claim. Partial work stays visible.
+    const { file, cleanup } = writeLeafFixture(201, 1);
+    try {
+      const { stdout } = await run("coverage", file);
+      assert.match(stdout, /1\/201\s+1%/);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 // ── Nested containers on the real corpus (sl-qzy3) ──────────────────────────
@@ -787,7 +855,9 @@ describe("satsuma coverage — nested containers", () => {
     );
     assert.deepEqual(
       { covered: source.covered, total: source.total, pct: source.pct },
-      { covered: 8, total: 9, pct: 89 },
+      // 8 of 9 is 88.9%, reported as 88: 100% is reserved for a complete
+      // schema and everything below it floors (sl-8ba4).
+      { covered: 8, total: 9, pct: 88 },
     );
   });
 

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -72,7 +72,11 @@ export interface CoverageTotals {
   coveredNl: number;
   /** Leaf fields declared. Zero for a schema with no leaves. */
   total: number;
-  /** covered/total as a whole-number percentage; 0 when `total` is 0. */
+  /**
+   * covered/total as a whole-number percentage, per
+   * {@link coveragePercentage}'s rule: 100 and 0 mean *exactly* complete and
+   * *exactly* nothing, and every state in between reports 1–99.
+   */
   pct: number;
 }
 
@@ -166,7 +170,7 @@ export function summarizeFieldCoverage(fields: FieldCoverageEntry[]): CoverageTo
     coveredDeclared: coveredLeaves.length - coveredNl,
     coveredNl,
     total: leaves.length,
-    pct: percentage(coveredLeaves.length, leaves.length),
+    pct: coveragePercentage(coveredLeaves.length, leaves.length),
   };
 }
 
@@ -215,9 +219,34 @@ function hasDescendant(path: string, paths: Set<string>): boolean {
   return false;
 }
 
-/** Whole-number percentage, defined as 0 when there is nothing to cover. */
-function percentage(covered: number, total: number): number {
-  return total > 0 ? Math.round((covered / total) * 100) : 0;
+/**
+ * The whole-number percentage every consumer reports and `--fail-under` gates.
+ *
+ * **Rule: 100 and 0 are reserved for the exact endpoints; everything between
+ * them floors into 1–99.** Rounding to nearest is what a gate cannot survive
+ * (`sl-8ba4`): 200 of 201 leaves rounds to 100, so `--fail-under 100` passed a
+ * spec with an unmapped field — failing open in the one direction a merge gate
+ * must not. Flooring alone fixes the gate but introduces the mirror-image lie at
+ * the bottom, where 1 of 201 reports 0% and reads as "nothing is mapped".
+ *
+ * So the two endpoints are decided by the counts, not by arithmetic on them:
+ *
+ * - `covered === total` → 100. The only way to print 100.
+ * - `covered === 0` → 0. The only way to print 0 (with `total === 0`, below).
+ * - otherwise → `floor`, clamped up to 1, so partial work never reports as none.
+ *
+ * A reviewer and CI therefore read the same number, which is why the gate reads
+ * `pct` rather than re-deriving a ratio of its own.
+ *
+ * `total === 0` reports 0: a schema with no leaves has nothing to cover, and
+ * calling that complete would let an empty schema satisfy any threshold.
+ */
+export function coveragePercentage(covered: number, total: number): number {
+  if (total <= 0) return 0;
+  if (covered >= total) return 100;
+  if (covered <= 0) return 0;
+  // Floor, then hold the bottom off 0 — a covered leaf must be visible.
+  return Math.max(1, Math.floor((covered / total) * 100));
 }
 
 /** Sum a set of totals, recomputing the percentage from the summed counts. */
@@ -232,7 +261,7 @@ function sumTotals(parts: Iterable<CoverageTotals>): CoverageTotals {
     coveredNl += part.coveredNl;
     total += part.total;
   }
-  return { covered, coveredDeclared, coveredNl, total, pct: percentage(covered, total) };
+  return { covered, coveredDeclared, coveredNl, total, pct: coveragePercentage(covered, total) };
 }
 
 // ── Aggregation ─────────────────────────────────────────────────────────────

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -52,6 +52,7 @@ export {
   summarizeFieldCoverage,
   leafFieldEntries,
   countContainerStates,
+  coveragePercentage,
 } from "./coverage-rollup.js";
 export type {
   MappingCoverageInput,

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -25,6 +25,7 @@ import {
   aggregateCoverage,
   summarizeFieldCoverage,
   countContainerStates,
+  coveragePercentage,
 } from "@satsuma/core";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -111,7 +112,7 @@ describe("summarizeFieldCoverage()", () => {
       { path: "address.line2", uri: "u", mapped: false },
       { path: "id", uri: "u", mapped: true },
     ]);
-    assert.deepEqual(totals, expectTotals(2, 3, 67));
+    assert.deepEqual(totals, expectTotals(2, 3, 66));
   });
 
   it("does not let a partly covered record vouch for its uncovered leaves", () => {
@@ -131,15 +132,51 @@ describe("summarizeFieldCoverage()", () => {
     assert.deepEqual(summarizeFieldCoverage([]), expectTotals(0, 0, 0));
   });
 
-  it("rounds the percentage to a whole number", () => {
-    // The CLI table and --fail-under both compare whole numbers, so rounding
-    // has to happen once, here, not per renderer.
+  it("reduces the percentage to a whole number in one place, not per renderer", () => {
+    // The CLI table, the status bar and --fail-under all compare whole numbers,
+    // so the reduction happens here and every consumer inherits the same rule.
     const totals = summarizeFieldCoverage([
       { path: "a", uri: "u", mapped: true },
       { path: "b", uri: "u", mapped: false },
       { path: "c", uri: "u", mapped: false },
     ]);
     assert.equal(totals.pct, 33);
+  });
+});
+
+// ── The percentage rule (sl-8ba4) ───────────────────────────────────────────
+
+describe("coveragePercentage()", () => {
+  it("reports 100 only when every leaf is covered", () => {
+    // The bug this rule exists for: rounding to nearest turned 200/201 into 100,
+    // so `--fail-under 100` passed a spec with an unmapped field — a merge gate
+    // failing open. 100 now means exactly complete, and nothing else does.
+    assert.equal(coveragePercentage(201, 201), 100);
+    assert.equal(coveragePercentage(200, 201), 99);
+    assert.equal(coveragePercentage(2000, 2001), 99);
+  });
+
+  it("reports 0 only when no leaf is covered", () => {
+    // The mirror-image lie flooring would introduce on its own: 1/201 floors to
+    // 0 and reads as "nothing is mapped". Partial work must stay visible, so the
+    // bottom is held off 0 for any non-zero numerator.
+    assert.equal(coveragePercentage(0, 201), 0);
+    assert.equal(coveragePercentage(1, 201), 1);
+    assert.equal(coveragePercentage(1, 100000), 1);
+  });
+
+  it("floors everything between the endpoints, so a figure never overstates", () => {
+    // 8/9 is 88.9%: it reports 88, and `--fail-under 89` therefore fails on it.
+    // Every printed figure is a claim the counts can support.
+    assert.equal(coveragePercentage(8, 9), 88);
+    assert.equal(coveragePercentage(2, 3), 66);
+    assert.equal(coveragePercentage(1, 2), 50);
+    assert.equal(coveragePercentage(1, 3), 33);
+  });
+
+  it("reports 0 for a schema with no leaves rather than dividing by zero", () => {
+    // Calling an empty schema complete would let it satisfy any threshold.
+    assert.equal(coveragePercentage(0, 0), 0);
   });
 });
 
@@ -242,7 +279,7 @@ mapping load_memos {
     // tgt is a target of two mappings; double counting it would halve the
     // workspace percentage for no reason.
     const { aggregate: result } = aggregate(SRC);
-    assert.deepEqual(entry(result, "target", "tgt").totals, expectTotals(2, 3, 67));
+    assert.deepEqual(entry(result, "target", "tgt").totals, expectTotals(2, 3, 66));
   });
 
   it("reports a record as covered when two mappings between them write every leaf", () => {
@@ -369,7 +406,7 @@ namespace billing {
     const crm = result.namespaces.find((n) => n.namespace === "crm");
     const billing = result.namespaces.find((n) => n.namespace === "billing");
     assert.deepEqual(crm.source, expectTotals(1, 2, 50), "crm::customers: id read, email not");
-    assert.deepEqual(billing.source, expectTotals(2, 3, 67), "billing::invoices: memo not read");
+    assert.deepEqual(billing.source, expectTotals(2, 3, 66), "billing::invoices: memo not read");
     assert.deepEqual(billing.target, expectTotals(2, 2, 100), "billing::ledger fully populated");
   });
 

--- a/tooling/vscode-satsuma/test/coverage-logic.test.js
+++ b/tooling/vscode-satsuma/test/coverage-logic.test.js
@@ -100,13 +100,14 @@ describe("groupCoverageByUri", () => {
 describe("computeTargetCoverageStats", () => {
   it("counts leaves, agreeing with satsuma coverage rather than its own rule", () => {
     // 3cc-t6uo: this counted top-level fields only, so it reported 1/2 (50%)
-    // where `satsuma coverage` reported 2/3 (67%) for the same mapping — a
+    // where `satsuma coverage` reported 2/3 (66%) for the same mapping — a
     // twelve-field `address` record counted as one unit, and one mapped leaf read
     // as a fully covered record. Two percentages for one mapping, and a user with
     // the terminal open beside the editor could not tell which was wrong. The
-    // count now comes from core's summarizeFieldCoverage.
+    // count now comes from core's summarizeFieldCoverage — including its rounding
+    // rule, so 2/3 reads 66% in both places rather than 67% here (sl-8ba4).
     const stats = computeTargetCoverageStats(sampleSchemas());
-    assert.deepEqual(stats, { mapped: 2, total: 3, pct: 67, mappedNl: 1 });
+    assert.deepEqual(stats, { mapped: 2, total: 3, pct: 66, mappedNl: 1 });
   });
 
   it("reports how much of the figure is inferred from prose", () => {


### PR DESCRIPTION
Closes `sl-8ba4` (P1) and `sl-pn00` (P2), the two you picked out. Three commits: the fix, the spec correction, and ADR-040.

## 1. `--fail-under` no longer passes an incomplete spec (`sl-8ba4`)

`CoverageTotals.pct` was `Math.round((covered / total) * 100)` and `evaluateGate` compared it, so any population where one leaf is worth under half a percent rounded up to 100:

```
  source  big_s  200/201  100%
  target  big_t  200/201  100%
    uncovered in big_t (target): 1 field
      f200
$ satsuma coverage rounding.stm --fail-under 100 ; echo $?
0
```

**Rule shipped** — option (a) from the ticket, as you chose:

| Counts | Reports | Why |
|---|---|---|
| `covered === total` | **100** | the only way to print 100 |
| `covered === 0`, or `total === 0` | **0** | the only way to print 0 |
| anything between | `floor`, clamped up to **1** | never overstates; never reads as "nothing mapped" |

So `200/201` → 99% and fails `--fail-under 100`; `201/201` → 100% and passes; `1/201` → 1%, not the 0% plain flooring would print.

The rejected alternative (keep rounding for display, gate the exact ratio) would have left the report printing `200/201 100%` directly above `NOT met`. ADR-034 exists so a reviewer and CI read one number, so the display had to move with the gate.

**Where it lives.** `coveragePercentage()` in `satsuma-core/src/coverage-rollup.ts`, exported. Every consumer already read `totals.pct`, so the CLI table, `--json`, the gate, the VS Code status bar and the viz card all moved together — no consumer-local rounding existed to miss (verified by grep). `evaluateGate` still compares `pct` rather than a ratio of its own, now noted at the call site as load-bearing.

**Documented** in `coverage --help` beside the exit codes, in `SATSUMA-CLI.md`, and in `CHANGELOG.md` with the migration warning: figures that were rounded up drop a point (`8/9` → 88%, `2/3` → 66%), so a threshold set just under a rounded-up figure starts failing. It was passing on an overstatement.

**Tests.** Boundary cases on `coveragePercentage()` in core — 201/201, 200/201, 2000/2001, 1/201, 1/100000, 8/9, 0/0 — plus three CLI tests driving a generated 201-leaf workspace end to end: exit 3 with `200/201 99%` under `--fail-under 100`, exit 0 once the last leaf is mapped, and 1% at 1/201. Six existing expectations moved with the rule (core 3, CLI 2, vscode 1), each with a comment saying why a `66` where you expect `67` is not a bug.

## 2. §4.4's nested-each example validates (`sl-pn00`)

The example nested `each LineItems` inside `each POReferences`, but the EDI schema it was drawn from declares those lists as siblings at the schema root — and paths inside a container are prefixed unconditionally, so it resolved to `POReferences.LineItems.*` and emitted three `field-not-in-schema` warnings.

- **§4.4** now demonstrates nested `each` over a source whose `lines` list is genuinely declared inside its `orders` list, and states the rule the old example broke: every path inside a block is relative to that block, dot or no dot — with a resolution table whose last row is the ancestor reference that resolves to nothing, because there is no notation for reaching an ancestor (`sl-8vqk`). The sibling-`each` form for lists declared side by side is documented alongside, correlation carried in a `note` with an `@ref`.
- **§8.2** now matches `examples/edi-to-json/pipeline.stm` — three sibling `each` blocks — with a comment explaining why it is not nested, so nobody "fixes" it back.
- Both rewritten snippets were run through `validate`, `coverage` and `lint`: clean, 100% both roles.

## 3. ADR-040

Records the percentage rule, the rejected alternative, and the accepted cost. `ADR-034`'s Status line notes the amendment alongside ADR-037's; its counting rule is untouched.

## Verification

Full `scripts/run-repo-checks.sh` green: lint, core 560, viz-model 6, CLI 983, vscode 34, LSP 295, Python 24 + 39, smoke 50. Also ran `satsuma-viz` (111) separately, since repo checks do not include it. The 15 Satsuma blocks in `docs/nested-data/README.md` still validate, and its two quoted figures that moved (42%→41%, 86%→85%) were re-captured from real runs rather than edited by hand.

`docs/nested-data/README.md` also gains a note that `--fail-under 100` now means every leaf, since nested schemas are where leaf counts get large enough for one field to vanish into a rounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
