### PR TITLE
Enforce opaque reference stages in core coverage

### DIFF
--- a/.tickets/cbdr-5r4d.md
+++ b/.tickets/cbdr-5r4d.md
@@ -27,4 +27,8 @@ schemaLocalFieldPath accepts only ContainerQualifiedFieldRef and returns SchemaL
 
 **2026-08-03T16:46:34Z**
 
-Cause: Coverage builders, localization, and declared-field probes still accepted interchangeable strings after the R5 stage vocabulary existed, so consumers could skip or reverse normalization without a compile error. Fix: Tightened coverage APIs to SchemaLocalPath and explicit authored/canonical inputs, migrated core producers and CLI/LSP/viz adapters through validated constructors and transitions, and added compile-only plus runtime regression coverage while preserving protocol strings (commit immediately after c4e4f231).
+Cause: Coverage builders, localization, and declared-field probes still accepted interchangeable strings after the R5 stage vocabulary existed, so consumers could skip or reverse normalization without a compile error. Fix: Tightened coverage APIs to SchemaLocalPath and explicit authored/canonical inputs, migrated core producers and CLI/LSP/viz adapters through validated constructors and transitions, and added compile-only plus runtime regression coverage while preserving protocol strings (commit immediately after a34b0224).
+
+**2026-08-03T16:55:11Z**
+
+Decision record: ADR-044 records opaque reference stages as the durable core boundary, extends ADR-039 without superseding it, and keeps serialized protocols string-based (documentation commit immediately after cd5ba86e).

--- a/.tickets/cbdr-5r4d.md
+++ b/.tickets/cbdr-5r4d.md
@@ -1,6 +1,6 @@
 ---
 id: cbdr-5r4d
-status: open
+status: closed
 deps: [cbdr-e6ft]
 links: []
 created: 2026-08-03T16:26:52Z
@@ -22,3 +22,9 @@ Migrate schemaLocalFieldPath to ContainerQualifiedFieldRef -> SchemaLocalPath | 
 
 schemaLocalFieldPath accepts only ContainerQualifiedFieldRef and returns SchemaLocalPath | null; buildCoveredFieldPaths and coverage path probes accept only SchemaLocalPath values; passing a raw string or AuthoredFieldRef to a schema-local coverage API fails a compile-only test while createSchemaLocalPath("city") succeeds; passing AuthoredEntityRef where CanonicalEntityRef is required fails compile-only checking; all core producers and CLI/viz consumers enter the typed domain through public validation or semantic transitions with no casts; JSON, VizModel, and LSP protocol shapes remain strings and existing snapshots/parity tests are unchanged; core, CLI, LSP, viz-backend, viz-model, and viz tests/builds pass.
 
+
+## Notes
+
+**2026-08-03T16:46:34Z**
+
+Cause: Coverage builders, localization, and declared-field probes still accepted interchangeable strings after the R5 stage vocabulary existed, so consumers could skip or reverse normalization without a compile error. Fix: Tightened coverage APIs to SchemaLocalPath and explicit authored/canonical inputs, migrated core producers and CLI/LSP/viz adapters through validated constructors and transitions, and added compile-only plus runtime regression coverage while preserving protocol strings (commit immediately after c4e4f231).

--- a/.tickets/cbdr-5r4d.md
+++ b/.tickets/cbdr-5r4d.md
@@ -1,0 +1,24 @@
+---
+id: cbdr-5r4d
+status: open
+deps: [cbdr-e6ft]
+links: []
+created: 2026-08-03T16:26:52Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r5, core, cli, viz, types]
+---
+# core: enforce opaque stages at coverage boundaries
+
+Tighten core coverage and path-resolution APIs to accept only values at the correct reference stage, then migrate every TypeScript consumer at the JSON, CST, LSP, or VizModel boundary through the validating constructors and named transitions.
+
+## Design
+
+Migrate schemaLocalFieldPath to ContainerQualifiedFieldRef -> SchemaLocalPath | null. Make covered-path builders and probes consume SchemaLocalPath and expose branded direct/ancestor sets; apply the stage vocabulary inside computeMappingCoverage and declared-field probing. Keep result models, VizModel, LSP payloads, and JSON serialized fields as strings. Update CLI lint and satsuma-viz resolution wrappers by constructing boundary values rather than casting. Consolidate stage-invariant compile tests in core; consumer tests assert only their own behaviour and protocol parity.
+
+## Acceptance Criteria
+
+schemaLocalFieldPath accepts only ContainerQualifiedFieldRef and returns SchemaLocalPath | null; buildCoveredFieldPaths and coverage path probes accept only SchemaLocalPath values; passing a raw string or AuthoredFieldRef to a schema-local coverage API fails a compile-only test while createSchemaLocalPath("city") succeeds; passing AuthoredEntityRef where CanonicalEntityRef is required fails compile-only checking; all core producers and CLI/viz consumers enter the typed domain through public validation or semantic transitions with no casts; JSON, VizModel, and LSP protocol shapes remain strings and existing snapshots/parity tests are unchanged; core, CLI, LSP, viz-backend, viz-model, and viz tests/builds pass.
+

--- a/.tickets/cbdr-e6ft.md
+++ b/.tickets/cbdr-e6ft.md
@@ -27,4 +27,4 @@ All five opaque types and their validating constructors are exported from @satsu
 
 **2026-08-03T16:30:01Z**
 
-Cause: Authored refs, container-qualified refs, schema-local paths, and canonical entity ids were all represented as interchangeable strings, so TypeScript could not reject a transition at the wrong normalization stage. Fix: Added five opaque core reference types, validating constructors, and named container-qualification/entity-canonicalization transitions with runtime and compile-only coverage (commit immediately after bc967469).
+Cause: Authored refs, container-qualified refs, schema-local paths, and canonical entity ids were all represented as interchangeable strings, so TypeScript could not reject a transition at the wrong normalization stage. Fix: Added five opaque core reference types, validating constructors, and named container-qualification/entity-canonicalization transitions with runtime and compile-only coverage (commit immediately after ac9e6fc6).

--- a/.tickets/cbdr-e6ft.md
+++ b/.tickets/cbdr-e6ft.md
@@ -1,0 +1,30 @@
+---
+id: cbdr-e6ft
+status: closed
+deps: [sl-46wr, sl-csrs]
+links: []
+created: 2026-08-03T16:26:40Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r5, core, types]
+---
+# core: define opaque path and entity-reference stages
+
+Introduce the runtime-erased core vocabulary for authored field refs, container-qualified field refs, schema-local paths, authored entity refs, and canonical entity refs. Add validating public constructors and the named semantic transitions for container qualification and workspace-aware entity canonicalization, with the brand key private to the module.
+
+## Design
+
+Keep the underlying representation as string so public JSON and protocol shapes do not change. Constructors reject empty or structurally invalid stage values; transitions are the only place that advances a value between stages. The sole type assertion belongs in the module-private validated representation boundary and is documented. Preserve existing string-returning helpers until the dependent migration ticket tightens their signatures.
+
+## Acceptance Criteria
+
+All five opaque types and their validating constructors are exported from @satsuma/core; container qualification accepts AuthoredFieldRef and returns ContainerQualifiedFieldRef; entity canonicalization accepts AuthoredEntityRef and returns CanonicalEntityRef or null after namespace-aware lookup; global canonical ids retain the :: prefix; the brand symbol is not exported and no assertion appears outside the module; runtime tests cover valid, invalid, qualified, unqualified, and unresolved values; compile-only tests prove raw strings and wrong-stage values cannot cross the new transitions; npm --prefix tooling/satsuma-core test passes.
+
+
+## Notes
+
+**2026-08-03T16:30:01Z**
+
+Cause: Authored refs, container-qualified refs, schema-local paths, and canonical entity ids were all represented as interchangeable strings, so TypeScript could not reject a transition at the wrong normalization stage. Fix: Added five opaque core reference types, validating constructors, and named container-qualification/entity-canonicalization transitions with runtime and compile-only coverage (commit immediately after bc967469).

--- a/adrs/adr-044-opaque-reference-types-enforce-semantic-stage-order.md
+++ b/adrs/adr-044-opaque-reference-types-enforce-semantic-stage-order.md
@@ -1,0 +1,135 @@
+# ADR-044 — Opaque Reference Types Enforce Semantic Stage Order
+
+**Status:** Accepted
+**Date:** 2026-08-03 (cbdr-e6ft, cbdr-5r4d; feature 39 R5)
+
+## Context
+
+ADR-039 chose to preserve authored entity references in extracted models and to
+resolve them only where workspace context is available. That decision made the
+two representations explicit in prose: `customer` is authored text, while
+`crm::customer` is a canonical workspace identity. Coverage has an analogous
+sequence for fields: `city` as written inside a nested arrow, then
+`home_address.city` after container qualification, then a path relative to one
+schema after schema localization.
+
+The implementation represented every stage as `string`. A function that needed
+a schema-local path could therefore receive authored text, a container-qualified
+path, or an entity name without TypeScript objecting. The same was true of
+authored and canonical entity references. Correctness depended on call order and
+reviewer memory rather than on the API contract.
+
+That weakness was already implicated in the coverage defects which led to
+feature 39. A path can be syntactically plausible at more than one stage:
+`city` may be a correct top-level schema-local path, while the same text inside
+`each home_address` still needs qualification. Runtime string validation cannot
+distinguish those histories. The useful invariant is therefore not “this string
+looks like a path”; it is “this value passed through the transition required at
+this point in the algorithm.”
+
+Adding stage-specific object wrappers would encode that invariant, but it would
+also change every JSON, LSP, and VizModel payload and add allocation and
+serialization work to values whose runtime representation is intentionally a
+string. Conversely, leaving the distinction as documentation would preserve the
+failure mode ADR-039 identified: two representations in flight with no type-level
+enforcement.
+
+## Decision
+
+**Core defines opaque, runtime-erased string types for the semantic stages of
+field paths and entity references.** The initial vocabulary is deliberately
+narrow:
+
+- `AuthoredFieldRef` — a field expression as written on an arrow;
+- `ContainerQualifiedFieldRef` — that expression made absolute against its
+  enclosing mapping containers;
+- `SchemaLocalPath` — a dotted path relative to one declared schema root;
+- `AuthoredEntityRef` — an entity reference as written in source, target, or
+  spread syntax; and
+- `CanonicalEntityRef` — a unique workspace identity, including `::` for the
+  global namespace.
+
+The shared representation is `string & { readonly [privateSymbol]: Stage }`.
+The brand symbol remains private to `reference-stages.ts`, so consumers cannot
+construct a staged value structurally. Public constructors validate strings at
+external boundaries, and named core transitions advance values between stages.
+The only unsafe assertion is inside the private constructor boundary, where it
+documents the fact that TypeScript brands have no runtime representation.
+
+**Construction and transition are separate concepts.** Constructors such as
+`createAuthoredFieldRef` and `createCanonicalEntityRef` are for values entering
+the typed domain from the CST, an existing model, or another protocol. They
+validate the representation that can be known locally: references are non-empty,
+and canonical entity ids have `[namespace]::name` form. Transitions such as
+`qualifyContainerFieldRef`, `schemaLocalFieldPath`, and
+`canonicalizeEntityRef` perform semantic work and expose that work in their
+signatures. A consumer cannot pass an `AuthoredFieldRef` where a
+`SchemaLocalPath` is required merely because both happen to contain `city`.
+
+**The branded domain begins and ends at process and protocol boundaries.** CST
+extraction, JSON, LSP, and VizModel contracts continue to carry strings.
+Consumers must use a public constructor or transition when those strings enter
+stage-sensitive core logic; they must not use casts to manufacture a brand.
+Returning a branded value through a string protocol requires no conversion
+because every stage remains assignable to `string`.
+
+**Coverage APIs state the stage they consume.** Covered-path builders and probes
+accept `SchemaLocalPath`, and schema localization returns
+`SchemaLocalPath | null`. Entity resolution receives `AuthoredEntityRef` and
+returns definitions whose identity is a `CanonicalEntityRef`. Intermediate arrow
+models carry their current path stage rather than erasing it back to `string`.
+This makes an omitted or reordered normalization step a compile error at the
+point of use.
+
+Compile-only tests are part of the contract. They prove that raw strings and
+values from the wrong stage are rejected, while runtime tests cover boundary
+validation and the actual normalization rules. Property and differential tests
+remain necessary: a brand proves that a transition was called, not that its
+algorithm produced the correct path.
+
+Two broader alternatives were rejected. Branding every semantic string in core
+would make the migration much larger without evidence that file URIs, namespace
+ids, or natural-language text suffer the same cross-stage defects. The decision
+therefore stops at reference normalization stages and treats this migration as
+evidence for any future expansion. Encoding provenance in runtime wrapper
+objects was also rejected because the invariant is internal to TypeScript and
+does not justify breaking stable external payloads.
+
+This **extends ADR-039**. Authored form is still preserved in models and
+resolution still occurs at point of use; this ADR makes the stages surrounding
+that resolution enforceable by the compiler. It does not supersede ADR-039.
+
+## Consequences
+
+**Positive:**
+
+- Missing container qualification, schema localization, or entity
+  canonicalization becomes a compile-time error at typed coverage boundaries.
+- The API documents semantic order directly in its parameter and return types,
+  so a reader can follow the normalization pipeline without reconstructing it
+  from string operations.
+- Core owns the transition rules once. CLI, LSP, viz-backend, and viz consumers
+  call the same constructors and canonicalizer rather than duplicating casts or
+  namespace lookup conventions.
+- Existing JSON, LSP, and VizModel contracts remain byte-for-byte compatible;
+  the safety has no runtime storage or serialization cost.
+- The private brand and compile-only negative tests make accidental weakening
+  visible. Adding `as SchemaLocalPath` in a consumer is recognizable as a breach
+  of the architecture rather than an ordinary type conversion.
+
+**Negative:**
+
+- Boundary code is more explicit. Values coming from models and protocols need
+  constructor calls even when the author already knows they are valid strings.
+- The types provide stage safety, not proof of origin or semantic correctness.
+  A faulty transition can still brand the wrong result, so runtime, property,
+  and differential tests cannot be replaced by nominal typing.
+- Brands are a TypeScript-only guarantee. JavaScript consumers and serialized
+  payloads do not carry them, and any TypeScript consumer can deliberately evade
+  the contract with an unsafe assertion.
+- Public APIs which previously accepted arbitrary strings become source
+  incompatible for TypeScript callers. Callers must identify the boundary or
+  transition that establishes the required stage.
+- The chosen vocabulary may need to grow if future defects reveal additional
+  meaningful stages. Each addition should be justified by a real invariant,
+  rather than turning every core string into a nominal type by default.

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Satsuma Tooling Architecture
 
-> Last updated: 2026-08-03 — documented the generated CST symbol contract boundary (ADR-043).
+> Last updated: 2026-08-03 — documented opaque reference stages at coverage boundaries (ADR-044).
 
 This document is the canonical architecture reference for the Satsuma language tooling — the packages under `tooling/` that parse, analyse, format, validate, visualize, and provide IDE support for `.stm` files. The design is influenced by [rust-analyzer's architecture](https://rust-analyzer.github.io/book/contributing/architecture.html), adapted for a tree-sitter-backed DSL rather than a full programming language compiler.
 
@@ -142,15 +142,17 @@ graph LR
   NL["nl-ref.ts\nDefinitionLookup (callback)\nAtRef · RefClassification\nextractAtRefs · classifyRef\nresolveRef · resolveAllAtRefs\nextractNLRefData"]
   FMT["format.ts\nformat(tree, source)"]
   STR["string-utils.ts\ncapitalize · truncate\nformatList · …"]
+  REF["reference-stages.ts\nAuthoredFieldRef · ContainerQualifiedFieldRef\nSchemaLocalPath · AuthoredEntityRef\nCanonicalEntityRef"]
   PAR["parser.ts\ninitParser() singleton\nparseSource()"]
   PE["parse-errors.ts\ncollectParseErrors()\nParseError"]
   COV["coverage.ts · coverage-paths.ts\nFieldCoverageEntry\nSchemaCoverageResult\nbuildCoveredFieldPaths()\nschemaLocalFieldPath()"]
   VAL["validate.ts\nSemanticIndex · SemanticDiagnostic\ncollectSemanticDiagnostics()"]
 
-  IDX --> TYPES & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & PAR & PE & COV & VAL
+  IDX --> TYPES & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & REF & PAR & PE & COV & VAL
   EXT --> CST & CLS & CAN & META & TYPES
   SPR --> EXT & TYPES
   NL --> SPR & TYPES
+  COV --> REF
   VAL --> CAN & TYPES
 ```
 
@@ -169,6 +171,8 @@ graph LR
 | `AtRef` | `types.ts` | `{ ref: string, offset: number }` — a single @-ref extracted from NL text |
 | `NLRefData` | `types.ts` | All NL strings + @-refs for a file |
 | `Resolution` | `types.ts` | `{ resolved: boolean, resolvedTo: { kind, name } \| null }` |
+| `AuthoredFieldRef` / `ContainerQualifiedFieldRef` / `SchemaLocalPath` | `reference-stages.ts` | Opaque strings that record field-reference normalization stages at compile time |
+| `AuthoredEntityRef` / `CanonicalEntityRef` | `reference-stages.ts` | Opaque strings that distinguish authored entity names from unique workspace identities |
 | `EntityFieldLookup` | `spread-expand.ts` | Callback for spread resolution: `(name, ns) => { fields } \| null` |
 | `DefinitionLookup` | `nl-ref.ts` | Callback for @-ref resolution: `(name, ns) => { kind, fields? } \| null` |
 | `SemanticIndex` | `validate.ts` | Minimal structural interface accepted by `collectSemanticDiagnostics`; satisfied by CLI `ExtractedWorkspace` |
@@ -176,6 +180,13 @@ graph LR
 | `FieldCoverageEntry` | `coverage.ts` | `{ path, mapped: boolean }` — coverage status for one field path |
 | `SchemaCoverageResult` | `coverage.ts` | Per-schema list of `FieldCoverageEntry` records |
 | `ParseError` | `parse-errors.ts` | `{ file, line, column, message }` — structural error from tree-sitter ERROR/MISSING nodes |
+
+Reference-stage brands are private and runtime-erased. CST, JSON, LSP, and
+VizModel boundaries continue to carry strings; consumers use core constructors
+when values enter stage-sensitive logic and named transitions when they advance
+from authored to qualified, schema-local, or canonical form. Coverage APIs accept
+the stage they actually require, so an omitted or reordered normalization step is
+a compile error without changing external protocols. See ADR-044.
 
 ---
 

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -437,8 +437,8 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 through R4 and R6 now have concrete tickets;
-later rows remain the agreed ticket shape and will receive IDs when scheduled.
+Feature epic: `gcsc-qka8`. R1 through R6 now have concrete tickets; later rows
+remain the agreed ticket shape and will receive IDs when scheduled.
 
 | Work | Ticket shape | Depends on |
 |---|---|---|
@@ -451,7 +451,8 @@ later rows remain the agreed ticket shape and will receive IDs when scheduled.
 | R3 semantic generators and coverage properties (`cbdr-o6xn`) | 1 task | — |
 | R3 generated formatter properties (`cbdr-yp9m`) | 1 task | `cbdr-o6xn` |
 | R4 independent oracle and differential suite (`cbdr-da0j`) | 1 task | `cbdr-o6xn` |
-| R5 opaque path/ref stages | 1 core task plus consumer migration subtasks if needed | `sl-46wr`, `sl-csrs` |
+| R5 opaque path/ref foundation (`cbdr-e6ft`) | 1 core task | `sl-46wr`, `sl-csrs` |
+| R5 coverage and consumer migration (`cbdr-5r4d`) | 1 task | `cbdr-e6ft` |
 | R6 CLI test typecheck gate (`cbdr-xgy5`) | 1 task | — |
 | R7 type-aware lint rollout | 1 task per package | R2 for CST-specific rules |
 | R8 `FieldDecl` variants and consumer migration | 1 task | schedule clear of active consumer-model work |

--- a/tooling/satsuma-cli/src/coverage-workspace.ts
+++ b/tooling/satsuma-cli/src/coverage-workspace.ts
@@ -17,7 +17,7 @@
  * independently maintained code.
  */
 
-import { computeMappingCoverage } from "@satsuma/core";
+import { canonicalizeEntityRef, computeMappingCoverage } from "@satsuma/core";
 import type {
   CoverageSchemaDefinition,
   CoverageSchemaResolver,
@@ -25,7 +25,6 @@ import type {
   MappingCoverageResult,
   ResolvedNLRef,
 } from "@satsuma/core";
-import { resolveScopedEntityRef } from "./index-builder.js";
 import { expandDeclaredFields } from "./spread-expand.js";
 import { toCoverageFields } from "./field-positions.js";
 import type { ExtractedWorkspace, ParsedFile, SchemaRecord } from "./types.js";
@@ -71,12 +70,15 @@ export function makeSchemaResolver(
   index: ExtractedWorkspace,
   mappingNamespace: string | null,
 ): CoverageSchemaResolver {
-  return (writtenRef: string): CoverageSchemaDefinition | null => {
-    const key = resolveScopedEntityRef(writtenRef, mappingNamespace, index.schemas);
-    const schema = key ? index.schemas.get(key) : undefined;
-    if (!key || !schema) return null;
+  return (writtenRef): CoverageSchemaDefinition | null => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, index.schemas);
+    if (!canonicalRef) return null;
+    const key = canonicalRef.startsWith("::") ? canonicalRef.slice(2) : canonicalRef;
+    const schema = index.schemas.get(key);
+    if (!schema) return null;
     return {
       schemaId: key,
+      canonicalRef,
       uri: schema.file,
       fields: toCoverageFields(expandedFields(schema, index), {
         file: schema.file,

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -9,6 +9,9 @@
 
 import {
   capitalize,
+  createAuthoredEntityRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
   declaredFieldKind,
   schemaLocalFieldPath,
   stripNLRefScopePrefix,
@@ -586,12 +589,14 @@ function endpointKind(
   index: ExtractedWorkspace,
 ): "container" | "leaf" | null {
   for (const ref of schemaRefs) {
-    const schema = index.schemas.get(resolveCanonicalKey(ref));
+    const canonicalKey = resolveCanonicalKey(ref);
+    const schema = index.schemas.get(canonicalKey);
     if (!schema || schema.hasSpreads) continue;
     const local = schemaLocalFieldPath(
-      path,
-      [ref],
-      schemaRefs.filter((r) => r !== ref),
+      createContainerQualifiedFieldRef(path),
+      createAuthoredEntityRef(ref),
+      createCanonicalEntityRef(canonicalKey.includes("::") ? canonicalKey : `::${canonicalKey}`),
+      schemaRefs.filter((r) => r !== ref).map(createAuthoredEntityRef),
       (name) => schema.fields.some((f) => f.name === name),
     );
     if (local === null) continue;

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -54,6 +54,10 @@
       "types": "./dist/source-files.d.ts",
       "default": "./dist/source-files.js"
     },
+    "./reference-stages": {
+      "types": "./dist/reference-stages.d.ts",
+      "default": "./dist/reference-stages.js"
+    },
     "./parser": {
       "types": "./dist/parser.d.ts",
       "default": "./dist/parser.js"

--- a/tooling/satsuma-core/src/coverage-paths.ts
+++ b/tooling/satsuma-core/src/coverage-paths.ts
@@ -44,6 +44,14 @@
  * modules can be reasoned about independently.
  */
 
+import { createSchemaLocalPath } from "./reference-stages.js";
+import type {
+  AuthoredEntityRef,
+  CanonicalEntityRef,
+  ContainerQualifiedFieldRef,
+  SchemaLocalPath,
+} from "./reference-stages.js";
+
 // ── The covered-path model ───────────────────────────────────────────────────
 
 /**
@@ -61,9 +69,9 @@
  */
 export interface CoveredFieldPaths {
   /** Paths an arrow or resolved NL `@ref` referenced exactly. */
-  direct: ReadonlySet<string>;
+  direct: ReadonlySet<SchemaLocalPath>;
   /** Proper ancestor prefixes of direct paths — containers something was written *into*. */
-  ancestors: ReadonlySet<string>;
+  ancestors: ReadonlySet<SchemaLocalPath>;
 }
 
 /**
@@ -88,9 +96,9 @@ export interface CoveredFieldPaths {
  * and it failed in the dangerous direction, silently reporting an incomplete
  * spec as complete. Callers must pass the schema-local qualified path.
  */
-export function buildCoveredFieldPaths(paths: Iterable<string>): CoveredFieldPaths {
-  const direct = new Set<string>();
-  const ancestors = new Set<string>();
+export function buildCoveredFieldPaths(paths: Iterable<SchemaLocalPath>): CoveredFieldPaths {
+  const direct = new Set<SchemaLocalPath>();
+  const ancestors = new Set<SchemaLocalPath>();
   for (const path of paths) {
     if (!path) continue;
     direct.add(path);
@@ -104,17 +112,17 @@ export function buildCoveredFieldPaths(paths: Iterable<string>): CoveredFieldPat
  * direct path. This is the boolean every consumer renders as "mapped", reached
  * through the `FieldCoverageEntry` list coverage.ts builds from it.
  */
-export function isCoveredPath(path: string, covered: CoveredFieldPaths): boolean {
+export function isCoveredPath(path: SchemaLocalPath, covered: CoveredFieldPaths): boolean {
   return covered.direct.has(path) || covered.ancestors.has(path);
 }
 
 /** Proper dotted prefixes of a path, shortest first: "a.b.c" → ["a", "a.b"]. */
-function properPrefixesOf(path: string): string[] {
-  const prefixes: string[] = [];
+function properPrefixesOf(path: SchemaLocalPath): SchemaLocalPath[] {
+  const prefixes: SchemaLocalPath[] = [];
   let prefix = "";
   for (const part of path.split(".").slice(0, -1)) {
     prefix = prefix ? `${prefix}.${part}` : part;
-    prefixes.push(prefix);
+    prefixes.push(createSchemaLocalPath(prefix));
   }
   return prefixes;
 }
@@ -154,7 +162,7 @@ function properPrefixesOf(path: string): string[] {
  *    is always fully canonical, so without this a global schema's NL coverage
  *    would never match.
  */
-export function schemaRefPrefixes(schemaRef: string): string[] {
+export function schemaRefPrefixes(schemaRef: AuthoredEntityRef | CanonicalEntityRef): string[] {
   const namespaceEnd = schemaRef.lastIndexOf("::");
   if (namespaceEnd < 0) return [schemaRef, `::${schemaRef}`];
   return [schemaRef, schemaRef.slice(namespaceEnd + 2)];
@@ -186,26 +194,28 @@ export function schemaRefPrefixes(schemaRef: string): string[] {
  * rather than to a prefix that only looks like one.
  *
  * @param fieldRef         Path as authored on the arrow, already container-qualified.
- * @param schemaRefs       Every form this schema may be named by — the reference
- *                         as written in the mapping and, when it differs, the
- *                         resolved canonical id.
+ * @param authoredSchemaRef  The schema reference exactly as written in the mapping.
+ * @param canonicalSchemaRef The unique workspace identity returned by resolution.
  * @param otherSchemaRefs  The other schemas referenced on this side of the mapping.
  * @param declaresTopLevel True when this schema declares a top-level field of the
  *                         given name. Supply it to disambiguate rules 1 and 2.
  */
 export function schemaLocalFieldPath(
-  fieldRef: string,
-  schemaRefs: readonly string[],
-  otherSchemaRefs: readonly string[],
+  fieldRef: ContainerQualifiedFieldRef,
+  authoredSchemaRef: AuthoredEntityRef,
+  canonicalSchemaRef: CanonicalEntityRef,
+  otherSchemaRefs: readonly AuthoredEntityRef[],
   declaresTopLevel?: (name: string) => boolean,
-): string | null {
+): SchemaLocalPath | null {
   const firstSegment = fieldRef.split(".")[0] ?? fieldRef;
   const shadowedByOwnField = declaresTopLevel?.(firstSegment) ?? false;
 
   if (!shadowedByOwnField) {
-    for (const prefix of schemaRefs.flatMap(schemaRefPrefixes)) {
+    for (const prefix of [authoredSchemaRef, canonicalSchemaRef].flatMap(schemaRefPrefixes)) {
       if (fieldRef === prefix) return null;
-      if (fieldRef.startsWith(`${prefix}.`)) return fieldRef.slice(prefix.length + 1);
+      if (fieldRef.startsWith(`${prefix}.`)) {
+        return createSchemaLocalPath(fieldRef.slice(prefix.length + 1));
+      }
     }
   }
 
@@ -214,5 +224,5 @@ export function schemaLocalFieldPath(
     .some((prefix) => fieldRef === prefix || fieldRef.startsWith(`${prefix}.`));
   if (namesAnotherSchema) return null;
 
-  return fieldRef;
+  return createSchemaLocalPath(fieldRef);
 }

--- a/tooling/satsuma-core/src/coverage.ts
+++ b/tooling/satsuma-core/src/coverage.ts
@@ -63,6 +63,17 @@ import type { CoveredFieldPaths } from "./coverage-paths.js";
 import { extractMappingArrowRecords } from "./extract.js";
 import type { ArrowDeclarationKind, ExtractedArrow } from "./extract.js";
 import type { ResolvedNLRef } from "./nl-ref.js";
+import {
+  createAuthoredEntityRef,
+  createContainerQualifiedFieldRef,
+  createSchemaLocalPath,
+} from "./reference-stages.js";
+import type {
+  AuthoredEntityRef,
+  CanonicalEntityRef,
+  ContainerQualifiedFieldRef,
+  SchemaLocalPath,
+} from "./reference-stages.js";
 import type { SyntaxNode, Tree } from "./types.js";
 
 // ── Resolver input contract ─────────────────────────────────────────────────
@@ -133,15 +144,21 @@ export interface CoverageSchemaDefinition {
   /** Top-level fields, in declaration order; nested fields hang off `children`. */
   fields: CoverageField[];
   /**
-   * Canonical id to report for this schema, when it differs from the reference
-   * as written in the mapping. Defaults to the written reference.
+   * Unique workspace identity used while localizing qualified field paths.
+   * Global definitions retain the leading `::`; adapters obtain this value by
+   * canonicalizing the authored reference against their workspace index.
+   */
+  canonicalRef: CanonicalEntityRef;
+  /**
+   * Stable protocol id to report for this schema, when it differs from the
+   * reference as written in the mapping. Defaults to the written reference.
    *
-   * Resolving a reference is the consumer's job, and the canonical id is an
-   * output of that resolution: a namespaced workspace can name the same schema
-   * `orders` inside its own namespace and `crm::orders` from outside. Reporting
-   * both forms would split one schema into two entries when results are rolled
-   * up across mappings, so a consumer that resolves references should report the
-   * resolved key here.
+   * This deliberately remains a plain string because it crosses JSON, LSP and
+   * VizModel boundaries, whose historical spelling uses `customers` for a
+   * global schema rather than the internal canonical `::customers`. A
+   * namespaced workspace can name the same schema `orders` inside its own
+   * namespace and `crm::orders` from outside; adapters report the resolved
+   * storage key here so rollups do not split those spellings into two entries.
    */
   schemaId?: string;
 }
@@ -166,7 +183,7 @@ export interface CoverageSchemaDefinition {
  * CLI and viz adapters do, having taken it from their own indexes.
  */
 export type CoverageSchemaResolver = (
-  schemaId: string,
+  schemaId: AuthoredEntityRef,
   mappingNamespace: string | null,
 ) => CoverageSchemaDefinition | null;
 
@@ -351,8 +368,8 @@ export function computeMappingCoverage(
   const body = child(found.node, "mapping_body");
   if (!body) return { schemas: [] };
 
-  const sourceIds = getSchemaIdsFromBlock(body, "source_block");
-  const targetIds = getSchemaIdsFromBlock(body, "target_block");
+  const sourceIds = getSchemaIdsFromBlock(body, "source_block").map(createAuthoredEntityRef);
+  const targetIds = getSchemaIdsFromBlock(body, "target_block").map(createAuthoredEntityRef);
 
   // Arrow references as authored: absolute (extraction has already applied every
   // enclosing container's prefix and stripped element-relative dots) but still
@@ -373,16 +390,23 @@ export function computeMappingCoverage(
 
   const arrows = extractMappingArrowRecords(found.node);
   const declaredSrc = arrows.flatMap((a) =>
-    a.sources.map((path) => ({ path, wholeStructure: declaresCorrespondence(a) })),
+    a.sources.map((path) => ({
+      path: createContainerQualifiedFieldRef(path),
+      wholeStructure: declaresCorrespondence(a),
+    })),
   );
-  const declaredTgt = arrows
-    .filter((a) => a.target !== null)
-    .map((a) => ({
-      path: a.target as string,
-      // Target-side only: a record is populated wholesale by an arrow that
-      // carries a record, not by one carrying a single scalar (ADR-038).
-      wholeStructure: declaresCorrespondence(a) && namesAContainer(a.sources, sources),
-    }));
+  const declaredTgt = arrows.flatMap((a) =>
+    a.target === null
+      ? []
+      : [
+          {
+            path: createContainerQualifiedFieldRef(a.target),
+            // Target-side only: a record is populated wholesale by an arrow that
+            // carries a record, not by one carrying a single scalar (ADR-038).
+            wholeStructure: declaresCorrespondence(a) && namesAContainer(a.sources, sources),
+          },
+        ],
+  );
 
   const nl = nlRefFieldPaths(nlRefs, found.mappingKey);
 
@@ -404,13 +428,13 @@ export function computeMappingCoverage(
 /**
  * One schema a mapping names, paired with the definition the resolver returned.
  *
- * `writtenRef` is the form the mapping used; `def.schemaId` may canonicalise it,
- * and a reference can legitimately use either — so both are kept and both are
- * matched when a path's schema prefix is stripped.
+ * `writtenRef` is the form the mapping used. `def.canonicalRef` is the resolved
+ * workspace identity; both are kept because a field path may use either
+ * spelling when its schema prefix is stripped.
  */
 interface ParticipatingSchema {
   /** Schema id exactly as written in the mapping's `source{}`/`target{}` block. */
-  writtenRef: string;
+  writtenRef: AuthoredEntityRef;
   /** The resolved field tree and its uri. */
   def: CoverageSchemaDefinition;
 }
@@ -425,7 +449,7 @@ interface ParticipatingSchema {
  * whole-structure expansion — see {@link namesAContainer}.
  */
 function resolveParticipants(
-  schemaIds: readonly string[],
+  schemaIds: readonly AuthoredEntityRef[],
   resolveSchema: CoverageSchemaResolver,
   mappingNamespace: string | null,
 ): ParticipatingSchema[] {
@@ -443,9 +467,9 @@ function resolveParticipants(
  * One path a mapping's arrows reference, tagged with how much of it the
  * declaration asserts.
  */
-interface ArrowFieldReference {
-  /** Path as authored — absolute, but still carrying any schema prefix. */
-  path: string;
+interface ArrowFieldReference<Path extends string> {
+  /** Container-qualified before localization; schema-local afterwards. */
+  path: Path;
   /**
    * True when the declaration asserts the *whole* structure at this path maps
    * (ADR-037). Two things must hold, and both are properties of the
@@ -540,7 +564,11 @@ function namesAContainer(
   const participatingRefs = schemas.map((s) => s.writtenRef);
   return paths.some((path) =>
     schemas.some((schema) => {
-      const local = schemaLocalPath(path, schema, participatingRefs);
+      const local = schemaLocalPath(
+        createContainerQualifiedFieldRef(path),
+        schema,
+        participatingRefs,
+      );
       return local !== null && declaredFieldKind(local, schema.def.fields) === "container";
     }),
   );
@@ -563,10 +591,10 @@ function namesAContainer(
  *               subtree contains.
  */
 function expandWholeStructureRefs(
-  refs: readonly ArrowFieldReference[],
+  refs: readonly ArrowFieldReference<SchemaLocalPath>[],
   fields: CoverageField[],
-): string[] {
-  const paths: string[] = [];
+): SchemaLocalPath[] {
+  const paths: SchemaLocalPath[] = [];
   for (const ref of refs) {
     paths.push(ref.path);
     if (!ref.wholeStructure) continue;
@@ -583,15 +611,15 @@ function expandWholeStructureRefs(
  * counts; the intermediate records are returned so a conferred record reads as
  * `covered` in its own right rather than only through its descendants.
  */
-function descendantPathsOf(path: string, fields: CoverageField[]): string[] {
+function descendantPathsOf(path: SchemaLocalPath, fields: CoverageField[]): SchemaLocalPath[] {
   const found = findDeclaredField(path, fields);
   if (!found) return [];
 
-  const paths: string[] = [];
+  const paths: SchemaLocalPath[] = [];
   const collect = (children: CoverageField[], prefix: string): void => {
     for (const child of children) {
       const childPath = `${prefix}.${child.name}`;
-      paths.push(childPath);
+      paths.push(createSchemaLocalPath(childPath));
       if (child.children) collect(child.children, childPath);
     }
   };
@@ -607,7 +635,7 @@ function descendantPathsOf(path: string, fields: CoverageField[]): string[] {
  * and {@link declaredFieldKind} both go through it, so "what does this path
  * name?" has one answer rather than one per caller.
  */
-function findDeclaredField(path: string, fields: CoverageField[]): CoverageField | null {
+function findDeclaredField(path: SchemaLocalPath, fields: CoverageField[]): CoverageField | null {
   let level: CoverageField[] | undefined = fields;
   let found: CoverageField | undefined;
   for (const segment of path.split(".")) {
@@ -640,7 +668,7 @@ function findDeclaredField(path: string, fields: CoverageField[]): CoverageField
  * the questions do.
  */
 export function declaredFieldKind(
-  path: string,
+  path: SchemaLocalPath,
   fields: CoverageField[],
 ): "container" | "leaf" | null {
   const found = findDeclaredField(path, fields);
@@ -654,23 +682,22 @@ export function declaredFieldKind(
  *
  * Wraps {@link schemaLocalFieldPath} with the three inputs every caller has to
  * assemble the same way: the schema's two legitimate spellings (as written in
- * the mapping, and the id the resolver canonicalised it to), the other schemas
+ * the mapping, and its canonical workspace identity), the other schemas
  * on that side, and whether the schema shadows a prefix with a top-level field
  * of the same name. Sharing it keeps `coverageForSchema` and
  * {@link namesAContainer} resolving prefixes identically — if they diverged, a
  * qualified arrow could confer a subtree in one and not the other.
  */
 function schemaLocalPath(
-  ref: string,
+  ref: ContainerQualifiedFieldRef,
   schema: ParticipatingSchema,
-  participatingRefs: readonly string[],
-): string | null {
-  const canonicalRef = schema.def.schemaId ?? schema.writtenRef;
-  const ownRefs =
-    canonicalRef === schema.writtenRef ? [schema.writtenRef] : [schema.writtenRef, canonicalRef];
+  participatingRefs: readonly AuthoredEntityRef[],
+): SchemaLocalPath | null {
   const otherRefs = participatingRefs.filter((r) => r !== schema.writtenRef);
   const topLevelNames = new Set(schema.def.fields.map((f) => f.name));
-  return schemaLocalFieldPath(ref, ownRefs, otherRefs, (name) => topLevelNames.has(name));
+  return schemaLocalFieldPath(ref, schema.writtenRef, schema.def.canonicalRef, otherRefs, (name) =>
+    topLevelNames.has(name),
+  );
 }
 
 // ── Resolved NL @ref paths (ADR-036) ────────────────────────────────────────
@@ -689,24 +716,25 @@ interface NLRefPaths {
    * Every resolved field ref in the mapping. Source schemas may claim any of
    * them: a ref in a join condition demonstrates the mapping reads that field.
    */
-  anyContext: string[];
+  anyContext: ContainerQualifiedFieldRef[];
   /**
    * Refs from arrow bodies and note blocks only — `context: "source_block"`
    * excluded. A join condition or filter names no *target* field, so it can
    * never contribute target coverage (ADR-036).
    */
-  arrowBodyOnly: string[];
+  arrowBodyOnly: ContainerQualifiedFieldRef[];
 }
 
 function nlRefFieldPaths(nlRefs: readonly ResolvedNLRef[], mappingKey: string): NLRefPaths {
-  const anyContext: string[] = [];
-  const arrowBodyOnly: string[] = [];
+  const anyContext: ContainerQualifiedFieldRef[] = [];
+  const arrowBodyOnly: ContainerQualifiedFieldRef[] = [];
 
   for (const ref of nlRefs) {
     if (ref.mapping !== mappingKey) continue;
     if (!ref.resolved || ref.resolvedTo?.kind !== "field") continue;
-    anyContext.push(ref.resolvedTo.name);
-    if (ref.context !== "source_block") arrowBodyOnly.push(ref.resolvedTo.name);
+    const path = createContainerQualifiedFieldRef(ref.resolvedTo.name);
+    anyContext.push(path);
+    if (ref.context !== "source_block") arrowBodyOnly.push(path);
   }
 
   return { anyContext, arrowBodyOnly };
@@ -722,17 +750,18 @@ function nlRefFieldPaths(nlRefs: readonly ResolvedNLRef[], mappingKey: string): 
 function coverageForSchema(
   schema: ParticipatingSchema,
   role: "source" | "target",
-  participatingRefs: readonly string[],
-  declaredRefs: readonly ArrowFieldReference[],
-  nlRefPaths: readonly string[],
+  participatingRefs: readonly AuthoredEntityRef[],
+  declaredRefs: readonly ArrowFieldReference<ContainerQualifiedFieldRef>[],
+  nlRefPaths: readonly ContainerQualifiedFieldRef[],
 ): SchemaCoverageResult {
   const { def } = schema;
   // A reference may name this schema by the form written in the mapping or by the
   // id the resolver canonicalised it to, so both must resolve.
-  const canonicalRef = def.schemaId ?? schema.writtenRef;
-  const toLocal = (ref: string): string | null => schemaLocalPath(ref, schema, participatingRefs);
+  const reportedSchemaId = def.schemaId ?? schema.writtenRef;
+  const toLocal = (ref: ContainerQualifiedFieldRef): SchemaLocalPath | null =>
+    schemaLocalPath(ref, schema, participatingRefs);
 
-  const declaredLocal: ArrowFieldReference[] = [];
+  const declaredLocal: ArrowFieldReference<SchemaLocalPath>[] = [];
   for (const ref of declaredRefs) {
     const local = toLocal(ref.path);
     if (local !== null) declaredLocal.push({ path: local, wholeStructure: ref.wholeStructure });
@@ -745,14 +774,14 @@ function coverageForSchema(
   //
   // NL refs never expand into a subtree: prose naming a record is a reference to
   // it, not a claim that every leaf beneath it maps (ADR-036).
-  const nlLocal: string[] = [];
+  const nlLocal: SchemaLocalPath[] = [];
   for (const ref of nlRefPaths) {
     const local = toLocal(ref);
-    if (local !== null && local !== ref) nlLocal.push(local);
+    if (local !== null && String(local) !== String(ref)) nlLocal.push(local);
   }
 
   return {
-    schemaId: canonicalRef,
+    schemaId: reportedSchemaId,
     role,
     fields: buildFieldCoverage(def.fields, def.uri, "", {
       declared: buildCoveredFieldPaths(expandWholeStructureRefs(declaredLocal, def.fields)),
@@ -854,7 +883,7 @@ function coverageForField(
   prefix: string,
   covered: TieredCoveredPaths,
 ): FieldCoverageSubtree {
-  const path = prefix ? `${prefix}.${f.name}` : f.name;
+  const path = createSchemaLocalPath(prefix ? `${prefix}.${f.name}` : f.name);
   const children = f.children ?? [];
 
   // An empty `record {}` has no descendants to roll up, so its own path decides
@@ -880,7 +909,7 @@ function coverageForField(
 
 /** Coverage of a leaf: binary, decided by its own path in the two tiers. */
 function leafState(
-  path: string,
+  path: SchemaLocalPath,
   covered: TieredCoveredPaths,
 ): { state: FieldCoverageState; tier?: CoverageTier } {
   if (isCoveredPath(path, covered.declared)) return { state: "covered", tier: "declared" };

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -13,6 +13,22 @@ export type {
   SatsumaCstType,
 } from "./generated/cst-types.js";
 export { SATSUMA_FILE_EXTENSIONS, SATSUMA_FILE_GLOB, isSatsumaFilePath } from "./source-files.js";
+export {
+  canonicalizeEntityRef,
+  createAuthoredEntityRef,
+  createAuthoredFieldRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
+  createSchemaLocalPath,
+  qualifyContainerFieldRef,
+} from "./reference-stages.js";
+export type {
+  AuthoredEntityRef,
+  AuthoredFieldRef,
+  CanonicalEntityRef,
+  ContainerQualifiedFieldRef,
+  SchemaLocalPath,
+} from "./reference-stages.js";
 export { findFieldByPath, collectFieldNames } from "./field-utils.js";
 export type { FieldTreeNode } from "./field-utils.js";
 export { collectSemanticDiagnostics, validateSemanticWorkspace } from "./validate.js";

--- a/tooling/satsuma-core/src/reference-stages.ts
+++ b/tooling/satsuma-core/src/reference-stages.ts
@@ -1,0 +1,131 @@
+/**
+ * reference-stages.ts — Nominal stages for field paths and entity references.
+ *
+ * Owns the runtime-erased vocabulary that separates authored text from values
+ * which have passed container qualification, schema localization, or workspace
+ * canonicalization. It does not resolve schemas or decide coverage; callers
+ * supply workspace identity and the coverage modules consume the resulting
+ * stage types.
+ */
+
+// This symbol is deliberately module-private. Consumers can obtain branded
+// values only from the validating constructors and semantic transitions below.
+declare const referenceStage: unique symbol;
+
+/** A string whose semantic normalization stage is tracked by TypeScript. */
+type ReferenceAt<Stage extends string> = string & { readonly [referenceStage]: Stage };
+
+/** Field expression exactly as authored on an arrow. */
+export type AuthoredFieldRef = ReferenceAt<"authored-field-ref">;
+
+/** Field expression made absolute against all enclosing mapping containers. */
+export type ContainerQualifiedFieldRef = ReferenceAt<"container-qualified-field-ref">;
+
+/** Dotted path relative to one declared schema root. */
+export type SchemaLocalPath = ReferenceAt<"schema-local-path">;
+
+/** Entity reference exactly as authored in a source, target, or spread. */
+export type AuthoredEntityRef = ReferenceAt<"authored-entity-ref">;
+
+/** Unique workspace entity id, including `::` for the global namespace. */
+export type CanonicalEntityRef = ReferenceAt<"canonical-entity-ref">;
+
+/**
+ * Validate and brand one external string at a semantic boundary.
+ *
+ * Extraction removes backticks before values reach core models. Consequently,
+ * punctuation, dots, namespace separators, and whitespace may all be literal
+ * identifier content and cannot be rejected here. The one representation that
+ * no valid Satsuma name or path can produce is the empty string.
+ *
+ * This is the module's sole unsafe assertion. Brands have no runtime
+ * representation, so after validation TypeScript must be told that the plain
+ * string carries the stage tracked by the return type.
+ */
+function validatedReference<Reference extends string>(value: string, stageName: string): Reference {
+  if (value.length === 0) {
+    throw new TypeError(`${stageName} must not be empty`);
+  }
+  return value as Reference;
+}
+
+/** Validate a field expression entering the typed domain from authored data. */
+export function createAuthoredFieldRef(value: string): AuthoredFieldRef {
+  return validatedReference<AuthoredFieldRef>(value, "Authored field reference");
+}
+
+/** Validate an already container-qualified field expression at a boundary. */
+export function createContainerQualifiedFieldRef(value: string): ContainerQualifiedFieldRef {
+  return validatedReference<ContainerQualifiedFieldRef>(
+    value,
+    "Container-qualified field reference",
+  );
+}
+
+/** Validate a dotted path known to be relative to one schema. */
+export function createSchemaLocalPath(value: string): SchemaLocalPath {
+  return validatedReference<SchemaLocalPath>(value, "Schema-local path");
+}
+
+/** Validate an entity name entering the typed domain from authored data. */
+export function createAuthoredEntityRef(value: string): AuthoredEntityRef {
+  return validatedReference<AuthoredEntityRef>(value, "Authored entity reference");
+}
+
+/**
+ * Validate a unique workspace entity id.
+ *
+ * Canonical ids always include the namespace separator. A global entity uses
+ * an empty namespace (`::customers`); a namespaced one uses its declared
+ * namespace (`crm::customers`).
+ */
+export function createCanonicalEntityRef(value: string): CanonicalEntityRef {
+  const separator = value.indexOf("::");
+  if (separator < 0 || value.slice(separator + 2).length === 0) {
+    throw new TypeError("Canonical entity reference must have [namespace]::name form");
+  }
+  return validatedReference<CanonicalEntityRef>(value, "Canonical entity reference");
+}
+
+/**
+ * Advance an authored field expression through container qualification.
+ *
+ * Child paths are relative to the enclosing `each`, `flatten`, or nested-arrow
+ * path. Mapping-body paths have no container and retain their string value;
+ * their distinct return type records that qualification has still occurred.
+ */
+export function qualifyContainerFieldRef(
+  ref: AuthoredFieldRef,
+  container: ContainerQualifiedFieldRef | null,
+): ContainerQualifiedFieldRef {
+  const qualified = container ? `${container}.${ref.replace(/^\./, "")}` : ref;
+  return createContainerQualifiedFieldRef(qualified);
+}
+
+/**
+ * Resolve an authored entity name to the canonical id present in a workspace.
+ *
+ * Resolution order mirrors Satsuma's namespace binding rule: an explicitly
+ * qualified name, then the current namespace, then the global namespace. Maps
+ * store global entities under their bare key, but the returned identity keeps
+ * the canonical leading `::` so it cannot collide with authored bare text.
+ */
+export function canonicalizeEntityRef(
+  ref: AuthoredEntityRef,
+  currentNamespace: string | null,
+  entities: ReadonlyMap<string, unknown>,
+): CanonicalEntityRef | null {
+  if (ref.includes("::")) {
+    const lookupKey = ref.startsWith("::") ? ref.slice(2) : ref;
+    if (!entities.has(lookupKey)) return null;
+    return createCanonicalEntityRef(ref.startsWith("::") ? ref : `${ref}`);
+  }
+
+  if (currentNamespace) {
+    const namespacedKey = `${currentNamespace}::${ref}`;
+    if (entities.has(namespacedKey)) return createCanonicalEntityRef(namespacedKey);
+  }
+
+  if (entities.has(ref)) return createCanonicalEntityRef(`::${ref}`);
+  return null;
+}

--- a/tooling/satsuma-core/test/coverage-paths.test.js
+++ b/tooling/satsuma-core/test/coverage-paths.test.js
@@ -9,7 +9,28 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildCoveredFieldPaths, isCoveredPath, schemaLocalFieldPath } from "@satsuma/core";
+import {
+  buildCoveredFieldPaths,
+  createAuthoredEntityRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
+  isCoveredPath,
+  schemaLocalFieldPath,
+} from "@satsuma/core";
+
+/** Exercise schema localization through every validated stage boundary. */
+function localize(fieldRef, authoredSchemaRef, otherSchemaRefs = [], declaresTopLevel) {
+  const canonicalRef = authoredSchemaRef.includes("::")
+    ? authoredSchemaRef
+    : `::${authoredSchemaRef}`;
+  return schemaLocalFieldPath(
+    createContainerQualifiedFieldRef(fieldRef),
+    createAuthoredEntityRef(authoredSchemaRef),
+    createCanonicalEntityRef(canonicalRef),
+    otherSchemaRefs.map(createAuthoredEntityRef),
+    declaresTopLevel,
+  );
+}
 
 // ── Path identity (sl-joeq, ADR-035) ────────────────────────────────────────
 //
@@ -157,32 +178,32 @@ describe("schemaLocalFieldPath()", () => {
   // this same reduction, so it is pinned once here.
 
   it("strips a prefix naming the schema itself", () => {
-    assert.equal(schemaLocalFieldPath("crm.email", ["crm"], []), "email");
+    assert.equal(localize("crm.email", "crm"), "email");
   });
 
   it("leaves an already-local path untouched", () => {
     // Single-source mappings write bare paths, and a nested path's first segment
     // is a field name, not a schema name.
-    assert.equal(schemaLocalFieldPath("customer.email", ["orders"], []), "customer.email");
+    assert.equal(localize("customer.email", "orders"), "customer.email");
   });
 
   it("returns null for a path naming another schema in the same block", () => {
     // Multi-source mappings report each schema separately; crediting one
     // schema's arrow to a sibling is the over-count sl-joeq is about.
-    assert.equal(schemaLocalFieldPath("ledger.email", ["crm"], ["ledger"]), null);
+    assert.equal(localize("ledger.email", "crm", ["ledger"]), null);
   });
 
   it("accepts a namespaced schema by its bare name as well as its qualified id", () => {
     // Arrows keep authored text: inside `namespace crm` an arrow writes
     // `customers.id` while the index reports `crm::customers` (sl-iqud).
-    assert.equal(schemaLocalFieldPath("customers.id", ["crm::customers"], []), "id");
-    assert.equal(schemaLocalFieldPath("crm::customers.id", ["crm::customers"], []), "id");
+    assert.equal(localize("customers.id", "crm::customers"), "id");
+    assert.equal(localize("crm::customers.id", "crm::customers"), "id");
   });
 
   it("treats a sibling schema's bare-name prefix as belonging to that sibling", () => {
     // The bare form has to be recognised on the rival side too, or a namespaced
     // multi-source mapping credits every arrow to every schema.
-    assert.equal(schemaLocalFieldPath("orders.total", ["crm::customers"], ["crm::orders"]), null);
+    assert.equal(localize("orders.total", "crm::customers", ["crm::orders"]), null);
   });
 
   it("returns null for a bare reference that is just the schema's name", () => {
@@ -190,15 +211,15 @@ describe("schemaLocalFieldPath()", () => {
     // (`flatten contacts -> tgt`), and extraction reports that target verbatim.
     // Without this rule `tgt` would enter the covered set as though a field of
     // that name had been written (sl-vu22).
-    assert.equal(schemaLocalFieldPath("tgt", ["tgt"], []), null);
-    assert.equal(schemaLocalFieldPath("customers", ["crm::customers"], []), null);
+    assert.equal(localize("tgt", "tgt"), null);
+    assert.equal(localize("customers", "crm::customers"), null);
   });
 
   it("keeps a bare reference that names a declared field, not the schema", () => {
     // A single-source mapping's `id -> id` is a field reference even when the
     // schema is called `id`; the declaration settles it.
     assert.equal(
-      schemaLocalFieldPath("id", ["id"], [], (n) => n === "id"),
+      localize("id", "id", [], (n) => n === "id"),
       "id",
     );
   });
@@ -207,11 +228,8 @@ describe("schemaLocalFieldPath()", () => {
     // A schema and one of its own top-level fields can collide. The declared
     // field is concrete evidence, so the path is read as-is rather than stripped.
     const declaresTopLevel = (name) => name === "orders";
-    assert.equal(
-      schemaLocalFieldPath("orders.amount", ["orders"], [], declaresTopLevel),
-      "orders.amount",
-    );
+    assert.equal(localize("orders.amount", "orders", [], declaresTopLevel), "orders.amount");
     // Without the declaration the same input is a schema-qualified reference.
-    assert.equal(schemaLocalFieldPath("orders.amount", ["orders"], []), "amount");
+    assert.equal(localize("orders.amount", "orders"), "amount");
   });
 });

--- a/tooling/satsuma-core/test/coverage.test.js
+++ b/tooling/satsuma-core/test/coverage.test.js
@@ -28,6 +28,7 @@ import {
   resolveAllNLRefs,
   summarizeFieldCoverage,
   countContainerStates,
+  createCanonicalEntityRef,
   declaresRecordBody,
 } from "@satsuma/core";
 
@@ -79,7 +80,15 @@ function coverage(source, mappingName) {
     mappingName,
     (schemaId) => {
       const schema = byId.get(schemaId);
-      return schema ? { uri: TEST_URI, fields: toCoverageFields(schema.fields) } : null;
+      return schema
+        ? {
+            canonicalRef: createCanonicalEntityRef(
+              schemaId.includes("::") ? schemaId : `::${schemaId}`,
+            ),
+            uri: TEST_URI,
+            fields: toCoverageFields(schema.fields),
+          }
+        : null;
     },
     resolveRefsIn(tree, byId),
   );
@@ -1057,7 +1066,13 @@ mapping load {
   id -> id
 }`);
     const result = computeMappingCoverage(tree, "load", (schemaId) =>
-      schemaId === "tgt" ? { uri: TEST_URI, fields: [{ name: "id" }, { name: "memo" }] } : null,
+      schemaId === "tgt"
+        ? {
+            canonicalRef: createCanonicalEntityRef("::tgt"),
+            uri: TEST_URI,
+            fields: [{ name: "id" }, { name: "memo" }],
+          }
+        : null,
     );
     for (const entry of forRole(result, "target").fields) {
       assert.ok(!("line" in entry), `expected no line key on ${entry.path}, got ${entry.line}`);

--- a/tooling/satsuma-core/test/generated-coverage-properties.test.js
+++ b/tooling/satsuma-core/test/generated-coverage-properties.test.js
@@ -14,6 +14,9 @@ import { fileURLToPath } from "node:url";
 import fc from "fast-check";
 import {
   buildCoveredFieldPaths,
+  createAuthoredEntityRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
   initParser,
   leafFieldEntries,
   schemaLocalFieldPath,
@@ -64,6 +67,16 @@ function coveredLeaves(schema) {
     leafFieldEntries(schema.fields)
       .filter((field) => field.mapped)
       .map((f) => f.path),
+  );
+}
+
+/** Run a generated reference through the explicit R5 localization stages. */
+function localizeGenerated(fieldRef, ownSchema, otherSchema) {
+  return schemaLocalFieldPath(
+    createContainerQualifiedFieldRef(fieldRef),
+    createAuthoredEntityRef(ownSchema),
+    createCanonicalEntityRef(`::${ownSchema}`),
+    [createAuthoredEntityRef(otherSchema)],
   );
 }
 
@@ -197,7 +210,7 @@ describe("generated coverage invariants", () => {
         ({ ownSchema, otherSchema, localPath, scenario }) => {
           const { source } = parseGeneratedScenario(scenario);
           assert.equal(
-            schemaLocalFieldPath(localPath, [ownSchema], [otherSchema]),
+            localizeGenerated(localPath, ownSchema, otherSchema),
             localPath,
             `generated schema-local ref changed:\n${source}`,
           );
@@ -216,7 +229,7 @@ describe("generated coverage invariants", () => {
         ({ ownSchema, otherSchema, localPath, scenario }) => {
           const { source } = parseGeneratedScenario(scenario);
           assert.equal(
-            schemaLocalFieldPath(`${otherSchema}.${localPath}`, [ownSchema], [otherSchema]),
+            localizeGenerated(`${otherSchema}.${localPath}`, ownSchema, otherSchema),
             null,
             `generated other-schema ref was claimed locally:\n${source}`,
           );
@@ -235,7 +248,7 @@ describe("generated coverage invariants", () => {
         ({ ownSchema, otherSchema, localPath, scenario }) => {
           const { source } = parseGeneratedScenario(scenario);
           assert.equal(
-            schemaLocalFieldPath(`${ownSchema}.${localPath}`, [ownSchema], [otherSchema]),
+            localizeGenerated(`${ownSchema}.${localPath}`, ownSchema, otherSchema),
             localPath,
             `generated own-schema prefix did not normalize once:\n${source}`,
           );

--- a/tooling/satsuma-core/test/reference-stages.test.js
+++ b/tooling/satsuma-core/test/reference-stages.test.js
@@ -1,0 +1,101 @@
+/**
+ * reference-stages.test.js — Runtime contracts for opaque reference stages.
+ *
+ * Type tests prove that stages cannot be mixed at compile time. These tests own
+ * the complementary runtime rules: boundary validation and the exact string
+ * values produced by the two semantic transitions.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  canonicalizeEntityRef,
+  createAuthoredEntityRef,
+  createAuthoredFieldRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
+  createSchemaLocalPath,
+  qualifyContainerFieldRef,
+} from "@satsuma/core";
+
+describe("reference-stage constructors", () => {
+  it("accepts every non-empty semantic string representation", () => {
+    // Backtick quoting is removed during extraction, so punctuation and spaces
+    // can be literal identifier content and must survive boundary validation.
+    assert.equal(createAuthoredFieldRef("`not retained`.field"), "`not retained`.field");
+    assert.equal(
+      createContainerQualifiedFieldRef("orders.line items.sku"),
+      "orders.line items.sku",
+    );
+    assert.equal(createSchemaLocalPath("city"), "city");
+    assert.equal(createAuthoredEntityRef("crm::customers"), "crm::customers");
+    assert.equal(createCanonicalEntityRef("::customers"), "::customers");
+  });
+
+  it("rejects empty values at every external construction boundary", () => {
+    // Empty strings come only from recovery/incomplete input and cannot name a
+    // field or entity at any semantic stage.
+    for (const construct of [
+      createAuthoredFieldRef,
+      createContainerQualifiedFieldRef,
+      createSchemaLocalPath,
+      createAuthoredEntityRef,
+      createCanonicalEntityRef,
+    ]) {
+      assert.throws(() => construct(""), TypeError);
+    }
+  });
+
+  it("rejects an entity id that is not in canonical namespace form", () => {
+    // Canonical ids always contain the namespace separator; global ids make
+    // their empty namespace explicit as the leading `::`.
+    assert.throws(() => createCanonicalEntityRef("customers"), TypeError);
+    assert.throws(() => createCanonicalEntityRef("crm::"), TypeError);
+  });
+});
+
+describe("reference-stage transitions", () => {
+  it("qualifies a relative child path against its already-qualified container", () => {
+    // Nested each/flatten/arrow bodies advance authored paths to the absolute
+    // container-qualified stage and remove the relative marker exactly once.
+    const authored = createAuthoredFieldRef(".sku");
+    const container = createContainerQualifiedFieldRef("orders.lines");
+    assert.equal(qualifyContainerFieldRef(authored, container), "orders.lines.sku");
+  });
+
+  it("advances a top-level authored path without changing its string value", () => {
+    // A stage transition may be representationally invisible; the nominal type
+    // still records that container qualification has been considered.
+    assert.equal(
+      qualifyContainerFieldRef(createAuthoredFieldRef("customer.id"), null),
+      "customer.id",
+    );
+  });
+
+  it("canonicalizes namespaced, local-namespace, and global entity refs", () => {
+    // The resolver checks the same lookup order as workspace indexing while
+    // ensuring the returned global id retains its unambiguous `::` prefix.
+    const entities = new Map([
+      ["crm::orders", {}],
+      ["customers", {}],
+    ]);
+    assert.equal(
+      canonicalizeEntityRef(createAuthoredEntityRef("crm::orders"), null, entities),
+      "crm::orders",
+    );
+    assert.equal(
+      canonicalizeEntityRef(createAuthoredEntityRef("orders"), "crm", entities),
+      "crm::orders",
+    );
+    assert.equal(
+      canonicalizeEntityRef(createAuthoredEntityRef("customers"), "crm", entities),
+      "::customers",
+    );
+  });
+
+  it("returns null when no workspace entity matches the authored ref", () => {
+    // Branding must not turn a syntactically valid but unresolved name into a
+    // canonical identity that does not exist.
+    assert.equal(canonicalizeEntityRef(createAuthoredEntityRef("missing"), "crm", new Map()), null);
+  });
+});

--- a/tooling/satsuma-core/test/support/generated-scenarios.js
+++ b/tooling/satsuma-core/test/support/generated-scenarios.js
@@ -12,6 +12,7 @@ import fc from "fast-check";
 import {
   collectParseErrors,
   computeMappingCoverage,
+  createCanonicalEntityRef,
   declaresRecordBody,
   expandDeclaredFields,
   extractFragments,
@@ -224,6 +225,7 @@ export function coverageForScenario(scenario) {
   const lookupFragment = (key) => fragments.get(key) ?? null;
   const schemas = new Map(
     extractSchemas(tree.rootNode).map((schema) => {
+      const key = entityKey(schema);
       const fields = expandDeclaredFields(
         schema,
         schema.namespace,
@@ -231,8 +233,12 @@ export function coverageForScenario(scenario) {
         lookupFragment,
       );
       return [
-        entityKey(schema),
-        { uri: "file:///generated.stm", fields: toCoverageFields(fields) },
+        key,
+        {
+          canonicalRef: createCanonicalEntityRef(key.includes("::") ? key : `::${key}`),
+          uri: "file:///generated.stm",
+          fields: toCoverageFields(fields),
+        },
       ];
     }),
   );

--- a/tooling/satsuma-core/type-tests/reference-stages.ts
+++ b/tooling/satsuma-core/type-tests/reference-stages.ts
@@ -1,0 +1,52 @@
+/**
+ * reference-stages.ts — Compile-time regression checks for opaque ref stages.
+ *
+ * Runtime strings remain serializable, but values can advance through semantic
+ * transitions only in the order described by Feature 39 R5.
+ */
+
+import {
+  canonicalizeEntityRef,
+  createAuthoredEntityRef,
+  createAuthoredFieldRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
+  createSchemaLocalPath,
+  qualifyContainerFieldRef,
+} from "../src/index.js";
+import type {
+  AuthoredEntityRef,
+  AuthoredFieldRef,
+  CanonicalEntityRef,
+  ContainerQualifiedFieldRef,
+  SchemaLocalPath,
+} from "../src/index.js";
+
+const authoredField: AuthoredFieldRef = createAuthoredFieldRef(".city");
+const container: ContainerQualifiedFieldRef = createContainerQualifiedFieldRef("address");
+const qualified: ContainerQualifiedFieldRef = qualifyContainerFieldRef(authoredField, container);
+const local: SchemaLocalPath = createSchemaLocalPath("address.city");
+const authoredEntity: AuthoredEntityRef = createAuthoredEntityRef("customers");
+const canonicalEntity: CanonicalEntityRef = createCanonicalEntityRef("::customers");
+
+canonicalizeEntityRef(authoredEntity, null, new Map([["customers", {}]]));
+
+// Raw boundary strings have not been validated and cannot acquire a stage.
+// @ts-expect-error Raw strings are not authored field references.
+qualifyContainerFieldRef(".city", container);
+
+// A qualified value cannot be sent backwards through the authored transition.
+// @ts-expect-error Container-qualified refs are not authored refs.
+qualifyContainerFieldRef(qualified, container);
+
+// Field-stage values and entity-stage values are intentionally unrelated.
+// @ts-expect-error A schema-local field path is not an authored entity ref.
+canonicalizeEntityRef(local, null, new Map());
+
+// Authored and canonical entity identity are separate stages.
+// @ts-expect-error A canonical entity id is not an authored entity ref.
+canonicalizeEntityRef(canonicalEntity, null, new Map());
+
+void qualified;
+void local;
+void canonicalEntity;

--- a/tooling/satsuma-core/type-tests/reference-stages.ts
+++ b/tooling/satsuma-core/type-tests/reference-stages.ts
@@ -6,13 +6,17 @@
  */
 
 import {
+  buildCoveredFieldPaths,
   canonicalizeEntityRef,
   createAuthoredEntityRef,
   createAuthoredFieldRef,
   createCanonicalEntityRef,
   createContainerQualifiedFieldRef,
   createSchemaLocalPath,
+  declaredFieldKind,
+  isCoveredPath,
   qualifyContainerFieldRef,
+  schemaLocalFieldPath,
 } from "../src/index.js";
 import type {
   AuthoredEntityRef,
@@ -31,6 +35,18 @@ const canonicalEntity: CanonicalEntityRef = createCanonicalEntityRef("::customer
 
 canonicalizeEntityRef(authoredEntity, null, new Map([["customers", {}]]));
 
+const schemaLocal = schemaLocalFieldPath(
+  createContainerQualifiedFieldRef("customers.address.city"),
+  authoredEntity,
+  canonicalEntity,
+  [],
+);
+if (schemaLocal !== null) {
+  const covered = buildCoveredFieldPaths([schemaLocal]);
+  isCoveredPath(schemaLocal, covered);
+  declaredFieldKind(schemaLocal, []);
+}
+
 // Raw boundary strings have not been validated and cannot acquire a stage.
 // @ts-expect-error Raw strings are not authored field references.
 qualifyContainerFieldRef(".city", container);
@@ -46,6 +62,27 @@ canonicalizeEntityRef(local, null, new Map());
 // Authored and canonical entity identity are separate stages.
 // @ts-expect-error A canonical entity id is not an authored entity ref.
 canonicalizeEntityRef(canonicalEntity, null, new Map());
+
+// Coverage accepts only paths that have completed schema localization.
+// @ts-expect-error Raw strings are not schema-local paths.
+buildCoveredFieldPaths(["address.city"]);
+
+// @ts-expect-error Authored field refs have not completed schema localization.
+buildCoveredFieldPaths([authoredField]);
+
+// @ts-expect-error Coverage probes require a schema-local path.
+isCoveredPath("address.city", buildCoveredFieldPaths([local]));
+
+// @ts-expect-error Declared-field probes require a schema-local path.
+declaredFieldKind("address.city", []);
+
+// Localization requires a container-qualified field reference.
+// @ts-expect-error Authored field refs have not completed container qualification.
+schemaLocalFieldPath(authoredField, authoredEntity, canonicalEntity, []);
+
+// Authored and canonical schema identity occupy different localization inputs.
+// @ts-expect-error The canonical identity cannot be replaced with an authored ref.
+schemaLocalFieldPath(qualified, authoredEntity, authoredEntity, []);
 
 void qualified;
 void local;

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -28,6 +28,7 @@ import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-ind
 import { resolveDefinition } from "./workspace-index";
 import { makeDefinitionLookup } from "@satsuma/viz-backend/coverage";
 import {
+  canonicalizeEntityRef,
   computeMappingCoverage as computeCoverage,
   declaresRecordBody,
   expandDeclaredFields,
@@ -35,6 +36,7 @@ import {
   resolveAllNLRefs,
 } from "@satsuma/core";
 import type {
+  AuthoredEntityRef,
   CoverageField,
   CoverageSchemaDefinition,
   FieldDecl,
@@ -150,16 +152,18 @@ function resolveNLRefs(uri: string, tree: Tree, wsIndex: WorkspaceIndex): Resolv
  */
 function resolveSchema(
   wsIndex: WorkspaceIndex,
-  schemaId: string,
+  schemaId: AuthoredEntityRef,
   mappingNamespace: string | null,
 ): CoverageSchemaDefinition | null {
+  const canonicalRef = canonicalizeEntityRef(schemaId, mappingNamespace, wsIndex.definitions);
+  if (!canonicalRef) return null;
   const defs = resolveDefinition(wsIndex, schemaId, mappingNamespace);
   const def = defs.find((d) => d.kind === "schema");
   if (!def) return null;
-  const canonicalId =
-    def.namespace && !schemaId.includes("::") ? `${def.namespace}::${schemaId}` : schemaId;
+  const reportedSchemaId = canonicalRef.startsWith("::") ? canonicalRef.slice(2) : canonicalRef;
   return {
-    schemaId: canonicalId,
+    schemaId: reportedSchemaId,
+    canonicalRef,
     uri: def.uri,
     fields: expandedFields(wsIndex, def).map(toCoverageField),
   };

--- a/tooling/satsuma-viz-backend/src/coverage.ts
+++ b/tooling/satsuma-viz-backend/src/coverage.ts
@@ -31,13 +31,16 @@ import type { Tree } from "./parser-utils";
 import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { resolveDefinition } from "./workspace-index";
 import {
+  canonicalizeEntityRef,
   computeMappingCoverage,
+  createCanonicalEntityRef,
   declaresRecordBody,
   extractMappings,
   extractNLRefData,
   resolveAllNLRefs,
 } from "@satsuma/core";
 import type {
+  CanonicalEntityRef,
   CoverageField,
   CoverageSchemaDefinition,
   CoverageSchemaResolver,
@@ -77,7 +80,7 @@ export function attachMappingCoverage(
     // The resolver is per namespace, not per model: a reference is resolved
     // relative to where the mapping is declared, so `stg_gl_entries` written
     // inside `namespace staging` means `staging::stg_gl_entries`.
-    const resolveSchema = makeCardResolver(cards, ns.name, wsIndex);
+    const resolveSchema = makeCardResolver(cards, ns.name);
     for (const mapping of ns.mappings) {
       // Identified by its start row, which names the block outright. A label is
       // not an identity: two namespaces may declare `mapping load`, and matching
@@ -119,8 +122,8 @@ function indexCardsByQualifiedId(
  * A bare `stg_gl_entries` written inside `namespace staging` therefore has to be
  * resolved against `mappingNamespace` first, exactly as `resolveMappingRef`
  * resolves the model's own `sourceRefs`. Resolving it namespace-blind instead
- * left every namespaced mapping's own-namespace target reporting 0%. The index
- * is consulted for that one step; the *fields* still come from the card.
+ * left every namespaced mapping's own-namespace target reporting 0%. The card
+ * index is canonicalized for that step, and the fields come from the same card.
  *
  * The canonical `schemaId` reported back is the card's `qualifiedId`, so results
  * for one schema line up when a consumer rolls them up across mappings that name
@@ -129,20 +132,12 @@ function indexCardsByQualifiedId(
 function makeCardResolver(
   cards: Map<string, CoverageSchemaDefinition>,
   mappingNamespace: string | null,
-  wsIndex: WorkspaceIndex,
 ): CoverageSchemaResolver {
-  return (writtenRef: string): CoverageSchemaDefinition | null => {
-    // Already qualified, or declared at file scope: the written form is the key.
-    const direct = cards.get(writtenRef);
-    if (direct) return direct;
-    // Unqualified inside a namespace — the mapping's own namespace wins, which
-    // is the order resolveDefinition applies.
-    if (writtenRef.includes("::")) return null;
-    for (const def of resolveDefinition(wsIndex, writtenRef, mappingNamespace)) {
-      const card = cards.get(def.namespace ? `${def.namespace}::${writtenRef}` : writtenRef);
-      if (card) return card;
-    }
-    return null;
+  return (writtenRef): CoverageSchemaDefinition | null => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, cards);
+    if (!canonicalRef) return null;
+    const cardKey = canonicalRef.startsWith("::") ? canonicalRef.slice(2) : canonicalRef;
+    return cards.get(cardKey) ?? null;
   };
 }
 
@@ -150,6 +145,7 @@ function makeCardResolver(
 function schemaCardDef(schema: SchemaCard): CoverageSchemaDefinition {
   return {
     schemaId: schema.qualifiedId,
+    canonicalRef: canonicalCardRef(schema.qualifiedId),
     uri: schema.location.uri,
     fields: schema.fields.map(toCoverageField),
   };
@@ -166,9 +162,15 @@ function schemaCardDef(schema: SchemaCard): CoverageSchemaDefinition {
 function metricCardDef(metric: MetricCard): CoverageSchemaDefinition {
   return {
     schemaId: metric.qualifiedId,
+    canonicalRef: canonicalCardRef(metric.qualifiedId),
     uri: metric.location.uri,
     fields: metric.fields.map((f) => ({ name: f.name, line: f.location.line })),
   };
+}
+
+/** Convert the model's qualified-id storage spelling into core's canonical form. */
+function canonicalCardRef(qualifiedId: string): CanonicalEntityRef {
+  return createCanonicalEntityRef(qualifiedId.includes("::") ? qualifiedId : `::${qualifiedId}`);
 }
 
 /**

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -22,6 +22,11 @@
  */
 
 import { schemaLocalFieldPath } from "@satsuma/core/coverage-paths";
+import {
+  createAuthoredEntityRef,
+  createCanonicalEntityRef,
+  createContainerQualifiedFieldRef,
+} from "@satsuma/core/reference-stages";
 import { unionFieldCoverage } from "@satsuma/core/coverage-rollup";
 import { uncoveredFieldCoverage } from "@satsuma/core/coverage";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
@@ -84,17 +89,30 @@ export function resolveSchemaLocalFieldPath(
   schema: FieldPathCard,
   sourceRefs: string[],
 ): string | null {
-  const otherRefs = sourceRefs.filter((ref) => ref !== schema.qualifiedId);
+  const authoredSchemaRef = createAuthoredEntityRef(schema.qualifiedId);
+  const canonicalSchemaRef = createCanonicalEntityRef(
+    schema.qualifiedId.includes("::") ? schema.qualifiedId : `::${schema.qualifiedId}`,
+  );
+  const otherRefs = sourceRefs
+    .filter((ref) => ref !== schema.qualifiedId)
+    .map(createAuthoredEntityRef);
   const declaresTopLevel = (name: string): boolean =>
     schema.fields.some((field) => field.name === name);
 
-  const local = schemaLocalFieldPath(fieldRef, [schema.qualifiedId], otherRefs, declaresTopLevel);
+  const qualifiedFieldRef = createContainerQualifiedFieldRef(fieldRef);
+  const local = schemaLocalFieldPath(
+    qualifiedFieldRef,
+    authoredSchemaRef,
+    canonicalSchemaRef,
+    otherRefs,
+    declaresTopLevel,
+  );
   if (local === null) return null;
 
   // An explicit `thisSchema.` prefix is proof enough that the ref is meant for
   // this card. Only an unprefixed ref — which could belong to any card on
   // screen — has to be confirmed against the declared fields.
-  if (local !== fieldRef) return local;
+  if (String(local) !== String(qualifiedFieldRef)) return local;
 
   return schemaHasFieldPath(schema, local) ? local : null;
 }


### PR DESCRIPTION
## Summary

- define opaque authored, qualified, schema-local, and canonical reference stages in satsuma-core
- enforce stage order through coverage APIs and migrate CLI, LSP, viz-backend, and viz boundary adapters
- preserve JSON, LSP, and VizModel strings while adding runtime and compile-only regression coverage
- record the durable boundary in ADR-044 and the canonical architecture guide

## Testing

- full pre-commit repository check after rebasing onto origin/main
- core: 614 tests plus compile-only type tests
- CLI: 1003 tests, including the configured test-source typecheck gate
- LSP: 300 tests
- viz-model: 6 tests
- viz-backend: 186 tests
- viz: 130 tests
- VS Code extension: 34 tests plus TextMate fixtures and golden corpus
- Python: 39 tests and 1172 subtests
- BDD smoke suite: 50 tests

The tree-sitter corpus step was skipped by the repository hook because the installed CLI lacks the wasm feature; no grammar or generated parser artifact changed.

Closes cbdr-e6ft
Closes cbdr-5r4d