### PR TITLE
Viz exploratory testing: 7 findings + Feature 40 (shared field lineage view)

### DIFF
--- a/.tickets/sl-12kz.md
+++ b/.tickets/sl-12kz.md
@@ -1,0 +1,17 @@
+---
+id: sl-12kz
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:24:14Z
+type: epic
+priority: 2
+assignee: Thorben Louw
+tags: [viz, field-lineage]
+---
+# Feature 40 — shared field lineage view
+
+Field lineage is the only viz surface with no test surface. The renderer lives only in vscode-satsuma (560-line renderer + 284-line panel + 330-line CSS, zero tests); the traversal lives in satsuma-cli/src/commands/field-lineage.ts coupled to CLI-only modules, so no browser host can call it. See features/40-shared-field-lineage-view/PRD.md.
+
+Outcome: one browser-portable traversal, one sz-field-lineage component rendered by BOTH the VS Code panel and the viz harness, and Playwright coverage for the lineage view.
+

--- a/.tickets/sl-4871.md
+++ b/.tickets/sl-4871.md
@@ -1,0 +1,25 @@
+---
+id: sl-4871
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:24:14Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-12kz
+tags: [field-lineage]
+---
+# Spike: determine the portable home for the field-lineage traversal
+
+field-lineage.ts imports four CLI-internal modules (index-builder, nl-ref-extract, spread-expand, load-workspace) plus command-runner/option-parsers. Before moving any code, report which of these are themselves portable and therefore whether the traversal belongs in satsuma-core (logic-only) or satsuma-viz-backend (workspace-index-dependent, already declared zero-Node-built-ins).
+
+Deliverable is a written finding on the epic, not a refactor.
+
+## Acceptance Criteria
+
+- Each of the four CLI-internal dependencies is classified portable / must-move / can-be-parameterised.
+- A target package is recommended with reasons.
+- The ExtractedWorkspace coupling is addressed: state what workspace shape the extracted function should take so both the CLI and the in-browser client can supply it.
+- No production code committed by this ticket.
+

--- a/.tickets/sl-7ind.md
+++ b/.tickets/sl-7ind.md
@@ -1,0 +1,25 @@
+---
+id: sl-7ind
+status: open
+deps: [sl-v3w5]
+links: []
+created: 2026-08-03T12:24:35Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-12kz
+tags: [vscode, field-lineage]
+---
+# VS Code panel renders sz-field-lineage; delete the duplicate renderer
+
+Repoint FieldLineagePanel at the shared component and remove the VS Code-only rendering path: field-lineage.ts (560 lines) and field-lineage.css (330 lines).
+
+Closing this ticket is what makes the feature a consolidation rather than an addition -- if the old renderer survives, the repo has two lineage renderers and the drift risk the feature exists to remove.
+
+## Acceptance Criteria
+
+- FieldLineagePanel renders sz-field-lineage.
+- vscode-satsuma/src/webview/field-lineage/field-lineage.ts and field-lineage.css are DELETED, not left unused.
+- Verified in a real VS Code session: the panel renders and matches the pre-port reference screenshots.
+- Exactly one lineage renderer exists in the repo afterwards.
+

--- a/.tickets/sl-f0x6.md
+++ b/.tickets/sl-f0x6.md
@@ -1,0 +1,33 @@
+---
+id: sl-f0x6
+status: open
+deps: []
+links: [sl-j6g9]
+created: 2026-08-03T12:31:53Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, ui, coverage]
+---
+# viz schema card: partial container coverage is visually identical to fully mapped
+
+Hierarchical coverage distinguishes four states, but the schema card's port dot renders only three. A record whose subtree is PARTLY covered gets the same solid filled dot as a record that is fully covered, so a reader scanning a card cannot see partial coverage at all.
+
+Evidence in satsuma-viz/src/components/sz-schema-card.ts:
+- The row computes portClass = unavailable ? 'unknown' : isMapped ? 'mapped' : 'unmapped' (line ~760), where isMapped is entry.mapped -- true for BOTH 'covered' and 'partial'.
+- The CSS defines exactly three port styles (lines 186-202): .port.mapped (solid fill), .port.unmapped (hollow ring), .port.unknown (dashed, faded). There is no .port.partial.
+- The state IS known and IS exposed to automation: the row sets data-coverage-state to the real value including 'partial'.
+- 'partial' currently reaches the human only through hover text: _fieldTitle appends '-- partly ...' (line 952) and the card ratio title appends '-- N records partly mapped' (lines 965-967). Both require hovering the exact element.
+
+Observed on examples/filter-flatten-governance/filter-flatten-governance.stm, mapping order-line-facts: the probe recorded 3 fields at state 'partial' tier 'declared' (and 1 partial/nl), all rendering an indistinguishable filled dot. In the captured screenshot the 'customer' record shows a solid dot while two of its three children are hollow.
+
+This undercuts the point of Feature 38 (epic sl-j6g9): the partial state is computed and carried through core, then discarded at the last rendering step. Note the .port.unknown comment already reasons carefully about needing a third state visually distinct from the other two -- the same argument applies to partial, which never got one.
+
+## Acceptance Criteria
+
+- A container at state 'partial' renders a port dot visually distinct from both 'covered' and 'uncovered' (e.g. a half-filled or ringed-and-filled dot), in light and dark themes.
+- The distinction survives at the rendered port size; it must be discernible without hovering and without zooming.
+- portClass derives from the coverage STATE, not from the boolean mapped, so a future fifth state cannot silently collapse into an existing style.
+- A test asserts the partial port class for a minimal snippet where one record has some covered and some uncovered children.
+- The existing hover text is kept as the detailed explanation, not removed.
+

--- a/.tickets/sl-fncf.md
+++ b/.tickets/sl-fncf.md
@@ -1,0 +1,32 @@
+---
+id: sl-fncf
+status: open
+deps: []
+links: []
+created: 2026-08-03T11:29:07Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz-harness, security]
+---
+# Viz harness servers bind all interfaces instead of loopback
+
+Both harness HTTP servers call listen(PORT) with no host argument, so Node binds 0.0.0.0/:: (all interfaces) rather than loopback. While a test run or dev session is in progress, ports 3333 and 3334 are reachable from any host on the same network.
+
+Exposed surface on 3333: GET /api/fixtures (absolute filesystem paths of every .stm under examples/) and GET /api/source?uri=... (full source text of any discovered fixture). Port 3334 serves the assembled static playground bundle.
+
+The fixture API is allowlist-keyed by discovered URI, so this is not a path-traversal or arbitrary-file-read issue -- the impact is bounded to disclosing local example/corpus content plus absolute paths to the local network. Low severity, but neither server has any reason to be off-box: the harness is a single-machine Playwright/dev tool and its own log lines already say http://localhost.
+
+Sites:
+- tooling/satsuma-viz-harness/src/server.ts:276
+- tooling/satsuma-viz-harness/scripts/serve-playground.mjs:69
+
+Found during a security review of the agent viz-testing workflow.
+
+## Acceptance Criteria
+
+- Both servers bind loopback explicitly: listen(PORT, "127.0.0.1").
+- A comment at each call site states why loopback is deliberate (single-machine harness; do not widen without a reason).
+- Playwright suites still pass unchanged: baseURL http://localhost:3333 and http://localhost:3334 resolve to loopback, so no test needs editing.
+- A unit test or assertion covers the bind host so a future edit cannot silently re-widen it.
+

--- a/.tickets/sl-hhdk.md
+++ b/.tickets/sl-hhdk.md
@@ -1,0 +1,26 @@
+---
+id: sl-hhdk
+status: open
+deps: [sl-v3w5, sl-prlp]
+links: []
+created: 2026-08-03T12:24:35Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-12kz
+tags: [viz-harness, field-lineage]
+---
+# Surface field lineage in the viz harness and cover it with Playwright
+
+The harness already receives the field-lineage event (src/client/app.ts:423) and only logs it. Make it call traceFieldLineage in-browser against the library-backed workspace it already assembles, and render sz-field-lineage.
+
+Must not introduce a server round-trip: playground-static.test.ts asserts editing/opening/saving complete with ZERO network requests, and that guarantee has to hold.
+
+## Acceptance Criteria
+
+- Clicking a field's lineage icon in the harness renders the lineage view.
+- A Playwright test asserts the rendered upstream/downstream entries for a known fixture field that has both directions populated.
+- Empty-upstream, empty-downstream and unknown-field states each have a test.
+- The zero-network-request assertion in playground-static.test.ts still passes.
+- The lineage view is captured light and dark in the screenshots project.
+

--- a/.tickets/sl-j6g9.md
+++ b/.tickets/sl-j6g9.md
@@ -2,7 +2,7 @@
 id: sl-j6g9
 status: open
 deps: [sl-joeq]
-links: [sl-joeq]
+links: [sl-joeq, sl-f0x6]
 created: 2026-07-31T14:42:52Z
 type: epic
 priority: 1

--- a/.tickets/sl-jetk.md
+++ b/.tickets/sl-jetk.md
@@ -1,0 +1,26 @@
+---
+id: sl-jetk
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:30:45Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [viz, ui]
+---
+# viz mapping detail: a mapping with no field arrows renders a bare table header and empty body
+
+Report and model consumer mappings legitimately declare no field arrows -- they declare source {schemas} and target {schema} only. In the mapping detail view these render an arrow table consisting of a header row (Source / Transform / Target) with nothing beneath it, which reads as a broken or half-loaded panel rather than a deliberate 'this consumer has no field-level arrows' state.
+
+Observed on examples/reports-and-models/pipeline.stm for both _weekly_sales_dashboard_report and _churn_predictor_pipeline (0 arrow rows each). That file's stated purpose is to demonstrate reports and models as first-class pipeline consumers, so this empty-header rendering IS the primary presentation of the documented pattern.
+
+Root cause: satsuma-viz/src/components/sz-mapping-detail.ts _renderArrowTable (line 670) always emits <thead> with the four column headers, and <tbody> receives nothing when arrows, eachBlocks, flattenBlocks and nestedArrows are all empty. There is no empty-state branch.
+
+## Acceptance Criteria
+
+- A mapping whose arrows, eachBlocks, flattenBlocks and nestedArrows are all empty renders a defined empty state instead of a bare header, explaining that the mapping declares no field-level arrows.
+- The column headers are not shown when there are no rows to head.
+- A test covers the empty case using a minimal report/model mapping snippet (not the whole example file).
+- The non-empty case is unchanged.
+

--- a/.tickets/sl-k7i4.md
+++ b/.tickets/sl-k7i4.md
@@ -1,0 +1,26 @@
+---
+id: sl-k7i4
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:30:52Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [viz, ui]
+---
+# viz mapping detail: sourceless derived arrows render an indistinguishable empty Source cell
+
+Satsuma allows a target-only arrow with no source field -- e.g. '-> is_closed { "True if @StageName is Closed_Won or Closed_Lost, false otherwise." }' in examples/sfdc-to-snowflake/pipeline.stm. In the mapping detail arrow table this renders as a completely blank Source cell, visually identical to a rendering failure. Nothing marks it as a deliberate derived value.
+
+Observed in the opportunity-ingestion detail view: the Source column reads Id, AccountId, Name, Amount, Amount, ARR_Override__c, StageName, <blank>, CloseDate, SystemModStamp. A reader cannot tell the blank row from a dropped source path, and the two consecutive 'Amount' rows just above it (legitimately two arrows off the same source) make the column look unreliable.
+
+Sourceless arrows are a first-class construct, so they deserve a first-class presentation.
+
+## Acceptance Criteria
+
+- An arrow with no source field renders an explicit marker in the Source cell (e.g. a muted 'derived' label) rather than empty space.
+- The marker is visually distinct from a real field path and does not read as a field name.
+- A test asserts the marker for a minimal sourceless-arrow snippet.
+- Arrows that do have sources are unchanged.
+

--- a/.tickets/sl-kap8.md
+++ b/.tickets/sl-kap8.md
@@ -1,0 +1,29 @@
+---
+id: sl-kap8
+status: open
+deps: []
+links: []
+created: 2026-08-03T11:35:29Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+tags: [viz-harness, tooling, agent-workflow]
+---
+# Viz harness watcher runs a stale bundle: watch-and-test.sh bypasses the pretest build
+
+watch-and-test.sh runs 'npx playwright test' directly. The harness package rebuilds only via the npm 'pretest' hook ('npm run build'), which npx bypasses entirely. So the sentinel workflow documented in CLAUDE.md (touch .run-tests) exercises whatever is already in tooling/satsuma-viz-harness/dist/ -- not the current source.
+
+Observed today on a clean main: dist/client/satsuma-viz.js was dated 14 Jul while tooling/satsuma-viz/dist/satsuma-viz.js was dated 3 Aug. The harness bundle did not contain the string 'data-coverage-state' at all, even though sz-schema-card.ts has emitted that attribute since PR #430 (coverage-via-core, ADR-042). A full 127-test run reported green against that three-week-old bundle.
+
+Impact: the harness's green result is not evidence about current code, and it is silently not evidence -- nothing in the output says the bundle is stale. Every agent following the documented sentinel workflow inherits this. It also invalidates the harness as a gate for exactly the recent viz work it should be covering (coverage rendering, field lineage).
+
+playwright.config.ts compounds it: webServer runs 'node dist/server.js', so a stale server binary is served too.
+
+## Acceptance Criteria
+
+- The sentinel workflow rebuilds before running: watch-and-test.sh invokes 'npm test' (which fires pretest -> build), or runs 'npm run build' explicitly before 'npx playwright test'.
+- Build failures are surfaced in .playwright-results.txt rather than silently falling through to a stale-bundle run.
+- .playwright-results.txt records what was built (e.g. the build step's output), so a reader can tell a fresh run from a stale one.
+- CLAUDE.md's viz-harness section states that the watcher rebuilds, so no agent assumes it must rebuild by hand.
+- Verified by touching a string in tooling/satsuma-viz/src and confirming it reaches the browser in the next sentinel-triggered run without any manual build.
+

--- a/.tickets/sl-prlp.md
+++ b/.tickets/sl-prlp.md
@@ -1,0 +1,26 @@
+---
+id: sl-prlp
+status: open
+deps: [sl-4871]
+links: []
+created: 2026-08-03T12:24:14Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-12kz
+tags: [field-lineage]
+---
+# Extract traceFieldLineage into a browser-portable package; CLI delegates
+
+Move the traversal out of satsuma-cli/src/commands/field-lineage.ts into the package chosen by the spike, as a pure traceFieldLineage(workspace, fieldRef, {depth, direction}) function. The command becomes a thin adapter: parse args, load workspace, call, format.
+
+FieldLineageResult must keep the shape the CLI's --json already emits (field, upstream[], downstream[] with field/via_mapping/classification) because the VS Code panel consumes it today.
+
+## Acceptance Criteria
+
+- traceFieldLineage has no Node built-in (fs/path/url) on its import path, asserted by a test over the module graph.
+- The 17 existing tests in satsuma-cli/test/field-lineage.test.ts pass UNCHANGED.
+- satsuma field-lineage output is byte-identical for every case those tests cover.
+- No second copy of the traversal remains in the CLI.
+- Cycle detection and the --depth limit move with the traversal and stay covered.
+

--- a/.tickets/sl-v3w5.md
+++ b/.tickets/sl-v3w5.md
@@ -1,0 +1,26 @@
+---
+id: sl-v3w5
+status: open
+deps: [sl-prlp]
+links: []
+created: 2026-08-03T12:24:35Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-12kz
+tags: [viz, field-lineage]
+---
+# Add sz-field-lineage Lit component to satsuma-viz
+
+Port the 560-line VS Code DOM renderer (vscode-satsuma/src/webview/field-lineage/field-lineage.ts) to a Lit component in satsuma-viz, alongside the other sz-* components. It takes a FieldLineageResult and renders the upstream and downstream chains.
+
+The existing renderer has no tests, so parity cannot be checked against anything automated -- capture screenshots of the live VS Code panel first and use them as the visual reference.
+
+## Acceptance Criteria
+
+- sz-field-lineage renders upstream and downstream chains from a FieldLineageResult.
+- Every chain entry carries a data-testid following the sz-schema-card pattern so Playwright can address it.
+- All colours come from tokens.css; the component renders correctly in light and dark.
+- Defined states for: no upstream, no downstream, unknown field, and a cyclic chain.
+- Unit/DOM tests cover each of those states.
+

--- a/.tickets/sl-zsv6.md
+++ b/.tickets/sl-zsv6.md
@@ -1,0 +1,26 @@
+---
+id: sl-zsv6
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:30:34Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+tags: [viz, ui]
+---
+# viz toolbar: title wraps to two lines and the trailing file filter is clipped at 1440px
+
+With the full toolbar rendered (title, Show File Notes, Fit, Refresh, Export SVG, namespace filter, file filter) the title '(*) Mapping Viz' breaks onto two lines ('Mapping' / 'Viz') and the trailing 'All files' select is pushed past the right edge. Observed in the harness at its default 1440x900 viewport with the source pane open, on examples/namespaces/ns-platform.stm (the fixture that renders the most toolbar controls, because namespace and file filters both appear).
+
+Root cause is in satsuma-viz/src/satsuma-viz.ts: .toolbar (line 465) is display:flex with no flex-wrap and no overflow handling. .toolbar-btn (line 494) sets white-space:nowrap so the buttons hold their width, but .toolbar-title (line 479) sets neither white-space:nowrap nor flex-shrink:0. The title is therefore the only flex item that can absorb the overflow, so it shrinks and wraps while the last select overflows the container.
+
+This is the viz component's own toolbar, so it affects the VS Code webview and the site playground at narrow widths too, not just the harness.
+
+## Acceptance Criteria
+
+- .toolbar-title does not wrap: it keeps one line at every viewport width.
+- The trailing file filter stays inside the toolbar's box, or the toolbar scrolls/collapses deliberately rather than overflowing.
+- A Playwright assertion covers it: at 1440x900 with the source pane open on ns-platform.stm, the title element's scrollHeight equals a single line height and the last toolbar control's right edge is within the toolbar's client box.
+- Verified in both light and dark themes.
+

--- a/features/40-shared-field-lineage-view/PRD.md
+++ b/features/40-shared-field-lineage-view/PRD.md
@@ -1,0 +1,183 @@
+# Feature 40 — Shared Field Lineage View
+
+> **Status: PROPOSED** (raised 2026-08-03) — found while assessing whether the
+> viz harness can visually exercise the four viz surfaces (overview, mapping
+> detail, coverage, field lineage). The first three are reachable from the
+> harness. Field lineage is not reachable from anywhere that can be tested.
+>
+> **State this PRD was checked against:** `main` at `dd5ac032`.
+>
+> **Recommendation.** Proceed. The traversal moves to a browser-portable
+> package, the view becomes one component in `satsuma-viz`, and both hosts
+> render it. This is a consolidation, not new product surface: it deletes a
+> duplicate rendering path and a subprocess round-trip rather than adding
+> features.
+>
+> **What this feature is not.** It changes no Satsuma syntax, adds no new
+> lineage semantics, and does not alter what `satsuma field-lineage` prints.
+> The CLI's observable output is a fixed contract here.
+
+## Goal
+
+Make field lineage a first-class, testable view rendered by one component, so
+that the lineage a VS Code user sees is the lineage a test can assert on.
+
+1. The lineage traversal is callable from a browser bundle, not only from a
+   Node CLI process.
+2. One renderer serves both the VS Code panel and the viz harness.
+3. The lineage view is covered by automated tests, including visual/DOM tests in
+   the Playwright harness.
+
+## Background — measured state
+
+### Field lineage is the only viz surface with no test surface
+
+`satsuma-viz` emits a `field-lineage` event when the user clicks the lineage
+icon on a schema-card field row (`satsuma-viz/src/satsuma-viz.ts:173` defines
+`SzFieldLineageEvent`; `sz-schema-card.ts:1053` dispatches it). What happens
+next depends entirely on the host:
+
+| Host | Response to `field-lineage` | Test coverage |
+|---|---|---|
+| VS Code extension | `webview/viz/viz.ts:49` forwards it as a `fieldLineage` message; `webview/viz/panel.ts:175` opens `FieldLineagePanel`, which **shells out** to `satsuma field-lineage <field> <entry.stm> --json` and renders the result in its own webview | none |
+| Viz harness | `src/client/app.ts:423` records the event in the harness event log and renders nothing | one test, asserting only that the event fires (`harness.test.ts:297`) |
+
+Line counts for the VS Code-only lineage UI:
+
+| File | Lines | Tests |
+|---|---|---|
+| `vscode-satsuma/src/webview/field-lineage/field-lineage.ts` (renderer) | 560 | 0 |
+| `vscode-satsuma/src/webview/field-lineage/panel.ts` (host + subprocess) | 284 | 0 |
+| `vscode-satsuma/src/webview/field-lineage/field-lineage.css` | 330 | — |
+
+No file under `tooling/vscode-satsuma/test/` references field lineage. So 844
+lines of lineage UI ship with no automated test of any kind, and the only place
+that *could* test a browser-rendered lineage view — the Playwright harness —
+has nothing to render.
+
+By contrast the traversal itself is reasonably covered:
+`satsuma-cli/test/field-lineage.test.ts` holds 17 tests.
+
+### The traversal cannot reach a browser
+
+`satsuma-cli/src/commands/field-lineage.ts` is 336 lines and mixes the
+traversal with CLI plumbing. Its imports:
+
+| Import | Why it blocks a browser bundle |
+|---|---|
+| `../load-workspace.js` | reads the workspace from disk (Node `fs`) |
+| `../command-runner.js` | process exit codes, `CommandError` |
+| `../option-parsers.js` | commander option parsing |
+| `../index-builder.js` (`resolveIndexKey`, `canonicalKey`, `distinctArrowRecords`) | CLI-internal index representation |
+| `../nl-ref-extract.js` (`resolveAllNLRefs`) | CLI-internal |
+| `../spread-expand.js` (`expandEntityFields`) | CLI-internal |
+| `@satsuma/core` (`collectFieldNames`, `findFieldByPath`, `qualifyField`) | already portable |
+| `../types.js` (`ExtractedWorkspace`) | CLI-internal workspace shape |
+
+The harness client cannot call any of this. It is deliberately server-free: the
+client builds VizModels in-browser via `@satsuma/viz-backend`
+(`viz-harness/src/client/model-pipeline.ts:17`), and
+`playground-static.test.ts:100` asserts that editing, opening, and saving
+complete with **zero** network requests. Shelling out to the CLI is not
+available to it, and adding a lineage HTTP endpoint would contradict that
+guarantee.
+
+This is also a violation of the Core vs Consumer rule in `CLAUDE.md`: lineage
+traversal is needed by the CLI, the VS Code extension, and the harness, so it
+does not belong in a consumer package.
+
+### There is already a portable home
+
+`satsuma-viz-backend` is explicitly browser-portable. `workspace-index.ts`
+opens by stating it has "zero Node built-in imports (no `path`/`url`/`fs`)"
+precisely so one code path can serve the CLI, LSP, and the in-browser
+playground. That, or `satsuma-core`, is where the traversal belongs.
+
+## Design
+
+### 1. Extract the traversal (`@satsuma/core` or `@satsuma/viz-backend`)
+
+Introduce a pure function with no Node dependencies:
+
+```
+traceFieldLineage(workspace, fieldRef, { depth, direction }): FieldLineageResult
+```
+
+`FieldLineageResult` keeps the shape the CLI's `--json` already emits (`field`,
+`upstream[]`, `downstream[]`, each entry carrying `field`, `via_mapping`,
+`classification`), because that shape is a published contract consumed by the
+VS Code panel today.
+
+The CLI command becomes a thin adapter: parse args, load the workspace, call
+the extracted function, format output. Its 17 existing tests must pass
+unchanged — they are the regression gate for the extraction.
+
+Placement decision (to be settled in the first ticket, not here): the traversal
+needs an index and NL-ref resolution that currently live in CLI-internal
+modules. If those are themselves portable, `satsuma-core` is the right home; if
+they depend on the workspace index, `satsuma-viz-backend` is. Whichever is
+chosen, the CLI must not keep a second copy.
+
+### 2. One renderer: `sz-field-lineage` in `satsuma-viz`
+
+Port the 560-line VS Code renderer to a Lit component in `satsuma-viz`,
+alongside the existing `sz-*` components. It takes a `FieldLineageResult` and
+renders the upstream/downstream chains. It carries `data-testid` attributes on
+the same pattern as `sz-schema-card` so Playwright can address chain entries,
+and it must theme from `tokens.css` so it works in light and dark like every
+other viz surface.
+
+The VS Code panel keeps its subprocess data path *or* moves to the extracted
+function, but either way it renders `sz-field-lineage` instead of its own DOM.
+The 330-line CSS file collapses into the component's styles.
+
+### 3. Surface it in the harness
+
+The harness client listens for `field-lineage` (it already receives the event at
+`app.ts:423`), calls `traceFieldLineage` in-browser against the library-backed
+workspace it already assembles, and renders `sz-field-lineage`. No server, no
+subprocess, no new network request — so the zero-request guarantee holds.
+
+## Success criteria
+
+1. `traceFieldLineage` is importable from a browser bundle and has no Node
+   built-in imports on its path.
+2. `satsuma field-lineage` output is byte-identical for every case covered by
+   the existing 17 CLI tests, which pass unchanged.
+3. Exactly one renderer for lineage exists in the repo; the VS Code-only
+   renderer and its CSS are deleted, not left in place.
+4. Clicking a field's lineage icon in the harness renders the lineage view.
+5. The VS Code panel renders the same component, verified in a real VS Code
+   session.
+
+## Acceptance tests
+
+1. **Portability** — a browser-targeted build that imports `traceFieldLineage`
+   succeeds, and a test asserts the module graph pulls in no `fs`/`path`/`url`.
+2. **Extraction is behaviour-preserving** — the 17 `field-lineage.test.ts` tests
+   pass with the CLI delegating to the extracted function.
+3. **Harness renders lineage** — a Playwright test clicks a field lineage icon
+   and asserts the rendered upstream/downstream chain entries for a known
+   fixture (e.g. a `sfdc-to-snowflake` field with both directions populated).
+4. **Both themes** — the lineage view is captured light and dark in the
+   screenshot project, and no token resolves to a literal colour outside
+   `tokens.css`.
+5. **Empty and error states** — a field with no upstream, a field with no
+   downstream, and an unknown field each render a defined state rather than an
+   empty panel.
+6. **Cycle handling** — a fixture with a cyclic field chain renders without
+   infinite recursion, matching the CLI's cycle detection.
+
+## Risks
+
+- **The extraction is the whole risk.** The traversal is entangled with four
+  CLI-internal modules; moving it may surface that those need to move too. The
+  first ticket should be a spike that reports what must move, before any code is
+  committed to a package.
+- **Renderer parity is unverified by construction.** The current renderer has no
+  tests, so "the port behaves the same" cannot be checked against anything.
+  Capture screenshots of the VS Code panel before the port to serve as the
+  reference.
+- **Scope creep into lineage semantics.** This feature must not change what
+  counts as lineage. Any semantic gap found during the port is a separate
+  ticket.


### PR DESCRIPTION
Visual exploratory testing of the viz component through the Playwright harness,
run entirely inside the agent sandbox via the sentinel protocol. No production
code changes — this PR is tickets plus one PRD.

## Workflow defect found first (and it invalidated the first two runs)

**`sl-kap8` (P1)** — `watch-and-test.sh` runs `npx playwright test`, which
bypasses the npm `pretest` → `npm run build` hook. The harness `dist/` was dated
**14 Jul** while `satsuma-viz/dist/` was dated **3 Aug**; the served bundle did
not contain `data-coverage-state` at all, even though `sz-schema-card.ts` has
emitted it since PR #430. A full 127-test run reported green against that
three-week-old bundle.

The documented agent workflow in CLAUDE.md therefore has not been evidence about
current code, and it is silently not evidence — nothing in the output says the
bundle is stale. Everything below was re-measured after a manual rebuild.

## GUI bugs

| Ticket | Sev | Finding |
|---|---|---|
| `sl-f0x6` | P2 | `partial` container coverage renders the same solid port dot as fully-mapped. `portClass` derives from the boolean `mapped` (true for both `covered` and `partial`) and the CSS defines only three port styles. The state is computed in core and carried in `data-coverage-state`, then discarded at the last rendering step — reaching the human only through hover text. Undercuts Feature 38 (linked to `sl-j6g9`). |
| `sl-zsv6` | P3 | `.toolbar-title` has neither `white-space: nowrap` nor `flex-shrink: 0` while `.toolbar-btn` has `nowrap`, so at 1440px the title absorbs all overflow, wraps to two lines, and the trailing file filter is pushed outside the toolbar. Affects the VS Code webview and site playground too. |
| `sl-jetk` | P3 | A mapping with no field arrows renders a bare `<thead>` with an empty body — no empty-state branch in `_renderArrowTable`. This is the primary presentation of the documented report/model consumer pattern. |
| `sl-k7i4` | P3 | Sourceless derived arrows (`-> is_closed { … }`) render a blank Source cell, indistinguishable from a dropped path. |
| `sl-fncf` | P2 | Both harness servers `listen(PORT)` with no host, binding all interfaces. During a run, ports 3333/3334 expose fixture paths and `.stm` source text to the LAN. Not a traversal issue — the fixture API is allowlist-keyed — but neither server has reason to be off-box. |

## Feature 40 — shared field lineage view

Field lineage turned out to be the only viz surface with **no test surface
anywhere**. The renderer lives only in `vscode-satsuma` (560-line renderer +
284-line panel + 330-line CSS, **zero tests**); the traversal lives in
`satsuma-cli/src/commands/field-lineage.ts` behind four Node-only modules, so no
browser host can call it and the harness has nothing to render — `app.ts:423`
just logs the event.

`features/40-shared-field-lineage-view/PRD.md` proposes a consolidation: one
browser-portable `traceFieldLineage`, one `sz-field-lineage` component rendered
by **both** hosts. Tickets: `sl-12kz` (epic) → `sl-4871` (spike) → `sl-prlp` →
`sl-v3w5` → `sl-hhdk` / `sl-7ind`. `sl-7ind` explicitly requires deleting the old
renderer, so this removes a rendering path rather than adding one.

## Verified correct, deliberately not raised

- Viz coverage ratios match `satsuma coverage` exactly (checked `fx_spot_rates
  0/3` on sfdc-to-snowflake) — ADR-042 consistency holds empirically.
- All 21 bundled fixtures load to `ready` with zero console and zero page errors.
- No clipped labels, zero-size cards, or `NaN`/`[object Object]`/`undefined`
  leaks in rendered text across the corpus.
- Field → arrow-table cross-highlight fires on every fixture probed.
- Nested records, badges, enum/pii/retention pills and `flatten` sections render
  correctly.
- `mapping _weekly_sales_dashboard_report`'s leading underscore is authored in
  the example, not a display artifact.

## Limits of this pass

- The arrow-table → field-row direction was measured with a synthetic
  `mouseenter` and leftover hover state, so those numbers are unreliable; one
  namespace-fixture anomaly there is **unverified** and deliberately not filed.
- I reviewed 5 of 18 captured screenshots in detail.
- The temporary probe spec was deleted; nothing under `test/` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)