### PR TITLE
Break down Feature 39 R2 migration

### DIFF
--- a/.tickets/tcc-chls.md
+++ b/.tickets/tcc-chls.md
@@ -1,0 +1,23 @@
+---
+id: tcc-chls
+status: open
+deps: [tcc-e35f]
+links: []
+created: 2026-08-03T14:38:22Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r2, viz-backend]
+---
+# viz-backend: migrate CST assembly to the generated contract
+
+Implement the satsuma-viz-backend consumer portion of Feature 39 R2. Type its workspace indexing and VizModel assembly comparisons with the generated CST contract, including the Node/browser model-from-sources parser path.
+
+## Design
+
+Consume the core SyntaxNode/Tree contract through parser-utils. Route model-from-sources parser output through the audited adapter established by tcc-e35f, usable in both Node and browser hosts. Narrow local block-kind maps and symbol-selecting helper parameters to SatsumaGrammarSymbol without changing FieldDecl or VizModel fields that merely happen to be named type.
+
+## Acceptance Criteria
+
+model-from-sources uses the audited typed parser boundary in both Node and browser hosts; parser-utils re-exports the typed core node/tree and symbol-aware helpers; workspace-index and viz-model direct CST comparisons, switch labels, lookup maps, and symbol selector parameters compile against SatsumaGrammarSymbol or SatsumaCstType as appropriate; unrelated VizModel and FieldDecl type strings remain semantically unchanged; no arbitrary CST casts are introduced; a removed referenced grammar symbol fails the package typecheck; all viz-backend tests and existing source-to-model parity coverage pass.

--- a/.tickets/tcc-e35f.md
+++ b/.tickets/tcc-e35f.md
@@ -1,0 +1,23 @@
+---
+id: tcc-e35f
+status: open
+deps: [gcsc-ejb2]
+links: []
+created: 2026-08-03T14:37:47Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r2, core, parser]
+---
+# core: enforce generated CST symbols at parser boundaries
+
+Implement the foundational core portion of Feature 39 R2. Make the shared CST node/tree contract recovery-aware and generated-symbol-typed, add the single audited narrowing boundary from web-tree-sitter parser output, and migrate core CST helpers and comparisons away from unchecked strings.
+
+## Design
+
+Import the R1 contract into core's public SyntaxNode and Tree types. Preserve web-tree-sitter's concrete runtime objects while isolating the unavoidable assertion in the parser adapter; extraction and formatting modules must not cast around the contract. Navigation helpers accept SatsumaGrammarSymbol, while recovery handling continues to name ERROR explicitly and missingness continues through isMissing. This ticket defines the adapter API consumed by the package migrations.
+
+## Acceptance Criteria
+
+SyntaxNode.type is SatsumaCstType and its child/parent properties recursively use the same typed interface; the public Tree root is typed; one documented core parser adapter narrows web-tree-sitter output and no extraction use site performs an arbitrary CST cast; child, children, allDescendants, formatter helpers, and other symbol-selecting core helpers accept SatsumaGrammarSymbol; every direct core CST comparison and switch compiles against the generated contract with ERROR handling explicit; a compile-time regression test proves an invalid or removed referenced symbol is rejected while adding a symbol does not impose exhaustive handling on partial walkers; existing and new core/parser tests pass.

--- a/.tickets/tcc-ef1b.md
+++ b/.tickets/tcc-ef1b.md
@@ -1,0 +1,23 @@
+---
+id: tcc-ef1b
+status: open
+deps: [tcc-e35f]
+links: []
+created: 2026-08-03T14:38:22Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r2, cli]
+---
+# cli: migrate CST use sites to the generated contract
+
+Implement the satsuma-cli consumer portion of Feature 39 R2 after the typed core boundary lands. Remove the CLI's parallel unchecked CST declarations, consume the core node/tree contract, and migrate CLI navigation helpers and direct CST symbol comparisons.
+
+## Design
+
+CLI file I/O remains in tooling/satsuma-cli/src/parser.ts, but parser output must enter through the audited adapter API established by tcc-e35f. Re-export shared core types instead of maintaining structural copies. Distinguish actual CST node types from unrelated domain fields named type so the migration stays semantically scoped.
+
+## Acceptance Criteria
+
+CLI SyntaxNode and Tree usages consume the shared core contract rather than a string-typed clone; parseFile and parseSource use the audited parser adapter without use-site casts; cst-query and other local symbol-selecting helpers accept SatsumaGrammarSymbol; direct CST comparisons and switch labels across CLI commands compile against the generated union, with domain model type fields left unchanged; a generated-symbol rename/removal affecting a CLI use site produces a compile failure; focused parser/query tests and the full CLI test suite pass.

--- a/.tickets/tcc-yb3z.md
+++ b/.tickets/tcc-yb3z.md
@@ -1,0 +1,23 @@
+---
+id: tcc-yb3z
+status: open
+deps: [tcc-e35f]
+links: []
+created: 2026-08-03T14:38:22Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r2, lsp]
+---
+# lsp: migrate concrete CST nodes to the generated contract
+
+Implement the satsuma-lsp consumer portion of Feature 39 R2. Preserve the concrete web-tree-sitter Node APIs needed by editor features while narrowing their type discriminant once and compiling every LSP CST comparison against the generated symbol contract.
+
+## Design
+
+The audited boundary belongs in parser-utils, which already owns LSP parser and navigation adaptation. Model the typed concrete node without weakening descendantForPosition, query capture, parent, and child APIs. Core helper wrappers accept SatsumaGrammarSymbol. Do not scatter assertions through hover, completion, definition, rename, semantic-token, diagnostic, or symbol handlers.
+
+## Acceptance Criteria
+
+LSP parser output and query-capture nodes cross one documented parser-utils narrowing boundary; the LSP's concrete node type preserves required web-tree-sitter methods while exposing SatsumaCstType recursively; child/children and equivalent helper parameters use SatsumaGrammarSymbol; every direct CST comparison and switch label in LSP handlers compiles against the generated contract, while LSP protocol discriminants remain unchanged; no arbitrary CST casts are introduced outside the audited adapter; an invalid referenced grammar symbol fails the LSP typecheck; all 299-or-current LSP tests pass with focused parser-utils and recovery coverage updated.

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -193,6 +193,9 @@ A string census would measure references, not semantic completeness.
 
 ### R2 — Enforce typed CST symbols at parser boundaries and use sites (fixes P1)
 
+Tickets: core/parser foundation `tcc-e35f`, CLI migration `tcc-ef1b`, LSP
+migration `tcc-yb3z`, and viz-backend migration `tcc-chls`.
+
 - `SyntaxNode.type` becomes `SatsumaCstType`, and its recursive child/parent
   properties use the same typed node interface.
 - Web-tree-sitter’s external `Node.type: string` is narrowed in one audited
@@ -431,15 +434,17 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 is the first implementation stage; later rows
-remain the agreed ticket shape and will receive concrete IDs when scheduled.
+Feature epic: `gcsc-qka8`. R1 and R2 now have concrete tickets; later rows
+remain the agreed ticket shape and will receive IDs when scheduled.
 
 | Work | Ticket shape | Depends on |
 |---|---|---|
 | Feature 39 epic (`gcsc-qka8`) | 1 epic | — |
 | R1 generated CST artifact and stale check (`gcsc-ejb2`) | 1 task | — |
-| R2 typed core node/helpers and parser adapters | 1 task | R1 |
-| R2 consumer CST-use migration | 1 task per consumer package or tightly coupled group | typed core task |
+| R2 typed core node/helpers and parser adapter (`tcc-e35f`) | 1 task | `gcsc-ejb2` |
+| R2 CLI CST-use migration (`tcc-ef1b`) | 1 task | `tcc-e35f` |
+| R2 LSP CST-use migration (`tcc-yb3z`) | 1 task | `tcc-e35f` |
+| R2 viz-backend CST-use migration (`tcc-chls`) | 1 task | `tcc-e35f` |
 | R3 semantic generators and coverage properties | 1 task | — |
 | R3 generated formatter properties | 1 task | semantic generator task |
 | R4 independent oracle and differential suite | 1 task | R3 semantic generator task |


### PR DESCRIPTION
## Summary

- split Feature 39 R2 into a core/parser foundation and independent CLI, LSP, and viz-backend migrations
- capture audited parser-boundary, generated-symbol, compile-failure, recovery, and package-test acceptance criteria
- encode `gcsc-ejb2` → `tcc-e35f` → consumer migration dependencies
- reference all four R2 tickets in the Feature 39 PRD

## Dependency graph

- `tcc-e35f`: core/parser foundation; depends on closed R1 `gcsc-ejb2`
- `tcc-ef1b`: CLI migration; depends on `tcc-e35f`
- `tcc-yb3z`: LSP migration; depends on `tcc-e35f`
- `tcc-chls`: viz-backend migration; depends on `tcc-e35f`

## Testing

- `tk dep cycle`: no dependency cycles
- markdown lint passed
- full repository pre-commit gate passed

Stacked on #443. Retarget/rebase onto `main` after #443 is rebase-merged.