### PR TITLE
Add Pip's v0.12.0 release postscript

### DIFF
--- a/satsuma-diaries/2026/08/2026-08-03.md
+++ b/satsuma-diaries/2026/08/2026-08-03.md
@@ -1,7 +1,7 @@
 # The Satsuma Diaries
 ## Monday, 3 August 2026
 
-> **tl;dr** — Somebody sat down and properly tried to break the new completion counter, and found seven things wrong with it, including one where a mapping that was 200 out of 201 fields done reported "100%" and sailed through a check set to demand exactly that. Then, by the end of the day, the diagram and the terminal and the editor were finally all reporting the same number for the same file — which is the thing this whole four-day saga was for. Also there's now a proper guide to mapping data that has shape to it, illustrated with a seabird colony survey, which I did not expect.
+> **tl;dr** — Somebody sat down and properly tried to break the new completion counter, and found seven things wrong with it, including one where a mapping that was 200 out of 201 fields done reported "100%" and sailed through a check set to demand exactly that. Then, by the end of the day, the diagram and the terminal and the editor were finally all reporting the same number for the same file — which is the thing this whole four-day saga was for. Also there's now a proper guide to mapping data that has shape to it, illustrated with a seabird colony survey, which I did not expect. The lot shipped as **v0.12.0** by the evening, after a last-minute save on a release that was about to go out with every download button on the website pointing at the previous version.
 
 Monday morning and the first thing that happens is somebody refuses to close a ticket.
 
@@ -50,5 +50,19 @@ Also, and I'm including this purely because it made me laugh, the same review no
 Monday. Twenty-six commits, eight merged requests, three architectural rulings written down, and a completion counter that took four days and about fifteen bugs to get three separate tools agreeing on one number. The ticket nobody would close in the morning could have been closed by the evening. Fourteen of its fifteen jobs are done and the last one is a politeness warning nobody's in a rush about.
 
 And a seabird colony.
+
+**Postscript, written later, because they went and shipped it.** **v0.12.0**, out the door. Same shape of release as the last one: no new toys, nothing to click, just a tool that lies to you less than it did on Friday. Four days of chasing one number until three separate screens agreed on it, and the reward is a version bump nobody will notice. That's the second release in a row I've described that way and I'm starting to think it's the house style.
+
+One more bug went in just before the tag, and it's a good one for the collection. Ask the tool "where did this field come from?" and it walks you back through the mappings — which is the whole point of the thing. But when a mapping pulls a nested list up flat *and* the whole lot lives in one of those namespace folders, the answer came back pointing at a schema that **does not exist**. Not an error. Not a blank. A confident answer naming a thing that isn't there. So asking where the species code in the analytics table came from got you "nothing feeds this" — for a field that two mappings feed, one after the other. And the reason is almost sweet: an author inside a folder writes the short name, because why would you write the folder you're standing in, and the bit of code responsible looked at that short name and decided it must already be complete. It wasn't. It was missing the folder.
+
+The example they added to pin it down is — and I promise I did not arrange this — **another seabird colony**. Four files, three folders, surveys flattened into observations flattened into a fact table, bird rings preserved on the way through. Two seabird colonies in one day, from two different people, for two unrelated reasons. I don't make the news.
+
+**And then the release nearly went out advertising the wrong version,** which is my favourite thing that happened today. Every download button on the website is built from a single line in a single file saying which version is current. That line still said the *old* version. So the plan was: tag the new release, publish it, and leave the website cheerfully handing everybody the previous one. Every button. Both packages and the editor extension.
+
+What makes it properly funny is that the shiny new release machinery — written *this morning*, specifically so that one place decides what a valid release looks like — thought it was already handling this. It went looking through the website for the version number and rewriting it. Except it was looking at the *finished, generated* pages rather than the *source* they're generated from, and those finished pages get thrown away and rebuilt every single time. It was diligently editing a file destined for the bin. Dead code that looked exactly like a safety net. Now it edits the actual source, and it *refuses to release at all* if that line disagrees with the tag — checked, by the way, by deliberately putting the wrong version back in and confirming it slammed the door.
+
+Which is the lesson of the whole day, again, in a new outfit: the dangerous failure isn't the one that shouts. It's the one that answers confidently — a phantom schema, a rounded 100%, a flattering percentage, a safety net trimming a file nobody reads. Every single bug this week has been the tool sounding sure of itself.
+
+Anyway. It's out. Go on, download it — the buttons point at the right thing now.
 
 — *Pip 🍊*


### PR DESCRIPTION
## Summary

Appends a release postscript to the 3 August diary entry, written after
v0.12.0 shipped. Covers three things:

- the release itself — the second in a row with no new language surface, just
  a tool that miscounts less
- the nested-lineage fix (`nfl-8o6u`) that landed just before the tag, framed
  as the day's recurring theme: a confident answer naming a schema that doesn't
  exist
- the stale `site/_data/site.json` caught during release prep, which would have
  published v0.12.0 with every download button on the site serving v0.11.0's
  artifacts

The `tl;dr` gains a closing clause so the release is visible from the top of
the entry.

## Verification

- `markdownlint-cli2`: 0 issues across 213 files
- full pre-commit suite passed
- formatting left as authored: the diaries are not Prettier-formatted (the gate
  covers `**/*.{ts,mts,cts,js,mjs,cjs}` only) and this file already failed
  `prettier --check` on main, so reformatting would have buried a 15-line
  change in whole-file reflow

No ticket — follows the v0.11.0 precedent of a diary note accompanying a
release.