### PR TITLE
fix(coverage): a spread no longer redeclares a field the body declared (sl-qead)

### DIFF
--- a/.tickets/sl-qead.md
+++ b/.tickets/sl-qead.md
@@ -1,8 +1,8 @@
 ---
 id: sl-qead
-status: open
+status: closed
 deps: []
-links: []
+links: [sqdsp-00kv]
 created: 2026-08-02T21:41:14Z
 type: bug
 priority: 2
@@ -43,3 +43,14 @@ Coverage should be fixed to dedupe regardless of how the spec question lands —
 
 The minimal fixture above reports 2/3 (67%) from the CLI, the LSP path and the viz path. coverage --json never emits two fields[] entries with the same path, pinned by a test. examples/namespaces/ns-platform.stm reports vault::sat_contact_details with 10 leaves. The spec question is resolved and recorded in docs/developer/SATSUMA-V2-SPEC.md; if the ruling is that a redeclaration is a diagnostic, it is raised as a separate lint ticket rather than folded in here.
 
+
+## Notes
+
+**2026-08-03T06:12:43Z**
+
+**2026-08-03T00:00:00Z**
+
+Cause: core's `expandEntityFields` returned every field a fragment declared, including names the entity's own body had already declared, so `expandDeclaredFields` concatenated two entries with one path — inflating both the denominator and, for a mapped field, the numerator.
+Fix: a spread now contributes only names the body has not claimed (explicit wins, first spread wins between spreads), seeded from the entity's own fields so the nested record form is covered by the same rule; the minimal fixture reports 2/3 67% and vault::sat_contact_details reports its true 10 leaves. (commit 92ce4b39)
+
+Spec question resolved as **override** and recorded in docs/developer/SATSUMA-V2-SPEC.md §5.1 ("Redeclaring a spread field") plus AI-AGENT-REFERENCE.md: redeclaration stays legal, shadowing is whole-field, no diagnostic today. The author-facing warning is raised separately as sqdsp-00kv.

--- a/.tickets/sqdsp-00kv.md
+++ b/.tickets/sqdsp-00kv.md
@@ -1,0 +1,34 @@
+---
+id: sqdsp-00kv
+status: open
+deps: []
+links: []
+created: 2026-08-03T06:09:18Z
+type: task
+priority: 3
+assignee: Thorben Louw
+parent: sl-j6g9
+tags: [feature-38, lint, validate, core]
+---
+# lint: warn when a fragment spread redeclares an explicitly declared field
+
+sl-qead settled the semantics: a spread contributes only the names the body has not already declared, and an explicit declaration shadows the fragment's field of the same name. That is now the rule in docs/developer/SATSUMA-V2-SPEC.md §5.1 ("Redeclaring a spread field").
+
+The author gets no signal that it happened. A redeclaration is legal but rarely deliberate — a reader has to know the fragment's contents to see that `...meta` adds less than it appears to, and the shadowed field silently loses whatever the fragment said about its type, constraints and note.
+
+satsuma validate reports nothing here today.
+
+## Design
+
+A warning-severity diagnostic, raised where the shadowing decision is made — core's expandEntityFields knows the colliding name and the fragment it came from, but it returns fields rather than diagnostics, so the reporting site needs choosing (validate's field-alignment pass is the natural home).
+
+Message should name both sides, e.g. `field 'load_ts' is declared here and also by fragment 'meta'; the fragment's copy is ignored`.
+
+The shipped corpus relies on the permissive reading and would warn on day one: examples/namespaces/ns-platform.stm (vault::sat_contact_details declares load_ts at line 85 and spreads ...standard_metadata) and tooling/satsuma-cli/test/fixtures/platform.stm. Decide whether to clean those up in the same change or accept the warnings — a sweep found no other cases.
+
+Warning, not error: the ruling on sl-qead was explicitly that redeclaration stays legal.
+
+## Acceptance Criteria
+
+A schema that declares a field and spreads a fragment declaring the same name produces one warning-severity diagnostic naming the field and the fragment. The LSP surfaces it on the redeclaring line. Nothing is reported when the names do not collide. Corpus files that warn are either cleaned up or listed in the ticket notes as accepted. Coverage counts are unchanged — sl-qead already fixed those.
+

--- a/.tickets/sqdsp-00kv.md
+++ b/.tickets/sqdsp-00kv.md
@@ -2,7 +2,7 @@
 id: sqdsp-00kv
 status: open
 deps: []
-links: []
+links: [sl-qead]
 created: 2026-08-03T06:09:18Z
 type: task
 priority: 3

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -132,6 +132,19 @@ Workspace scope is also file-based everywhere:
   - IDE/LSP features for an open file use only that file's import-reachable graph
   - the surrounding folder is never an implicit merged scope
 
+## Fragment spreads in a schema body
+A spread contributes only the names the body has not already declared. An
+explicit declaration shadows the fragment's field of the same name — the
+body's type, constraints and note stand, and the field exists once, not twice:
+  fragment meta { load_ts TIMESTAMPTZ  batch_id STRING(36) }
+  schema contact {
+    id       STRING(10)
+    load_ts  TIMESTAMPTZ (pk)   // this one stands
+    ...meta                     // contributes batch_id only
+  }
+`contact` has three fields. Where two spreads declare a name, the first wins.
+Shadowing is whole-field, never a merge of record children.
+
 ## Source blocks — not just schema names
   source {
     schema_ref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+### A spread no longer redeclares a field the schema body declared (`sl-qead`)
+
+**Percentages drop for any schema that redeclares a spread field.** A schema that
+wrote out a field _and_ spread a fragment declaring the same name counted it
+twice. The duplicate landed in the denominator and, when the field was mapped, in
+the numerator too, so a schema's percentage moved with how many times a name
+happened to be written — upward, since authors write out the fields they are
+working with.
+
+```satsuma
+fragment meta { load_ts TIMESTAMPTZ  batch_id STRING(36) }
+schema contact { id STRING(10)  load_ts TIMESTAMPTZ  ...meta }
+```
+
+`contact` has three fields. With two mapped it reported `3/4 75%`; it now reports
+`2/3 66%`. In the shipped examples, `vault::sat_contact_details` in
+`examples/namespaces/ns-platform.stm` goes from eleven leaves to ten. Re-baseline
+any `--fail-under` threshold set against a schema with a redeclaration; the old
+figure overstated the spec.
+
+`coverage --json` also stopped emitting two `fields[]` entries with the same
+`path`, which ADR-035 makes the identity of an entry — a consumer keying by path
+collapsed them and then disagreed with the printed totals.
+
+The language rule this settles, now in the v2 spec (§5.1, "Redeclaring a spread
+field"): **a spread contributes only the names the body has not already
+declared.** The explicit declaration wins, keeping its own type, constraints and
+note; between two spreads the first wins; shadowing is whole-field and never
+merges record children. Redeclaring stays legal and still raises no diagnostic —
+that is tracked separately. See ADR-041.
+
 ### `--fail-under` no longer passes an incomplete spec (`sl-8ba4`)
 
 **Some percentages move by a point.** `coverage` reported a percentage rounded to

--- a/adrs/adr-035-coverage-identity-is-the-qualified-path.md
+++ b/adrs/adr-035-coverage-identity-is-the-qualified-path.md
@@ -1,6 +1,6 @@
 # ADR-035 — Coverage Identity Is the Qualified Field Path
 
-**Status:** Accepted
+**Status:** Accepted — amended by ADR-041
 **Date:** 2026-07-31 (sl-joeq)
 
 ## Context

--- a/adrs/adr-041-one-entry-per-path-a-spread-cannot-redeclare.md
+++ b/adrs/adr-041-one-entry-per-path-a-spread-cannot-redeclare.md
@@ -1,0 +1,132 @@
+# ADR-041 — One Coverage Entry Per Path: A Spread Cannot Redeclare a Field the Body Declared
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-qead, feature 38)
+
+## Context
+
+ADR-035 settled what identifies a coverage entry: **the qualified field path from
+the schema root, and nothing else.** It said so as a rule about *lookup* — a
+covered-path set keyed by path rather than by bare field name, and every consumer
+obliged to build a qualified path before probing it. It did not say the
+corresponding thing about *emission*, and the omission turned out to matter:
+nothing in core guaranteed that the list of declared fields a schema produces
+holds each path once.
+
+It did not, and a shipped example proved it. `expandDeclaredFields()` in
+`spread-expand.ts` answers "what fields does this schema declare?" by
+concatenating the fields the body wrote out with the fields its fragment spreads
+contribute. `expandEntityFields()` returned every field of every resolved
+fragment, including names the body had already declared itself, so a schema that
+both wrote out a field and spread a fragment declaring it got two
+`FieldCoverageEntry` rows with an identical `path`.
+
+`examples/namespaces/ns-platform.stm`'s `vault::sat_contact_details` declares
+`load_ts` and spreads `...standard_metadata`, which declares it again. Coverage
+reported eleven leaves for a ten-leaf schema, and `coverage --json` listed
+`load_ts` twice in `fields[]`. The same shape is in
+`tooling/satsuma-cli/test/fixtures/platform.stm`; a sweep of `examples/` found no
+other case.
+
+Two things follow from a duplicated path, and both are worse than a cosmetic
+repeat.
+
+**The percentage moves with how many times a name is written.** The duplicate
+lands in the denominator, and when the field is mapped it lands in the numerator
+too. Three distinct leaves with two mapped reported 3/4 rather than 2/3. The
+error is not symmetric: a redeclared field is more likely to be a mapped one
+(authors write out the fields they are working with), so the bias is toward
+*overstating* coverage — the one direction a `--fail-under` merge gate must not
+fail in, and the same failure mode ADR-035 and ADR-040 were each written to close
+from a different side.
+
+**A path-keyed consumer silently disagrees with the printed counts.** This is
+the part ADR-035 owns. That ADR obliges consumers to treat the path as identity;
+any consumer that does so — building a `Map` from `fields[]`, decorating a gutter
+line, joining an overlay to a card — collapses the two entries into one and then
+reports a total that does not match `total` in the same JSON object. The contract
+was violated by the producer, on its own terms, and no consumer could detect it.
+
+Underneath the counting bug sat an unanswered language question. The v2 spec said
+nothing about a spread colliding with an explicitly declared field: not that it
+overrides, not that it is an error, not that it warns. Tooling had therefore
+picked a behaviour by accident — emit both — and that accident was the bug.
+
+## Decision
+
+**A spread contributes only those field names the body has not already declared,
+and every consumer therefore sees each path exactly once.**
+
+The rule has a language half and a tooling half, and they are the same rule
+stated at two levels.
+
+*In the language* (`docs/developer/SATSUMA-V2-SPEC.md` §5.1, "Redeclaring a
+spread field"): an explicit declaration **shadows** a same-named field reached
+through a spread. The body's declaration — its type, constraints and note —
+stands, and the fragment's copy is not a second field. Where two spreads in the
+same body declare a name, the first wins. Shadowing is **whole-field, never a
+merge**: if the body declares a record and a spread declares a record of the same
+name, the body's record stands entire and the fragment's version of its children
+contributes nothing, so a reader can always predict the field set from the
+nearest declaration.
+
+Redeclaration stays **legal and undiagnosed**. The permissive reading is what the
+shipped corpus relies on, and a stricter one would either warn on two example
+files from day one or invalidate them outright. That the author gets no signal is
+a real gap — a reader has to know a fragment's contents to see that `...meta`
+adds less than it appears to — and it is booked as a separate warning-level lint
+(sqdsp-00kv), not folded in here, because cleaning up or accepting the corpus
+warnings is its own decision.
+
+*In the tooling*: the rule is enforced once, in core's `expandEntityFields()`,
+which threads a set of claimed names seeded from the entity's own fields and
+skips any fragment field whose name is already claimed. Seeding from the entity's
+own fields is what makes the **nested** form fall out for free —
+`expandNestedSpreads()` passes a record's children as that entity's fields, so
+`audit record { load_ts  ...meta }` goes through the identical path. Every
+consumer that reports declared fields reaches this through
+`expandDeclaredFields()`, so the CLI, the LSP gutter and the viz card cannot
+disagree.
+
+**This amends ADR-035.** Read together, the identity rule now has both halves:
+a path identifies a coverage entry *and* a path identifies at most one coverage
+entry. The second half is the producer-side obligation the first half had always
+assumed.
+
+## Consequences
+
+**Positive:**
+
+- Coverage figures no longer depend on how many times a name was written. A
+  schema's percentage is a function of its distinct leaves.
+- The correction moves figures **down**, which is the safe direction for a gate:
+  a spec that was reported more complete than it is stops being.
+- ADR-035's contract is now something a consumer can rely on rather than
+  something it happens to get. Keying `fields[]` by path is safe.
+- The language question is answered in the spec instead of being decided by
+  whatever the expander happened to do, and the answer is the one an author would
+  guess: the declaration in front of you wins.
+- One rule, one place. Because it lives where spreads are resolved rather than in
+  a per-consumer dedupe, the CLI, LSP and viz were fixed by the same change and a
+  fourth consumer inherits it.
+
+**Negative:**
+
+- **Recorded coverage figures move.** `vault::sat_contact_details` goes from
+  eleven leaves to ten; any workspace with a redeclaration re-baselines. As with
+  ADR-035, a consumer cannot tell a correction from a regression by looking at
+  the number.
+- **A redeclaration is still silent.** This ADR makes the shadowing correct
+  without making it visible, and the case where an author *meant* to override a
+  fragment's type or constraints is indistinguishable from the case where they
+  forgot the fragment already had the field. That gap is sqdsp-00kv.
+- **Whole-field shadowing loses information the author may have wanted.** If the
+  body declares `address record { number }` and the fragment declares `address
+  record { street, city }`, the fragment's two children are dropped rather than
+  merged. Merging is defensible and was rejected for predictability — but a
+  future contributor could reasonably ask for it, and the corpus contains no case
+  that forces the question either way.
+- **Order now carries meaning between spreads.** "First spread wins" makes
+  reordering two `...` lines a semantic change in the collision case. It is a
+  rule nobody has to think about until two fragments overlap, at which point it
+  is a rule they must know.

--- a/docs/developer/SATSUMA-V2-SPEC.md
+++ b/docs/developer/SATSUMA-V2-SPEC.md
@@ -291,7 +291,7 @@ schema customers {
 }
 ```
 
-The spread `...address fields` inlines all fields from the fragment into the schema.
+The spread `...address fields` inlines the fragment's fields into the schema — all of them, unless the schema body declares one of those names itself, in which case the body's declaration stands (see [Redeclaring a spread field](#redeclaring-a-spread-field)).
 
 ---
 
@@ -591,6 +591,39 @@ schema users {
   ...audit fields
 }
 ```
+
+#### Redeclaring a spread field
+
+**A spread contributes only those fields the body has not already declared.** An
+explicitly declared field *shadows* a same-named field reached through a spread:
+the spread's copy is not a second field, and the body's declaration — its type,
+constraints and note — is the one that stands. Where two spreads in the same body
+declare a name, the first one wins.
+
+```
+fragment `audit fields` {
+  created_at  TIMESTAMPTZ
+  created_by  VARCHAR(100)
+}
+
+schema users {
+  user_id     UUID (pk)
+  created_at  TIMESTAMPTZ (pk)   // this declaration stands
+  ...audit fields                // contributes created_by only
+}
+```
+
+`users` therefore has three fields, and `created_at` keeps its `(pk)`.
+
+Shadowing is whole-field, not a merge. If the body declares a record and a spread
+declares a record of the same name, the body's record stands entire and the
+fragment's version of its children contributes nothing — so the field set can
+always be read off the nearest declaration.
+
+Redeclaration is legal and carries no diagnostic today, but it is rarely
+deliberate: a reader has to know the fragment's contents to see that the spread
+adds less than it appears to. Prefer removing the redundant declaration, or the
+spread, when the two say the same thing.
 
 ### 5.2 Named Transforms
 

--- a/docs/developer/SATSUMA-V2-SPEC.md
+++ b/docs/developer/SATSUMA-V2-SPEC.md
@@ -595,7 +595,7 @@ schema users {
 #### Redeclaring a spread field
 
 **A spread contributes only those fields the body has not already declared.** An
-explicitly declared field *shadows* a same-named field reached through a spread:
+explicitly declared field _shadows_ a same-named field reached through a spread:
 the spread's copy is not a second field, and the body's declaration — its type,
 constraints and note — is the one that stands. Where two spreads in the same body
 declare a name, the first one wins.

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -1001,8 +1001,9 @@ describe("satsuma coverage — fragment spreads", () => {
     // sl-qead. `contact` writes out `load_ts` and also spreads `...meta`, which
     // declares it again — one field, declared twice. Emitting both copies put
     // the duplicate in the denominator and, because it is mapped, in the
-    // numerator too: 3/4 (75%) for a schema that is 2/3 (67%). The error
-    // overstates coverage, the one direction `--fail-under` must not fail in.
+    // numerator too: 3/4 (75%) for a schema that is 2/3 (66%, floored per
+    // ADR-040). The error overstates coverage, the one direction `--fail-under`
+    // must not fail in.
     const { stdout } = await run("coverage", REDECLARED_SPREAD, "--json");
     const target = schemaEntry(parseJson(stdout), "::contact_load", "target", "::contact");
     assert.deepEqual(
@@ -1015,7 +1016,7 @@ describe("satsuma coverage — fragment spreads", () => {
     );
     assert.equal(target.covered, 2);
     assert.equal(target.total, 3);
-    assert.equal(target.pct, 67);
+    assert.equal(target.pct, 66);
   });
 
   it("never emits two fields[] entries sharing a path, anywhere in the corpus", async () => {

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -951,6 +951,9 @@ describe("satsuma coverage — key spelling", () => {
 describe("satsuma coverage — fragment spreads", () => {
   const NESTED_SPREAD = resolve(__dirname, "fixtures/nested-record-spread.stm");
   const LIST_OF_SPREAD = resolve(__dirname, "fixtures/list-of-record-spread.stm");
+  const REDECLARED_SPREAD = resolve(__dirname, "fixtures/redeclared-spread-field.stm");
+  /** The shipped example the duplicate-path bug was actually found in. */
+  const NS_PLATFORM = resolve(__dirname, "../../../examples/namespaces/ns-platform.stm");
 
   it("counts the leaves a spread materialises inside a record body", async () => {
     // `address record { ...address_fields }` declares three leaves. Counting the
@@ -992,5 +995,61 @@ describe("satsuma coverage — fragment spreads", () => {
     assert.equal(target.covered, 2);
     assert.equal(target.total, 4);
     assert.equal(target.pct, 50);
+  });
+
+  it("counts a field the body and a spread both declare exactly once", async () => {
+    // sl-qead. `contact` writes out `load_ts` and also spreads `...meta`, which
+    // declares it again — one field, declared twice. Emitting both copies put
+    // the duplicate in the denominator and, because it is mapped, in the
+    // numerator too: 3/4 (75%) for a schema that is 2/3 (67%). The error
+    // overstates coverage, the one direction `--fail-under` must not fail in.
+    const { stdout } = await run("coverage", REDECLARED_SPREAD, "--json");
+    const target = schemaEntry(parseJson(stdout), "::contact_load", "target", "::contact");
+    assert.deepEqual(
+      target.fields.map((f: any) => [f.path, f.mapped]),
+      [
+        ["id", true],
+        ["load_ts", true],
+        ["batch_id", false],
+      ],
+    );
+    assert.equal(target.covered, 2);
+    assert.equal(target.total, 3);
+    assert.equal(target.pct, 67);
+  });
+
+  it("never emits two fields[] entries sharing a path, anywhere in the corpus", async () => {
+    // ADR-035 makes the qualified path a coverage entry's identity, so this is
+    // a contract on the JSON itself and not just on these fixtures: a consumer
+    // keying fields[] by path silently collapses a duplicate and then disagrees
+    // with the printed totals. Swept over the shipped examples because the bug
+    // was found there (vault::sat_contact_details), not in contrived input.
+    for (const file of [REDECLARED_SPREAD, NS_PLATFORM]) {
+      const report = parseJson((await run("coverage", file, "--json")).stdout);
+      for (const mapping of report.mappings) {
+        for (const schema of mapping.schemas) {
+          const paths = schema.fields.map((f: any) => f.path);
+          assert.deepEqual(
+            paths.filter((p: string, i: number) => paths.indexOf(p) !== i),
+            [],
+            `${schema.schema} in ${file} lists a path twice`,
+          );
+        }
+      }
+    }
+  });
+
+  it("reports the corpus schema that exposed the bug with its true leaf count", async () => {
+    // vault::sat_contact_details declares load_ts and spreads
+    // ...standard_metadata, which declares it again. Coverage reported eleven
+    // leaves for a ten-leaf schema — the shipped corpus, not a contrived file.
+    const report = parseJson((await run("coverage", NS_PLATFORM, "--json")).stdout);
+    const entries = report.mappings
+      .flatMap((m: any) => m.schemas)
+      .filter((s: any) => s.schema === "vault::sat_contact_details");
+    assert.ok(entries.length > 0, "the corpus schema should appear in the report");
+    for (const entry of entries) {
+      assert.equal(entry.total, 10);
+    }
   });
 });

--- a/tooling/satsuma-cli/test/fixtures/redeclared-spread-field.stm
+++ b/tooling/satsuma-cli/test/fixtures/redeclared-spread-field.stm
@@ -2,8 +2,9 @@
 //
 // `load_ts` is written out in `contact` AND declared by `...meta`. It is one
 // field, so the schema has three leaves — id, load_ts, batch_id — and the two
-// mapped ones make it 2/3 (67%). Counting the spread's copy as a second field
-// reported 3/4 (75%), overstating coverage. Shared with the LSP and viz suites.
+// mapped ones make it 2/3 (66%, floored per ADR-040). Counting the spread's copy
+// as a second field reported 3/4 (75%), overstating coverage — and 75% happens
+// to be exact, so the rounding rule never hid it. Shared with LSP and viz.
 fragment meta {
   load_ts TIMESTAMPTZ
   batch_id STRING(36)

--- a/tooling/satsuma-cli/test/fixtures/redeclared-spread-field.stm
+++ b/tooling/satsuma-cli/test/fixtures/redeclared-spread-field.stm
@@ -1,0 +1,24 @@
+// Fixture for sl-qead: a spread redeclares a field the body already declares.
+//
+// `load_ts` is written out in `contact` AND declared by `...meta`. It is one
+// field, so the schema has three leaves — id, load_ts, batch_id — and the two
+// mapped ones make it 2/3 (67%). Counting the spread's copy as a second field
+// reported 3/4 (75%), overstating coverage. Shared with the LSP and viz suites.
+fragment meta {
+  load_ts TIMESTAMPTZ
+  batch_id STRING(36)
+}
+
+schema contact {
+  id STRING(10)
+  load_ts TIMESTAMPTZ
+  ...meta
+}
+
+mapping contact_load {
+  source { raw_contact }
+  target { contact }
+
+  raw_id -> id
+  raw_ts -> load_ts
+}

--- a/tooling/satsuma-core/src/spread-expand.ts
+++ b/tooling/satsuma-core/src/spread-expand.ts
@@ -163,8 +163,27 @@ function expandNestedFieldPaths(
 
 /**
  * Expand fragment spreads for a single entity (schema or fragment), returning
- * the expanded field objects (not paths). Useful for commands that need the
- * actual field objects rather than just path strings.
+ * *only the fields the spreads contribute* — the caller already has the ones
+ * the body wrote out, and concatenates the two.
+ *
+ * **Rule: a spread contributes only names the body has not already declared.**
+ * An explicit declaration shadows a same-named field reached through a spread,
+ * and the first spread to contribute a name shadows any later one. A shadowed
+ * field is not returned at all, so `[...entity.fields, ...expandEntityFields()]`
+ * holds each name exactly once.
+ *
+ * This is what makes the concatenation safe (sl-qead). Emitting the shadowed
+ * copy too put the same field in a schema twice: `sat_contact_details` declares
+ * `load_ts` and spreads `...standard_metadata`, which declares it again, and
+ * coverage counted eleven leaves in a ten-leaf schema — the duplicate landing in
+ * both numerator and denominator, so the percentage moved with how many times a
+ * name happened to be written. ADR-035 makes the qualified path a coverage
+ * entry's identity, so two entries sharing one path is a contract violation on
+ * its own terms.
+ *
+ * Shadowing is whole-field: a record shadowed by an explicit record keeps the
+ * explicit body, and the fragment's version of its children is not merged in.
+ * See "Fragment spreads" in the v2 spec.
  */
 export function expandEntityFields(
   entity: SpreadEntity | null | undefined,
@@ -176,12 +195,27 @@ export function expandEntityFields(
   if (!entity?.hasSpreads) return expandedFields;
 
   const visited = new Set<string>();
-  collectExpandedFields(entity, currentNs, resolveRef, lookupFragment, expandedFields, visited, []);
+  // Seeded with what the body declares, so those names win over any spread.
+  const declared = new Set((entity.fields ?? []).map((f) => f.name));
+  collectExpandedFields(
+    entity,
+    currentNs,
+    resolveRef,
+    lookupFragment,
+    expandedFields,
+    visited,
+    [],
+    declared,
+  );
   return expandedFields;
 }
 
 /**
  * Recursively collect expanded field objects from fragment spreads.
+ *
+ * `declared` carries the names already spoken for — the entity's own fields
+ * plus everything collected so far — and grows as fields are taken, which is
+ * how nearer declarations shadow further ones through transitive spreads.
  */
 function collectExpandedFields(
   entity: SpreadEntity,
@@ -191,6 +225,7 @@ function collectExpandedFields(
   fields: ExpandedField[],
   visited: Set<string>,
   chain: string[],
+  declared: Set<string>,
 ): void {
   const spreads = entity.spreads ?? [];
   if (spreads.length === 0) return;
@@ -207,14 +242,22 @@ function collectExpandedFields(
     if (!fragment) continue;
 
     for (const f of fragment.fields) {
+      if (declared.has(f.name)) continue; // shadowed by the body or an earlier spread
+      declared.add(f.name);
       fields.push({ ...f, fromFragment: resolvedKey });
     }
 
     if (fragment.hasSpreads) {
-      collectExpandedFields(fragment, currentNs, resolveRef, lookupFragment, fields, visited, [
-        ...chain,
-        resolvedKey,
-      ]);
+      collectExpandedFields(
+        fragment,
+        currentNs,
+        resolveRef,
+        lookupFragment,
+        fields,
+        visited,
+        [...chain, resolvedKey],
+        declared,
+      );
     }
   }
 }
@@ -270,6 +313,10 @@ export function expandNestedSpreads(
  * childless leaf, and the viz expanded only the schema-level form. Three
  * numbers, one file. Consumers now call this rather than sequencing the two
  * passes themselves.
+ *
+ * Each name appears once at each level: a field the body declares shadows a
+ * same-named field from a spread, so the returned tree yields no duplicate
+ * dotted paths. `expandEntityFields` owns that rule and explains why.
  *
  * The input is never mutated — `expandNestedSpreads` works in place, and index
  * records are shared with every other command in the process, so the field tree

--- a/tooling/satsuma-core/test/spread-expand.test.js
+++ b/tooling/satsuma-core/test/spread-expand.test.js
@@ -115,6 +115,47 @@ describe("expandEntityFields()", () => {
     const result = expandEntityFields(entity, null, resolve, lookup);
     assert.equal(result.filter((f) => f.name === "shared").length, 1);
   });
+
+  it("omits a fragment field whose name the body already declares", () => {
+    // The shadowing rule (sl-qead). Returning the fragment's copy as well put
+    // the same field in a schema twice — one path, two entries — which ADR-035
+    // forbids and which moved coverage percentages with how many times a name
+    // happened to be written.
+    const frag = fragment("::meta", [field("load_ts"), field("batch_id")]);
+    const entity = {
+      fields: [field("id"), field("load_ts")],
+      hasSpreads: true,
+      spreads: ["::meta"],
+    };
+    const resolve = (ref) => ref;
+    const lookup = (key) => (key === "::meta" ? frag : null);
+
+    assert.deepEqual(
+      expandEntityFields(entity, null, resolve, lookup).map((f) => f.name),
+      ["batch_id"],
+      "the spread contributes only what the body left unsaid",
+    );
+  });
+
+  it("gives a name to the first spread that declares it, not the last", () => {
+    // Two unrelated fragments can declare the same name without either being an
+    // ancestor of the other, so the diamond guard (which keys on the fragment)
+    // does not catch it — only the name-level rule does.
+    const first = fragment("::first", [field("load_ts")]);
+    const second = fragment("::second", [field("load_ts"), field("batch_id")]);
+    const entity = { fields: [], hasSpreads: true, spreads: ["::first", "::second"] };
+    const resolve = (ref) => ref;
+    const lookup = (key) => (key === "::first" ? first : key === "::second" ? second : null);
+
+    const result = expandEntityFields(entity, null, resolve, lookup);
+    assert.deepEqual(
+      result.map((f) => [f.name, f.fromFragment]),
+      [
+        ["load_ts", "::first"],
+        ["batch_id", "::second"],
+      ],
+    );
+  });
 });
 
 // ── expandNestedSpreads ───────────────────────────────────────────────────────
@@ -151,7 +192,11 @@ describe("expandNestedSpreads()", () => {
 
 describe("expandDeclaredFields()", () => {
   const addressFields = fragment("address_fields", [field("street"), field("city")]);
-  const entities = new Map([["address_fields", addressFields]]);
+  const meta = fragment("meta", [field("load_ts"), field("batch_id")]);
+  const entities = new Map([
+    ["address_fields", addressFields],
+    ["meta", meta],
+  ]);
   const resolveRef = makeEntityRefResolver(entities);
   const lookup = (key) => entities.get(key) ?? null;
 
@@ -206,6 +251,59 @@ describe("expandDeclaredFields()", () => {
       "address.street",
       "address.city",
       "street",
+      "city",
+    ]);
+  });
+
+  it("counts a field the body and a spread both declare exactly once", () => {
+    // sl-qead, at the level every coverage consumer reads. Three distinct
+    // leaves must yield three paths, not four: the duplicate landed in both the
+    // denominator and (when mapped) the numerator, so a schema's percentage
+    // depended on how many times a name was declared — overstating coverage,
+    // the one direction `--fail-under` must not fail in.
+    const schema = {
+      fields: [field("id"), field("load_ts")],
+      hasSpreads: true,
+      spreads: ["meta"],
+    };
+    assert.deepEqual(leaves(expandDeclaredFields(schema, null, resolveRef, lookup)), [
+      "id",
+      "load_ts",
+      "batch_id",
+    ]);
+  });
+
+  it("applies the same rule inside a record body", () => {
+    // The nested form of the collision. It reaches consumers through the same
+    // function, so it must not need its own dedupe at the call site.
+    const schema = {
+      fields: [
+        {
+          ...field("audit", "record", [field("load_ts")]),
+          hasSpreads: true,
+          spreads: ["meta"],
+        },
+      ],
+      hasSpreads: false,
+      spreads: [],
+    };
+    assert.deepEqual(leaves(expandDeclaredFields(schema, null, resolveRef, lookup)), [
+      "audit.load_ts",
+      "audit.batch_id",
+    ]);
+  });
+
+  it("keeps the explicit record's children when a spread declares that record too", () => {
+    // Shadowing is whole-field, not a deep merge: the body's `address` wins
+    // outright and the fragment's version contributes nothing, so a reader can
+    // predict the field set from the nearest declaration alone.
+    const schema = {
+      fields: [field("street", "record", [field("number")])],
+      hasSpreads: true,
+      spreads: ["address_fields"],
+    };
+    assert.deepEqual(leaves(expandDeclaredFields(schema, null, resolveRef, lookup)), [
+      "street.number",
       "city",
     ]);
   });

--- a/tooling/satsuma-lsp/test/coverage.test.js
+++ b/tooling/satsuma-lsp/test/coverage.test.js
@@ -152,6 +152,24 @@ describe("LSP coverage adapter — fragment spreads", () => {
     );
   });
 
+  it("counts a field the body and a spread both declare exactly once", () => {
+    // sl-qead, the gutter's half of the parity claim. `contact` writes out
+    // `load_ts` and also spreads `...meta`, which declares it again. Two
+    // decorations on one line is the visible symptom; the CLI reports 2/3 for
+    // this file and the gutter must be counting the same three leaves.
+    const target = coverage(fixture("redeclared-spread-field.stm"), "contact_load").schemas.find(
+      (s) => s.role === "target",
+    );
+    assert.deepEqual(
+      target.fields.map((f) => [f.path, f.state]),
+      [
+        ["id", "covered"],
+        ["load_ts", "covered"],
+        ["batch_id", "uncovered"],
+      ],
+    );
+  });
+
   it("keeps two records spread from one fragment independently covered", () => {
     // The examples/lib/sfdc_fragments.stm shape. Both records materialise a
     // field named `Street` from the same fragment, so a coverage model keyed by

--- a/tooling/satsuma-viz-backend/test/viz-model.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model.test.js
@@ -1244,6 +1244,14 @@ describe("nested fragment spreads (sl-5nsv)", () => {
     ]);
   });
 
+  it("lists a field the body and a spread both declare only once", () => {
+    // sl-qead, the card's half of the parity claim. A schema card that printed
+    // `load_ts` twice would also feed a duplicated leaf list to the coverage
+    // meter, disagreeing with the 2/3 the CLI reports for the same file.
+    const contact = schemaNamed(fixture("redeclared-spread-field.stm"), "contact");
+    assert.deepEqual(leafPaths(contact.fields), ["id", "load_ts", "batch_id"]);
+  });
+
   it("keeps the declaring field's own display data when it gains children", () => {
     // Expansion runs over core's FieldDecl, which carries no constraints, notes
     // or source location. A record that merely acquires children must keep the


### PR DESCRIPTION
Closes sl-qead. Rebased onto main (picks up ADR-040's percentage rule — see "Figures" below).

## The bug

A schema that wrote out a field *and* spread a fragment declaring the same name got two coverage entries for it. Both landed in the denominator and, when the field was mapped, both landed in the numerator — so a schema's percentage moved with how many times a name happened to be written, always upward. Overstating coverage is the one direction `--fail-under` must not fail in.

```satsuma
fragment meta { load_ts TIMESTAMPTZ  batch_id STRING(36) }
schema s_d { id STRING(10)  load_ts TIMESTAMPTZ  ...meta }
```

`source  s_d  3/4  75%` — where the schema has three leaves and is 2/3.

Not contrived. `examples/namespaces/ns-platform.stm`'s `vault::sat_contact_details` declares `load_ts` and spreads `...standard_metadata`, which declares it again: coverage reported eleven leaves for a ten-leaf schema.

## The fix

One change, in core's `expandEntityFields`, which the CLI, the LSP gutter and the viz card all reach through `expandDeclaredFields`: **a spread contributes only the names the body has not already declared.** Explicit wins; between two spreads, the first wins.

Seeding the claimed-name set from the entity's own fields also fixes the nested form for free — `expandNestedSpreads` passes a record's children as that entity's fields, so `audit record { load_ts  ...meta }` goes through the same rule.

## ADR-041, amending ADR-035

ADR-035 made the qualified path a coverage entry's identity — but only as a rule about *lookup*. It never stated the producer-side half: that a path identifies *at most one* entry. This bug was exactly that gap, and it was undetectable from the consumer side — anything keying `fields[]` by path (a `Map`, a gutter decoration, an overlay join) collapsed the two entries and then disagreed with `total` in the same JSON object.

**ADR-041** states both halves and records the language ruling. ADR-035's Status line is updated to `Accepted — amended by ADR-041`; its body is untouched.

## The language question

The v2 spec said nothing about a spread colliding with an explicit field. Settled as **override**: the explicit declaration wins and keeps its own type, constraints and note; shadowing is whole-field, never a merge of record children; the case stays legal. Recorded in `docs/developer/SATSUMA-V2-SPEC.md` §5.1 ("Redeclaring a spread field") and `AI-AGENT-REFERENCE.md`.

Authors still get no signal, which is rarely what they meant. Raised separately as **sqdsp-00kv** — a warning-level lint — since `ns-platform.stm` and `test/fixtures/platform.stm` would warn on day one and that needs its own decision.

## Figures

The example above now reports **2/3 66%** — floored, per ADR-040, which landed on main between this branch's first push and the rebase. 75% was exact either way, so the rounding rule never masked the bug. CHANGELOG records the re-baseline, as ADR-035 did for the same reason: the correction moves recorded percentages down and a consumer can't tell that from the number alone.

## Tests

New shared fixture `redeclared-spread-field.stm`, asserted by all three consumer suites in the cross-consumer parity style the `sl-5nsv` fixtures established — CLI, LSP and viz must agree on the same three leaves. Plus, in core, the shadowing rule itself (body-wins, first-spread-wins, whole-field), and in the CLI a sweep asserting `coverage --json` never emits two `fields[]` entries sharing a path, run over `ns-platform.stm` as well as the fixture.

Post-rebase local: core 565, cli 986, lsp 296, viz-backend 175, all green. Full `scripts/run-repo-checks.sh` green and gating every commit via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)