### PR TITLE
fix(viz): draw partly covered records with their own port dot (sl-f0x6)

### DIFF
--- a/.tickets/sl-f0x6.md
+++ b/.tickets/sl-f0x6.md
@@ -38,3 +38,7 @@ This undercuts the point of Feature 38 (epic sl-j6g9): the partial state is comp
 
 Cause: sz-schema-card chose the port-dot class from entry.mapped, which core defines as state !== "uncovered" — true for 'covered' and 'partial' alike — so a partly covered record painted the same solid dot as a fully covered one, and the tri-state reached a reader only through hover text.
 Fix: the dot class now derives from the coverage state via a total Record<FieldCoverageState, string> map (a fourth state fails to compile rather than collapsing into an existing style), and a new .port.partial rule draws a half-filled dot inside an accent ring. Verified in Firefox in both themes on examples/filter-flatten-governance (order-line-facts): order_totals and line_items render half-moons between currency's solid dot and subtotal's hollow ring.
+
+**2026-08-03T13:30:02Z**
+
+Commit: 9c4c253c (PR #440).

--- a/.tickets/sl-f0x6.md
+++ b/.tickets/sl-f0x6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-f0x6
-status: open
+status: closed
 deps: []
 links: [sl-j6g9]
 created: 2026-08-03T12:31:53Z
@@ -31,3 +31,10 @@ This undercuts the point of Feature 38 (epic sl-j6g9): the partial state is comp
 - A test asserts the partial port class for a minimal snippet where one record has some covered and some uncovered children.
 - The existing hover text is kept as the detailed explanation, not removed.
 
+
+## Notes
+
+**2026-08-03T13:27:27Z**
+
+Cause: sz-schema-card chose the port-dot class from entry.mapped, which core defines as state !== "uncovered" — true for 'covered' and 'partial' alike — so a partly covered record painted the same solid dot as a fully covered one, and the tri-state reached a reader only through hover text.
+Fix: the dot class now derives from the coverage state via a total Record<FieldCoverageState, string> map (a fourth state fails to compile rather than collapsing into an existing style), and a new .port.partial rule draws a half-filled dot inside an accent ring. Verified in Firefox in both themes on examples/filter-flatten-governance (order-line-facts): order_totals and line_items render half-moons between currency's solid dot and subtotal's hollow ring.

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -750,6 +750,34 @@ test.describe("Mapping detail — order line facts (flatten)", () => {
 // the .hl class.  Both non-nested and nested fixtures are exercised.
 // ---------------------------------------------------------------------------
 
+/**
+ * How the coverage port dot on one field row is actually painted, as a single
+ * comparable string.
+ *
+ * Every property that can carry the distinction between coverage states is
+ * folded in — fill, gradient, ring colour and style, and the fade the "not
+ * computed" dot uses — so two states comparing equal here look the same on
+ * screen, whichever property a future style change reaches for. `rowTestId` is
+ * the field row's test id; the dot is its `.port` child inside the card's shadow
+ * root, which Playwright's CSS selectors pierce.
+ */
+async function portAppearance(
+  detail: ReturnType<Page["locator"]>,
+  rowTestId: string,
+): Promise<string> {
+  return detail.locator(`[data-testid='${rowTestId}'] .port`).evaluate((el) => {
+    const style = getComputedStyle(el);
+    return [
+      style.backgroundColor,
+      style.backgroundImage,
+      style.borderColor,
+      style.borderStyle,
+      style.borderWidth,
+      style.opacity,
+    ].join(" | ");
+  });
+}
+
 test.describe("Field coverage indicators", () => {
   test("target fields with arrows are mapped, target fields without arrows are unmapped", async ({
     page,
@@ -811,6 +839,53 @@ test.describe("Field coverage indicators", () => {
       detail.locator(`[data-testid='${targetCardPrefix}-field-line-number']`),
     ).toHaveAttribute("data-coverage", "mapped");
   });
+
+  // sl-f0x6: the port dot was chosen from the `mapped` boolean, which is true for
+  // a fully covered record and a partly covered one alike, so a record with one
+  // covered leaf out of three painted the same solid dot as a record with three.
+  // Only a real browser can prove the three states are actually *drawn*
+  // differently — the component test can only see the class names — and it has to
+  // hold in both palettes, since a distinction carried by colour alone may
+  // survive one theme and vanish in the other.
+  for (const theme of ["light", "dark"] as const) {
+    test(`a partly covered record's port dot is drawn unlike covered and uncovered ones (${theme})`, async ({
+      page,
+    }) => {
+      await page.goto(`/?theme=${theme}`);
+      await page.waitForFunction(() => {
+        const harness = window.__satsumaHarness;
+        if (!harness?.setViewMode) return false; // app.js not evaluated yet
+        harness.setViewMode("single");
+        return true;
+      });
+      await loadFixture(page, ffgUri);
+      const detail = await openMappingByName(page, "order-line-facts");
+
+      // order_events.customer is the case from the ticket: the mapping writes
+      // `customer.customer_id` and leaves `email` and `tier` alone, so the record
+      // is partial with one covered and two uncovered children beneath it.
+      const sourceCardPrefix = "mapping-detail-order-line-facts-source-schema-card-order-events";
+      const row = (path: string) =>
+        detail.locator(`[data-testid='${sourceCardPrefix}-field-${path}']`);
+
+      await expect(row("customer")).toHaveAttribute("data-coverage-state", "partial");
+      await expect(row("customer-customer-id")).toHaveAttribute("data-coverage-state", "covered");
+      await expect(row("customer-email")).toHaveAttribute("data-coverage-state", "uncovered");
+
+      const appearances = {
+        partial: await portAppearance(detail, `${sourceCardPrefix}-field-customer`),
+        covered: await portAppearance(detail, `${sourceCardPrefix}-field-customer-customer-id`),
+        uncovered: await portAppearance(detail, `${sourceCardPrefix}-field-customer-email`),
+      };
+
+      // Pairwise distinct is the whole requirement: `partial` reading like either
+      // neighbour is the defect, in either direction.
+      expect(new Set(Object.values(appearances)).size, JSON.stringify(appearances)).toBe(3);
+      // And the difference is one of shape, not shade: the half-fill is a
+      // gradient, so it survives at the 8px port size and in monochrome.
+      expect(appearances.partial).toMatch(/gradient/);
+    });
+  }
 });
 
 test.describe("Hover highlighting between arrows and field rows", () => {

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -4,7 +4,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SchemaCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
-import type { FieldCoverageEntry } from "@satsuma/core/coverage";
+import type { FieldCoverageEntry, FieldCoverageState } from "@satsuma/core/coverage";
 import { uncoveredFieldCoverage } from "@satsuma/core/coverage";
 import { toCoverageFields } from "../field-coverage.js";
 import { summarizeFieldCoverage, countContainerStates } from "@satsuma/core/coverage-rollup";
@@ -28,6 +28,27 @@ export interface SzCompactToggledDetail {
   /** The state the user asked for: true = expand fields, false = collapse. */
   expanded: boolean;
 }
+
+/**
+ * The port-dot style each coverage state renders as.
+ *
+ * **Keyed by the state, never by `entry.mapped`.** `mapped` is true for both
+ * `covered` and `partial` (it means "not uncovered"), so a class chosen from it
+ * painted a partly covered record with the same solid dot as a fully covered
+ * one: the state core computes and the payload carries was discarded at the last
+ * rendering step, and partial coverage was invisible on the card (sl-f0x6). A
+ * total map over {@link FieldCoverageState} also means a fourth state added to
+ * that union fails to compile here rather than silently collapsing into one of
+ * these styles.
+ *
+ * The "coverage not computed" case is deliberately absent — it is not one of
+ * core's verdicts, and {@link SzSchemaCard._portClass} handles it separately.
+ */
+const PORT_CLASS_BY_COVERAGE_STATE: Record<FieldCoverageState, string> = {
+  covered: "mapped",
+  partial: "partial",
+  uncovered: "unmapped",
+};
 
 function sanitizeTestIdSegment(value: string): string {
   const lowered = value.toLowerCase();
@@ -190,6 +211,18 @@ export class SzSchemaCard extends LitElement {
     .port.unmapped {
       border: 1.5px solid var(--sz-text-muted);
       background: transparent;
+    }
+
+    /* Partly covered: something under this record is mapped and something is
+       not. A half-filled dot inside an accent ring reads as the state between
+       the solid dot and the hollow one, and it is a difference in *shape* — at
+       the 8px port size a difference in shade alone would not survive (sl-f0x6).
+       The ring takes the accent rather than the muted outline of .port.unmapped
+       because part of this subtree is mapped; the unfilled half is what still
+       needs attention. */
+    .port.partial {
+      border: 1.5px solid var(--sz-orange-dark);
+      background: linear-gradient(to right, var(--sz-orange-dark) 0 50%, transparent 50% 100%);
     }
 
     /* Coverage not computed: neither filled nor the hollow ring that reads as a
@@ -731,17 +764,19 @@ export class SzSchemaCard extends LitElement {
 
   private _renderField(f: FieldEntry, depth: number, prefix = ""): TemplateResult {
     const fieldPath = prefix ? `${prefix}.${f.name}` : f.name;
-    // Three states, not two. With `coverage` null nothing was computed, and a row
-    // must not then read as a gap: the header says no figure was produced, and a
-    // hollow "unmapped" dot beside it would contradict it — a reader would see
-    // every field as unmapped, and automation could not tell those rows from real
-    // uncovered results.
+    // With `coverage` null nothing was computed, and a row must not then read as
+    // a gap: the header says no figure was produced, and a hollow "unmapped" dot
+    // beside it would contradict it — a reader would see every field as unmapped,
+    // and automation could not tell those rows from real uncovered results.
     const unavailable = this.coverage === null;
     const entry = unavailable ? undefined : this._coverageByPath().get(fieldPath);
-    // A record is "mapped" as soon as anything beneath it is, which is the
-    // threshold a port dot has always painted on; `state` carries the finer
-    // distinction for anyone who needs it.
-    const isMapped = entry?.mapped ?? false;
+    // How much of this field is covered — core's tri-state, or `unknown` when no
+    // verdict exists. A path core reported nothing for is uncovered; a card with
+    // no coverage at all is `unknown`, per the paragraph above. This drives both
+    // the port dot and the attribute automation reads.
+    const coverageState: FieldCoverageState | "unknown" = unavailable
+      ? "unknown"
+      : (entry?.state ?? "uncovered");
     const hasWarning = f.comments.some((c) => c.kind === "warning");
     const hasQuestion = f.comments.some((c) => c.kind === "question");
     const hasPii = f.constraints.includes("pii");
@@ -752,18 +787,24 @@ export class SzSchemaCard extends LitElement {
     // Use the dotted path so nested customer.email is distinguishable from a
     // sibling top-level email field (sl-eikr).
     const fieldTestId = `${this.testIdPrefix}-field-${sanitizeTestIdSegment(fieldPath)}`;
-    // `unknown` rather than `unmapped`/`uncovered`: those two are verdicts, and
-    // there is no verdict here. Automation keys on these, so the third state has
-    // to be nameable.
-    const coverageState = unavailable ? "unknown" : isMapped ? "mapped" : "unmapped";
-    const portClass = unavailable ? "unknown" : isMapped ? "mapped" : "unmapped";
+    // The older, coarser attribute, kept byte-identical for the automation built
+    // on it: a record is "mapped" as soon as anything beneath it is (core's
+    // `entry.mapped`, i.e. state !== "uncovered"). `unknown` rather than
+    // `unmapped` when nothing was computed — those two are verdicts and there is
+    // no verdict here, so the third case has to be nameable.
+    const mappedVerdict =
+      coverageState === "unknown"
+        ? "unknown"
+        : coverageState === "uncovered"
+          ? "unmapped"
+          : "mapped";
 
     return html`
       <div
         class="field-row ${depth > 0 ? "nested" : ""} ${hlClass}"
         data-testid=${fieldTestId}
-        data-coverage=${coverageState}
-        data-coverage-state=${unavailable ? "unknown" : (entry?.state ?? "uncovered")}
+        data-coverage=${mappedVerdict}
+        data-coverage-state=${coverageState}
         data-coverage-tier=${entry?.tier ?? ""}
         style=${depth > 0 ? `padding-left: ${12 + depth * 20}px` : ""}
         @click=${() => this._navigate(f.location)}
@@ -771,7 +812,7 @@ export class SzSchemaCard extends LitElement {
         @mouseleave=${() => this._onFieldHover(null)}
         title=${this._fieldTitle(f, entry)}
       >
-        <span class="port ${portClass}"></span>
+        <span class="port ${this._portClass(coverageState)}"></span>
         <span class="field-name">${f.name}</span>
         <span class="field-type">${f.type}</span>
         <span class="badges">
@@ -860,6 +901,18 @@ export class SzSchemaCard extends LitElement {
     );
   }
 
+  /**
+   * The port-dot class for a row reporting `coverage`.
+   *
+   * Four states reach a dot and each gets its own style: core's three verdicts
+   * via {@link PORT_CLASS_BY_COVERAGE_STATE}, plus `unknown` for a card whose
+   * coverage was never computed — which must not borrow the hollow ring that
+   * reads as a measured gap (see {@link coverage}).
+   */
+  private _portClass(coverage: FieldCoverageState | "unknown"): string {
+    return coverage === "unknown" ? "unknown" : PORT_CLASS_BY_COVERAGE_STATE[coverage];
+  }
+
   private _commentText(f: FieldEntry, kind: "warning" | "question"): string {
     return f.comments
       .filter((c) => c.kind === kind)
@@ -937,9 +990,9 @@ export class SzSchemaCard extends LitElement {
    * The NL tier is called out because ADR-036 requires a consumer to *show* the
    * distinction rather than let a reader assume every covered field has an arrow:
    * a hop inferred from prose is a weaker claim than a declared one, and a
-   * reviewer has to be able to tell which they are looking at. `partial` is
-   * called out for the same reason — a record row's dot says "something under
-   * here is mapped" and cannot say "not all of it".
+   * reviewer has to be able to tell which they are looking at. `partial` is named
+   * here too: the half-filled dot says a record is partly mapped at a glance, and
+   * this is where that reading is spelled out in words (sl-f0x6).
    *
    * When coverage was not computed the row says so, rather than saying nothing
    * and leaving the bare type to be read alongside an unmarked dot as a gap.

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -234,15 +234,14 @@ describe("sz-schema-card renders the verdict it was given", () => {
   });
 
   it("distinguishes a partly covered record from a fully covered one", async () => {
-    // Both render a filled port dot, because "something under here is mapped"
-    // is the threshold the dot has always painted on. Only the tri-state
-    // attribute and the tooltip can tell them apart, so both must carry it.
+    // The tri-state attribute and the tooltip are the machine-readable and the
+    // detailed forms of the distinction; the port class below is the one a reader
+    // sees without hovering. All three must carry it.
     const card = await makeCard(AMOUNT_AND_ADDRESS, ONLY_CITY);
     const text = renderText(card);
     assert.match(text, /data-coverage-state="?partial/);
     assert.match(text, /partly mapped/);
   });
-
   it("shows a field count instead of a ratio when coverage was not computed", async () => {
     // `null` is "not computed", not "nothing is mapped" — a model assembled
     // without a workspace index, or a cached payload from an older host. The
@@ -272,6 +271,10 @@ describe("sz-schema-card renders the verdict it was given", () => {
     assert.doesNotMatch(text, /data-coverage-state="?uncovered/);
     assert.doesNotMatch(text, /data-coverage-tier="?(nl|declared)/);
     assert.match(text, /coverage not computed/);
+    // The dot has to agree too: `unknown` gets its own faded, dashed style, and
+    // must not borrow the hollow ring a reader reads as a measured gap.
+    assert.match(text, /class="port unknown"/);
+    assert.doesNotMatch(text, /class="port (unmapped|mapped|partial)"/);
   });
 
   it("keeps unmapped for a real uncovered verdict", async () => {
@@ -310,5 +313,38 @@ describe("sz-schema-card renders the verdict it was given", () => {
     const text = renderText(card);
     assert.match(text, /header-count[^>]*>0\/4</);
     assert.match(text, /data-coverage-available="?true/);
+  });
+});
+
+// ── The port dot (sl-f0x6) ──────────────────────────────────────────────────
+//
+// The dot was chosen from `entry.mapped`, which is true for `covered` *and*
+// `partial`, so a record with one covered leaf out of three looked exactly like
+// one with all three covered: the state core computes and the payload carries was
+// discarded at the last rendering step, and partial coverage reached a reader only
+// by hovering the exact row. These cases pin the dot to the state instead.
+
+describe("sz-schema-card port dot", () => {
+  it("gives each of the three coverage states its own port class", async () => {
+    // One card, all three states: `address.city` covered, `amount` uncovered and
+    // `address` partial between them. Distinct classes are what lets a reader tell
+    // the states apart at a glance, so the property under test is that no two
+    // states share one — `partial` collapsing into `mapped` is the defect.
+    const text = renderText(await makeCard(AMOUNT_AND_ADDRESS, ONLY_CITY));
+    const classes = [...text.matchAll(/class="port ([a-z]+)"/g)].map((m) => m[1]);
+    // Declaration order: amount, address, address.city, address.line1, .postcode.
+    assert.deepEqual(classes, ["unmapped", "partial", "mapped", "unmapped", "unmapped"]);
+  });
+
+  it("styles every port class it renders", async () => {
+    // A class with no rule behind it renders an unstyled dot — the same defect
+    // reintroduced from the CSS side, and invisible to the case above. Pairing
+    // each class with its own selector is what makes the classes distinct on
+    // screen; this fails if a state is added to the class map without a style.
+    const mod = await import("../dist/satsuma-viz.js");
+    const cssText = [mod.SzSchemaCard.styles].flat().join("\n");
+    for (const portClass of ["mapped", "partial", "unmapped", "unknown"]) {
+      assert.match(cssText, new RegExp(`\\.port\\.${portClass}\\s*{`), `no rule for ${portClass}`);
+    }
   });
 });

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -39,7 +39,7 @@
     },
     "../satsuma-lsp": {
       "name": "@satsuma/lsp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@satsuma/core": "file:../satsuma-core",
         "@satsuma/viz-backend": "file:../satsuma-viz-backend",


### PR DESCRIPTION
## What

The schema card's port dot was chosen from `entry.mapped`, which core defines as `state !== "uncovered"` — true for a fully covered record and a partly covered one alike. A record with one covered leaf out of three painted the same solid dot as a record with three, so the `partial` state Feature 38 computes in core and carries through the payload was discarded at the last rendering step. It reached a reader only by hovering the exact row.

- The dot class now derives from the coverage **state**, through a total `Record<FieldCoverageState, string>` map — a fourth state added to that union fails to compile here rather than silently collapsing into an existing style (the ticket's third acceptance criterion).
- New `.port.partial` rule: a half-filled dot inside an accent ring. The distinction is one of **shape**, which survives at the 8px port size where a difference in shade would not.
- `data-coverage` (mapped|unmapped|unknown) is unchanged for the automation built on it; the hover text stays as the detailed explanation.

## Verification

Captured in Firefox via the harness at 3x, both themes — on `examples/filter-flatten-governance` (`order-line-facts`), `order_totals` and `line_items` render half-moons, sitting visibly between `currency`'s solid dot and `subtotal`'s hollow ring.

- `satsuma-viz`: **130 pass** (+2). One case pins the three states to three distinct classes on a card holding all three; another requires every class the card renders to have a style rule of its own, so the defect cannot be reintroduced from the CSS side.
- `satsuma-viz-harness`: **103 pass** (+2). A real browser proves the three dots are *painted* differently — computed fill, gradient, ring colour, style, width and opacity folded into one comparable signature, asserted pairwise distinct in light **and** dark, since a distinction carried by colour alone can survive one palette and vanish in the other.
- Full pre-commit repo checks green.

## Note

Also syncs `tooling/vscode-satsuma/package-lock.json`, which still recorded `../satsuma-lsp` at 0.11.0 — any `npm install` in that package regenerates it, so it was churn on every fresh worktree.

No ADR: this applies ADR-042 and PRD 38 R2 rather than deciding anything new.

Closes sl-f0x6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)