### PR TITLE
Restore examples table order and file the schema-root container-header bug

### DIFF
--- a/.tickets/r0-7w76.md
+++ b/.tickets/r0-7w76.md
@@ -1,0 +1,32 @@
+---
+id: r0-7w76
+status: open
+deps: []
+links: []
+created: 2026-08-03T12:43:49Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+---
+# graph invents a field when a container header targets the schema root
+
+`satsuma graph` and `satsuma field-lineage` emit an edge onto a field that does not exist when a `flatten`/`each` header names the target schema root rather than a field in it.
+
+For `flatten observations -> species_fact` in examples/seabird-colony-lineage/mart.stm, the header arrow's target is the bare token `species_fact`. `qualifyField` finds no dot in it, so it falls through to its last branch and appends the token to the first target schema, producing `mart::species_fact.species_fact`. The two commands then disagree with the rest of the CLI about the same line:
+
+    $ satsuma graph examples/seabird-colony-lineage/platform.stm --json
+      science::colony_observations.observations -> mart::species_fact.species_fact
+
+    $ satsuma field-lineage mart::species_fact.species_fact examples/seabird-colony-lineage/platform.stm
+      Field 'species_fact' not found in schema 'mart::species_fact'.
+
+`satsuma validate` accepts the construct, correctly treating the token as a schema root (see `resolveFieldPath`), so core holds two readings of one authored form.
+
+Not namespace-specific and not a regression from nfl-8o6u: the same doubling occurs in the global namespace (`::src.items -> ::fact.fact`), and it predates that fix, which only addressed the dotted child paths beneath such a header.
+
+Deciding the fix needs a call on what a container-header edge onto a schema root should say. Graph edges are field-to-field today, so the options are a schema-level endpoint (a new edge shape for consumers to handle), the schema's canonical key with no field part, or omitting the header edge and keeping only its children. Worth checking what the viz and LSP do with whatever is chosen — see ADR-042 for where coverage takes its own path.
+
+## Acceptance Criteria
+
+A container header naming the target schema root no longer produces an edge onto a non-existent field. The chosen representation is documented and consistent between graph, field-lineage, and validate. Covered for both a namespaced and a global-namespace schema, since the doubling occurs in both. Existing consumers (viz overview edges, LSP) either handle the new endpoint or are shown not to receive it.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,8 +20,8 @@ The CLI requires a `.stm` file entry point (not a directory). The workspace is d
 | [`nested-iteration/`](nested-iteration/) | `pipeline.stm` | Nested `each`/`flatten` sub-blocks mapping hierarchical dispatch events to a courier manifest |
 | [`protobuf-to-parquet/`](protobuf-to-parquet/) | `pipeline.stm` | Protobuf Kafka commerce events to session-level Parquet |
 | [`reports-and-models/`](reports-and-models/) | `pipeline.stm` | Reports, dashboards, and ML models as first-class pipeline consumers |
-| [`seabird-colony-lineage/`](seabird-colony-lineage/) | `platform.stm` | Deeply nested field lineage and coverage across files and namespaces |
 | [`sap-po-to-mfcs/`](sap-po-to-mfcs/) | `pipeline.stm` | SAP ERP purchase order to Oracle MFCS ingestion contract |
+| [`seabird-colony-lineage/`](seabird-colony-lineage/) | `platform.stm` | Deeply nested field lineage and coverage across files and namespaces |
 | [`sfdc-to-snowflake/`](sfdc-to-snowflake/) | `pipeline.stm` | Salesforce Opportunity/Account objects to Snowflake analytics |
 | [`xml-to-parquet/`](xml-to-parquet/) | `pipeline.stm` | Commerce order XML to Lakehouse Parquet |
 


### PR DESCRIPTION
## Summary

The two loose ends from reviewing PR #435, neither of which belonged in the
release.

**`examples/README.md`** — the `seabird-colony-lineage` row was inserted one
place early, ahead of `sap-po-to-mfcs`. The scenarios table is alphabetical
everywhere else; it is again now (asserted by reading the rows back and
comparing against `sorted()`).

**`r0-7w76`** — filed, not fixed. A `flatten`/`each` header that names the
target *schema root* rather than a field in it makes `graph` and
`field-lineage` emit an edge onto a field that does not exist:

```console
$ satsuma graph examples/seabird-colony-lineage/platform.stm --json
  science::colony_observations.observations -> mart::species_fact.species_fact

$ satsuma field-lineage mart::species_fact.species_fact examples/…/platform.stm
  Field 'species_fact' not found in schema 'mart::species_fact'.
```

`qualifyField` finds no dot in the bare token and falls through to appending it
to the first target schema. `validate` reads the same token correctly as a
schema root, so core holds two readings of one authored form.

## Why file rather than fix

Verified this is **not** a regression from `nfl-8o6u` and not namespace-specific
— the same doubling occurs in the global namespace (`::src.items -> ::fact.fact`)
and predates that fix, which only addressed the dotted child paths beneath such
a header. It surfaced now because `seabird-colony-lineage` is the first shipped
example whose container header targets a schema root.

The fix needs a decision rather than a patch: graph edges are field-to-field
today, so representing a schema-root endpoint means either a new edge shape for
consumers, a canonical key with no field part, or dropping the header edge and
keeping its children. That is a contract change for the viz and LSP, so it wants
a deliberate call rather than a drive-by in a docs PR.

## Verification

- full pre-commit suite passed
- both symptoms reproduced against released `main` before writing the ticket, in
  a namespaced example and a minimal global-namespace fixture