### PR TITLE
fix(viz): compute coverage once, in core, and carry it in the model (sl-46wr, sl-csrs)

### DIFF
--- a/.tickets/sl-46wr.md
+++ b/.tickets/sl-46wr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-46wr
-status: open
+status: closed
 deps: []
 links: [sl-csrs, sl-3de8, sl-5nsv]
 created: 2026-08-02T21:40:23Z
@@ -41,3 +41,10 @@ Note the viz card renders a tier-blind boolean today; ADR-036 requires consumers
 
 The viz path and satsuma coverage --json report identical covered counts, totals and percentages for every file under examples/ — asserted by a sweep-style test or at minimum by extending tooling/satsuma-viz/test/coverage-parity.test.js with a fixture whose coverage includes an nl-tier leaf. examples/contracts/buy-to-om-order.stm reports 8/8 on the source side from the viz path. The parity test fails if the NL tier is removed from either side.
 
+
+## Notes
+
+**2026-08-03T07:08:36Z**
+
+Cause: the viz maintained a third derivation of covered paths (satsuma-viz/src/field-coverage.ts, buildMappingCoveredFields), walking the model's arrows. A leaf named only by a resolved NL @ref is covered (ADR-036) but nothing about that is visible in an arrow's endpoints, so the schema card reported every such leaf as a gap while satsuma coverage and the VS Code gutter reported it covered.
+Fix: deleted the derivation. @satsuma/viz-backend now calls core's computeMappingCoverage when it assembles a VizModel and attaches the result — tiers and all — to each MappingBlock.coverage; the card selects and counts those entries via core's summarizeFieldCoverage/countContainerStates, and renders the tier in a data attribute and tooltip. core's fieldCoverageFromCoveredPaths and the whole flat-set view (buildCoveredFieldSet, isCoveredFieldPath) are gone: a set of paths cannot express either the tier or ADR-037's conferral, so it was the shape that made this class of bug possible. Pinned by a corpus sweep (satsuma-cli/test/coverage-viz-parity.test.ts) asserting the viz path and satsuma coverage agree on covered count, denominator and percentage for every mapping the model renders in every examples/**.stm — 0 disagreements, down from 45 — plus nl-tier cases on the new coverage-nl-tier.stm fixture.

--- a/.tickets/sl-csrs.md
+++ b/.tickets/sl-csrs.md
@@ -1,6 +1,6 @@
 ---
 id: sl-csrs
-status: open
+status: closed
 deps: []
 links: [sl-46wr, sl-3de8]
 created: 2026-08-02T21:40:38Z
@@ -31,3 +31,10 @@ Fix with sl-46wr, by having the host pass core's computed FieldCoverageEntry lis
 
 A viz-path/CLI parity test over a fixture containing a whole-record arrow, a whole-list_of-record arrow, an empty-body arrow and a pipe-chain-body arrow asserts identical leaf verdicts, container states and percentages. The enumerating form still confers only its enumerated children.
 
+
+## Notes
+
+**2026-08-03T07:08:36Z**
+
+Cause: second half of sl-46wr's root cause. ADR-037's whole-structure conferral is gated on the arrow's declaration kind and on whether its body enumerates children, neither of which survives into a flat set of covered paths, so the viz's own derivation reported every leaf under a record-to-record or list_of-record arrow as uncovered.
+Fix: fixed with sl-46wr by deleting the derivation — the viz now consumes core's FieldCoverageEntry list, which already has conferral applied. New fixture tooling/satsuma-cli/test/fixtures/coverage-whole-structure.stm carries all five forms the rule distinguishes on one file (bare record-to-record, list_of record, empty body, pipe-chain body, and the enumerating form that must confer only what it lists) plus ADR-038's scalar-into-record case; satsuma coverage reports src 12/14 and tgt 11/15 on it and the viz parity suite asserts the same figures and the per-leaf verdicts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,14 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
 - `tooling/tree-sitter-satsuma/`: tree-sitter grammar (318 corpus tests), generated parser artifacts, and queries
+- `tooling/satsuma-core/`: **the shared library every other package builds on** (572 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
 - `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (987 tests)
-- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio`
-- `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp`
+- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio` (299 tests)
+- `tooling/satsuma-viz-model/`: the VizModel protocol contract (6 tests) — the payload shape the LSP produces and the viz component consumes, defined once so neither can drift
+- `tooling/satsuma-viz-backend/`: workspace indexing and VizModel assembly shared by the LSP and browser hosts (182 tests); also computes the field coverage the payload carries (ADR-042)
+- `tooling/satsuma-viz/`: the `satsuma-viz` Lit web component (128 tests) — overview graph and per-mapping detail view, embedded in the VS Code webview and the site playground
+- `tooling/satsuma-viz-harness/`: Playwright harness for the viz component (99 tests) — human-in-the-loop, see [Viz harness Playwright tests](#viz-harness-playwright-tests-human-in-the-loop-workflow)
+- `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp` (34 tests)
 
 ## Platform Lineage Entry Point
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `useful-prompts/`: self-contained system prompts for web LLMs (Excel-to-Satsuma, Satsuma-to-Excel)
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
-- `tooling/tree-sitter-satsuma/`: tree-sitter grammar (315 corpus tests), generated parser artifacts, and queries
-- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (879 tests)
+- `tooling/tree-sitter-satsuma/`: tree-sitter grammar (318 corpus tests), generated parser artifacts, and queries
+- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (987 tests)
 - `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio`
 - `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp`
 
@@ -218,7 +218,7 @@ XDG_CACHE_HOME="$SCRATCHPAD/ts-cache" npm --prefix tooling/tree-sitter-satsuma t
 ```
 
 Do **not** conclude from the lock error that the corpus tests cannot be run
-locally — they can, and they must be before any grammar change is pushed. All 315
+locally — they can, and they must be before any grammar change is pushed. All 318
 parses should pass.
 
 ## Code Search with ast-grep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 ## Unreleased
 
+### The viz coverage figures now match `satsuma coverage` (`sl-46wr`, `sl-csrs`)
+
+**Schema-card percentages rise, on twelve of the shipped examples.** The
+visualization worked out for itself which fields a mapping covers, by walking the
+arrows in its own model. That could not see two of the rules coverage is defined
+by, because neither is visible in an arrow's endpoints: a leaf named by a resolved
+NL `@ref` is covered (ADR-036, needs the ref resolver), and an arrow onto a record
+covers that record's subtree when it enumerates no children (ADR-037, needs the
+arrow's declaration kind). So the card reported gaps the CLI did not.
+
+On `examples/contracts/buy-to-om-order.stm` the source schema read `7/8` against
+the CLI's `8/8`, the single difference being `tax_amount` — reached only through
+`@tax_amount` in a transform. Across `examples/` there were 45 such
+disagreements, per mapping, schema and role. There are now none, asserted by a
+sweep over the whole corpus.
+
+Coverage is computed once, by `@satsuma/core`, when the model is assembled, and
+travels to the client in the payload; the card renders and counts those verdicts
+rather than deriving any. It also now shows the tier — a field reached only
+through prose is marked as such — and distinguishes a partly covered record from
+a fully covered one. Nothing in the CLI's own figures changes. See ADR-042.
+
+Two related fixes to what the card _shows_:
+
+- A schema spreading a fragment from an **imported** file rendered without those
+  fields. `examples/multi-source/multi-source-join.stm`'s `customer_360` showed 26
+  leaves where `satsuma coverage` counts 30.
+- A card whose coverage could not be computed at all — a model built without a
+  workspace index, or a payload cached by an older host — showed `0/N` and marked
+  every field unmapped. It now shows a plain field count, because "not measured"
+  is not "nothing is mapped". A schema that genuinely no mapping references still
+  reports `0/N`.
+
+### `coverage` no longer confuses two mappings that share a label (`sl-46wr`)
+
+**Figures change for any workspace with the same mapping name in two
+namespaces.** Coverage looked a mapping up by its label, and a label is not
+unique: `namespace a { mapping load … }` and `namespace b { mapping load … }` both
+resolved to whichever was declared first. Where the two namespaces also declare
+schemas of the same name the resolution _succeeded_, so the second mapping was
+reported using the first one's arrows — a plausible figure that belonged to
+another mapping.
+
+```satsuma
+namespace b { mapping load { source { s } target { t } x -> x  y -> y } }
+```
+
+`b::load` maps both leaves and reported `1/2`; it now reports `2/2`. Re-baseline
+any `--fail-under` threshold set against such a workspace — in this direction the
+old figure _understated_ the spec, so a threshold that was passing still passes.
+
+Anonymous `mapping { … }` blocks are affected too: having no label, they could not
+be looked up at all. `satsuma coverage` still skips them by design (it reports
+them as skipped, since it keys by label), but the visualization renders them and
+now reports on them.
+
+A mapping is identified to core by namespace and position rather than by label, so
+the CLI, the VS Code gutter and the viz card resolve the same mapping.
+
 ### A spread no longer redeclares a field the schema body declared (`sl-qead`)
 
 **Percentages drop for any schema that redeclares a spread field.** A schema that

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ What exists today:
 
 - the Satsuma v2 language specification
 - a canonical example corpus (25 `.stm` files covering major integration patterns)
-- a tree-sitter parser (315 corpus tests, all examples parse clean)
+- a tree-sitter parser (318 corpus tests, all examples parse clean)
 - a TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting) and TextMate grammar

--- a/adrs/adr-042-coverage-computed-once-and-transported.md
+++ b/adrs/adr-042-coverage-computed-once-and-transported.md
@@ -1,0 +1,125 @@
+# ADR-042 — Coverage Is Computed Once, at Model Assembly, and Transported in the Payload
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-46wr, sl-csrs; feature 38)
+
+## Context
+
+Three consumers report field coverage for the same workspace: `satsuma coverage`,
+the VS Code gutter and status bar, and the viz schema card. ADR-034 moved the
+*counting* into core and told consumers not to compute their own denominators.
+It did not say where the per-field *verdicts* come from, and the viz answered that
+question for itself: `satsuma-viz/src/field-coverage.ts` walked the VizModel's
+arrows, resolved each endpoint against the cards on screen, and built a flat
+`Set<string>` of covered paths. Core offered `fieldCoverageFromCoveredPaths(fields,
+uri, coveredPaths)` to turn such a set into entries, so the card counted through
+core's shapes while deciding for itself what was covered.
+
+That looked equivalent and was not. Two coverage rules are invisible in an
+arrow's endpoints. A leaf named by a *resolved* NL `@ref` is covered (ADR-036),
+which needs the ref resolver and the mapping's prose — neither reachable from a
+path. An arrow onto a record covers that record's whole declared subtree when it
+states a correspondence and enumerates no children (ADR-037), which needs the
+arrow's *declaration kind* and whether its body listed anything — both discarded
+the moment an arrow becomes a path. So the card silently under-reported: on
+twelve of the shipped examples it disagreed with `satsuma coverage`, and on
+`examples/contracts/buy-to-om-order.stm` it read 7/8 against the CLI's 8/8, the
+differing leaf being `tax_amount`, which the CLI tags `tier=nl`. A sweep over
+`examples/` found 45 disagreements across mappings, schemas and roles.
+
+The failure mode matters more than the count. Every rule added to coverage since
+had to be implemented twice or the card drifted again, and the second
+implementation had no way to detect that it was incomplete — a flat set of paths
+answers "is this path covered?" perfectly well while being wrong about what the
+covered set should have contained. That is the "one workspace, three completeness
+figures" defect PRD 38 R3 exists to remove, and it survived sl-5nsv's parity test
+because that test exercised only fragment-spread fixtures.
+
+Two alternatives were considered. **Teach the viz derivation the two rules** —
+rejected: it requires the viz model to carry the arrow's declaration kind and
+enumeration signal purely so a second implementation can re-apply core's rules,
+and the next rule would need the same treatment. **Resolve schemas from the
+workspace index**, as the LSP's `resolveSchema` adapter does — rejected because
+the card renders `SchemaCard.fields`, so counting any other field tree puts a
+ratio next to rows it does not describe; it also drops metric endpoints, since the
+index classifies a metric under its own kind while the detail view renders it as a
+schema card.
+
+## Decision
+
+**Field coverage is computed once, by core, when a VizModel is assembled, and
+travels to the client inside the payload. A consumer selects and counts those
+entries; it never derives them.** The mechanism:
+
+- `attachMappingCoverage(uri, tree, namespaces, wsIndex)` in
+  `satsuma-viz-backend/src/coverage.ts` calls core's `computeMappingCoverage` for
+  every mapping and assigns the result to `MappingBlock.coverage`. It runs last in
+  `buildVizModel`, after `resolveAndStripSpreads`, so the tree it judges is the
+  tree the card renders. Absent coverage means "not computed" — a consumer must
+  not render it as 0%.
+- **Schemas resolve to the model's own cards**, via `indexCardsByQualifiedId`, so
+  the counted field tree and the rendered field tree are the same object. The
+  index is consulted for one step only: core reads schema references off the CST
+  *as authored* (ADR-039), so an unqualified reference is resolved relative to the
+  namespace its mapping is declared in before the card is looked up. Metric cards
+  are registered alongside schema cards.
+- `MappingBlock.coverage` is part of the protocol in `@satsuma/viz-model`, typed
+  as core's `MappingCoverageResult`. That package now depends on `@satsuma/core`
+  and re-exports the coverage types, so the payload carries core's types verbatim
+  rather than a structural copy that could drift.
+- Combining entries is core's too. `unionFieldCoverage(lists)` in
+  `coverage-rollup.ts` is the single implementation of the union rule — a leaf is
+  covered when any input covers it, under the strongest tier any input claims, and
+  containers are re-derived from the unioned leaves. `aggregateCoverage` and the
+  viz overview index both go through it.
+- **No API accepts an arbitrary set of covered paths.**
+  `fieldCoverageFromCoveredPaths`, `buildCoveredFieldSet` and `isCoveredFieldPath`
+  are deleted. A consumer with real coverage to report calls
+  `computeMappingCoverage`; one that only needs a denominator for a schema no
+  mapping references calls `uncoveredFieldCoverage(fields, uri)`, which answers
+  exactly that degenerate case and nothing wider.
+
+Consumers must also *render* the tier rather than reconstruct it (ADR-036), which
+is why the transported entry carries `tier` and `state` and not a boolean.
+
+The rule for a new consumer is therefore: if you are about to build a collection
+of covered paths, you are reintroducing this defect.
+
+## Consequences
+
+**Positive:**
+
+- The CLI, the gutter and the card cannot disagree by construction — there is one
+  computation, not three that must be kept in step. A corpus sweep
+  (`satsuma-cli/test/coverage-viz-parity.test.ts`) asserts identical covered
+  count, denominator and percentage for every mapping the model renders in every
+  `examples/**.stm`: 0 disagreements, down from 45.
+- A new coverage rule is one change in core and reaches every consumer. ADR-036's
+  tier and ADR-037's conferral needed no viz work at all once the derivation was
+  gone.
+- The card gained the tri-state and the tier for free, so a partly-mapped record
+  and an `@ref`-derived hop are now distinguishable in the UI.
+- Metric endpoints report coverage on the card, which the index-based resolver
+  does not manage.
+- Deleting the path-set API removes the shape that made the defect expressible,
+  rather than documenting a hazard and leaving it in place.
+
+**Negative:**
+
+- `@satsuma/viz-model` is no longer dependency-free. It was deliberately a
+  contract-only package, and the coverage types are the one thing it now imports.
+- Model assembly does more work: every mapping's coverage is computed even when no
+  consumer displays it, and NL refs are resolved per document. Assembly is
+  per-file and already parses and indexes, so this is a small addition to an
+  existing cost, but it is not free — and the live editor re-assembles on edit.
+- Coverage is attached per file, before `mergeVizModels`, which upgrades an
+  imported stub card to its full definition. The stub carries the index's fields,
+  so the tree is stable in practice, but a future change to what a stub contains
+  would need coverage recomputed after the merge.
+- The card is now inert without a host that supplies coverage: a model assembled
+  with no workspace index renders rows with no verdicts. That is the honest
+  reading, and it is why absent must not be displayed as zero, but it is a
+  behaviour a consumer has to handle rather than a default it inherits.
+- `uncoveredFieldCoverage` exists only to give a card a denominator, which is a
+  narrow reason for a public function. The alternative — letting the card count
+  its own fields — is what ADR-034 forbids.

--- a/adrs/adr-042-coverage-computed-once-and-transported.md
+++ b/adrs/adr-042-coverage-computed-once-and-transported.md
@@ -67,6 +67,23 @@ entries; it never derives them.** The mechanism:
   as core's `MappingCoverageResult`. That package now depends on `@satsuma/core`
   and re-exports the coverage types, so the payload carries core's types verbatim
   rather than a structural copy that could drift.
+- **A mapping is named by identity, not by label.** `computeMappingCoverage`
+  takes a `MappingTarget`: a `MappingSelector` — `{namespace, name, row}`, any
+  part of which narrows the match — or a bare label for the one caller that has
+  nothing else (the LSP's `satsuma/mappingCoverage` request). A label is not
+  unique: two namespaces may declare `mapping load`, and matching on the label
+  alone gave the first-declared block's arrows to both, so a card and
+  `satsuma coverage` agreed on a figure that belonged to the other mapping. An
+  anonymous `mapping { … }` block has no label at all, so a label lookup found
+  nothing and dropped its coverage. The CLI passes `{name, namespace}`; the viz
+  passes `{namespace, row}`, which identifies the block outright.
+- **Absent coverage is "not computed", and stays distinguishable from `0/N`.**
+  The viz's selectors (`mappingSchemaCoverage`, `buildCoverageIndex`) return
+  `null` for it, and the card then shows a plain leaf count in place of a ratio.
+  A schema no mapping references is the genuine zero and does report `0/N`, from
+  `uncoveredFieldCoverage`. Collapsing the two would let a model assembled
+  without a workspace index — or a payload cached by an older host — assert a
+  completeness figure nobody measured.
 - Combining entries is core's too. `unionFieldCoverage(lists)` in
   `coverage-rollup.ts` is the single implementation of the union rule — a leaf is
   covered when any input covers it, under the strongest tier any input claims, and
@@ -116,6 +133,12 @@ of covered paths, you are reintroducing this defect.
   imported stub card to its full definition. The stub carries the index's fields,
   so the tree is stable in practice, but a future change to what a stub contains
   would need coverage recomputed after the merge.
+- The corpus sweep can only catch what the corpus contains. It found neither the
+  duplicate-label nor the anonymous-mapping defect above, because no file under
+  `examples/` has either shape — both are pinned by fixtures instead
+  (`coverage-duplicate-mapping-labels.stm`, `coverage-anonymous-mapping.stm`). A
+  sweep over real files is a good net for rules that apply everywhere and no
+  substitute for a case built to exercise one.
 - The card is now inert without a host that supplies coverage: a model assembled
   with no workspace index renders rows with no verdicts. That is the honest
   reading, and it is why absent must not be displayed as zero, but it is a

--- a/docs/product-owner/PROJECT-OVERVIEW.md
+++ b/docs/product-owner/PROJECT-OVERVIEW.md
@@ -249,7 +249,7 @@ How we'll know Satsuma is working:
 - Formal language specification ([SATSUMA-V2-SPEC.md](../developer/SATSUMA-V2-SPEC.md))
 - Canonical example library covering major integration patterns (16 `.stm` files)
 - AI-oriented quick reference and compact grammar for prompts ([AI-AGENT-REFERENCE.md](../../AI-AGENT-REFERENCE.md))
-- Tree-sitter parser (482 corpus tests)
+- Tree-sitter parser (318 corpus tests)
 - TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](../../SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - `satsuma lint` with 3 policy rules and `--fix` support

--- a/features/36-viz-coverage-and-chain-view/PRD.md
+++ b/features/36-viz-coverage-and-chain-view/PRD.md
@@ -39,11 +39,23 @@ The primary success criteria are:
   ELK-laid-out overview (schema/metric cards, mapping edges) and a
   per-mapping detail view. It is embedded in the VS Code webview panels and
   in the site's client-only "Try it Live!" playground (Features 33/34).
-- `tooling/satsuma-viz/src/field-coverage.ts` already consumes
-  `@satsuma/core/coverage-paths` (`buildCoveredFieldSet`) so the detail view
-  shares the LSP's nested-field coverage semantics. The component is one step
-  short of *showing* coverage as a first-class signal — the semantics are
-  wired in, the presentation is not.
+- Coverage arrives in the model, already computed. `@satsuma/viz-backend`
+  calls core's `computeMappingCoverage` when it assembles a VizModel and
+  attaches the result to each `MappingBlock.coverage`; the component selects
+  and counts those entries (`mappingSchemaCoverage`, `buildCoverageIndex` in
+  `tooling/satsuma-viz/src/field-coverage.ts`) and never decides what is
+  covered. The overlay must read the same entries.
+
+  This replaces an earlier plan for the detail view to build its own
+  covered-path set via `buildCoveredFieldSet`. That set could not express the
+  NL `@ref` tier (ADR-036) or whole-structure conferral (ADR-037), because both
+  are properties of the *arrow* rather than of the path it names, so the card
+  disagreed with `satsuma coverage` on twelve shipped examples (sl-46wr,
+  sl-csrs). The API is gone; R2's "numbers equal `coverage --json`" is now
+  structural rather than something the overlay has to re-achieve.
+
+  The component is therefore one step short of *showing* coverage as a
+  first-class signal — the semantics are wired in, the presentation is not.
 - Feature 35 relocates `computeMappingCoverage` into `@satsuma/core`. Because
   the playground is client-only, this relocation is what makes a coverage
   overlay *possible* there at all: viz can call the core function directly on

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -3,7 +3,7 @@ layout: default.njk
 title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
 description: "The Satsuma CLI gives AI agents 22 deterministic, parser-backed commands to slice, query, and validate Satsuma workspaces. Humans use it for formatting, validation, and linting."
 og_title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
-og_description: "Give your AI agent 22 commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
+og_description: "Give your AI agent 23 commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
 nav_id: cli
 permalink: cli.html
 ---
@@ -14,7 +14,7 @@ permalink: cli.html
         <div>
           <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-6">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-            22 commands &middot; 879 tests
+            23 commands &middot; 987 tests
           </div>
           <h1 class="text-4xl sm:text-5xl font-extrabold text-charcoal leading-tight mb-6">
             The agent's <span class="text-orange">toolkit</span> for Satsuma
@@ -606,7 +606,7 @@ permalink: cli.html
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
-<span class="output">22 commands available</span></pre>
+<span class="output">23 commands available</span></pre>
         </div>
         <details class="mt-4 text-sm">
           <summary class="cursor-pointer text-warm-gray hover:text-charcoal transition-colors font-medium">Latest unstable build (from main)</summary>
@@ -636,7 +636,7 @@ permalink: cli.html
   <section id="command-reference" class="py-16 lg:py-24">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12 reveal">
-        <h2 class="text-3xl font-bold text-charcoal mb-3">All 22 commands</h2>
+        <h2 class="text-3xl font-bold text-charcoal mb-3">All 23 commands</h2>
         <p class="text-warm-gray max-w-2xl mx-auto">Complete reference for every command in the CLI. See the <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-CLI.md" target="_blank" class="text-orange hover:underline">full reference on GitHub</a> for detailed usage and examples.</p>
       </div>
 
@@ -722,6 +722,10 @@ permalink: cli.html
           <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">fields</h4>
             <p class="text-xs text-warm-gray">Field list with types. Supports <code class="font-mono text-xs">--unmapped-by</code>.</p>
+          </div>
+          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
+            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">coverage</h4>
+            <p class="text-xs text-warm-gray">How much of each schema a mapping touches, counted in leaf fields. Gate CI with <code class="font-mono text-xs">--fail-under</code>.</p>
           </div>
           <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
             <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">match-fields</h4>

--- a/site/index.njk
+++ b/site/index.njk
@@ -242,7 +242,7 @@ permalink: index.html
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Machine-Parseable</h3>
-          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with 315 corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with 318 corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
         </div>
         <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
           <div class="w-12 h-12 bg-charcoal rounded-xl flex items-center justify-center mb-4">
@@ -455,7 +455,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">Satsuma CLI</h3>
-              <p class="text-sm text-warm-gray">22 commands &middot; 879 tests</p>
+              <p class="text-sm text-warm-gray">23 commands &middot; 987 tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">
@@ -482,7 +482,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">VS Code Extension</h3>
-              <p class="text-sm text-warm-gray">Full LSP &middot; 293 tests</p>
+              <p class="text-sm text-warm-gray">Full LSP &middot; 296 tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -97,7 +97,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
             <pre><code class="font-mono text-charcoal">satsuma validate my-mapping.stm</code></pre>
           </div>
           <p class="text-warm-gray text-sm leading-relaxed mb-3">The parser checks syntax, reference resolution, and structural correctness. Zero errors means you are ready to go. The VS Code extension also shows diagnostics in real time as you type.</p>
-          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all 22 commands &rarr;</a>
+          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all 23 commands &rarr;</a>
         </div>
       </div>
     </div>

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -50,7 +50,7 @@ permalink: vscode.html
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">293</div>
+          <div class="text-2xl font-bold text-green">296</div>
           <div class="text-sm text-warm-gray">LSP Tests</div>
         </div>
         <div class="stat-item">

--- a/tooling/satsuma-cli/package-lock.json
+++ b/tooling/satsuma-cli/package-lock.json
@@ -22,6 +22,7 @@
         "satsuma": "dist/index.js"
       },
       "devDependencies": {
+        "@satsuma/viz-backend": "file:../satsuma-viz-backend",
         "@types/node": "^25.5.0",
         "c8": "^11.0.0",
         "tsx": "^4.23.1",
@@ -39,6 +40,22 @@
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
         "typescript": "^6.0.3"
+      }
+    },
+    "../satsuma-viz-backend": {
+      "name": "@satsuma/viz-backend",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core",
+        "@satsuma/viz-model": "file:../satsuma-viz-model",
+        "vscode-languageserver-types": "^3.18.0"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "c8": "^11.0.0",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -533,6 +550,10 @@
     },
     "node_modules/@satsuma/core": {
       "resolved": "../satsuma-core",
+      "link": true
+    },
+    "node_modules/@satsuma/viz-backend": {
+      "resolved": "../satsuma-viz-backend",
       "link": true
     },
     "node_modules/@types/istanbul-lib-coverage": {

--- a/tooling/satsuma-cli/package.json
+++ b/tooling/satsuma-cli/package.json
@@ -31,6 +31,7 @@
     "web-tree-sitter": "^0.26.7"
   },
   "devDependencies": {
+    "@satsuma/viz-backend": "file:../satsuma-viz-backend",
     "@types/node": "^25.5.0",
     "c8": "^11.0.0",
     "tsx": "^4.23.1",

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -126,9 +126,13 @@ export function coverageForMapping(
   if (!parsed) return null;
 
   const namespace = mapping.namespace ?? null;
+  // Named by (namespace, label), not by label alone: two mappings may carry the
+  // same label in different namespaces, and matching on the label gave the
+  // first-declared block's arrows to both — `b::load` reported its sibling's
+  // figures rather than its own, with no sign anything was wrong.
   const result: MappingCoverageResult = computeMappingCoverage(
     parsed.tree,
-    mapping.name,
+    { name: mapping.name, namespace },
     makeSchemaResolver(index, namespace),
     nlRefs,
   );

--- a/tooling/satsuma-cli/test/coverage-viz-parity.test.ts
+++ b/tooling/satsuma-cli/test/coverage-viz-parity.test.ts
@@ -56,6 +56,22 @@ function corpusFiles(dir: string, out: string[] = []): string[] {
   return out;
 }
 
+/** What the viz side reports for one file: figures, plus what it could not report. */
+interface VizFigures {
+  /** Per {@link figureKey}, the figures the card would show. */
+  figures: Map<string, Figures>;
+  /**
+   * Mapping ids whose `MappingBlock.coverage` is absent.
+   *
+   * Reported rather than skipped: absent coverage is a legitimate state for a
+   * mapping the CLI also cannot report on (an anonymous block, which `coverage`
+   * skips by design), and a defect for any mapping it can. The assertion below
+   * draws that line — the sweep is otherwise blind to a whole class of
+   * regression, since a mapping with no coverage produces no keys to compare.
+   */
+  uncomputed: string[];
+}
+
 /** Covered/total/pct, the three figures a reviewer reads off either surface. */
 interface Figures {
   covered: number;
@@ -101,7 +117,7 @@ async function cliFigures(entryPath: string): Promise<Map<string, Figures>> {
  * resolve, scope the model to the entry's own import graph, then read
  * `MappingBlock.coverage` — the payload the card is handed.
  */
-function vizFigures(entryPath: string, corpus: string[]): Map<string, Figures> {
+function vizFigures(entryPath: string, corpus: string[]): VizFigures {
   const parser = getParser();
   const index = createWorkspaceIndex();
   const trees = new Map<string, ReturnType<typeof parser.parse>>();
@@ -114,21 +130,30 @@ function vizFigures(entryPath: string, corpus: string[]): Map<string, Figures> {
 
   const entryUri = `file://${entryPath}`;
   const entryTree = trees.get(entryUri);
-  if (!entryTree) return new Map();
+  if (!entryTree) return { figures: new Map(), uncomputed: [] };
   const scoped = createScopedIndex(index, getImportReachableUris(entryUri, index));
   const model = buildVizModel(entryUri, entryTree, scoped);
 
   const figures = new Map<string, Figures>();
+  const uncomputed: string[] = [];
   for (const ns of model.namespaces) {
     for (const mapping of ns.mappings) {
       const mappingId = ns.name ? `${ns.name}::${mapping.id}` : mapping.id;
-      for (const schema of mapping.coverage?.schemas ?? []) {
+      // Tracked separately, because a mapping with no coverage contributes no
+      // keys and would be *invisible* to a comparison that only walks entries.
+      // That blind spot is why an anonymous mapping silently losing its coverage
+      // survived a corpus-wide sweep.
+      if (!mapping.coverage) {
+        uncomputed.push(mappingId);
+        continue;
+      }
+      for (const schema of mapping.coverage.schemas) {
         const { covered, total, pct } = summarizeFieldCoverage(schema.fields);
         figures.set(figureKey(mappingId, schema.schemaId, schema.role), { covered, total, pct });
       }
     }
   }
-  return figures;
+  return { figures, uncomputed };
 }
 
 describe("viz coverage equals satsuma coverage across the example corpus (sl-46wr, sl-csrs)", () => {
@@ -151,8 +176,20 @@ describe("viz coverage equals satsuma coverage across the example corpus (sl-46w
 
     for (const file of corpus) {
       const cli = await cliFigures(file);
-      const viz = vizFigures(file, corpus);
+      const { figures: viz, uncomputed } = vizFigures(file, corpus);
       const relative = file.slice(EXAMPLES.length + 1);
+
+      // A mapping the CLI reports on must have coverage on the viz side. The
+      // converse is fine: `coverage` skips anonymous mappings by design, so one
+      // the CLI never mentions may legitimately be absent here.
+      const cliMappings = new Set([...cli.keys()].map((k) => k.split("|")[0]));
+      for (const mappingId of uncomputed) {
+        if (cliMappings.has(mappingId)) {
+          disagreements.push(
+            `${relative} ${mappingId}: no coverage attached, but the CLI reports on it`,
+          );
+        }
+      }
 
       for (const [key, vizFigure] of viz) {
         const cliFigure = cli.get(key);

--- a/tooling/satsuma-cli/test/coverage-viz-parity.test.ts
+++ b/tooling/satsuma-cli/test/coverage-viz-parity.test.ts
@@ -1,0 +1,182 @@
+/**
+ * coverage-viz-parity.test.ts — `satsuma coverage` and the viz card agree on
+ * every file in the example corpus.
+ *
+ * Feature 38's epic acceptance criterion is that the CLI, the VS Code status bar
+ * and the viz card report identical figures for the same workspace. It held on
+ * two fixtures (sl-5nsv) and failed on twelve shipped examples, because the viz
+ * derived its own covered-path set from the model's arrows and so could not see
+ * the resolved NL `@ref` tier (sl-46wr, ADR-036) or whole-structure conferral
+ * (sl-csrs, ADR-037). Named-rule cases live in satsuma-viz's coverage-parity
+ * suite; this file is the sweep that would have caught both without anyone
+ * knowing to look for them.
+ *
+ * This is the one place both consumer paths are reachable in one process, which
+ * is why the sweep lives here: `@satsuma/viz-backend` assembles the model the
+ * webview receives, `coverageForWorkspace` produces what the command prints, and
+ * both are compared per mapping, schema and role — counts, denominators and
+ * percentages alike.
+ *
+ * **Scope differs by design and is accounted for, not ignored.** `coverage` reads
+ * the whole workspace (entry file plus transitive imports); a VizModel is one
+ * file. So the comparison iterates the *viz* side: every mapping the card can
+ * render must match the CLI, and a mapping declared only in an imported file is
+ * absent from the model without being a disagreement. A viz mapping with no CLI
+ * counterpart is still a failure — that direction would mean the card is
+ * reporting on something the CLI does not.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getParser, summarizeFieldCoverage } from "@satsuma/core";
+import {
+  createWorkspaceIndex,
+  indexFile,
+  getImportReachableUris,
+  createScopedIndex,
+} from "@satsuma/viz-backend/workspace-index";
+import { buildVizModel } from "@satsuma/viz-backend/viz-model";
+import { loadWorkspace } from "#src/load-workspace.js";
+import { coverageForWorkspace } from "#src/coverage-workspace.js";
+import { resolveAllNLRefs } from "#src/nl-ref-extract.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXAMPLES = resolve(__dirname, "../../../examples");
+
+/** Every `.stm` file under `examples/`, sorted for a stable report order. */
+function corpusFiles(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir).sort()) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) corpusFiles(path, out);
+    else if (name.endsWith(".stm")) out.push(path);
+  }
+  return out;
+}
+
+/** Covered/total/pct, the three figures a reviewer reads off either surface. */
+interface Figures {
+  covered: number;
+  total: number;
+  pct: number;
+}
+
+/**
+ * A `mapping|schema|role` key naming one reported figure on both sides.
+ *
+ * File-scope ids are written `::name` by the CLI's index and bare in a VizModel,
+ * so the empty namespace is stripped to make the two comparable. A *named*
+ * namespace is kept — `crm::orders` and `billing::orders` are different schemas.
+ */
+function figureKey(mapping: string, schema: string, role: string): string {
+  const bare = (id: string) => (id.startsWith("::") ? id.slice(2) : id);
+  return `${bare(mapping)}|${bare(schema)}|${role}`;
+}
+
+/** What `satsuma coverage` reports for `entryPath`, keyed by {@link figureKey}. */
+async function cliFigures(entryPath: string): Promise<Map<string, Figures>> {
+  const { files, index } = await loadWorkspace(entryPath);
+  const { mappings } = coverageForWorkspace(index, files, resolveAllNLRefs(index));
+
+  const figures = new Map<string, Figures>();
+  for (const mapping of mappings) {
+    for (const schema of mapping.result.schemas) {
+      const { covered, total, pct } = summarizeFieldCoverage(schema.fields);
+      figures.set(figureKey(mapping.mappingId, schema.schemaId, schema.role), {
+        covered,
+        total,
+        pct,
+      });
+    }
+  }
+  return figures;
+}
+
+/**
+ * What the viz card reports for `entryPath`, keyed by {@link figureKey}.
+ *
+ * Built the way a host builds it: index the whole corpus so cross-file imports
+ * resolve, scope the model to the entry's own import graph, then read
+ * `MappingBlock.coverage` — the payload the card is handed.
+ */
+function vizFigures(entryPath: string, corpus: string[]): Map<string, Figures> {
+  const parser = getParser();
+  const index = createWorkspaceIndex();
+  const trees = new Map<string, ReturnType<typeof parser.parse>>();
+  for (const path of corpus) {
+    const tree = parser.parse(readFileSync(path, "utf8"));
+    if (!tree) continue;
+    trees.set(`file://${path}`, tree);
+    indexFile(index, `file://${path}`, tree);
+  }
+
+  const entryUri = `file://${entryPath}`;
+  const entryTree = trees.get(entryUri);
+  if (!entryTree) return new Map();
+  const scoped = createScopedIndex(index, getImportReachableUris(entryUri, index));
+  const model = buildVizModel(entryUri, entryTree, scoped);
+
+  const figures = new Map<string, Figures>();
+  for (const ns of model.namespaces) {
+    for (const mapping of ns.mappings) {
+      const mappingId = ns.name ? `${ns.name}::${mapping.id}` : mapping.id;
+      for (const schema of mapping.coverage?.schemas ?? []) {
+        const { covered, total, pct } = summarizeFieldCoverage(schema.fields);
+        figures.set(figureKey(mappingId, schema.schemaId, schema.role), { covered, total, pct });
+      }
+    }
+  }
+  return figures;
+}
+
+describe("viz coverage equals satsuma coverage across the example corpus (sl-46wr, sl-csrs)", () => {
+  let corpus: string[];
+
+  before(() => {
+    corpus = corpusFiles(EXAMPLES);
+    // A sweep that silently swept nothing would pass forever. The corpus is
+    // dozens of files; a single digit means the walk broke, not that the repo
+    // shrank.
+    assert.ok(corpus.length > 20, `expected a corpus to sweep, found ${corpus.length} files`);
+  });
+
+  it("reports the same covered count, denominator and percentage for every mapping it renders", async () => {
+    // The assertion the epic turns on. Reported as a list of disagreements
+    // rather than failing on the first, so a rule that shifts many files shows
+    // its whole footprint in one run instead of one file per fix-and-rerun.
+    const disagreements: string[] = [];
+    let compared = 0;
+
+    for (const file of corpus) {
+      const cli = await cliFigures(file);
+      const viz = vizFigures(file, corpus);
+      const relative = file.slice(EXAMPLES.length + 1);
+
+      for (const [key, vizFigure] of viz) {
+        const cliFigure = cli.get(key);
+        if (!cliFigure) {
+          disagreements.push(`${relative} ${key}: viz reports on a mapping the CLI does not`);
+          continue;
+        }
+        compared++;
+        const shown = (f: Figures) => `${f.covered}/${f.total} ${f.pct}%`;
+        if (
+          vizFigure.covered !== cliFigure.covered ||
+          vizFigure.total !== cliFigure.total ||
+          vizFigure.pct !== cliFigure.pct
+        ) {
+          disagreements.push(
+            `${relative} ${key}: viz ${shown(vizFigure)}, cli ${shown(cliFigure)}`,
+          );
+        }
+      }
+    }
+
+    assert.deepEqual(disagreements, []);
+    // Guards the guard: if the viz stopped attaching coverage entirely, every
+    // key would vanish and the loop above would compare nothing at all.
+    assert.ok(compared > 50, `expected the sweep to compare real figures, compared ${compared}`);
+  });
+});

--- a/tooling/satsuma-cli/test/fixtures/coverage-anonymous-mapping.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-anonymous-mapping.stm
@@ -1,0 +1,20 @@
+// Fixture for the sl-46wr review: an anonymous mapping has no label.
+//
+// `mapping { … }` with no label is valid. The viz model calls it "unknown", and
+// no CST block carries that label — so looking the mapping up by label found
+// nothing, coverage was never attached, and the card rendered every field as
+// unmapped. Resolving by the block's position finds it.
+//
+// `satsuma coverage` skips anonymous mappings by design (it reports them as
+// `skippedAnonymous`, since coverage is keyed by mapping label), so this file
+// exists for the viz side: the card renders the mapping, so it must report on it.
+//
+// Correct on the viz side: 1 of 2 covered on each side.
+schema src { x STRING y STRING }
+schema tgt { x STRING y STRING }
+
+mapping {
+  source { src }
+  target { tgt }
+  x -> x
+}

--- a/tooling/satsuma-cli/test/fixtures/coverage-duplicate-mapping-labels.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-duplicate-mapping-labels.stm
@@ -1,0 +1,38 @@
+// Fixture for the sl-46wr review: a mapping label is not an identity.
+//
+// The same label in two namespaces is valid, and `viz-model.test.js` pins that
+// the model keeps them apart (sl-aeae). Coverage did not: it looked the mapping
+// up by label alone, so both `a::load` and `b::load` resolved to whichever block
+// was declared first. Every consumer was affected — `satsuma coverage` reported
+// `b::load` as 1/2 using `a::load`'s single arrow, and the viz reported the same
+// wrong figure or none at all depending on whether the namespaces happened to
+// share schema names.
+//
+// The schemas are deliberately named identically in both namespaces, which is
+// the case that produces a *plausible* wrong answer rather than an empty one:
+// `b`'s resolver finds `b::s`, so the figure looks reasonable and is simply not
+// `b::load`'s.
+//
+// Correct: a::load covers 1 of 2 on each side; b::load covers 2 of 2.
+namespace a {
+  schema s { x STRING y STRING }
+  schema t { x STRING y STRING }
+
+  mapping load {
+    source { s }
+    target { t }
+    x -> x
+  }
+}
+
+namespace b {
+  schema s { x STRING y STRING }
+  schema t { x STRING y STRING }
+
+  mapping load {
+    source { s }
+    target { t }
+    x -> x
+    y -> y
+  }
+}

--- a/tooling/satsuma-cli/test/fixtures/coverage-nl-tier.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-nl-tier.stm
@@ -1,0 +1,58 @@
+// Fixture for sl-46wr: the resolved NL `@ref` coverage tier (ADR-036).
+//
+// A leaf named by a *resolved* `@ref` in a mapping is covered, in the `nl` tier —
+// the same lineage weight `arrows`, `graph`, `lineage` and `lint` have always
+// given it (ADR-013). The tier is invisible in an arrow's endpoints, so a
+// consumer deriving covered paths from arrows alone reports these leaves as gaps
+// while `satsuma coverage` reports them covered. That is the divergence sl-46wr
+// records across twelve shipped examples, reduced here to one file.
+//
+// Covered, declared:  id, net_amount, status
+// Covered, nl:        tax_amount   — named only by @tax_amount in a transform
+//                     discount     — named only by @discount in a transform
+// Uncovered:          internal_ref — described in prose but never @ref'd, so it
+//                                    stays a gap: coverage follows explicit
+//                                    references, it does not read prose.
+//                     unresolved   — @no_such_field resolves to nothing, and a
+//                                    ref that resolves to nothing must never
+//                                    raise coverage (that is lint's
+//                                    unresolved-nl-ref).
+schema buy_order {
+  id STRING
+  net_amount DECIMAL(12, 2)
+  tax_amount DECIMAL(12, 2)
+  discount DECIMAL(12, 2)
+  internal_ref STRING
+  unresolved STRING
+  status STRING
+}
+
+schema om_order {
+  order_id STRING
+  goods_total DECIMAL(12, 2)
+  gross_total DECIMAL(12, 2)
+  rebate DECIMAL(12, 2)
+  state STRING
+}
+
+mapping `nl tier` {
+  source { buy_order }
+  target { om_order }
+
+  id -> order_id
+  net_amount -> goods_total
+  status -> state
+
+  // `tax_amount` reaches the target only through this @ref: no arrow names it.
+  -> gross_total { "Sum of @net_amount and @tax_amount" }
+
+  // `discount` likewise: prose is its only route to the target.
+  -> rebate { "Carried over from @discount on the buying document" }
+
+  // Prose alone confers nothing, and neither does a ref that resolves to
+  // nothing — both `internal_ref` and `unresolved` must stay uncovered.
+  note {
+    "The internal reference field is deliberately not carried across. See
+     @no_such_field for the decision record."
+  }
+}

--- a/tooling/satsuma-cli/test/fixtures/coverage-whole-structure.stm
+++ b/tooling/satsuma-cli/test/fixtures/coverage-whole-structure.stm
@@ -1,0 +1,111 @@
+// Fixture for sl-csrs: whole-structure arrow conferral (ADR-037), in all the
+// forms the rule distinguishes, on one file.
+//
+// ADR-037 rules that an arrow whose path resolves to a record or `list_of
+// record` covers that node's whole declared subtree when it states a
+// correspondence and enumerates no child arrows. Three shapes confer and two do
+// not, and telling them apart needs the arrow's *declaration kind* — which is
+// exactly what a flat set of covered paths has thrown away. The viz derived such
+// a set from the model's arrows until sl-csrs and so reported every leaf under a
+// conferring arrow as a gap.
+//
+// Conferring (record arrives, body enumerates nothing):
+//   addr -> address        bare record-to-record
+//   rows -> lines          list_of record to list_of record
+//   plain -> plain_out     empty braced body
+//   trimmed -> trimmed_out pipe-chain body: a pipeline, not a nesting scope
+// Not conferring:
+//   enum_src -> enum_out { .kept -> .kept }   enumerates, so covers only `kept`
+//   full_name -> scalar_into_record           a scalar cannot fill a record (ADR-038)
+schema src {
+  addr record {
+    street STRING
+    city STRING
+    zip STRING
+  }
+  rows list_of record {
+    sku STRING
+    qty INT
+  }
+  bill record {
+    city STRING
+    country STRING
+  }
+  plain record {
+    a STRING
+    b STRING
+  }
+  trimmed record {
+    c STRING
+    d STRING
+  }
+  enum_src record {
+    kept STRING
+    dropped STRING
+  }
+  full_name STRING
+}
+
+schema tgt {
+  address record {
+    line1 STRING
+    city STRING
+    postcode STRING
+  }
+  lines list_of record {
+    code STRING
+    quantity INT
+  }
+  billing record {
+    city STRING
+    country STRING
+  }
+  plain_out record {
+    a STRING
+    b STRING
+  }
+  trimmed_out record {
+    c STRING
+    d STRING
+  }
+  enum_out record {
+    kept STRING
+    dropped STRING
+  }
+  scalar_into_record record {
+    first STRING
+    last STRING
+  }
+}
+
+mapping whole_structure {
+  source { src }
+  target { tgt }
+
+  // Confers: a record maps across as a whole.
+  addr -> address
+
+  // Confers: a list of records is still a container.
+  rows -> lines
+
+  // Confers: an empty body enumerates nothing.
+  plain -> plain_out { }
+
+  // Confers: a pipe-chain body is a transform pipeline, not a nesting scope
+  // (spec §4.4), so the header's claim over the whole structure stands.
+  trimmed -> trimmed_out { trim }
+
+  // Does not confer: the body narrows the claim to what it lists, so
+  // `enum_out.dropped` stays a genuine gap.
+  enum_src -> enum_out {
+    .kept -> .kept
+  }
+
+  // Does not confer on the target side: one scalar cannot fill two leaves, and
+  // the arrow says nothing about which (ADR-038).
+  full_name -> scalar_into_record
+
+  // A plain leaf arrow, so `billing.country` stays uncovered and `billing`
+  // reads as partial — the state that proves conferral is not blanket.
+  bill.city -> billing.city
+}

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -101,12 +101,8 @@ export function buildCoveredFieldPaths(paths: Iterable<string>): CoveredFieldPat
 
 /**
  * True when the path is covered at all — directly or as the ancestor of a
- * direct path. This is the boolean every current consumer renders as "mapped",
- * and it is exactly what the flat-set probe has always answered.
- *
- * Same-named sibling: {@link isCoveredFieldPath} answers the identical question
- * over the flat `Set<string>` view for consumers that never build the model.
- * This one takes the model; that one takes the set.
+ * direct path. This is the boolean every consumer renders as "mapped", reached
+ * through the `FieldCoverageEntry` list coverage.ts builds from it.
  */
 export function isCoveredPath(path: string, covered: CoveredFieldPaths): boolean {
   return covered.direct.has(path) || covered.ancestors.has(path);
@@ -123,43 +119,22 @@ function properPrefixesOf(path: string): string[] {
   return prefixes;
 }
 
-// ── Flat-set compatibility view ──────────────────────────────────────────────
+// ── No flat-set view ─────────────────────────────────────────────────────────
 //
-// Consumers that only need the "covered at all?" boolean (the viz card, the
-// LSP gutter) work over a flat Set<string>. That view is now *defined* as the
-// union of the model's two sets, so the splitting rules exist once.
-
-/**
- * Expand a collection of field paths into a flat coverage set — the union of
- * the model's direct and ancestor sets, for consumers that only need the
- * "covered at all?" boolean and none of the why. The registration rules
- * (qualified paths only, never bare segments; no bracket normalisation) are
- * the model's — see {@link buildCoveredFieldPaths} for the rules and their
- * history (sl-joeq, sl-8o1n).
- */
-export function buildCoveredFieldSet(paths: Iterable<string>): Set<string> {
-  const { direct, ancestors } = buildCoveredFieldPaths(paths);
-  return new Set([...direct, ...ancestors]);
-}
-
-/**
- * Return true when a schema-local field path is covered by the expanded set.
- *
- * The caller must pass the schema-local *qualified* path (`customer.email`, not
- * `orders.customer.email` and not the bare leaf `email`). Matching is exact:
- * buildCoveredFieldSet() registers ancestor prefixes, so a record whose
- * descendant is covered matches on its own path, but a field is never matched
- * by local name alone (sl-joeq).
- *
- * Same-named sibling: {@link isCoveredPath} answers the identical question over
- * the {@link CoveredFieldPaths} model. This one takes the flat `Set<string>`
- * view (the viz card's shape); that one takes the model. Consumers moving onto
- * the model should prefer it — this set-based probe exists for call sites that
- * only ever see the flat view.
- */
-export function isCoveredFieldPath(path: string, coveredPaths: Set<string>): boolean {
-  return coveredPaths.has(path);
-}
+// There was one — `buildCoveredFieldSet(paths)` returning the union of the two
+// sets above, plus `isCoveredFieldPath(path, set)` to probe it — for consumers
+// that only wanted the "covered at all?" boolean. It is gone, with its last
+// consumer (sl-46wr, sl-csrs).
+//
+// It has to stay gone. A flat set of paths cannot express either of the two
+// rules coverage has gained since: which tier covered a field (ADR-036) and
+// whether an arrow's declaration confers its whole subtree (ADR-037). Both are
+// properties of the *arrow*, not of the path it names, so a consumer holding
+// only paths cannot apply them — and, worse, cannot tell that it is failing to.
+// The viz card held such a set and under-reported twelve of the shipped examples
+// while looking entirely plausible. A consumer with real coverage to report goes
+// through `computeMappingCoverage`, which has the arrows and the resolved refs;
+// one that merely needs a denominator uses `uncoveredFieldCoverage`.
 
 // ── Schema-qualified arrow references ───────────────────────────────────────
 

--- a/tooling/satsuma-core/src/coverage-rollup.ts
+++ b/tooling/satsuma-core/src/coverage-rollup.ts
@@ -264,6 +264,37 @@ function sumTotals(parts: Iterable<CoverageTotals>): CoverageTotals {
   return { covered, coveredDeclared, coveredNl, total, pct: coveragePercentage(covered, total) };
 }
 
+// ── Union ───────────────────────────────────────────────────────────────────
+
+/**
+ * Union several field-coverage lists for the *same schema* into one.
+ *
+ * **Union rule:** a leaf is covered when any input covers it, under the
+ * strongest tier any input claims; every container is then re-derived from the
+ * unioned leaves. Entries are returned in the order the first input declared
+ * them, with fields only later inputs know about appended.
+ *
+ * Exported because three questions reduce to this one operation and must not
+ * answer it differently: "does any mapping in the workspace cover this field?"
+ * ({@link aggregateCoverage}), "does this mapping cover it on either side?" (a
+ * schema can appear in both `source{}` and `target{}`), and "does anything in
+ * this file touch it?" — the viz overview card's index. Each of those was, or
+ * would have become, its own re-implementation of the same three rules.
+ *
+ * The inputs are not mutated; the result is a fresh list of fresh entries.
+ *
+ * Why containers cannot simply be OR-ed: two mappings that each cover half of
+ * `address` both report it `partial`, but between them every leaf is written,
+ * so the union is `covered`. Taking the strongest per-input state would say
+ * `partial` and understate the union — see {@link recomputeContainerStates}.
+ */
+export function unionFieldCoverage(lists: Iterable<FieldCoverageEntry[]>): FieldCoverageEntry[] {
+  const accumulated: FieldCoverageEntry[] = [];
+  for (const list of lists) unionInto(accumulated, list);
+  recomputeContainerStates(accumulated);
+  return accumulated;
+}
+
 // ── Aggregation ─────────────────────────────────────────────────────────────
 
 /**
@@ -287,7 +318,15 @@ export function aggregateCoverage(inputs: MappingCoverageInput[]): AggregateCove
   // Keyed by role + schemaId. Role is a two-value enum containing no spaces,
   // so the first space always separates the two parts — the key stays
   // unambiguous even for backtick-quoted schema names that contain spaces.
-  const byRoleAndSchema = new Map<string, AggregateSchemaCoverage>();
+  const byRoleAndSchema = new Map<
+    string,
+    {
+      schemaId: string;
+      role: "source" | "target";
+      mappings: string[];
+      lists: FieldCoverageEntry[][];
+    }
+  >();
 
   for (const { mappingId, result } of inputs) {
     for (const schema of result.schemas) {
@@ -298,22 +337,19 @@ export function aggregateCoverage(inputs: MappingCoverageInput[]): AggregateCove
           schemaId: schema.schemaId,
           role: schema.role,
           mappings: [mappingId],
-          fields: schema.fields.map((f) => ({ ...f })),
-          // Placeholder; every entry's totals are computed once all mappings
-          // have been unioned in, below.
-          totals: { covered: 0, coveredDeclared: 0, coveredNl: 0, total: 0, pct: 0 },
+          lists: [schema.fields],
         });
         continue;
       }
       if (!existing.mappings.includes(mappingId)) existing.mappings.push(mappingId);
-      unionInto(existing.fields, schema.fields);
+      existing.lists.push(schema.fields);
     }
   }
 
-  const schemas = [...byRoleAndSchema.values()];
-  for (const schema of schemas) {
-    recomputeContainerStates(schema.fields);
-    schema.totals = summarizeFieldCoverage(schema.fields);
+  const schemas: AggregateSchemaCoverage[] = [];
+  for (const { schemaId, role, mappings, lists } of byRoleAndSchema.values()) {
+    const fields = unionFieldCoverage(lists);
+    schemas.push({ schemaId, role, mappings, fields, totals: summarizeFieldCoverage(fields) });
   }
 
   return {
@@ -327,16 +363,23 @@ export function aggregateCoverage(inputs: MappingCoverageInput[]): AggregateCove
 }
 
 /**
- * Merge one mapping's field entries into the accumulated aggregate list.
+ * Merge one input's field entries into the accumulated list, copying rather
+ * than aliasing so the caller's entries are never mutated.
  *
  * `mapped` is OR-ed — that is the union rule. A field the accumulator has not
- * seen is appended, which only happens if two mappings resolved the same schema
+ * seen is appended, which only happens when two inputs resolved the same schema
  * id to different definitions; keeping it is safer than dropping a declared
  * field from the report.
  *
- * Containers are OR-ed here too, but that answer is provisional: their real
- * aggregate state can only be read off the unioned *leaves*, which is why
- * {@link recomputeContainerStates} runs once afterwards.
+ * `state` is re-derived from the OR-ed `mapped` rather than merged, because a
+ * merged state would be the *first* input's answer to a question the union has
+ * since changed: a leaf mapping A ignores and mapping B writes is covered, and
+ * leaving `state: "uncovered"` on it beside `mapped: true` contradicts the
+ * documented invariant that the two always agree. The binary form applied here
+ * is right for a leaf and provisional for a container, whose real unioned state
+ * can only be read off the unioned *leaves* — which is why
+ * {@link recomputeContainerStates} runs once afterwards, overwriting it. Both
+ * happen inside {@link unionFieldCoverage}, the only caller.
  */
 function unionInto(accumulated: FieldCoverageEntry[], incoming: FieldCoverageEntry[]): void {
   const byPath = new Map(accumulated.map((f) => [f.path, f]));
@@ -349,6 +392,7 @@ function unionInto(accumulated: FieldCoverageEntry[], incoming: FieldCoverageEnt
       continue;
     }
     existing.mapped = existing.mapped || field.mapped;
+    existing.state = existing.mapped ? "covered" : "uncovered";
     // Tier unions toward the stronger claim: a field one mapping declares and
     // another only mentions in prose is declared-covered in the aggregate
     // (ADR-036). Without this the aggregate could report a declared field as
@@ -362,14 +406,14 @@ function unionInto(accumulated: FieldCoverageEntry[], incoming: FieldCoverageEnt
 /**
  * Recompute every container's tri-state from the unioned leaves beneath it.
  *
- * A container's state cannot be unioned the way a leaf's can. Two mappings that
- * each cover half of `address` both report it `partial`; the aggregate must
+ * A container's state cannot be unioned the way a leaf's can. Two inputs that
+ * each cover half of `address` both report it `partial`; the union must
  * report `covered`, because between them every leaf is written. Taking the
- * strongest per-mapping state would say `partial`, understating the aggregate;
+ * strongest per-input state would say `partial`, understating the union;
  * OR-ing `mapped` alone would lose the distinction entirely. So the union
  * happens on leaves, where it is well defined, and containers are derived from
  * the result — the same rule `coverageForField` applies per mapping, restated
- * over a flat list because that is the shape the aggregate holds.
+ * over a flat list because that is the shape the union holds.
  *
  * Mutates `fields` in place. Leaf entries are left exactly as unioned.
  */

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -211,6 +211,44 @@ export interface MappingCoverageResult {
   schemas: SchemaCoverageResult[];
 }
 
+// ── Naming the mapping to report on ─────────────────────────────────────────
+
+/**
+ * Which mapping in a tree to report on, when a label alone will not do.
+ *
+ * A label is not an identity: two mappings may carry the same one in different
+ * namespaces, and an anonymous `mapping { … }` block has none at all. Supplying
+ * the parts a caller knows makes the match exact.
+ *
+ * Every field is optional, and each one supplied narrows the match:
+ */
+export interface MappingSelector {
+  /**
+   * Label as authored, backticks already stripped. `null` names an anonymous
+   * mapping — but a label is not unique on its own, so pair it with
+   * {@link namespace}, and use {@link row} for an anonymous block.
+   */
+  name?: string | null;
+  /**
+   * Namespace the mapping is declared in, or `null` for file scope. Matched
+   * exactly when supplied: omitting it matches a mapping in any namespace, which
+   * is what makes a bare label ambiguous.
+   */
+  namespace?: string | null;
+  /**
+   * 0-indexed CST start row of the `mapping` block. **Decisive when supplied** —
+   * it identifies the block outright, so it is the form to use for an anonymous
+   * mapping and the safest form for any consumer that already holds a position.
+   */
+  row?: number;
+}
+
+/**
+ * How a caller names the mapping to report on: a label, or a
+ * {@link MappingSelector} when the label is not enough to identify it.
+ */
+export type MappingTarget = string | MappingSelector;
+
 // ── Entry point ─────────────────────────────────────────────────────────────
 
 /**
@@ -222,8 +260,10 @@ export interface MappingCoverageResult {
  * resolve is omitted from the result entirely.
  *
  * @param tree         Parse tree of the file declaring the mapping.
- * @param mappingName  Mapping label to report on; matched against top-level
- *                     and namespaced `mapping` blocks in this tree.
+ * @param target       Which mapping to report on. A bare label matches the first
+ *                     block carrying it, in any namespace — pass a
+ *                     {@link MappingSelector} to name one exactly, which any
+ *                     caller holding a namespace or a position should do.
  * @param resolveSchema Adapter from the caller's index to field trees.
  * @param nlRefs       Resolved NL `@refs` for the workspace, from
  *                     `resolveAllNLRefs()`. Those belonging to this mapping
@@ -234,11 +274,11 @@ export interface MappingCoverageResult {
  */
 export function computeMappingCoverage(
   tree: Tree,
-  mappingName: string,
+  target: MappingTarget,
   resolveSchema: CoverageSchemaResolver,
   nlRefs: readonly ResolvedNLRef[] = [],
 ): MappingCoverageResult {
-  const found = findMappingBlock(tree, mappingName);
+  const found = findMappingBlock(tree, target);
   if (!found) return { schemas: [] };
 
   const body = child(found.node, "mapping_body");
@@ -812,25 +852,82 @@ interface LocatedMapping {
   mappingKey: string;
 }
 
-/** Find a `mapping` block by label, at file scope or inside a namespace block. */
-function findMappingBlock(tree: Tree, name: string): LocatedMapping | null {
+/** One `mapping` block in the tree, paired with the namespace it is declared in. */
+interface MappingCandidate {
+  node: SyntaxNode;
+  /** Enclosing namespace name, or null at file scope. */
+  namespace: string | null;
+  /** Label as authored, or null for an anonymous `mapping { … }` block. */
+  label: string | null;
+}
+
+/**
+ * Every `mapping` block in the tree, at file scope and inside namespaces, in
+ * declaration order.
+ *
+ * A namespace's name is its first `identifier` child, not a label — the same
+ * read extract.ts's `collectFromNamespaces()` does, so the keys built from it
+ * match the ones `resolveAllNLRefs()` files refs under.
+ */
+function mappingCandidates(tree: Tree): MappingCandidate[] {
+  const found: MappingCandidate[] = [];
   for (const node of tree.rootNode.namedChildren) {
-    if (node.type === "mapping_block" && labelText(node) === name) {
-      return { node, mappingKey: name };
+    if (node.type === "mapping_block") {
+      found.push({ node, namespace: null, label: labelText(node) });
+      continue;
     }
     if (node.type === "namespace_block") {
-      // A namespace's name is its first `identifier` child, not a label — the
-      // same read extract.ts's collectFromNamespaces() does, so the key built
-      // here matches the one resolveAllNLRefs() files refs under.
       const namespace = node.namedChildren.find((c) => c.type === "identifier")?.text ?? null;
       for (const ch of node.namedChildren) {
-        if (ch.type === "mapping_block" && labelText(ch) === name) {
-          return { node: ch, mappingKey: namespace ? `${namespace}::${name}` : name };
+        if (ch.type === "mapping_block") {
+          found.push({ node: ch, namespace, label: labelText(ch) });
         }
       }
     }
   }
-  return null;
+  return found;
+}
+
+/**
+ * The NL-ref key for one mapping — what `resolveAllNLRefs` files its refs under.
+ *
+ * An anonymous mapping is keyed by its start row, matching
+ * `extractMappingNLRefs`'s `<anon>@:<row>` synthesis, so a mapping with no label
+ * can still be credited with the refs in its own body.
+ */
+function nlRefKeyFor(candidate: MappingCandidate): string {
+  const name = candidate.label ?? `<anon>@:${candidate.node.startPosition.row}`;
+  return candidate.namespace ? `${candidate.namespace}::${name}` : name;
+}
+
+/**
+ * Locate the mapping a {@link MappingTarget} names.
+ *
+ * **A bare string matches by label alone, and that is ambiguous.** Two mappings
+ * may share a label in different namespaces (viz-model's sl-aeae case), and the
+ * first one declared wins the match — so the caller gets another mapping's
+ * arrows judged against its own schemas, which reads as a plausible but wrong
+ * figure rather than as an error. Callers that know which mapping they mean must
+ * pass a {@link MappingSelector}; the string form is retained only for the LSP's
+ * `satsuma/mappingCoverage` request, whose params carry a name and nothing else.
+ *
+ * A selector matches on the parts it supplies. `row` is decisive when given and
+ * is the only way to name an anonymous mapping, which has no label to match.
+ */
+function findMappingBlock(tree: Tree, target: MappingTarget): LocatedMapping | null {
+  const candidates = mappingCandidates(tree);
+
+  if (typeof target === "string") {
+    const match = candidates.find((c) => c.label === target);
+    return match ? { node: match.node, mappingKey: nlRefKeyFor(match) } : null;
+  }
+
+  const match = candidates.find((c) => {
+    if (target.namespace !== undefined && c.namespace !== target.namespace) return false;
+    if (target.row !== undefined) return c.node.startPosition.row === target.row;
+    return c.label === (target.name ?? null);
+  });
+  return match ? { node: match.node, mappingKey: nlRefKeyFor(match) } : null;
 }
 
 /** Schema references declared in the mapping's `source {}` or `target {}` block. */

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -113,8 +113,24 @@ export interface CoverageSchemaDefinition {
  * (bare name or `ns::name`) to its definition, or null when it cannot be
  * resolved. Unresolvable schemas are skipped rather than reported: coverage
  * is not a validation pass, and `validate` already flags missing refs.
+ *
+ * `mappingNamespace` is the namespace of the mapping being reported on, or null
+ * at file scope — supplied because a reference is only resolvable relative to
+ * where it was written: a bare `orders` inside `namespace crm` means
+ * `crm::orders`. A resolver that ignores it resolves nothing for any namespaced
+ * mapping whose references are unqualified, which is the normal way to write one;
+ * the LSP's did, so the editor reported no coverage at all for those mappings
+ * while the CLI reported them fine. Core passes it rather than leaving each
+ * consumer to re-derive the mapping's namespace, which is work core has already
+ * done by the time it calls this.
+ *
+ * A resolver that closes over the namespace itself may ignore the argument — the
+ * CLI and viz adapters do, having taken it from their own indexes.
  */
-export type CoverageSchemaResolver = (schemaId: string) => CoverageSchemaDefinition | null;
+export type CoverageSchemaResolver = (
+  schemaId: string,
+  mappingNamespace: string | null,
+) => CoverageSchemaDefinition | null;
 
 // ── Public result types ─────────────────────────────────────────────────────
 
@@ -301,8 +317,8 @@ export function computeMappingCoverage(
   // below. The target side's whole-structure test has to ask what the *source*
   // path names (ADR-038), so the source field trees must be in hand before
   // `declaredTgt` is built.
-  const sources = resolveParticipants(sourceIds, resolveSchema);
-  const targets = resolveParticipants(targetIds, resolveSchema);
+  const sources = resolveParticipants(sourceIds, resolveSchema, found.namespace);
+  const targets = resolveParticipants(targetIds, resolveSchema, found.namespace);
 
   const arrows = extractMappingArrowRecords(found.node);
   const declaredSrc = arrows.flatMap((a) =>
@@ -360,10 +376,11 @@ interface ParticipatingSchema {
 function resolveParticipants(
   schemaIds: readonly string[],
   resolveSchema: CoverageSchemaResolver,
+  mappingNamespace: string | null,
 ): ParticipatingSchema[] {
   const resolved: ParticipatingSchema[] = [];
   for (const writtenRef of schemaIds) {
-    const def = resolveSchema(writtenRef);
+    const def = resolveSchema(writtenRef, mappingNamespace);
     if (def) resolved.push({ writtenRef, def });
   }
   return resolved;
@@ -850,6 +867,8 @@ interface LocatedMapping {
    * over-count of exactly the kind ADR-036's "only resolved refs" rule guards.
    */
   mappingKey: string;
+  /** Namespace the mapping is declared in, or null at file scope. */
+  namespace: string | null;
 }
 
 /** One `mapping` block in the tree, paired with the namespace it is declared in. */
@@ -919,7 +938,7 @@ function findMappingBlock(tree: Tree, target: MappingTarget): LocatedMapping | n
 
   if (typeof target === "string") {
     const match = candidates.find((c) => c.label === target);
-    return match ? { node: match.node, mappingKey: nlRefKeyFor(match) } : null;
+    return match ? located(match) : null;
   }
 
   const match = candidates.find((c) => {
@@ -927,7 +946,16 @@ function findMappingBlock(tree: Tree, target: MappingTarget): LocatedMapping | n
     if (target.row !== undefined) return c.node.startPosition.row === target.row;
     return c.label === (target.name ?? null);
   });
-  return match ? { node: match.node, mappingKey: nlRefKeyFor(match) } : null;
+  return match ? located(match) : null;
+}
+
+/** Project a matched candidate onto the shape the walk needs. */
+function located(candidate: MappingCandidate): LocatedMapping {
+  return {
+    node: candidate.node,
+    mappingKey: nlRefKeyFor(candidate),
+    namespace: candidate.namespace,
+  };
 }
 
 /** Schema references declared in the mapping's `source {}` or `target {}` block. */

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -472,8 +472,8 @@ function expandWholeStructureRefs(
  * root — empty when the path names a leaf or is not declared here.
  *
  * Both records and their leaves are returned. The leaves are what coverage
- * counts; the intermediate records keep the flat set view (`buildCoveredFieldSet`)
- * consistent with the model for consumers that only hold the set.
+ * counts; the intermediate records are returned so a conferred record reads as
+ * `covered` in its own right rather than only through its descendants.
  */
 function descendantPathsOf(path: string, fields: CoverageField[]): string[] {
   const found = findDeclaredField(path, fields);
@@ -657,40 +657,27 @@ interface TieredCoveredPaths {
 }
 
 /**
- * Coverage entries for a declared field tree, judged against the flat
- * covered-path set view (`buildCoveredFieldSet`).
+ * Coverage entries for a declared field tree that no mapping touches: every
+ * field `uncovered`, with the leaf and container rules applied as usual.
  *
- * The entry point for a consumer that holds a *set* of covered paths rather
- * than a mapping's CST — the viz card, which builds its set in the browser from
- * the viz model. Without it that consumer has to re-derive the tri-state and
- * leaf rules itself, and ADR-034 requires the opposite: `satsuma coverage`, the
- * VS Code status bar and the viz card must report one number for one workspace,
- * so every one of them counts through the shapes this module emits.
+ * Exists so "nothing covers this schema" is still an answer *this* module
+ * produces. A consumer showing a schema no mapping references — the viz overview
+ * renders one card per declared schema — still needs a denominator, and deriving
+ * "0 of N" from its own count of the field tree is how a card ends up counting
+ * containers into the ratio that ADR-034 excludes (sl-hcan).
  *
- * Re-deriving the model from the flat set changes no answer. The set is defined
- * as the union of the model's `direct` and `ancestors` sets, and
- * {@link isCoveredPath} asks for membership of either, so a path is covered here
- * exactly when it was covered in the model the set came from. Containers are
- * judged from their leaves regardless of how their own path was registered.
- *
- * **Tier:** a flat set records no tier, so every covered leaf is reported as
- * `declared`. That is accurate for the only caller today — the viz builds its
- * set from declared arrows alone — but a consumer that starts folding resolved
- * NL `@ref` coverage into its set must move to {@link computeMappingCoverage}
- * rather than have it mislabelled here (ADR-036).
- *
- * **Whole-structure arrows are not expanded** (ADR-037): the expansion needs the
- * arrow's declaration kind, which a set of paths has thrown away. A caller whose
- * set may contain a whole-record arrow's target must expand it into that
- * record's leaves before building the set, or the record will read as uncovered.
+ * There is deliberately **no** entry point taking an arbitrary set of covered
+ * paths. One existed, and it was the shape that let the viz keep deriving its
+ * own covered set: a flat set of paths has thrown away the two things coverage
+ * now needs — which tier covered a field (ADR-036) and whether an arrow's
+ * declaration confers its whole subtree (ADR-037) — so anything built that way
+ * silently under-reports both, as the viz card did on twelve shipped examples
+ * (sl-46wr, sl-csrs). A consumer with real coverage to report must go through
+ * {@link computeMappingCoverage}, which has the arrows and the resolved refs.
  */
-export function fieldCoverageFromCoveredPaths(
-  fields: CoverageField[],
-  uri: string,
-  coveredPaths: Iterable<string>,
-): FieldCoverageEntry[] {
+export function uncoveredFieldCoverage(fields: CoverageField[], uri: string): FieldCoverageEntry[] {
   return buildFieldCoverage(fields, uri, "", {
-    declared: buildCoveredFieldPaths(coveredPaths),
+    declared: buildCoveredFieldPaths([]),
     nl: buildCoveredFieldPaths([]),
   });
 }

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -33,6 +33,8 @@ export type {
   CoverageField,
   CoverageSchemaDefinition,
   CoverageSchemaResolver,
+  MappingSelector,
+  MappingTarget,
 } from "./coverage.js";
 export {
   buildCoveredFieldPaths,

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -23,11 +23,7 @@ export { initParser, getParser, getLanguage, createQuery } from "./parser.js";
 export type { ParserInitOptions } from "./parser.js";
 export { collectParseErrors } from "./parse-errors.js";
 export type { ParseErrorEntry } from "./parse-errors.js";
-export {
-  computeMappingCoverage,
-  declaredFieldKind,
-  fieldCoverageFromCoveredPaths,
-} from "./coverage.js";
+export { computeMappingCoverage, declaredFieldKind, uncoveredFieldCoverage } from "./coverage.js";
 export type {
   CoverageTier,
   FieldCoverageState,
@@ -40,8 +36,6 @@ export type {
 } from "./coverage.js";
 export {
   buildCoveredFieldPaths,
-  buildCoveredFieldSet,
-  isCoveredFieldPath,
   isCoveredPath,
   schemaLocalFieldPath,
   schemaRefPrefixes,
@@ -49,6 +43,7 @@ export {
 export type { CoveredFieldPaths } from "./coverage-paths.js";
 export {
   aggregateCoverage,
+  unionFieldCoverage,
   summarizeFieldCoverage,
   leafFieldEntries,
   countContainerStates,

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -9,33 +9,34 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import {
-  buildCoveredFieldPaths,
-  buildCoveredFieldSet,
-  isCoveredFieldPath,
-  isCoveredPath,
-  schemaLocalFieldPath,
-} from "@satsuma/core";
+import { buildCoveredFieldPaths, isCoveredPath, schemaLocalFieldPath } from "@satsuma/core";
 
-describe("buildCoveredFieldSet()", () => {
+// ── Path identity (sl-joeq, ADR-035) ────────────────────────────────────────
+//
+// Coverage identity is the qualified path and nothing else. These cases were
+// written against the flat-set view; that view was deleted with its last
+// consumer (sl-46wr), and they now assert the same rules on the model, which is
+// where the rules always lived — the set was only ever its union.
+
+describe("covered-path registration is by qualified path alone", () => {
   it("marks nested field paths and their parents as covered", () => {
     // Coverage of "address" must fire when an arrow targets a path inside it —
     // without ancestor registration the parent record always reads as unmapped.
-    const covered = buildCoveredFieldSet(["customer.email"]);
-    assert.equal(isCoveredFieldPath("customer", covered), true);
-    assert.equal(isCoveredFieldPath("customer.email", covered), true);
+    const covered = buildCoveredFieldPaths(["customer.email"]);
+    assert.equal(isCoveredPath("customer", covered), true);
+    assert.equal(isCoveredPath("customer.email", covered), true);
   });
 
   it("registers every ancestor of a deep path, not just one level", () => {
     // Three-level paths appear in real workbooks; a one-level implementation
     // would leave "a.b" unregistered and report the middle record uncovered.
-    const covered = buildCoveredFieldSet(["a.b.c"]);
-    assert.deepEqual([...covered].sort(), ["a", "a.b", "a.b.c"]);
+    const covered = buildCoveredFieldPaths(["a.b.c"]);
+    assert.deepEqual([...covered.direct, ...covered.ancestors].sort(), ["a", "a.b", "a.b.c"]);
   });
 
   it("returns false for unrelated paths", () => {
-    const covered = buildCoveredFieldSet(["customer.email"]);
-    assert.equal(isCoveredFieldPath("customer.tier", covered), false);
+    const covered = buildCoveredFieldPaths(["customer.email"]);
+    assert.equal(isCoveredPath("customer.tier", covered), false);
   });
 
   it("leaves a top-level field uncovered when only a nested field shares its name", () => {
@@ -43,34 +44,34 @@ describe("buildCoveredFieldSet()", () => {
     // bare name, so bare-segment registration made it collide with any nested
     // leaf of the same name. Reported 100% for a schema half of whose fields
     // no arrow touches.
-    const covered = buildCoveredFieldSet(["home_address.city"]);
-    assert.equal(isCoveredFieldPath("city", covered), false);
+    const covered = buildCoveredFieldPaths(["home_address.city"]);
+    assert.equal(isCoveredPath("city", covered), false);
   });
 
   it("leaves every intermediate segment of a deep path uncovered as a top-level name", () => {
     // Middle segments leaked as well as leaves: with only a.b.c.d covered,
     // top-level fields named b, c or d all read as mapped.
-    const covered = buildCoveredFieldSet(["a.b.c.d"]);
+    const covered = buildCoveredFieldPaths(["a.b.c.d"]);
     for (const segment of ["b", "c", "d"]) {
-      assert.equal(isCoveredFieldPath(segment, covered), false, `'${segment}' must be uncovered`);
+      assert.equal(isCoveredPath(segment, covered), false, `'${segment}' must be uncovered`);
     }
-    assert.equal(isCoveredFieldPath("a", covered), true, "'a' is a genuine ancestor prefix");
+    assert.equal(isCoveredPath("a", covered), true, "'a' is a genuine ancestor prefix");
   });
 
   it("leaves a sibling record's same-named leaf uncovered", () => {
     // Sibling records sharing a leaf name (the fragment-spread shape of
     // examples/lib/sfdc_fragments.stm, where one fragment lands in both
     // BillingAddress and ShippingAddress) must be judged independently.
-    const covered = buildCoveredFieldSet(["home_address.city"]);
-    assert.equal(isCoveredFieldPath("work_address.city", covered), false);
+    const covered = buildCoveredFieldPaths(["home_address.city"]);
+    assert.equal(isCoveredPath("work_address.city", covered), false);
   });
 
   it("leaves a sibling list container's same-named leaf uncovered", () => {
     // Sibling lists whose element records share field names are the norm in
     // nested schemas; only the container an arrow actually writes is covered.
-    const covered = buildCoveredFieldSet(["orders.lines.sku"]);
-    assert.equal(isCoveredFieldPath("orders.lines.sku", covered), true);
-    assert.equal(isCoveredFieldPath("orders.packed.sku", covered), false);
+    const covered = buildCoveredFieldPaths(["orders.lines.sku"]);
+    assert.equal(isCoveredPath("orders.lines.sku", covered), true);
+    assert.equal(isCoveredPath("orders.packed.sku", covered), false);
   });
 });
 
@@ -138,15 +139,13 @@ describe("buildCoveredFieldPaths() — the direct/derived model", () => {
     assert.ok(covered.ancestors.has("items[]"), "the ancestor split is on dots alone");
   });
 
-  it("keeps the flat-set view equal to the union of direct and ancestors", () => {
-    // buildCoveredFieldSet is defined as the model's union, so consumers on the
-    // boolean view can never drift from consumers on the model.
-    const paths = ["a.b.c", "x", "a.other"];
-    const flat = buildCoveredFieldSet(paths);
-    const model = buildCoveredFieldPaths(paths);
-    assert.deepEqual(flat, new Set([...model.direct, ...model.ancestors]));
-    for (const p of flat) {
-      assert.equal(isCoveredPath(p, model), true, `'${p}' must probe as covered on the model too`);
+  it("probes every registered path as covered, whichever set it landed in", () => {
+    // The property the deleted flat-set view existed to guarantee: `isCoveredPath`
+    // must accept membership of either set, so which set a path lands in is an
+    // internal detail and never changes the "mapped" answer a consumer renders.
+    const model = buildCoveredFieldPaths(["a.b.c", "x", "a.other"]);
+    for (const p of [...model.direct, ...model.ancestors]) {
+      assert.equal(isCoveredPath(p, model), true, `'${p}' must probe as covered`);
     }
   });
 });

--- a/tooling/satsuma-core/test/coverage-rollup.test.js
+++ b/tooling/satsuma-core/test/coverage-rollup.test.js
@@ -23,6 +23,7 @@ import {
   extractSchemas,
   extractMappings,
   aggregateCoverage,
+  unionFieldCoverage,
   summarizeFieldCoverage,
   countContainerStates,
   coveragePercentage,
@@ -467,5 +468,109 @@ describe("aggregateCoverage() — degenerate inputs", () => {
     // find or resolve; that must not create a phantom zero-coverage entry.
     const result = aggregateCoverage([{ mappingId: "ghost", result: { schemas: [] } }]);
     assert.deepEqual(result.schemas, []);
+  });
+});
+
+// ── The union operation on its own ──────────────────────────────────────────
+
+describe("unionFieldCoverage()", () => {
+  // aggregateCoverage unions by (schema, role); the viz overview card unions a
+  // schema's roles together; `fields --unmapped-by` unions the two sides of one
+  // mapping. Same three rules each time, so they are pinned here once against
+  // the exported operation rather than three times through its callers.
+
+  /** One schema's entries: a leaf plus a two-leaf record. */
+  const half = (city, line1, amount, tier = "declared") => [
+    {
+      path: "amount",
+      uri: "u",
+      mapped: amount,
+      state: amount ? "covered" : "uncovered",
+      ...(amount ? { tier } : {}),
+    },
+    {
+      path: "address",
+      uri: "u",
+      mapped: city || line1,
+      state: city && line1 ? "covered" : city || line1 ? "partial" : "uncovered",
+      ...(city || line1 ? { tier } : {}),
+    },
+    {
+      path: "address.city",
+      uri: "u",
+      mapped: city,
+      state: city ? "covered" : "uncovered",
+      ...(city ? { tier } : {}),
+    },
+    {
+      path: "address.line1",
+      uri: "u",
+      mapped: line1,
+      state: line1 ? "covered" : "uncovered",
+      ...(line1 ? { tier } : {}),
+    },
+  ];
+
+  it("promotes a record to covered when two inputs each cover half of it", () => {
+    // The rule a plain OR of container states cannot express: both inputs call
+    // `address` partial, but between them every leaf is written, so the union
+    // is covered. Getting this wrong understates the union.
+    const union = unionFieldCoverage([half(true, false, false), half(false, true, false)]);
+    const byPath = new Map(union.map((f) => [f.path, f]));
+    assert.equal(byPath.get("address").state, "covered");
+    assert.equal(byPath.get("address.city").state, "covered");
+    assert.equal(byPath.get("address.line1").state, "covered");
+  });
+
+  it("leaves a record partial when no input covers one of its leaves", () => {
+    // The mirror case: union must not round a genuine gap up to covered.
+    const union = unionFieldCoverage([half(true, false, false), half(true, false, true)]);
+    const byPath = new Map(union.map((f) => [f.path, f]));
+    assert.equal(byPath.get("address").state, "partial");
+    assert.equal(byPath.get("address.line1").state, "uncovered");
+    assert.equal(byPath.get("address.line1").tier, undefined);
+  });
+
+  it("reports a leaf covered by prose in one input and by an arrow in another as declared", () => {
+    // Tier unions toward the stronger claim (ADR-036). Without it, whether a
+    // declared field reads as merely inferred would depend on input order.
+    const union = unionFieldCoverage([half(true, false, false, "nl"), half(true, false, false)]);
+    const byPath = new Map(union.map((f) => [f.path, f]));
+    assert.equal(byPath.get("address.city").tier, "declared");
+    assert.equal(byPath.get("address").tier, "declared");
+  });
+
+  it("re-derives a leaf's state from the unioned flag, not from the first input", () => {
+    // `mapped` and `state` are documented to always agree. Merging `mapped` but
+    // keeping the first input's `state` left `mapped: true, state: "uncovered"`
+    // on any leaf the first input missed — invisible while only the counts were
+    // read, wrong the moment a consumer renders the tri-state.
+    const union = unionFieldCoverage([half(false, false, false), half(false, false, true)]);
+    const amount = union.find((f) => f.path === "amount");
+    assert.equal(amount.mapped, true);
+    assert.equal(amount.state, "covered");
+  });
+
+  it("keeps the NL tier when no input declares the field", () => {
+    // The tier must survive the union, not be flattened to `declared` — a
+    // reviewer has to see that nothing but prose names this field.
+    const union = unionFieldCoverage([half(true, false, false, "nl"), half(false, false, false)]);
+    assert.equal(union.find((f) => f.path === "address.city").tier, "nl");
+  });
+
+  it("does not mutate the inputs", () => {
+    // Callers hold the per-mapping results and render them separately; a union
+    // that wrote through would silently turn every per-mapping figure into the
+    // aggregate one.
+    const first = half(true, false, false);
+    const second = half(false, true, false);
+    unionFieldCoverage([first, second]);
+    assert.equal(first.find((f) => f.path === "address.line1").mapped, false);
+    assert.equal(second.find((f) => f.path === "address").state, "partial");
+  });
+
+  it("returns an empty list for no inputs", () => {
+    // A schema no mapping references unions to nothing, not to a phantom entry.
+    assert.deepEqual(unionFieldCoverage([]), []);
   });
 });

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -19,11 +19,9 @@ import { fileURLToPath } from "node:url";
 import {
   initParser,
   getParser,
-  buildCoveredFieldSet,
   computeMappingCoverage,
-  countContainerStates,
   extractSchemas,
-  fieldCoverageFromCoveredPaths,
+  uncoveredFieldCoverage,
   extractMappings,
   extractNLRefData,
   leafFieldEntries,
@@ -1586,25 +1584,19 @@ mapping load {
   });
 });
 
-// ── Set-based entry building (sl-hcan) ───────────────────────────────────────
+// ── Schemas no mapping touches (sl-hcan) ─────────────────────────────────────
 //
-// The path a consumer takes when it holds a covered-path *set* rather than a
-// mapping's CST — the viz card, which builds its set in the browser. ADR-034
+// A consumer showing a schema that no mapping references still needs a
+// denominator — the viz overview renders one card per declared schema. ADR-034
 // requires one number per workspace across `satsuma coverage`, the VS Code
-// status bar and the viz card, so what matters here is that this entry point
-// answers exactly as the CST path does.
+// status bar and the viz card, so that denominator has to be counted by the
+// same rules as every other, not by the consumer counting its own field tree.
 
-describe("fieldCoverageFromCoveredPaths()", () => {
+describe("uncoveredFieldCoverage()", () => {
   const NESTED = `
-schema src { city STRING }
 schema tgt {
   amount DECIMAL
   address record { city STRING line1 STRING postcode STRING }
-}
-mapping load {
-  source { src }
-  target { tgt }
-  city -> address.city
 }`;
 
   /** The declared field tree of `tgt`, in core's minimal coverage shape. */
@@ -1614,70 +1606,69 @@ mapping load {
     return toCoverageFields(schema.fields);
   }
 
-  it("reports the same entries as computeMappingCoverage for the same arrows", () => {
-    // The parity property sl-hcan exists for. If the two paths can disagree,
-    // the viz card and the CLI can print different numbers for one file, which
-    // is exactly what they did before this entry point existed.
-    const viaCst = forRole(coverage(NESTED, "load"), "target");
-    const viaSet = fieldCoverageFromCoveredPaths(
-      targetFields(),
-      TEST_URI,
-      buildCoveredFieldSet(["address.city"]),
+  it("reports every field uncovered, records included", () => {
+    // The container must read `uncovered` rather than be omitted or left
+    // undefined: a card renders the tri-state per row, and an absent state is
+    // not the same claim as "nothing under here is mapped".
+    const entries = uncoveredFieldCoverage(targetFields(), TEST_URI);
+    assert.deepEqual(
+      entries.map((f) => [f.path, f.state, f.mapped]),
+      [
+        ["amount", "uncovered", false],
+        ["address", "uncovered", false],
+        ["address.city", "uncovered", false],
+        ["address.line1", "uncovered", false],
+        ["address.postcode", "uncovered", false],
+      ],
     );
-    assert.deepEqual(viaSet, viaCst.fields);
+    assert.equal(
+      entries.every((f) => f.tier === undefined),
+      true,
+    );
   });
 
-  it("counts leaves only, so nesting depth alone cannot move the percentage", () => {
-    // The concrete figure sl-hcan cites: `amount` plus a three-leaf `address`
-    // with only `address.city` covered is 1/4 — 25%. Counting the record too
-    // (the viz card's old rule) gave 2/5 — 40%.
-    const entries = fieldCoverageFromCoveredPaths(
-      targetFields(),
-      TEST_URI,
-      buildCoveredFieldSet(["address.city"]),
-    );
-    assert.deepEqual(summarizeFieldCoverage(entries), {
-      covered: 1,
-      coveredDeclared: 1,
+  it("counts leaves only, so nesting depth alone cannot move the denominator", () => {
+    // The figure sl-hcan cites, in its zero-covered form: `amount` plus a
+    // three-leaf `address` is 0/4, not 0/5. Counting the record too — the viz
+    // card's old rule — inflated every denominator by its nesting.
+    assert.deepEqual(summarizeFieldCoverage(uncoveredFieldCoverage(targetFields(), TEST_URI)), {
+      covered: 0,
+      coveredDeclared: 0,
       coveredNl: 0,
       total: 4,
-      pct: 25,
+      pct: 0,
     });
-    assert.deepEqual(countContainerStates(entries), { covered: 0, partial: 1, uncovered: 0 });
   });
 
-  it("gives a flat and a deeply nested schema with the same leaves the same percentage", () => {
+  it("gives a flat and a deeply nested schema with the same leaves the same denominator", () => {
     // Depth invariance, stated as a property rather than a figure: re-nesting a
-    // schema without changing its leaves or the arrows into it must not move the
-    // number. This is what makes a coverage percentage comparable between two
-    // schemas, and what counting containers destroyed.
+    // schema without changing its leaves must not move the number. This is what
+    // makes a coverage percentage comparable between two schemas, and what
+    // counting containers destroyed.
     const FLAT = `schema tgt { a STRING b STRING c STRING d STRING }`;
     const DEEP = `schema tgt { a STRING outer record { b STRING mid record { c STRING inner record { d STRING } } } }`;
-    const COVERED = new Set(["a"]);
 
-    const flat = summarizeFieldCoverage(
-      fieldCoverageFromCoveredPaths(targetFields(FLAT), TEST_URI, COVERED),
-    );
-    const deep = summarizeFieldCoverage(
-      fieldCoverageFromCoveredPaths(targetFields(DEEP), TEST_URI, COVERED),
-    );
+    const flat = summarizeFieldCoverage(uncoveredFieldCoverage(targetFields(FLAT), TEST_URI));
+    const deep = summarizeFieldCoverage(uncoveredFieldCoverage(targetFields(DEEP), TEST_URI));
     assert.deepEqual(flat, deep);
     assert.equal(flat.total, 4);
-    assert.equal(flat.pct, 25);
   });
 
-  it("judges a container from its leaves even when the set names the container itself", () => {
-    // A set built from `each parcels -> .packed { }` contains "packed" with no
-    // leaf beneath it covered. A container reference must not manufacture leaf
-    // coverage (PRD 38 R2) — the same rule the CST path applies, reached here
-    // through a set that has forgotten which arrow put the path there.
-    const SCHEMA = `schema tgt { packed record { weight DECIMAL sku STRING } }`;
-    const entries = fieldCoverageFromCoveredPaths(
-      targetFields(SCHEMA),
-      TEST_URI,
-      buildCoveredFieldSet(["packed"]),
-    );
-    assert.equal(entries.find((f) => f.path === "packed").state, "uncovered");
-    assert.equal(summarizeFieldCoverage(entries).covered, 0);
+  it("agrees with computeMappingCoverage on a mapping that covers nothing", () => {
+    // The two entry points must produce the same shape for the same schema, or
+    // a card seeded with this list and later unioned with a real result would
+    // disagree with itself.
+    const EMPTY = `
+schema src { unused STRING }
+schema tgt {
+  amount DECIMAL
+  address record { city STRING line1 STRING postcode STRING }
+}
+mapping load {
+  source { src }
+  target { tgt }
+}`;
+    const viaCst = forRole(coverage(EMPTY, "load"), "target");
+    assert.deepEqual(uncoveredFieldCoverage(targetFields(EMPTY), TEST_URI), viaCst.fields);
   });
 });

--- a/tooling/satsuma-lsp/package-lock.json
+++ b/tooling/satsuma-lsp/package-lock.json
@@ -57,6 +57,9 @@
       "name": "@satsuma/viz-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",

--- a/tooling/satsuma-lsp/src/action-context.ts
+++ b/tooling/satsuma-lsp/src/action-context.ts
@@ -8,6 +8,18 @@ export interface ActionContext {
   schemaName: string | null;
   fieldPath: string | null;
   mappingName: string | null;
+  /**
+   * 0-indexed start row of the enclosing `mapping` block, or null when the cursor
+   * is not inside one.
+   *
+   * **This, not `mappingName`, identifies the mapping.** A label is not unique —
+   * two namespaces may each declare `mapping load` — and an anonymous block has
+   * none at all, so a consumer that asks core about a mapping by label alone gets
+   * the first block carrying it. The cursor is already inside the right block, so
+   * the row is free to carry and settles the question outright; `satsuma
+   * coverage`'s figures and the gutter's disagreed until it did.
+   */
+  mappingRow: number | null;
   targetSchema: string | null;
 }
 
@@ -20,42 +32,56 @@ export function computeActionContext(
 ): ActionContext {
   const node = nodeAtPosition(tree, line, character);
   if (!node) {
-    return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
+    return {
+      schemaName: null,
+      fieldPath: null,
+      mappingName: null,
+      mappingRow: null,
+      targetSchema: null,
+    };
   }
 
   const ctx = findNodeContext(node);
-  const { mappingName, targetSchema } = inferMappingContext(node);
+  const { mappingName, mappingRow, targetSchema } = inferMappingContext(node);
 
   if (!ctx) {
-    return { schemaName: null, fieldPath: null, mappingName, targetSchema };
+    return { schemaName: null, fieldPath: null, mappingName, mappingRow, targetSchema };
   }
 
   return {
     schemaName: inferSchemaName(ctx),
     fieldPath: inferFieldPath(ctx),
     mappingName,
+    mappingRow,
     targetSchema,
   };
 }
 
 /**
- * Walk up the CST from the cursor node to find an enclosing named mapping_block,
- * then extract the mapping name and the first target schema reference.
+ * Walk up the CST from the cursor node to find the enclosing mapping_block, then
+ * extract its name, its start row and the first target schema reference.
+ *
+ * The row comes from the same node the name does. Returning only the name threw
+ * away the one thing that identifies the block — see
+ * {@link ActionContext.mappingRow}.
  */
 function inferMappingContext(node: SyntaxNode): {
   mappingName: string | null;
+  mappingRow: number | null;
   targetSchema: string | null;
 } {
   let current: SyntaxNode | null = node;
   while (current) {
     if (current.type === "mapping_block") {
-      const mappingName = labelText(current);
-      const targetSchema = extractTargetSchema(current);
-      return { mappingName, targetSchema };
+      return {
+        mappingName: labelText(current),
+        mappingRow: current.startPosition.row,
+        targetSchema: extractTargetSchema(current),
+      };
     }
     current = current.parent;
   }
-  return { mappingName: null, targetSchema: null };
+  return { mappingName: null, mappingRow: null, targetSchema: null };
 }
 
 function extractTargetSchema(mappingNode: SyntaxNode): string | null {

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -9,9 +9,12 @@
  * `(uri, tree, mappingName, wsIndex)` signature that server.ts's
  * `satsuma/mappingCoverage` request handler already calls.
  *
- * It owns nothing else: no path rules, no field walking, no counting. If coverage
- * output looks wrong, the bug is in core unless the schema being reported is the
- * wrong one — that resolution step is what lives here.
+ * It owns nothing else: no path rules, no field walking, no counting, and no
+ * longer the `DefinitionLookup` either — that is `@satsuma/viz-backend`'s, shared
+ * with the viz's own coverage adapter so the gutter and the schema card cannot
+ * resolve the same prose differently. If coverage output looks wrong, the bug is
+ * in core unless the schema being reported is the wrong one — that resolution
+ * step is what lives here.
  *
  * The gutter must agree with `satsuma coverage` field for field, so it feeds core
  * the same two inputs the CLI does. Resolved `@refs` are one of them (ADR-036):
@@ -23,17 +26,16 @@
 import type { Tree } from "./parser-utils";
 import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
+import { makeDefinitionLookup } from "@satsuma/viz-backend/coverage";
 import {
   computeMappingCoverage as computeCoverage,
   expandDeclaredFields,
-  extractMappings,
   extractNLRefData,
   resolveAllNLRefs,
 } from "@satsuma/core";
 import type {
   CoverageField,
   CoverageSchemaDefinition,
-  DefinitionLookup,
   FieldDecl,
   ResolvedNLRef,
   SpreadEntity,
@@ -85,57 +87,6 @@ function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): Resolv
   if (items.length === 0) return [];
   return resolveAllNLRefs(items, makeDefinitionLookup(tree, wsIndex));
 }
-
-/**
- * Adapt the LSP index to core's `DefinitionLookup` (ADR-006's callback pattern).
- *
- * Schemas and fragments come from the workspace index, so an `@ref` to an
- * imported schema resolves. Mapping source/target lists are read from this tree
- * instead: the index does not record them in that shape, and the only mapping
- * whose context matters is the one declared here.
- */
-function makeDefinitionLookup(tree: Tree, wsIndex: WorkspaceIndex): DefinitionLookup {
-  const mappings = new Map<string, { sources: string[]; targets: string[] }>();
-  for (const m of extractMappings(tree.rootNode)) {
-    // Anonymous mappings have no label, so no ref can be filed under them.
-    if (!m.name) continue;
-    const key = m.namespace ? `${m.namespace}::${m.name}` : m.name;
-    mappings.set(key, { sources: m.sources, targets: m.targets });
-  }
-
-  const entryOfKind = (key: string, kind: DefinitionEntryKind) =>
-    resolveDefinition(wsIndex, key, null).find((d) => d.kind === kind) ?? null;
-
-  // `hasSpreads: false` because the LSP index stores each schema's fields
-  // already flattened; there is no unresolved spread left for core to expand.
-  const schemaLike = (key: string) => {
-    const def = entryOfKind(key, "schema");
-    return def ? { fields: def.fields, hasSpreads: false, namespace: def.namespace } : null;
-  };
-
-  return {
-    hasSchema: (key) => schemaLike(key) !== null,
-    getSchema: (key) => schemaLike(key),
-    hasFragment: (key) => entryOfKind(key, "fragment") !== null,
-    getFragment: (key) => {
-      const def = entryOfKind(key, "fragment");
-      return def ? { fields: def.fields, hasSpreads: false } : null;
-    },
-    hasTransform: (key) => entryOfKind(key, "transform") !== null,
-    getMapping: (key) => mappings.get(key) ?? null,
-    iterateSchemas: () => {
-      const out: Array<[string, { fields: FieldInfo[]; hasSpreads: boolean }]> = [];
-      for (const [key, entries] of wsIndex.definitions) {
-        const def = entries.find((d) => d.kind === "schema");
-        if (def) out.push([key, { fields: def.fields, hasSpreads: false }]);
-      }
-      return out;
-    },
-  } as DefinitionLookup;
-}
-
-/** The `kind` values a `DefinitionEntry` can carry that this module looks up. */
-type DefinitionEntryKind = "schema" | "fragment" | "transform";
 
 /**
  * Resolve a schema reference to core's coverage input shape.

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -59,35 +59,42 @@ import type { MappingCoverageResult } from "@satsuma/core";
  * parse tree) — it is retained because the request handler passes it and
  * because a future scoped resolver may need the requesting document.
  *
- * `mappingName` may be namespace-qualified (`crm::load`), and should be whenever
- * the caller knows the namespace. A bare label is ambiguous: two mappings may
- * carry the same one in different namespaces, and core then matches the
- * first-declared block, reporting its arrows under the other's name. The
- * `satsuma/mappingCoverage` request accepts either form so a client holding only
- * a label still works, at that cost.
+ * **Pass `mappingRow` whenever the caller has it** — it identifies the block
+ * outright, and every caller reaching this through `satsuma/actionContext` does,
+ * because that request read the row off the very node the cursor sits in. Without
+ * it a label has to be matched, and a label is not unique: two namespaces may each
+ * declare `mapping load`, so core matches the first-declared block and the gutter
+ * reports one mapping's arrows under the other's name. That is not hypothetical —
+ * it is what left the editor disagreeing with `satsuma coverage` after the CLI and
+ * the viz were fixed.
+ *
+ * `mappingName` is still accepted alone, for a client predating the field, and is
+ * split on a qualifying `ns::` when it carries one.
  */
 export function computeMappingCoverage(
   uri: string,
   tree: Tree,
   mappingName: string,
   wsIndex: WorkspaceIndex,
+  mappingRow?: number,
 ): MappingCoverageResult {
   return computeCoverage(
     tree,
-    mappingTargetOf(mappingName),
-    (schemaId) => resolveSchema(wsIndex, schemaId),
+    mappingTargetOf(mappingName, mappingRow),
+    (schemaId, mappingNamespace) => resolveSchema(wsIndex, schemaId, mappingNamespace),
     resolveNLRefs(uri, tree, wsIndex),
   );
 }
 
 /**
- * Split a possibly-qualified mapping name into an exact selector.
+ * Turn what the request supplied into the most precise target available.
  *
- * `crm::load` names one mapping; a bare `load` cannot, so it is passed through as
- * a label and matched as before. Split on the *last* `::` so a namespace
- * containing one still resolves.
+ * A row wins outright. Failing that, `crm::load` names one mapping; a bare `load`
+ * cannot, so it is passed through as a label and matched as before. The `::` split
+ * takes the *last* occurrence so a namespace containing one still resolves.
  */
-function mappingTargetOf(mappingName: string): MappingTarget {
+function mappingTargetOf(mappingName: string, mappingRow?: number): MappingTarget {
+  if (mappingRow !== undefined) return { row: mappingRow };
   const separator = mappingName.lastIndexOf("::");
   if (separator < 0) return mappingName;
   return {
@@ -115,6 +122,20 @@ function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): Resolv
 /**
  * Resolve a schema reference to core's coverage input shape.
  *
+ * **Resolved relative to `mappingNamespace`.** A mapping inside `namespace crm`
+ * normally writes `orders`, not `crm::orders`, and this passed `null` as the
+ * scope — so `resolveDefinition` looked only at file scope, found nothing, and
+ * core skipped the schema. Every namespaced mapping with unqualified references
+ * therefore reported *no* coverage in the editor while `satsuma coverage`
+ * reported it correctly: the gutter painted nothing and the status bar had no
+ * figure. The namespace now comes from core, which located the mapping and so
+ * already knows it.
+ *
+ * The canonical `schemaId` is reported back so results line up when they are
+ * rolled up across mappings that name the same schema differently — a mapping in
+ * `crm` writing `orders` and one outside writing `crm::orders` are the same
+ * schema.
+ *
  * Only `kind === "schema"` definitions participate: a mapping's source/target
  * blocks may name something the index also knows as another kind, and coverage
  * is defined over declared schema fields.
@@ -126,11 +147,21 @@ function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): Resolv
  * }` to the gutter as a single childless leaf, while `satsuma coverage` reported
  * the three leaves the fragment materialises (sl-5nsv).
  */
-function resolveSchema(wsIndex: WorkspaceIndex, schemaId: string): CoverageSchemaDefinition | null {
-  const defs = resolveDefinition(wsIndex, schemaId, null);
+function resolveSchema(
+  wsIndex: WorkspaceIndex,
+  schemaId: string,
+  mappingNamespace: string | null,
+): CoverageSchemaDefinition | null {
+  const defs = resolveDefinition(wsIndex, schemaId, mappingNamespace);
   const def = defs.find((d) => d.kind === "schema");
   if (!def) return null;
-  return { uri: def.uri, fields: expandedFields(wsIndex, def).map(toCoverageField) };
+  const canonicalId =
+    def.namespace && !schemaId.includes("::") ? `${def.namespace}::${schemaId}` : schemaId;
+  return {
+    schemaId: canonicalId,
+    uri: def.uri,
+    fields: expandedFields(wsIndex, def).map(toCoverageField),
+  };
 }
 
 /**

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -37,6 +37,7 @@ import type {
   CoverageField,
   CoverageSchemaDefinition,
   FieldDecl,
+  MappingTarget,
   ResolvedNLRef,
   SpreadEntity,
 } from "@satsuma/core";
@@ -57,6 +58,13 @@ import type { MappingCoverageResult } from "@satsuma/core";
  * `uri` is not used to locate the mapping (the caller already supplies its
  * parse tree) — it is retained because the request handler passes it and
  * because a future scoped resolver may need the requesting document.
+ *
+ * `mappingName` may be namespace-qualified (`crm::load`), and should be whenever
+ * the caller knows the namespace. A bare label is ambiguous: two mappings may
+ * carry the same one in different namespaces, and core then matches the
+ * first-declared block, reporting its arrows under the other's name. The
+ * `satsuma/mappingCoverage` request accepts either form so a client holding only
+ * a label still works, at that cost.
  */
 export function computeMappingCoverage(
   uri: string,
@@ -66,10 +74,26 @@ export function computeMappingCoverage(
 ): MappingCoverageResult {
   return computeCoverage(
     tree,
-    mappingName,
+    mappingTargetOf(mappingName),
     (schemaId) => resolveSchema(wsIndex, schemaId),
     resolveNLRefs(uri, tree, wsIndex),
   );
+}
+
+/**
+ * Split a possibly-qualified mapping name into an exact selector.
+ *
+ * `crm::load` names one mapping; a bare `load` cannot, so it is passed through as
+ * a label and matched as before. Split on the *last* `::` so a namespace
+ * containing one still resolves.
+ */
+function mappingTargetOf(mappingName: string): MappingTarget {
+  const separator = mappingName.lastIndexOf("::");
+  if (separator < 0) return mappingName;
+  return {
+    namespace: mappingName.slice(0, separator),
+    name: mappingName.slice(separator + 2),
+  };
 }
 
 /**

--- a/tooling/satsuma-lsp/src/server.ts
+++ b/tooling/satsuma-lsp/src/server.ts
@@ -417,12 +417,30 @@ connection.onRequest("satsuma/fieldLocations", (params: { name: string }) => {
   return result;
 });
 
-/** Return per-field coverage for both source and target schemas of a mapping. */
-connection.onRequest("satsuma/mappingCoverage", (params: { uri: string; mappingName: string }) => {
-  const tree = trees.get(params.uri);
-  if (!tree) return { schemas: [] };
-  return computeMappingCoverage(params.uri, tree, params.mappingName, scopeIndex(params.uri));
-});
+/**
+ * Return per-field coverage for both source and target schemas of a mapping.
+ *
+ * `mappingRow` identifies the block outright and should always be sent — a label
+ * is not unique (two namespaces may each declare `mapping load`) and an anonymous
+ * block has none, so resolving by name alone reports the first block carrying it.
+ * The client gets the row from `satsuma/actionContext`, which read it off the very
+ * node the cursor sits in. `mappingName` alone is still accepted, for a client
+ * that predates the field.
+ */
+connection.onRequest(
+  "satsuma/mappingCoverage",
+  (params: { uri: string; mappingName: string; mappingRow?: number }) => {
+    const tree = trees.get(params.uri);
+    if (!tree) return { schemas: [] };
+    return computeMappingCoverage(
+      params.uri,
+      tree,
+      params.mappingName,
+      scopeIndex(params.uri),
+      params.mappingRow,
+    );
+  },
+);
 
 connection.onRequest(
   "satsuma/actionContext",
@@ -434,7 +452,15 @@ connection.onRequest(
     };
   }) => {
     const tree = trees.get(params.uri);
-    if (!tree) return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
+    if (!tree) {
+      return {
+        schemaName: null,
+        fieldPath: null,
+        mappingName: null,
+        mappingRow: null,
+        targetSchema: null,
+      };
+    }
     return computeActionContext(
       tree,
       params.position.line,

--- a/tooling/satsuma-lsp/test/coverage.test.js
+++ b/tooling/satsuma-lsp/test/coverage.test.js
@@ -201,3 +201,81 @@ mapping load {
     );
   });
 });
+
+// ── The request path the editor actually takes (review of #430) ──────────────
+//
+// `showCoverage` does not pass core a mapping selector directly: it asks
+// `satsuma/actionContext` what the cursor is inside, then sends that to
+// `satsuma/mappingCoverage`. Fixing the CLI and the viz to name a mapping
+// exactly left this path still resolving by label, so the gutter and the status
+// bar stayed wrong while the other two consumers were right — the parity the
+// whole feature exists for, broken at the surface a user actually looks at.
+//
+// These exercise the two hops together, which is the only way to catch a fix
+// that stops short of the request contract.
+
+describe("the editor's coverage request resolves the mapping the cursor is in", () => {
+  const { computeActionContext } = require("../dist/action-context");
+
+  // Two namespaces declaring the same mapping label *and* the same schema names.
+  // The shared schema names matter: they make the wrong answer look right, since
+  // `b`'s resolver finds `b::s` and reports a plausible figure that belongs to
+  // `a::load`.
+  const SRC = `namespace a {
+  schema s { x STRING y STRING }
+  schema t { x STRING y STRING }
+  mapping load { source { s } target { t } x -> x }
+}
+namespace b {
+  schema s { x STRING y STRING }
+  schema t { x STRING y STRING }
+  mapping load { source { s } target { t } x -> x  y -> y }
+}`;
+
+  const URI = "file:///ns-dup.stm";
+
+  /** Coverage as the command computes it: cursor position → context → request. */
+  function coverageAtCursor(line) {
+    const tree = parse(SRC);
+    const index = createWorkspaceIndex();
+    indexFile(index, URI, tree);
+    const ctx = computeActionContext(tree, line, 30, URI, index);
+    const result = computeMappingCoverage(URI, tree, ctx.mappingName, index, ctx.mappingRow);
+    return {
+      mappingRow: ctx.mappingRow,
+      figures: result.schemas.map((s) => {
+        const leaves = s.fields.filter((f) => !f.path.includes("."));
+        return `${s.role} ${s.schemaId} ${leaves.filter((f) => f.mapped).length}/${leaves.length}`;
+      }),
+    };
+  }
+
+  it("reports the second of two same-labelled namespace mappings, not the first", () => {
+    // `b::load` maps both leaves. Resolving by label gave it `a::load`'s single
+    // arrow — 1/2 — and `satsuma coverage` printed 2/2 for the same mapping.
+    const b = coverageAtCursor(8);
+    assert.equal(b.mappingRow, 8, "the action context must carry the block's row");
+    assert.deepEqual(b.figures, ["source b::s 2/2", "target b::t 2/2"]);
+  });
+
+  it("still reports the first one correctly when the cursor is inside it", () => {
+    // The control: the fix must not simply invert which one wins.
+    const a = coverageAtCursor(3);
+    assert.equal(a.mappingRow, 3);
+    assert.deepEqual(a.figures, ["source a::s 1/2", "target a::t 1/2"]);
+  });
+
+  it("resolves an unqualified reference against the mapping's own namespace", () => {
+    // Both mappings above write `source { s }`, not `source { a::s }` — the normal
+    // way to write a mapping inside a namespace. The adapter passed `null` as the
+    // resolution scope, so nothing resolved and core skipped every schema: the
+    // editor reported no coverage at all for namespaced mappings while the CLI
+    // reported them fine. Non-empty figures above are the assertion; this pins the
+    // canonical id, which is what makes them roll up with the CLI's.
+    const b = coverageAtCursor(8);
+    assert.ok(
+      b.figures.every((f) => f.includes("b::")),
+      `expected namespace-qualified schema ids, got ${JSON.stringify(b.figures)}`,
+    );
+  });
+});

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -36,6 +36,9 @@
       "name": "@satsuma/viz-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",

--- a/tooling/satsuma-viz-backend/package.json
+++ b/tooling/satsuma-viz-backend/package.json
@@ -19,6 +19,10 @@
     "./viz-model": {
       "types": "./dist/viz-model.d.ts",
       "default": "./dist/viz-model.js"
+    },
+    "./coverage": {
+      "types": "./dist/coverage.d.ts",
+      "default": "./dist/coverage.js"
     }
   },
   "scripts": {

--- a/tooling/satsuma-viz-backend/src/coverage.ts
+++ b/tooling/satsuma-viz-backend/src/coverage.ts
@@ -78,7 +78,18 @@ export function attachMappingCoverage(
     // inside `namespace staging` means `staging::stg_gl_entries`.
     const resolveSchema = makeCardResolver(cards, ns.name, wsIndex);
     for (const mapping of ns.mappings) {
-      const result = computeMappingCoverage(tree, mapping.id, resolveSchema, nlRefs);
+      // Identified by its start row, which names the block outright. A label is
+      // not an identity: two namespaces may declare `mapping load`, and matching
+      // on the label alone judged the second one's schemas against the first
+      // one's arrows — a plausible figure that was simply wrong. An anonymous
+      // mapping has no label at all (the model calls it "unknown"), so a
+      // label-based lookup found nothing and dropped its coverage entirely.
+      const result = computeMappingCoverage(
+        tree,
+        { namespace: ns.name, row: mapping.location.line },
+        resolveSchema,
+        nlRefs,
+      );
       if (result.schemas.length > 0) mapping.coverage = result;
     }
   }

--- a/tooling/satsuma-viz-backend/src/coverage.ts
+++ b/tooling/satsuma-viz-backend/src/coverage.ts
@@ -1,0 +1,247 @@
+/**
+ * coverage.ts — field coverage for an assembled VizModel, computed by core.
+ *
+ * The viz used to work out for itself which fields a mapping covers, by walking
+ * the arrows in the VizModel. That derivation looked equivalent to core's and
+ * was not: it counted declared arrows and nothing else, so it missed the
+ * resolved NL `@ref` tier (ADR-036) and whole-structure conferral (ADR-037), and
+ * disagreed with `satsuma coverage` on twelve of the shipped examples
+ * (sl-46wr, sl-csrs). Every rule added to coverage since had to be implemented
+ * twice or the card drifted. This module removes the second implementation:
+ * coverage is computed here, once, by `@satsuma/core`, and travels to the client
+ * inside the payload as `MappingBlock.coverage`.
+ *
+ * Owns: adapting an assembled model plus a workspace index to the two callbacks
+ * core needs — a `CoverageSchemaResolver` and a `DefinitionLookup` for `@ref`
+ * resolution — and attaching the results to the model.
+ * Does not own: coverage semantics, counting, or rendering. If a figure looks
+ * wrong, the bug is in core unless the schema being reported is the wrong one.
+ *
+ * **Schemas resolve to the model's own cards, not to the workspace index.** The
+ * card is what the client renders, so counting any other field tree would put a
+ * ratio next to rows it does not describe — and the model's tree is already the
+ * index's, with fragment spreads materialised (sl-5nsv). Resolving against the
+ * cards also means metric endpoints are covered for free: a metric is a schema
+ * card as far as the detail view is concerned, and the index classifies it under
+ * a different kind, which is why the LSP's index-based resolver reports nothing
+ * for a mapping that writes into one.
+ */
+
+import type { Tree } from "./parser-utils";
+import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
+import { resolveDefinition } from "./workspace-index";
+import {
+  computeMappingCoverage,
+  extractMappings,
+  extractNLRefData,
+  resolveAllNLRefs,
+} from "@satsuma/core";
+import type {
+  CoverageField,
+  CoverageSchemaDefinition,
+  CoverageSchemaResolver,
+  DefinitionLookup,
+  ResolvedNLRef,
+} from "@satsuma/core";
+import type { FieldEntry, MetricCard, NamespaceGroup, SchemaCard } from "@satsuma/viz-model";
+
+/**
+ * Compute per-mapping field coverage for every mapping in `namespaces` and
+ * attach it to each `MappingBlock.coverage`, in place.
+ *
+ * Must run **after** fragment spreads have been resolved into the cards: the
+ * card's field tree is the tree coverage is judged against, and judging the
+ * pre-expansion tree would report `address record { ...address_fields }` as one
+ * uncovered leaf where the CLI reports the three the fragment materialises.
+ *
+ * A mapping core cannot resolve to any schema is left without coverage rather
+ * than given an empty result — absent means "not computed", which a consumer
+ * must not render as 0% (see `MappingBlock.coverage`).
+ *
+ * @param uri         URI of the file being modelled, used to file NL refs.
+ * @param tree        Its parse tree — the authority on what the arrows say.
+ * @param namespaces  The assembled namespace groups, mutated in place.
+ * @param wsIndex     Import-scoped index, used only to resolve `@refs`.
+ */
+export function attachMappingCoverage(
+  uri: string,
+  tree: Tree,
+  namespaces: NamespaceGroup[],
+  wsIndex: WorkspaceIndex,
+): void {
+  const cards = indexCardsByQualifiedId(namespaces);
+  const nlRefs = resolveNLRefs(uri, tree, wsIndex);
+
+  for (const ns of namespaces) {
+    // The resolver is per namespace, not per model: a reference is resolved
+    // relative to where the mapping is declared, so `stg_gl_entries` written
+    // inside `namespace staging` means `staging::stg_gl_entries`.
+    const resolveSchema = makeCardResolver(cards, ns.name, wsIndex);
+    for (const mapping of ns.mappings) {
+      const result = computeMappingCoverage(tree, mapping.id, resolveSchema, nlRefs);
+      if (result.schemas.length > 0) mapping.coverage = result;
+    }
+  }
+}
+
+// ── Schema resolution, from the model's cards ───────────────────────────────
+
+/** Every schema and metric card in the model, keyed by its qualified id. */
+function indexCardsByQualifiedId(
+  namespaces: NamespaceGroup[],
+): Map<string, CoverageSchemaDefinition> {
+  const cards = new Map<string, CoverageSchemaDefinition>();
+  for (const ns of namespaces) {
+    for (const schema of ns.schemas) cards.set(schema.qualifiedId, schemaCardDef(schema));
+    for (const metric of ns.metrics) cards.set(metric.qualifiedId, metricCardDef(metric));
+  }
+  return cards;
+}
+
+/**
+ * Resolve the schema references written in a mapping's `source {}` / `target {}`
+ * blocks to the field trees the client will render.
+ *
+ * References arrive **as authored** — core reads them off the CST, because only
+ * the authored form can be matched against the schema prefix on an arrow path.
+ * A bare `stg_gl_entries` written inside `namespace staging` therefore has to be
+ * resolved against `mappingNamespace` first, exactly as `resolveMappingRef`
+ * resolves the model's own `sourceRefs`. Resolving it namespace-blind instead
+ * left every namespaced mapping's own-namespace target reporting 0%. The index
+ * is consulted for that one step; the *fields* still come from the card.
+ *
+ * The canonical `schemaId` reported back is the card's `qualifiedId`, so results
+ * for one schema line up when a consumer rolls them up across mappings that name
+ * it differently.
+ */
+function makeCardResolver(
+  cards: Map<string, CoverageSchemaDefinition>,
+  mappingNamespace: string | null,
+  wsIndex: WorkspaceIndex,
+): CoverageSchemaResolver {
+  return (writtenRef: string): CoverageSchemaDefinition | null => {
+    // Already qualified, or declared at file scope: the written form is the key.
+    const direct = cards.get(writtenRef);
+    if (direct) return direct;
+    // Unqualified inside a namespace — the mapping's own namespace wins, which
+    // is the order resolveDefinition applies.
+    if (writtenRef.includes("::")) return null;
+    for (const def of resolveDefinition(wsIndex, writtenRef, mappingNamespace)) {
+      const card = cards.get(def.namespace ? `${def.namespace}::${writtenRef}` : writtenRef);
+      if (card) return card;
+    }
+    return null;
+  };
+}
+
+/** A schema card as core's coverage input: its qualified id, uri and field tree. */
+function schemaCardDef(schema: SchemaCard): CoverageSchemaDefinition {
+  return {
+    schemaId: schema.qualifiedId,
+    uri: schema.location.uri,
+    fields: schema.fields.map(toCoverageField),
+  };
+}
+
+/**
+ * A metric card as core's coverage input.
+ *
+ * Metric measures are flat — a metric declares no records — so the projection
+ * has no recursion to do. Metrics participate because a pipeline mapping writes
+ * into one and a report mapping reads from one, and the detail view renders both
+ * as schema cards; excluding them would leave those cards with no figures.
+ */
+function metricCardDef(metric: MetricCard): CoverageSchemaDefinition {
+  return {
+    schemaId: metric.qualifiedId,
+    uri: metric.location.uri,
+    fields: metric.fields.map((f) => ({ name: f.name, line: f.location.line })),
+  };
+}
+
+/** Project a model `FieldEntry` onto core's minimal coverage field shape. */
+function toCoverageField(field: FieldEntry): CoverageField {
+  return {
+    name: field.name,
+    line: field.location.line,
+    children: field.children.map(toCoverageField),
+  };
+}
+
+// ── Resolved NL @refs (ADR-036) ─────────────────────────────────────────────
+
+/**
+ * Resolve this document's NL `@refs` so core can credit the ones that name
+ * declared fields.
+ *
+ * Scoped to this document deliberately: core consults only the refs belonging to
+ * the mapping it is reporting on, and every such mapping is in this tree.
+ * Schema lookups still span the workspace, via the index, because a source
+ * schema is routinely declared in an imported file.
+ *
+ * Kept identical in shape to the LSP's adapter on purpose — the gutter and the
+ * card must credit the same refs, and ADR-036 exists because coverage that
+ * ignores a resolved ref reports a field as unmapped that `arrows`, `graph`,
+ * `lineage` and `lint` all treat as a real hop.
+ */
+function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): ResolvedNLRef[] {
+  const items = extractNLRefData(tree.rootNode).map((item) => ({ ...item, file: uri }));
+  if (items.length === 0) return [];
+  return resolveAllNLRefs(items, makeDefinitionLookup(tree, wsIndex));
+}
+
+/**
+ * Adapt a workspace index to core's `DefinitionLookup` (ADR-006's callback
+ * pattern).
+ *
+ * Schemas and fragments come from the index, so an `@ref` to an imported schema
+ * resolves. Mapping source/target lists are read from `tree` instead: the index
+ * does not record them in that shape, and the only mappings whose context
+ * matters are the ones declared here.
+ *
+ * Exported because the LSP's coverage adapter needs exactly this lookup over
+ * exactly this index type, and two copies would let the gutter and the card
+ * resolve the same prose differently.
+ */
+export function makeDefinitionLookup(tree: Tree, wsIndex: WorkspaceIndex): DefinitionLookup {
+  const mappings = new Map<string, { sources: string[]; targets: string[] }>();
+  for (const m of extractMappings(tree.rootNode)) {
+    // Anonymous mappings have no label, so no ref can be filed under them.
+    if (!m.name) continue;
+    const key = m.namespace ? `${m.namespace}::${m.name}` : m.name;
+    mappings.set(key, { sources: m.sources, targets: m.targets });
+  }
+
+  const entryOfKind = (key: string, kind: DefinitionEntryKind): DefinitionEntry | null =>
+    resolveDefinition(wsIndex, key, null).find((d) => d.kind === kind) ?? null;
+
+  // `hasSpreads: false` because the index stores each schema's fields already
+  // flattened; there is no unresolved spread left for core to expand.
+  const schemaLike = (key: string) => {
+    const def = entryOfKind(key, "schema");
+    return def ? { fields: def.fields, hasSpreads: false, namespace: def.namespace } : null;
+  };
+
+  return {
+    hasSchema: (key) => schemaLike(key) !== null,
+    getSchema: (key) => schemaLike(key),
+    hasFragment: (key) => entryOfKind(key, "fragment") !== null,
+    getFragment: (key) => {
+      const def = entryOfKind(key, "fragment");
+      return def ? { fields: def.fields, hasSpreads: false } : null;
+    },
+    hasTransform: (key) => entryOfKind(key, "transform") !== null,
+    getMapping: (key) => mappings.get(key) ?? null,
+    iterateSchemas: () => {
+      const out: Array<[string, { fields: FieldInfo[]; hasSpreads: boolean }]> = [];
+      for (const [key, entries] of wsIndex.definitions) {
+        const def = entries.find((d) => d.kind === "schema");
+        if (def) out.push([key, { fields: def.fields, hasSpreads: false }]);
+      }
+      return out;
+    },
+  } as DefinitionLookup;
+}
+
+/** The `kind` values a `DefinitionEntry` can carry that this module looks up. */
+type DefinitionEntryKind = "schema" | "fragment" | "transform";

--- a/tooling/satsuma-viz-backend/src/index.ts
+++ b/tooling/satsuma-viz-backend/src/index.ts
@@ -10,3 +10,4 @@
 export * from "./workspace-index";
 export * from "./viz-model";
 export * from "./model-from-sources";
+export * from "./coverage";

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -8,7 +8,8 @@
 
 import type { SyntaxNode, Tree } from "./parser-utils";
 import { child, children, labelText, stringText } from "./parser-utils";
-import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
+import { attachMappingCoverage } from "./coverage";
+import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { findReferences, resolveDefinition } from "./workspace-index";
 import type { DefinitionLookup } from "@satsuma/core";
 import {
@@ -132,7 +133,11 @@ export function buildVizModel(uri: string, tree: Tree, wsIndex: WorkspaceIndex):
 
   // Pre-resolve all fragment spreads into schema fields so the viz never sees
   // spread placeholders or fragment nodes — spreads are an authoring shorthand only.
-  resolveAndStripSpreads(namespaces);
+  resolveAndStripSpreads(namespaces, wsIndex);
+
+  // Coverage last: it is judged against the cards' field trees, which are only
+  // final once spreads have been materialised into them (sl-5nsv).
+  attachMappingCoverage(uri, tree, namespaces, wsIndex);
 
   return { uri, fileNotes, namespaces };
 }
@@ -254,16 +259,28 @@ function fieldInfoToEntry(fi: FieldInfo, defUri: string): FieldEntry {
  * nodes from every namespace group.
  *
  * Resolution is cross-namespace (a schema in `src` can spread `common::frag`),
- * namespace-relative (a bare `...frag` resolves within the schema's own
- * namespace first), and transitive (a fragment may itself spread another
- * fragment). Core's expandEntityFields() handles cycle detection and
- * diamond-shaped graphs. Spreads that resolve are replaced by their fields and
- * removed; spreads that don't resolve are left in place so the schema card can
- * surface the dangling reference instead of silently dropping it.
+ * cross-*file* (a fragment reached through an `import`), namespace-relative (a
+ * bare `...frag` resolves within the schema's own namespace first), and
+ * transitive (a fragment may itself spread another fragment). Core's
+ * expandEntityFields() handles cycle detection and diamond-shaped graphs.
+ * Spreads that resolve are replaced by their fields and removed; spreads that
+ * don't resolve are left in place so the schema card can surface the dangling
+ * reference instead of silently dropping it.
  */
-function resolveAndStripSpreads(namespaces: NamespaceGroup[]): void {
+function resolveAndStripSpreads(namespaces: NamespaceGroup[], wsIndex: WorkspaceIndex): void {
   // Build a flat entity lookup for spread resolution across all namespaces.
+  //
+  // Imported fragments come from the index, because a single-file model holds
+  // only the fragments this file declares. `examples/multi-source/multi-source-join.stm`
+  // spreads `audit columns` from `../lib/common.stm`, and resolving against the
+  // model alone left the card four leaves short of what `satsuma coverage`
+  // counts — the cross-file half of the defect sl-5nsv fixed within a file.
+  // Model entries are written last so a locally declared entity wins.
   const entityMap = new Map<string, SpreadEntity>();
+  for (const [key, entries] of wsIndex.definitions) {
+    const fragment = entries.find((d) => d.kind === "fragment");
+    if (fragment) entityMap.set(key, definitionToSpreadEntity(fragment));
+  }
   for (const ns of namespaces) {
     for (const f of ns.fragments) {
       entityMap.set(f.id, fragmentToSpreadEntity(f));
@@ -310,6 +327,33 @@ function fragmentToSpreadEntity(f: FragmentCard): SpreadEntity {
     fields: f.fields.map(fieldEntryToDecl),
     hasSpreads: f.spreads.length > 0,
     spreads: f.spreads,
+  };
+}
+
+/**
+ * Convert an indexed definition to core's SpreadEntity, for a fragment declared
+ * in a file this model does not itself contain.
+ *
+ * The index stores fields unexpanded, so the fragment's own spreads are carried
+ * through and core resolves them transitively.
+ */
+function definitionToSpreadEntity(def: DefinitionEntry): SpreadEntity {
+  return {
+    fields: def.fields.map(fieldInfoToDecl),
+    hasSpreads: (def.spreads?.length ?? 0) > 0,
+    spreads: def.spreads ?? [],
+  };
+}
+
+/** Convert an indexed FieldInfo to core's FieldDecl for spread expansion input. */
+function fieldInfoToDecl(fi: FieldInfo): FieldDecl {
+  return {
+    name: fi.name,
+    type: fi.type ?? "",
+    startRow: fi.range.start.line,
+    children: fi.children.map(fieldInfoToDecl),
+    hasSpreads: (fi.spreads?.length ?? 0) > 0,
+    spreads: fi.spreads ?? [],
   };
 }
 

--- a/tooling/satsuma-viz-backend/test/coverage.test.js
+++ b/tooling/satsuma-viz-backend/test/coverage.test.js
@@ -1,0 +1,184 @@
+/**
+ * coverage.test.js — Attaching core's field coverage to an assembled VizModel.
+ *
+ * Coverage *semantics* are core's and are tested there; cross-consumer agreement
+ * is swept over the whole example corpus by
+ * satsuma-cli/test/coverage-viz-parity.test.ts. What can only break here is this
+ * package's adaptation: which card a written schema reference resolves to, and
+ * whether a mapping gets coverage attached at all.
+ *
+ * The resolver is the load-bearing part. Core reads schema references off the
+ * CST *as authored*, because only the authored form can be matched against the
+ * schema prefix on an arrow path — so an unqualified reference has to be
+ * resolved relative to the namespace its mapping is declared in, and the field
+ * tree then has to come from the card the client will render rather than from
+ * the index. Each of those two halves silently zeroed a whole class of schema
+ * while the other kept working, which is why they are pinned separately.
+ */
+
+const { describe, it, before } = require("node:test");
+const assert = require("node:assert/strict");
+const { initTestParser, parse } = require("./helper");
+const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
+const { buildVizModel } = require("../dist/viz-model");
+const { summarizeFieldCoverage } = require("@satsuma/core");
+
+before(async () => {
+  await initTestParser();
+});
+
+/** Build a VizModel from source text, as a single-file host would. */
+function vizModel(source, uri = "file:///test.stm") {
+  const tree = parse(source);
+  const idx = createWorkspaceIndex();
+  indexFile(idx, uri, tree);
+  return buildVizModel(uri, tree, idx);
+}
+
+/** The coverage entry for one schema in one role, from the model's payload. */
+function coverageFor(model, mappingId, schemaId, role) {
+  const mapping = model.namespaces.flatMap((ns) => ns.mappings).find((m) => m.id === mappingId);
+  return mapping?.coverage?.schemas.find((s) => s.role === role && s.schemaId === schemaId) ?? null;
+}
+
+describe("attachMappingCoverage — what a mapping's coverage is attached for", () => {
+  it("attaches per-schema coverage for both roles of a file-scope mapping", () => {
+    // The baseline contract: the payload the card is handed carries an entry per
+    // participating schema, with core's verdicts on it.
+    const model = vizModel(`
+schema src { id INT unused STRING }
+schema tgt { id INT spare STRING }
+mapping load {
+  source { src }
+  target { tgt }
+  id -> id
+}`);
+    const source = coverageFor(model, "load", "src", "source");
+    const target = coverageFor(model, "load", "tgt", "target");
+    assert.deepEqual(summarizeFieldCoverage(source.fields), {
+      covered: 1,
+      coveredDeclared: 1,
+      coveredNl: 0,
+      total: 2,
+      pct: 50,
+    });
+    assert.equal(summarizeFieldCoverage(target.fields).covered, 1);
+  });
+
+  it("resolves an unqualified reference against the namespace its mapping is declared in", () => {
+    // The regression this test exists for: `stg` written inside `namespace
+    // staging` names `staging::stg`, and resolving it namespace-blind found no
+    // card at all — so every namespaced mapping's own-namespace target reported
+    // 0/N while its fully-qualified cross-namespace sources kept working. The
+    // asymmetry is what made it easy to miss.
+    const model = vizModel(`
+namespace raw {
+  schema feed { a STRING b STRING }
+}
+namespace staging {
+  schema stg { a STRING b STRING }
+  mapping stage {
+    source { raw::feed }
+    target { stg }
+    raw::feed.a -> a
+  }
+}`);
+    const target = coverageFor(model, "stage", "staging::stg", "target");
+    assert.ok(target, "the target card must resolve through the mapping's own namespace");
+    assert.equal(summarizeFieldCoverage(target.fields).covered, 1);
+    assert.equal(summarizeFieldCoverage(target.fields).total, 2);
+
+    // The cross-namespace source, written fully qualified, resolves directly.
+    const source = coverageFor(model, "stage", "raw::feed", "source");
+    assert.equal(summarizeFieldCoverage(source.fields).covered, 1);
+  });
+
+  it("reports coverage for a metric endpoint, which the index classifies apart from schemas", () => {
+    // A pipeline mapping writes into a metric and a report mapping reads from
+    // one, and the detail view renders both as schema cards. Resolving against
+    // the index instead of the cards would skip them — the index upgrades a
+    // metric's kind away from "schema" — leaving those cards with no figures at
+    // all while every ordinary schema looked fine.
+    const model = vizModel(`
+schema orders { amount DECIMAL(12,2) refunds DECIMAL(12,2) }
+schema revenue (metric) { total DECIMAL(12,2) net DECIMAL(12,2) }
+mapping roll_up {
+  source { orders }
+  target { revenue }
+  amount -> total
+}`);
+    const target = coverageFor(model, "roll_up", "revenue", "target");
+    assert.ok(target, "a metric target must resolve to its card");
+    assert.deepEqual(summarizeFieldCoverage(target.fields), {
+      covered: 1,
+      coveredDeclared: 1,
+      coveredNl: 0,
+      total: 2,
+      pct: 50,
+    });
+  });
+
+  it("judges coverage against the card's field tree, spreads already materialised", () => {
+    // Coverage must run after spread resolution, or the leaves the card renders
+    // and the leaves it counts disagree: the record would be judged as one
+    // childless leaf while three rows are drawn under it (sl-5nsv).
+    const model = vizModel(`
+fragment address_fields { street STRING city STRING zip STRING }
+schema tgt { id INT address record { ...address_fields } }
+mapping load {
+  source { src }
+  target { tgt }
+  raw_city -> address.city
+}
+schema src { raw_city STRING }`);
+    const target = coverageFor(model, "load", "tgt", "target");
+    assert.deepEqual(
+      target.fields.map((f) => [f.path, f.state]),
+      [
+        ["id", "uncovered"],
+        ["address", "partial"],
+        ["address.street", "uncovered"],
+        ["address.city", "covered"],
+        ["address.zip", "uncovered"],
+      ],
+    );
+  });
+
+  it("leaves coverage absent when no schema resolves, rather than reporting zero", () => {
+    // Absent means "not computed" and a consumer must not render it as 0%. An
+    // empty result would be indistinguishable from a mapping that genuinely
+    // covers nothing.
+    const model = vizModel(`
+mapping orphan {
+  source { nowhere }
+  target { nothing }
+  a -> b
+}`);
+    const mapping = model.namespaces.flatMap((ns) => ns.mappings).find((m) => m.id === "orphan");
+    assert.equal(mapping.coverage, undefined);
+  });
+
+  it("credits a leaf named only by a resolved NL @ref, in the nl tier", () => {
+    // ADR-036 through this package's own plumbing: the refs have to be resolved
+    // here and handed to core, because a VizModel carries no CST for core to
+    // find them in. Omitting them would silently drop the tier for every viz
+    // consumer while the CLI kept reporting it (sl-46wr).
+    const model = vizModel(`
+schema src { net DECIMAL(12,2) tax DECIMAL(12,2) }
+schema tgt { gross DECIMAL(12,2) }
+mapping load {
+  source { src }
+  target { tgt }
+  -> gross { "Sum of @net and @tax" }
+}`);
+    const source = coverageFor(model, "load", "src", "source");
+    assert.deepEqual(
+      source.fields.map((f) => [f.path, f.tier]),
+      [
+        ["net", "nl"],
+        ["tax", "nl"],
+      ],
+    );
+    assert.equal(summarizeFieldCoverage(source.fields).coveredNl, 2);
+  });
+});

--- a/tooling/satsuma-viz-backend/test/coverage.test.js
+++ b/tooling/satsuma-viz-backend/test/coverage.test.js
@@ -21,6 +21,7 @@ const assert = require("node:assert/strict");
 const { initTestParser, parse } = require("./helper");
 const { createWorkspaceIndex, indexFile } = require("../dist/workspace-index");
 const { buildVizModel } = require("../dist/viz-model");
+const { buildModelFromSources } = require("../dist/model-from-sources");
 const { summarizeFieldCoverage } = require("@satsuma/core");
 
 before(async () => {
@@ -156,6 +157,37 @@ mapping orphan {
 }`);
     const mapping = model.namespaces.flatMap((ns) => ns.mappings).find((m) => m.id === "orphan");
     assert.equal(mapping.coverage, undefined);
+  });
+
+  it("keeps coverage through the lineage merge, for a schema imported from another file", () => {
+    // Coverage is attached per file, *before* mergeVizModels, which upgrades an
+    // imported stub card to its full definition. ADR-042 records that as a
+    // residual risk: it is safe only because a stub carries the index's fields,
+    // so the tree the merge swaps in is the tree that was judged. This pins the
+    // property both ways round — single-file and merged must agree, and a
+    // cross-file source schema must be counted rather than skipped.
+    const docs = [
+      { uri: "file:///lib.stm", source: `schema shared { a STRING b STRING }` },
+      {
+        uri: "file:///main.stm",
+        source: `import { shared } from "./lib.stm"
+schema tgt { a STRING b STRING }
+mapping load { source { shared } target { tgt } shared.a -> a }`,
+      },
+    ];
+
+    const figures = (lineage) => {
+      const model = buildModelFromSources("file:///main.stm", docs, { lineage });
+      const mapping = model.namespaces.flatMap((ns) => ns.mappings)[0];
+      return (mapping.coverage?.schemas ?? []).map((s) => {
+        const t = summarizeFieldCoverage(s.fields);
+        return `${s.role} ${s.schemaId} ${t.covered}/${t.total}`;
+      });
+    };
+
+    const expected = ["source shared 1/2", "target tgt 1/2"];
+    assert.deepEqual(figures(false), expected);
+    assert.deepEqual(figures(true), expected, "the lineage merge must not drop or alter coverage");
   });
 
   it("credits a leaf named only by a resolved NL @ref, in the nl tier", () => {

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -52,6 +52,9 @@
       "name": "@satsuma/viz-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",

--- a/tooling/satsuma-viz-model/package-lock.json
+++ b/tooling/satsuma-viz-model/package-lock.json
@@ -8,6 +8,22 @@
       "name": "@satsuma/viz-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core"
+      },
+      "devDependencies": {
+        "@types/node": "^26.1.2",
+        "c8": "^12.0.0",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../satsuma-core": {
+      "name": "@satsuma/core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "web-tree-sitter": "^0.26.11"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
@@ -61,6 +77,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@satsuma/core": {
+      "resolved": "../satsuma-core",
+      "link": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/tooling/satsuma-viz-model/package.json
+++ b/tooling/satsuma-viz-model/package.json
@@ -13,11 +13,16 @@
   },
   "types": "./dist/index.d.ts",
   "scripts": {
+    "build:core": "npm --prefix ../satsuma-core run build",
+    "prebuild": "npm run build:core",
     "build": "tsc",
     "prepare": "tsc",
     "test": "node --test test/**/*.test.js",
-    "pretest": "tsc",
+    "pretest": "npm run build:core && tsc",
     "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary --include='dist/**/*.js' --exclude='dist/**/*.d.ts' node --test test/**/*.test.js"
+  },
+  "dependencies": {
+    "@satsuma/core": "file:../satsuma-core"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -12,7 +12,24 @@
  *           ├─ MappingBlock[]     (one per mapping block)
  *           ├─ MetricCard[]       (one per metric block)
  *           └─ FragmentCard[]     (one per fragment block)
+ *
+ * Field coverage travels *in* this payload rather than being derived from it —
+ * see {@link MappingBlock.coverage}. That is why this otherwise self-contained
+ * contract package depends on `@satsuma/core`: the coverage types it carries are
+ * core's, verbatim, so a consumer reading them cannot be reading a re-derivation.
  */
+
+import type { MappingCoverageResult } from "@satsuma/core";
+
+// Coverage types are part of this contract, so a consumer needs no second
+// import to read the payload it just received.
+export type {
+  MappingCoverageResult,
+  SchemaCoverageResult,
+  FieldCoverageEntry,
+  FieldCoverageState,
+  CoverageTier,
+} from "@satsuma/core";
 
 // ---------- Top-level document model ----------
 
@@ -120,6 +137,27 @@ export interface MappingBlock {
   notes: NoteBlock[];
   comments: CommentEntry[];
   location: SourceLocation;
+  /**
+   * Per-field coverage for this mapping, one entry per schema its `source {}`
+   * and `target {}` blocks name — computed by core's `computeMappingCoverage`
+   * when the model was assembled.
+   *
+   * **The client must render these verdicts, never re-derive them.** Deriving
+   * covered paths from `arrows`/`eachBlocks` on the client looks equivalent and
+   * is not: it silently omits every coverage rule that is not visible in an
+   * arrow's endpoints — the resolved NL `@ref` tier (ADR-036) and
+   * whole-structure conferral (ADR-037), which need the ref resolver and the
+   * arrow's declaration kind respectively. The viz did derive its own set until
+   * sl-46wr / sl-csrs, and disagreed with `satsuma coverage` on twelve of the
+   * shipped examples. Counting is core's too: `summarizeFieldCoverage` and
+   * `countContainerStates` over these entries (ADR-034).
+   *
+   * Optional because a model may be assembled without a workspace index to
+   * resolve schemas against, and because a payload cached by an older host will
+   * not carry it. Absent means "not computed" — it is not the same as "nothing
+   * is covered", and a consumer must not render 0% for it.
+   */
+  coverage?: MappingCoverageResult;
 }
 
 /** A single arrow within a mapping, each_block, or flatten_block. */

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -55,6 +55,9 @@
       "name": "@satsuma/viz-model",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@satsuma/core": "file:../satsuma-core"
+      },
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -19,7 +19,7 @@ import {
 import type { ContainerScope } from "../field-coverage.js";
 import { highlightAtRefs } from "../markdown.js";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
-import type { FieldCoverageEntry } from "@satsuma/core/coverage";
+import type { SchemaCoverage } from "../field-coverage.js";
 
 function sanitizeTestIdSegment(value: string): string {
   const lowered = value.toLowerCase();
@@ -338,11 +338,11 @@ export class SzMappingDetail extends LitElement {
    * one schema can legitimately appear on both sides of one mapping.
    */
   @property({ type: Object })
-  sourceCoverage: Map<string, FieldCoverageEntry[]> = new Map();
+  sourceCoverage: Map<string, SchemaCoverage> = new Map();
 
-  /** Core's coverage entries for the target schema. */
+  /** Core's coverage entries for the target schema, or null when not computed. */
   @property({ type: Array })
-  targetCoverage: FieldCoverageEntry[] = [];
+  targetCoverage: SchemaCoverage = null;
 
   @property({ type: String, attribute: "namespace-label" })
   namespaceLabel: string | null = null;
@@ -564,7 +564,7 @@ export class SzMappingDetail extends LitElement {
             (s) => html`
               <sz-schema-card
                 .schema=${s}
-                .coverage=${this.sourceCoverage.get(s.qualifiedId) ?? []}
+                .coverage=${this.sourceCoverage.get(s.qualifiedId) ?? null}
                 .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
                 highlightColor="source"
                 test-id-prefix=${`${sourcePrefix}-${sanitizeTestIdSegment(s.qualifiedId)}`}

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -19,6 +19,7 @@ import {
 import type { ContainerScope } from "../field-coverage.js";
 import { highlightAtRefs } from "../markdown.js";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
+import type { FieldCoverageEntry } from "@satsuma/core/coverage";
 
 function sanitizeTestIdSegment(value: string): string {
   const lowered = value.toLowerCase();
@@ -329,13 +330,19 @@ export class SzMappingDetail extends LitElement {
   @property({ type: Object })
   targetSchema: SchemaCard | null = null;
 
-  /** Set of mapped field names for source schemas. */
+  /**
+   * Core's coverage entries for each source schema, keyed by `qualifiedId`.
+   *
+   * Source and target coverage are separate properties because they answer
+   * separate questions — what this mapping *reads* versus what it *writes* — and
+   * one schema can legitimately appear on both sides of one mapping.
+   */
   @property({ type: Object })
-  sourceMappedFields: Map<string, Set<string>> = new Map();
+  sourceCoverage: Map<string, FieldCoverageEntry[]> = new Map();
 
-  /** Set of mapped field names for the target schema. */
-  @property({ type: Object })
-  targetMappedFields: Set<string> = new Set();
+  /** Core's coverage entries for the target schema. */
+  @property({ type: Array })
+  targetCoverage: FieldCoverageEntry[] = [];
 
   @property({ type: String, attribute: "namespace-label" })
   namespaceLabel: string | null = null;
@@ -557,7 +564,7 @@ export class SzMappingDetail extends LitElement {
             (s) => html`
               <sz-schema-card
                 .schema=${s}
-                .mappedFields=${this.sourceMappedFields.get(s.qualifiedId) ?? new Set()}
+                .coverage=${this.sourceCoverage.get(s.qualifiedId) ?? []}
                 .highlightFields=${sourceHL.get(s.qualifiedId) ?? new Set()}
                 highlightColor="source"
                 test-id-prefix=${`${sourcePrefix}-${sanitizeTestIdSegment(s.qualifiedId)}`}
@@ -578,7 +585,7 @@ export class SzMappingDetail extends LitElement {
             this.targetSchema
               ? html`<sz-schema-card
                   .schema=${this.targetSchema}
-                  .mappedFields=${this.targetMappedFields}
+                  .coverage=${this.targetCoverage}
                   .highlightFields=${targetHL}
                   highlightColor="target"
                   test-id-prefix=${`${targetPrefix}-${sanitizeTestIdSegment(this.targetSchema.qualifiedId)}`}

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -5,6 +5,8 @@ import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
 import type { FieldCoverageEntry } from "@satsuma/core/coverage";
+import { uncoveredFieldCoverage } from "@satsuma/core/coverage";
+import { toCoverageFields } from "../field-coverage.js";
 import { summarizeFieldCoverage, countContainerStates } from "@satsuma/core/coverage-rollup";
 import type { CoverageTotals, ContainerStateCounts } from "@satsuma/core/coverage-rollup";
 import {
@@ -506,11 +508,14 @@ export class SzSchemaCard extends LitElement {
    * disagreed with `satsuma coverage` on twelve shipped examples until it began
    * consuming core's verdicts instead (sl-46wr, sl-csrs).
    *
-   * Empty means the parent supplied nothing — the card then renders its fields
-   * with no coverage marking rather than claiming they are all unmapped.
+   * **`null` means "not computed", which is not "nothing is mapped".** The card
+   * then shows a plain field count in place of a ratio and leaves every row
+   * unmarked, because `0/N` would assert a completeness figure nobody produced.
+   * A schema that genuinely no mapping references arrives as an all-uncovered
+   * list instead, and does show `0/N`.
    */
   @property({ type: Array })
-  coverage: FieldCoverageEntry[] = [];
+  coverage: FieldCoverageEntry[] | null = null;
 
   /** Compact mode: hides fields, port dots, constraints, spread indicators, lineage buttons.
    *  Shows namespace::name in header when schema has a namespace (qualifiedId contains ::). */
@@ -612,7 +617,7 @@ export class SzSchemaCard extends LitElement {
 
     if (this.compact) return this._renderCompact(s);
 
-    const { totals, containers } = this._coverage();
+    const coverage = this._coverage();
     const hasNotes = s.notes.length > 0;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
@@ -627,11 +632,23 @@ export class SzSchemaCard extends LitElement {
         >
           ${this._headerIcon(isReport)}
           <span class="header-name">${s.id}</span>
+          <!-- No ratio when coverage was not computed: a plain field count states
+               what is known, where "0/N" would assert completeness nobody
+               measured (ADR-042). -->
           <span
             class="header-count"
             data-testid=${`${this.testIdPrefix}-header-count`}
-            title=${this._coverageTitle(totals, containers)}
-            >${totals.covered}/${totals.total}</span
+            data-coverage-available=${coverage !== null}
+            title=${
+              coverage
+                ? this._coverageTitle(coverage.totals, coverage.containers)
+                : "Coverage not computed for this schema"
+            }
+            >${
+              coverage
+                ? `${coverage.totals.covered}/${coverage.totals.total}`
+                : `${this._leafCount(s)} fields`
+            }</span
           >
           <span
             class="header-toggle"
@@ -839,11 +856,11 @@ export class SzSchemaCard extends LitElement {
    * field count, which a wide schema card notices.
    */
   private _coverageIndex: Map<string, FieldCoverageEntry> | null = null;
-  private _coverageIndexFor: FieldCoverageEntry[] | null = null;
+  private _coverageIndexFor: FieldCoverageEntry[] | null | undefined = undefined;
 
   private _coverageByPath(): Map<string, FieldCoverageEntry> {
     if (this._coverageIndexFor !== this.coverage || this._coverageIndex === null) {
-      this._coverageIndex = new Map(this.coverage.map((entry) => [entry.path, entry]));
+      this._coverageIndex = new Map((this.coverage ?? []).map((entry) => [entry.path, entry]));
       this._coverageIndexFor = this.coverage;
     }
     return this._coverageIndex;
@@ -865,15 +882,33 @@ export class SzSchemaCard extends LitElement {
    * Container states come back beside the ratio rather than inside it — a
    * reviewer wants to know two records are partly mapped, but that fact must not
    * enter the number.
+   *
+   * `null` when coverage was not computed — see {@link coverage}. Callers must
+   * render the absence rather than substitute zeroes.
    */
   private _coverage(): {
     totals: CoverageTotals;
     containers: ContainerStateCounts;
-  } {
+  } | null {
+    if (this.coverage === null) return null;
     return {
       totals: summarizeFieldCoverage(this.coverage),
       containers: countContainerStates(this.coverage),
     };
+  }
+
+  /**
+   * The schema's leaf count, for the header when there is no ratio to show.
+   *
+   * Counted by core from an all-uncovered projection of the declared fields, not
+   * by the card: "how many fields?" must be answered in leaves, the same unit the
+   * ratio is denominated in (ADR-034), or a compact card and an expanded one
+   * disagree about the same schema (sl-hcan).
+   */
+  private _leafCount(s: SchemaCard): number {
+    return summarizeFieldCoverage(
+      uncoveredFieldCoverage(toCoverageFields(s.fields), s.location.uri),
+    ).total;
   }
 
   /**
@@ -913,8 +948,9 @@ export class SzSchemaCard extends LitElement {
     const displayName = s.id;
     // Leaf count, the same unit the expanded card's ratio is denominated in
     // (ADR-034). One card must not answer "how many fields?" two ways depending
-    // on whether it happens to be compact.
-    const totalFields = this._coverage().totals.total;
+    // on whether it happens to be compact — and the compact header shows a count
+    // rather than a ratio, so it needs no coverage at all.
+    const totalFields = this._leafCount(s);
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
 

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -192,6 +192,15 @@ export class SzSchemaCard extends LitElement {
       background: transparent;
     }
 
+    /* Coverage not computed: neither filled nor the hollow ring that reads as a
+       gap. A dashed, faded outline says "no verdict" rather than "no coverage"
+       — see the coverage property's doc comment. */
+    .port.unknown {
+      border: 1.5px dashed var(--sz-text-muted);
+      background: transparent;
+      opacity: 0.45;
+    }
+
     .field-name {
       font-family: var(--sz-font-mono);
       font-size: 12px;
@@ -722,7 +731,13 @@ export class SzSchemaCard extends LitElement {
 
   private _renderField(f: FieldEntry, depth: number, prefix = ""): TemplateResult {
     const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
-    const entry = this._coverageByPath().get(fieldPath);
+    // Three states, not two. With `coverage` null nothing was computed, and a row
+    // must not then read as a gap: the header says no figure was produced, and a
+    // hollow "unmapped" dot beside it would contradict it — a reader would see
+    // every field as unmapped, and automation could not tell those rows from real
+    // uncovered results.
+    const unavailable = this.coverage === null;
+    const entry = unavailable ? undefined : this._coverageByPath().get(fieldPath);
     // A record is "mapped" as soon as anything beneath it is, which is the
     // threshold a port dot has always painted on; `state` carries the finer
     // distinction for anyone who needs it.
@@ -737,14 +752,18 @@ export class SzSchemaCard extends LitElement {
     // Use the dotted path so nested customer.email is distinguishable from a
     // sibling top-level email field (sl-eikr).
     const fieldTestId = `${this.testIdPrefix}-field-${sanitizeTestIdSegment(fieldPath)}`;
-    const coverageState = isMapped ? "mapped" : "unmapped";
+    // `unknown` rather than `unmapped`/`uncovered`: those two are verdicts, and
+    // there is no verdict here. Automation keys on these, so the third state has
+    // to be nameable.
+    const coverageState = unavailable ? "unknown" : isMapped ? "mapped" : "unmapped";
+    const portClass = unavailable ? "unknown" : isMapped ? "mapped" : "unmapped";
 
     return html`
       <div
         class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         data-testid=${fieldTestId}
         data-coverage=${coverageState}
-        data-coverage-state=${entry?.state ?? "uncovered"}
+        data-coverage-state=${unavailable ? "unknown" : (entry?.state ?? "uncovered")}
         data-coverage-tier=${entry?.tier ?? ""}
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
@@ -752,7 +771,7 @@ export class SzSchemaCard extends LitElement {
         @mouseleave=${() => this._onFieldHover(null)}
         title=${this._fieldTitle(f, entry)}
       >
-        <span class="port ${isMapped ? "mapped" : "unmapped"}"></span>
+        <span class="port ${portClass}"></span>
         <span class="field-name">${f.name}</span>
         <span class="field-type">${f.type}</span>
         <span class="badges">
@@ -921,9 +940,13 @@ export class SzSchemaCard extends LitElement {
    * reviewer has to be able to tell which they are looking at. `partial` is
    * called out for the same reason — a record row's dot says "something under
    * here is mapped" and cannot say "not all of it".
+   *
+   * When coverage was not computed the row says so, rather than saying nothing
+   * and leaving the bare type to be read alongside an unmarked dot as a gap.
    */
   private _fieldTitle(f: FieldEntry, entry: FieldCoverageEntry | undefined): string {
     const base = `${f.name}: ${f.type}`;
+    if (this.coverage === null) return `${base} — coverage not computed`;
     if (!entry?.mapped) return base;
     const how = entry.tier === "nl" ? "mapped via an @ref in prose" : "mapped";
     return entry.state === "partial" ? `${base} — partly ${how}` : `${base} — ${how}`;

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -4,8 +4,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
-import { isCoveredFieldPath } from "@satsuma/core/coverage-paths";
-import { fieldCoverageFromCoveredPaths } from "@satsuma/core/coverage";
+import type { FieldCoverageEntry } from "@satsuma/core/coverage";
 import { summarizeFieldCoverage, countContainerStates } from "@satsuma/core/coverage-rollup";
 import type { CoverageTotals, ContainerStateCounts } from "@satsuma/core/coverage-rollup";
 import {
@@ -496,9 +495,22 @@ export class SzSchemaCard extends LitElement {
   @property({ type: Object })
   schema: SchemaCard | null = null;
 
-  /** Set of mapped target field names — set by parent to indicate which fields have arrows. */
-  @property({ type: Object })
-  mappedFields: Set<string> = new Set();
+  /**
+   * This schema's field coverage, as computed by `@satsuma/core` and carried in
+   * the model — one entry per declared field, in declaration order.
+   *
+   * **Set by the parent; never derived here.** The card used to receive a set of
+   * covered paths and work the rest out itself, which quietly cost it two
+   * coverage rules it had no way to see: the resolved NL `@ref` tier (ADR-036)
+   * and whole-structure conferral (ADR-037). Both live in core, and the card
+   * disagreed with `satsuma coverage` on twelve shipped examples until it began
+   * consuming core's verdicts instead (sl-46wr, sl-csrs).
+   *
+   * Empty means the parent supplied nothing — the card then renders its fields
+   * with no coverage marking rather than claiming they are all unmapped.
+   */
+  @property({ type: Array })
+  coverage: FieldCoverageEntry[] = [];
 
   /** Compact mode: hides fields, port dots, constraints, spread indicators, lineage buttons.
    *  Shows namespace::name in header when schema has a namespace (qualifiedId contains ::). */
@@ -600,7 +612,7 @@ export class SzSchemaCard extends LitElement {
 
     if (this.compact) return this._renderCompact(s);
 
-    const { totals, containers } = this._coverage(s);
+    const { totals, containers } = this._coverage();
     const hasNotes = s.notes.length > 0;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
@@ -693,7 +705,11 @@ export class SzSchemaCard extends LitElement {
 
   private _renderField(f: FieldEntry, depth: number, prefix = ""): TemplateResult {
     const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
-    const isMapped = isCoveredFieldPath(fieldPath, this.mappedFields);
+    const entry = this._coverageByPath().get(fieldPath);
+    // A record is "mapped" as soon as anything beneath it is, which is the
+    // threshold a port dot has always painted on; `state` carries the finer
+    // distinction for anyone who needs it.
+    const isMapped = entry?.mapped ?? false;
     const hasWarning = f.comments.some((c) => c.kind === "warning");
     const hasQuestion = f.comments.some((c) => c.kind === "question");
     const hasPii = f.constraints.includes("pii");
@@ -711,11 +727,13 @@ export class SzSchemaCard extends LitElement {
         class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         data-testid=${fieldTestId}
         data-coverage=${coverageState}
+        data-coverage-state=${entry?.state ?? "uncovered"}
+        data-coverage-tier=${entry?.tier ?? ""}
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
         @mouseenter=${() => this._onFieldHover(fieldPath)}
         @mouseleave=${() => this._onFieldHover(null)}
-        title=${f.name + ": " + f.type}
+        title=${this._fieldTitle(f, entry)}
       >
         <span class="port ${isMapped ? "mapped" : "unmapped"}"></span>
         <span class="field-name">${f.name}</span>
@@ -814,31 +832,66 @@ export class SzSchemaCard extends LitElement {
   }
 
   /**
-   * The card's coverage figures, counted by core.
+   * `coverage` indexed by field path, for the row renderer.
    *
-   * **The card does not compute its own denominator** (ADR-034). It used to:
-   * `_countFields`/`_countMapped` counted every node, records included, so one
-   * covered leaf lifted the numerator once per ancestor level and a schema of
-   * `amount` plus `address record { city, line1, postcode }` with only
-   * `address.city` mapped read as 2/5 — 40% — where `satsuma coverage` reported
-   * 25% and the VS Code status bar reported something different again (sl-hcan).
-   * Coverage is counted in *leaves* because a record is structure, not data:
-   * counting it alongside its children counts the same data twice and lets
-   * nesting depth move the percentage on its own.
+   * Rebuilt only when the `coverage` array identity changes: `_renderField` runs
+   * once per row and a linear scan per row would make rendering quadratic in the
+   * field count, which a wide schema card notices.
+   */
+  private _coverageIndex: Map<string, FieldCoverageEntry> | null = null;
+  private _coverageIndexFor: FieldCoverageEntry[] | null = null;
+
+  private _coverageByPath(): Map<string, FieldCoverageEntry> {
+    if (this._coverageIndexFor !== this.coverage || this._coverageIndex === null) {
+      this._coverageIndex = new Map(this.coverage.map((entry) => [entry.path, entry]));
+      this._coverageIndexFor = this.coverage;
+    }
+    return this._coverageIndex;
+  }
+
+  /**
+   * The card's coverage figures, counted by core from the entries it was given.
+   *
+   * **The card computes neither the verdicts nor the denominator.** It used to do
+   * both, and lost a rule each time one was added. `_countFields`/`_countMapped`
+   * counted every node, records included, so a schema of `amount` plus `address
+   * record { city, line1, postcode }` with only `address.city` mapped read as 2/5
+   * — 40% — where `satsuma coverage` reported 25% (sl-hcan); coverage is counted
+   * in *leaves* because a record is structure, not data. Deriving the covered set
+   * from the model's arrows then missed the NL `@ref` tier and whole-structure
+   * conferral (sl-46wr, sl-csrs). Both jobs now belong to core, and this method
+   * is the whole of what is left.
    *
    * Container states come back beside the ratio rather than inside it — a
    * reviewer wants to know two records are partly mapped, but that fact must not
    * enter the number.
    */
-  private _coverage(s: SchemaCard): {
+  private _coverage(): {
     totals: CoverageTotals;
     containers: ContainerStateCounts;
   } {
-    const entries = fieldCoverageFromCoveredPaths(s.fields, s.location.uri, this.mappedFields);
     return {
-      totals: summarizeFieldCoverage(entries),
-      containers: countContainerStates(entries),
+      totals: summarizeFieldCoverage(this.coverage),
+      containers: countContainerStates(this.coverage),
     };
+  }
+
+  /**
+   * A field row's tooltip: its type, plus how it came to be covered when that is
+   * not the ordinary case.
+   *
+   * The NL tier is called out because ADR-036 requires a consumer to *show* the
+   * distinction rather than let a reader assume every covered field has an arrow:
+   * a hop inferred from prose is a weaker claim than a declared one, and a
+   * reviewer has to be able to tell which they are looking at. `partial` is
+   * called out for the same reason — a record row's dot says "something under
+   * here is mapped" and cannot say "not all of it".
+   */
+  private _fieldTitle(f: FieldEntry, entry: FieldCoverageEntry | undefined): string {
+    const base = `${f.name}: ${f.type}`;
+    if (!entry?.mapped) return base;
+    const how = entry.tier === "nl" ? "mapped via an @ref in prose" : "mapped";
+    return entry.state === "partial" ? `${base} — partly ${how}` : `${base} — ${how}`;
   }
 
   /**
@@ -861,7 +914,7 @@ export class SzSchemaCard extends LitElement {
     // Leaf count, the same unit the expanded card's ratio is denominated in
     // (ADR-034). One card must not answer "how many fields?" two ways depending
     // on whether it happens to be compact.
-    const totalFields = this._coverage(s).totals.total;
+    const totalFields = this._coverage().totals.total;
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
 

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -249,31 +249,41 @@ export function countMappingArrows(mapping: MappingBlock): number {
 // ── Reading core's coverage out of the model ────────────────────────────────
 
 /**
- * The coverage entries for one schema card in one mapping and role, as core
- * computed them.
+ * Coverage for a schema card, or `null` when it could not be computed.
  *
- * Falls back to "every field uncovered" when the mapping carries no coverage —
- * a model assembled without a workspace index, or a payload cached by a host
- * predating `MappingBlock.coverage`. The fallback is core's
- * {@link uncoveredFieldCoverage} rather than an empty list because the card
- * still needs a denominator, and a card that counts its own fields is how the
- * ratio started including containers (sl-hcan).
+ * **`null` is not `0/N`.** A model assembled without a workspace index, and a
+ * payload cached by a host predating `MappingBlock.coverage`, both carry no
+ * coverage at all — and rendering that as "nothing is mapped" states a fact
+ * nobody established. `MappingBlock.coverage`'s contract and ADR-042 both say
+ * absent means "not computed", so the unavailable case has to survive all the
+ * way to the renderer rather than being flattened into an all-uncovered list
+ * here. A schema that no mapping references is the genuine `0/N`, and stays
+ * distinguishable from this.
+ */
+export type SchemaCoverage = FieldCoverageEntry[] | null;
+
+/**
+ * The coverage entries for one schema card in one mapping and role, as core
+ * computed them, or `null` when this mapping carries none.
  *
  * `role` matters: a schema may sit on both sides of one mapping, and the detail
  * view renders it as two cards asking two different questions — what this
  * mapping *reads* from it, and what this mapping *writes* into it.
+ *
+ * A mapping whose coverage *is* present but which lists no entry for this schema
+ * also reports `null`: core could not resolve the reference, which is again "no
+ * answer" rather than "no coverage".
  */
 export function mappingSchemaCoverage(
   mapping: MappingBlock,
   schema: SchemaCard,
   role: "source" | "target",
-): FieldCoverageEntry[] {
-  const found = mapping.coverage?.schemas.find(
+): SchemaCoverage {
+  if (!mapping.coverage) return null;
+  const found = mapping.coverage.schemas.find(
     (s) => s.role === role && s.schemaId === schema.qualifiedId,
   );
-  return found
-    ? found.fields
-    : uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri);
+  return found ? found.fields : null;
 }
 
 /**
@@ -288,40 +298,59 @@ export function mappingSchemaCoverage(
  * not the same as OR-ing the containers, since two mappings that each cover half
  * of a record cover all of it between them.
  *
- * Every declared schema gets an entry, seeded with its own all-uncovered field
- * list, so a schema no mapping references reports `0/N` rather than dropping out
- * of the index and leaving its card with nothing to count.
+ * Three outcomes, kept apart:
+ *
+ * - **A mapping references the schema but carries no coverage** → `null`. The
+ *   answer is unknown, and the card must not imply one.
+ * - **No mapping references the schema** → its own all-uncovered list. `0/N` is
+ *   the true answer, and it comes from core's {@link uncoveredFieldCoverage} so
+ *   the denominator counts leaves by the same rule as every other (ADR-034).
+ * - **Otherwise** → the union of every referencing mapping's entries, seeded with
+ *   that same all-uncovered list so the card's own field tree fixes the
+ *   denominator and the row order.
  */
-export function buildCoverageIndex(model: VizModel): Map<string, FieldCoverageEntry[]> {
-  const contributions = new Map<string, FieldCoverageEntry[][]>();
+export function buildCoverageIndex(model: VizModel): Map<string, SchemaCoverage> {
+  const mappings = model.namespaces.flatMap((ns) => ns.mappings);
+  const index = new Map<string, SchemaCoverage>();
 
-  // Seed first: the card's own field tree defines the denominator and the row
-  // order, and every mapping's entries merge into it.
   for (const ns of model.namespaces) {
     for (const schema of ns.schemas) {
-      contributions.set(schema.qualifiedId, [
-        uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri),
-      ]);
-    }
-  }
+      const referencing = mappings.filter((m) => referencesSchema(m, schema.qualifiedId));
 
-  for (const ns of model.namespaces) {
-    for (const mapping of ns.mappings) {
-      for (const covered of mapping.coverage?.schemas ?? []) {
-        contributions.get(covered.schemaId)?.push(covered.fields);
+      // Unknown beats partial: if anything that touches this schema could not be
+      // reported on, the union below would silently omit its contribution and
+      // understate the result.
+      if (referencing.some((m) => !m.coverage)) {
+        index.set(schema.qualifiedId, null);
+        continue;
       }
+
+      const lists = [uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri)];
+      for (const mapping of referencing) {
+        for (const covered of mapping.coverage?.schemas ?? []) {
+          if (covered.schemaId === schema.qualifiedId) lists.push(covered.fields);
+        }
+      }
+      index.set(schema.qualifiedId, unionFieldCoverage(lists));
     }
   }
 
-  const index = new Map<string, FieldCoverageEntry[]>();
-  for (const [schemaId, lists] of contributions) {
-    index.set(schemaId, unionFieldCoverage(lists));
-  }
   return index;
 }
 
-/** Project the model's field entries onto core's minimal coverage field shape. */
-function toCoverageFields(fields: FieldEntry[]): CoverageField[] {
+/** True when the mapping names this schema on either side. */
+function referencesSchema(mapping: MappingBlock, qualifiedId: string): boolean {
+  return mapping.sourceRefs.includes(qualifiedId) || mapping.targetRef === qualifiedId;
+}
+
+/**
+ * Project the model's field entries onto core's minimal coverage field shape.
+ *
+ * Exported because the schema card needs it for the one figure it may show
+ * without coverage — a leaf count, when coverage was not computed — and that
+ * count must be core's, counted in leaves, not the card's own tally (ADR-034).
+ */
+export function toCoverageFields(fields: FieldEntry[]): CoverageField[] {
   return fields.map((f) => ({
     name: f.name,
     line: f.location.line,

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -1,12 +1,31 @@
 /**
- * field-coverage.ts — Shared mapping-detail coverage helpers for satsuma-viz.
+ * field-coverage.ts — Reading field coverage, and resolving arrow paths, in satsuma-viz.
  *
- * The web component should consume the same nested-field coverage semantics as
- * the LSP coverage path utilities instead of comparing leaf names ad hoc.
+ * Two jobs that used to be one. **Resolving** an arrow's paths against the
+ * containers and schemas it refers to is this module's own work, and every
+ * hover, highlight and layout surface goes through {@link forEachMappingArrow}
+ * and {@link resolveSchemaLocalFieldPath} so they cannot disagree about what an
+ * arrow points at. **Coverage** is not: it arrives precomputed by `@satsuma/core`
+ * in `MappingBlock.coverage`, and the functions here only select and combine
+ * those entries.
+ *
+ * That split is the fix for sl-46wr and sl-csrs. This module used to derive its
+ * own covered-path set by walking the model's arrows — a third derivation
+ * alongside the CLI's and the LSP's — and it counted declared arrows only. Two
+ * coverage rules are invisible in an arrow's endpoints: a leaf named by a
+ * resolved NL `@ref` is covered (ADR-036), and an arrow onto a record covers
+ * that record's subtree when it enumerates no children (ADR-037). Neither could
+ * be seen from here, so the schema card disagreed with `satsuma coverage` on
+ * twelve of the shipped examples, and every rule added to coverage had to be
+ * written twice or the card drifted again. Nothing in this module decides what
+ * is covered any more.
  */
 
-import { buildCoveredFieldSet, schemaLocalFieldPath } from "@satsuma/core/coverage-paths";
+import { schemaLocalFieldPath } from "@satsuma/core/coverage-paths";
+import { unionFieldCoverage } from "@satsuma/core/coverage-rollup";
+import { uncoveredFieldCoverage } from "@satsuma/core/coverage";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
+import type { CoverageField, FieldCoverageEntry } from "@satsuma/core/coverage";
 import type {
   ArrowEntry,
   EachBlock,
@@ -227,83 +246,85 @@ export function countMappingArrows(mapping: MappingBlock): number {
   return count;
 }
 
+// ── Reading core's coverage out of the model ────────────────────────────────
+
 /**
- * Build schema-local covered-field sets for one mapping detail view.
+ * The coverage entries for one schema card in one mapping and role, as core
+ * computed them.
+ *
+ * Falls back to "every field uncovered" when the mapping carries no coverage —
+ * a model assembled without a workspace index, or a payload cached by a host
+ * predating `MappingBlock.coverage`. The fallback is core's
+ * {@link uncoveredFieldCoverage} rather than an empty list because the card
+ * still needs a denominator, and a card that counts its own fields is how the
+ * ratio started including containers (sl-hcan).
+ *
+ * `role` matters: a schema may sit on both sides of one mapping, and the detail
+ * view renders it as two cards asking two different questions — what this
+ * mapping *reads* from it, and what this mapping *writes* into it.
  */
-export function buildMappingCoveredFields(
+export function mappingSchemaCoverage(
   mapping: MappingBlock,
-  sourceSchemas: SchemaCard[],
-  targetSchema: SchemaCard | null,
-): { sourceMapped: Map<string, Set<string>>; targetMapped: Set<string> } {
-  const sourceFieldRefs = new Map<string, string[]>();
-  for (const schema of sourceSchemas) sourceFieldRefs.set(schema.qualifiedId, []);
-
-  const targetFieldRefs: string[] = [];
-
-  // Resolution reads the *qualified* paths: `.line1` under `each parcels ->
-  // packed` declares no field on its own, and matching it as authored resolved
-  // to nothing, so every relative-path arrow contributed no coverage (3cdd-yavi).
-  forEachMappingArrow(mapping, ({ sourceFields, targetField }) => {
-    if (targetSchema) {
-      const targetPath = resolveSchemaLocalFieldPath(targetField, targetSchema, [
-        mapping.targetRef,
-      ]);
-      if (targetPath) targetFieldRefs.push(targetPath);
-    }
-
-    for (const sourceField of sourceFields) {
-      for (const schema of sourceSchemas) {
-        const localPath = resolveSchemaLocalFieldPath(sourceField, schema, mapping.sourceRefs);
-        if (localPath) sourceFieldRefs.get(schema.qualifiedId)!.push(localPath);
-      }
-    }
-  });
-
-  const sourceMapped = new Map<string, Set<string>>();
-  for (const [schemaId, refs] of sourceFieldRefs) {
-    sourceMapped.set(schemaId, buildCoveredFieldSet(refs));
-  }
-
-  return {
-    sourceMapped,
-    targetMapped: buildCoveredFieldSet(targetFieldRefs),
-  };
+  schema: SchemaCard,
+  role: "source" | "target",
+): FieldCoverageEntry[] {
+  const found = mapping.coverage?.schemas.find(
+    (s) => s.role === role && s.schemaId === schema.qualifiedId,
+  );
+  return found
+    ? found.fields
+    : uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri);
 }
 
 /**
- * Build the overview-level mapped-field index across the whole VizModel.
+ * Coverage for every schema card in the model, unioned across every mapping and
+ * both roles — what the overview card reports.
+ *
+ * The overview asks "does anything in this workspace touch this field?", so a
+ * schema read by one mapping and written by another is reported once, with both
+ * contributions merged. Merging is core's {@link unionFieldCoverage}: a leaf is
+ * covered when any mapping covers it, under the strongest tier any of them
+ * claims, and containers are then re-derived from the unioned leaves — which is
+ * not the same as OR-ing the containers, since two mappings that each cover half
+ * of a record cover all of it between them.
+ *
+ * Every declared schema gets an entry, seeded with its own all-uncovered field
+ * list, so a schema no mapping references reports `0/N` rather than dropping out
+ * of the index and leaving its card with nothing to count.
  */
-export function buildMappedFieldsIndex(model: VizModel): Map<string, Set<string>> {
-  const index = new Map<string, Set<string>>();
-  const allSchemas = new Map(
-    model.namespaces.flatMap((ns) =>
-      ns.schemas.map((schema) => [schema.qualifiedId, schema] as const),
-    ),
-  );
+export function buildCoverageIndex(model: VizModel): Map<string, FieldCoverageEntry[]> {
+  const contributions = new Map<string, FieldCoverageEntry[][]>();
+
+  // Seed first: the card's own field tree defines the denominator and the row
+  // order, and every mapping's entries merge into it.
+  for (const ns of model.namespaces) {
+    for (const schema of ns.schemas) {
+      contributions.set(schema.qualifiedId, [
+        uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri),
+      ]);
+    }
+  }
 
   for (const ns of model.namespaces) {
     for (const mapping of ns.mappings) {
-      const sourceSchemas = mapping.sourceRefs
-        .map((schemaId) => allSchemas.get(schemaId))
-        .filter((schema): schema is SchemaCard => schema != null);
-      const targetSchema = allSchemas.get(mapping.targetRef) ?? null;
-      const { sourceMapped, targetMapped } = buildMappingCoveredFields(
-        mapping,
-        sourceSchemas,
-        targetSchema,
-      );
-
-      for (const [schemaId, covered] of sourceMapped) {
-        if (!index.has(schemaId)) index.set(schemaId, new Set());
-        for (const path of covered) index.get(schemaId)!.add(path);
-      }
-
-      if (targetSchema) {
-        if (!index.has(targetSchema.qualifiedId)) index.set(targetSchema.qualifiedId, new Set());
-        for (const path of targetMapped) index.get(targetSchema.qualifiedId)!.add(path);
+      for (const covered of mapping.coverage?.schemas ?? []) {
+        contributions.get(covered.schemaId)?.push(covered.fields);
       }
     }
   }
 
+  const index = new Map<string, FieldCoverageEntry[]>();
+  for (const [schemaId, lists] of contributions) {
+    index.set(schemaId, unionFieldCoverage(lists));
+  }
   return index;
+}
+
+/** Project the model's field entries onto core's minimal coverage field shape. */
+function toCoverageFields(fields: FieldEntry[]): CoverageField[] {
+  return fields.map((f) => ({
+    name: f.name,
+    line: f.location.line,
+    children: toCoverageFields(f.children),
+  }));
 }

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -19,7 +19,7 @@ import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 import { renderMarkdown } from "./markdown.js";
 import { buildCoverageIndex, mappingSchemaCoverage } from "./field-coverage.js";
-import type { FieldCoverageEntry } from "@satsuma/core/coverage";
+import type { SchemaCoverage } from "./field-coverage.js";
 import { metricAsSchemaCard } from "./metric-adapter.js";
 
 export { VizModel } from "./model.js";
@@ -978,7 +978,7 @@ export class SatsumaViz extends LitElement {
    * model, so a schema pulled in by a cross-file expansion is counted too.
    */
   @state()
-  private _coverageBySchema = new Map<string, FieldCoverageEntry[]>();
+  private _coverageBySchema = new Map<string, SchemaCoverage>();
 
   @state()
   private _renderedNamespaceBoxes: Array<{
@@ -1980,7 +1980,7 @@ export class SatsumaViz extends LitElement {
     );
     const targetCoverage = expandedTarget
       ? mappingSchemaCoverage(mapping, expandedTarget, "target")
-      : [];
+      : null;
 
     const namespaceLabel = this._namespaceForMapping(mapping);
 
@@ -2373,7 +2373,7 @@ export class SatsumaViz extends LitElement {
             ...ns.schemas.flatMap((s) => {
               const node = layout.nodes.get(s.qualifiedId);
               if (!node) return [html``];
-              const coverage = this._coverageBySchema.get(s.qualifiedId) ?? [];
+              const coverage = this._coverageBySchema.get(s.qualifiedId) ?? null;
               const isExpanded = expandedIds.has(s.qualifiedId);
               const results = [
                 html`
@@ -2463,7 +2463,7 @@ export class SatsumaViz extends LitElement {
   private _renderFlexCards(ns: NamespaceGroup) {
     return html`
       ${ns.schemas.map((s) => {
-        const coverage = this._coverageBySchema.get(s.qualifiedId) ?? [];
+        const coverage = this._coverageBySchema.get(s.qualifiedId) ?? null;
         return html`<sz-schema-card
           data-testid=${`fallback-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
           .testIdPrefix=${`fallback-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -18,7 +18,8 @@ import {
 import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 import { renderMarkdown } from "./markdown.js";
-import { buildMappedFieldsIndex, buildMappingCoveredFields } from "./field-coverage.js";
+import { buildCoverageIndex, mappingSchemaCoverage } from "./field-coverage.js";
+import type { FieldCoverageEntry } from "@satsuma/core/coverage";
 import { metricAsSchemaCard } from "./metric-adapter.js";
 
 export { VizModel } from "./model.js";
@@ -44,9 +45,10 @@ export {
 } from "./layout/geometry.js";
 import { countMappingArrows } from "./field-coverage.js";
 export {
-  buildMappingCoveredFields,
-  buildMappedFieldsIndex,
+  buildCoverageIndex,
+  mappingSchemaCoverage,
   countMappingArrows,
+  forEachMappingArrow,
   resolveSchemaLocalFieldPath,
   schemaHasFieldPath,
 } from "./field-coverage.js";
@@ -970,8 +972,13 @@ export class SatsumaViz extends LitElement {
   @state()
   private _expandedModels = new Map<string, VizModel[]>();
 
+  /**
+   * Core's coverage entries per schema, unioned across every mapping on screen
+   * — what the overview cards report. Rebuilt with the layout, from the *merged*
+   * model, so a schema pulled in by a cross-file expansion is counted too.
+   */
   @state()
-  private _mappedFieldsBySchema = new Map<string, Set<string>>();
+  private _coverageBySchema = new Map<string, FieldCoverageEntry[]>();
 
   @state()
   private _renderedNamespaceBoxes: Array<{
@@ -1176,8 +1183,8 @@ export class SatsumaViz extends LitElement {
     // Build a merged model that includes expanded cross-file schemas
     const mergedModel = this._buildMergedModel();
 
-    // Build mapped fields index for card rendering
-    this._mappedFieldsBySchema = this._buildMappedFieldsIndex();
+    // Coverage index for card rendering, over the same model that is laid out.
+    this._coverageBySchema = buildCoverageIndex(mergedModel);
 
     try {
       const [detail, overview] = await Promise.all([
@@ -1964,11 +1971,16 @@ export class SatsumaViz extends LitElement {
       .filter((s): s is SchemaCard => s !== null);
     const expandedTarget = resolveEndpoint(mapping.targetRef);
 
-    const { sourceMapped, targetMapped } = buildMappingCoveredFields(
-      mapping,
-      sourceSchemas,
-      expandedTarget,
+    // Coverage per side, straight from core's per-mapping result. The detail
+    // view asks a *per-mapping* question — what does this mapping read, what
+    // does it write — which is not the overview's union across mappings, so the
+    // two indexes are deliberately built from different shapes.
+    const sourceCoverage = new Map(
+      sourceSchemas.map((s) => [s.qualifiedId, mappingSchemaCoverage(mapping, s, "source")]),
     );
+    const targetCoverage = expandedTarget
+      ? mappingSchemaCoverage(mapping, expandedTarget, "target")
+      : [];
 
     const namespaceLabel = this._namespaceForMapping(mapping);
 
@@ -1979,8 +1991,8 @@ export class SatsumaViz extends LitElement {
         .mapping=${mapping}
         .sourceSchemas=${sourceSchemas}
         .targetSchema=${expandedTarget}
-        .sourceMappedFields=${sourceMapped}
-        .targetMappedFields=${targetMapped}
+        .sourceCoverage=${sourceCoverage}
+        .targetCoverage=${targetCoverage}
         .namespaceLabel=${namespaceLabel}
       ></sz-mapping-detail>
     `;
@@ -2361,7 +2373,7 @@ export class SatsumaViz extends LitElement {
             ...ns.schemas.flatMap((s) => {
               const node = layout.nodes.get(s.qualifiedId);
               if (!node) return [html``];
-              const mapped = this._mappedFieldsBySchema.get(s.qualifiedId) ?? new Set();
+              const coverage = this._coverageBySchema.get(s.qualifiedId) ?? [];
               const isExpanded = expandedIds.has(s.qualifiedId);
               const results = [
                 html`
@@ -2374,7 +2386,7 @@ export class SatsumaViz extends LitElement {
                       data-testid=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
                       .testIdPrefix=${`detail-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
                       .schema=${s}
-                      .mappedFields=${mapped}
+                      .coverage=${coverage}
                       .namespaceLabel=${ns.name}
                     ></sz-schema-card>
                   </div>
@@ -2451,12 +2463,12 @@ export class SatsumaViz extends LitElement {
   private _renderFlexCards(ns: NamespaceGroup) {
     return html`
       ${ns.schemas.map((s) => {
-        const mapped = this._mappedFieldsBySchema.get(s.qualifiedId) ?? new Set();
+        const coverage = this._coverageBySchema.get(s.qualifiedId) ?? [];
         return html`<sz-schema-card
           data-testid=${`fallback-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
           .testIdPrefix=${`fallback-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
           .schema=${s}
-          .mappedFields=${mapped}
+          .coverage=${coverage}
           .namespaceLabel=${ns.name}
         ></sz-schema-card>`;
       })}
@@ -2671,9 +2683,6 @@ export class SatsumaViz extends LitElement {
       width: maxX - minX + padding * 2,
       height: maxY - minY + padding * 2,
     };
-  }
-  private _buildMappedFieldsIndex(): Map<string, Set<string>> {
-    return this.model ? buildMappedFieldsIndex(this.model) : new Map();
   }
 }
 

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -58,7 +58,15 @@ describe("viz automation helpers", () => {
     const mod = await import("../dist/satsuma-viz.js");
     const card = new mod.SzSchemaCard();
     card.testIdPrefix = "src-customers";
-    card.mappedFields = new Set(["customer.email"]);
+    card.coverage = [
+      {
+        path: "customer.email",
+        uri: "file:///t.stm",
+        mapped: true,
+        state: "covered",
+        tier: "declared",
+      },
+    ];
     const child = {
       name: "email",
       type: "STRING",
@@ -73,7 +81,16 @@ describe("viz automation helpers", () => {
     const serialized = [...childTpl.strings, ...childTpl.values.map(String)].join(" ");
     assert.match(serialized, /src-customers-field-customer-email/);
     assert.match(serialized, /data-coverage/);
-    assert.match(serialized, /mapped/);
+    // Asserted against the interpolated values, not as a substring of the joined
+    // output: this serialization concatenates `strings` and `values` separately,
+    // so an attribute name is never adjacent to its value, and a bare /mapped/
+    // matched the word inside "unmapped". The case therefore kept passing after
+    // the property it set was renamed away and the card was rendering no verdict
+    // at all — Playwright asserts the exact attribute values, so the unit test
+    // should too.
+    const values = childTpl.values.map(String);
+    assert.ok(values.includes("mapped"), `expected a mapped verdict, got ${values.join()}`);
+    assert.ok(values.includes("covered"), `expected state=covered, got ${values.join()}`);
     // The parent struct must not collide with a top-level "email" segment.
     assert.ok(!/src-customers-field-email[^-]/.test(serialized));
   });
@@ -85,7 +102,7 @@ describe("viz automation helpers", () => {
     const mod = await import("../dist/satsuma-viz.js");
     const card = new mod.SzSchemaCard();
     card.testIdPrefix = "src-legacy";
-    card.mappedFields = new Set();
+    card.coverage = [];
     const legacyField = {
       name: "amount",
       type: "DECIMAL",
@@ -109,7 +126,7 @@ describe("viz automation helpers", () => {
     const mod = await import("../dist/satsuma-viz.js");
     const card = new mod.SzSchemaCard();
     card.testIdPrefix = "src-orders";
-    card.mappedFields = new Set();
+    card.coverage = [];
     const field = {
       name: "order_key",
       type: "VARCHAR",

--- a/tooling/satsuma-viz/test/coverage-parity.test.js
+++ b/tooling/satsuma-viz/test/coverage-parity.test.js
@@ -43,6 +43,27 @@ before(async () => {
 });
 
 /**
+ * Coverage of the Nth mapping's schema, in one role, as the card receives it.
+ *
+ * `mappingIndex` matters for the duplicate-label fixture, where two mappings
+ * share a label and only their position tells them apart.
+ */
+function coverageOfMapping(fixtureName, mappingIndex, schemaId, role) {
+  const uri = `file://${resolve(FIXTURES, fixtureName)}`;
+  const tree = getParser().parse(readFileSync(resolve(FIXTURES, fixtureName), "utf8"));
+  const index = createWorkspaceIndex();
+  indexFile(index, uri, tree);
+  const model = buildVizModel(uri, tree, index);
+
+  const schema = model.namespaces
+    .flatMap((ns) => ns.schemas)
+    .find((s) => s.qualifiedId === schemaId);
+  const mapping = model.namespaces.flatMap((ns) => ns.mappings)[mappingIndex];
+  const entries = viz.mappingSchemaCoverage(mapping, schema, role);
+  return entries === null ? null : summarizeFieldCoverage(entries);
+}
+
+/**
  * Coverage of one schema in one role as the card receives it: model from the
  * backend, entries from the model, counting from core.
  *
@@ -206,5 +227,36 @@ describe("viz coverage applies whole-structure conferral (sl-csrs)", () => {
     assert.equal(tgt.totals.covered, 11);
     assert.equal(tgt.totals.total, 15);
     assert.equal(tgt.totals.pct, 73);
+  });
+});
+
+// ── A mapping label is not an identity (sl-46wr review) ─────────────────────
+
+describe("viz coverage identifies the right mapping block", () => {
+  it("keeps two same-named mappings in different namespaces apart", () => {
+    // Coverage looked the mapping up by label, so both `a::load` and `b::load`
+    // resolved to whichever was declared first. With the two namespaces
+    // declaring identically-named schemas — the fixture's shape — `b::load`'s
+    // card showed `a::load`'s single arrow as 1/2 where the truth is 2/2: a
+    // plausible figure that was simply another mapping's. `satsuma coverage`
+    // printed the same wrong number, so the two agreed while both were wrong.
+    const a = coverageOfMapping("coverage-duplicate-mapping-labels.stm", 0, "a::t", "target");
+    assert.equal(a.covered, 1);
+    assert.equal(a.total, 2);
+
+    const b = coverageOfMapping("coverage-duplicate-mapping-labels.stm", 1, "b::t", "target");
+    assert.equal(b.covered, 2, "b::load has two arrows and must not inherit a::load's one");
+    assert.equal(b.total, 2);
+  });
+
+  it("attaches coverage to an anonymous mapping, which has no label to look up", () => {
+    // The model names an anonymous `mapping { … }` block "unknown", and no CST
+    // block carries that label — so a label-based lookup found nothing and
+    // dropped the coverage entirely, which the card then rendered as 0/N.
+    // Resolving by position finds it.
+    const anon = coverageOfMapping("coverage-anonymous-mapping.stm", 0, "tgt", "target");
+    assert.notEqual(anon, null, "an anonymous mapping must still get coverage");
+    assert.equal(anon.covered, 1);
+    assert.equal(anon.total, 2);
   });
 });

--- a/tooling/satsuma-viz/test/coverage-parity.test.js
+++ b/tooling/satsuma-viz/test/coverage-parity.test.js
@@ -3,14 +3,17 @@
  *
  * Feature 36's overlay is only worth building if its figures equal the CLI's,
  * and that guarantee had no test that would fail if it broke (sl-5nsv). This
- * file supplies it end to end on the viz side: parse a fixture, build the model
- * through `@satsuma/viz-backend` exactly as the VS Code host does, derive the
- * covered-field set the card is given, and count it the way the card counts.
+ * file supplies it on the viz side: parse a fixture, build the model through
+ * `@satsuma/viz-backend` exactly as the VS Code host does, read the coverage the
+ * card is given, and count it the way the card counts.
  *
  * The expected figures are the ones `satsuma coverage --json` prints for the
  * same files, asserted in satsuma-cli/test/coverage.test.ts, and the same leaves
  * the editor gutter reports, asserted in satsuma-lsp/test/coverage.test.js. One
  * fixture, three suites, one set of numbers — change one and the others fail.
+ * satsuma-cli/test/coverage-viz-parity.test.ts extends the same guarantee across
+ * every file in `examples/`, in one process; the cases here are the named rules,
+ * kept close to the consumer that used to get them wrong.
  *
  * `@satsuma/viz-backend` is a devDependency here for exactly this: the runtime
  * dependency still runs component → core only, and nothing in the bundle
@@ -22,13 +25,7 @@ import * as assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  countContainerStates,
-  fieldCoverageFromCoveredPaths,
-  getParser,
-  initParser,
-  summarizeFieldCoverage,
-} from "@satsuma/core";
+import { countContainerStates, getParser, initParser, summarizeFieldCoverage } from "@satsuma/core";
 import { createWorkspaceIndex, indexFile } from "@satsuma/viz-backend/workspace-index";
 import { buildVizModel } from "@satsuma/viz-backend/viz-model";
 
@@ -46,24 +43,26 @@ before(async () => {
 });
 
 /**
- * Coverage of one target schema as the card computes it: model from the
- * backend, covered set from the mapping's arrows, counting from core.
+ * Coverage of one schema in one role as the card receives it: model from the
+ * backend, entries from the model, counting from core.
+ *
+ * Deliberately reaches the entries through `mappingSchemaCoverage` — the same
+ * selector `satsuma-viz.ts` uses to feed the card — so a test cannot pass
+ * against a path the UI does not take.
  */
-function targetCoverage(fixtureName, schemaId) {
+function coverageOf(fixtureName, schemaId, role = "target") {
   const uri = `file://${resolve(FIXTURES, fixtureName)}`;
   const tree = getParser().parse(readFileSync(resolve(FIXTURES, fixtureName), "utf8"));
   const index = createWorkspaceIndex();
   indexFile(index, uri, tree);
   const model = buildVizModel(uri, tree, index);
 
-  const schemas = model.namespaces.flatMap((ns) => ns.schemas);
-  const schema = schemas.find((s) => s.id === schemaId);
+  const schema = model.namespaces.flatMap((ns) => ns.schemas).find((s) => s.id === schemaId);
   const mapping = model.namespaces.flatMap((ns) => ns.mappings)[0];
-  const { targetMapped } = viz.buildMappingCoveredFields(mapping, [], schema);
-
-  const entries = fieldCoverageFromCoveredPaths(schema.fields, uri, targetMapped);
+  const entries = viz.mappingSchemaCoverage(mapping, schema, role);
   return {
     leaves: entries.map((f) => [f.path, f.state]),
+    tiers: entries.filter((f) => f.mapped).map((f) => [f.path, f.tier]),
     totals: summarizeFieldCoverage(entries),
     containers: countContainerStates(entries),
   };
@@ -75,7 +74,7 @@ describe("viz coverage equals satsuma coverage (sl-5nsv)", () => {
     // covered. Every part of that has to match: the leaf list (the model must
     // materialise the spread), the verdicts, the container state, and the
     // percentage.
-    const { leaves, totals, containers } = targetCoverage("nested-record-spread.stm", "customer");
+    const { leaves, totals, containers } = coverageOf("nested-record-spread.stm", "customer");
     assert.deepEqual(leaves, [
       ["id", "uncovered"],
       ["name", "uncovered"],
@@ -95,7 +94,7 @@ describe("viz coverage equals satsuma coverage (sl-5nsv)", () => {
     // leaves (sl-5nsv) and `.item_code -> .sku` inside the `each` has to
     // resolve against its container (3cdd-yavi). Miss either and the card reads
     // 0 covered where the CLI reads 2/4.
-    const { leaves, totals } = targetCoverage("list-of-record-spread.stm", "invoice");
+    const { leaves, totals } = coverageOf("list-of-record-spread.stm", "invoice");
     assert.deepEqual(leaves, [
       ["invoice_no", "covered"],
       ["lines", "partial"],
@@ -106,5 +105,106 @@ describe("viz coverage equals satsuma coverage (sl-5nsv)", () => {
     assert.equal(totals.covered, 2);
     assert.equal(totals.total, 4);
     assert.equal(totals.pct, 50);
+  });
+});
+
+// ── The NL @ref tier (sl-46wr, ADR-036) ─────────────────────────────────────
+
+describe("viz coverage counts the resolved NL @ref tier (sl-46wr)", () => {
+  it("reports a leaf named only by a resolved @ref as covered, in the nl tier", () => {
+    // The divergence sl-46wr records: the CLI reports buy_order 5/7 with
+    // tax_amount and discount at tier=nl, and the card reported 3/7 because a
+    // covered-path set derived from arrows cannot see a ref at all. The tier
+    // must travel with the verdict — ADR-036 forbids a consumer reconstructing
+    // the declared/NL split, and a boolean cannot carry it.
+    const { totals, tiers } = coverageOf("coverage-nl-tier.stm", "buy_order", "source");
+    assert.equal(totals.covered, 5);
+    assert.equal(totals.total, 7);
+    assert.equal(totals.pct, 71);
+    assert.equal(totals.coveredDeclared, 3);
+    assert.equal(totals.coveredNl, 2);
+    assert.deepEqual(tiers, [
+      ["id", "declared"],
+      ["net_amount", "declared"],
+      ["tax_amount", "nl"],
+      ["discount", "nl"],
+      ["status", "declared"],
+    ]);
+  });
+
+  it("leaves a field described in prose without an @ref, and an unresolved @ref, uncovered", () => {
+    // The two ways coverage must NOT rise. Reading prose would make coverage an
+    // NL interpreter; counting an unresolved ref would make coverage rise when a
+    // spec breaks. If either leaked in, the total above would be 6 or 7.
+    const { leaves } = coverageOf("coverage-nl-tier.stm", "buy_order", "source");
+    const byPath = new Map(leaves);
+    assert.equal(byPath.get("internal_ref"), "uncovered");
+    assert.equal(byPath.get("unresolved"), "uncovered");
+  });
+});
+
+// ── Whole-structure conferral (sl-csrs, ADR-037/038) ────────────────────────
+
+describe("viz coverage applies whole-structure conferral (sl-csrs)", () => {
+  it("credits every leaf under a record-to-record and a list_of-record arrow", () => {
+    // sl-csrs's repro: `addr -> address` and `rows -> lines` confer their whole
+    // subtrees, and the card read them as gaps because conferral needs the
+    // arrow's declaration kind, which a set of paths has discarded.
+    const { leaves } = coverageOf("coverage-whole-structure.stm", "tgt", "target");
+    const byPath = new Map(leaves);
+    assert.equal(byPath.get("address"), "covered");
+    assert.equal(byPath.get("address.line1"), "covered");
+    assert.equal(byPath.get("address.postcode"), "covered");
+    assert.equal(byPath.get("lines"), "covered");
+    assert.equal(byPath.get("lines.quantity"), "covered");
+  });
+
+  it("confers from an empty body and from a pipe-chain body alike", () => {
+    // ADR-037 names both forms explicitly: `p -> p { }` enumerates nothing, and
+    // `r -> r { trim }` is a transform pipeline rather than a nesting scope
+    // (spec §4.4), so neither narrows the header's claim.
+    const { leaves } = coverageOf("coverage-whole-structure.stm", "tgt", "target");
+    const byPath = new Map(leaves);
+    assert.equal(byPath.get("plain_out"), "covered");
+    assert.equal(byPath.get("plain_out.b"), "covered");
+    assert.equal(byPath.get("trimmed_out"), "covered");
+    assert.equal(byPath.get("trimmed_out.d"), "covered");
+  });
+
+  it("confers only the enumerated children when the body lists any", () => {
+    // The limit of the rule, and the reason it is gated on the body: a header
+    // that lists child arrows says nothing about the siblings it omits, so
+    // reading it as wholesale would report `dropped` as covered when nothing
+    // writes it.
+    const { leaves } = coverageOf("coverage-whole-structure.stm", "tgt", "target");
+    const byPath = new Map(leaves);
+    assert.equal(byPath.get("enum_out"), "partial");
+    assert.equal(byPath.get("enum_out.kept"), "covered");
+    assert.equal(byPath.get("enum_out.dropped"), "uncovered");
+  });
+
+  it("does not let a scalar source fill a record target (ADR-038)", () => {
+    // One scalar cannot fill two leaves and the arrow says nothing about which,
+    // so `full_name -> scalar_into_record` confers nothing — under-counting is
+    // the safe direction for a figure `--fail-under` gates.
+    const { leaves } = coverageOf("coverage-whole-structure.stm", "tgt", "target");
+    const byPath = new Map(leaves);
+    assert.equal(byPath.get("scalar_into_record"), "uncovered");
+    assert.equal(byPath.get("scalar_into_record.first"), "uncovered");
+  });
+
+  it("agrees with the CLI's totals on both sides of the conferral fixture", () => {
+    // The figures `satsuma coverage` prints for this file: src 12/14 (85%) and
+    // tgt 11/15 (73%). Asserting the totals as well as the verdicts is what
+    // catches a rule that confers the right leaves but miscounts them.
+    const src = coverageOf("coverage-whole-structure.stm", "src", "source");
+    assert.equal(src.totals.covered, 12);
+    assert.equal(src.totals.total, 14);
+    assert.equal(src.totals.pct, 85);
+
+    const tgt = coverageOf("coverage-whole-structure.stm", "tgt", "target");
+    assert.equal(tgt.totals.covered, 11);
+    assert.equal(tgt.totals.total, 15);
+    assert.equal(tgt.totals.pct, 73);
   });
 });

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -34,9 +34,10 @@ describe("field-coverage helpers", () => {
 
   it("loads the bundle exports", async () => {
     mod = await import("../dist/satsuma-viz.js");
-    assert.equal(typeof mod.buildMappingCoveredFields, "function");
     assert.equal(typeof mod.resolveSchemaLocalFieldPath, "function");
     assert.equal(typeof mod.schemaHasFieldPath, "function");
+    assert.equal(typeof mod.mappingSchemaCoverage, "function");
+    assert.equal(typeof mod.buildCoverageIndex, "function");
   });
 
   it("resolves unqualified nested source paths against the owning schema", () => {
@@ -57,47 +58,6 @@ describe("field-coverage helpers", () => {
       ]),
       "region",
     );
-  });
-
-  it("builds mapping coverage sets that include nested parents and children", () => {
-    const orderEvents = schema("order_events", [
-      field("customer", [field("email"), field("tier")]),
-    ]);
-    const target = schema("completed_orders", [field("customer_email")]);
-    const mapping = {
-      id: "completed orders",
-      sourceRefs: ["order_events", "customer_profiles"],
-      targetRef: "completed_orders",
-      arrows: [
-        {
-          sourceFields: ["customer.email"],
-          targetField: "customer_email",
-          transform: null,
-          metadata: [],
-          comments: [],
-          location: loc,
-        },
-      ],
-      eachBlocks: [],
-      flattenBlocks: [],
-      nestedArrows: [],
-      sourceBlock: null,
-      notes: [],
-      comments: [],
-      location: loc,
-    };
-
-    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
-      mapping,
-      [orderEvents],
-      target,
-    );
-
-    const sourceSet = sourceMapped.get("order_events");
-    assert.ok(sourceSet);
-    assert.equal(sourceSet.has("customer"), true);
-    assert.equal(sourceSet.has("customer.email"), true);
-    assert.equal(targetMapped.has("customer_email"), true);
   });
 
   it("strips authored bare-id prefixes for namespaced schemas (sl-iqud)", () => {
@@ -129,59 +89,6 @@ describe("field-coverage helpers", () => {
       mod.resolveSchemaLocalFieldPath("orders.id", customers, ["crm::customers", "crm::orders"]),
       null,
     );
-  });
-
-  it("covers both schemas of a namespaced multi-source mapping (sl-iqud)", () => {
-    // End-to-end coverage repro from the ticket: a namespaced join mapping
-    // with bare-prefixed arrow refs left sourceMapped empty for both schemas.
-    const customers = schema("customers", [field("id"), field("email")], "crm::customers");
-    const orders = schema("orders", [field("customer_id"), field("total")], "crm::orders");
-    const target = schema(
-      "customer_orders",
-      [field("email"), field("total")],
-      "crm::customer_orders",
-    );
-    const mapping = {
-      id: "join_orders",
-      sourceRefs: ["crm::customers", "crm::orders"],
-      targetRef: "crm::customer_orders",
-      arrows: [
-        {
-          sourceFields: ["customers.email"],
-          targetField: "email",
-          transform: null,
-          metadata: [],
-          comments: [],
-          location: loc,
-        },
-        {
-          sourceFields: ["orders.total"],
-          targetField: "total",
-          transform: null,
-          metadata: [],
-          comments: [],
-          location: loc,
-        },
-      ],
-      eachBlocks: [],
-      flattenBlocks: [],
-      nestedArrows: [],
-      sourceBlock: null,
-      notes: [],
-      comments: [],
-      location: loc,
-    };
-
-    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
-      mapping,
-      [customers, orders],
-      target,
-    );
-
-    assert.deepEqual([...sourceMapped.get("crm::customers")], ["email"]);
-    assert.deepEqual([...sourceMapped.get("crm::orders")], ["total"]);
-    assert.equal(targetMapped.has("email"), true);
-    assert.equal(targetMapped.has("total"), true);
   });
 });
 
@@ -383,14 +290,15 @@ describe("sz-mapping-detail hover lookups recurse into nestedEach (sl-fm0q)", ()
 // matching an arrow against a *declared field* has to qualify first — and until
 // this ticket nothing did, so `resolveSchemaLocalFieldPath(".line1", …)` split
 // to ["", "line1"], matched no field, and every relative-path arrow silently
-// contributed nothing to coverage, hover highlighting or overview edges.
+// contributed nothing to hover highlighting or overview edges.
+//
+// Asserted on the resolved paths themselves rather than through coverage: since
+// sl-46wr coverage is core's answer, not this module's, so the property this
+// module still owns is "what absolute path does this arrow name?".
 
 describe("relative arrow paths resolve against their container (3cdd-yavi)", () => {
   /** @type {typeof import("../dist/satsuma-viz.js")} */
   let mod;
-
-  const src = schema("s", [field("addr", [field("line1")]), field("orders", [field("id")])]);
-  const tgt = schema("t", [field("address", [field("line1")]), field("orders", [field("id")])]);
 
   /** A mapping whose only arrow sits inside `blocks`, authored relatively. */
   const mappingWith = (over) => ({
@@ -419,31 +327,33 @@ describe("relative arrow paths resolve against their container (3cdd-yavi)", () 
     ...over,
   });
 
+  /** Every arrow's resolved `source -> target` pair, in walk order. */
+  const resolvedPaths = (mapping) => {
+    const pairs = [];
+    mod.forEachMappingArrow(mapping, ({ sourceFields, targetField }) => {
+      pairs.push(`${sourceFields.join(",")} -> ${targetField}`);
+    });
+    return pairs;
+  };
+
   before(async () => {
     mod = await import("../dist/satsuma-viz.js");
   });
 
-  it("counts a nested_arrow body's relative arrow as covering the qualified leaf", () => {
+  it("qualifies a nested_arrow body's relative arrow against the header", () => {
     // The ticket's headline case: `.line1 -> .line1` under `addr -> address`
-    // covers addr.line1 and address.line1 on their respective cards.
+    // names addr.line1 and address.line1. The header itself is an arrow too —
+    // it maps record to record — so both appear.
     const mapping = mappingWith({
       nestedArrows: [block("addr", "address", { arrows: [arrow(".line1", ".line1")] })],
     });
-    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(mapping, [src], tgt);
-
-    assert.equal(sourceMapped.get("s").has("addr.line1"), true);
-    assert.equal(targetMapped.has("address.line1"), true);
-    // The containers come along as ancestors of a covered leaf, which is what
-    // makes the record row render as touched rather than as a gap.
-    assert.equal(targetMapped.has("address"), true);
+    assert.deepEqual(resolvedPaths(mapping), ["addr -> address", "addr.line1 -> address.line1"]);
   });
 
   it("accumulates prefixes through a flatten nested inside an each", () => {
     // The sl-vu22 shape. Each container level contributes one segment, so the
     // rule has to compose — a single level of qualification would resolve
     // `.sku` to `parcels.sku` and still match nothing.
-    const deepSrc = schema("s", [field("orders", [field("parcels", [field("sku")])])]);
-    const deepTgt = schema("t", [field("orders", [field("packed", [field("sku")])])]);
     const mapping = mappingWith({
       eachBlocks: [
         block("orders", "orders", {
@@ -451,24 +361,19 @@ describe("relative arrow paths resolve against their container (3cdd-yavi)", () 
         }),
       ],
     });
-
-    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(
-      mapping,
-      [deepSrc],
-      deepTgt,
-    );
-    assert.equal(sourceMapped.get("s").has("orders.parcels.sku"), true);
-    assert.equal(targetMapped.has("orders.packed.sku"), true);
+    assert.deepEqual(resolvedPaths(mapping), ["orders.parcels.sku -> orders.packed.sku"]);
   });
 
   it("leaves a mapping-level arrow untouched, dot and all", () => {
     // At mapping-body level there is no container to resolve against, so a
-    // stray leading dot must stay unresolvable rather than be quietly matched
-    // to a top-level field — coverage must never rise on a malformed path.
+    // stray leading dot must stay as authored rather than be quietly matched to
+    // a top-level field — nothing may rise on a malformed path.
     const mapping = mappingWith({ arrows: [arrow(".orders", ".orders")] });
-    const { sourceMapped, targetMapped } = mod.buildMappingCoveredFields(mapping, [src], tgt);
+    assert.deepEqual(resolvedPaths(mapping), [".orders -> .orders"]);
 
-    assert.equal(sourceMapped.get("s").has("orders"), false);
-    assert.equal(targetMapped.has("orders"), false);
+    // And it still resolves to no declared field, which is what keeps it out of
+    // every path-matched surface.
+    const src = schema("s", [field("orders", [field("id")])]);
+    assert.equal(mod.resolveSchemaLocalFieldPath(".orders", src, ["s"]), null);
   });
 });

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -377,3 +377,79 @@ describe("relative arrow paths resolve against their container (3cdd-yavi)", () 
     assert.equal(mod.resolveSchemaLocalFieldPath(".orders", src, ["s"]), null);
   });
 });
+
+// ── "Not computed" is not "nothing is covered" (sl-46wr review) ──────────────
+//
+// `MappingBlock.coverage` is optional, and its contract — with ADR-042 — says
+// absent means the figure was not produced: a model assembled without a
+// workspace index, or a payload cached by a host predating the field. Rendering
+// that as `0/N` asserts a completeness figure nobody measured, and it is
+// indistinguishable from the genuine zero of a schema no mapping references.
+//
+// These go through the two public selectors the UI actually calls. Passing an
+// empty array straight to the card tests the card and skips the conversion,
+// which is how the fallback survived review of the card's own tests.
+
+describe("absent coverage stays unavailable, distinct from 0/N", () => {
+  /** @type {typeof import("../dist/satsuma-viz.js")} */
+  let mod;
+
+  const src = schema("s", [field("a"), field("b")]);
+  const orphan = schema("orphan", [field("z")]);
+
+  /** A mapping referencing `s`, with no coverage attached. */
+  const uncomputed = () => ({
+    id: "m",
+    sourceRefs: ["s"],
+    targetRef: "t",
+    arrows: [],
+    eachBlocks: [],
+    flattenBlocks: [],
+    nestedArrows: [],
+    sourceBlock: null,
+    metadata: [],
+    notes: [],
+    comments: [],
+    location: loc,
+  });
+
+  const modelWith = (mappings, schemas) => ({
+    uri: loc.uri,
+    fileNotes: [],
+    namespaces: [{ name: null, schemas, mappings, metrics: [], fragments: [] }],
+  });
+
+  before(async () => {
+    mod = await import("../dist/satsuma-viz.js");
+  });
+
+  it("reports null from the detail selector when the mapping carries no coverage", () => {
+    // The detail view's own accessor. Returning an all-uncovered list here is
+    // what made the card claim 0/N for a payload that simply never had coverage.
+    assert.equal(mod.mappingSchemaCoverage(uncomputed(), src, "source"), null);
+  });
+
+  it("reports null from the detail selector when coverage omits this schema", () => {
+    // Coverage present but naming no entry for this schema means core could not
+    // resolve the reference — again no answer, not an answer of zero.
+    const mapping = { ...uncomputed(), coverage: { schemas: [] } };
+    assert.equal(mod.mappingSchemaCoverage(mapping, src, "source"), null);
+  });
+
+  it("reports null from the overview index for a schema a coverage-less mapping references", () => {
+    // Unknown has to beat partial: the union would otherwise silently omit that
+    // mapping's contribution and understate the schema.
+    const index = mod.buildCoverageIndex(modelWith([uncomputed()], [src]));
+    assert.equal(index.get("s"), null);
+  });
+
+  it("still reports a genuine 0/N for a schema no mapping references", () => {
+    // The case that must NOT be swept up with it: nothing touches `orphan`, so
+    // every leaf really is uncovered and the card should say so.
+    const index = mod.buildCoverageIndex(modelWith([uncomputed()], [src, orphan]));
+    assert.deepEqual(
+      index.get("orphan").map((e) => [e.path, e.state]),
+      [["z", "uncovered"]],
+    );
+  });
+});

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -93,8 +93,13 @@ function renderText(card) {
   return serialize(card.render());
 }
 
-/** A card bound to `fields`, reporting `coverage`. */
-async function makeCard(fields, coverage = [], { compact = false } = {}) {
+/**
+ * A card bound to `fields`, reporting `coverage`.
+ *
+ * `null` — "not computed" — is the default, so a case that forgets to supply
+ * verdicts cannot accidentally assert against zeroes.
+ */
+async function makeCard(fields, coverage = null, { compact = false } = {}) {
   const mod = await import("../dist/satsuma-viz.js");
   const card = new mod.SzSchemaCard();
   card.schema = schemaCard(fields);
@@ -238,13 +243,45 @@ describe("sz-schema-card renders the verdict it was given", () => {
     assert.match(text, /partly mapped/);
   });
 
-  it("renders every row unmarked when given no coverage at all", async () => {
-    // A model assembled without a workspace index carries no coverage. That is
-    // "not computed", not "nothing is mapped", so the card must not claim a
-    // verdict it was never given — and must not crash looking one up.
-    const card = await makeCard(AMOUNT_AND_ADDRESS, []);
+  it("shows a field count instead of a ratio when coverage was not computed", async () => {
+    // `null` is "not computed", not "nothing is mapped" — a model assembled
+    // without a workspace index, or a cached payload from an older host. The
+    // header must not print `0/4`, which asserts a completeness figure nobody
+    // measured and is indistinguishable from a genuinely unmapped schema. The
+    // count itself still comes from core, in leaves (ADR-034), so it agrees with
+    // the denominator a ratio would have used.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, null);
+    const text = renderText(card);
+    assert.match(text, /header-count[^>]*>4 fields</);
+    assert.doesNotMatch(text, /header-count[^>]*>0\/4</);
+    assert.match(text, /data-coverage-available="?false/);
+    assert.match(text, /Coverage not computed/);
+  });
+
+  it("renders every row unmarked when coverage was not computed", async () => {
+    // The rows must claim no verdict either, and looking one up must not crash.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, null);
     const text = renderText(card);
     assert.match(text, /data-coverage="?unmapped/);
     assert.doesNotMatch(text, /data-coverage-tier="?(nl|declared)/);
+  });
+
+  it("still shows 0/N when coverage says nothing is covered", async () => {
+    // The distinction the case above exists for: a schema no mapping references
+    // has a real answer, and the card must give the number rather than fall back
+    // to the count.
+    const card = await makeCard(
+      AMOUNT_AND_ADDRESS,
+      entries(
+        ["amount", "uncovered"],
+        ["address", "uncovered"],
+        ["address.city", "uncovered"],
+        ["address.line1", "uncovered"],
+        ["address.postcode", "uncovered"],
+      ),
+    );
+    const text = renderText(card);
+    assert.match(text, /header-count[^>]*>0\/4</);
+    assert.match(text, /data-coverage-available="?true/);
   });
 });

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -258,12 +258,39 @@ describe("sz-schema-card renders the verdict it was given", () => {
     assert.match(text, /Coverage not computed/);
   });
 
-  it("renders every row unmarked when coverage was not computed", async () => {
-    // The rows must claim no verdict either, and looking one up must not crash.
+  it("marks rows as unknown, not unmapped, when coverage was not computed", async () => {
+    // The rows have to agree with the header. Collapsing "not computed" to the
+    // `unmapped` verdict made every field read as a gap directly beneath a header
+    // saying no figure existed — and left automation unable to tell those rows
+    // from genuine uncovered results. `unknown` is a third state, so both a reader
+    // and a test can see there is no verdict.
     const card = await makeCard(AMOUNT_AND_ADDRESS, null);
     const text = renderText(card);
-    assert.match(text, /data-coverage="?unmapped/);
+    assert.match(text, /data-coverage="?unknown/);
+    assert.match(text, /data-coverage-state="?unknown/);
+    assert.doesNotMatch(text, /data-coverage="?unmapped/);
+    assert.doesNotMatch(text, /data-coverage-state="?uncovered/);
     assert.doesNotMatch(text, /data-coverage-tier="?(nl|declared)/);
+    assert.match(text, /coverage not computed/);
+  });
+
+  it("keeps unmapped for a real uncovered verdict", async () => {
+    // The counterpart: `unknown` must not swallow the genuine case, or the
+    // distinction is useless in the other direction.
+    const card = await makeCard(
+      AMOUNT_AND_ADDRESS,
+      entries(
+        ["amount", "uncovered"],
+        ["address", "uncovered"],
+        ["address.city", "uncovered"],
+        ["address.line1", "uncovered"],
+        ["address.postcode", "uncovered"],
+      ),
+    );
+    const text = renderText(card);
+    assert.match(text, /data-coverage="?unmapped/);
+    assert.match(text, /data-coverage-state="?uncovered/);
+    assert.doesNotMatch(text, /data-coverage="?unknown/);
   });
 
   it("still shows 0/N when coverage says nothing is covered", async () => {

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -1,21 +1,23 @@
 /**
- * schema-card-coverage.test.js — What the schema card's header ratio counts.
+ * schema-card-coverage.test.js — What the schema card does with core's verdicts.
  *
- * The card used to compute its own coverage figures, counting every node —
- * records included — in both numerator and denominator, so one covered leaf
- * lifted the numerator once per ancestor level. `satsuma coverage`, the VS Code
- * status bar and this card then reported three different percentages for one
- * mapping (sl-hcan). ADR-034 settles the rule — leaves only, on each leaf's own
- * flag — and states that consumers must not compute their own denominators.
+ * The card used to work coverage out for itself, and lost a rule each time one
+ * was added: counting every node — records included — in both halves of the
+ * ratio (sl-hcan), then deriving covered paths from the model's arrows, which
+ * cannot see the NL `@ref` tier or whole-structure conferral (sl-46wr, sl-csrs).
+ * It now receives `FieldCoverageEntry[]` from `@satsuma/core` and only renders
+ * them, so these cases are written the same way: *given* these verdicts, this is
+ * what the card must show.
  *
- * These cases pin the card's end of that: the figures it renders, and the
- * depth-invariance property that makes them comparable between schemas. The
- * counting rule itself is core's, and is tested there.
+ * The verdicts are therefore hand-written rather than computed. Whether core
+ * produces them correctly is core's own test, and asserting it again here would
+ * test the same invariant twice; what is only testable here is the rendering —
+ * that leaves alone reach the ratio, that container state reaches the tooltip
+ * and not the number, and that the tier is visible at all.
  */
 import "./dom-shim.js";
 import { describe, it } from "node:test";
 import * as assert from "node:assert/strict";
-import { buildCoveredFieldSet } from "@satsuma/core/coverage-paths";
 
 const LOC = { uri: "file:///test.stm", line: 0, character: 0 };
 
@@ -56,6 +58,23 @@ function schemaCard(fields) {
 }
 
 /**
+ * Coverage entries as core emits them, from `[path, state, tier?]` triples.
+ *
+ * Declarative on purpose: the card is a renderer of these, so a test states the
+ * verdicts it is rendering rather than deriving them and re-testing the
+ * derivation. `mapped` is `state !== "uncovered"`, core's own invariant.
+ */
+function entries(...specs) {
+  return specs.map(([path, state, tier]) => ({
+    path,
+    uri: LOC.uri,
+    mapped: state !== "uncovered",
+    state,
+    ...(tier ? { tier } : {}),
+  }));
+}
+
+/**
  * Render a card and return its markup as text, with template values
  * interleaved in source order — the ratio is `${covered}/${total}`, so only an
  * interleaved serialization can tell "1/4" from "4/1".
@@ -74,12 +93,12 @@ function renderText(card) {
   return serialize(card.render());
 }
 
-/** A card bound to `fields`, with `covered` schema-local paths marked mapped. */
-async function makeCard(fields, covered = [], { compact = false } = {}) {
+/** A card bound to `fields`, reporting `coverage`. */
+async function makeCard(fields, coverage = [], { compact = false } = {}) {
   const mod = await import("../dist/satsuma-viz.js");
   const card = new mod.SzSchemaCard();
   card.schema = schemaCard(fields);
-  card.mappedFields = buildCoveredFieldSet(covered);
+  card.coverage = coverage;
   card.compact = compact;
   return card;
 }
@@ -91,12 +110,21 @@ const AMOUNT_AND_ADDRESS = [
   record("address", [leaf("city"), leaf("line1"), leaf("postcode")]),
 ];
 
+/** Coverage of AMOUNT_AND_ADDRESS with only `address.city` covered. */
+const ONLY_CITY = entries(
+  ["amount", "uncovered"],
+  ["address", "partial", "declared"],
+  ["address.city", "covered", "declared"],
+  ["address.line1", "uncovered"],
+  ["address.postcode", "uncovered"],
+);
+
 describe("sz-schema-card header ratio (sl-hcan)", () => {
   it("counts leaves only, excluding the record that contains them", async () => {
     // 1 of 4 leaves — not 2 of 5, which is what counting `address` itself in
     // both halves produced. The old figure claimed 40% coverage of a schema
     // `satsuma coverage` reports as 25%.
-    const card = await makeCard(AMOUNT_AND_ADDRESS, ["address.city"]);
+    const card = await makeCard(AMOUNT_AND_ADDRESS, ONLY_CITY);
     assert.match(renderText(card), /header-count[^>]*>1\/4</);
   });
 
@@ -104,13 +132,29 @@ describe("sz-schema-card header ratio (sl-hcan)", () => {
     // Depth invariance is what makes one card's percentage comparable with
     // another's. Counting containers broke it: re-nesting four leaves three
     // levels deep moved the denominator without a field being added.
-    const flat = await makeCard([leaf("a"), leaf("b"), leaf("c"), leaf("d")], ["a"]);
+    const flat = await makeCard(
+      [leaf("a"), leaf("b"), leaf("c"), leaf("d")],
+      entries(
+        ["a", "covered", "declared"],
+        ["b", "uncovered"],
+        ["c", "uncovered"],
+        ["d", "uncovered"],
+      ),
+    );
     const deep = await makeCard(
       [
         leaf("a"),
         record("outer", [leaf("b"), record("mid", [leaf("c"), record("in", [leaf("d")])])]),
       ],
-      ["a"],
+      entries(
+        ["a", "covered", "declared"],
+        ["outer", "uncovered"],
+        ["outer.b", "uncovered"],
+        ["outer.mid", "uncovered"],
+        ["outer.mid.c", "uncovered"],
+        ["outer.mid.in", "uncovered"],
+        ["outer.mid.in.d", "uncovered"],
+      ),
     );
     assert.match(renderText(flat), /header-count[^>]*>1\/4</);
     assert.match(renderText(deep), /header-count[^>]*>1\/4</);
@@ -120,18 +164,23 @@ describe("sz-schema-card header ratio (sl-hcan)", () => {
     // Containers are excluded from the percentage, so the count beside it is
     // the only place a reviewer learns that a record needs attention. A record
     // with one covered and two uncovered leaves is the reviewable state.
-    const card = await makeCard(AMOUNT_AND_ADDRESS, ["address.city"]);
+    const card = await makeCard(AMOUNT_AND_ADDRESS, ONLY_CITY);
     assert.match(renderText(card), /1\/4 leaf fields mapped \(25%\) — 1 record partly mapped/);
   });
 
   it("says nothing about records when none is partly mapped", async () => {
     // A fully covered or wholly uncovered record is already legible from the
     // field rows; only the partial state is worth a phrase.
-    const card = await makeCard(AMOUNT_AND_ADDRESS, [
-      "address.city",
-      "address.line1",
-      "address.postcode",
-    ]);
+    const card = await makeCard(
+      AMOUNT_AND_ADDRESS,
+      entries(
+        ["amount", "uncovered"],
+        ["address", "covered", "declared"],
+        ["address.city", "covered", "declared"],
+        ["address.line1", "covered", "declared"],
+        ["address.postcode", "covered", "declared"],
+      ),
+    );
     const text = renderText(card);
     assert.match(text, /3\/4 leaf fields mapped \(75%\)/);
     assert.doesNotMatch(text, /partly mapped/);
@@ -141,7 +190,61 @@ describe("sz-schema-card header ratio (sl-hcan)", () => {
     // One card must not answer "how many fields?" two ways depending on which
     // form it is rendered in — the compact header showed 5 for the schema the
     // expanded header denominated in 4.
-    const card = await makeCard(AMOUNT_AND_ADDRESS, [], { compact: true });
+    const card = await makeCard(
+      AMOUNT_AND_ADDRESS,
+      entries(
+        ["amount", "uncovered"],
+        ["address", "uncovered"],
+        ["address.city", "uncovered"],
+        ["address.line1", "uncovered"],
+        ["address.postcode", "uncovered"],
+      ),
+      { compact: true },
+    );
     assert.match(renderText(card), /header-count[^>]*>4 fields</);
+  });
+});
+
+// ── Rendering core's tri-state and tier (sl-46wr, sl-csrs) ──────────────────
+//
+// The card received a single boolean per path until these tickets, so a field
+// covered only by a resolved `@ref` was indistinguishable from one no arrow and
+// no prose touches — it simply read as unmapped. ADR-036 requires a consumer to
+// render the declared/NL distinction rather than reconstruct it, which it
+// cannot do from a boolean at all.
+
+describe("sz-schema-card renders the verdict it was given", () => {
+  it("marks a leaf covered only by a resolved @ref as mapped, and says so", async () => {
+    // The `tax_amount` case from sl-46wr: the CLI tags it tier=nl and the card
+    // used to show it as a gap. It must now read as mapped *and* be
+    // distinguishable from a declared hop.
+    const card = await makeCard(
+      [leaf("tax_amount", "DECIMAL")],
+      entries(["tax_amount", "covered", "nl"]),
+    );
+    const text = renderText(card);
+    assert.match(text, /data-coverage="?mapped/);
+    assert.match(text, /data-coverage-tier="?nl/);
+    assert.match(text, /mapped via an @ref in prose/);
+  });
+
+  it("distinguishes a partly covered record from a fully covered one", async () => {
+    // Both render a filled port dot, because "something under here is mapped"
+    // is the threshold the dot has always painted on. Only the tri-state
+    // attribute and the tooltip can tell them apart, so both must carry it.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, ONLY_CITY);
+    const text = renderText(card);
+    assert.match(text, /data-coverage-state="?partial/);
+    assert.match(text, /partly mapped/);
+  });
+
+  it("renders every row unmarked when given no coverage at all", async () => {
+    // A model assembled without a workspace index carries no coverage. That is
+    // "not computed", not "nothing is mapped", so the card must not claim a
+    // verdict it was never given — and must not crash looking one up.
+    const card = await makeCard(AMOUNT_AND_ADDRESS, []);
+    const text = renderText(card);
+    assert.match(text, /data-coverage="?unmapped/);
+    assert.doesNotMatch(text, /data-coverage-tier="?(nl|declared)/);
   });
 });

--- a/tooling/vscode-satsuma/README.md
+++ b/tooling/vscode-satsuma/README.md
@@ -167,7 +167,7 @@ npm run check
 # TextMate grammar tests only
 npm test
 
-# LSP server tests only (142 tests)
+# LSP server tests only (296 tests)
 npm run test:lsp
 
 # Build .vsix locally

--- a/tooling/vscode-satsuma/esbuild.js
+++ b/tooling/vscode-satsuma/esbuild.js
@@ -25,6 +25,21 @@ const serverConfig = {
   format: "cjs",
   sourcemap: true,
   nodePaths: [path.resolve(__dirname, "../satsuma-lsp/node_modules")],
+  // The server is bundled from @satsuma/viz-backend's TypeScript *sources*, not
+  // its dist, so the extension builds without that package having been compiled
+  // first. esbuild's `alias` takes no wildcard, so every subpath the LSP imports
+  // needs its own entry here.
+  //
+  // **This list must mirror the `exports` map in satsuma-viz-backend's
+  // package.json.** A subpath that is missing falls back to the bare-package
+  // alias and has its remainder appended to it, so the error names a path that
+  // was never written anywhere:
+  //
+  //     Cannot read directory "../satsuma-viz-backend/src/index.ts": not a directory
+  //     Could not resolve ".../src/index.ts/coverage" (originally "@satsuma/viz-backend/coverage")
+  //
+  // Nothing but `npm run build` in this package catches it — the unit, fixture
+  // and golden suites never invoke esbuild.
   alias: {
     "@satsuma/viz-backend": path.resolve(__dirname, "../satsuma-viz-backend/src/index.ts"),
     "@satsuma/viz-backend/workspace-index": path.resolve(
@@ -34,6 +49,10 @@ const serverConfig = {
     "@satsuma/viz-backend/viz-model": path.resolve(
       __dirname,
       "../satsuma-viz-backend/src/viz-model.ts",
+    ),
+    "@satsuma/viz-backend/coverage": path.resolve(
+      __dirname,
+      "../satsuma-viz-backend/src/coverage.ts",
     ),
   },
   // web-tree-sitter uses import.meta.url internally (for createRequire and

--- a/tooling/vscode-satsuma/src/commands/action-context.ts
+++ b/tooling/vscode-satsuma/src/commands/action-context.ts
@@ -5,13 +5,32 @@ export interface EditorActionContext {
   schemaName: string | null;
   fieldPath: string | null;
   mappingName: string | null;
+  /**
+   * 0-indexed start row of the enclosing `mapping` block, or null when the cursor
+   * is not inside one.
+   *
+   * Identity, where `mappingName` is only a display label: two namespaces may each
+   * declare `mapping load`, and an anonymous block has no label at all, so a
+   * request carrying the name alone gets whichever block was declared first. Pass
+   * this to `satsuma/mappingCoverage`.
+   */
+  mappingRow: number | null;
   targetSchema: string | null;
 }
+
+/** No cursor context: every field absent rather than a partial shape. */
+const EMPTY_CONTEXT: EditorActionContext = {
+  schemaName: null,
+  fieldPath: null,
+  mappingName: null,
+  mappingRow: null,
+  targetSchema: null,
+};
 
 export async function getEditorActionContext(client: LanguageClient): Promise<EditorActionContext> {
   const editor = vscode.window.activeTextEditor;
   if (!editor || editor.document.languageId !== "satsuma") {
-    return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
+    return EMPTY_CONTEXT;
   }
 
   try {
@@ -23,6 +42,6 @@ export async function getEditorActionContext(client: LanguageClient): Promise<Ed
       },
     });
   } catch {
-    return { schemaName: null, fieldPath: null, mappingName: null, targetSchema: null };
+    return EMPTY_CONTEXT;
   }
 }

--- a/tooling/vscode-satsuma/src/commands/coverage.ts
+++ b/tooling/vscode-satsuma/src/commands/coverage.ts
@@ -114,7 +114,7 @@ export function registerCoverageCommand(
       if (!editor || editor.document.languageId !== "satsuma") return;
 
       const actionContext = await getEditorActionContext(client);
-      const { mappingName } = actionContext;
+      const { mappingName, mappingRow } = actionContext;
 
       if (!mappingName) {
         vscode.window.showWarningMessage(
@@ -125,9 +125,14 @@ export function registerCoverageCommand(
 
       let coverageResult: { schemas: CoverageSchema[] };
       try {
+        // The row is what identifies the mapping; the name is for the messages
+        // below. Sending the name alone reported the first block carrying that
+        // label, so a cursor inside the second of two same-labelled namespace
+        // mappings painted the wrong schema's gutter.
         coverageResult = await client.sendRequest("satsuma/mappingCoverage", {
           uri: editor.document.uri.toString(),
           mappingName,
+          ...(mappingRow !== null ? { mappingRow } : {}),
         });
       } catch {
         vscode.window.showWarningMessage("Could not compute mapping coverage.");


### PR DESCRIPTION
Closes sl-46wr and sl-csrs — the pair blocking Feature 36 (sl-3de8) and the
reason the Feature 38 epic (sl-j6g9) could not close its "CLI, VS Code and viz
report identical figures" criterion.

## The problem

The viz kept a **third derivation** of covered paths — walking the VizModel's
arrows in `satsuma-viz/src/field-coverage.ts` — alongside the CLI's and the
LSP's. It counted declared arrows and nothing else, and two coverage rules are
invisible in an arrow's endpoints:

- a leaf named by a resolved NL `@ref` is covered (ADR-036) — needs the ref
  resolver and the mapping's prose;
- an arrow onto a record covers its whole declared subtree when it enumerates no
  children (ADR-037) — needs the arrow's *declaration kind*.

Both are discarded the moment an arrow becomes a path, so the card silently
under-reported. A sweep over `examples/` found **45 disagreements**;
`examples/contracts/buy-to-om-order.stm` read 7/8 against the CLI's 8/8, the
differing leaf being `tax_amount` (`tier=nl`).

The failure mode matters more than the count: a flat set of paths answers "is
this path covered?" perfectly well while being wrong about what the set should
have contained, so every rule added to coverage had to be implemented twice or
the card drifted again — with no way to notice.

## The fix

Coverage is computed **once**, by core, at model assembly, and travels in the
payload as `MappingBlock.coverage`. The viz selects and counts; it no longer
decides. What `field-coverage.ts` still owns — resolving an arrow's paths against
its containers for hover, highlight and layout — stays, and its tests now assert
on the resolved paths rather than through coverage.

Two decisions worth reviewing explicitly, both recorded in ADR-042:

- **Schemas resolve to the model's own cards**, not to the workspace index the
  LSP uses. The card renders `SchemaCard.fields`, so counting any other tree puts
  a ratio next to rows it does not describe — and it also picks up metric
  endpoints, which the index classifies under a different kind.
- **The path-set API is deleted, deliberately.**
  `fieldCoverageFromCoveredPaths`, `buildCoveredFieldSet` and
  `isCoveredFieldPath` had no consumer left, and they are the shape that made
  this class of bug expressible. Replaced by `uncoveredFieldCoverage`, which
  answers only the degenerate case a card genuinely needs (a schema no mapping
  references still needs a denominator).

## Result: 45 disagreements → 0

`satsuma-cli/test/coverage-viz-parity.test.ts` is a new corpus sweep: for every
mapping the model renders in every `examples/**.stm`, the viz path and
`satsuma coverage` must report the same covered count, denominator and
percentage. It runs both consumer paths in one process — the one place that is
possible. Scope difference is accounted for rather than ignored: `coverage` reads
the whole workspace and a VizModel is one file, so the sweep iterates the viz
side and still fails on a viz mapping the CLI does not have.

Two new fixtures carry the named rules, asserted in both the viz and CLI suites:

- `coverage-nl-tier.stm` — an nl-tier leaf, plus prose without an `@ref` and an
  unresolved `@ref`, so the test fails if coverage rises on either.
- `coverage-whole-structure.stm` — all five conferral forms ADR-037
  distinguishes (bare record-to-record, `list_of record`, empty body, pipe-chain
  body, and the enumerating form that must confer only what it lists) plus
  ADR-038's scalar-into-record case.

## Two incidental fixes found on the way

Both were needed to get the sweep green, and each is its own commit:

- **`fix(coverage): union a leaf's state, not just its mapped flag`** —
  `aggregateCoverage` OR-ed `mapped` but left each leaf's `state` at the first
  mapping's answer, so a leaf one mapping ignores and another writes came out
  `mapped: true, state: "uncovered"`. Latent while only counts were read; wrong
  as soon as a consumer renders the tri-state.
- **`fix(viz): materialise spreads of fragments declared in imported files`** —
  `resolveAndStripSpreads` looked only at the model's own fragments, so
  `multi-source-join.stm`'s `...audit columns` (from `../lib/common.stm`) never
  resolved and its card rendered 26 leaves where the CLI counts 30. The
  cross-file half of what sl-5nsv fixed within a file.

## Verification

- Every package suite green: core 572, viz-model 6, viz-backend 181, viz 119,
  lsp 296, cli 987, vscode 34.
- tree-sitter corpus: 318/318 parses.
- Viz harness Playwright: **99 passed**, run against the rebased tree via the
  watcher protocol.
- `npm run lint` clean; the site builds and renders the corrected figures.

## Also in this PR

`docs: correct the test and command counts` — every documented figure was stale,
several badly (`vscode-satsuma/README.md` said the LSP had 142 tests; it has
296). The command count was not merely stale: `site/cli.njk`'s "All 22 commands"
listing was **missing `coverage` entirely**, so the page documented 22 of the 23
commands that exist. Added a card and verified both directions against
`satsuma --help`.

Feature 36's PRD is updated too: it prescribed the `buildCoveredFieldSet`
approach this PR removes, so R2's "numbers equal `coverage --json`" is now
structural rather than something the overlay has to re-achieve.

## Note on scope

`sl-lctd` (container state counts never reported by the CLI) is the remaining
child of sl-j6g9 and is deliberately **not** here — it touches the CLI's output
and help text, a different surface, and would blur what this PR asks a reviewer
to agree to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)