### PR TITLE
Fix stale viz harness sentinel builds

### DIFF
--- a/.tickets/sl-kap8.md
+++ b/.tickets/sl-kap8.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kap8
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-08-03T11:35:29Z

--- a/.tickets/sl-kap8.md
+++ b/.tickets/sl-kap8.md
@@ -1,6 +1,6 @@
 ---
 id: sl-kap8
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-03T11:35:29Z
@@ -27,3 +27,10 @@ playwright.config.ts compounds it: webServer runs 'node dist/server.js', so a st
 - CLAUDE.md's viz-harness section states that the watcher rebuilds, so no agent assumes it must rebuild by hand.
 - Verified by touching a string in tooling/satsuma-viz/src and confirming it reaches the browser in the next sentinel-triggered run without any manual build.
 
+
+## Notes
+
+**2026-08-03T13:17:42Z**
+
+Cause: The sentinel watcher invoked npx directly, bypassing the harness package pretest lifecycle and allowing stale client and server bundles to be tested.
+Fix: Route sentinel runs through npm test, preserve pipeline failures in the results file, document the rebuild contract, and cover success and failure behavior with isolated watcher tests. (commit 28b6da6f)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,10 @@ results without shell access to the browser process:
    ```
    ./tooling/satsuma-viz-harness/watch-and-test.sh &
    ```
-   The watcher polls for `.run-tests`, runs `npx playwright test` when it appears,
-   writes output to `.playwright-results.txt`, then removes the sentinel.
+   The watcher polls for `.run-tests`, runs `npm test` when it appears, and therefore
+   rebuilds the core, backend, viz, and harness bundles through npm's `pretest` hook
+   before Playwright starts. Build and test output is written to
+   `.playwright-results.txt`, then the sentinel is removed.
 
 2. The agent triggers a run by creating the sentinel:
    ```bash
@@ -154,6 +156,8 @@ Then touch the sentinel, wait for it to disappear (the watcher picks it up withi
 - **Never** try to run `npx playwright test` directly — it will be blocked or
   will produce no usable output in the sandbox.
 - **Never** try to start a browser process directly.
+- The watcher rebuilds everything needed by the harness. Do not rebuild by hand
+  before triggering it; confirm the fresh build output in `.playwright-results.txt`.
 - The watcher kills any stale server on port 3333 before each run, so there is
   no need to manage the server separately.
 - If `.playwright-results.txt` is stale (timestamp older than your sentinel

--- a/tooling/satsuma-viz-harness/README.md
+++ b/tooling/satsuma-viz-harness/README.md
@@ -94,8 +94,8 @@ sentinel file:
 agent ──touch .run-tests──▶ watch-and-test.sh
                                 │
                                 ├── kills any stale server on :3333
-                                ├── runs `npx playwright test`
-                                ├── writes .playwright-results.txt
+                                ├── runs `npm test` (pretest rebuild + Playwright)
+                                ├── writes build and test output to .playwright-results.txt
                                 └── removes .run-tests on pickup
 ```
 
@@ -120,7 +120,9 @@ touch tooling/satsuma-viz-harness/.run-tests
 
 A full run takes roughly 30–90 seconds. Results from the previous run remain
 in `.playwright-results.txt` until the next run overwrites them, so always
-check the file timestamp after triggering.
+check the file timestamp after triggering. The watcher performs the complete
+build itself; its build output in the results file proves the browser received
+fresh harness and viz bundles.
 
 ### Run directly (developer, not agent)
 

--- a/tooling/satsuma-viz-harness/scripts/watch-and-test.test.mjs
+++ b/tooling/satsuma-viz-harness/scripts/watch-and-test.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * watch-and-test.test.mjs — contract tests for the sentinel watcher.
+ *
+ * Runs an isolated copy of the watcher with fake process commands. This proves
+ * the agent-facing workflow enters through npm (and therefore the pretest build)
+ * without launching Playwright or relying on a developer-machine browser.
+ */
+
+import { afterEach, describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const WATCHER_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "watch-and-test.sh");
+const RESULT_WAIT_TIMEOUT_MS = 5_000;
+const RESULT_POLL_INTERVAL_MS = 25;
+
+describe("watch-and-test sentinel workflow", () => {
+  const runningWatchers = new Set();
+  const temporaryDirectories = new Set();
+
+  afterEach(() => {
+    for (const watcher of runningWatchers) watcher.kill("SIGTERM");
+    for (const directory of temporaryDirectories)
+      rmSync(directory, { recursive: true, force: true });
+    runningWatchers.clear();
+    temporaryDirectories.clear();
+  });
+
+  it("runs npm test so the pretest build output is recorded before Playwright", async () => {
+    // Calling npx directly bypasses npm's pretest lifecycle. The fake npm marker
+    // represents build output and must be visible to an agent reading the result.
+    const run = startWatcher("echo 'fresh build marker'");
+    const results = await waitForResults(run.resultsPath, "fresh build marker");
+
+    assert.equal(readFileSync(run.invocationPath, "utf8").trim(), "test -- --timeout=60000");
+    assert.match(results, /fresh build marker/);
+    assert.match(results, /run passed/);
+  });
+
+  it("records a failed build or test run instead of presenting stale results as green", async () => {
+    // npm stops before Playwright when pretest fails; the watcher must preserve
+    // that output and label the sentinel run as failed for its agent reader.
+    const run = startWatcher("echo 'build failure marker'; exit 23");
+    const results = await waitForResults(run.resultsPath, "run failed with exit code 23");
+
+    assert.match(results, /build failure marker/);
+    assert.match(results, /run failed with exit code 23/);
+  });
+
+  /** Start an isolated watcher whose npm executable runs the supplied shell body. */
+  function startWatcher(npmBody) {
+    const directory = mkdtempSync(join(tmpdir(), "satsuma-viz-watcher-"));
+    const binDirectory = join(directory, "bin");
+    const watcherPath = join(directory, "watch-and-test.sh");
+    const invocationPath = join(directory, "npm-invocation.txt");
+    const resultsPath = join(directory, ".playwright-results.txt");
+    temporaryDirectories.add(directory);
+
+    writeFileSync(join(directory, ".run-tests"), "");
+    copyFileSync(WATCHER_PATH, watcherPath);
+    chmodSync(watcherPath, 0o755);
+
+    return createFakeCommandsAndSpawn({
+      directory,
+      binDirectory,
+      invocationPath,
+      npmBody,
+      watcherPath,
+      resultsPath,
+    });
+  }
+
+  /** Install fake external commands, then start the watcher in its fixture directory. */
+  function createFakeCommandsAndSpawn({
+    directory,
+    binDirectory,
+    invocationPath,
+    npmBody,
+    watcherPath,
+    resultsPath,
+  }) {
+    mkdirSync(binDirectory);
+    const npmPath = join(binDirectory, "npm");
+    const lsofPath = join(binDirectory, "lsof");
+    writeFileSync(
+      npmPath,
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "${invocationPath}"\n${npmBody}\n`,
+    );
+    writeFileSync(lsofPath, "#!/usr/bin/env bash\nexit 1\n");
+    chmodSync(npmPath, 0o755);
+    chmodSync(lsofPath, 0o755);
+
+    const watcher = spawn("bash", [watcherPath], {
+      cwd: directory,
+      env: { ...process.env, PATH: `${binDirectory}:${process.env.PATH}` },
+      stdio: "ignore",
+    });
+    runningWatchers.add(watcher);
+    return { invocationPath, resultsPath };
+  }
+
+  /** Poll until the watcher has atomically appended the expected completion marker. */
+  async function waitForResults(resultsPath, marker) {
+    const deadline = Date.now() + RESULT_WAIT_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      try {
+        const results = readFileSync(resultsPath, "utf8");
+        if (results.includes(marker)) return results;
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, RESULT_POLL_INTERVAL_MS));
+    }
+    assert.fail(`watcher results did not contain ${JSON.stringify(marker)}`);
+  }
+});

--- a/tooling/satsuma-viz-harness/watch-and-test.sh
+++ b/tooling/satsuma-viz-harness/watch-and-test.sh
@@ -6,8 +6,8 @@
 # When .run-tests is created (e.g. by `touch .run-tests`), this script:
 #   1. Kills any stale server on ports 3333 (dev server) and 3334 (static
 #      playground file server)
-#   2. Runs `npx playwright test`
-#   3. Writes output to .playwright-results.txt
+#   2. Runs `npm test`, whose pretest hook rebuilds the harness and viz bundles
+#   3. Writes build and Playwright output to .playwright-results.txt
 #   4. Removes .run-tests so the trigger is reset
 #
 # Claude touches .run-tests to request a test run; results appear in
@@ -16,6 +16,10 @@
 TRIGGER=".run-tests"
 RESULTS=".playwright-results.txt"
 DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Preserve npm's failure status across tee so a failed pretest build is reported
+# as a failed sentinel run rather than looking like a successful stale-bundle run.
+set -o pipefail
 
 echo "[watch-and-test] watching for $TRIGGER in $DIR"
 
@@ -27,7 +31,12 @@ while true; do
     kill "$(lsof -ti:3334)" 2>/dev/null || true
     sleep 1
     cd "$DIR"
-    npx playwright test --timeout=60000 2>&1 | tee "$RESULTS"
+    if npm test -- --timeout=60000 2>&1 | tee "$RESULTS"; then
+      echo "[watch-and-test] run passed" | tee -a "$RESULTS"
+    else
+      STATUS=$?
+      echo "[watch-and-test] run failed with exit code $STATUS" | tee -a "$RESULTS"
+    fi
     echo "[watch-and-test] done — results in $RESULTS"
   fi
   sleep 1


### PR DESCRIPTION
## Summary
- route sentinel-triggered runs through `npm test` so the `pretest` build runs first
- preserve build/test failures and output in `.playwright-results.txt`
- add isolated watcher contract tests and document the fresh-build guarantee

## Verification
- sentinel acceptance run with a temporary browser-visible source marker: 100 passed
- clean sentinel run after removing the marker: 99 passed
- `npm --prefix tooling/satsuma-viz-harness run test:unit`: 28 passed
- full `.githooks/pre-commit` repository suite passed on both commits

ADR assessment: no ADR required; this restores the existing npm lifecycle contract without changing architecture.

Closes sl-kap8