### PR TITLE
Fix nested field lineage across namespaces

### DIFF
--- a/.tickets/nfl-8o6u.md
+++ b/.tickets/nfl-8o6u.md
@@ -1,6 +1,6 @@
 ---
 id: nfl-8o6u
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-03T11:06:19Z
@@ -15,3 +15,10 @@ CLI graph and field-lineage drop the target namespace when an each/flatten child
 ## Acceptance Criteria
 
 A parser-valid multi-file namespaced seabird example demonstrates nested flatten/each and a two-hop lineage chain. satsuma coverage reports the expected leaf counts and paths. satsuma field-lineage and graph retain qualified schema names through both hops. Shared canonical-ref tests cover bare-schema-prefixed paths for namespaced schemas. Relevant core, CLI, viz-backend, LSP, viz, and VS Code tests pass.
+
+## Notes
+
+**2026-08-03T11:18:02Z**
+
+Cause: Nested container extraction prefixes child targets with the authored bare schema name, but qualifyField treated that as fully qualified and discarded the mapping endpoint namespace; validation likewise recognized only canonical namespaced keys as schema-root targets.
+Fix: Restored the namespace from the resolved mapping endpoint for bare-schema-prefixed paths, accepted bare namespaced schema roots in validation, and added the multi-file seabird regression example and cross-consumer tests. (commit 7944ce71)

--- a/.tickets/nfl-8o6u.md
+++ b/.tickets/nfl-8o6u.md
@@ -1,0 +1,17 @@
+---
+id: nfl-8o6u
+status: in_progress
+deps: []
+links: []
+created: 2026-08-03T11:06:19Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+---
+# Fix nested field lineage through namespaced flatten targets
+
+CLI graph and field-lineage drop the target namespace when an each/flatten child path is prefixed by the bare target schema name. Coverage remains correct, so the VS Code lineage panel can disagree with the viz coverage overlay. Add a canonical multi-file seabird example and lock cross-namespace nested lineage and coverage.
+
+## Acceptance Criteria
+
+A parser-valid multi-file namespaced seabird example demonstrates nested flatten/each and a two-hop lineage chain. satsuma coverage reports the expected leaf counts and paths. satsuma field-lineage and graph retain qualified schema names through both hops. Shared canonical-ref tests cover bare-schema-prefixed paths for namespaced schemas. Relevant core, CLI, viz-backend, LSP, viz, and VS Code tests pass.

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ The CLI requires a `.stm` file entry point (not a directory). The workspace is d
 | [`nested-iteration/`](nested-iteration/) | `pipeline.stm` | Nested `each`/`flatten` sub-blocks mapping hierarchical dispatch events to a courier manifest |
 | [`protobuf-to-parquet/`](protobuf-to-parquet/) | `pipeline.stm` | Protobuf Kafka commerce events to session-level Parquet |
 | [`reports-and-models/`](reports-and-models/) | `pipeline.stm` | Reports, dashboards, and ML models as first-class pipeline consumers |
+| [`seabird-colony-lineage/`](seabird-colony-lineage/) | `platform.stm` | Deeply nested field lineage and coverage across files and namespaces |
 | [`sap-po-to-mfcs/`](sap-po-to-mfcs/) | `pipeline.stm` | SAP ERP purchase order to Oracle MFCS ingestion contract |
 | [`sfdc-to-snowflake/`](sfdc-to-snowflake/) | `pipeline.stm` | Salesforce Opportunity/Account objects to Snowflake analytics |
 | [`xml-to-parquet/`](xml-to-parquet/) | `pipeline.stm` | Commerce order XML to Lakehouse Parquet |

--- a/examples/seabird-colony-lineage/README.md
+++ b/examples/seabird-colony-lineage/README.md
@@ -1,0 +1,30 @@
+# seabird-colony-lineage
+
+Exercises deeply nested field lineage and coverage across file and namespace
+boundaries. A field-tablet survey is flattened into science observations, while
+preserving nested bird-ring records, then flattened again into an analytics fact.
+
+## Key features demonstrated
+
+- A platform entry point importing schemas from three files and namespaces
+- A two-hop field lineage chain across `survey`, `science`, and `mart`
+- `flatten` over nested sightings, with an `each` block preserving nested rings
+- Leaf-only hierarchical coverage with one deliberate source gap
+
+## Entry point and expected results
+
+Use `platform.stm` for platform-wide traversal:
+
+```console
+$ satsuma field-lineage survey::colony_survey.transects.sightings.species_code platform.stm --downstream
+survey::colony_survey.transects.sightings.species_code — 2 lineage connections
+
+  downstream (2):
+    science::colony_observations.observations.species  via science::extract observations  [none]
+    mart::species_fact.species_code  via mart::publish species fact  [none]
+```
+
+The first mapping covers 6/7 source leaves (85%) and all 5 target leaves. The
+second covers 3/5 source leaves (60%) and all 3 target leaves. The only source
+gap in the survey is `transects.transect_ref`; ring fields intentionally stop at
+the science observation schema.

--- a/examples/seabird-colony-lineage/mart.stm
+++ b/examples/seabird-colony-lineage/mart.stm
@@ -1,0 +1,22 @@
+// Analytics mart — flatten observations into one row per species sighting.
+import { science::colony_observations } from "./observations.stm"
+
+namespace mart {
+  schema species_fact (format parquet) {
+    survey_id     UUID
+    species_code  STRING
+    total_birds   INT
+  }
+
+  mapping `publish species fact` {
+    source { science::colony_observations }
+    target { species_fact }
+
+    survey_id -> survey_id
+
+    flatten observations -> species_fact {
+      .species -> species_code
+      .birds -> total_birds
+    }
+  }
+}

--- a/examples/seabird-colony-lineage/observations.stm
+++ b/examples/seabird-colony-lineage/observations.stm
@@ -1,0 +1,35 @@
+// Science observations — preserve sightings and their nested bird rings.
+import { survey::colony_survey } from "./source.stm"
+
+namespace science {
+  schema colony_observations (format json) {
+    survey_id  UUID
+
+    observations list_of record {
+      species  STRING
+      birds    INT
+
+      rings list_of record {
+        identifier  STRING
+        condition   STRING
+      }
+    }
+  }
+
+  mapping `extract observations` {
+    source { survey::colony_survey }
+    target { colony_observations }
+
+    survey_id -> survey_id
+
+    flatten transects.sightings -> observations {
+      .species_code -> .species
+      .adults, .chicks -> .birds { "Sum the adult and chick counts" }
+
+      each rings -> .rings {
+        .ring_id -> .identifier
+        .condition -> .condition
+      }
+    }
+  }
+}

--- a/examples/seabird-colony-lineage/platform.stm
+++ b/examples/seabird-colony-lineage/platform.stm
@@ -1,0 +1,4 @@
+// Platform entry point — imports the schemas whose mappings form the lineage graph.
+import { survey::colony_survey } from "./source.stm"
+import { science::colony_observations } from "./observations.stm"
+import { mart::species_fact } from "./mart.stm"

--- a/examples/seabird-colony-lineage/source.stm
+++ b/examples/seabird-colony-lineage/source.stm
@@ -1,0 +1,22 @@
+// Seabird colony survey — nested source owned by the field team.
+
+namespace survey {
+  schema colony_survey (format json) {
+    survey_id  UUID
+
+    transects list_of record {
+      transect_ref  STRING
+
+      sightings list_of record {
+        species_code  STRING
+        adults        INT
+        chicks        INT
+
+        rings list_of record {
+          ring_id    STRING
+          condition  STRING
+        }
+      }
+    }
+  }
+}

--- a/tooling/satsuma-cli/test/coverage.test.ts
+++ b/tooling/satsuma-cli/test/coverage.test.ts
@@ -29,6 +29,10 @@ const NESTED = resolve(__dirname, "fixtures/unmapped-nested.stm");
 // `flatten` inside them. Fully mapped apart from one deliberately unread field,
 // which makes it the reference case for nested container coverage (sl-qzy3).
 const NESTED_ITERATION = resolve(__dirname, "../../../examples/nested-iteration/pipeline.stm");
+const SEABIRD_PLATFORM = resolve(
+  __dirname,
+  "../../../examples/seabird-colony-lineage/platform.stm",
+);
 const NESTED_ARROW = resolve(__dirname, "fixtures/nested-arrow-lookup.stm");
 // Two source schemas declaring the same field names, arrows qualified by schema
 // and written inside a namespace — the pairing that exercises prefix resolution
@@ -100,6 +104,34 @@ function schemaEntry(data: any, mapping: string, role: string, schema: string): 
 // ── Default report ──────────────────────────────────────────────────────────
 
 describe("satsuma coverage — default report", () => {
+  it("reports the expected nested leaf coverage across the seabird platform imports", async () => {
+    // This is the end-to-end contract shared with lineage: deeply nested paths
+    // retain their full identity while mappings cross file and namespace
+    // boundaries. The deliberately unread transect_ref is the only source gap.
+    const { stdout, stderr, code } = await run("coverage", SEABIRD_PLATFORM, "--json");
+    assert.equal(code, 0, stderr);
+    const report = parseJson(stdout);
+    const extracted = schemaEntry(
+      report,
+      "science::extract observations",
+      "source",
+      "survey::colony_survey",
+    );
+    assert.deepEqual([extracted.covered, extracted.total, extracted.pct], [6, 7, 85]);
+    assert.deepEqual(
+      extracted.fields.filter((field: any) => !field.mapped).map((field: any) => field.path),
+      ["transects.transect_ref"],
+    );
+
+    const published = schemaEntry(
+      report,
+      "mart::publish species fact",
+      "target",
+      "mart::species_fact",
+    );
+    assert.deepEqual([published.covered, published.total, published.pct], [3, 3, 100]);
+  });
+
   it("reports every named mapping in the workspace, not just the entry file's first", async () => {
     // The command's reason to exist is a workspace-wide answer; reporting one
     // mapping would leave the caller composing the rest by hand.

--- a/tooling/satsuma-cli/test/field-lineage.test.ts
+++ b/tooling/satsuma-cli/test/field-lineage.test.ts
@@ -15,6 +15,10 @@ import { run as _run } from "./helpers.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLI = resolve(__dirname, "../dist/index.js");
 const FIXTURES = resolve(__dirname, "fixtures");
+const SEABIRD_PLATFORM = resolve(
+  __dirname,
+  "../../../examples/seabird-colony-lineage/platform.stm",
+);
 
 const run = (...args: string[]) => _run(CLI, ...args);
 
@@ -284,6 +288,50 @@ describe("field-lineage — NL @refs inside containers (sl-hrql, sl-ez36)", () =
       targets,
       ["::mfcs_purchase_order.items.orderedQty"],
       "nl and nl-derived edges for one arrow must name one target field",
+    );
+  });
+});
+
+describe("field-lineage — nested fields across files and namespaces (nfl-8o6u)", () => {
+  it("validates the documented namespaced flatten target without a field warning", async () => {
+    // A top-level flatten may name its target schema. Inside a namespace the
+    // authored bare name and resolved qualified key are the same endpoint, so
+    // the canonical example must validate cleanly before its lineage is trusted.
+    const { stdout, stderr, code } = await run("validate", SEABIRD_PLATFORM, "--json");
+    assert.equal(code, 0, stderr);
+    assert.deepEqual(JSON.parse(stdout).findings, []);
+  });
+
+  it("traces a nested source leaf through two imported namespaced mappings", async () => {
+    // The first mapping preserves a nested path while the second flatten uses
+    // the bare target schema name. Losing `mart::` on that child target breaks
+    // the chain even though coverage correctly counts the same arrow.
+    const { stdout, stderr, code } = await run(
+      "field-lineage",
+      "survey::colony_survey.transects.sightings.species_code",
+      SEABIRD_PLATFORM,
+      "--json",
+      "--downstream",
+    );
+    assert.equal(code, 0, stderr);
+    assert.deepEqual(
+      JSON.parse(stdout).downstream.map((edge: any) => edge.field),
+      ["science::colony_observations.observations.species", "mart::species_fact.species_code"],
+    );
+  });
+
+  it("exports the same namespaced child target from the graph command", async () => {
+    // `graph` has its own edge builder. Locking this consumer separately keeps
+    // exported graph data from reintroducing the phantom global schema that
+    // field-lineage no longer follows.
+    const { stdout, stderr, code } = await run("graph", SEABIRD_PLATFORM, "--json");
+    assert.equal(code, 0, stderr);
+    const speciesEdges = JSON.parse(stdout).edges.filter((edge: any) =>
+      edge.from.endsWith("observations.species"),
+    );
+    assert.deepEqual(
+      speciesEdges.map((edge: any) => edge.to),
+      ["mart::species_fact.species_code"],
     );
   });
 });

--- a/tooling/satsuma-core/src/canonical-ref.ts
+++ b/tooling/satsuma-core/src/canonical-ref.ts
@@ -49,7 +49,8 @@ export function canonicalEntityName(entity: {
  *
  * Handles the field forms emitted by arrow and NL-ref extraction:
  * - `.field` paths inherit the first schema and drop the leading dot.
- * - `schema.field` and `ns::schema.field` paths are already qualified.
+ * - `schema.field` paths inherit a namespace from the matching mapping schema.
+ * - `ns::schema.field` paths are already fully qualified.
  * - Bare fields are attached to the first schema in the mapping side.
  */
 export function qualifyField(field: string, schemas: string[]): string {
@@ -67,7 +68,7 @@ export function qualifyField(field: string, schemas: string[]): string {
     for (const schema of schemas) {
       const nsIdx = schema.indexOf("::");
       const bare = nsIdx !== -1 ? schema.slice(nsIdx + 2) : schema;
-      if (bare === prefix) return field;
+      if (bare === prefix) return `${schema}${field.slice(dotIdx)}`;
     }
   }
 

--- a/tooling/satsuma-core/src/validate.ts
+++ b/tooling/satsuma-core/src/validate.ts
@@ -1240,6 +1240,13 @@ function qualifiedSourceSchema(path: string, schemaNames: string[]): string | nu
   );
 }
 
+/** Whether an authored schema reference names a resolved schema key. */
+function matchesResolvedSchema(reference: string, resolvedKey: string): boolean {
+  if (reference === resolvedKey) return true;
+  const namespaceSeparator = resolvedKey.indexOf("::");
+  return namespaceSeparator !== -1 && resolvedKey.slice(namespaceSeparator + 2) === reference;
+}
+
 /**
  * Pick the schema to blame in a field-not-in-schema message: a qualified path
  * (s2.created_at) blames the schema it is qualified with; anything else
@@ -1268,7 +1275,7 @@ function resolveFieldPath(
 ): boolean {
   if (path.startsWith(".")) return true;
   if (fieldPaths.has(path)) return true;
-  if (schemaNames.includes(path)) return true;
+  if (schemaNames.some((schemaName) => matchesResolvedSchema(path, schemaName))) return true;
 
   const matchedSchema = qualifiedSourceSchema(path, schemaNames);
   if (matchedSchema) {

--- a/tooling/satsuma-core/test/canonical-ref.test.js
+++ b/tooling/satsuma-core/test/canonical-ref.test.js
@@ -55,8 +55,11 @@ describe("qualifyField()", () => {
     assert.equal(qualifyField(".address.street", ["customers"]), "customers.address.street");
   });
 
-  it("leaves fields qualified by a namespace-qualified schema name unchanged", () => {
-    assert.equal(qualifyField("customers.id", ["crm::customers"]), "customers.id");
+  it("restores the namespace on a field prefixed by a namespaced schema's bare name", () => {
+    // Container extraction prefixes flatten children with the authored target
+    // schema (`customers.id`). That is not canonical until the namespace from
+    // the mapping endpoint has been restored.
+    assert.equal(qualifyField("customers.id", ["crm::customers"]), "crm::customers.id");
   });
 
   it("leaves fully namespace-qualified field paths unchanged", () => {

--- a/tooling/satsuma-core/test/validate.test.js
+++ b/tooling/satsuma-core/test/validate.test.js
@@ -310,6 +310,42 @@ describe("metric source reference diagnostics", () => {
 // ---------- Section 6: Arrow field references ----------
 
 describe("arrow field-not-in-schema diagnostics", () => {
+  it("accepts a namespaced target schema's bare name as a flatten root", () => {
+    // A flatten header targets the schema root, and authors inside that
+    // namespace may use its bare name. Treating only the canonical key as the
+    // root produces a false warning before any child arrow is considered.
+    const index = makeIndex({
+      schemas: [
+        { name: "source", namespace: "survey", fields: [{ name: "items", type: "list" }] },
+        { name: "fact", namespace: "mart", fields: [{ name: "value", type: "INT" }] },
+      ],
+      mappings: [
+        {
+          name: "publish",
+          namespace: "mart",
+          sources: ["survey::source"],
+          targets: ["fact"],
+        },
+      ],
+      fieldArrows: [
+        {
+          mapping: "publish",
+          namespace: "mart",
+          sources: ["items"],
+          target: "fact",
+          steps: [],
+          line: 5,
+          file: "test.stm",
+        },
+      ],
+    });
+
+    const fieldDiags = collectSemanticDiagnostics(index).filter(
+      (diagnostic) => diagnostic.rule === "field-not-in-schema",
+    );
+    assert.deepEqual(fieldDiags, []);
+  });
+
   it("warns when an arrow source field is not declared in the source schema", () => {
     // Arrow paths that don't match any declared field are almost always typos.
     // The check fires only when the source schema is known and has no unresolved spreads.

--- a/tooling/vscode-satsuma/test/viz-integration.test.js
+++ b/tooling/vscode-satsuma/test/viz-integration.test.js
@@ -155,7 +155,13 @@ describe("loadExpandedModels", () => {
 });
 
 describe("buildFieldLineagePath", () => {
-  it("builds the schema.field path emitted from a viz field-lineage action", () => {
-    assert.equal(buildFieldLineagePath("customers", "email"), "customers.email");
+  it("preserves namespace and nesting in the path emitted by a viz field-lineage action", () => {
+    // The VS Code panel passes this value directly to `satsuma field-lineage`.
+    // Dropping either part would make a valid nested field resolve to a phantom
+    // global schema or a same-named leaf elsewhere in the workspace.
+    assert.equal(
+      buildFieldLineagePath("science::colony_observations", "observations.rings.identifier"),
+      "science::colony_observations.observations.rings.identifier",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- retain target namespaces when nested each/flatten paths use the authored bare schema name
- recognize those schema-root paths during validation
- add a canonical four-file seabird-colony lineage example
- cover CLI field-lineage, graph, coverage, core canonicalization, validation, and VS Code viz click-through

## Verification

- full repository pre-commit checks pass
- satsuma-core: 591 tests pass
- satsuma-cli: 1002 tests pass
- satsuma-lsp: 299 tests pass
- vscode-satsuma: 34 tests pass
- tree-sitter corpus: 318/318 pass with --wasm
- Python parser/smoke suites: 39 tests + 1172 subtests and 50 BDD scenarios pass

## Architecture

No ADR is warranted: this restores the existing shared-core canonical-reference contract and aligns with ADR-020 and ADR-039 rather than introducing or superseding an architectural decision.

Ticket: nfl-8o6u