### PR TITLE
docs(features): record the ArrowEntry declaration-kind deferral (sl-kwet)

### DIFF
--- a/.tickets/sl-kwet.md
+++ b/.tickets/sl-kwet.md
@@ -22,3 +22,25 @@ Replicate satsuma-cli/test/coverage-viz-parity.test.ts for edges. Over every .st
 
 The sweep runs over every .stm in examples/ and reports any disagreement with the file, mapping and edge that differ. A deliberate divergence introduced into any one of the three consumers is reported by the sweep. Where a real disagreement exists on current behaviour, it is recorded against the owning bug ticket rather than accommodated by weakening the assertion.
 
+
+## Notes
+
+**2026-08-03T16:43:02Z**
+
+Protocol decision this sweep gates (PRD decision 7, recorded 2026-08-03).
+
+Labelling an arrow's declaration kind on the VizModel's `ArrowEntry` was assessed
+and deferred pending this sweep's findings. The viz encodes the kind structurally
+(`eachBlocks`/`flattenBlocks`/`NestedArrowBlock`, and `sourceFields: []` for a
+computed arrow) while core states it as data (`ExtractedArrow.kind`), so the two
+agree today only by careful reading.
+
+The field was rejected for now mainly because supplying it would re-arm the
+client-side coverage derivation ADR-042 removed: `MappingBlock.coverage`'s
+doc-comment records that the client cannot derive coverage partly because it lacks
+the arrow's declaration kind.
+
+**What this means for whoever runs this sweep:** if it surfaces a genuine kind
+disagreement between the consumers, say so explicitly in the ticket notes rather
+than only fixing the symptom — that finding is the trigger to revisit the protocol
+decision, and it identifies which side was wrong.

--- a/features/41-lineage-graph-confidence/PRD.md
+++ b/features/41-lineage-graph-confidence/PRD.md
@@ -376,6 +376,37 @@ container header onto a schema root should mean; that remains `r0-7w76`.
    remaining requirements nor Feature 40, and are the work to begin immediately.
 6. **R6 waits for Feature 39 R5,** which is not yet ticketed. R6 must not
    pre-empt that design by inventing its own brands.
+7. **`ArrowEntry` does not gain a declaration-kind field — considered and
+   deferred, 2026-08-03.** The viz encodes an arrow's declaration kind
+   *structurally* (`eachBlocks` / `flattenBlocks` / `NestedArrowBlock`, and
+   `sourceFields: []` for a computed arrow — `viz-model.ts:1064`) while core
+   states it as data (`ExtractedArrow.kind`). Labelling it in the protocol was
+   assessed and rejected for now:
+
+   - it is **redundant** — every value is recoverable from position today, so a
+     label introduces a payload that can disagree with its own structure, the
+     opposite direction from Feature 39 R8's variant work on `FieldDecl`;
+   - it would **re-arm the derivation ADR-042 removed**. `MappingBlock.coverage`'s
+     doc-comment records that client-side coverage derivation fails partly because
+     the client lacks "the arrow's declaration kind"; supplying it hands back the
+     missing ingredient for the path deleted by `sl-46wr` / `sl-csrs`;
+   - `arrow.transform.kind` is already `"nl" | "map"`, so a sibling `kind`
+     containing `"map"` with a different meaning needs a clumsier name;
+   - as an LSP↔webview contract field it would land optional (as `coverage?` did),
+     so consumers keep the positional fallback and the derivation survives anyway;
+   - no logged defect motivates it — `3cdd-yavi` and `sl-l7u0` were path
+     qualification failures, not kind misclassification.
+
+   **Trigger to revisit:** a genuine kind disagreement surfaced by R5's parity
+   sweep (`sl-kwet`). That evidence would both justify the field and identify
+   which side was wrong. Until then R5 covers the risk without a protocol change.
+   The cheaper intermediate step, if the derivation risk needs cutting sooner, is
+   to export a named predicate from core for the "does this header count as an
+   arrow" decision and have the viz's walk call it — the shape of `sl-3yuz`.
+
+   Separately, `sl-k7i4` (a sourceless derived arrow renders an indistinguishable
+   empty Source cell) is a real user-visible bug that does **not** depend on this
+   decision: the renderer can treat `sourceFields.length === 0` as computed today.
 
 ## Ticket Map
 


### PR DESCRIPTION
## Why

Following the assessment of the arrow-resolution sites for Feature 41, the question came up of whether `satsuma-viz-model`'s `ArrowEntry` should carry an arrow's declaration kind. The decision is **no, for now** — and a deferral with a named trigger is worth recording, or the next reader hits it cold.

## The finding behind the decision

The kind is already fully recoverable from the VizModel, so this was never missing data:

| Kind | How the model encodes it |
|---|---|
| `each` / `flatten` | the entry sits in `MappingBlock.eachBlocks` / `flattenBlocks` |
| `nested` | it is a `NestedArrowBlock` |
| `computed` | in `arrows` with `sourceFields: []` (`viz-model.ts:1064`, deliberate and documented) |
| `map` | in `arrows` with sources |

Core states the same thing as data on `ExtractedArrow.kind`. So the viz encodes the rule *structurally* and core encodes it as *data*, and they agree today by careful reading.

**The decisive reason not to add it:** `MappingBlock.coverage`'s own doc-comment records that client-side coverage derivation fails partly because the client lacks "the arrow's declaration kind". Supplying it hands back the missing ingredient for exactly the derivation path ADR-042 deleted in `sl-46wr` / `sl-csrs`. Also: it is redundant with position (so a payload could disagree with its own structure — the opposite direction from Feature 39 R8's `FieldDecl` variants), `arrow.transform.kind` is already `"nl" | "map"`, and as an LSP↔webview contract field it would land optional like `coverage?`, so the positional fallback survives anyway.

No logged defect motivates it: `3cdd-yavi` and `sl-l7u0` were path-qualification failures, not kind misclassification.

## What this PR contains

- PRD decision 7, with the reasoning and an explicit **trigger to revisit**: a genuine kind disagreement surfaced by R5's parity sweep. That evidence would both justify the field and identify which side was wrong.
- The same note on `sl-kwet`, so whoever runs the sweep knows to *report* such a finding rather than only fix the symptom.
- The cheaper intermediate step is named for whoever wants the risk cut sooner: export a named predicate from core for the "does this header count as an arrow" decision and have the viz's walk call it — the shape of `sl-3yuz`.
- Notes that `sl-k7i4` does not depend on this decision; the renderer can treat `sourceFields.length === 0` as computed today.

## Verification

Docs and one ticket note; no source changed. Full repo checks ran on commit and passed, including the 50-test pytest-bdd smoke suite. markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)