### PR TITLE
test(core): generate semantic coverage and formatter properties

### DIFF
--- a/.tickets/cbdr-o6xn.md
+++ b/.tickets/cbdr-o6xn.md
@@ -27,4 +27,4 @@ fast-check is added only to satsuma-core devDependencies and npm audit reports n
 **2026-08-03T15:48:11Z**
 
 Cause: Coverage and path semantics were protected only by hand-selected examples, so small combinations such as spread collisions or source/target shape changes could escape the suite.
-Fix: Added a semantic-first fast-check generator, strict recovery-free rendering, reproducible failure diagnostics, and generated properties for all eight R3 coverage/path invariants (commit 380beaaa).
+Fix: Added a semantic-first fast-check generator, strict recovery-free rendering, reproducible failure diagnostics, and generated properties for all eight R3 coverage/path invariants (commit d747d887).

--- a/.tickets/cbdr-o6xn.md
+++ b/.tickets/cbdr-o6xn.md
@@ -1,0 +1,23 @@
+---
+id: cbdr-o6xn
+status: open
+deps: []
+links: []
+created: 2026-08-03T15:34:41Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r3, core, property-testing]
+---
+# core: add semantic generators and generated coverage properties
+
+Implement Feature 39 R3's generated-input coverage hardening. Add a reusable test-only semantic scenario model and renderer, then use it to check coverage and path invariants over generated valid Satsuma rather than only hand-selected examples.
+
+## Design
+
+Add fast-check as a dev dependency of satsuma-core. Keep the scenario model, arbitraries, renderer, and failure-reporting helpers under core test support: they are test infrastructure, not a second production API. Generate declarations, nested fields, refs, arrows, and fragment spreads as semantic data before rendering source. Every scenario used for a semantic assertion must first parse without ERROR or MISSING recovery nodes. Configure property execution and assertion messages so failures expose fast-check's seed/path plus the shrunk rendered Satsuma. Keep domains bounded and readable so counterexamples remain small. Do not reuse production coverage helpers to manufacture expected values; R4 owns the independent oracle.
+
+## Acceptance Criteria
+
+fast-check is added only to satsuma-core devDependencies and npm audit reports no high or critical vulnerability introduced; a documented test-support module generates bounded semantic scenarios with declarations, nested leaves, authored refs, mappings/arrows, and spread/explicit redeclaration cases and renders valid Satsuma; generated semantic tests fail immediately with the seed, replay path, and shrunk source if rendering produces ERROR or MISSING nodes; purpose-commented properties prove all eight R3 invariants: exact 0%/100% endpoints for non-empty schemas, one coverage entry per qualified declared path after spread expansion, record-to-record whole-structure target expansion, no target subtree expansion from scalar or unresolved sources, exact proper-prefix ancestor derivation, the three schemaLocalFieldPath normalization cases, coverage-ratio preservation under structure-preserving re-nesting, and monotonic leaf coverage when a valid arrow is added; each property names its ADR or contract and uses minimal bounded inputs without filtering away invalid renders; existing hand-authored coverage/path regressions remain and the full satsuma-core suite passes.

--- a/.tickets/cbdr-o6xn.md
+++ b/.tickets/cbdr-o6xn.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-o6xn
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-08-03T15:34:41Z

--- a/.tickets/cbdr-o6xn.md
+++ b/.tickets/cbdr-o6xn.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-o6xn
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-03T15:34:41Z
@@ -21,3 +21,10 @@ Add fast-check as a dev dependency of satsuma-core. Keep the scenario model, arb
 ## Acceptance Criteria
 
 fast-check is added only to satsuma-core devDependencies and npm audit reports no high or critical vulnerability introduced; a documented test-support module generates bounded semantic scenarios with declarations, nested leaves, authored refs, mappings/arrows, and spread/explicit redeclaration cases and renders valid Satsuma; generated semantic tests fail immediately with the seed, replay path, and shrunk source if rendering produces ERROR or MISSING nodes; purpose-commented properties prove all eight R3 invariants: exact 0%/100% endpoints for non-empty schemas, one coverage entry per qualified declared path after spread expansion, record-to-record whole-structure target expansion, no target subtree expansion from scalar or unresolved sources, exact proper-prefix ancestor derivation, the three schemaLocalFieldPath normalization cases, coverage-ratio preservation under structure-preserving re-nesting, and monotonic leaf coverage when a valid arrow is added; each property names its ADR or contract and uses minimal bounded inputs without filtering away invalid renders; existing hand-authored coverage/path regressions remain and the full satsuma-core suite passes.
+
+## Notes
+
+**2026-08-03T15:48:11Z**
+
+Cause: Coverage and path semantics were protected only by hand-selected examples, so small combinations such as spread collisions or source/target shape changes could escape the suite.
+Fix: Added a semantic-first fast-check generator, strict recovery-free rendering, reproducible failure diagnostics, and generated properties for all eight R3 coverage/path invariants (commit 380beaaa).

--- a/.tickets/cbdr-yp9m.md
+++ b/.tickets/cbdr-yp9m.md
@@ -27,4 +27,4 @@ generated formatter properties reuse cbdr-o6xn's semantic scenarios and renderer
 **2026-08-03T15:52:53Z**
 
 Cause: Formatter round-trip guarantees were exercised only by the fixed examples corpus, leaving valid combinations from the new semantic generator unexplored.
-Fix: Reused the recovery-free semantic generator for independent idempotence, CST-equivalence, and error-free reparse properties, sharing the corpus serializer (commit 194fd06d).
+Fix: Reused the recovery-free semantic generator for independent idempotence, CST-equivalence, and error-free reparse properties, sharing the corpus serializer (commit 724d5de7).

--- a/.tickets/cbdr-yp9m.md
+++ b/.tickets/cbdr-yp9m.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-yp9m
-status: open
+status: in_progress
 deps: [cbdr-o6xn]
 links: []
 created: 2026-08-03T15:34:49Z

--- a/.tickets/cbdr-yp9m.md
+++ b/.tickets/cbdr-yp9m.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-yp9m
-status: in_progress
+status: closed
 deps: [cbdr-o6xn]
 links: []
 created: 2026-08-03T15:34:49Z
@@ -21,3 +21,10 @@ Consume the test-only scenario renderer from cbdr-o6xn rather than creating a se
 ## Acceptance Criteria
 
 generated formatter properties reuse cbdr-o6xn's semantic scenarios and renderer; every property test opens with a purpose comment naming the invariant it protects; generated source parses with no ERROR or MISSING nodes before formatting and formatted output reparses with no recovery nodes; format(format(source)) equals format(source); formatting preserves CST structure under the repository's existing structure comparison; failures report seed, replay path, and shrunk source; canonical corpus round-trip tests and all focused formatter regressions remain in place; the complete satsuma-core test suite passes.
+
+## Notes
+
+**2026-08-03T15:52:53Z**
+
+Cause: Formatter round-trip guarantees were exercised only by the fixed examples corpus, leaving valid combinations from the new semantic generator unexplored.
+Fix: Reused the recovery-free semantic generator for independent idempotence, CST-equivalence, and error-free reparse properties, sharing the corpus serializer (commit 194fd06d).

--- a/.tickets/cbdr-yp9m.md
+++ b/.tickets/cbdr-yp9m.md
@@ -1,0 +1,23 @@
+---
+id: cbdr-yp9m
+status: open
+deps: [cbdr-o6xn]
+links: []
+created: 2026-08-03T15:34:49Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r3, core, formatter, property-testing]
+---
+# core: add generated formatter round-trip properties
+
+Complete Feature 39 R3 by reusing its semantic scenario generator to exercise formatter round-trips over generated valid Satsuma in addition to the canonical examples corpus.
+
+## Design
+
+Consume the test-only scenario renderer from cbdr-o6xn rather than creating a second arbitrary grammar-string generator. For every generated source, establish the recovery-free parse precondition, format it, reparse the output, and check the three formatter properties independently: idempotence, CST structural equivalence, and error-free reparse. Share small structure/error helpers with existing formatter tests where doing so removes duplication without weakening the canonical corpus coverage. Preserve fast-check replay diagnostics and include the shrunk Satsuma source in failures.
+
+## Acceptance Criteria
+
+generated formatter properties reuse cbdr-o6xn's semantic scenarios and renderer; every property test opens with a purpose comment naming the invariant it protects; generated source parses with no ERROR or MISSING nodes before formatting and formatted output reparses with no recovery nodes; format(format(source)) equals format(source); formatting preserves CST structure under the repository's existing structure comparison; failures report seed, replay path, and shrunk source; canonical corpus round-trip tests and all focused formatter regressions remain in place; the complete satsuma-core test suite passes.

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -213,6 +213,9 @@ migration `tcc-yb3z`, and viz-backend migration `tcc-chls`.
 
 ### R3 — Add generated-input properties for coverage and formatting (fixes P3)
 
+Tickets: semantic generators and coverage properties `cbdr-o6xn`, followed by
+generated formatter properties `cbdr-yp9m`.
+
 Add `fast-check` as a dev dependency of `satsuma-core`. Generators build a small
 semantic scenario first — declarations, refs, arrows, nesting, and spreads —
 then render valid Satsuma from that scenario. A property run must never discard
@@ -434,7 +437,7 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 and R2 now have concrete tickets; later rows
+Feature epic: `gcsc-qka8`. R1 through R3 now have concrete tickets; later rows
 remain the agreed ticket shape and will receive IDs when scheduled.
 
 | Work | Ticket shape | Depends on |
@@ -445,8 +448,8 @@ remain the agreed ticket shape and will receive IDs when scheduled.
 | R2 CLI CST-use migration (`tcc-ef1b`) | 1 task | `tcc-e35f` |
 | R2 LSP CST-use migration (`tcc-yb3z`) | 1 task | `tcc-e35f` |
 | R2 viz-backend CST-use migration (`tcc-chls`) | 1 task | `tcc-e35f` |
-| R3 semantic generators and coverage properties | 1 task | — |
-| R3 generated formatter properties | 1 task | semantic generator task |
+| R3 semantic generators and coverage properties (`cbdr-o6xn`) | 1 task | — |
+| R3 generated formatter properties (`cbdr-yp9m`) | 1 task | `cbdr-o6xn` |
 | R4 independent oracle and differential suite | 1 task | R3 semantic generator task |
 | R5 opaque path/ref stages | 1 core task plus consumer migration subtasks if needed | `sl-46wr`, `sl-csrs` |
 | R6 CLI test typecheck gate | 1 task | — |

--- a/tooling/satsuma-core/package-lock.json
+++ b/tooling/satsuma-core/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },
@@ -217,6 +218,29 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/find-up": {
@@ -493,6 +517,23 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -90,6 +90,7 @@
   "devDependencies": {
     "@types/node": "^26.1.2",
     "c8": "^12.0.0",
+    "fast-check": "^4.9.0",
     "typescript": "^6.0.3"
   }
 }

--- a/tooling/satsuma-core/test/format.test.js
+++ b/tooling/satsuma-core/test/format.test.js
@@ -17,6 +17,7 @@ import { readFileSync, readdirSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { format, initParser, getParser } from "../dist/index.js";
+import { cstStructure } from "./support/cst-structure.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -49,19 +50,6 @@ function fmt(src) {
   return format(tree, src);
 }
 
-function structureOf(node) {
-  if (node.childCount === 0) {
-    if (node.isNamed) return node.type + "=" + JSON.stringify(node.text);
-    return null;
-  }
-  const kids = [];
-  for (const c of node.children) {
-    const s = structureOf(c);
-    if (s !== null) kids.push(s);
-  }
-  return node.type + "(" + kids.join(",") + ")";
-}
-
 // ── Corpus Round-Trip (Idempotency + Structural Equivalence) ─────────────────
 
 describe("corpus round-trip", () => {
@@ -82,8 +70,8 @@ describe("corpus round-trip", () => {
         const out = fmt(src);
         const { tree: tree2 } = parseSource(out);
         assert.equal(
-          structureOf(tree1.rootNode),
-          structureOf(tree2.rootNode),
+          cstStructure(tree1.rootNode),
+          cstStructure(tree2.rootNode),
           "parse trees should be structurally identical",
         );
       });

--- a/tooling/satsuma-core/test/generated-coverage-properties.test.js
+++ b/tooling/satsuma-core/test/generated-coverage-properties.test.js
@@ -1,0 +1,300 @@
+/**
+ * generated-coverage-properties.test.js — Generated checks for settled coverage rules.
+ *
+ * Hand-authored regressions remain the clearest examples of known defects.
+ * These bounded fast-check properties explore combinations their authors did
+ * not select, while rendering every semantic input through the real parser and
+ * extraction boundary before asserting coverage behaviour.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import fc from "fast-check";
+import {
+  buildCoveredFieldPaths,
+  initParser,
+  leafFieldEntries,
+  schemaLocalFieldPath,
+  summarizeFieldCoverage,
+} from "@satsuma/core";
+import {
+  coverageEndpointScenarioArbitrary,
+  coverageForScenario,
+  dottedPathsArbitrary,
+  GENERATED_PROPERTY_PARAMETERS,
+  monotonicScenarioArbitrary,
+  nonContainerSourceScenarioArbitrary,
+  parseGeneratedScenario,
+  renestingScenarioArbitrary,
+  schemaLocalRefScenarioArbitrary,
+  spreadRedeclarationScenarioArbitrary,
+  wholeStructureScenarioArbitrary,
+} from "./support/generated-scenarios.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+/** Return the one schema coverage entry for a generated mapping role. */
+function forRole(result, role, source) {
+  const schema = result.schemas.find((entry) => entry.role === role);
+  assert.ok(schema, `expected generated ${role} coverage:\n${source}`);
+  return schema;
+}
+
+/** Sorted array form keeps set equality failures concise and deterministic. */
+function sorted(values) {
+  return [...values].sort();
+}
+
+/** All proper dotted prefixes of one path, shortest first. */
+function properPrefixes(path) {
+  const parts = path.split(".");
+  return parts.slice(0, -1).map((_, index) => parts.slice(0, index + 1).join("."));
+}
+
+/** Covered leaf paths from one generated schema result. */
+function coveredLeaves(schema) {
+  return new Set(
+    leafFieldEntries(schema.fields)
+      .filter((field) => field.mapped)
+      .map((f) => f.path),
+  );
+}
+
+describe("generated coverage invariants", () => {
+  it("reserves 0% and 100% for the exact uncovered and complete endpoints", () => {
+    // ADR-040: on every non-empty generated schema, an endpoint percentage is
+    // an exact claim about every leaf rather than a rounding bucket.
+    fc.assert(
+      fc.property(coverageEndpointScenarioArbitrary, ({ scenario, complete, leafCount }) => {
+        const { source, result } = coverageForScenario(scenario);
+        const target = forRole(result, "target", source);
+        const totals = summarizeFieldCoverage(target.fields);
+        assert.equal(totals.total, leafCount, `generated denominator changed:\n${source}`);
+        assert.equal(
+          totals.covered,
+          complete ? leafCount : 0,
+          `generated endpoint count is not exact:\n${source}`,
+        );
+        assert.equal(
+          totals.pct,
+          complete ? 100 : 0,
+          `generated endpoint percentage is not exact:\n${source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("emits one coverage entry per qualified path after spread expansion", () => {
+    // ADR-041: a body declaration shadows a spread field, so writing the same
+    // name through both routes cannot duplicate a coverage row or denominator.
+    fc.assert(
+      fc.property(spreadRedeclarationScenarioArbitrary, ({ scenario, expectedPaths }) => {
+        const { source, result } = coverageForScenario(scenario);
+        const paths = forRole(result, "target", source).fields.map((field) => field.path);
+        assert.equal(
+          paths.length,
+          new Set(paths).size,
+          `generated spread produced duplicate coverage paths:\n${source}`,
+        );
+        assert.deepEqual(
+          sorted(paths),
+          sorted(expectedPaths),
+          `generated spread changed the declared path set:\n${source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("covers every target leaf under a record-to-record whole-structure arrow", () => {
+    // ADR-037 constrained by ADR-038: a correspondence carrying a declared
+    // record populates the target record's entire declared leaf subtree.
+    fc.assert(
+      fc.property(wholeStructureScenarioArbitrary, ({ scenario, expectedTargetLeaves }) => {
+        const { source, result } = coverageForScenario(scenario);
+        const target = forRole(result, "target", source);
+        const covered = coveredLeaves(target);
+        assert.deepEqual(
+          sorted(covered),
+          sorted(expectedTargetLeaves),
+          `generated whole-structure arrow missed a target leaf:\n${source}`,
+        );
+        assert.equal(
+          summarizeFieldCoverage(target.fields).pct,
+          100,
+          `generated record correspondence must be complete:\n${source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("never expands a target record from a scalar or unresolved source", () => {
+    // ADR-038's fail-closed rule: neither a declared scalar nor an unresolved
+    // path is evidence that every target-record leaf has been populated.
+    fc.assert(
+      fc.property(
+        nonContainerSourceScenarioArbitrary,
+        ({ scenario, sourceKind, expectedTargetLeaves }) => {
+          const { source, result } = coverageForScenario(scenario);
+          const target = forRole(result, "target", source);
+          const leafByPath = new Map(leafFieldEntries(target.fields).map((f) => [f.path, f]));
+          for (const path of expectedTargetLeaves) {
+            assert.equal(
+              leafByPath.get(path)?.mapped,
+              false,
+              `${sourceKind} source expanded generated target leaf ${path}:\n${source}`,
+            );
+          }
+          assert.equal(
+            summarizeFieldCoverage(target.fields).pct,
+            0,
+            `${sourceKind} source manufactured generated target coverage:\n${source}`,
+          );
+        },
+      ),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("derives exactly the proper dotted prefixes of every direct path", () => {
+    // coverage-paths.ts contract: `ancestors` is a derived prefix set, never a
+    // bag of bare segments or a place for unrelated paths.
+    fc.assert(
+      fc.property(dottedPathsArbitrary, ({ paths, scenario }) => {
+        const { source } = parseGeneratedScenario(scenario);
+        const covered = buildCoveredFieldPaths(paths);
+        const expectedAncestors = new Set(paths.flatMap(properPrefixes));
+        assert.deepEqual(
+          sorted(covered.direct),
+          sorted(new Set(paths)),
+          `generated direct paths changed:\n${source}`,
+        );
+        assert.deepEqual(
+          sorted(covered.ancestors),
+          sorted(expectedAncestors),
+          `generated ancestor paths changed:\n${source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("leaves a ref already known to be schema-local unchanged", () => {
+    // schemaLocalFieldPath contract: normalization must not edit an authored
+    // local path merely because it contains several dotted segments.
+    fc.assert(
+      fc.property(
+        schemaLocalRefScenarioArbitrary,
+        ({ ownSchema, otherSchema, localPath, scenario }) => {
+          const { source } = parseGeneratedScenario(scenario);
+          assert.equal(
+            schemaLocalFieldPath(localPath, [ownSchema], [otherSchema]),
+            localPath,
+            `generated schema-local ref changed:\n${source}`,
+          );
+        },
+      ),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("rejects a ref belonging to another participating schema", () => {
+    // schemaLocalFieldPath contract: a multi-source sibling claims its own
+    // qualified ref; the schema currently being reported must return null.
+    fc.assert(
+      fc.property(
+        schemaLocalRefScenarioArbitrary,
+        ({ ownSchema, otherSchema, localPath, scenario }) => {
+          const { source } = parseGeneratedScenario(scenario);
+          assert.equal(
+            schemaLocalFieldPath(`${otherSchema}.${localPath}`, [ownSchema], [otherSchema]),
+            null,
+            `generated other-schema ref was claimed locally:\n${source}`,
+          );
+        },
+      ),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("removes an unshadowed own-schema prefix exactly once", () => {
+    // schemaLocalFieldPath contract: the schema prefix is one normalization
+    // stage, so stripping it must yield the untouched schema-local remainder.
+    fc.assert(
+      fc.property(
+        schemaLocalRefScenarioArbitrary,
+        ({ ownSchema, otherSchema, localPath, scenario }) => {
+          const { source } = parseGeneratedScenario(scenario);
+          assert.equal(
+            schemaLocalFieldPath(`${ownSchema}.${localPath}`, [ownSchema], [otherSchema]),
+            localPath,
+            `generated own-schema prefix did not normalize once:\n${source}`,
+          );
+        },
+      ),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("preserves the leaf coverage ratio under structure-preserving re-nesting", () => {
+    // Feature 38 depth-invariance goal: adding record structure and rewriting
+    // every arrow through the same path bijection cannot move a leaf ratio.
+    fc.assert(
+      fc.property(renestingScenarioArbitrary, ({ flat, nested }) => {
+        const flatCoverage = coverageForScenario(flat);
+        const nestedCoverage = coverageForScenario(nested);
+        const flatTotals = summarizeFieldCoverage(
+          forRole(flatCoverage.result, "target", flatCoverage.source).fields,
+        );
+        const nestedTotals = summarizeFieldCoverage(
+          forRole(nestedCoverage.result, "target", nestedCoverage.source).fields,
+        );
+        assert.deepEqual(
+          nestedTotals,
+          flatTotals,
+          `re-nesting changed generated leaf coverage:\nFLAT\n${flatCoverage.source}\nNESTED\n${nestedCoverage.source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("cannot remove a covered leaf when one valid arrow is added", () => {
+    // Coverage monotonicity: adding a valid declaration may cover another leaf
+    // but must never invalidate a leaf that `--fail-under` already counted.
+    fc.assert(
+      fc.property(monotonicScenarioArbitrary, ({ before, after, addedPath }) => {
+        const beforeCoverage = coverageForScenario(before);
+        const afterCoverage = coverageForScenario(after);
+        const beforeCovered = coveredLeaves(
+          forRole(beforeCoverage.result, "target", beforeCoverage.source),
+        );
+        const afterCovered = coveredLeaves(
+          forRole(afterCoverage.result, "target", afterCoverage.source),
+        );
+        for (const path of beforeCovered) {
+          assert.equal(
+            afterCovered.has(path),
+            true,
+            `adding ${addedPath} removed generated coverage for ${path}:\n${afterCoverage.source}`,
+          );
+        }
+        assert.equal(
+          afterCovered.has(addedPath),
+          true,
+          `added generated arrow did not cover ${addedPath}:\n${afterCoverage.source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+});

--- a/tooling/satsuma-core/test/generated-format-properties.test.js
+++ b/tooling/satsuma-core/test/generated-format-properties.test.js
@@ -1,0 +1,108 @@
+/**
+ * generated-format-properties.test.js — Formatter properties over generated Satsuma.
+ *
+ * These checks extend the canonical examples corpus with bounded semantic
+ * scenarios from generated-scenarios.js. Inputs are rendered from declarations
+ * and mappings, not arbitrary grammar text, and must parse without recovery
+ * before the formatter is allowed to run.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import fc from "fast-check";
+import { collectParseErrors, format, getParser, initParser } from "@satsuma/core";
+import { cstStructure } from "./support/cst-structure.js";
+import {
+  GENERATED_PROPERTY_PARAMETERS,
+  parseGeneratedScenario,
+  semanticScenarioArbitrary,
+} from "./support/generated-scenarios.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+/** Format one strictly parsed scenario and reparse the formatter output. */
+function formatScenario(scenario) {
+  const { source, tree } = parseGeneratedScenario(scenario);
+  const formatted = format(tree, source);
+  const formattedTree = getParser().parse(formatted);
+  assert.ok(
+    formattedTree,
+    `formatter output returned no parse tree:\nSOURCE\n${source}\nFORMATTED\n${formatted}`,
+  );
+  return {
+    source,
+    sourceTree: tree,
+    formatted,
+    formattedTree,
+    formattedErrors: collectParseErrors(formattedTree),
+  };
+}
+
+describe("generated formatter properties", () => {
+  it("is idempotent over generated recovery-free Satsuma", () => {
+    // Formatter idempotence: once canonical layout is produced, a second pass
+    // must be byte-identical for every generated semantic scenario.
+    fc.assert(
+      fc.property(semanticScenarioArbitrary, (scenario) => {
+        const { source, formatted, formattedTree, formattedErrors } = formatScenario(scenario);
+        assert.deepEqual(
+          formattedErrors,
+          [],
+          `first formatter pass introduced recovery:\nSOURCE\n${source}\nFORMATTED\n${formatted}`,
+        );
+        const formattedTwice = format(formattedTree, formatted);
+        assert.equal(
+          formattedTwice,
+          formatted,
+          `formatter is not idempotent:\nSOURCE\n${source}\nFIRST\n${formatted}\nSECOND\n${formattedTwice}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("preserves generated CST structure", () => {
+    // Structural equivalence: formatting may change layout and anonymous
+    // punctuation placement, never named grammar structure or semantic leaves.
+    fc.assert(
+      fc.property(semanticScenarioArbitrary, (scenario) => {
+        const { source, sourceTree, formatted, formattedTree, formattedErrors } =
+          formatScenario(scenario);
+        assert.deepEqual(
+          formattedErrors,
+          [],
+          `structural comparison requires a clean reparse:\nSOURCE\n${source}\nFORMATTED\n${formatted}`,
+        );
+        assert.equal(
+          cstStructure(formattedTree.rootNode),
+          cstStructure(sourceTree.rootNode),
+          `formatter changed generated CST structure:\nSOURCE\n${source}\nFORMATTED\n${formatted}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("reparses generated formatter output without recovery nodes", () => {
+    // Error-free reparse: a formatter must never turn a valid generated file
+    // into one that tree-sitter repairs with ERROR or MISSING nodes.
+    fc.assert(
+      fc.property(semanticScenarioArbitrary, (scenario) => {
+        const { source, formatted, formattedErrors } = formatScenario(scenario);
+        assert.deepEqual(
+          formattedErrors,
+          [],
+          `formatter introduced recovery nodes:\nSOURCE\n${source}\nFORMATTED\n${formatted}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+});

--- a/tooling/satsuma-core/test/support/cst-structure.js
+++ b/tooling/satsuma-core/test/support/cst-structure.js
@@ -1,0 +1,26 @@
+/**
+ * cst-structure.js — Layout-independent CST serialization for formatter tests.
+ *
+ * The formatter's structural contract is shared by the canonical corpus and
+ * generated inputs. Keeping its serializer here prevents the two suites from
+ * drifting into subtly different definitions of "same parse tree".
+ */
+
+/**
+ * Serialize named structure and named leaf text while ignoring anonymous
+ * punctuation. Formatting may move punctuation and whitespace, but it must not
+ * change the named grammar structure or authored semantic tokens.
+ */
+export function cstStructure(node) {
+  if (node.childCount === 0) {
+    if (node.isNamed) return `${node.type}=${JSON.stringify(node.text)}`;
+    return null;
+  }
+
+  const children = [];
+  for (const child of node.children) {
+    const structure = cstStructure(child);
+    if (structure !== null) children.push(structure);
+  }
+  return `${node.type}(${children.join(",")})`;
+}

--- a/tooling/satsuma-core/test/support/generated-scenarios.js
+++ b/tooling/satsuma-core/test/support/generated-scenarios.js
@@ -1,0 +1,461 @@
+/**
+ * generated-scenarios.js — Semantic-first generated Satsuma test inputs.
+ *
+ * Property tests build bounded declarations, mappings, arrows, nesting, and
+ * fragment spreads as plain semantic data, then render that data to Satsuma.
+ * This module owns test generation and rendering only: expected coverage rules
+ * stay in the property tests, and R4's independent oracle remains separate.
+ */
+
+import assert from "node:assert/strict";
+import fc from "fast-check";
+import {
+  collectParseErrors,
+  computeMappingCoverage,
+  declaresRecordBody,
+  expandDeclaredFields,
+  extractFragments,
+  extractSchemas,
+  getParser,
+  makeEntityRefResolver,
+} from "@satsuma/core";
+
+/** Enough runs to explore combinations while keeping the full repository suite quick. */
+const GENERATED_PROPERTY_RUNS = 100;
+
+/** Maximum generated leaves; small bounds make shrunk counterexamples reviewable. */
+const MAX_GENERATED_LEAVES = 5;
+
+/** Shared fast-check settings; fast-check adds the replay seed and path on failure. */
+export const GENERATED_PROPERTY_PARAMETERS = Object.freeze({
+  numRuns: GENERATED_PROPERTY_RUNS,
+  verbose: true,
+  // fast-check 4 omits the thrown assertion by default. Keeping it in the
+  // report is what places the final shrunk Satsuma beside the seed and path.
+  includeErrorInReport: true,
+});
+
+// ── Semantic model ─────────────────────────────────────────────────────────
+
+/** @typedef {{ name: string, kind: "scalar" }} ScalarField */
+/**
+ * @typedef {{
+ *   name: string,
+ *   kind: "record",
+ *   fields: SemanticField[],
+ *   spreads?: string[],
+ * }} RecordField
+ */
+/** @typedef {ScalarField | RecordField} SemanticField */
+/**
+ * @typedef {{
+ *   name: string,
+ *   fields: SemanticField[],
+ *   spreads?: string[],
+ * }} SemanticEntity
+ */
+/** @typedef {{ sources: string[], target: string }} SemanticArrow */
+/**
+ * @typedef {{
+ *   name: string,
+ *   sources: string[],
+ *   targets: string[],
+ *   arrows: SemanticArrow[],
+ * }} SemanticMapping
+ */
+/**
+ * @typedef {{
+ *   fragments: SemanticEntity[],
+ *   schemas: SemanticEntity[],
+ *   mapping: SemanticMapping,
+ * }} SemanticScenario
+ */
+
+/** Construct one scalar declaration in the generated semantic model. */
+function scalarField(name) {
+  return { name, kind: "scalar" };
+}
+
+/** Construct one record declaration in the generated semantic model. */
+function recordField(name, fields, spreads = []) {
+  return { name, kind: "record", fields, ...(spreads.length > 0 ? { spreads } : {}) };
+}
+
+/** Stable leaf names derived from a generated count rather than arbitrary text. */
+function leafNames(count) {
+  return Array.from({ length: count }, (_, index) => `field_${index}`);
+}
+
+/** A minimal two-schema mapping scenario used by most generated properties. */
+function mappingScenario({ sourceFields, targetFields, arrows, fragments = [] }) {
+  return {
+    fragments,
+    schemas: [
+      { name: "src", fields: sourceFields },
+      { name: "tgt", fields: targetFields },
+    ],
+    mapping: { name: "load", sources: ["src"], targets: ["tgt"], arrows },
+  };
+}
+
+/** Prefix every field path with the same generated record chain. */
+function nestFields(fields, depth) {
+  let nested = fields;
+  for (let level = depth - 1; level >= 0; level -= 1) {
+    nested = [recordField(`group_${level}`, nested)];
+  }
+  return nested;
+}
+
+/** Prefix one leaf path with the record chain produced by {@link nestFields}. */
+function nestedPath(path, depth) {
+  const prefixes = Array.from({ length: depth }, (_, level) => `group_${level}`);
+  return [...prefixes, path].join(".");
+}
+
+/** Turn one dotted path into the smallest semantic field tree declaring it. */
+function fieldTreeForPath(path) {
+  const [head, ...tail] = path.split(".");
+  return tail.length === 0
+    ? [scalarField(head)]
+    : [recordField(head, fieldTreeForPath(tail.join(".")))];
+}
+
+/** Every semantic leaf path, qualified from the schema root. */
+export function semanticLeafPaths(fields, prefix = "") {
+  return fields.flatMap((field) => {
+    const path = prefix ? `${prefix}.${field.name}` : field.name;
+    return field.kind === "record" ? semanticLeafPaths(field.fields, path) : [path];
+  });
+}
+
+// ── Rendering and strict parsing ───────────────────────────────────────────
+
+/** Render fields and spreads at one declaration level. */
+function renderMembers(fields, spreads, indent) {
+  const members = fields.map((field) => renderField(field, indent));
+  members.push(...(spreads ?? []).map((spread) => `${indent}...${spread}`));
+  return members.join("\n");
+}
+
+/** Render one scalar or record field declaration. */
+function renderField(field, indent) {
+  if (field.kind === "scalar") return `${indent}${field.name} STRING`;
+
+  const body = renderMembers(field.fields, field.spreads, `${indent}  `);
+  return body.length > 0
+    ? `${indent}${field.name} record {\n${body}\n${indent}}`
+    : `${indent}${field.name} record {}`;
+}
+
+/** Render a schema-shaped fragment or schema declaration. */
+function renderEntity(keyword, entity) {
+  const body = renderMembers(entity.fields, entity.spreads, "  ");
+  return body.length > 0
+    ? `${keyword} ${entity.name} {\n${body}\n}`
+    : `${keyword} ${entity.name} {}`;
+}
+
+/** Render the generated mapping, preserving the semantic arrow order. */
+function renderMapping(mapping) {
+  const lines = [
+    `mapping ${mapping.name} {`,
+    `  source { ${mapping.sources.join(", ")} }`,
+    `  target { ${mapping.targets.join(", ")} }`,
+    ...mapping.arrows.map((arrow) => `  ${arrow.sources.join(", ")} -> ${arrow.target}`),
+    "}",
+  ];
+  return lines.join("\n");
+}
+
+/** Render one semantic scenario into a complete Satsuma source file. */
+export function renderScenario(scenario) {
+  return [
+    ...scenario.fragments.map((fragment) => renderEntity("fragment", fragment)),
+    ...scenario.schemas.map((schema) => renderEntity("schema", schema)),
+    renderMapping(scenario.mapping),
+  ].join("\n\n");
+}
+
+/**
+ * Parse generated source and reject every ERROR or MISSING recovery node.
+ *
+ * The source is included in the assertion message. When fast-check shrinks a
+ * failure, its seed/path report therefore sits beside the final shrunk Satsuma
+ * input instead of an opaque semantic object.
+ */
+export function parseGeneratedScenario(scenario) {
+  const source = renderScenario(scenario);
+  const tree = getParser().parse(source);
+  assert.ok(tree, `generated Satsuma returned no parse tree:\n${source}`);
+  const errors = collectParseErrors(tree);
+  assert.deepEqual(errors, [], `generated Satsuma must be recovery-free:\n${source}`);
+  return { source, tree };
+}
+
+/** Project extracted fields onto the deliberately narrow coverage input shape. */
+function toCoverageFields(fields) {
+  return fields.map((field) => ({
+    name: field.name,
+    line: field.startRow,
+    ...(declaresRecordBody(field.type) ? { container: true } : {}),
+    children: field.children ? toCoverageFields(field.children) : undefined,
+  }));
+}
+
+/** Canonical key for a generated schema or fragment extracted from the CST. */
+function entityKey(entity) {
+  assert.ok(entity.name, "generated entities always carry a name");
+  return entity.namespace ? `${entity.namespace}::${entity.name}` : entity.name;
+}
+
+/**
+ * Run the production parser, extraction, spread expansion, and coverage path.
+ *
+ * Expected values are intentionally not built here. Each property states its
+ * invariant directly, while R4 will supply the independent semantic oracle.
+ */
+export function coverageForScenario(scenario) {
+  const { source, tree } = parseGeneratedScenario(scenario);
+  const fragments = new Map(
+    extractFragments(tree.rootNode).map((fragment) => [entityKey(fragment), fragment]),
+  );
+  const resolveFragment = makeEntityRefResolver(fragments);
+  const lookupFragment = (key) => fragments.get(key) ?? null;
+  const schemas = new Map(
+    extractSchemas(tree.rootNode).map((schema) => {
+      const fields = expandDeclaredFields(
+        schema,
+        schema.namespace,
+        resolveFragment,
+        lookupFragment,
+      );
+      return [
+        entityKey(schema),
+        { uri: "file:///generated.stm", fields: toCoverageFields(fields) },
+      ];
+    }),
+  );
+  const result = computeMappingCoverage(
+    tree,
+    scenario.mapping.name,
+    (schemaId) => schemas.get(schemaId) ?? null,
+  );
+  return { source, tree, result };
+}
+
+// ── Scenario arbitraries ───────────────────────────────────────────────────
+
+/** Non-empty generated leaf count shared by coverage domains. */
+const leafCountArbitrary = fc.integer({ min: 1, max: MAX_GENERATED_LEAVES });
+
+/**
+ * Non-empty schemas at an exact coverage endpoint: either no arrow or one for
+ * every leaf. Used to enforce ADR-040's exact 0% and 100% meanings.
+ */
+export const coverageEndpointScenarioArbitrary = leafCountArbitrary.chain((leafCount) =>
+  fc.boolean().map((complete) => {
+    const names = leafNames(leafCount);
+    const fields = names.map(scalarField);
+    return {
+      scenario: mappingScenario({
+        sourceFields: fields,
+        targetFields: fields,
+        arrows: complete ? names.map((name) => ({ sources: [name], target: name })) : [],
+      }),
+      complete,
+      leafCount,
+    };
+  }),
+);
+
+/**
+ * A fragment spread whose generated fields may also be declared explicitly in
+ * the target body. The body declaration must shadow, never duplicate, a spread.
+ */
+export const spreadRedeclarationScenarioArbitrary = leafCountArbitrary.chain((leafCount) => {
+  const names = leafNames(leafCount);
+  return fc.subarray(names).map((redeclared) => ({
+    scenario: {
+      fragments: [{ name: "shared_fields", fields: names.map(scalarField) }],
+      schemas: [
+        { name: "src", fields: [scalarField("source_value")] },
+        {
+          name: "tgt",
+          fields: [scalarField("body_only"), ...redeclared.map(scalarField)],
+          spreads: ["shared_fields"],
+        },
+      ],
+      mapping: { name: "load", sources: ["src"], targets: ["tgt"], arrows: [] },
+    },
+    expectedPaths: ["body_only", ...names],
+  }));
+});
+
+/** A record-to-record correspondence with a bounded nested leaf subtree. */
+export const wholeStructureScenarioArbitrary = leafCountArbitrary
+  .chain((leafCount) =>
+    fc.integer({ min: 0, max: 2 }).map((extraDepth) => ({ leafCount, extraDepth })),
+  )
+  .map(({ leafCount, extraDepth }) => {
+    const leaves = leafNames(leafCount).map(scalarField);
+    const sourceChildren = extraDepth > 0 ? nestFields(leaves, extraDepth) : leaves;
+    const targetChildren = extraDepth > 0 ? nestFields(leaves, extraDepth) : leaves;
+    const sourceFields = [recordField("source_record", sourceChildren)];
+    const targetFields = [recordField("target_record", targetChildren)];
+    return {
+      scenario: mappingScenario({
+        sourceFields,
+        targetFields,
+        arrows: [{ sources: ["source_record"], target: "target_record" }],
+      }),
+      expectedTargetLeaves: semanticLeafPaths(targetFields),
+    };
+  });
+
+/** Scalar and unresolved sources are the two fail-closed branches of ADR-038. */
+export const nonContainerSourceScenarioArbitrary = leafCountArbitrary.chain((leafCount) =>
+  fc.constantFrom("scalar", "unresolved").map((sourceKind) => {
+    const targetFields = [recordField("target_record", leafNames(leafCount).map(scalarField))];
+    const scalarSource = sourceKind === "scalar";
+    return {
+      scenario: {
+        fragments: [],
+        schemas: [
+          ...(scalarSource ? [{ name: "src", fields: [scalarField("source_value")] }] : []),
+          { name: "tgt", fields: targetFields },
+        ],
+        mapping: {
+          name: "load",
+          sources: [scalarSource ? "src" : "missing_src"],
+          targets: ["tgt"],
+          arrows: [
+            {
+              sources: [scalarSource ? "source_value" : "unresolved_value"],
+              target: "target_record",
+            },
+          ],
+        },
+      },
+      sourceKind,
+      expectedTargetLeaves: semanticLeafPaths(targetFields),
+    };
+  }),
+);
+
+/** One valid dotted path with identifiers that cannot collide with schema names. */
+export const dottedPathArbitrary = fc
+  .array(fc.integer({ min: 0, max: 20 }), { minLength: 1, maxLength: 5 })
+  .map((parts) => parts.map((part, index) => `segment_${index}_${part}`).join("."));
+
+/** Several direct paths for checking the union of all derived proper prefixes. */
+export const dottedPathsArbitrary = fc
+  .array(dottedPathArbitrary, {
+    minLength: 1,
+    maxLength: MAX_GENERATED_LEAVES,
+  })
+  .map((localPaths) => {
+    const paths = localPaths.map((path, index) => `root_${index}.${path}`);
+    const fields = localPaths.map((path, index) =>
+      recordField(`root_${index}`, fieldTreeForPath(path)),
+    );
+    return {
+      paths,
+      scenario: mappingScenario({ sourceFields: fields, targetFields: fields, arrows: [] }),
+    };
+  });
+
+/** Authored refs covering schema-local, own-schema, and other-schema spellings. */
+export const schemaLocalRefScenarioArbitrary = fc
+  .record({
+    schemaId: fc.integer({ min: 0, max: 20 }),
+    otherId: fc.integer({ min: 0, max: 20 }),
+    localPath: dottedPathArbitrary,
+  })
+  .map(({ schemaId, otherId, localPath }) => {
+    const ownSchema = `schema_${schemaId}`;
+    const otherSchema = `other_${schemaId}_${otherId}`;
+    const fields = fieldTreeForPath(localPath);
+    return {
+      ownSchema,
+      otherSchema,
+      localPath,
+      scenario: {
+        fragments: [],
+        schemas: [
+          { name: ownSchema, fields },
+          { name: otherSchema, fields },
+          { name: "tgt", fields: [scalarField("result")] },
+        ],
+        mapping: {
+          name: "load",
+          sources: [ownSchema, otherSchema],
+          targets: ["tgt"],
+          arrows: [],
+        },
+      },
+    };
+  });
+
+/**
+ * Two isomorphic scenarios: one flat and one under a generated record chain,
+ * with every arrow rewritten through the same path bijection.
+ */
+export const renestingScenarioArbitrary = leafCountArbitrary.chain((leafCount) => {
+  const names = leafNames(leafCount);
+  return fc.tuple(fc.subarray(names), fc.integer({ min: 1, max: 3 })).map(([covered, depth]) => {
+    const flatFields = names.map(scalarField);
+    const nestedFields = nestFields(flatFields, depth);
+    return {
+      flat: mappingScenario({
+        sourceFields: flatFields,
+        targetFields: flatFields,
+        arrows: covered.map((path) => ({ sources: [path], target: path })),
+      }),
+      nested: mappingScenario({
+        sourceFields: nestedFields,
+        targetFields: nestedFields,
+        arrows: covered.map((path) => ({
+          sources: [nestedPath(path, depth)],
+          target: nestedPath(path, depth),
+        })),
+      }),
+    };
+  });
+});
+
+/** A valid mapping before and after adding one previously absent leaf arrow. */
+export const monotonicScenarioArbitrary = leafCountArbitrary.chain((leafCount) =>
+  fc.integer({ min: 0, max: leafCount - 1 }).chain((addedIndex) => {
+    const names = leafNames(leafCount);
+    const addedPath = names[addedIndex];
+    const candidates = names.filter((name) => name !== addedPath);
+    return fc.subarray(candidates).map((initiallyCovered) => {
+      const fields = names.map(scalarField);
+      const arrows = initiallyCovered.map((path) => ({ sources: [path], target: path }));
+      return {
+        before: mappingScenario({ sourceFields: fields, targetFields: fields, arrows }),
+        after: mappingScenario({
+          sourceFields: fields,
+          targetFields: fields,
+          arrows: [...arrows, { sources: [addedPath], target: addedPath }],
+        }),
+        addedPath,
+      };
+    });
+  }),
+);
+
+/**
+ * General recovery-free semantic inputs reused by generated formatter tests.
+ * The union deliberately includes flat, nested, whole-structure, unresolved,
+ * and spread/redeclaration forms instead of generating grammar text directly.
+ */
+export const semanticScenarioArbitrary = fc.oneof(
+  coverageEndpointScenarioArbitrary.map(({ scenario }) => scenario),
+  spreadRedeclarationScenarioArbitrary.map(({ scenario }) => scenario),
+  wholeStructureScenarioArbitrary.map(({ scenario }) => scenario),
+  nonContainerSourceScenarioArbitrary.map(({ scenario }) => scenario),
+  renestingScenarioArbitrary.map(({ nested }) => nested),
+  monotonicScenarioArbitrary.map(({ after }) => after),
+);


### PR DESCRIPTION
## Summary

- add bounded semantic-first fast-check scenarios for schemas, fragments, nested records, spreads, mappings, and arrows
- verify the eight Feature 39 R3 coverage/path invariants with recovery-free generated Satsuma
- verify formatter idempotence, CST structural equivalence, and error-free reparse over generated inputs
- preserve reproducible failures through fast-check seed, replay path, and shrunk source output

## Tickets

- closes cbdr-o6xn
- closes cbdr-yp9m

## Verification

- satsuma-core: 606 tests passed
- repository pre-commit suite passed after implementation, ticket closure, and final rebase bookkeeping
- npm audit in satsuma-core: 0 vulnerabilities

## Architecture

ADR assessment completed. No ADR is warranted: this is test-only infrastructure inside satsuma-core and changes no production boundary, language semantics, or cross-system convention.