### PR TITLE
feat(core+cli): satsuma.config.yaml lint configuration (sl-npi6)

### DIFF
--- a/.tickets/sl-npi6.md
+++ b/.tickets/sl-npi6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-npi6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:14:15Z
@@ -27,4 +27,18 @@ Malformed-config exit code is 3, not 2, per the lint exit-code table established
 ## Acceptance Criteria
 
 Config loads from default path ./satsuma.config.yaml and from a --config override; lint.suppress removes a rule from output; --select on a config-suppressed rule still runs it; --ignore and lint.suppress union correctly; alias groups and strict flag parse into typed config; an invalid rule id in lint.suppress is reported like an invalid --ignore id; missing file yields defaults silently; malformed file exits 3 with an actionable message; unknown top-level keys warn; core and CLI tests pass locally; npm audit clean.
+
+## Notes
+
+**2026-08-03T17:11:02Z**
+
+Cause: PRD 37 R4 called for a workspace config but nothing implemented it, so `--ignore` was the only way to suppress a rule and it could not be persisted; the flag also accepted unknown rule ids in silence, meaning there was no existing rule-id validation to "reuse" for `lint.suppress`.
+Fix: Added `@satsuma/core/config` (typed shape, YAML parse/validate, and the one suppression-precedence rule) plus a CLI `load-config.ts` for path resolution and reading, wired `--config` and config suppression into `lint`, and made an unknown rule id an error wherever it is written — flag or config — exiting the new lint-scoped code 3 (commit immediately after ac9e6fc6).
+
+Two deliberate departures from the ticket text, both documented in code:
+
+1. **The loader is split, not wholly in core.** Core imports no Node built-ins and `satsuma-viz` bundles core for the browser, so `readFileSync` cannot live there. Core owns the config semantics; each consumer owns finding and reading the file. The `yaml` dependency is reachable only through the `@satsuma/core/config` subpath (not re-exported from `index.ts`), verified absent from the built viz browser bundle.
+2. **Rule-id validation had to be created, not reused.** Satisfying "reported the way a typo in --ignore is" meant defining that behaviour for the first time, so `--select`/`--ignore` now reject unknown ids too. This is a user-visible change to existing flags: a misspelled value used to be accepted and silently filter nothing.
+
+`lint.strict` and `lint.typeAliases` parse and validate but have no consumer yet (sl-1u6r, sl-j30s). Rather than accept them silently, `lint` warns that they are not enforced, so a config cannot read as an active gate.
 

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -102,7 +102,9 @@ Operations that check or compare workspace structure.
 
 `lint` checks **policy and conventions**: duplicate definitions, hidden schema dependencies in NL text, unresolved NL `@ref` references. It answers "does this workspace follow best practices?" Some lint rules support `--fix` for safe, deterministic autofix.
 
-Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rules>` / `--ignore <rules>` (filter rules), `--quiet` (exit code only), `--rules` (list available rules).
+Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rules>` / `--ignore <rules>` (filter rules), `--config <path>` (config file, see [Workspace configuration](#workspace-configuration)), `--quiet` (exit code only), `--rules` (list available rules).
+
+A rule id that does not exist is an error wherever it is written — `--select`, `--ignore`, or the config file — and exits `3`. A typo that silently suppressed nothing would leave the author believing a rule was off.
 
 | Rule                         | Severity | Fixable | Description                                                         |
 | ---------------------------- | -------- | ------- | ------------------------------------------------------------------- |
@@ -110,6 +112,36 @@ Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rule
 | `unresolved-nl-ref`          | warning  | no      | `@ref` in NL does not resolve to any known identifier               |
 | `duplicate-definition`       | error    | no      | Named definition is declared more than once in a namespace          |
 | `unenumerated-record-target` | warning  | no      | Arrow targets a record without a record source or child arrows      |
+
+### Workspace configuration
+
+`lint` reads an optional `satsuma.config.yaml` from the working directory, overridable with `--config <path>`. Every setting is optional and the file itself is optional — **a workspace with no config runs every rule**, so adding the file is always opt-in.
+
+```yaml
+# satsuma.config.yaml — workspace lint configuration.
+lint:
+  # Rules to skip in every run. The persistent form of --ignore.
+  # An id that is not a real rule is an error, not a no-op.
+  suppress:
+    - unresolved-nl-ref
+
+  # Declared types to treat as equivalent, as groups. Groups stay separate:
+  # one flat list would make STRING equivalent to INT in the workspace below.
+  typeAliases:
+    - [STRING, TEXT, VARCHAR]
+    - [INT, INTEGER, BIGINT]
+
+  # Escalate warnings to a failing exit code.
+  strict: false
+```
+
+**Precedence — one rule.** Flags win over config, and the union of `--ignore` and `lint.suppress` is suppressed. The single exception: `--select` means "run exactly these", so a rule named on the command line runs even when the config suppresses it — naming a rule is an unambiguous instruction to run it.
+
+Unrecognised settings are reported as warnings and ignored, so a config written for a newer CLI still runs. Anything that makes the file unusable — invalid YAML, a wrong-shaped setting, an unknown rule id — aborts the run with exit `3` rather than falling back to defaults: linting with rules the author did not ask for, and reporting success, is worse than refusing to lint.
+
+`lint.typeAliases` and `lint.strict` are accepted and validated now, but nothing consumes them yet — the CLI prints a warning saying so, so a config cannot look like an active gate when no code enforces it. Their consumers ship with the type-mismatch rule and strict-mode exit codes respectively.
+
+Lint exit codes: `0` no error-severity findings, `2` error-severity findings present, `3` lint could not run.
 
 ### coverage
 
@@ -345,6 +377,8 @@ Cycles are handled gracefully — each field is visited at most once. NL-derived
 | 0    | Success                         |
 | 1    | Not found or no results         |
 | 2    | Parse error or filesystem error |
+
+Two commands add a code that means something specific to them, so a script can tell a failing gate from a broken run: `coverage --fail-under` exits `3` when measured coverage is below the threshold, and `lint` exits `3` when it could not run at all (see [Workspace configuration](#workspace-configuration)). They never collide in one invocation — `lint` has no threshold and `coverage` reads no rules.
 
 ## How Agents Use the CLI
 

--- a/tooling/satsuma-cli/package-lock.json
+++ b/tooling/satsuma-cli/package-lock.json
@@ -39,6 +39,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/satsuma-cli/src/command-runner.ts
+++ b/tooling/satsuma-cli/src/command-runner.ts
@@ -73,6 +73,24 @@ export const EXIT_PARSE_ERROR = 2;
 export const EXIT_THRESHOLD_NOT_MET = 3;
 
 /**
+ * `lint`: the command could not run as instructed — an unusable
+ * `satsuma.config.yaml`, or a rule id that does not exist named by
+ * `--select`/`--ignore`/`lint.suppress`.
+ *
+ * Numerically the same as {@link EXIT_THRESHOLD_NOT_MET} but a different
+ * meaning, which is intentional and command-scoped: `lint` publishes its own
+ * exit-code table (PRD 37 R5), following the `fmt --check` precedent of a
+ * command owning codes that mean something specific to it. The two never
+ * collide in one invocation — `lint` has no threshold gate and `coverage`
+ * reads no lint rules.
+ *
+ * Distinct from {@link EXIT_PARSE_ERROR} on purpose: `2` means "the workspace
+ * has lint errors", so "lint never got far enough to judge the workspace"
+ * needs its own code for CI to tell a failing gate from a broken setup.
+ */
+export const EXIT_LINT_CANNOT_RUN = 3;
+
+/**
  * Structured failure raised by command handlers and shared utilities.
  *
  * Throwing a `CommandError` is the canonical way for a handler to abort

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -8,21 +8,94 @@
  *   0 — no error-severity findings (warnings alone do not cause exit 2)
  *   1 — internal error (filesystem, parser crash, bad arguments)
  *   2 — error-severity lint findings present
+ *   3 — lint could not run (unusable config, unknown rule id)
  *
  * Flags:
  *   --json     machine-readable JSON output
  *   --fix      apply safe, deterministic fixes
  *   --select   run only listed rules (comma-separated)
  *   --ignore   skip listed rules (comma-separated)
+ *   --config   path to satsuma.config.yaml (default ./satsuma.config.yaml)
  *   --quiet    exit code only
+ *
+ * Rule selection combines flags and config through
+ * `resolveSuppressedRuleIds` — see its contract for the precedence rule.
  */
 
 import type { Command } from "commander";
 import { readFileSync, writeFileSync } from "fs";
+import {
+  SATSUMA_CONFIG_FILENAME,
+  resolveSuppressedRuleIds,
+  unknownRuleIds,
+  type SatsumaConfig,
+} from "@satsuma/core/config";
 import { loadWorkspace } from "../load-workspace.js";
-import { runCommand, EXIT_PARSE_ERROR } from "../command-runner.js";
+import { loadSatsumaConfig } from "../load-config.js";
+import {
+  CommandError,
+  runCommand,
+  EXIT_PARSE_ERROR,
+  EXIT_LINT_CANNOT_RUN,
+} from "../command-runner.js";
 import { runLint, applyFixes, RULES } from "../lint-engine.js";
 import type { LintFix } from "../types.js";
+
+/** Every rule id the engine knows, used to reject typos wherever ids are named. */
+const KNOWN_RULE_IDS: readonly string[] = RULES.map((r) => r.id);
+
+/** Split a comma-separated rule-id flag value, dropping incidental whitespace. */
+function parseRuleList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Reject rule ids that do not exist, so a typo fails loudly instead of quietly
+ * selecting or suppressing nothing.
+ *
+ * Applies the same check and message to `--select` and `--ignore` that
+ * `@satsuma/core/config` applies to `lint.suppress`: a rule id is a rule id
+ * wherever it is written, and until now a misspelled flag value was accepted
+ * in silence.
+ */
+function assertKnownRuleIds(flag: string, ids: readonly string[]): void {
+  const unknown = unknownRuleIds(ids, KNOWN_RULE_IDS);
+  if (unknown.length === 0) return;
+
+  const plural = unknown.length > 1 ? "s" : "";
+  throw new CommandError(
+    `Error: ${flag}: unknown lint rule${plural} ${unknown.map((id) => `"${id}"`).join(", ")}. ` +
+      `Valid rules: ${[...KNOWN_RULE_IDS].sort().join(", ")}`,
+    EXIT_LINT_CANNOT_RUN,
+  );
+}
+
+/**
+ * Warn about settings this CLI version parses but does not yet act on.
+ *
+ * `lint.strict` and `lint.typeAliases` are part of the config contract from the
+ * start (the LSP and CI need a stable shape to write against) but their
+ * consumers ship separately: strict-mode exit codes in `sl-1u6r`, type aliasing
+ * with the `type-mismatch-direct-arrow` rule in `sl-j30s`. Accepting them in
+ * silence would let an author believe a gate is active when nothing enforces it
+ * — the exact failure the config was added to prevent.
+ */
+function warnInertSettings(
+  config: SatsumaConfig,
+  warn: ((message: string) => void) | undefined,
+): void {
+  if (!warn) return;
+
+  if (config.lint.strict) {
+    warn("lint.strict is not enforced yet — warnings still exit 0 (see sl-1u6r).");
+  }
+  if (config.lint.typeAliases.length > 0) {
+    warn("lint.typeAliases has no consumer yet — no rule compares declared types (see sl-j30s).");
+  }
+}
 
 export function register(program: Command): void {
   program
@@ -32,6 +105,7 @@ export function register(program: Command): void {
     .option("--fix", "apply safe, deterministic fixes")
     .option("--select <rules>", "run only listed rules (comma-separated)")
     .option("--ignore <rules>", "skip listed rules (comma-separated)")
+    .option("--config <path>", `path to config (default ./${SATSUMA_CONFIG_FILENAME})`)
     .option("--quiet", "exit code only")
     .option("--rules", "list available lint rules and exit")
     .addHelpText(
@@ -49,12 +123,27 @@ JSON shape (--json):
     "summary":  {"files": int, "findings": int, "fixable": int, "fixed": int}
   }
 
+Exit codes:
+  0  no error-severity findings
+  2  error-severity findings present
+  3  lint could not run (unusable config, or an unknown rule id)
+
+Configuration (${SATSUMA_CONFIG_FILENAME}, override with --config):
+  lint:
+    suppress: [unresolved-nl-ref]   # rules to skip in every run
+    typeAliases: [[STRING, TEXT]]   # declared types to treat as equivalent
+    strict: false                   # make warnings exit non-zero
+
+  A missing config file is not an error. Suppression is the union of --ignore
+  and lint.suppress, except that a rule named by --select always runs.
+
 Examples:
   satsuma lint pipeline.stm                  # check conventions
   satsuma lint pipeline.stm --json           # structured diagnostics
   satsuma lint pipeline.stm --fix            # auto-fix fixable issues
   satsuma lint --rules                       # list available rules
-  satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only`,
+  satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only
+  satsuma lint pipeline.stm --config ci.yaml # lint with a specific config`,
     )
     .action(
       runCommand(
@@ -65,6 +154,7 @@ Examples:
             fix?: boolean;
             select?: string;
             ignore?: string;
+            config?: string;
             quiet?: boolean;
             rules?: boolean;
           },
@@ -77,13 +167,36 @@ Examples:
             return;
           }
 
+          // Resolve rule selection before touching the workspace: a typo in a
+          // rule id or an unusable config is worth reporting without waiting
+          // for a large workspace to parse.
+          const select = opts.select ? parseRuleList(opts.select) : undefined;
+          const ignore = opts.ignore ? parseRuleList(opts.ignore) : undefined;
+          if (select) assertKnownRuleIds("--select", select);
+          if (ignore) assertKnownRuleIds("--ignore", ignore);
+
+          const config = loadSatsumaConfig({
+            explicitPath: opts.config,
+            knownRuleIds: KNOWN_RULE_IDS,
+            // Config notes go to stderr so they never pollute --json output on
+            // stdout, and are silenced entirely by --quiet.
+            ...(opts.quiet ? {} : { onWarning: (m: string) => console.error(`Warning: ${m}`) }),
+          });
+
+          warnInertSettings(config, opts.quiet ? undefined : (m) => console.error(`Warning: ${m}`));
+
+          const suppressed = resolveSuppressedRuleIds({
+            ...(select ? { select } : {}),
+            ...(ignore ? { ignore } : {}),
+            configSuppress: config.lint.suppress,
+          });
+
           const { files, index } = await loadWorkspace(pathArg);
           const fileCount = files.length;
 
-          // Run lint rules
           const ruleOpts: { select?: string[]; ignore?: string[] } = {};
-          if (opts.select) ruleOpts.select = opts.select.split(",").map((s) => s.trim());
-          if (opts.ignore) ruleOpts.ignore = opts.ignore.split(",").map((s) => s.trim());
+          if (select) ruleOpts.select = select;
+          if (suppressed.size > 0) ruleOpts.ignore = [...suppressed];
 
           let diagnostics = runLint(index, ruleOpts);
 

--- a/tooling/satsuma-cli/src/load-config.ts
+++ b/tooling/satsuma-cli/src/load-config.ts
@@ -1,0 +1,95 @@
+/**
+ * load-config.ts — find and read the workspace's `satsuma.config.yaml`.
+ *
+ * Owns the CLI's *filesystem* half of workspace configuration: where the file
+ * lives, whether its absence is an error, and how a bad config aborts the
+ * command. The config's shape, validation, and precedence semantics live in
+ * `@satsuma/core/config` so the LSP applies the identical rules when it mirrors
+ * lint diagnostics — core imports no Node built-ins, which is why reading the
+ * file cannot live there.
+ *
+ * The asymmetry between the two lookup paths is deliberate:
+ *
+ *   • **No `--config` flag** — a missing `./satsuma.config.yaml` is normal.
+ *     Most workspaces have no config and must keep working untouched.
+ *   • **`--config <path>` given** — a missing file is an error. The user named
+ *     a specific file; silently linting with defaults would report a
+ *     suppressed rule or skip a strict gate they explicitly configured.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  DEFAULT_SATSUMA_CONFIG,
+  SATSUMA_CONFIG_FILENAME,
+  parseSatsumaConfig,
+  type SatsumaConfig,
+} from "@satsuma/core/config";
+import { CommandError, EXIT_LINT_CANNOT_RUN } from "./command-runner.js";
+
+/** Options for {@link loadSatsumaConfig}. */
+export interface LoadSatsumaConfigOptions {
+  /** Value of `--config <path>`, if the user passed it. */
+  explicitPath?: string | undefined;
+
+  /**
+   * Directory the default config path is resolved against. Defaults to the
+   * process working directory; tests and embedders pass their own.
+   */
+  cwd?: string;
+
+  /**
+   * Rule ids that exist, so a typo in `lint.suppress` is rejected rather than
+   * silently suppressing nothing.
+   */
+  knownRuleIds?: readonly string[];
+
+  /**
+   * Sink for non-fatal notes such as unrecognised settings. Callers route these
+   * to stderr; omitting it discards them, which is what `--quiet` and `--json`
+   * runs want.
+   */
+  onWarning?: (message: string) => void;
+}
+
+/**
+ * Load the workspace config, or the defaults when there is none to load.
+ *
+ * @throws CommandError with {@link EXIT_LINT_CANNOT_RUN} when a config exists
+ *         (or was explicitly named) but cannot be used — malformed YAML, a
+ *         wrong-shaped setting, an unknown rule id, or an unreadable file. The
+ *         message names the file and every problem found in it.
+ */
+export function loadSatsumaConfig(options: LoadSatsumaConfigOptions = {}): SatsumaConfig {
+  const { explicitPath, cwd = process.cwd(), knownRuleIds, onWarning } = options;
+
+  const path = explicitPath ?? join(cwd, SATSUMA_CONFIG_FILENAME);
+
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (err: unknown) {
+    if (!explicitPath && isFileNotFound(err)) return DEFAULT_SATSUMA_CONFIG;
+
+    const reason = (err as { message?: string })?.message ?? String(err);
+    throw new CommandError(`Error: cannot read config ${path}: ${reason}`, EXIT_LINT_CANNOT_RUN);
+  }
+
+  const result = parseSatsumaConfig(text, knownRuleIds ? { knownRuleIds } : {});
+
+  if (!result.ok) {
+    const detail = result.errors.map((e) => `  ${e}`).join("\n");
+    throw new CommandError(`Error: invalid config ${path}\n${detail}`, EXIT_LINT_CANNOT_RUN);
+  }
+
+  if (onWarning) {
+    for (const warning of result.warnings) onWarning(`${path}: ${warning}`);
+  }
+
+  return result.config;
+}
+
+/** True for the "no such file or directory" error `readFileSync` raises. */
+function isFileNotFound(err: unknown): boolean {
+  return (err as { code?: string })?.code === "ENOENT";
+}

--- a/tooling/satsuma-cli/test/load-config.test.ts
+++ b/tooling/satsuma-cli/test/load-config.test.ts
@@ -1,0 +1,256 @@
+/**
+ * load-config.test.ts — the CLI's filesystem half of workspace configuration.
+ *
+ * Covers where the config is looked up, when its absence is an error, and how
+ * an unusable one aborts the command. Config *semantics* (valid shapes, rule-id
+ * validation, suppression precedence) are tested once in
+ * `satsuma-core/test/satsuma-config.test.js` and are not re-tested here.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { DEFAULT_SATSUMA_CONFIG, SATSUMA_CONFIG_FILENAME } from "@satsuma/core/config";
+import { loadSatsumaConfig } from "#src/load-config.js";
+import { CommandError, EXIT_LINT_CANNOT_RUN } from "#src/command-runner.js";
+import { run } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+
+/** Rule ids the real engine ships, for validating suppression entries. */
+const KNOWN_RULES = ["hidden-source-in-nl", "unresolved-nl-ref", "duplicate-definition"];
+
+/** Create a throwaway workspace directory, optionally containing a config file. */
+function workspaceWith(configText?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "satsuma-config-"));
+  if (configText !== undefined) {
+    writeFileSync(join(dir, SATSUMA_CONFIG_FILENAME), configText, "utf8");
+  }
+  return dir;
+}
+
+// ── Default lookup: absence is normal ──────────────────────────────────────
+
+describe("default config lookup", () => {
+  it("returns the defaults silently when the workspace has no config file", () => {
+    // Every existing workspace is in this state. If a missing file were an
+    // error, adding the config feature would break all of them at once.
+    const config = loadSatsumaConfig({ cwd: workspaceWith(), knownRuleIds: KNOWN_RULES });
+    assert.deepEqual(config, DEFAULT_SATSUMA_CONFIG);
+  });
+
+  it("reads satsuma.config.yaml from the given directory", () => {
+    // Pins the default lookup to <cwd>/satsuma.config.yaml — the path documented
+    // in the command help and PRD 37 R4.
+    const dir = workspaceWith("lint:\n  suppress:\n    - unresolved-nl-ref\n");
+    const config = loadSatsumaConfig({ cwd: dir, knownRuleIds: KNOWN_RULES });
+    assert.deepEqual(config.lint.suppress, ["unresolved-nl-ref"]);
+  });
+
+  it("does not search parent directories for a config", () => {
+    // Lookup is deliberately non-recursive: an ancestor config silently
+    // changing lint results in a subdirectory would be surprising, and the
+    // ticket scopes lookup to ./satsuma.config.yaml.
+    const parent = workspaceWith("lint:\n  strict: true\n");
+    const child = join(parent, "nested");
+    mkdirSync(child);
+    const config = loadSatsumaConfig({ cwd: child, knownRuleIds: KNOWN_RULES });
+    assert.equal(config.lint.strict, false);
+  });
+});
+
+// ── Explicit --config: absence is an error ─────────────────────────────────
+
+describe("explicit --config path", () => {
+  it("fails when the named file does not exist", () => {
+    // The user named a specific file. Falling back to defaults would run lint
+    // with different rules than they asked for and report success.
+    const missing = join(workspaceWith(), "nope.yaml");
+    assert.throws(
+      () => loadSatsumaConfig({ explicitPath: missing, knownRuleIds: KNOWN_RULES }),
+      (err: unknown) =>
+        err instanceof CommandError &&
+        err.code === EXIT_LINT_CANNOT_RUN &&
+        err.message.includes(missing),
+    );
+  });
+
+  it("reads the named file instead of the default path", () => {
+    // The override must win even when a default-named config sits alongside it.
+    const dir = workspaceWith("lint:\n  suppress:\n    - unresolved-nl-ref\n");
+    const override = join(dir, "ci.yaml");
+    writeFileSync(override, "lint:\n  suppress:\n    - duplicate-definition\n", "utf8");
+
+    const config = loadSatsumaConfig({
+      explicitPath: override,
+      cwd: dir,
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.deepEqual(config.lint.suppress, ["duplicate-definition"]);
+  });
+});
+
+// ── Unusable configs abort with lint's "could not run" code ────────────────
+
+describe("unusable config", () => {
+  it("aborts with exit code 3 rather than linting with defaults", () => {
+    // 3 means "lint could not run", distinct from 2 ("the workspace has lint
+    // errors"). CI must be able to tell a broken setup from a failing gate.
+    const dir = workspaceWith("lint:\n  suppress: [unclosed\n");
+    assert.throws(
+      () => loadSatsumaConfig({ cwd: dir, knownRuleIds: KNOWN_RULES }),
+      (err: unknown) => err instanceof CommandError && err.code === EXIT_LINT_CANNOT_RUN,
+    );
+  });
+
+  it("names the offending file and every problem in it", () => {
+    // One run should be enough to fix the file, and the author needs to know
+    // which file to open — the path may have come from --config.
+    const dir = workspaceWith('lint:\n  strict: "no"\n  suppress:\n    - nope\n');
+    assert.throws(
+      () => loadSatsumaConfig({ cwd: dir, knownRuleIds: KNOWN_RULES }),
+      (err: unknown) => {
+        assert.ok(err instanceof CommandError);
+        assert.match(err.message, new RegExp(SATSUMA_CONFIG_FILENAME));
+        assert.match(err.message, /lint\.strict/);
+        assert.match(err.message, /nope/);
+        return true;
+      },
+    );
+  });
+});
+
+// ── Warnings ──────────────────────────────────────────────────────────────
+
+describe("config warnings", () => {
+  it("reports unrecognised settings through the caller's warning sink", () => {
+    // The loader must not write to the console itself: --json runs need stdout
+    // clean, so the caller decides where notes go.
+    const dir = workspaceWith("lnit:\n  strict: true\n");
+    const warnings: string[] = [];
+    loadSatsumaConfig({ cwd: dir, knownRuleIds: KNOWN_RULES, onWarning: (m) => warnings.push(m) });
+
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0]!, /lnit/);
+    assert.match(warnings[0]!, new RegExp(SATSUMA_CONFIG_FILENAME));
+  });
+});
+
+// ── End-to-end through the lint command ───────────────────────────────────
+
+describe("satsuma lint --config", () => {
+  /** A workspace whose only lint finding is an unresolved NL ref (a warning). */
+  function workspaceWithFinding(): string {
+    const dir = mkdtempSync(join(tmpdir(), "satsuma-lint-config-"));
+    writeFileSync(
+      join(dir, "pipeline.stm"),
+      [
+        "schema src {",
+        "  id  STRING",
+        "}",
+        "",
+        "schema dst {",
+        "  id  STRING",
+        "}",
+        "",
+        "mapping `copy id` {",
+        "  source { `src` }",
+        "  target { `dst` }",
+        "",
+        // @missing_field resolves to nothing, which is exactly what
+        // unresolved-nl-ref reports (warning severity, so exit stays 0).
+        '  id -> id { "Copy the value of @missing_field." }',
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    return dir;
+  }
+
+  it("suppresses a rule named in lint.suppress", async () => {
+    // The end-to-end proof that config suppression reaches the engine, not just
+    // the typed config object.
+    const dir = workspaceWithFinding();
+    const configPath = join(dir, "ci.yaml");
+    writeFileSync(configPath, "lint:\n  suppress:\n    - unresolved-nl-ref\n", "utf8");
+
+    const withoutConfig = await run(CLI, "lint", join(dir, "pipeline.stm"), "--json");
+    assert.match(withoutConfig.stdout, /unresolved-nl-ref/);
+
+    const withConfig = await run(
+      CLI,
+      "lint",
+      join(dir, "pipeline.stm"),
+      "--json",
+      "--config",
+      configPath,
+    );
+    assert.doesNotMatch(withConfig.stdout, /unresolved-nl-ref/);
+  });
+
+  it("runs a config-suppressed rule when --select names it", async () => {
+    // Locks the one exception to "flags and config union": naming a rule is an
+    // unambiguous instruction to run it.
+    const dir = workspaceWithFinding();
+    const configPath = join(dir, "ci.yaml");
+    writeFileSync(configPath, "lint:\n  suppress:\n    - unresolved-nl-ref\n", "utf8");
+
+    const result = await run(
+      CLI,
+      "lint",
+      join(dir, "pipeline.stm"),
+      "--json",
+      "--config",
+      configPath,
+      "--select",
+      "unresolved-nl-ref",
+    );
+    assert.match(result.stdout, /unresolved-nl-ref/);
+  });
+
+  it("exits 3 with an actionable message when the config is malformed", async () => {
+    // The user-visible contract for a broken config: a non-zero code that is
+    // not the "workspace has lint errors" code, and a message naming the file.
+    const dir = workspaceWithFinding();
+    const configPath = join(dir, "broken.yaml");
+    writeFileSync(configPath, "lint:\n  suppress: [unclosed\n", "utf8");
+
+    const result = await run(CLI, "lint", join(dir, "pipeline.stm"), "--config", configPath);
+    assert.equal(result.code, EXIT_LINT_CANNOT_RUN);
+    assert.match(result.stderr, /broken\.yaml/);
+  });
+
+  it("exits 3 when --ignore names a rule that does not exist", async () => {
+    // Before this, a misspelled --ignore value was accepted in silence and the
+    // rule kept running. A typo must not look like a working suppression.
+    const dir = workspaceWithFinding();
+    const result = await run(
+      CLI,
+      "lint",
+      join(dir, "pipeline.stm"),
+      "--ignore",
+      "unresolvd-nl-ref",
+    );
+    assert.equal(result.code, EXIT_LINT_CANNOT_RUN);
+    assert.match(result.stderr, /unresolvd-nl-ref/);
+    assert.match(result.stderr, /unresolved-nl-ref/);
+  });
+
+  it("warns that lint.strict is parsed but not yet enforced", async () => {
+    // strict: true with no enforcement would read as an active gate. Until
+    // sl-1u6r ships, the CLI must say so out loud.
+    const dir = workspaceWithFinding();
+    const configPath = join(dir, "strict.yaml");
+    writeFileSync(configPath, "lint:\n  strict: true\n", "utf8");
+
+    const result = await run(CLI, "lint", join(dir, "pipeline.stm"), "--config", configPath);
+    assert.match(result.stderr, /lint\.strict is not enforced yet/);
+    assert.equal(result.code, 0);
+  });
+});

--- a/tooling/satsuma-core/package-lock.json
+++ b/tooling/satsuma-core/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",
@@ -730,6 +731,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/tooling/satsuma-core/package.json
+++ b/tooling/satsuma-core/package.json
@@ -73,6 +73,10 @@
     "./coverage-rollup": {
       "types": "./dist/coverage-rollup.d.ts",
       "default": "./dist/coverage-rollup.js"
+    },
+    "./config": {
+      "types": "./dist/satsuma-config.d.ts",
+      "default": "./dist/satsuma-config.js"
     }
   },
   "types": "./dist/index.d.ts",
@@ -85,7 +89,8 @@
     "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary --include='dist/**/*.js' --exclude='dist/**/*.d.ts' node --test test/**/*.test.js"
   },
   "dependencies": {
-    "web-tree-sitter": "^0.26.11"
+    "web-tree-sitter": "^0.26.11",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/tooling/satsuma-core/src/satsuma-config.ts
+++ b/tooling/satsuma-core/src/satsuma-config.ts
@@ -1,0 +1,358 @@
+/**
+ * satsuma-config.ts — the shape, parsing, and validation of `satsuma.config.yaml`.
+ *
+ * Owns the workspace config *semantics*: the typed shape, what makes a document
+ * valid, and the one precedence rule that decides which lint rules a run
+ * suppresses. Every consumer that honours the config — the CLI today, the LSP
+ * when it mirrors lint diagnostics — must go through this module rather than
+ * reading YAML keys itself, so a config means the same thing in an editor as it
+ * does in CI.
+ *
+ * It does **not** own reading the file. Core imports no Node built-ins (the viz
+ * component bundles core for the browser), and each consumer already has its own
+ * way of resolving a workspace root and reading files. Consumers pass the text
+ * in and map {@link SatsumaConfigParseResult} errors onto their own exit codes
+ * or diagnostics.
+ *
+ * Deliberately not re-exported from `index.ts`: reaching it through the
+ * `@satsuma/core/config` subpath keeps the `yaml` dependency out of the
+ * browser bundle for consumers that never read a config.
+ */
+
+import { parse as parseYaml } from "yaml";
+
+/**
+ * Default config file name, resolved relative to the workspace root by each
+ * consumer.
+ *
+ * Not a dotfile: `.satsuma` is a first-class Satsuma *source* extension
+ * (`SATSUMA_FILE_EXTENSIONS`), so a config named `.satsumacfg` would sit one
+ * character from a source-file glob and would get no editor YAML association or
+ * schema support. Settled in doc review 2026-07-31 (PRD 37 R4).
+ */
+export const SATSUMA_CONFIG_FILENAME = "satsuma.config.yaml";
+
+/** Recognised top-level config sections. Anything else earns a warning. */
+const KNOWN_TOP_LEVEL_KEYS = ["lint"] as const;
+
+/** Recognised keys inside the `lint` section. Anything else earns a warning. */
+const KNOWN_LINT_KEYS = ["suppress", "typeAliases", "strict"] as const;
+
+/**
+ * An alias group declares a set of declared-type tokens as equivalent for the
+ * `type-mismatch-direct-arrow` rule — e.g. `["STRING", "TEXT", "VARCHAR"]` in a
+ * workspace where three layers spell the same type three ways.
+ *
+ * Groups stay separate rather than being flattened into one set: flattening
+ * would make `STRING` equivalent to `INT` as soon as a workspace declares both
+ * a string group and an integer group. Tokens are stored exactly as authored;
+ * how they are compared (case, parameters) is the consuming rule's business.
+ */
+export type TypeAliasGroup = readonly string[];
+
+/** The `lint` section of the config. */
+export interface LintConfig {
+  /**
+   * Rule ids excluded from every run — the persistent form of `--ignore`.
+   * Empty by default: a workspace with no config runs every rule.
+   */
+  readonly suppress: readonly string[];
+
+  /**
+   * Declared-type equivalence groups consumed by the type-mismatch rule.
+   * Empty by default, meaning types are compared without any aliasing.
+   */
+  readonly typeAliases: readonly TypeAliasGroup[];
+
+  /**
+   * When true, warning-severity findings make `lint` exit non-zero. Off by
+   * default so adding a config file cannot break an existing CI job.
+   */
+  readonly strict: boolean;
+}
+
+/** A fully resolved workspace config. Every section is present after parsing. */
+export interface SatsumaConfig {
+  readonly lint: LintConfig;
+}
+
+/**
+ * The config a workspace gets when it has no config file — every rule runs,
+ * nothing is aliased, warnings stay advisory.
+ */
+export const DEFAULT_SATSUMA_CONFIG: SatsumaConfig = {
+  lint: { suppress: [], typeAliases: [], strict: false },
+};
+
+/**
+ * Outcome of parsing a config document.
+ *
+ * `ok: false` means the document cannot be used at all — the consumer must
+ * abort rather than fall back to defaults, because silently ignoring a config
+ * the author wrote is how suppression and strictness get lost. Warnings are
+ * non-fatal: they carry forward-compatibility notes such as unrecognised keys.
+ */
+export type SatsumaConfigParseResult =
+  | { readonly ok: true; readonly config: SatsumaConfig; readonly warnings: string[] }
+  | { readonly ok: false; readonly errors: string[] };
+
+/** Options accepted by {@link parseSatsumaConfig}. */
+export interface ParseSatsumaConfigOptions {
+  /**
+   * The rule ids that exist, used to reject typos in `lint.suppress`. Optional
+   * because a consumer may parse a config before its rule registry is known;
+   * when omitted, rule ids are accepted as authored. Validation must be opt-in
+   * rather than assumed-empty, or an unvalidated parse would reject every id.
+   */
+  readonly knownRuleIds?: readonly string[];
+}
+
+/**
+ * Parse and validate a `satsuma.config.yaml` document.
+ *
+ * @param text     raw file contents. An empty document yields the defaults —
+ *                 a file someone created but has not filled in is not broken.
+ * @param options  see {@link ParseSatsumaConfigOptions}.
+ * @returns the resolved config plus warnings, or the errors that make the
+ *          document unusable. Never throws: a YAML syntax error is returned as
+ *          an error string so consumers own the failure policy.
+ */
+export function parseSatsumaConfig(
+  text: string,
+  options: ParseSatsumaConfigOptions = {},
+): SatsumaConfigParseResult {
+  let document: unknown;
+  try {
+    document = parseYaml(text);
+  } catch (err: unknown) {
+    const message = (err as { message?: string })?.message ?? String(err);
+    return { ok: false, errors: [`invalid YAML: ${message}`] };
+  }
+
+  // An empty file, or one containing only comments, parses to null/undefined.
+  if (document === null || document === undefined) {
+    return { ok: true, config: DEFAULT_SATSUMA_CONFIG, warnings: [] };
+  }
+
+  if (!isPlainObject(document)) {
+    return {
+      ok: false,
+      errors: [
+        `expected the document root to be a mapping of sections, found ${describe(document)}`,
+      ],
+    };
+  }
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  warnUnknownKeys(document, KNOWN_TOP_LEVEL_KEYS, "", warnings);
+
+  const lint = parseLintSection(document.lint, options.knownRuleIds, errors, warnings);
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, config: { lint }, warnings };
+}
+
+/**
+ * Parse the `lint` section, defaulting each key the author omitted.
+ *
+ * Accumulates into `errors`/`warnings` rather than returning early so one run
+ * reports every problem in the file — an author fixing a config should not have
+ * to re-run once per mistake.
+ */
+function parseLintSection(
+  raw: unknown,
+  knownRuleIds: readonly string[] | undefined,
+  errors: string[],
+  warnings: string[],
+): LintConfig {
+  if (raw === undefined || raw === null) return DEFAULT_SATSUMA_CONFIG.lint;
+
+  if (!isPlainObject(raw)) {
+    errors.push(`lint: expected a mapping of settings, found ${describe(raw)}`);
+    return DEFAULT_SATSUMA_CONFIG.lint;
+  }
+
+  warnUnknownKeys(raw, KNOWN_LINT_KEYS, "lint.", warnings);
+
+  return {
+    suppress: parseSuppress(raw.suppress, knownRuleIds, errors),
+    typeAliases: parseTypeAliases(raw.typeAliases, errors),
+    strict: parseStrict(raw.strict, errors),
+  };
+}
+
+/** Parse `lint.suppress`, rejecting rule ids that do not exist. */
+function parseSuppress(
+  raw: unknown,
+  knownRuleIds: readonly string[] | undefined,
+  errors: string[],
+): readonly string[] {
+  if (raw === undefined || raw === null) return DEFAULT_SATSUMA_CONFIG.lint.suppress;
+
+  if (!isStringArray(raw)) {
+    errors.push(`lint.suppress: expected a list of rule ids, found ${describe(raw)}`);
+    return DEFAULT_SATSUMA_CONFIG.lint.suppress;
+  }
+
+  const suppress = raw.map((id) => id.trim());
+
+  if (knownRuleIds) {
+    const unknown = unknownRuleIds(suppress, knownRuleIds);
+    for (const id of unknown) {
+      errors.push(
+        `lint.suppress: unknown lint rule "${id}". Valid rules: ${[...knownRuleIds].sort().join(", ")}`,
+      );
+    }
+  }
+
+  return suppress;
+}
+
+/** A group naming fewer than two types declares nothing equivalent to anything. */
+const MIN_ALIAS_GROUP_MEMBERS = 2;
+
+/** Parse `lint.typeAliases` into groups, rejecting groups that cannot mean anything. */
+function parseTypeAliases(raw: unknown, errors: string[]): readonly TypeAliasGroup[] {
+  if (raw === undefined || raw === null) return DEFAULT_SATSUMA_CONFIG.lint.typeAliases;
+
+  if (!Array.isArray(raw)) {
+    errors.push(`lint.typeAliases: expected a list of alias groups, found ${describe(raw)}`);
+    return DEFAULT_SATSUMA_CONFIG.lint.typeAliases;
+  }
+
+  const groups: TypeAliasGroup[] = [];
+
+  raw.forEach((group, index) => {
+    const location = `lint.typeAliases[${index}]`;
+
+    if (!isStringArray(group)) {
+      errors.push(`${location}: expected a list of type names, found ${describe(group)}`);
+      return;
+    }
+
+    const members = group.map((type) => type.trim()).filter((type) => type.length > 0);
+
+    if (members.length < MIN_ALIAS_GROUP_MEMBERS) {
+      errors.push(
+        `${location}: an alias group needs at least two type names to declare an equivalence`,
+      );
+      return;
+    }
+
+    groups.push(members);
+  });
+
+  return groups;
+}
+
+/** Parse `lint.strict`, refusing to read truthiness into a non-boolean. */
+function parseStrict(raw: unknown, errors: string[]): boolean {
+  if (raw === undefined || raw === null) return DEFAULT_SATSUMA_CONFIG.lint.strict;
+
+  if (typeof raw !== "boolean") {
+    // `strict: "no"` is a non-empty string: treating it as truthy would invert
+    // an explicit opt-out.
+    errors.push(`lint.strict: expected true or false, found ${describe(raw)}`);
+    return DEFAULT_SATSUMA_CONFIG.lint.strict;
+  }
+
+  return raw;
+}
+
+/**
+ * Rule ids from `candidates` that are not in `knownRuleIds`, in the order and
+ * spelling the author used.
+ *
+ * Shared with the CLI's `--select`/`--ignore` validation so a typo is reported
+ * the same way wherever it is written. Matching is case-sensitive: rule ids are
+ * lowercase-kebab identifiers, not prose.
+ */
+export function unknownRuleIds(
+  candidates: readonly string[],
+  knownRuleIds: readonly string[],
+): string[] {
+  const known = new Set(knownRuleIds);
+  return candidates.filter((id) => !known.has(id));
+}
+
+/** Inputs to {@link resolveSuppressedRuleIds}. */
+export interface SuppressionInputs {
+  /** Rule ids named by `--select`, if the caller passed the flag. */
+  readonly select?: readonly string[];
+  /** Rule ids named by `--ignore`, if the caller passed the flag. */
+  readonly ignore?: readonly string[];
+  /** Rule ids from `lint.suppress`. */
+  readonly configSuppress?: readonly string[];
+}
+
+/**
+ * Decide which rule ids a run must skip, applying the one precedence rule from
+ * PRD 37 R4:
+ *
+ *   **Flags win over config, and the union of `--ignore` and `lint.suppress`
+ *   is suppressed** — except that `--select` still means "run exactly these",
+ *   so a rule the author named on the command line runs even when the config
+ *   suppresses it. Naming a rule is an unambiguous instruction to run it.
+ *
+ * `--ignore` keeps beating `--select` when both name the same rule, which is
+ * the behaviour the flags already had before the config existed.
+ *
+ * @returns the ids to skip. Rule *selection* itself stays with the caller; this
+ *          function owns only the suppression decision.
+ */
+export function resolveSuppressedRuleIds(inputs: SuppressionInputs): Set<string> {
+  const explicitlySelected = new Set(inputs.select ?? []);
+
+  const suppressed = new Set(inputs.ignore ?? []);
+  for (const id of inputs.configSuppress ?? []) {
+    if (!explicitlySelected.has(id)) suppressed.add(id);
+  }
+
+  return suppressed;
+}
+
+// ── Shape helpers ──────────────────────────────────────────────────────────
+//
+// YAML gives us `unknown`; these narrow it without letting a wrong-shaped
+// value through as a silently-coerced default.
+
+/** True for a YAML mapping — an object that is neither null nor an array. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** True for a YAML sequence whose every member is a string. */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/**
+ * Describe an unexpected value for an error message — enough for the author to
+ * recognise what they wrote, without dumping a whole nested document.
+ */
+function describe(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "a list";
+  if (isPlainObject(value)) return "a mapping";
+  if (typeof value === "string") return `the string "${value}"`;
+  return String(value);
+}
+
+/** Warn about keys we do not recognise, so a misspelled section is visible. */
+function warnUnknownKeys(
+  container: Record<string, unknown>,
+  knownKeys: readonly string[],
+  pathPrefix: string,
+  warnings: string[],
+): void {
+  const known = new Set(knownKeys);
+  for (const key of Object.keys(container)) {
+    if (!known.has(key)) {
+      warnings.push(
+        `unrecognised setting "${pathPrefix}${key}" ignored. Known: ${knownKeys.map((k) => `${pathPrefix}${k}`).join(", ")}`,
+      );
+    }
+  }
+}

--- a/tooling/satsuma-core/test/satsuma-config.test.js
+++ b/tooling/satsuma-core/test/satsuma-config.test.js
@@ -1,0 +1,263 @@
+/**
+ * satsuma-config.test.js — parsing and validation of `satsuma.config.yaml`.
+ *
+ * These tests own the config *semantics*: what a well-formed config means,
+ * what makes one unusable, and the suppression-precedence rule shared by every
+ * consumer. Filesystem concerns (default path, `--config` override, missing
+ * file) belong to each consumer and are tested there — the CLI's
+ * `load-config.test.ts` covers the CLI's half.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_SATSUMA_CONFIG,
+  SATSUMA_CONFIG_FILENAME,
+  parseSatsumaConfig,
+  resolveSuppressedRuleIds,
+  unknownRuleIds,
+} from "@satsuma/core/config";
+
+// Rule ids used throughout. Real ids from the CLI's registry, so a rename that
+// breaks the CLI's `--ignore` validation shows up as a failure here too.
+const KNOWN_RULES = ["hidden-source-in-nl", "unresolved-nl-ref", "duplicate-definition"];
+
+// ── The config file's identity ──────────────────────────────────────────────
+
+describe("config file naming", () => {
+  it("names the config file so it cannot be mistaken for a Satsuma source file", () => {
+    // Doc review 2026-07-31 rejected `.satsumacfg` precisely because `.satsuma`
+    // is a source extension. If someone renames this constant back to a
+    // dotfile-style name, that decision is being reversed silently.
+    assert.equal(SATSUMA_CONFIG_FILENAME, "satsuma.config.yaml");
+  });
+});
+
+// ── Defaults: a workspace with no config behaves as if fully permissive ─────
+
+describe("default configuration", () => {
+  it("suppresses nothing, aliases nothing, and leaves strict mode off", () => {
+    // These defaults are what a workspace without a config file gets. Any
+    // change here silently alters behaviour for every existing workspace.
+    assert.deepEqual(DEFAULT_SATSUMA_CONFIG.lint.suppress, []);
+    assert.deepEqual(DEFAULT_SATSUMA_CONFIG.lint.typeAliases, []);
+    assert.equal(DEFAULT_SATSUMA_CONFIG.lint.strict, false);
+  });
+
+  it("treats an empty document as the default config rather than an error", () => {
+    // A file someone created but has not filled in yet is not a broken file.
+    const result = parseSatsumaConfig("", { knownRuleIds: KNOWN_RULES });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.config, DEFAULT_SATSUMA_CONFIG);
+  });
+
+  it("fills in the sections the author omitted", () => {
+    // Partial configs are the common case: setting `strict` must not blank out
+    // the suppress/typeAliases defaults.
+    const result = parseSatsumaConfig("lint:\n  strict: true\n", { knownRuleIds: KNOWN_RULES });
+    assert.equal(result.ok, true);
+    assert.equal(result.config.lint.strict, true);
+    assert.deepEqual(result.config.lint.suppress, []);
+    assert.deepEqual(result.config.lint.typeAliases, []);
+  });
+});
+
+// ── lint.suppress ──────────────────────────────────────────────────────────
+
+describe("lint.suppress", () => {
+  it("parses a list of rule ids to suppress workspace-wide", () => {
+    const result = parseSatsumaConfig("lint:\n  suppress:\n    - unresolved-nl-ref\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.config.lint.suppress, ["unresolved-nl-ref"]);
+  });
+
+  it("rejects an unknown rule id so a typo cannot silently disable nothing", () => {
+    // The failure mode this prevents: `supress: [unresolvd-nl-ref]` looks like
+    // it works, changes nothing, and the author believes the rule is off.
+    const result = parseSatsumaConfig("lint:\n  suppress:\n    - unresolvd-nl-ref\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /unresolvd-nl-ref/);
+  });
+
+  it("names the valid rule ids when reporting an unknown one", () => {
+    // An error that says only "unknown rule" forces the author to go hunting.
+    const result = parseSatsumaConfig("lint:\n  suppress:\n    - nope\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /hidden-source-in-nl/);
+  });
+
+  it("accepts any rule id when the caller supplies no registry to check against", () => {
+    // The LSP may parse a config before its rule set is known. Validation is
+    // opt-in so an unvalidated parse cannot reject a config the CLI accepts.
+    const result = parseSatsumaConfig("lint:\n  suppress:\n    - anything-at-all\n");
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.config.lint.suppress, ["anything-at-all"]);
+  });
+
+  it("rejects a bare string where a list of rule ids is required", () => {
+    // YAML makes `suppress: unresolved-nl-ref` easy to write; silently
+    // iterating its characters would suppress nothing and report nothing.
+    const result = parseSatsumaConfig("lint:\n  suppress: unresolved-nl-ref\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /lint\.suppress/);
+  });
+});
+
+// ── lint.typeAliases ───────────────────────────────────────────────────────
+
+describe("lint.typeAliases", () => {
+  it("parses alias groups as groups, preserving which types are equivalent to which", () => {
+    // Flattening the groups into one set would make STRING equivalent to INT
+    // as soon as a workspace declares both groups.
+    const yaml = [
+      "lint:",
+      "  typeAliases:",
+      "    - [STRING, TEXT, VARCHAR]",
+      "    - [INT, INTEGER]",
+    ].join("\n");
+    const result = parseSatsumaConfig(yaml, { knownRuleIds: KNOWN_RULES });
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.config.lint.typeAliases, [
+      ["STRING", "TEXT", "VARCHAR"],
+      ["INT", "INTEGER"],
+    ]);
+  });
+
+  it("rejects a group with fewer than two members as a no-op the author did not intend", () => {
+    // A one-member group declares nothing equivalent to anything. Accepting it
+    // silently would hide an unfinished edit.
+    const result = parseSatsumaConfig("lint:\n  typeAliases:\n    - [STRING]\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /at least two/i);
+  });
+
+  it("rejects a non-string alias member rather than coercing it", () => {
+    // `- [1, INT]` — YAML types the 1 as a number; coercing it would make the
+    // config's meaning depend on quoting.
+    const result = parseSatsumaConfig("lint:\n  typeAliases:\n    - [1, INT]\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /lint\.typeAliases/);
+  });
+});
+
+// ── lint.strict ────────────────────────────────────────────────────────────
+
+describe("lint.strict", () => {
+  it("rejects a non-boolean strict flag rather than treating it as truthy", () => {
+    // `strict: "no"` is a non-empty string. Truthiness would turn an explicit
+    // "off" into "on" — the opposite of what the author wrote.
+    const result = parseSatsumaConfig('lint:\n  strict: "no"\n', { knownRuleIds: KNOWN_RULES });
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /lint\.strict/);
+  });
+});
+
+// ── Malformed and unrecognised input ───────────────────────────────────────
+
+describe("malformed configuration", () => {
+  it("reports a YAML syntax error with its location instead of throwing", () => {
+    // Consumers map errors to their own exit code, so the parser must return
+    // them rather than throw a YAMLParseError through the call stack.
+    const result = parseSatsumaConfig("lint:\n  suppress: [unclosed\n");
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.length > 0);
+  });
+
+  it("rejects a document whose root is not a mapping", () => {
+    // A list or scalar at the root means the author has the shape wrong; every
+    // key lookup below would silently miss.
+    const result = parseSatsumaConfig("- lint\n");
+    assert.equal(result.ok, false);
+    assert.match(result.errors.join("\n"), /mapping/i);
+  });
+
+  it("warns about an unknown top-level key without rejecting the config", () => {
+    // Forward compatibility: a config written for a newer CLI should still run,
+    // but a misspelled section must not pass unnoticed.
+    const result = parseSatsumaConfig("lnit:\n  strict: true\n", { knownRuleIds: KNOWN_RULES });
+    assert.equal(result.ok, true);
+    assert.match(result.warnings.join("\n"), /lnit/);
+  });
+
+  it("warns about an unknown key inside the lint section", () => {
+    // Same reasoning one level down: `lint.supress` is the likeliest typo of
+    // all and must not be silently ignored.
+    const result = parseSatsumaConfig("lint:\n  supress:\n    - unresolved-nl-ref\n", {
+      knownRuleIds: KNOWN_RULES,
+    });
+    assert.equal(result.ok, true);
+    assert.match(result.warnings.join("\n"), /supress/);
+  });
+});
+
+// ── Rule-id validation shared with the CLI's --ignore/--select flags ───────
+
+describe("unknownRuleIds", () => {
+  it("returns the ids not present in the registry, preserving the author's spelling", () => {
+    // The caller echoes these back in its message, so the original spelling is
+    // what the author needs to see.
+    assert.deepEqual(unknownRuleIds(["unresolved-nl-ref", "Nope"], KNOWN_RULES), ["Nope"]);
+  });
+
+  it("treats rule ids as case-sensitive", () => {
+    // Rule ids are lowercase-kebab identifiers, not prose. Accepting
+    // `Unresolved-NL-Ref` would make the config's vocabulary ambiguous.
+    assert.deepEqual(unknownRuleIds(["UNRESOLVED-NL-REF"], KNOWN_RULES), ["UNRESOLVED-NL-REF"]);
+  });
+});
+
+// ── Suppression precedence (PRD 37 R4) ─────────────────────────────────────
+
+describe("resolveSuppressedRuleIds", () => {
+  it("suppresses the union of --ignore and lint.suppress", () => {
+    // The stated rule: config suppression is the persistent form of --ignore,
+    // so both apply together rather than one replacing the other.
+    const suppressed = resolveSuppressedRuleIds({
+      ignore: ["hidden-source-in-nl"],
+      configSuppress: ["unresolved-nl-ref"],
+    });
+    assert.deepEqual([...suppressed].sort(), ["hidden-source-in-nl", "unresolved-nl-ref"]);
+  });
+
+  it("runs a config-suppressed rule when --select names it explicitly", () => {
+    // Naming a rule on the command line is an unambiguous instruction to run
+    // it; the persistent config must not override a direct request.
+    const suppressed = resolveSuppressedRuleIds({
+      select: ["unresolved-nl-ref"],
+      configSuppress: ["unresolved-nl-ref"],
+    });
+    assert.deepEqual([...suppressed], []);
+  });
+
+  it("keeps --ignore winning over --select when both name the same rule", () => {
+    // Pre-existing flag behaviour (runLint applies select then ignore). Config
+    // precedence must not quietly change how two flags interact.
+    const suppressed = resolveSuppressedRuleIds({
+      select: ["unresolved-nl-ref"],
+      ignore: ["unresolved-nl-ref"],
+      configSuppress: [],
+    });
+    assert.deepEqual([...suppressed], ["unresolved-nl-ref"]);
+  });
+
+  it("still suppresses config-suppressed rules that --select does not name", () => {
+    // --select rescues only the rules it names, not every suppressed rule.
+    const suppressed = resolveSuppressedRuleIds({
+      select: ["hidden-source-in-nl"],
+      configSuppress: ["unresolved-nl-ref"],
+    });
+    assert.deepEqual([...suppressed], ["unresolved-nl-ref"]);
+  });
+});

--- a/tooling/satsuma-lsp/package-lock.json
+++ b/tooling/satsuma-lsp/package-lock.json
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -30,6 +30,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/satsuma-viz-model/package-lock.json
+++ b/tooling/satsuma-viz-model/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -34,6 +34,7 @@
       "devDependencies": {
         "@types/node": "^26.1.2",
         "c8": "^12.0.0",
+        "fast-check": "^4.9.0",
         "typescript": "^6.0.3"
       }
     },


### PR DESCRIPTION
Implements PRD 37 R4 — the workspace config file that unblocks the rest of Feature 37 (`sl-1u6r` strict-mode exit codes, `sl-j30s` type-mismatch rule, `sl-hysg` lineage-cycle rule).

## What this adds

`satsuma lint` now reads an optional `./satsuma.config.yaml`, overridable with `--config <path>`:

```yaml
lint:
  suppress: [unresolved-nl-ref]     # persistent form of --ignore
  typeAliases: [[STRING, TEXT]]     # declared types to treat as equivalent
  strict: false                     # escalate warnings to a failing exit code
```

A missing config file is normal and yields defaults. A missing `--config` target is an error — the user named that file, and linting with different rules while reporting success is the failure the config exists to prevent.

## Two departures from the ticket text

**1. The loader is split; only the semantics live in core.** The ticket said "loader and config types live in `@satsuma/core`". Core imports no Node built-ins and `satsuma-viz` bundles it for the browser, so `readFileSync` cannot live there. Core owns the shape, validation, and precedence rule; `satsuma-cli/src/load-config.ts` owns path resolution and reading. The LSP will reuse the core half unchanged when it mirrors these diagnostics.

The `yaml` dependency is reachable only through the `@satsuma/core/config` subpath and is deliberately *not* re-exported from `index.ts` — verified as zero occurrences of `yaml` in the built `satsuma-viz` browser bundle.

**2. Rule-id validation had to be created, not reused.** The ticket asked that a typo in `lint.suppress` be "reported the way a typo in `--ignore` is". `--ignore` accepted unknown rule ids in silence, so there was nothing to reuse — both paths now share one validator in core.

⚠️ **User-visible change to existing flags:** a misspelled `--select`/`--ignore` value previously filtered nothing and exited 0. It now fails with the valid rule ids listed. This seemed clearly better than the alternative reading (make config typos silent too), but it is a behaviour change on flags that shipped, so worth a look.

## Exit code 3

An unusable config exits `3` — lint's command-scoped "could not run", distinct from `2` ("the workspace has lint errors") so CI can tell a broken setup from a failing gate. Numerically the same as `coverage --fail-under`'s code but a different, command-scoped meaning; they cannot collide in one invocation. `sl-1u6r` extends this into lint's full published table.

## Inert settings warn rather than pass silently

`lint.strict` and `lint.typeAliases` validate now (the shape is part of the contract the LSP and CI write against) but their consumers ship separately. Setting either prints a warning naming the ticket, so a config cannot read as an active gate when nothing enforces it.

## Testing

- `satsuma-core`: 630 tests pass (22 new — config semantics, precedence, malformed input)
- `satsuma-cli`: 1016 tests pass (13 new — lookup paths, exit codes, end-to-end through `lint`)
- `scripts/run-repo-checks.sh`: all checks pass
- `npm audit`: 0 vulnerabilities after adding `yaml@^2.9.0`

## Note for review

Worth deciding whether the core-owns-semantics / consumer-owns-filesystem split deserves an ADR — it is a reusable pattern for anything else that wants config, and it contradicts the ticket's stated design. Happy to draft one if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)