### PR TITLE
test(core): differentially verify coverage semantics

### DIFF
--- a/.tickets/cbdr-da0j.md
+++ b/.tickets/cbdr-da0j.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-da0j
-status: in_progress
+status: closed
 deps: [cbdr-o6xn]
 links: []
 created: 2026-08-03T16:03:45Z
@@ -21,3 +21,10 @@ Add the oracle in satsuma-core test support, separate from generated-scenarios.j
 ## Acceptance Criteria
 
 A purpose-commented fast-check differential suite compares every qualified source and target field's mapped/state verdict plus covered/total/pct rollups between the semantic oracle and coverageForScenario after recovery-free parse, extraction, spread expansion, and production coverage computation; the oracle does not import or call production coverage helpers and has a concise rule-to-ADR table; failures retain fast-check seed/path and shrunk rendered Satsuma; a local mutation restoring bare-segment registration fails with a repeated-name counterexample; a local mutation restoring spread/explicit duplication fails the oracle or uniqueness property; a local mutation removing ADR-038's container-source condition fails with a shrunk scalar-to-record counterexample; existing R3 properties and hand-authored regressions remain; npm --prefix tooling/satsuma-core test and npm audit pass; the ticket receives a timestamped cause/fix note before closure.
+
+## Notes
+
+**2026-08-03T16:14:13Z**
+
+Cause: R3's individual properties stated settled invariants separately, but no independent reference model crossed the renderer, parser, extraction, spread-expansion, and production coverage boundaries, so coordinated drift or path-identity regressions lacked a holistic comparison.
+Fix: Added a test-only semantic oracle and repeated-name scenario that compare every generated field state and leaf rollup with production; verified the three mandated mutations fail, 607 core tests and the full repository hook pass, and npm audit reports zero vulnerabilities. (commit 24c98433)

--- a/.tickets/cbdr-da0j.md
+++ b/.tickets/cbdr-da0j.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-da0j
-status: open
+status: in_progress
 deps: [cbdr-o6xn]
 links: []
 created: 2026-08-03T16:03:45Z

--- a/.tickets/cbdr-da0j.md
+++ b/.tickets/cbdr-da0j.md
@@ -1,0 +1,23 @@
+---
+id: cbdr-da0j
+status: open
+deps: [cbdr-o6xn]
+links: []
+created: 2026-08-03T16:03:45Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r4, core, property-testing]
+---
+# core: differentially test coverage against an independent oracle
+
+Implement Feature 39 R4. Build a deliberately small, test-only coverage oracle over R3's semantic scenarios, render each scenario through the real parser/extraction/coverage pipeline, and compare qualified field states and rollups without reusing production coverage helpers to calculate expected results.
+
+## Design
+
+Add the oracle in satsuma-core test support, separate from generated-scenarios.js's production-path adapter. Materialise declarations and spread-expanded qualified paths directly from semantic data; apply direct-arrow, whole-record, scalar/unresolved fail-closed, and spread-shadowing rules as plain set operations; derive container state and leaf rollups independently. Document the rule-to-ADR mapping beside the oracle. Extend the bounded semantic arbitrary only as needed to exercise combinations rather than creating grammar strings directly. Keep production types/helpers out of expected-value calculation and keep the oracle test-only.
+
+## Acceptance Criteria
+
+A purpose-commented fast-check differential suite compares every qualified source and target field's mapped/state verdict plus covered/total/pct rollups between the semantic oracle and coverageForScenario after recovery-free parse, extraction, spread expansion, and production coverage computation; the oracle does not import or call production coverage helpers and has a concise rule-to-ADR table; failures retain fast-check seed/path and shrunk rendered Satsuma; a local mutation restoring bare-segment registration fails with a repeated-name counterexample; a local mutation restoring spread/explicit duplication fails the oracle or uniqueness property; a local mutation removing ADR-038's container-source condition fails with a shrunk scalar-to-record counterexample; existing R3 properties and hand-authored regressions remain; npm --prefix tooling/satsuma-core test and npm audit pass; the ticket receives a timestamped cause/fix note before closure.

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -437,7 +437,7 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 through R3 now have concrete tickets; later rows
+Feature epic: `gcsc-qka8`. R1 through R4 now have concrete tickets; later rows
 remain the agreed ticket shape and will receive IDs when scheduled.
 
 | Work | Ticket shape | Depends on |
@@ -450,7 +450,7 @@ remain the agreed ticket shape and will receive IDs when scheduled.
 | R2 viz-backend CST-use migration (`tcc-chls`) | 1 task | `tcc-e35f` |
 | R3 semantic generators and coverage properties (`cbdr-o6xn`) | 1 task | — |
 | R3 generated formatter properties (`cbdr-yp9m`) | 1 task | `cbdr-o6xn` |
-| R4 independent oracle and differential suite | 1 task | R3 semantic generator task |
+| R4 independent oracle and differential suite (`cbdr-da0j`) | 1 task | `cbdr-o6xn` |
 | R5 opaque path/ref stages | 1 core task plus consumer migration subtasks if needed | `sl-46wr`, `sl-csrs` |
 | R6 CLI test typecheck gate | 1 task | — |
 | R7 type-aware lint rollout | 1 task per package | R2 for CST-specific rules |

--- a/tooling/satsuma-core/test/generated-coverage-oracle.test.js
+++ b/tooling/satsuma-core/test/generated-coverage-oracle.test.js
@@ -1,0 +1,60 @@
+/**
+ * generated-coverage-oracle.test.js — Differential coverage verification.
+ *
+ * The expected result comes from a semantic, test-only oracle. The actual
+ * result crosses the real renderer, parser, extractor, spread expander, and
+ * coverage implementation so drift at any production boundary is observable.
+ */
+
+import assert from "node:assert/strict";
+import { before, describe, it } from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import fc from "fast-check";
+import { initParser, summarizeFieldCoverage } from "@satsuma/core";
+import { coverageOracleForScenario } from "./support/coverage-oracle.js";
+import {
+  coverageForScenario,
+  differentialCoverageScenarioArbitrary,
+  GENERATED_PROPERTY_PARAMETERS,
+} from "./support/generated-scenarios.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+/** Keep only the production facts the semantic oracle is responsible for. */
+function comparableProductionResult(result) {
+  return result.schemas.map((schema) => ({
+    schemaId: schema.schemaId,
+    role: schema.role,
+    fields: schema.fields.map((field) => ({
+      path: field.path,
+      mapped: field.mapped,
+      state: field.state,
+    })),
+    totals: summarizeFieldCoverage(schema.fields),
+  }));
+}
+
+describe("generated coverage oracle", () => {
+  it("agrees with production after parsing and extracting every semantic scenario", () => {
+    // Feature 39 R4: an independent statement of ADR-034–041 must agree field
+    // by field and rollup by rollup with the complete production path.
+    fc.assert(
+      fc.property(differentialCoverageScenarioArbitrary, (scenario) => {
+        const production = coverageForScenario(scenario);
+        const oracle = coverageOracleForScenario(scenario);
+        assert.deepEqual(
+          comparableProductionResult(production.result),
+          oracle,
+          `production coverage diverged from the semantic oracle:\n${production.source}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+});

--- a/tooling/satsuma-core/test/support/coverage-oracle.js
+++ b/tooling/satsuma-core/test/support/coverage-oracle.js
@@ -1,0 +1,238 @@
+/**
+ * coverage-oracle.js — Independent expected coverage for semantic scenarios.
+ *
+ * This test-only module interprets R3's deliberately small generated domain:
+ * file-scope schemas, schema-local arrow refs, nested scalar/record fields, and
+ * schema-level fragment spreads. It imports no production coverage, extraction,
+ * spread, or path helper. Keeping the domain explicit and the implementation
+ * plain is what makes this a useful differential oracle rather than a second
+ * production walker.
+ *
+ * Rule                                      Authority
+ * ----------------------------------------  ---------------------------
+ * Count declared leaves, never containers   ADR-034
+ * Identify coverage by qualified path       ADR-035
+ * Derive container state from child state   ADR-037
+ * Expand source record correspondences      ADR-037
+ * Expand target records only from records   ADR-038
+ * Reserve 0% and 100% for exact endpoints   ADR-040
+ * Let explicit fields shadow spread fields  ADR-041
+ */
+
+/** @typedef {{ name: string, kind: "scalar" }} ScalarField */
+/**
+ * @typedef {{
+ *   name: string,
+ *   kind: "record",
+ *   fields: SemanticField[],
+ * }} RecordField
+ */
+/** @typedef {ScalarField | RecordField} SemanticField */
+/**
+ * @typedef {{
+ *   name: string,
+ *   fields: SemanticField[],
+ *   spreads?: string[],
+ * }} SemanticEntity
+ */
+/** @typedef {{ sources: string[], target: string }} SemanticArrow */
+/**
+ * @typedef {{
+ *   sources: string[],
+ *   targets: string[],
+ *   arrows: SemanticArrow[],
+ * }} SemanticMapping
+ */
+/**
+ * @typedef {{
+ *   fragments: SemanticEntity[],
+ *   schemas: SemanticEntity[],
+ *   mapping: SemanticMapping,
+ * }} SemanticScenario
+ */
+
+// ── Declarations and paths ────────────────────────────────────────────────
+
+/** Copy a semantic field tree so the oracle never mutates generated input. */
+function copyField(field) {
+  return field.kind === "record" ? { ...field, fields: field.fields.map(copyField) } : { ...field };
+}
+
+/**
+ * Materialise schema-level spreads, with body declarations and then earlier
+ * spreads winning each name exactly once (ADR-041).
+ */
+function materializeFields(entity, fragments) {
+  const fields = entity.fields.map(copyField);
+  const declaredNames = new Set(fields.map((field) => field.name));
+  for (const spreadName of entity.spreads ?? []) {
+    const fragment = fragments.get(spreadName);
+    if (!fragment) continue;
+    for (const field of fragment.fields) {
+      if (declaredNames.has(field.name)) continue;
+      declaredNames.add(field.name);
+      fields.push(copyField(field));
+    }
+  }
+  return fields;
+}
+
+/** Find the field declared at one schema-local dotted path. */
+function findField(fields, path) {
+  let level = fields;
+  let found = null;
+  for (const segment of path.split(".")) {
+    found = level.find((field) => field.name === segment) ?? null;
+    if (!found) return null;
+    level = found.kind === "record" ? found.fields : [];
+  }
+  return found;
+}
+
+/** Every declared path below a record, retaining full qualification. */
+function descendantPaths(record, path) {
+  return record.fields.flatMap((field) => {
+    const fieldPath = `${path}.${field.name}`;
+    return field.kind === "record"
+      ? [fieldPath, ...descendantPaths(field, fieldPath)]
+      : [fieldPath];
+  });
+}
+
+// ── Arrow membership ──────────────────────────────────────────────────────
+
+/** Register one endpoint and, when asserted, its declared record subtree. */
+function registerEndpoint(coveredPaths, fields, path, expandRecord) {
+  coveredPaths.add(path);
+  const field = findField(fields, path);
+  if (expandRecord && field?.kind === "record") {
+    for (const descendant of descendantPaths(field, path)) coveredPaths.add(descendant);
+  }
+}
+
+/** True when at least one resolved source endpoint names a non-empty record. */
+function sourceCarriesRecord(sourceRefs, sourceSchemas) {
+  return sourceRefs.some((ref) =>
+    sourceSchemas.some((schema) => {
+      const field = findField(schema.fields, ref);
+      return field?.kind === "record" && field.fields.length > 0;
+    }),
+  );
+}
+
+/** Apply the arrow rules directly for one schema and mapping role. */
+function coveredPathsForSchema(schema, role, mapping, sourceSchemas) {
+  const coveredPaths = new Set();
+  for (const arrow of mapping.arrows) {
+    if (role === "source") {
+      for (const ref of arrow.sources) {
+        registerEndpoint(coveredPaths, schema.fields, ref, true);
+      }
+    } else {
+      registerEndpoint(
+        coveredPaths,
+        schema.fields,
+        arrow.target,
+        sourceCarriesRecord(arrow.sources, sourceSchemas),
+      );
+    }
+  }
+  return coveredPaths;
+}
+
+// ── Per-field state and leaf rollups ──────────────────────────────────────
+
+/** Roll a non-empty record up from its direct children's states (ADR-037). */
+function containerState(children) {
+  if (children.every((child) => child.entry.state === "covered")) return "covered";
+  if (children.every((child) => child.entry.state === "uncovered")) return "uncovered";
+  return "partial";
+}
+
+/** Build one field entry and its descendants in declaration-first order. */
+function oracleField(field, prefix, coveredPaths) {
+  const path = prefix ? `${prefix}.${field.name}` : field.name;
+  if (field.kind === "scalar" || field.fields.length === 0) {
+    const state = coveredPaths.has(path) ? "covered" : "uncovered";
+    return { entry: { path, mapped: state === "covered", state }, descendants: [] };
+  }
+
+  const children = field.fields.map((child) => oracleField(child, path, coveredPaths));
+  const state = containerState(children);
+  return {
+    entry: { path, mapped: state !== "uncovered", state },
+    descendants: children.flatMap(({ entry, descendants }) => [entry, ...descendants]),
+  };
+}
+
+/** Flatten a semantic field tree in the order production coverage reports it. */
+function oracleFields(fields, coveredPaths) {
+  return fields.flatMap((field) => {
+    const { entry, descendants } = oracleField(field, "", coveredPaths);
+    return [entry, ...descendants];
+  });
+}
+
+/** Qualified paths of the scalar leaves that form ADR-034's denominator. */
+function leafPaths(fields, prefix = "") {
+  return fields.flatMap((field) => {
+    const path = prefix ? `${prefix}.${field.name}` : field.name;
+    return field.kind === "record" ? leafPaths(field.fields, path) : [path];
+  });
+}
+
+/** Whole-number percentage with exact endpoint meanings from ADR-040. */
+function coveragePercentage(covered, total) {
+  if (total === 0 || covered === 0) return 0;
+  if (covered === total) return 100;
+  return Math.max(1, Math.min(99, Math.floor((covered / total) * 100)));
+}
+
+/** Build the independent leaf rollup compared with production's public result. */
+function oracleTotals(fields, entries) {
+  const paths = leafPaths(fields);
+  const stateByPath = new Map(entries.map((entry) => [entry.path, entry.state]));
+  const covered = paths.filter((path) => stateByPath.get(path) === "covered").length;
+  return {
+    covered,
+    coveredDeclared: covered,
+    coveredNl: 0,
+    total: paths.length,
+    pct: coveragePercentage(covered, paths.length),
+  };
+}
+
+/** Build one role's oracle results in authored participant order. */
+function schemasForRole(role, names, mapping, schemas, sourceSchemas) {
+  return names.flatMap((name) => {
+    const schema = schemas.get(name);
+    if (!schema) return [];
+    const coveredPaths = coveredPathsForSchema(schema, role, mapping, sourceSchemas);
+    const fields = oracleFields(schema.fields, coveredPaths);
+    return [{ schemaId: name, role, fields, totals: oracleTotals(schema.fields, fields) }];
+  });
+}
+
+/**
+ * Interpret one generated semantic scenario without using production helpers.
+ *
+ * Only state and rollup facts are returned. Parser positions, URIs, tiers, and
+ * protocol details remain production concerns rather than duplicated behaviour.
+ */
+export function coverageOracleForScenario(scenario) {
+  const fragments = new Map(scenario.fragments.map((fragment) => [fragment.name, fragment]));
+  const schemas = new Map(
+    scenario.schemas.map((schema) => [
+      schema.name,
+      { ...schema, fields: materializeFields(schema, fragments) },
+    ]),
+  );
+  const sourceSchemas = scenario.mapping.sources.flatMap((name) => {
+    const schema = schemas.get(name);
+    return schema ? [schema] : [];
+  });
+  return [
+    ...schemasForRole("source", scenario.mapping.sources, scenario.mapping, schemas, sourceSchemas),
+    ...schemasForRole("target", scenario.mapping.targets, scenario.mapping, schemas, sourceSchemas),
+  ];
+}

--- a/tooling/satsuma-core/test/support/generated-scenarios.js
+++ b/tooling/satsuma-core/test/support/generated-scenarios.js
@@ -447,15 +447,41 @@ export const monotonicScenarioArbitrary = leafCountArbitrary.chain((leafCount) =
 );
 
 /**
- * General recovery-free semantic inputs reused by generated formatter tests.
- * The union deliberately includes flat, nested, whole-structure, unresolved,
- * and spread/redeclaration forms instead of generating grammar text directly.
+ * A nested leaf and a top-level leaf sharing one name, with only the nested
+ * path referenced. This is the smallest family that distinguishes path
+ * identity from the bare-segment registration defect behind sl-joeq.
  */
-export const semanticScenarioArbitrary = fc.oneof(
+export const repeatedNameScenarioArbitrary = leafCountArbitrary.map((leafCount) => {
+  const repeatedName = "shared_value";
+  const siblingLeaves = leafNames(leafCount).map(scalarField);
+  const fields = [
+    scalarField(repeatedName),
+    recordField("group", [scalarField(repeatedName), ...siblingLeaves]),
+  ];
+  return mappingScenario({
+    sourceFields: fields,
+    targetFields: fields,
+    arrows: [{ sources: [`group.${repeatedName}`], target: `group.${repeatedName}` }],
+  });
+});
+
+/**
+ * Scenarios broad enough for an independent oracle to cross-check the full
+ * production parser/extraction boundary, including every R3 semantic family.
+ */
+export const differentialCoverageScenarioArbitrary = fc.oneof(
   coverageEndpointScenarioArbitrary.map(({ scenario }) => scenario),
   spreadRedeclarationScenarioArbitrary.map(({ scenario }) => scenario),
   wholeStructureScenarioArbitrary.map(({ scenario }) => scenario),
   nonContainerSourceScenarioArbitrary.map(({ scenario }) => scenario),
   renestingScenarioArbitrary.map(({ nested }) => nested),
   monotonicScenarioArbitrary.map(({ after }) => after),
+  repeatedNameScenarioArbitrary,
 );
+
+/**
+ * General recovery-free semantic inputs reused by generated formatter tests.
+ * The union deliberately includes flat, nested, whole-structure, unresolved,
+ * and spread/redeclaration forms instead of generating grammar text directly.
+ */
+export const semanticScenarioArbitrary = differentialCoverageScenarioArbitrary;


### PR DESCRIPTION
## Summary

- breaks Feature 39 R4 into ticket `cbdr-da0j` and records it in the PRD ticket map
- adds a test-only semantic coverage oracle independent of production coverage, extraction, spread, and path helpers
- compares every generated source/target field state and leaf rollup after the real render, parse, extraction, and coverage pipeline
- adds a repeated-name scenario that distinguishes qualified path identity from bare-segment registration

## Verification

- full pre-commit repository gate passed on the implementation and ticket-close commits
- `npm --prefix tooling/satsuma-core test` — 607 passed
- `npm audit --audit-level=high` in `tooling/satsuma-core` — 0 vulnerabilities
- mutation checks proved failure for bare-segment registration, spread/body duplication, and removal of ADR-038 source-record gating; fast-check reported seeds, replay paths, and shrunk Satsuma

## ADR assessment

No ADR is warranted: this is test-only enforcement of ADR-034–041 and changes no production boundary or semantic decision.

Closes cbdr-da0j.