### PR TITLE
Make FieldDecl variants explicit

### DIFF
--- a/.tickets/cbdr-hqhh.md
+++ b/.tickets/cbdr-hqhh.md
@@ -1,0 +1,30 @@
+---
+id: cbdr-hqhh
+status: closed
+deps: []
+links: []
+created: 2026-08-03T17:07:55Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: gcsc-qka8
+tags: [feature-39, r8, core, cli, lsp, viz-backend]
+---
+# core: model FieldDecl as structural variants and migrate consumers
+
+Implement Feature 39 R8 as one atomic public-model migration. Replace the optional FieldDecl property bag with explicit scalar, record, scalar-list, and record-list variants in satsuma-core; update extraction, shared helpers, CLI, LSP, and viz-backend consumers; and preserve the existing runtime and JSON field shape.
+
+## Design
+
+Keep the existing serialized properties as the compatibility boundary: no new enumerable discriminator and no protocol-shape change. Express valid shapes through named exported variants and shared base/location fields; record-bearing variants own children and spread state, list variants make list element shape explicit. Add a core assertNever helper for intentionally exhaustive domain handling. Consolidate union invariant tests in core and leave consumer tests at rendering or protocol boundaries. Coordinate with the separate R7 lint rollout instead of absorbing its package-wide configuration changes.
+
+## Acceptance Criteria
+
+Core exports documented ScalarFieldDecl, RecordFieldDecl, ScalarListFieldDecl, RecordListFieldDecl, and FieldDecl union contracts plus assertNever; scalar fields cannot carry children or spread state and record-list fields require children in compile-only tests; extractFieldTree returns all four variants while preserving existing enumerable runtime and JSON properties; shared spread, validation, NL-ref, and field utilities narrow safely; CLI, LSP, and viz-backend compile and retain their existing output/protocol behavior; core owns the structural invariant tests and consumers do not duplicate them; CHANGELOG Unreleased calls out the stricter TypeScript source contract; relevant package tests, typechecks, lint, and repository checks pass.
+
+## Notes
+
+**2026-08-03T18:17:58Z**
+
+Cause: `FieldDecl` represented four grammar-defined shapes as one optional-property bag, so TypeScript admitted scalar children and spreads, bodyless record lists, and inconsistent consumer inference.
+Fix: Introduced JSON-compatible structural variants, a branded scalar type, shared normalization and classification, and exhaustive handling; migrated extraction and all consumers; added compile/runtime coverage, ADR-045, and release documentation. (commit immediately after b97ecec9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### `FieldDecl` now rejects impossible field shapes (`cbdr-hqhh`)
+
+**This is a TypeScript source-contract change for consumers of `@satsuma/core`;
+runtime objects and JSON output keep their existing properties.** `FieldDecl` is
+now a union of scalar, record, scalar-list, and record-list variants. A scalar
+cannot carry `children` or fragment-spread state, and a record list must carry
+its record body, even when that body is empty.
+
+Code constructing scalar declarations should pass dynamic type strings through
+`createScalarTypeExpression`. LSP- or visualization-style type strings such as
+`list_of STRING` can use `fieldDeclFromRenderedType`, which normalizes the
+rendered spelling into core's existing `{ type: "STRING", isList: true }` shape.
+Use `classifyFieldDecl` with `assertNever` when handling every variant
+exhaustively. No Satsuma syntax, CLI JSON field, LSP payload, or VizModel field
+has changed.
+
 ## v0.12.0 — 2026-08-03
 
 ### Nested lineage keeps its target namespace (`nfl-8o6u`)

--- a/adrs/adr-045-field-decl-structural-variants.md
+++ b/adrs/adr-045-field-decl-structural-variants.md
@@ -1,0 +1,81 @@
+# ADR-045 — FieldDecl Uses JSON-Compatible Structural Variants
+
+**Status:** Accepted
+**Date:** 2026-08-03 (cbdr-hqhh, feature 39 R8)
+
+## Context
+
+`FieldDecl` is the shared representation of a schema or fragment field after
+tree-sitter extraction. It crosses every internal tooling boundary: core emits
+it, the CLI and LSP index it, viz-backend adapts it, and coverage and spread
+expansion recurse through it. The grammar permits four shapes — scalar, record,
+scalar list, and record list — but `tooling/satsuma-core/src/types.ts` represented
+all four as one interface whose `children`, `isList`, `hasSpreads`, and `spreads`
+properties were optional.
+
+That optional-property bag admitted states the grammar cannot produce. A scalar
+could carry record children or spreads, and `list_of record` could omit its
+children. Consumer code then inferred the intended shape independently from a
+mixture of `type`, `isList`, and `children`, so TypeScript could neither reject
+an invalid construction nor prove a four-way branch exhaustive. The weakness was
+at the core boundary described by ADR-020: downstream consumers shared the type,
+but not an enforceable definition of its valid states.
+
+Three representations were considered. Keeping one interface and adding
+documentation would preserve the invalid states. Adding a required `kind`
+discriminator would create a conventional discriminated union, but it would also
+change the runtime objects and every JSON, LSP, and VizModel payload that carries
+their existing shape. A structural union over the existing properties preserves
+those payloads while making the grammar's four variants explicit, at the cost of
+requiring a classifier where code needs a transient discriminator.
+
+## Decision
+
+`FieldDecl` is a union of `ScalarFieldDecl`, `RecordFieldDecl`,
+`ScalarListFieldDecl`, and `RecordListFieldDecl`. Record-bearing variants use
+`type: "record"` and require `children`; list variants require `isList: true`;
+scalar variants prohibit `children`, `hasSpreads`, and `spreads` with `never`.
+`ScalarTypeExpression` is a runtime-erased branded string constructed through
+`createScalarTypeExpression`, which prevents the reserved `record` keyword from
+being used to manufacture a scalar variant without changing its serialized
+value.
+
+The union deliberately adds no serialized discriminator. Existing `type`,
+`isList`, and `children` properties remain the runtime contract.
+`classifyFieldDecl()` in `tooling/satsuma-core/src/field-decl.ts` converts the
+structural union into a transient discriminated wrapper when a consumer needs an
+exhaustive four-way switch, and shared helpers in that module own normalization
+to and from rendered type strings. Exhaustive switches terminate through core's
+`assertNever()` helper.
+
+Core extraction constructs only the four public variants. Values entering from
+consumer or protocol models pass through `fieldDeclFromRenderedType()` instead
+of duplicating shape inference. Compile-only tests prove illegal constructions
+are rejected, and runtime tests prove exact JSON output is unchanged. This
+extends ADR-020's core-as-single-truth boundary; it does not alter the authored
+form or reference-stage decisions in ADR-039 and ADR-044.
+
+## Consequences
+
+**Positive:**
+
+- Invalid combinations of scalar, record, list, child, and spread state fail at
+  compile time rather than reaching coverage or workspace indexing.
+- Consumers share one normalization and classification rule in core, so adding
+  or changing a field variant has one implementation boundary.
+- Existing CLI JSON, LSP data, and VizModel payloads remain byte-compatible
+  because the safety contract is erased at runtime.
+- Exhaustive four-way handling is explicit and testable without storing a
+  discriminator in every field object.
+
+**Negative:**
+
+- Boundary adapters must call core constructors and normalizers instead of
+  assigning arbitrary strings directly to `FieldDecl.type`.
+- Structural narrowing is less direct than switching on a stored `kind`, so
+  exhaustive consumers need the transient `classifyFieldDecl()` wrapper.
+- `ScalarTypeExpression` and the union are TypeScript guarantees only; JavaScript
+  callers and deliberately unsafe assertions can bypass them.
+- Adding a fifth grammar-level field shape requires coordinated updates to the
+  union, classifier, normalization helpers, and compile-only exhaustiveness
+  tests.

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Satsuma Tooling Architecture
 
-> Last updated: 2026-08-03 — documented opaque reference stages at coverage boundaries (ADR-044).
+> Last updated: 2026-08-03 — documented `FieldDecl` structural variants (ADR-045).
 
 This document is the canonical architecture reference for the Satsuma language tooling — the packages under `tooling/` that parse, analyse, format, validate, visualize, and provide IDE support for `.stm` files. The design is influenced by [rust-analyzer's architecture](https://rust-analyzer.github.io/book/contributing/architecture.html), adapted for a tree-sitter-backed DSL rather than a full programming language compiler.
 
@@ -132,6 +132,8 @@ flowchart TD
 graph LR
   IDX["index.ts\n(re-exports all)"]
   TYPES["types.ts\nSyntaxNode · Tree · FieldDecl\nExtracted* · NLRefData · AtRef\nMappingContext · Resolution · …"]
+  FD["field-decl.ts\nvariant construction · classification\nrendered-type normalization"]
+  NEVER["assert-never.ts\nexhaustive-switch backstop"]
   GENCST["generated/cst-types.ts\nSatsumaNamedKind · SatsumaAnonymousToken\nSatsumaGrammarSymbol · SatsumaCstType"]
   CST["cst-utils.ts\nchild · children\nallDescendants\nlabelText · stringText"]
   CLS["classify.ts\nclassifyTransform\nclassifyArrow"]
@@ -148,8 +150,9 @@ graph LR
   COV["coverage.ts · coverage-paths.ts\nFieldCoverageEntry\nSchemaCoverageResult\nbuildCoveredFieldPaths()\nschemaLocalFieldPath()"]
   VAL["validate.ts\nSemanticIndex · SemanticDiagnostic\ncollectSemanticDiagnostics()"]
 
-  IDX --> TYPES & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & REF & PAR & PE & COV & VAL
-  EXT --> CST & CLS & CAN & META & TYPES
+  IDX --> TYPES & FD & NEVER & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & REF & PAR & PE & COV & VAL
+  FD --> TYPES
+  EXT --> CST & CLS & CAN & META & FD & TYPES
   SPR --> EXT & TYPES
   NL --> SPR & TYPES
   COV --> REF
@@ -163,7 +166,7 @@ graph LR
 | `SyntaxNode` | `types.ts` | Abstract CST node interface (structurally matches web-tree-sitter `Node`) |
 | `Tree` | `types.ts` | Parsed tree with `rootNode: SyntaxNode` |
 | `SatsumaCstType` | `generated/cst-types.ts` | Generated union of named CST kinds, anonymous grammar tokens, and tree-sitter's synthetic `ERROR` recovery type |
-| `FieldDecl` | `types.ts` | Recursive field: `{ name, type, isList?, children?, spreads?, metadata? }` |
+| `FieldDecl` | `types.ts` | JSON-compatible union of scalar, record, scalar-list, and record-list fields; only record-bearing variants expose `children` and spread state |
 | `ExtractedSchema` | `types.ts` | Schema block: name, namespace, fields, spreads, metadata |
 | `ExtractedMapping` | `types.ts` | Mapping block: sourceRefs, targetRef, arrows |
 | `ExtractedArrow` | `types.ts` | Arrow: sourceFields, targetField, transform steps, classification |
@@ -311,7 +314,12 @@ schema orders {
 }
 ```
 
-**Rule:** Any code that works with fields must recurse through `FieldDecl.children`. Use `satsuma-core`'s public `extractFieldTree()` to get the full recursive tree. Use `collectFieldPaths()` from `spread-expand.ts` to flatten to dotted paths (e.g. `line_items.product_id`).
+**Rule:** Any code that works with record-bearing fields must recurse through
+`FieldDecl.children`. The property exists only on the record and record-list
+variants; use `classifyFieldDecl()` when a consumer intentionally handles all
+four variants. Use `satsuma-core`'s public `extractFieldTree()` to get the full
+recursive tree. Use `collectFieldPaths()` from `spread-expand.ts` to flatten to
+dotted paths (e.g. `line_items.product_id`).
 
 The `fieldLocations` LSP handler was historically flat (only top-level fields). This was fixed in Feature 26 (ticket sl-ysy4) by routing through `extractFieldTree()`.
 

--- a/features/39-correctness-by-default/PRD.md
+++ b/features/39-correctness-by-default/PRD.md
@@ -437,8 +437,8 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 through R6 now have concrete tickets; later rows
-remain the agreed ticket shape and will receive IDs when scheduled.
+Feature epic: `gcsc-qka8`. R1 through R6 and R8 now have concrete tickets; the
+remaining rows retain the agreed ticket shape until scheduled.
 
 | Work | Ticket shape | Depends on |
 |---|---|---|
@@ -455,7 +455,7 @@ remain the agreed ticket shape and will receive IDs when scheduled.
 | R5 coverage and consumer migration (`cbdr-5r4d`) | 1 task | `cbdr-e6ft` |
 | R6 CLI test typecheck gate (`cbdr-xgy5`) | 1 task | — |
 | R7 type-aware lint rollout | 1 task per package | R2 for CST-specific rules |
-| R8 `FieldDecl` variants and consumer migration | 1 task | schedule clear of active consumer-model work |
+| R8 `FieldDecl` variants and consumer migration (`cbdr-hqhh`) | 1 task | schedule clear of active consumer-model work |
 | I1 bounded consistency model | optional spike | Feature 38 epic closed |
 | I2 compositional semantics proposal | optional spike | Feature 38 epic closed |
 

--- a/tooling/satsuma-cli/src/commands/fields.ts
+++ b/tooling/satsuma-cli/src/commands/fields.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Command } from "commander";
+import { assertNever, classifyFieldDecl } from "@satsuma/core";
 import { loadWorkspace } from "../load-workspace.js";
 import { runCommand, CommandError, EXIT_NOT_FOUND } from "../command-runner.js";
 import { resolveIndexKey } from "../index-builder.js";
@@ -25,9 +26,9 @@ import type {
   MetricRecord,
 } from "../types.js";
 
-interface FieldWithTags extends FieldDecl {
+type FieldWithTags = FieldDecl & {
   tags?: string[];
-}
+};
 
 export function register(program: Command): void {
   program
@@ -169,11 +170,9 @@ Examples:
 }
 
 function deepCopyFields(fields: FieldDecl[]): FieldWithTags[] {
-  return fields.map((f) => {
-    const copy: FieldWithTags = { ...f };
-    if (f.children) copy.children = deepCopyFields(f.children);
-    return copy;
-  });
+  return fields.map((field) =>
+    field.children ? { ...field, children: deepCopyFields(field.children) } : { ...field },
+  );
 }
 
 /**
@@ -252,9 +251,18 @@ function printFieldTree(
 ): void {
   const maxName = Math.max(...fields.map((f) => f.name.length), 4);
   const displayType = (f: FieldWithTags): string => {
-    if (!f.isList) return f.type;
-    const inner = f.children && f.children.length > 0 ? "record" : f.type;
-    return `list_of ${inner}`;
+    const classified = classifyFieldDecl(f);
+    switch (classified.kind) {
+      case "scalar":
+      case "record":
+        return classified.field.type;
+      case "scalar-list":
+        return classified.field.type ? `list_of ${classified.field.type}` : "list_of";
+      case "record-list":
+        return "list_of record";
+      default:
+        return assertNever(classified, "Unhandled FieldDecl variant");
+    }
   };
   const maxType = Math.max(...fields.map((f) => displayType(f).length), 4);
   const pad = "  ".repeat(indent);

--- a/tooling/satsuma-cli/src/index-builder.ts
+++ b/tooling/satsuma-cli/src/index-builder.ts
@@ -54,9 +54,10 @@ function mergeFields(existing: FieldDecl[], incoming: FieldDecl[]): void {
     if (!prev) {
       existing.push(f);
       byName.set(f.name, f);
-    } else if (f.children?.length) {
-      // Recursively merge children when both sides are records
-      if (!prev.children) prev.children = [];
+    } else if (f.children?.length && prev.children) {
+      // Schema declarations split across files merge only like-shaped record
+      // bodies. A scalar declaration cannot be mutated into an invalid record
+      // variant; duplicate validation reports that conflicting declaration.
       mergeFields(prev.children, f.children);
     }
   }

--- a/tooling/satsuma-cli/test/field-positions.test.ts
+++ b/tooling/satsuma-cli/test/field-positions.test.ts
@@ -14,7 +14,7 @@ import { describe, it } from "node:test";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import "./setup.js";
-import { extractSchemas, extractFragments } from "@satsuma/core";
+import { extractSchemas, extractFragments, fieldDeclFromRenderedType } from "@satsuma/core";
 import { parseSource } from "../dist/parser.js";
 import { buildIndex } from "../dist/index-builder.js";
 import { expandEntityFields, expandNestedSpreads } from "../dist/spread-expand.js";
@@ -46,7 +46,11 @@ describe("fieldDeclarationRow()", () => {
   it("reports a schema's own field at its extracted declaration row", () => {
     // The common case: core's extractFieldTree always sets startRow, and it is
     // a row in the same file the command reports, so it passes straight through.
-    const field: ExpandedField = { name: "id", type: "INT", startRow: 12 };
+    const field: ExpandedField = fieldDeclFromRenderedType({
+      name: "id",
+      type: "INT",
+      startRow: 12,
+    });
     assert.equal(fieldDeclarationRow(field, CONSUMER, false), 12);
   });
 
@@ -55,9 +59,7 @@ describe("fieldDeclarationRow()", () => {
     // the consuming schema's file would send a jump link into the wrong file at
     // a plausible-looking line, so the consuming entity's row wins.
     const field: ExpandedField = {
-      name: "email",
-      type: "STRING",
-      startRow: 3,
+      ...fieldDeclFromRenderedType({ name: "email", type: "STRING", startRow: 3 }),
       fromFragment: "contact",
     };
     assert.equal(fieldDeclarationRow(field, CONSUMER, false), CONSUMER.row);
@@ -67,14 +69,21 @@ describe("fieldDeclarationRow()", () => {
     // Only the field copied directly out of the fragment carries fromFragment;
     // its children do not. Without inherited provenance a nested child of a
     // spread record would silently fall back to the fragment's row.
-    const child: ExpandedField = { name: "city", type: "STRING", startRow: 4 };
+    const child: ExpandedField = fieldDeclFromRenderedType({
+      name: "city",
+      type: "STRING",
+      startRow: 4,
+    });
     assert.equal(fieldDeclarationRow(child, CONSUMER, true), CONSUMER.row);
   });
 
   it("returns undefined when the field carries no position at all", () => {
     // Absence must propagate as absence. Substituting 0 would read as line 1
     // and point a reader at the top of the file (sl-5sjp).
-    assert.equal(fieldDeclarationRow({ name: "id", type: "INT" }, CONSUMER, false), undefined);
+    assert.equal(
+      fieldDeclarationRow(fieldDeclFromRenderedType({ name: "id", type: "INT" }), CONSUMER, false),
+      undefined,
+    );
   });
 });
 

--- a/tooling/satsuma-cli/test/normalize.test.ts
+++ b/tooling/satsuma-cli/test/normalize.test.ts
@@ -8,13 +8,20 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { fieldDeclFromRenderedType } from "@satsuma/core";
+import type { FieldDecl } from "@satsuma/core";
 import { matchFields } from "#src/normalize.js";
+
+/** Build strict core fixtures while these tests stay focused on CLI matching. */
+function field(name: string, type: string, children?: FieldDecl[]): FieldDecl {
+  return fieldDeclFromRenderedType({ name, type, ...(children ? { children } : {}) });
+}
 
 describe("matchFields", () => {
   it("matches fields by normalized name", () => {
     // Verifies the full matching pipeline: normalization + lookup + result shape.
-    const src = [{ name: "FirstName", type: "VARCHAR" }];
-    const tgt = [{ name: "first_name", type: "VARCHAR" }];
+    const src = [field("FirstName", "VARCHAR")];
+    const tgt = [field("first_name", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.equal(result.matched.length, 1);
     assert.equal(result.matched[0].source, "FirstName");
@@ -24,14 +31,8 @@ describe("matchFields", () => {
 
   it("returns source-only and target-only correctly", () => {
     // Ensures unmatched fields on each side are correctly categorised.
-    const src = [
-      { name: "id", type: "INT" },
-      { name: "email", type: "VARCHAR" },
-    ];
-    const tgt = [
-      { name: "email", type: "VARCHAR" },
-      { name: "phone", type: "VARCHAR" },
-    ];
+    const src = [field("id", "INT"), field("email", "VARCHAR")];
+    const tgt = [field("email", "VARCHAR"), field("phone", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.equal(result.matched.length, 1);
     assert.deepEqual(result.sourceOnly, ["id"]);
@@ -47,14 +48,8 @@ describe("matchFields", () => {
 
   it("flattens nested fields into dotted paths for matching", () => {
     // Nested source "address.city" should match flat target "city" by leaf name.
-    const src = [
-      {
-        name: "address",
-        type: "record",
-        children: [{ name: "city", type: "VARCHAR" }],
-      },
-    ];
-    const tgt = [{ name: "city", type: "VARCHAR" }];
+    const src = [field("address", "record", [field("city", "VARCHAR")])];
+    const tgt = [field("city", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.ok(
       result.matched.some((m) => m.source === "address.city" && m.target === "city"),
@@ -64,14 +59,8 @@ describe("matchFields", () => {
 
   it("matches cross-level: flat source matches nested target by leaf name", () => {
     // Flat source "city" should match nested target "address.city" by leaf.
-    const src = [{ name: "city", type: "VARCHAR" }];
-    const tgt = [
-      {
-        name: "address",
-        type: "record",
-        children: [{ name: "city", type: "VARCHAR" }],
-      },
-    ];
+    const src = [field("city", "VARCHAR")];
+    const tgt = [field("address", "record", [field("city", "VARCHAR")])];
     const result = matchFields(src, tgt);
     assert.ok(
       result.matched.some((m) => m.source === "city"),
@@ -82,11 +71,8 @@ describe("matchFields", () => {
   it("uses first-wins when two target fields normalize identically", () => {
     // Both "first_name" and "firstName" normalize to "firstname".
     // The first one in the target list should win.
-    const src = [{ name: "FIRST_NAME", type: "VARCHAR" }];
-    const tgt = [
-      { name: "first_name", type: "VARCHAR" },
-      { name: "firstName", type: "VARCHAR" },
-    ];
+    const src = [field("FIRST_NAME", "VARCHAR")];
+    const tgt = [field("first_name", "VARCHAR"), field("firstName", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.equal(result.matched.length, 1);
     assert.equal(result.matched[0].target, "first_name", "first occurrence wins");
@@ -95,19 +81,9 @@ describe("matchFields", () => {
   it("deeply nested fields are flattened correctly", () => {
     // Two levels of nesting: address.billing.zip
     const src = [
-      {
-        name: "address",
-        type: "record",
-        children: [
-          {
-            name: "billing",
-            type: "record",
-            children: [{ name: "zip", type: "VARCHAR" }],
-          },
-        ],
-      },
+      field("address", "record", [field("billing", "record", [field("zip", "VARCHAR")])]),
     ];
-    const tgt = [{ name: "zip", type: "VARCHAR" }];
+    const tgt = [field("zip", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.ok(
       result.matched.some((m) => m.source === "address.billing.zip"),
@@ -117,17 +93,8 @@ describe("matchFields", () => {
 
   it("parent record names appear as both container and matchable fields", () => {
     // "address" itself is a field, plus its child "city" is also a field.
-    const src = [
-      {
-        name: "address",
-        type: "record",
-        children: [{ name: "city", type: "VARCHAR" }],
-      },
-    ];
-    const tgt = [
-      { name: "address", type: "record" },
-      { name: "city", type: "VARCHAR" },
-    ];
+    const src = [field("address", "record", [field("city", "VARCHAR")])];
+    const tgt = [field("address", "record", []), field("city", "VARCHAR")];
     const result = matchFields(src, tgt);
     assert.ok(
       result.matched.some((m) => m.source === "address" && m.target === "address"),

--- a/tooling/satsuma-core/src/assert-never.ts
+++ b/tooling/satsuma-core/src/assert-never.ts
@@ -1,0 +1,11 @@
+/**
+ * assert-never.ts — Exhaustiveness guard for discriminated domain unions.
+ *
+ * Consumers use this at intentionally exhaustive switches so adding a variant
+ * becomes a compile-time error and an invalid boundary value still fails loud.
+ */
+
+/** Throw for a value that a complete TypeScript narrowing should make impossible. */
+export function assertNever(value: never, context = "Unexpected value"): never {
+  throw new TypeError(`${context}: ${String(value)}`);
+}

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -8,6 +8,7 @@
 
 import { canonicalRef } from "./canonical-ref.js";
 import { classifyTransform, classifyArrow } from "./classify.js";
+import { createScalarTypeExpression } from "./field-decl.js";
 import { extractMetadata } from "./meta-extract.js";
 import {
   child,
@@ -20,7 +21,17 @@ import {
   sourceRefStructuralText,
   isPresent,
 } from "./cst-utils.js";
-import type { Classification, FieldDecl, MetaEntry, PipeStep, SyntaxNode } from "./types.js";
+import type {
+  Classification,
+  FieldDecl,
+  MetaEntry,
+  PipeStep,
+  RecordFieldDecl,
+  RecordListFieldDecl,
+  ScalarFieldDecl,
+  ScalarListFieldDecl,
+  SyntaxNode,
+} from "./types.js";
 import type { SatsumaCstType, SatsumaGrammarSymbol } from "./generated/cst-types.js";
 
 // ── Internal field tree ────────────────────────────────────────────────────
@@ -57,9 +68,9 @@ function extractDirectFields(bodyNode: SyntaxNode): FieldDecl[] {
     let name = inner?.text ?? "";
     if (inner?.type === "backtick_name") name = name.slice(1, -1);
     const meta = extractMetadata(child(fd, "metadata_block"));
-    const decl: FieldDecl = {
+    const decl: ScalarFieldDecl = {
       name,
-      type: typeNode?.text ?? "",
+      type: createScalarTypeExpression(typeNode?.text ?? ""),
       startRow: fd.startPosition.row,
       startColumn: fd.startPosition.column,
     };
@@ -97,14 +108,23 @@ export function extractFieldTree(bodyNode: SyntaxNode): FieldTree {
       if (innerBody) {
         const isList = hasListOfKeyword(c);
         const nested = extractFieldTree(innerBody);
-        const decl: FieldDecl = {
-          name,
-          type: "record",
-          isList,
-          children: nested.fields,
-          startRow: c.startPosition.row,
-          startColumn: c.startPosition.column,
-        };
+        const decl: RecordFieldDecl | RecordListFieldDecl = isList
+          ? {
+              name,
+              type: "record",
+              isList: true,
+              children: nested.fields,
+              startRow: c.startPosition.row,
+              startColumn: c.startPosition.column,
+            }
+          : {
+              name,
+              type: "record",
+              isList: false,
+              children: nested.fields,
+              startRow: c.startPosition.row,
+              startColumn: c.startPosition.column,
+            };
         if (meta.length > 0) decl.metadata = meta;
         if (nested.hasSpreads) {
           decl.hasSpreads = true;
@@ -116,24 +136,32 @@ export function extractFieldTree(bodyNode: SyntaxNode): FieldTree {
         const isList = hasListOfKeyword(c);
         const hasRecordKeyword = c.children?.some((ch) => !ch.isNamed && ch.text === "record");
         if (hasRecordKeyword) {
-          const decl: FieldDecl = {
-            name,
-            type: "record",
-            isList: isList || undefined,
-            children: [],
-            startRow: c.startPosition.row,
-            startColumn: c.startPosition.column,
-          };
+          const decl: RecordFieldDecl | RecordListFieldDecl = isList
+            ? {
+                name,
+                type: "record",
+                isList: true,
+                children: [],
+                startRow: c.startPosition.row,
+                startColumn: c.startPosition.column,
+              }
+            : {
+                name,
+                type: "record",
+                children: [],
+                startRow: c.startPosition.row,
+                startColumn: c.startPosition.column,
+              };
           if (meta.length > 0) decl.metadata = meta;
           fields.push(decl);
         } else {
-          const decl: FieldDecl = {
+          const decl: ScalarFieldDecl | ScalarListFieldDecl = {
             name,
-            type: typeNode?.text ?? "",
+            type: createScalarTypeExpression(typeNode?.text ?? ""),
             startRow: c.startPosition.row,
             startColumn: c.startPosition.column,
+            ...(isList ? { isList: true as const } : {}),
           };
-          if (isList) decl.isList = true;
           if (meta.length > 0) decl.metadata = meta;
           fields.push(decl);
         }

--- a/tooling/satsuma-core/src/field-decl.ts
+++ b/tooling/satsuma-core/src/field-decl.ts
@@ -1,0 +1,119 @@
+/**
+ * field-decl.ts — Construction and classification boundaries for FieldDecl.
+ *
+ * The public union stays JSON-compatible with the historic object shape. This
+ * module supplies the runtime checks and temporary discriminator needed when a
+ * consumer intentionally handles all four structural variants.
+ */
+
+import type {
+  FieldDecl,
+  FieldDeclBase,
+  RecordFieldDecl,
+  RecordListFieldDecl,
+  ScalarFieldDecl,
+  ScalarListFieldDecl,
+  ScalarTypeExpression,
+} from "./types.js";
+
+/** The reserved type keyword that denotes a nested record rather than a scalar. */
+const RECORD_TYPE_KEYWORD = "record";
+
+/**
+ * Validate a string crossing into a scalar FieldDecl variant.
+ *
+ * Literal `record` calls fail at compile time, while the runtime guard protects
+ * dynamic strings from JSON, LSP, or other protocol boundaries.
+ */
+export function createScalarTypeExpression<const Type extends string>(
+  type: Type extends typeof RECORD_TYPE_KEYWORD ? never : Type,
+): ScalarTypeExpression {
+  if (type === RECORD_TYPE_KEYWORD) {
+    throw new TypeError("The reserved 'record' keyword is not a scalar type expression");
+  }
+  // The runtime guard above is the sole audited transition from a protocol
+  // string to the branded scalar domain.
+  return type as unknown as ScalarTypeExpression;
+}
+
+/** A transient discriminated view over the JSON-compatible FieldDecl union. */
+export type ClassifiedFieldDecl =
+  | { kind: "scalar"; field: ScalarFieldDecl }
+  | { kind: "record"; field: RecordFieldDecl }
+  | { kind: "scalar-list"; field: ScalarListFieldDecl }
+  | { kind: "record-list"; field: RecordListFieldDecl };
+
+/**
+ * Classify a validated FieldDecl without adding a discriminator to its runtime
+ * or serialized representation.
+ */
+export function classifyFieldDecl(field: FieldDecl): ClassifiedFieldDecl {
+  if (field.children !== undefined) {
+    return field.isList ? { kind: "record-list", field } : { kind: "record", field };
+  }
+  return field.isList ? { kind: "scalar-list", field } : { kind: "scalar", field };
+}
+
+/**
+ * Input accepted when an LSP or visualization model stores `list_of` in the
+ * rendered type string instead of core's separate `isList` property.
+ */
+export interface RenderedFieldDeclInput extends FieldDeclBase {
+  /** Rendered type spelling, including an optional `list_of ` prefix. */
+  type: string | null;
+  /** Recursively normalized children supplied for record-bearing fields. */
+  children?: FieldDecl[];
+  /** Fragment names spread directly into a record body. */
+  spreads?: string[];
+}
+
+/**
+ * Normalize a consumer's rendered field spelling into the strict core union.
+ *
+ * This is the shared protocol boundary for the LSP and viz backend. It rejects
+ * children or spreads attached to a scalar spelling instead of guessing that
+ * malformed consumer data denotes a record.
+ */
+export function fieldDeclFromRenderedType(input: RenderedFieldDeclInput): FieldDecl {
+  const { type: renderedType, children = [], spreads = [], ...base } = input;
+  const type = renderedType ?? "";
+
+  if (type === "record" || type === "list_of record") {
+    const recordState: Omit<RecordFieldDecl, "isList"> = {
+      ...base,
+      type: RECORD_TYPE_KEYWORD,
+      children,
+      ...(spreads.length > 0 ? { hasSpreads: true, spreads } : {}),
+    };
+    return type === "list_of record" ? { ...recordState, isList: true } : recordState;
+  }
+
+  if (children.length > 0 || spreads.length > 0) {
+    throw new TypeError(`Scalar field '${input.name}' cannot carry a record body or spreads`);
+  }
+
+  if (type === "list_of" || type.startsWith("list_of ")) {
+    const elementType = type === "list_of" ? "" : type.slice("list_of ".length);
+    return {
+      ...base,
+      type: createScalarTypeExpression(elementType),
+      isList: true,
+    };
+  }
+
+  return { ...base, type: createScalarTypeExpression(type) };
+}
+
+/** Render core's structural list marker back into the established public spelling. */
+export function renderFieldDeclType(field: FieldDecl): string {
+  const classified = classifyFieldDecl(field);
+  switch (classified.kind) {
+    case "scalar":
+    case "record":
+      return classified.field.type;
+    case "scalar-list":
+      return classified.field.type ? `list_of ${classified.field.type}` : "list_of";
+    case "record-list":
+      return "list_of record";
+  }
+}

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -111,8 +111,22 @@ export type {
   MetaEntryEnum,
   MetaEntryNote,
   MetaEntrySlice,
+  ScalarTypeExpression,
+  FieldDeclBase,
+  ScalarFieldDecl,
+  RecordFieldDecl,
+  ScalarListFieldDecl,
+  RecordListFieldDecl,
   FieldDecl,
 } from "./types.js";
+export {
+  createScalarTypeExpression,
+  classifyFieldDecl,
+  fieldDeclFromRenderedType,
+  renderFieldDeclType,
+} from "./field-decl.js";
+export type { ClassifiedFieldDecl, RenderedFieldDeclInput } from "./field-decl.js";
+export { assertNever } from "./assert-never.js";
 export {
   child,
   children,

--- a/tooling/satsuma-core/src/spread-expand.ts
+++ b/tooling/satsuma-core/src/spread-expand.ts
@@ -41,9 +41,10 @@ export interface SpreadEntity {
   row?: number;
 }
 
-export interface ExpandedField extends FieldDecl {
+export type ExpandedField = FieldDecl & {
+  /** Canonical fragment key that contributed this expanded field. */
   fromFragment?: string;
-}
+};
 
 export interface SpreadDiagnostic {
   file: string;

--- a/tooling/satsuma-core/src/types.ts
+++ b/tooling/satsuma-core/src/types.ts
@@ -96,23 +96,28 @@ export interface MetaEntrySlice {
 
 export type MetaEntry = MetaEntryTag | MetaEntryKV | MetaEntryEnum | MetaEntryNote | MetaEntrySlice;
 
-// ── Extracted record shapes ─────────────────────────────────────────────────
+// ── Extracted field shapes ──────────────────────────────────────────────────
 
-export interface FieldDecl {
+declare const scalarTypeExpressionBrand: unique symbol;
+
+/**
+ * A scalar type expression such as `INT`, `VARCHAR(MAX)`, or the empty string
+ * used for a metadata-only field declaration.
+ *
+ * The brand keeps the reserved `record` keyword out of scalar variants without
+ * changing the string stored at runtime. Construct values through
+ * `createScalarTypeExpression` at parser or protocol boundaries.
+ */
+export type ScalarTypeExpression = string & {
+  readonly [scalarTypeExpressionBrand]: "ScalarTypeExpression";
+};
+
+/** Properties shared by every field declaration variant. */
+export interface FieldDeclBase {
   /** The field name as written in source (backtick quoting stripped). */
   name: string;
-  /** The type expression text (e.g. "INT", "STRING"), or "record" for nested record fields. */
-  type: string;
-  /** Nested field declarations for record-typed fields. */
-  children?: FieldDecl[];
-  /** True when the field is declared with the `list_of` keyword. */
-  isList?: boolean;
   /** Metadata entries from an inline metadata block on this field. */
   metadata?: MetaEntry[];
-  /** True when any child position contains a fragment spread. */
-  hasSpreads?: boolean;
-  /** Names of fragments spread into this field's record body. */
-  spreads?: string[];
   /**
    * 0-indexed row of the field_decl node's start position in the source file.
    * Sourced from `node.startPosition.row` in the CST. Present when the field
@@ -126,3 +131,69 @@ export interface FieldDecl {
    */
   startColumn?: number;
 }
+
+/** A single primitive value, including metadata-only fields with an empty type. */
+export interface ScalarFieldDecl extends FieldDeclBase {
+  /** Scalar type expression exactly as authored; never the reserved `record` keyword. */
+  type: ScalarTypeExpression;
+  /** Scalar fields are not lists; explicit false is accepted at compatibility boundaries. */
+  isList?: false;
+  /** Scalar fields cannot own a nested record body. */
+  children?: never;
+  /** Scalar fields cannot contain fragment spreads. */
+  hasSpreads?: never;
+  /** Scalar fields cannot name fragments from a record body. */
+  spreads?: never;
+}
+
+/** A nested record value with an explicit, possibly empty, field body. */
+export interface RecordFieldDecl extends FieldDeclBase {
+  /** The stable runtime spelling for a record-bearing field. */
+  type: "record";
+  /** A non-list record may retain an explicit false from the extractor. */
+  isList?: false;
+  /** Fields declared inside the record body. */
+  children: FieldDecl[];
+  /** True when the authored body contains at least one fragment spread. */
+  hasSpreads?: boolean;
+  /** Fragment names spread directly into this record body. */
+  spreads?: string[];
+}
+
+/** A list whose elements are primitive scalar values. */
+export interface ScalarListFieldDecl extends FieldDeclBase {
+  /** Type expression of each scalar list element. */
+  type: ScalarTypeExpression;
+  /** The list marker separates this shape from a scalar field. */
+  isList: true;
+  /** Scalar-list elements cannot own a nested record body. */
+  children?: never;
+  /** Scalar-list elements cannot contain fragment spreads. */
+  hasSpreads?: never;
+  /** Scalar-list elements cannot name fragments from a record body. */
+  spreads?: never;
+}
+
+/** A list whose elements are records with an explicit, possibly empty, body. */
+export interface RecordListFieldDecl extends FieldDeclBase {
+  /** The stable runtime spelling for each record element. */
+  type: "record";
+  /** The list marker distinguishes this shape from a single record. */
+  isList: true;
+  /** Fields declared inside the record element body. */
+  children: FieldDecl[];
+  /** True when the authored body contains at least one fragment spread. */
+  hasSpreads?: boolean;
+  /** Fragment names spread directly into this record element body. */
+  spreads?: string[];
+}
+
+/**
+ * A field declaration in one of the four shapes the grammar can emit.
+ *
+ * The union deliberately uses the existing `type`, `isList`, and `children`
+ * properties, so tightening the TypeScript contract does not add a serialized
+ * discriminator or change CLI/LSP/VizModel payloads.
+ */
+export type FieldDecl =
+  ScalarFieldDecl | RecordFieldDecl | ScalarListFieldDecl | RecordListFieldDecl;

--- a/tooling/satsuma-core/test/extract.test.js
+++ b/tooling/satsuma-core/test/extract.test.js
@@ -236,6 +236,58 @@ describe("extractImports()", () => {
 // ── extractFieldTree ──────────────────────────────────────────────────────────
 
 describe("extractFieldTree()", () => {
+  it("emits the four FieldDecl variants without adding runtime discriminator fields", () => {
+    // R8 tightens only the TypeScript source contract; exact object comparison
+    // locks the scalar, record, scalar-list, and record-list JSON-compatible shape.
+    const recordBody = schemaBody([fieldDecl("city", "STRING", 2, 4)]);
+    const record = n(
+      "field_decl",
+      [fieldName("address"), recordBody],
+      "address record { city STRING }",
+      1,
+      ["record"],
+    );
+    const scalarList = n(
+      "field_decl",
+      [fieldName("tags"), n("type_expr", [], "STRING")],
+      "tags list_of STRING",
+      3,
+      ["list_of"],
+    );
+    const recordList = n(
+      "field_decl",
+      [fieldName("items"), schemaBody([])],
+      "items list_of record {}",
+      4,
+      ["list_of", "record"],
+    );
+
+    assert.deepEqual(
+      extractFieldTree(schemaBody([fieldDecl("id", "UUID"), record, scalarList, recordList]))
+        .fields,
+      [
+        { name: "id", type: "UUID", startRow: 0, startColumn: 0 },
+        {
+          name: "address",
+          type: "record",
+          isList: false,
+          children: [{ name: "city", type: "STRING", startRow: 2, startColumn: 4 }],
+          startRow: 1,
+          startColumn: 0,
+        },
+        { name: "tags", type: "STRING", startRow: 3, startColumn: 0, isList: true },
+        {
+          name: "items",
+          type: "record",
+          isList: true,
+          children: [],
+          startRow: 4,
+          startColumn: 0,
+        },
+      ],
+    );
+  });
+
   it("extracts scalar fields", () => {
     const body = schemaBody([fieldDecl("id", "INT"), fieldDecl("name", "STRING")]);
     const result = extractFieldTree(body);

--- a/tooling/satsuma-core/test/field-decl.test.js
+++ b/tooling/satsuma-core/test/field-decl.test.js
@@ -1,0 +1,73 @@
+/**
+ * field-decl.test.js — Runtime boundaries for the strict FieldDecl union.
+ *
+ * Compile-only tests own assignability invariants. These cases prove dynamic
+ * protocol strings are validated and normalized without changing JSON shapes.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  assertNever,
+  classifyFieldDecl,
+  createScalarTypeExpression,
+  fieldDeclFromRenderedType,
+  renderFieldDeclType,
+} from "../dist/index.js";
+
+describe("FieldDecl runtime boundaries", () => {
+  it("normalizes all four rendered shapes into the established JSON properties", () => {
+    // The LSP and viz protocols keep their rendered list spelling, while core
+    // retains the historic separate isList marker and record body.
+    const scalar = fieldDeclFromRenderedType({ name: "id", type: "UUID" });
+    const record = fieldDeclFromRenderedType({ name: "address", type: "record", children: [] });
+    const scalarList = fieldDeclFromRenderedType({ name: "tags", type: "list_of STRING" });
+    const recordList = fieldDeclFromRenderedType({
+      name: "items",
+      type: "list_of record",
+      children: [],
+    });
+
+    assert.deepEqual(JSON.parse(JSON.stringify([scalar, record, scalarList, recordList])), [
+      { name: "id", type: "UUID" },
+      { name: "address", type: "record", children: [] },
+      { name: "tags", type: "STRING", isList: true },
+      { name: "items", type: "record", children: [], isList: true },
+    ]);
+    assert.deepEqual(
+      [scalar, record, scalarList, recordList].map(classifyFieldDecl).map(({ kind }) => kind),
+      ["scalar", "record", "scalar-list", "record-list"],
+    );
+    assert.deepEqual([scalar, record, scalarList, recordList].map(renderFieldDeclType), [
+      "UUID",
+      "record",
+      "list_of STRING",
+      "list_of record",
+    ]);
+  });
+
+  it("rejects dynamic values that would manufacture an invalid scalar variant", () => {
+    // Static literals are covered by type-tests; runtime checks protect strings
+    // arriving through JSON and protocol models.
+    const dynamicRecordType = ["rec", "ord"].join("");
+    assert.throws(() => createScalarTypeExpression(dynamicRecordType), /reserved 'record' keyword/);
+    assert.throws(
+      () =>
+        fieldDeclFromRenderedType({
+          name: "invalid",
+          type: "STRING",
+          children: [fieldDeclFromRenderedType({ name: "child", type: "INT" })],
+        }),
+      /cannot carry a record body/,
+    );
+  });
+
+  it("assertNever fails loud if malformed boundary data reaches an exhaustive consumer", () => {
+    // The helper is a runtime backstop as well as a compile-time exhaustiveness
+    // marker, so corrupted untyped input reports the consumer context.
+    assert.throws(
+      () => assertNever("future-variant", "Unhandled FieldDecl variant"),
+      /Unhandled FieldDecl variant: future-variant/,
+    );
+  });
+});

--- a/tooling/satsuma-core/type-tests/field-decl-variants.ts
+++ b/tooling/satsuma-core/type-tests/field-decl-variants.ts
@@ -1,0 +1,77 @@
+/**
+ * field-decl-variants.ts — Compile-time checks for valid extracted field shapes.
+ *
+ * Field declarations keep their existing serializable properties, while the
+ * public source contract rejects combinations the Satsuma grammar cannot emit.
+ */
+
+import { createScalarTypeExpression } from "../src/index.js";
+import type {
+  FieldDecl,
+  RecordFieldDecl,
+  RecordListFieldDecl,
+  ScalarFieldDecl,
+  ScalarListFieldDecl,
+} from "../src/index.js";
+
+const scalar: ScalarFieldDecl = {
+  name: "customer_id",
+  type: createScalarTypeExpression("UUID"),
+};
+
+const record: RecordFieldDecl = {
+  name: "address",
+  type: "record",
+  children: [scalar],
+};
+
+const scalarList: ScalarListFieldDecl = {
+  name: "tags",
+  type: createScalarTypeExpression("STRING"),
+  isList: true,
+};
+
+const recordList: RecordListFieldDecl = {
+  name: "line_items",
+  type: "record",
+  isList: true,
+  children: [],
+};
+
+const validFields: FieldDecl[] = [scalar, record, scalarList, recordList];
+
+// A scalar cannot expose a record body.
+const scalarWithChildren: ScalarFieldDecl = {
+  name: "invalid",
+  type: createScalarTypeExpression("STRING"),
+  // @ts-expect-error Scalar fields never carry children.
+  children: [],
+};
+
+// A scalar cannot carry record-body spread state either.
+const scalarWithSpreads: ScalarFieldDecl = {
+  name: "invalid",
+  type: createScalarTypeExpression("STRING"),
+  // @ts-expect-error Scalar fields never own fragment-spread state.
+  hasSpreads: true,
+  // @ts-expect-error Scalar fields never name fragments from a record body.
+  spreads: ["common"],
+};
+
+// The scalar type constructor is the boundary that prevents the record keyword
+// from masquerading as a primitive element type.
+// @ts-expect-error The record keyword denotes a record body, not a scalar type.
+createScalarTypeExpression("record");
+
+// A record list without a body previously matched the scalar-list bag shape.
+// @ts-expect-error Record-list declarations always carry their record body.
+const recordListWithoutBody: FieldDecl = {
+  name: "invalid",
+  type: "record",
+  isList: true,
+};
+
+void validFields;
+void scalarWithChildren;
+void scalarWithSpreads;
+void recordListWithoutBody;

--- a/tooling/satsuma-lsp/src/coverage.ts
+++ b/tooling/satsuma-lsp/src/coverage.ts
@@ -33,6 +33,7 @@ import {
   declaresRecordBody,
   expandDeclaredFields,
   extractNLRefData,
+  fieldDeclFromRenderedType,
   resolveAllNLRefs,
 } from "@satsuma/core";
 import type {
@@ -206,14 +207,13 @@ function toSpreadEntity(def: DefinitionEntry): SpreadEntity {
  * unresolved spreads so nested expansion can see them.
  */
 function toFieldDecl(field: FieldInfo): FieldDecl {
-  return {
+  return fieldDeclFromRenderedType({
     name: field.name,
     type: field.type ?? "",
     startRow: field.range.start.line,
     children: field.children.map(toFieldDecl),
-    hasSpreads: (field.spreads?.length ?? 0) > 0,
-    spreads: field.spreads ?? [],
-  };
+    ...(field.spreads ? { spreads: field.spreads } : {}),
+  });
 }
 
 /**

--- a/tooling/satsuma-lsp/src/semantic-diagnostics.ts
+++ b/tooling/satsuma-lsp/src/semantic-diagnostics.ts
@@ -23,7 +23,7 @@ import {
   createScopedIndex,
   getImportReachableUris,
 } from "./workspace-index";
-import { validateSemanticWorkspace } from "@satsuma/core";
+import { fieldDeclFromRenderedType, validateSemanticWorkspace } from "@satsuma/core";
 import type {
   SemanticIndex,
   SemanticSchema,
@@ -31,6 +31,7 @@ import type {
   SemanticMapping,
   SemanticMetric,
   SemanticDiagnostic,
+  FieldDecl,
   ResolvedFileImport,
   ImportScopeViolation,
 } from "@satsuma/core";
@@ -321,11 +322,7 @@ function defEntryToSchema(name: string, entry: DefinitionEntry): SemanticSchema 
     namespace: ns,
     file: entry.uri,
     row: entry.range.start.line,
-    fields: entry.fields.map((f) => ({
-      name: f.name,
-      type: f.type ?? "",
-      children: f.children.map((c) => ({ name: c.name, type: c.type ?? "" })),
-    })),
+    fields: entry.fields.map(fieldInfoToDecl),
   };
 }
 
@@ -337,12 +334,18 @@ function defEntryToFragment(name: string, entry: DefinitionEntry): SemanticFragm
     namespace: ns,
     file: entry.uri,
     row: entry.range.start.line,
-    fields: entry.fields.map((f) => ({
-      name: f.name,
-      type: f.type ?? "",
-      children: f.children.map((c) => ({ name: c.name, type: c.type ?? "" })),
-    })),
+    fields: entry.fields.map(fieldInfoToDecl),
   };
+}
+
+/** Normalize the workspace index's rendered type spelling for core validation. */
+function fieldInfoToDecl(field: DefinitionEntry["fields"][number]): FieldDecl {
+  return fieldDeclFromRenderedType({
+    name: field.name,
+    type: field.type,
+    children: field.children.map(fieldInfoToDecl),
+    ...(field.spreads ? { spreads: field.spreads } : {}),
+  });
 }
 
 /**

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -22,7 +22,9 @@ import {
   expandDeclaredFields,
   makeEntityRefResolver,
   extractFieldTree,
+  fieldDeclFromRenderedType,
   isMetricSchema,
+  renderFieldDeclType,
 } from "@satsuma/core";
 import type { MetaEntry, FieldDecl, SpreadEntity } from "@satsuma/core";
 
@@ -347,14 +349,13 @@ function definitionToSpreadEntity(def: DefinitionEntry): SpreadEntity {
 
 /** Convert an indexed FieldInfo to core's FieldDecl for spread expansion input. */
 function fieldInfoToDecl(fi: FieldInfo): FieldDecl {
-  return {
+  return fieldDeclFromRenderedType({
     name: fi.name,
     type: fi.type ?? "",
     startRow: fi.range.start.line,
     children: fi.children.map(fieldInfoToDecl),
-    hasSpreads: (fi.spreads?.length ?? 0) > 0,
-    spreads: fi.spreads ?? [],
-  };
+    ...(fi.spreads ? { spreads: fi.spreads } : {}),
+  });
 }
 
 /** Convert a SchemaCard to core's SpreadEntity interface for spread expansion. */
@@ -368,13 +369,12 @@ function schemaToSpreadEntity(s: SchemaCard): SpreadEntity {
 
 /** Convert a viz FieldEntry to core's FieldDecl for spread expansion input. */
 function fieldEntryToDecl(fe: FieldEntry): FieldDecl {
-  return {
+  return fieldDeclFromRenderedType({
     name: fe.name,
     type: fe.type,
     children: fe.children.map(fieldEntryToDecl),
-    hasSpreads: (fe.spreads?.length ?? 0) > 0,
-    spreads: fe.spreads ?? [],
-  };
+    ...(fe.spreads ? { spreads: fe.spreads } : {}),
+  });
 }
 
 /**
@@ -417,7 +417,7 @@ function mergeExpandedField(decl: FieldDecl, original: FieldEntry | undefined): 
 function expandedFieldToEntry(decl: FieldDecl): FieldEntry {
   return {
     name: decl.name,
-    type: decl.type,
+    type: renderFieldDeclType(decl),
     constraints: [],
     metadata: [],
     notes: [],
@@ -723,10 +723,7 @@ function fieldDeclToEntry(decl: FieldDecl, uri: string, cstNode: SyntaxNode | nu
 
   // Build the type string: core uses "record" for nested, but viz distinguishes
   // "list_of record", "list_of <type>", and plain types.
-  let type = decl.type;
-  if (decl.isList && decl.type === "record") type = "list_of record";
-  else if (decl.isList && decl.type) type = `list_of ${decl.type}`;
-  else if (decl.isList) type = "list_of";
+  const type = renderFieldDeclType(decl);
 
   // Child fields: recursively zip with nested CST nodes
   const nestedBody = cstNode ? child(cstNode, "schema_body") : null;
@@ -784,7 +781,7 @@ function makeVizLookup(wsIndex: WorkspaceIndex): DefinitionLookup {
       const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "schema");
       if (!def) return null;
       return {
-        fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+        fields: def.fields.map(fieldInfoToDecl),
         hasSpreads: false,
       };
     },
@@ -793,7 +790,7 @@ function makeVizLookup(wsIndex: WorkspaceIndex): DefinitionLookup {
       const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "fragment");
       if (!def) return null;
       return {
-        fields: def.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+        fields: def.fields.map(fieldInfoToDecl),
         hasSpreads: false,
       };
     },
@@ -807,10 +804,10 @@ function makeVizLookup(wsIndex: WorkspaceIndex): DefinitionLookup {
           yield [
             key,
             {
-              fields: schemaDef.fields.map((f) => ({ name: f.name, type: f.type ?? "" })),
+              fields: schemaDef.fields.map(fieldInfoToDecl),
               hasSpreads: false,
             },
-          ] as [string, { fields: { name: string; type: string }[]; hasSpreads: boolean }];
+          ];
         }
       }
     },

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -31,6 +31,7 @@ import {
   extractFieldTree,
   isMetricSchema,
   createAtRefRegex,
+  renderFieldDeclType,
 } from "@satsuma/core";
 import type { FieldDecl, SatsumaCstType, SatsumaGrammarSymbol } from "@satsuma/core";
 
@@ -1184,11 +1185,10 @@ function extractBodySpreads(body: SyntaxNode | null): string[] {
  * decl's startRow/startColumn.
  */
 function fieldDeclToInfo(decl: FieldDecl, cstNode: SyntaxNode | null): FieldInfo {
-  // Build the type string: core uses "record" for nested, LSP distinguishes list_of variants
-  let type: string | null = decl.type || null;
-  if (decl.isList && decl.type === "record") type = "list_of record";
-  else if (decl.isList && decl.type) type = `list_of ${decl.type}`;
-  else if (decl.isList) type = "list_of";
+  // Preserve null for metadata-only fields while rendering list variants with
+  // the spelling the LSP and VizModel protocols have always exposed.
+  const renderedType = renderFieldDeclType(decl);
+  const type: string | null = renderedType || null;
 
   // Range from CST node (precise) or from core position data (approximate)
   const nameNode = cstNode ? child(cstNode, "field_name") : null;


### PR DESCRIPTION
## Summary

- replace the optional FieldDecl property bag with four JSON-compatible structural variants
- centralize field construction, rendered-type normalization, classification, and exhaustive handling in satsuma-core
- migrate CLI, LSP, and viz-backend consumers without changing runtime or protocol payloads
- add compile-only and runtime coverage, release notes, and ADR-045
- close cbdr-hqhh

## Validation

- ./scripts/run-repo-checks.sh
- 641 satsuma-core tests
- 1026 satsuma-cli tests
- 300 satsuma-lsp tests
- 39 Tree-sitter Python tests with 1172 subtests
- 50 BDD smoke tests

## Architecture

ADR-045 records the JSON-compatible structural-variant contract and extends ADR-020. No existing ADR is superseded.