### PR TITLE
docs(features): Feature 41 PRD — generated-input confidence for lineage and graph (sl-8f2p)

### DIFF
--- a/.tickets/sl-8f2p.md
+++ b/.tickets/sl-8f2p.md
@@ -1,0 +1,19 @@
+---
+id: sl-8f2p
+status: open
+deps: []
+links: []
+created: 2026-08-03T16:23:18Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [feature-41, lineage, graph, tooling]
+---
+# Feature 41: generated-input confidence for lineage and graph
+
+Deliver Feature 41 from features/41-lineage-graph-confidence/PRD.md: point Feature 39's generated-input machinery at the lineage and graph surfaces, where the generated scenario is itself the ground-truth graph and so needs no independent oracle. Covers the reusable generator package, a workspace-shaped scenario model, structural edge invariants, reachability properties, a cross-consumer parity sweep, and branded endpoints.
+
+## Acceptance Criteria
+
+R1-R6 are delivered through linked child tickets with their PRD acceptance tests passing; every child records its cause/fix note and passing relevant automated tests before closure; the PRD ticket map and status are reconciled when the epic closes; no lineage or graph semantics change and r0-7w76 remains undecided by this epic.
+

--- a/.tickets/sl-dqyu.md
+++ b/.tickets/sl-dqyu.md
@@ -1,0 +1,24 @@
+---
+id: sl-dqyu
+status: open
+deps: [sl-puky]
+links: []
+created: 2026-08-03T16:23:38Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, testing]
+---
+# test-support: extend the scenario model from one mapping to a workspace
+
+The scenario model is one mapping over scalar/record fields with optional fragment spreads — the right domain for coverage, insufficient for lineage. Lineage needs chains, and the interesting endpoint defects live in namespaces, containers and NL refs, none of which the model can express.
+
+## Design
+
+Add each axis as its own arbitrary so a property can pick the smallest domain that exercises it: multiple mappings forming chains, diamonds and deliberate cycles (traversal properties; sg-pufq is a diamond, sl-y89y a re-entered node); multiple files plus import (the LSP's computeFullLineage merges per-file models across the import-reachable set); namespaces (qualifyField's namespace-matching branch at canonical-ref.ts:68-72 has no generated coverage, and r0-7w76 reproduces in both global and namespaced cases); each/flatten containers with container-relative arrows (the shape of 3cdd-yavi and r0-7w76); NL @ref transform text (cbh-y5og's phantom edges and the nl-derived tier both CLI builders emit); derived blocks (sourceless arrows, from: null); metrics (the metric_source edge role). Two gates on every generated workspace: it parses recovery-free via the existing parseGeneratedScenario assertion, AND it validates clean via core's validateSemanticWorkspace, so no lineage property asserts over input the toolchain considers broken. Expose ground truth derived from the scenario and not from any production code: scenarioFieldEdges, scenarioSchemaEdges, scenarioDeclaredFieldPaths.
+
+## Acceptance Criteria
+
+Every generated workspace parses recovery-free and produces no semantic diagnostics from validateSemanticWorkspace. A generated workspace containing a namespace, an each container, an NL @ref, a derived block and a metric renders, parses and validates. scenarioFieldEdges, scenarioSchemaEdges and scenarioDeclaredFieldPaths are computed from the scenario alone, with a purpose comment stating that independence. Existing core property suites still pass.
+

--- a/.tickets/sl-hi0z.md
+++ b/.tickets/sl-hi0z.md
@@ -1,0 +1,24 @@
+---
+id: sl-hi0z
+status: open
+deps: [sl-dqyu]
+links: []
+created: 2026-08-03T16:23:59Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, testing, graph]
+---
+# graph+viz: structural edge invariants over generated workspaces
+
+No consumer checks that an edge endpoint names a declared field, and every resolver in the chain fails closed by skipping — so a dropped edge is indistinguishable from no edge. qualifyField ends with an unconditional `${schemas[0]}.${field}` (canonical-ref.ts:75) and invents mart::species_fact.species_fact for a container header naming the schema root (r0-7w76). elk-layout.ts:754 skips any arrow whose ports do not resolve, which once made every nested-iteration mapping draw no lines at all with no test failing (3cdd-yavi, sl-l7u0).
+
+## Design
+
+Properties over generated workspaces, aimed at the CLI's graph assembly, the portable traversal and the VizModel plus its layout: every emitted endpoint is in scenarioDeclaredFieldPaths; every edge in scenarioFieldEdges is emitted exactly once and every emitted edge is in scenarioFieldEdges (both directions — dropped and invented); an edge may be omitted only where a named, commented exception applies and the property enumerates the permitted exceptions, so legitimate skips stay legal; every edge endpoint is backed by a node including under --namespace (promotes sl-p895's backfill block at graph-builder.ts:196-249 to a stated invariant); graph --namespace edges are a subset of the unfiltered edges; the edge SET is invariant under permuting declaration order and under splitting the same declarations across more files. The viz-side property runs in satsuma-viz's node suite — layout.test.js and dom-shim.js already make ELK layout reachable without a browser, so no harness work is needed. This ticket does not change lineage or graph semantics and does not decide r0-7w76; if a property fails on current behaviour, record it against the owning bug ticket.
+
+## Acceptance Criteria
+
+Reverting qualifyField's guard makes the endpoint-existence property fail and the counterexample names the invented field. Restoring an unconditional continue in elk-layout.ts's port resolution makes the arrow-to-edge completeness property fail. Removing the nsFilter node backfill in graph-builder.ts makes the endpoint-has-a-node property fail. Reordering declarations does not change the emitted edge set. Every property carries a purpose comment naming the invariant or defect class it defends, and failures report seed, path and shrunk Satsuma source.
+

--- a/.tickets/sl-jsyn.md
+++ b/.tickets/sl-jsyn.md
@@ -1,0 +1,24 @@
+---
+id: sl-jsyn
+status: open
+deps: [sl-dqyu, sl-prlp]
+links: []
+created: 2026-08-03T16:23:59Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, testing, lineage]
+---
+# lineage: reachability properties with the generated scenario as oracle
+
+Traversal correctness is asserted on chosen graphs today (37 graph, 17 field-lineage and 11 lineage tests, each a remembered case). Depth limits, cycles, diamonds and multi-branch upstreams interact, and all three known defects are combinations: lineage --to returned one upstream chain instead of every declared branch (sg-pufq), a plain visited-set silently truncated subtrees under a depth limit (sl-y89y), and NL backtick refs manufactured phantom source edges (cbh-y5og). Unlike coverage, lineage needs no independent oracle: reachability over the scenario's own arrow set IS the expected answer.
+
+## Design
+
+Aim every property at the single portable traversal extracted by sl-prlp, not at the CLI-internal function. Properties: upstream(X) at depth d is exactly the ancestors of X within d hops of scenarioFieldEdges (sg-pufq); downstream(X) at depth d is exactly the descendants within d hops; duality Y in downstream(X) iff X in upstream(Y) (asymmetric edge construction between the two walks); depth EXACTNESS — the result at depth n is exactly the nodes whose shortest path is <= n, which is sl-y89y stated as a property, chosen over monotonicity because the buggy version satisfied monotonicity too; a generated cyclic workspace terminates and reports no duplicate entries; schema-level lineage equals the projection of field-level edges onto owning schemas, tying lineage to graph --schema-only.
+
+## Acceptance Criteria
+
+Replacing lineage.ts's shallowest-depth bookkeeping with a plain visited-set makes the depth-exactness property fail and does NOT make a monotonicity-only property fail, demonstrating why exactness is the property worth having. Restricting the upstream walk to a single predecessor makes the ancestor-set property fail with a generated diamond. A generated cyclic workspace completes within the depth limit and reports each field once. Every property carries a purpose comment naming its invariant or defect class.
+

--- a/.tickets/sl-jyee.md
+++ b/.tickets/sl-jyee.md
@@ -1,0 +1,24 @@
+---
+id: sl-jyee
+status: open
+deps: [sl-hi0z]
+links: []
+created: 2026-08-03T16:24:15Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, lineage, graph]
+---
+# core: brand lineage and graph endpoints with Feature 39's path/ref stages
+
+Lineage endpoints are the same unbranded strings Feature 39 R5 addresses for coverage. qualifyField (canonical-ref.ts:56) cannot distinguish a bare field name from a container header naming a schema root, and its final branch guesses; graph-builder.ts:622 re-derives an owning schema with edge.from.split('.')[0]. BLOCKED on Feature 39 R5, which is not yet ticketed — this ticket must not pre-empt that design by inventing its own brands.
+
+## Design
+
+Apply the branded stages from Feature 39 R5 to graph and lineage endpoints so an authored ref cannot be emitted where a qualified endpoint is required. Give qualifyField a signature that cannot silently conflate a bare field name with a schema root token: the caller handles the ambiguous case rather than receiving a guess. Replace ad-hoc unbranding such as edge.from.split('.')[0] with a named core accessor. This removes the type-level permission to guess; it does NOT decide what a container header onto a schema root should mean, which remains r0-7w76.
+
+## Acceptance Criteria
+
+Passing an authored ref where a qualified endpoint is required fails a compile-only test. qualifyField's ambiguous case is visible in its return type and handled explicitly at every call site. No ad-hoc schema-prefix extraction from an endpoint string remains in graph or lineage code. JSON, VizModel and LSP protocol shapes are unchanged. r0-7w76 remains open and undecided.
+

--- a/.tickets/sl-kwet.md
+++ b/.tickets/sl-kwet.md
@@ -1,0 +1,24 @@
+---
+id: sl-kwet
+status: open
+deps: [sl-hi0z, sl-prlp]
+links: []
+created: 2026-08-03T16:24:15Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, testing, lineage, viz]
+---
+# cli: cross-consumer lineage parity sweep over the example corpus
+
+Cross-consumer edge agreement is a prose claim: satsuma-viz/src/field-coverage.ts states its arrow walk 'mirrors core's extractArrowRecords' and nothing tests the mirroring. Coverage learned this the expensive way — a consumer deriving its own answer from the model's arrows drifts, and the coverage sweep held on two fixtures then failed on twelve shipped examples. ADR-042 resolved it for coverage; edges are still in the pre-ADR-042 position, with a mirrored arrow walk and a private port resolver.
+
+## Design
+
+Replicate satsuma-cli/test/coverage-viz-parity.test.ts for edges. Over every .stm under examples/ and over generated workspaces, the CLI's field edges, the edges the viz layout would draw, and the arrows in the LSP's merged full-lineage model must agree. Account for scope differences rather than skipping them, exactly as the coverage sweep accounts for workspace-versus-file scope: iterate the narrower side, and treat an edge present only on the narrower side as a failure. Lives in satsuma-cli/test/ for the same reason the coverage sweep does — that is the one place both consumer paths are reachable in a single process.
+
+## Acceptance Criteria
+
+The sweep runs over every .stm in examples/ and reports any disagreement with the file, mapping and edge that differ. A deliberate divergence introduced into any one of the three consumers is reported by the sweep. Where a real disagreement exists on current behaviour, it is recorded against the owning bug ticket rather than accommodated by weakening the assertion.
+

--- a/.tickets/sl-puky.md
+++ b/.tickets/sl-puky.md
@@ -1,0 +1,24 @@
+---
+id: sl-puky
+status: open
+deps: []
+links: []
+created: 2026-08-03T16:23:38Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-8f2p
+tags: [feature-41, testing]
+---
+# test-support: promote the scenario generator to a shared satsuma-scenario-gen package
+
+The generated-input machinery from Feature 39 R3 lives in tooling/satsuma-core/test/support/generated-scenarios.js. It is under test/, is not compiled to dist/, and is absent from core's exports map, so no other package can reach it. Split it along the line already present in the file: the semantic model, semanticLeafPaths, renderScenario and helpers, the arbitraries and GENERATED_PROPERTY_PARAMETERS are pure string building; only parseGeneratedScenario, coverageForScenario, toCoverageFields and entityKey import @satsuma/core.
+
+## Design
+
+New private workspace package tooling/satsuma-scenario-gen: type module, plain ESM .js with JSDoc types as today, no build step. Only dependency is fast-check. It must NOT depend on @satsuma/core — core's tests will depend on it, so a dependency back on core creates a build cycle where core's test run needs the package output and the package build needs core's dist. Pipeline adapters stay in satsuma-core/test/support/; each consumer owns its own thin adapter beside the pipeline it drives (same reasoning as Feature 39 decision 3: keeping pipeline code out of the package is what stops it becoming a second production implementation). Rename the exported JSDoc typedefs with a Scenario prefix (ScenarioMapping, ScenarioArrow, ScenarioField, ScenarioEntity) — core's validate.ts already exports SemanticMapping, SemanticArrow and SemanticSchema for an unrelated purpose and the collision would be actively misleading.
+
+## Acceptance Criteria
+
+satsuma-scenario-gen has no dependency on @satsuma/core and npm install from a clean checkout resolves without a cycle. Core's generated-coverage-properties.test.js and generated-format-properties.test.js keep every property they have and change only their import path; both pass. The CLI, viz and viz-backend test suites can import the package. Exported type names do not collide with core's validation model. Wired into npm run install:all and the repo checks.
+

--- a/features/41-lineage-graph-confidence/PRD.md
+++ b/features/41-lineage-graph-confidence/PRD.md
@@ -1,0 +1,396 @@
+# Feature 41 — Generated-Input Confidence for Lineage and Graph
+
+> **Status: PROPOSED** (raised 2026-08-03) — raised while assessing whether
+> Feature 39's generated-input machinery, which is deliberately scoped to
+> coverage, transfers to the rest of the toolchain.
+>
+> **State this PRD was checked against:** `main` at `c93b1130`.
+>
+> **Recommendation.** Proceed. Lineage is the strongest available target for
+> generated-input testing in this repository, for a reason that does not apply to
+> coverage: the generated scenario *is* the ground-truth graph, so the oracle is
+> free rather than something that has to be re-derived from ADRs. Deliver it as a
+> sequence of independently valuable tickets, starting with the two that are
+> unblocked today.
+>
+> **What this feature is not.** It changes no Satsuma syntax, no lineage or graph
+> semantics, and no command output. It decides nothing about `r0-7w76`. It adds
+> no user-facing surface. Every deliverable is a test, a test-only generator, or
+> a type that makes an existing prose rule mechanical.
+
+## Goal
+
+Make the lineage and graph surfaces defend their own invariants, so that an
+invented endpoint, a silently dropped edge, or a truncated traversal fails a test
+instead of shipping.
+
+1. Every edge any consumer emits names a field the workspace actually declares.
+2. Every arrow the model holds produces an edge, or is dropped by a named and
+   commented exception.
+3. Traversal answers are checked against reachability over a graph whose shape
+   the test chose, not against hand-picked fixtures.
+4. The CLI, the viz and the LSP are shown to agree about the edges of one
+   workspace, rather than asserting it in prose.
+
+## Background — measured state
+
+### What Feature 39 already banked, and what is still landlocked
+
+| Feature 39 asset | State at `c93b1130` | Applies to lineage/graph? |
+|---|---|---|
+| R1/R2 generated CST symbol contract | Delivered in core, CLI, LSP and viz-backend (`gcsc-ejb2`, `tcc-e35f`, `tcc-ef1b`, `tcc-yb3z`, `tcc-chls`) | **Already applies.** No further work — a renamed grammar symbol is already a compile error in every package that builds lineage. |
+| R3 semantic generator and renderer | Delivered (`cbdr-o6xn`, `cbdr-yp9m`), but lives in `satsuma-core/test/support/generated-scenarios.js`, which is under `test/`, is not compiled to `dist/`, and is absent from core's `exports` map | Needs promoting and extending. This is the reusable asset. |
+| R4 independent coverage oracle | Not ticketed | **Not needed here.** See below. |
+| R5 opaque path/ref stages | Not ticketed | Directly relevant — lineage endpoints are the same unbranded strings. |
+| Parity sweep (`satsuma-cli/test/coverage-viz-parity.test.ts`) | Delivered for coverage, 219 lines, one sweep over the corpus | The single highest-value pattern to replicate for edges. |
+
+### Why lineage needs no independent oracle
+
+Coverage required R4 because the expected answer had to be restated from
+ADR-034–041, and the PRD for Feature 39 correctly warns that two implementations
+can share one misunderstanding.
+
+Lineage does not have that shape. A generated scenario already declares its
+arrows, so the expected upstream set of a field is the set of its ancestors under
+reachability over those arrows — a definition with no Satsuma-specific content
+and nothing to misunderstand. The oracle is a breadth-first search over data the
+generator produced.
+
+This is why lineage is a better target than coverage was, not merely another one.
+
+### Five sites resolve one question, and their agreement is prose
+
+"What field does this arrow point at, and which schema owns it" is answered in
+five places:
+
+| Site | What it does |
+|---|---|
+| `satsuma-core/src/canonical-ref.ts:56` `qualifyField` | qualifies an authored ref against a mapping's schema list |
+| `satsuma-cli/src/commands/graph-builder.ts:458` `buildFieldEdges` | declared arrows plus NL-derived edges → `FieldEdge[]` |
+| `satsuma-cli/src/commands/field-lineage.ts:159` `buildFieldEdgeGraph` | a near line-for-line duplicate of the above, minus namespace filtering and NL text |
+| `satsuma-viz/src/field-coverage.ts:82` `resolveSchemaLocalFieldPath` and `forEachMappingArrow` | wraps core's `schemaLocalFieldPath`, adding one card-specific rule; its doc-comment states the walk "mirrors core's `extractArrowRecords`" |
+| `satsuma-viz/src/layout/elk-layout.ts:705` `findPort` | resolves each endpoint to an ELK port |
+
+Only the fourth of these delegates its path rules to core, and even there the
+*arrow walk* mirrors core's by hand. Nothing tests the mirroring.
+
+### Three failure modes, all previously caught by hand
+
+**1. Invented endpoints.** `qualifyField` ends with an unconditional
+`` `${schemas[0]}.${field}` `` (`canonical-ref.ts:75`). It has no access to the
+declared field set, so it cannot tell a bare field name from a container header
+naming the schema root, and emits `mart::species_fact.species_fact` for
+`flatten observations -> species_fact`. `satsuma validate` reads the same token
+correctly via `resolveFieldPath`, so core holds two readings of one authored
+form. Open as **`r0-7w76`**.
+
+**2. Silently dropped edges.** `elk-layout.ts:754` reads
+`if (!sourceNode || !srcPort || !tgtPort) continue;`. When container-relative
+arrows were not qualified against their container, every such arrow resolved to
+no port and its edge vanished — nested-iteration mappings drew no lines at all
+and no test failed (**`3cdd-yavi`**; **`sl-l7u0`** is the same class). There is no
+assertion anywhere that an arrow in the model must produce an edge.
+
+**3. Truncated or invented traversals.** `lineage.ts` records the shallowest
+depth each node was expanded at because a plain visited-set silently truncates a
+subtree when a later, shorter path arrives with budget remaining (**`sl-y89y`**).
+`lineage --to` once returned a single upstream chain instead of every declared
+branch (**`sg-pufq`**). NL backtick refs in transform text once manufactured
+phantom source edges (**`cbh-y5og`**). Each of these is one sentence about
+reachability.
+
+A fourth pattern is adjacent: `sl-p895` was fixed by a node-backfill block
+(`graph-builder.ts:196-249`) that walks the schema edges and adds any endpoint
+missing from `nodes`, so callers "can rely on structural consistency without
+further checks". That is an invariant maintained by construction with nothing
+stating it.
+
+### The existing test surface is a list of remembered cases
+
+| Suite | Tests |
+|---|---:|
+| `satsuma-cli/test/graph.test.ts` | 37 |
+| `satsuma-cli/test/field-lineage.test.ts` | 17 |
+| `satsuma-cli/test/lineage.test.ts` | 11 |
+
+All 65 are valuable and all 65 are cases someone thought of. By contrast, the
+coverage parity sweep — one test — held on the two fixtures it was written
+against and failed on twelve shipped examples the moment it was pointed at the
+corpus.
+
+### The generator is one mapping wide
+
+`generated-scenarios.js` models a single `mapping` over scalar/record fields with
+optional fragment spreads, and renders arrows as `sources -> target`
+(`renderMapping`, line 160). That was the right domain for coverage. Lineage
+needs chains, so it needs more than one mapping, and the interesting endpoint
+bugs live in namespaces, containers and NL refs — none of which the model can
+express today.
+
+The module does, however, already split along the line this feature needs: the
+semantic model, the arbitraries and `renderScenario` are pure string building,
+while only `parseGeneratedScenario`, `coverageForScenario`, `toCoverageFields`
+and `entityKey` import `@satsuma/core`.
+
+## Problems
+
+### P1 — An emitted endpoint need not exist
+
+No consumer checks that the field it names is declared. The failure is invisible
+in the emitting command and surfaces only when a different command is asked about
+the same name (`r0-7w76`).
+
+### P2 — A dropped edge is indistinguishable from no edge
+
+Every resolver in the chain fails closed by skipping. Skipping is sometimes
+correct, but nothing separates the correct skips from the regressions, so a
+whole class of mapping can stop rendering silently.
+
+### P3 — Traversal correctness is asserted on chosen graphs
+
+Depth limits, cycles, diamonds and multi-branch upstreams interact. The three
+defects above are all combinations, and combinations are what generated inputs
+explore.
+
+### P4 — Cross-consumer edge agreement is a prose claim
+
+Coverage learned this the expensive way: a consumer that derives its own answer
+from the model's arrows drifts, and every new rule has to be written twice
+(ADR-042 records the resolution for coverage). Edges are still in the
+pre-ADR-042 position, with a mirrored arrow walk and a private port resolver.
+
+### P5 — The generator cannot be reached from the packages that need it
+
+It is a `test/` file in another package. Consuming it from the CLI, viz or LSP
+test suites requires either a cross-package relative import into a test tree or a
+new home.
+
+## Delivery Requirements
+
+### R1 — Promote the scenario generator to a shared, cycle-free test package
+
+Create `tooling/satsuma-scenario-gen`: private, `type: module`, plain ESM `.js`
+with JSDoc types exactly as today, and **no build step** — the current file needs
+none.
+
+- It takes the pure half of `generated-scenarios.js`: the semantic model
+  constructors, `semanticLeafPaths`, `renderScenario` and its helpers, the
+  arbitraries, and `GENERATED_PROPERTY_PARAMETERS`.
+- Its only dependency is `fast-check`.
+- It **must not** depend on `@satsuma/core`. Core's tests will depend on this
+  package, so a dependency back on core would create a build cycle where core's
+  test run needs the package's output and the package's build needs core's
+  `dist/`.
+- The core-pipeline adapters — `parseGeneratedScenario`, `coverageForScenario`,
+  `toCoverageFields`, `entityKey` — stay in `satsuma-core/test/support/`. Each
+  consumer package owns its own equivalent thin adapter next to the pipeline it
+  drives. This is the same reasoning as Feature 39's decision 3: keeping the
+  scenario package free of pipeline code is what stops it becoming a second
+  production implementation.
+- Exported type names must not collide with core's validation model, which
+  already exports `SemanticMapping`, `SemanticArrow` and `SemanticSchema` from
+  `validate.ts` for an unrelated purpose. Use a `Scenario` prefix
+  (`ScenarioMapping`, `ScenarioArrow`, `ScenarioField`) in the new package and
+  rename the JSDoc typedefs accordingly.
+- `satsuma-core/test/generated-coverage-properties.test.js` and
+  `generated-format-properties.test.js` keep every property they have and change
+  only their import path. Their pass/fail behaviour is the regression gate for
+  the move.
+
+### R2 — Extend the semantic model from one mapping to a workspace
+
+Grow the model to a workspace of files, adding each axis as its own arbitrary so
+that a property can pick the smallest domain that exercises it rather than paying
+for every axis at once:
+
+| Axis | Why lineage needs it |
+|---|---|
+| Multiple mappings forming chains, diamonds and deliberate cycles | the entire subject of traversal properties; `sg-pufq` is a diamond and `sl-y89y` is a re-entered node |
+| Multiple files plus `import` | the LSP's `computeFullLineage` merges per-file models across the import-reachable set; a single-file scenario cannot reach it |
+| Namespaces | `qualifyField` has a namespace-matching branch (`canonical-ref.ts:68-72`) with no generated coverage, and `r0-7w76` reproduces in both the global and namespaced cases |
+| `each`/`flatten` containers with container-relative arrows | the exact shape of `3cdd-yavi` and `r0-7w76` |
+| NL `@ref` transform text | `cbh-y5og`'s phantom edges, and the `nl-derived` edge tier both CLI builders emit |
+| `derived` blocks | sourceless arrows, which the graph represents as `from: null` |
+| Metrics | `metric_source` schema edges, a distinct edge role |
+
+Two gates on every generated workspace:
+
+1. it parses recovery-free — the existing `parseGeneratedScenario` assertion; and
+2. it validates clean via core's `validateSemanticWorkspace`, so no lineage
+   property ever asserts over input the toolchain itself considers broken.
+
+Expose the ground truth the properties consume, derived from the scenario and not
+from any production code:
+
+- `scenarioFieldEdges(scenario)` — every `(fromField, toField, mapping)` the
+  scenario declares, with fully qualified endpoints;
+- `scenarioSchemaEdges(scenario)` — the same projected onto schemas, with roles;
+- `scenarioDeclaredFieldPaths(scenario)` — every qualified declared leaf and
+  container path, for the endpoint-existence property.
+
+### R3 — Structural invariants: nothing invented, nothing silently dropped
+
+Over generated workspaces, for the CLI's graph assembly, the portable traversal
+and the VizModel plus its layout:
+
+| Property | Catches |
+|---|---|
+| Every endpoint of every emitted edge is in `scenarioDeclaredFieldPaths` | P1; fails today on `r0-7w76`'s shape |
+| Every edge in `scenarioFieldEdges` is emitted exactly once, and every emitted edge is in `scenarioFieldEdges` | P2 in both directions — dropped and invented |
+| An edge may be omitted only where a named, commented exception applies; the property enumerates the permitted exceptions | closes the `elk-layout.ts:754` blind spot without forbidding legitimate skips |
+| Every edge endpoint is backed by a node, including under `--namespace` | promotes `sl-p895`'s backfill to a stated invariant |
+| `graph --namespace ns` edges are a subset of the unfiltered edges | filter soundness, currently untested as a general rule |
+| The edge *set* is invariant under permuting declaration order, and under splitting the same declarations across more files | order- and file-independence, which the import-merge path assumes |
+
+The viz-side property runs in `satsuma-viz`'s node test suite: `layout.test.js`
+and `dom-shim.js` already make ELK layout reachable without a browser, so this
+needs no Playwright harness work.
+
+### R4 — Reachability properties with the scenario as oracle
+
+Against the portable traversal extracted by `sl-prlp`:
+
+| Property | Catches |
+|---|---|
+| `upstream(X)` at depth *d* is exactly the ancestors of X within *d* hops of `scenarioFieldEdges` | `sg-pufq` |
+| `downstream(X)` at depth *d* is exactly the descendants within *d* hops | the same class, other direction |
+| Duality: `Y ∈ downstream(X) ⟺ X ∈ upstream(Y)` | asymmetric edge construction between the two walks |
+| Depth *exactness*: the result at depth *n* is exactly the nodes whose shortest path is ≤ *n* | `sl-y89y` stated as a property, rather than monotonicity, which the buggy version also satisfied |
+| A generated cyclic workspace terminates and reports no duplicate entries | cycle handling |
+| Schema-level `lineage` equals the projection of field-level edges onto owning schemas | ties `lineage` to `graph --schema-only`, two walks that must agree |
+
+### R5 — Cross-consumer lineage parity sweep
+
+Replicate `coverage-viz-parity.test.ts` for edges: over every `.stm` under
+`examples/` and over generated workspaces, the CLI's field edges, the edges the
+viz layout would draw, and the arrows in the LSP's merged full-lineage model must
+agree.
+
+- Scope differences are accounted for, not skipped, exactly as the coverage sweep
+  accounts for workspace-versus-file scope: iterate the narrower side, and treat
+  an edge present only on the narrower side as a failure.
+- It lives in `satsuma-cli/test/` for the same reason the coverage sweep does —
+  that is the one place both consumer paths are reachable in a single process.
+- This is what makes `field-coverage.ts`'s "mirrors core's `extractArrowRecords`"
+  an executable claim.
+
+### R6 — Path/ref stage types for lineage endpoints
+
+Depends on Feature 39's R5 brands existing.
+
+- Apply the branded stages to graph and lineage endpoints, so an authored ref
+  cannot be emitted where a qualified endpoint is required.
+- Give `qualifyField` a signature that cannot silently conflate "bare field name"
+  with "schema root token" — the caller must handle the ambiguous case rather
+  than receiving a guess.
+- Replace ad-hoc unbranding such as `edge.from.split(".")[0]`
+  (`graph-builder.ts:622`) with a named core accessor.
+
+This removes the type-level permission to guess. It does **not** decide what a
+container header onto a schema root should mean; that remains `r0-7w76`.
+
+## Acceptance Tests
+
+### Generator package (R1, R2)
+
+1. `satsuma-scenario-gen` has no dependency on `@satsuma/core`, and
+   `npm install` from a clean checkout resolves without a cycle.
+2. Core's two existing generated-property suites pass unchanged apart from their
+   import path.
+3. The CLI, viz and viz-backend test suites can import the package.
+4. Every generated workspace parses recovery-free and produces no semantic
+   diagnostics from `validateSemanticWorkspace`.
+5. A generated workspace containing a namespace, an `each` container, an NL
+   `@ref`, a `derived` block and a metric renders, parses and validates.
+
+### Structural invariants (R3)
+
+6. Reverting `qualifyField`'s guard makes the endpoint-existence property fail,
+   and the reported counterexample names the invented field.
+7. Restoring an unconditional `continue` in `elk-layout.ts`'s port resolution
+   makes the arrow-to-edge completeness property fail.
+8. Removing the `nsFilter` node backfill in `graph-builder.ts` makes the
+   endpoint-has-a-node property fail.
+9. Reordering declarations in a generated workspace does not change the emitted
+   edge set.
+
+### Reachability (R4)
+
+10. Replacing `lineage.ts`'s shallowest-depth bookkeeping with a plain
+    visited-set makes the depth-exactness property fail, and does **not** make a
+    monotonicity-only property fail — demonstrating why exactness is the property
+    worth having.
+11. Restricting the upstream walk to a single predecessor makes the ancestor-set
+    property fail with a generated diamond.
+12. A generated cyclic workspace completes within the depth limit and reports
+    each field once.
+
+### Parity (R5)
+
+13. The sweep runs over every `.stm` in `examples/` and reports any disagreement
+    with the file, mapping and edge that differ.
+14. A deliberate divergence introduced into any one of the three consumers is
+    reported by the sweep.
+
+### Repository (all)
+
+15. Every property has a purpose comment naming the invariant or defect class it
+    defends, per the repository's test-quality standards.
+16. A failed generated test reports its seed, path and shrunk Satsuma source.
+17. All existing package suites, the 318 grammar corpus parses, formatter checks,
+    lint, the typecheck gates and the pytest-bdd smoke suite pass.
+
+## Out of Scope
+
+- Changing lineage or graph semantics, or deciding `r0-7w76`. This feature makes
+  the disagreement visible and typed; the decision stays on its own ticket.
+- The cross-command count and JSON-consistency family — arrow header counts
+  (`cbh-ekvb`, `cbh-zdk3`, `sl-wta4`), row-index base (`cbh-7rvo`, `cbh-s9w6`,
+  `cbh-gz2v`) and field-count agreement (`cbh-mpz2`). These are a strong
+  follow-on feature over the same generator and should not be folded in here.
+- Mutation-based generation of deliberately invalid workspaces for `validate` and
+  `lint`. That needs a second generator with a known expected diagnostic, and is
+  its own feature.
+- Expanding the Playwright harness, beyond adopting any shrunk counterexample
+  worth keeping as a fixture.
+- Parser or scanner fuzzing, which Feature 39 already places out of scope.
+- Performance work.
+
+## Decisions and Sequencing
+
+1. **Generator home:** a new private test-only package, not `satsuma-core/src`.
+   Core would make generators importable by production code, which Feature 39
+   decision 3 explicitly argues against, and would ship them inside the CLI's
+   bundled `@satsuma/core`.
+2. **No core dependency in the generator package:** required to avoid a build
+   cycle, and it costs nothing because the renderer is pure string building.
+   Pipeline adapters live with their pipelines.
+3. **No independent oracle:** the scenario is the oracle. R4 of Feature 39 does
+   not need a counterpart here.
+4. **Traversal extraction first:** Feature 40's `sl-4871` spike and `sl-prlp`
+   extraction land before R4 and R5, so the properties and the sweep aim at one
+   portable function instead of a CLI-internal one that is about to move — and so
+   the `graph-builder.ts` / `field-lineage.ts` duplication is deleted rather than
+   acquiring two parallel test suites.
+5. **Start where nothing blocks:** R1 and R2 depend on neither Feature 39's
+   remaining requirements nor Feature 40, and are the work to begin immediately.
+6. **R6 waits for Feature 39 R5,** which is not yet ticketed. R6 must not
+   pre-empt that design by inventing its own brands.
+
+## Ticket Map
+
+Feature epic: `sl-8f2p`.
+
+| Work | Ticket | Depends on |
+|---|---|---|
+| Feature 41 epic | `sl-8f2p` | — |
+| R1 promote the generator to `satsuma-scenario-gen` | `sl-puky` | — |
+| R2 workspace-shaped scenario model and ground truth | `sl-dqyu` | `sl-puky` |
+| R3 structural edge invariants | `sl-hi0z` | `sl-dqyu` |
+| R4 reachability properties over the portable traversal | `sl-jsyn` | `sl-dqyu`, `sl-prlp` |
+| R5 cross-consumer lineage parity sweep | `sl-kwet` | `sl-hi0z`, `sl-prlp` |
+| R6 branded lineage endpoints | `sl-jyee` | `sl-hi0z`; also blocked on Feature 39 R5, which has no ticket yet — recorded in the ticket body, not as a `tk` dependency |
+
+The best first slice is **R1 + R2**: both are unblocked, neither touches
+production code, and together they are what makes every later requirement — and
+the follow-on count/consistency feature — cheap to write.


### PR DESCRIPTION
## Why

Feature 39 is deliberately scoped to coverage. This PRD answers whether its generated-input machinery transfers to the rest of the toolchain, with lineage as the surface of interest.

**It does, and lineage is a better target than coverage was** — for a reason that does not apply to coverage. Coverage needed an independent oracle (Feature 39 R4) because the expected answer had to be re-derived from ADR-034–041. A generated lineage scenario already declares its arrows, so the expected upstream set of a field is just its ancestors under reachability over those arrows. The oracle is a BFS over data the generator produced, and no R4-equivalent is needed.

## What the PRD records

Already banked: R1/R2's typed CST contract is delivered in all four packages, so a renamed grammar symbol is already a compile error everywhere lineage is built. Still landlocked: the R3 generator lives in `satsuma-core/test/support/`, outside `dist/` and absent from core's `exports` map, so no other package can reach it.

Five sites resolve "what field does this arrow point at, and which schema owns it", and their agreement is asserted in prose — `field-coverage.ts` literally states its arrow walk "mirrors core's `extractArrowRecords`". Three failure modes follow, each previously caught by hand rather than by a mechanism:

| Failure mode | Evidence |
|---|---|
| Invented endpoints | `qualifyField` ends with an unconditional `` `${schemas[0]}.${field}` `` (`canonical-ref.ts:75`) and has no view of the declared field set — `r0-7w76` |
| Silently dropped edges | `elk-layout.ts:754` skips any arrow whose ports do not resolve; nested-iteration mappings once drew no lines at all with nothing failing — `3cdd-yavi`, `sl-l7u0` |
| Truncated traversals | `sl-y89y` (depth bookkeeping), `sg-pufq` (one upstream branch instead of all), `cbh-y5og` (phantom NL edges) |

Existing coverage for all of this is 65 hand-authored tests. For contrast, the coverage parity sweep — one test — held on its two fixtures and failed on twelve shipped examples the moment it was pointed at the corpus.

## Requirements

- **R1** promote the generator to a private, build-free `satsuma-scenario-gen` package. It must not depend on `@satsuma/core` (core's tests depend on it — a dependency back creates a build cycle), and the exported typedefs need a `Scenario` prefix because core's `validate.ts` already exports `SemanticMapping`/`SemanticArrow`/`SemanticSchema` for an unrelated purpose.
- **R2** extend the model from one mapping to a workspace: chains/diamonds/cycles, imports, namespaces, containers, NL `@ref`s, `derived` blocks, metrics. Every generated workspace must parse recovery-free *and* validate clean.
- **R3** structural edge invariants — nothing invented, nothing silently dropped, every endpoint backed by a node, edge set invariant under reordering.
- **R4** reachability properties with the scenario as oracle, including depth *exactness* rather than monotonicity (the `sl-y89y` bug satisfied monotonicity).
- **R5** cross-consumer lineage parity sweep, replicating `coverage-viz-parity.test.ts` for edges.
- **R6** branded lineage endpoints, once Feature 39 R5 exists.

Explicitly out of scope: any change to lineage or graph semantics, deciding `r0-7w76`, the cross-command count/JSON-consistency family, and validate/lint mutation generators.

## Tickets

Epic `sl-8f2p` with `sl-puky` (R1), `sl-dqyu` (R2), `sl-hi0z` (R3), `sl-jsyn` (R4), `sl-kwet` (R5), `sl-jyee` (R6). Dependencies wired, no cycles; `sl-puky` is the only child ready today. R4 and R5 also depend on Feature 40's `sl-prlp`, so the properties aim at one portable traversal instead of a CLI-internal function that is about to move.

`sl-jyee` is additionally blocked on Feature 39 R5, which has no ticket yet — recorded in the ticket body rather than as a `tk` dependency, since there is nothing to point at.

## Verification

Docs and tickets only; no code changed. Full repo checks ran on commit and passed: lint (js/md/yaml/python), all package suites, `fmt --check` over the examples, and the 50-test pytest-bdd smoke suite.

One note for anyone else on this clone: the two Feature 39 generated-property suites failed locally until `npm install` was run in `tooling/satsuma-core` — `fast-check` arrived with `cbdr-o6xn` and stale `node_modules` makes both suites error rather than fail informatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)