### PR TITLE
Archive completed Feature 38

### DIFF
--- a/.tickets/sl-j6g9.md
+++ b/.tickets/sl-j6g9.md
@@ -11,7 +11,7 @@ tags: [feature-38, coverage, core]
 ---
 # Feature 38 epic: hierarchical field coverage
 
-Implement features/38-hierarchical-coverage/PRD.md. Make field coverage correct and single-definition for nested records, lists of records, and schemas that reuse field names across depths, so a coverage percentage can be trusted as a merge gate.
+Implement archive/features/38-hierarchical-coverage/PRD.md. Make field coverage correct and single-definition for nested records, lists of records, and schemas that reuse field names across depths, so a coverage percentage can be trusted as a merge gate.
 
 Six defects verified against branch feat/35-coverage-command (HEAD fc3d5a5), not main — feature 35 is substantially implemented there:
 1. Bare-segment registration makes coverage name-based, reporting unmapped fields as mapped (raised separately as sl-joeq, this epic depends on it).

--- a/.tickets/sl-j6g9.md
+++ b/.tickets/sl-j6g9.md
@@ -1,6 +1,6 @@
 ---
 id: sl-j6g9
-status: open
+status: closed
 deps: [sl-joeq]
 links: [sl-joeq, sl-f0x6]
 created: 2026-07-31T14:42:52Z
@@ -37,3 +37,8 @@ Exploratory test pass over the merged feature-35 + feature-38 work (main @ e831b
 Verified passing against the PRD's acceptance tests: name-shadowing at every depth (AT1-4, AT6 on deep-nested-bugs.stm), nested_arrow (AT7), flatten-in-each on examples/nested-iteration/pipeline.stm reporting 8/9 and 8/8 with orders.parcels.barcode the single gap (AT8, AT29), empty each body and computed-arrow-into-container both uncovered (AT16, AT17, per ADR-037), leaf-only percentages and depth invariance (AT18, AT19), whole-structure conferral including the empty-body and pipe-chain-body forms and the direct-vs-derived distinction (AT22-25, ADR-037/038). CLI, LSP and VS Code paths agree everywhere tested. fields --unmapped-by matches coverage --uncovered leaf for leaf across every mapping in examples/ and the CLI fixtures, with one exception (sl-ymxs).
 
 The epic stays open on its own acceptance criterion — 'coverage figures reported by the CLI, the VS Code status bar and the viz card are identical for the same workspace'. The viz card is not identical: it keeps a third derivation of covered paths (satsuma-viz/src/field-coverage.ts) that implements neither the NL @ref tier (sl-46wr, twelve shipped examples disagree) nor whole-structure conferral (sl-csrs). Also raised: sl-qead (a spread redeclaring an explicit field counts it twice, in the shipped corpus) and sl-lctd (R3/AT21 container state counts never reported by the CLI). Outside this epic: sl-8ba4 (--fail-under gates a rounded percentage, so 200/201 passes --fail-under 100), sl-ymxs, sl-v6rt.
+
+**2026-08-03T14:00:04Z**
+
+Cause: Feature 38 remained open after all coverage semantics, implementation, reporting, and cross-consumer parity children had shipped because a newly discovered fragment-redeclaration lint warning was parented to the coverage epic and the roadmap/PRD status was not reconciled.
+Fix: Archived the implemented PRD, moved Feature 38 into the shipped roadmap, unblocked Feature 39 dependencies, and detached sqdsp-00kv as a standalone lint follow-up. (commit a76836f6)

--- a/.tickets/sqdsp-00kv.md
+++ b/.tickets/sqdsp-00kv.md
@@ -7,8 +7,7 @@ created: 2026-08-03T06:09:18Z
 type: task
 priority: 3
 assignee: Thorben Louw
-parent: sl-j6g9
-tags: [feature-38, lint, validate, core]
+tags: [lint, validate, core, follow-up]
 ---
 # lint: warn when a fragment spread redeclares an explicitly declared field
 
@@ -17,6 +16,10 @@ sl-qead settled the semantics: a spread contributes only the names the body has 
 The author gets no signal that it happened. A redeclaration is legal but rarely deliberate — a reader has to know the fragment's contents to see that `...meta` adds less than it appears to, and the shadowed field silently loses whatever the fragment said about its type, constraints and note.
 
 satsuma validate reports nothing here today.
+
+This warning was discovered while closing Feature 38, but it does not change
+coverage semantics or cross-consumer parity. It remains open as a standalone
+lint follow-up rather than a child of the completed coverage epic.
 
 ## Design
 
@@ -31,4 +34,3 @@ Warning, not error: the ruling on sl-qead was explicitly that redeclaration stay
 ## Acceptance Criteria
 
 A schema that declares a field and spreads a fragment declaring the same name produces one warning-severity diagnostic naming the field and the fragment. The LSP surfaces it on the redeclaring line. Nothing is reported when the names do not collide. Corpus files that warn are either cleaned up or listed in the ticket notes as accepted. Coverage counts are unchanged — sl-qead already fixed those.
-

--- a/adrs/adr-036-nl-ref-coverage-tier.md
+++ b/adrs/adr-036-nl-ref-coverage-tier.md
@@ -18,7 +18,7 @@ auto-fix edits the mapping's `source {}` block to match.
 Feature 35 then introduced `satsuma coverage`, and excluded `@refs` from it —
 "NL interpretation: a field populated *implicitly* by prose in a note block is
 uncovered by definition" (`archive/features/35-coverage-command/PRD.md:233`), restated
-in `features/38-hierarchical-coverage/PRD.md:576`, in the `coverage.ts` module
+in `archive/features/38-hierarchical-coverage/PRD.md:576`, in the `coverage.ts` module
 comment ("deliberately *structural only*"), in `coverage --help`, and in
 `SATSUMA-CLI.md:126`. That carve-out was never recorded as an amendment to
 ADR-013, which remains Accepted and unsuperseded.

--- a/archive/features/35-coverage-command/PRD.md
+++ b/archive/features/35-coverage-command/PRD.md
@@ -4,7 +4,7 @@
 > epic `sl-ce11`. Archived 2026-08-02. The coverage-correctness defects found
 > while implementing this feature (nested records, whole-subtree arrows,
 > disagreeing percentage conventions across consumers) are out of scope here
-> and are tracked as Feature 38, which is still in flight.
+> and were subsequently delivered in Feature 38.
 >
 > Original motivation, retained as context — motivated by recurring
 > engagements where mapping specs are reverse-engineered from spreadsheet

--- a/archive/features/38-hierarchical-coverage/PRD.md
+++ b/archive/features/38-hierarchical-coverage/PRD.md
@@ -1,13 +1,10 @@
 # Feature 38 — Hierarchical Field Coverage
 
-> **Status: PROPOSED** (2026-07-31) — raised after reading the coverage
-> implementation and reproducing its behaviour. Six defects were found: coverage
-> resolves field names rather than paths and so reports unmapped fields as
-> mapped, two nesting constructs were not walked at all, three different
-> percentage conventions ship, two independent walkers derive the same paths, and
-> the container semantics the CLI and LSP each rely on are mutually
-> contradictory. The two unwalked constructs are fixed (`sl-qzy3`); the rest are
-> open, and share one root cause.
+> **Status: IMPLEMENTED** (2026-08-03) — all coverage semantics, implementation,
+> reporting, and cross-consumer parity work delivered under epic `sl-j6g9`.
+> Archived 2026-08-03. The author-facing fragment-redeclaration warning found
+> during parity work is a separate lint follow-up (`sqdsp-00kv`), not unfinished
+> coverage scope.
 >
 > **State this PRD was written against:** branch `feat/35-coverage-command` at
 > `47438ac`, since merged to `main` as **PR #405** (Feature 35 complete —
@@ -22,9 +19,12 @@
 > and none by a test, which is the case for removing the duplicate walker
 > rather than patching it a fourth time.
 >
-> **Defects 1, 4, 5 and 6 remain open.** Defect 5's *symptom* is gone — the two
-> walkers agree again on the nested corpus — but the duplication that caused it
-> is still there, which is what `sl-vu22` addresses. R1–R7 are unchanged.
+> **All six defects are fixed.** The implementation separates direct and derived
+> coverage, uses one extraction-backed path model, defines container tri-state and
+> whole-subtree semantics, and gives every consumer the core leaf-only ratio.
+> Cross-consumer parity tests cover fragment-spread expansion and the NL `@ref`
+> tier. The original defect analysis and acceptance criteria remain below as the
+> historical record of the feature.
 >
 > **Relationship to ADR-034 (Accepted).** This feature is not in tension with
 > it — ADR-034 reaches the same conclusion from the same evidence and names the

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -8,17 +8,7 @@ Feature specs live in `features/` while active and move to `archive/features/` o
 
 ## Active Feature Specs
 
-The four specs currently in `features/`. Everything numbered 01–35 has shipped and is archived (see [Shipped Features](#shipped-features)).
-
-### Feature 38 — Hierarchical Field Coverage (in flight)
-
-Makes field coverage correct and single-definition for nested records, lists of records, and schemas that reuse field names across depths, so a coverage percentage can be trusted as a merge gate. Four of nine tickets are closed (epic `sl-j6g9`).
-
-**Remaining:** `sl-0pun` (container tri-state: covered / partial / uncovered) and `sl-r6b0` (whole-subtree arrow coverage) are both unblocked and ready; then `sl-hcan` (the viz card counts containers in its ratio, disagreeing with `satsuma coverage`) and `sl-5nsv` (cross-consumer parity tests, including fragment-spread expansion).
-
-**Why it matters most:** until this lands, `--fail-under` can fail a fully-mapped spec — the repo's own canonical nested example reports 75% when it is 100% mapped.
-
-**Source:** `features/38-hierarchical-coverage/PRD.md`
+The three specs currently in `features/`. Everything numbered 01–35 and Feature 38 has shipped and is archived (see [Shipped Features](#shipped-features)).
 
 ### Feature 36 — Viz Coverage Overlay and Field Chain View (not started)
 
@@ -48,11 +38,11 @@ Two warning-severity lint rules — `type-mismatch-direct-arrow` (bare arrows be
 
 Moves the invariants this toolchain documents in prose into the build: node-kind types generated from `node-types.json` so a grammar rename cannot silently change behaviour, branded path and ref types so `sl-joeq`'s name-for-path confusion is unrepresentable, generated-input properties for the ADR-034–041 coverage rules, a naive reference model to differentially test against, and type-aware linting across the four packages that currently have none.
 
-**Why it matters:** the recent defect clusters were *specification* defects — `sl-joeq`, `sl-qead` (which forced ADR-041 to amend ADR-035), ADR-038 constraining ADR-037 — where the code correctly implemented a rule that was wrong or absent, and a green suite said so. Feature 38 is deciding what those rules should be; this feature makes them machine-checked so they cannot quietly stop holding.
+**Why it matters:** the recent defect clusters were *specification* defects — `sl-joeq`, `sl-qead` (which forced ADR-041 to amend ADR-035), ADR-038 constraining ADR-037 — where the code correctly implemented a rule that was wrong or absent, and a green suite said so. Feature 38 decided those rules; this feature makes them machine-checked so they cannot quietly stop holding.
 
 **Ready now:** R1 (generated node-kind types) is small, mechanical, blocks two other requirements, and touches nothing Feature 38 is changing. R5 and the R6 lint rollout follow.
 
-**Sequenced behind Feature 38:** R2, R3 and R4 touch `coverage.ts` and `coverage-paths.ts`, which `sl-0pun` and `sl-r6b0` are still changing; the two spikes (R7 rule-consistency model, R8 denotational spec section) wait for epic `sl-j6g9` to close.
+**Newly unblocked by Feature 38:** R2, R3 and R4 can now build on the settled coverage semantics, and the R7 rule-consistency and R8 denotational-spec spikes can begin now that epic `sl-j6g9` is closed.
 
 **Source:** `features/39-correctness-by-default/PRD.md`
 
@@ -64,6 +54,7 @@ Delivered and moved to `archive/features/`. Recent work, most recent first:
 
 | Feature | Shipped | What landed |
 | --- | --- | --- |
+| 38 — Hierarchical field coverage | 2026-08-03 | Path-correct nested coverage, container tri-state, whole-subtree arrow semantics, leaf-only ratios, and parity across the CLI, LSP, VS Code, and viz consumers (ADR-035–041) |
 | 35 — Workspace coverage command | 2026-08-01 | `satsuma coverage` with per-mapping/per-schema/workspace rollups, a stable `--json` contract, and a `--fail-under` CI gate on exit code 3; `computeMappingCoverage` relocated into `@satsuma/core` |
 | 34 — Live editor UX polish | 2026-06-10 | All eight R1–R8 fixes to the public playground chrome and edit-loop behaviour (ADR-029, ADR-030) |
 | 33 — Live editor / "Try it Live!" | 2026-06-10 | The client-only browser playground (ADR-027, ADR-028) — see [below](#browser-playground--live-editor-shipped--feature-33) |

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -419,11 +419,9 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
    production implementation.
 4. **Brands:** stop at coverage/ref normalization stages. The first migration is
    evidence for whether more nominal types are worth their ergonomics.
-5. **Feature 38 state:** the core path model and whole-structure semantics are
-   now implemented (`sl-fmx0`, `sl-r6b0`, `3ct-cs4y`, `sl-qead` closed). R3 and
-   R4 can begin against those accepted rules. R5 should wait for the remaining
-   viz coverage parity work (`sl-46wr`, `sl-csrs`) because it changes the same
-   consumer boundaries. I1 and I2 wait for the Feature 38 epic to close.
+5. **Feature 38 state:** the core path model, whole-structure semantics, and
+   cross-consumer parity are implemented and epic `sl-j6g9` is closed. R3, R4,
+   and R5 can begin against those accepted rules; I1 and I2 are also unblocked.
 6. **Static-check rollout:** R1/R2 first, then package-by-package R7. R6 is
    independent and can land immediately. R8 is a separate public-model migration
    and must not be hidden inside lint cleanup.


### PR DESCRIPTION
## Summary

- mark hierarchical field coverage as implemented and archive its PRD
- update the roadmap shipped list and unblock Feature 39 follow-on work
- detach `sqdsp-00kv` as a standalone lint follow-up and close epic `sl-j6g9`
- repair the moved Feature 38 path in ADR-036 and related historical references

## Validation

- `XDG_CACHE_HOME=/private/tmp/satsuma-feature38-ts-cache pyenv exec ./scripts/run-repo-checks.sh`
- parser fixtures: 39 passed, 1,172 subtests passed
- Excel skill: 24 passed
- smoke tests: 50 passed

Closes `sl-j6g9`. `sqdsp-00kv` remains open as a standalone lint follow-up.