### PR TITLE
feat(core+cli): structural lint rules and lint's own exit-code table (Feature 37)

### DIFF
--- a/.tickets/sl-1u6r.md
+++ b/.tickets/sl-1u6r.md
@@ -1,6 +1,6 @@
 ---
 id: sl-1u6r
-status: open
+status: closed
 deps: [sl-npi6]
 links: []
 created: 2026-07-31T13:14:15Z
@@ -29,3 +29,12 @@ This moves lint's "could not run" case off 2 and leaves 2 meaning "the workspace
 
 Full exit-code matrix tested: clean 0; warnings without --strict 0; warnings with --strict 1; error findings 2; unparseable workspace 3; --strict flag overrides config strict false; suppressed rules do not trigger strict failure; lint exit-code table documented in command help and SATSUMA-CLI.md; the code change for error findings (2) and parse failures (3) called out in CHANGELOG.md as breaking for CI consumers; CLI tests pass locally.
 
+
+## Notes
+
+**2026-08-03T17:52:28Z**
+
+**2026-08-03T17:52:28Z**
+
+Cause: lint returned 2 both for error-severity findings and for failing to run at all, so 2 contradicted the CLI-wide table's 'parse or filesystem error' and CI could not tell a failing gate from a broken checkout. Adding strict mode on top would have given 1 a third meaning.
+Fix: Pinned lint's own table (0 clean or advisory warnings, 1 strict warnings, 2 error findings, 3 could not run) via a new EXIT_LINT_STRICT_WARNINGS constant, a lintExitCode() helper stating the whole rule in one place, and a loadLintWorkspace() wrapper remapping the loader's 2 to 3; added --strict/--no-strict overriding lint.strict in either direction. Documented in the command help, SATSUMA-CLI.md, HOW-DO-I.md and called out as breaking in CHANGELOG.md. 15 CLI tests cover the matrix. (commit immediately after acbb3b96)

--- a/.tickets/sl-ay8a.md
+++ b/.tickets/sl-ay8a.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ay8a
-status: open
+status: closed
 deps: [sl-j30s, sl-hysg, sl-1u6r]
 links: []
 created: 2026-07-31T13:14:15Z
@@ -22,3 +22,12 @@ Also document, added in doc review 2026-07-31: the lint exit-code table from sl-
 
 SATSUMA-CLI.md rules table, config-file section and lint exit-code table added; exemptions (transform bodies, value maps, self-mappings) documented with their rationale and citations; suppression precedence documented; SCC-per-finding behaviour explained; AI-AGENT-REFERENCE.md updated and regenerated into the CLI agent-reference output; HOW-DO-I.md updated if it indexes lint guidance.
 
+
+## Notes
+
+**2026-08-03T17:52:37Z**
+
+**2026-08-03T17:52:37Z**
+
+Cause: R6's documentation overlaps sl-1u6r's acceptance criteria — both require the lint exit-code table in SATSUMA-CLI.md — and documenting the table without the rules it governs would have shipped a half-consistent reference.
+Fix: Landed with the three rule/exit-code tickets rather than after them. SATSUMA-CLI.md gained both rules in the table plus a per-rule subsection covering every exemption with its rationale and the roadmap citation, and a Lint exit codes table; the CLI-wide exit-code section now points at it. AI-AGENT-REFERENCE.md tells authors a bare arrow asserts type-preserving identity and a transform body suppresses the check (baked into satsuma agent-reference at build time, so no separate regeneration step). HOW-DO-I.md gained four lint questions. Suppression precedence was already documented by sl-npi6 and stands. (commit immediately after acbb3b96)

--- a/.tickets/sl-hysg.md
+++ b/.tickets/sl-hysg.md
@@ -1,6 +1,6 @@
 ---
 id: sl-hysg
-status: open
+status: closed
 deps: [sl-npi6]
 links: []
 created: 2026-07-31T13:14:15Z
@@ -26,3 +26,12 @@ Canonicalise the representative: enter the SCC at its lexicographically smallest
 
 Minimal-snippet tests in core: two mappings forming a-b-a yield exactly one warning with canonical path and both mapping names; self-mapping yields no warning (regression-locks the roadmap decision); three-schema cycle reported once regardless of declaration order; a densely connected component containing several elementary cycles yields exactly one finding and names the component's other schemas; representative path is identical across shuffled file/mapping orderings; no truncation cap is needed or present; CLI-level tests cover registration and --json shape; all suites pass locally.
 
+
+## Notes
+
+**2026-08-03T17:52:28Z**
+
+**2026-08-03T17:52:28Z**
+
+Cause: Every traversal in the toolchain is cycle-guarded, so an unintended cycle across distinct schemas showed up only as lineage output that quietly omitted an expected upstream hop — guarding is not reporting, and users had no diagnostic pointing at the cause.
+Fix: Added detectLineageCycles() in satsuma-core/src/lint-lineage-cycle.ts — schema-level edges with self-mapping edges dropped per-edge before detection (roadmap decision cited in the module), iterative Tarjan SCCs, one finding per component with a canonical representative path (entry at the smallest id, BFS shortest cycle over sorted adjacency), each hop attributed to its mapping and unvisited members named — plus a thin lineage-cycle wrapper in the CLI's lint-engine. 18 core tests lock it, determinism under shuffled mapping order included. (commit immediately after acbb3b96)

--- a/.tickets/sl-iffm.md
+++ b/.tickets/sl-iffm.md
@@ -1,6 +1,6 @@
 ---
 id: sl-iffm
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:14:15Z
@@ -15,3 +15,12 @@ Implement features/37-lint-structural-rules/PRD.md: two new warning-severity lin
 
 Doc review 2026-07-31 settled four further points. (1) Config file is satsuma.config.yaml, not .satsumacfg — .satsuma is a first-class source extension. (2) Config suppression is the persistent form of the existing --ignore flag, not a parallel mechanism; flags win over config. (3) lineage-cycle reports one finding per strongly-connected component rather than per elementary cycle, which removes the need for a truncation cap. (4) Strict mode forced lint's exit codes to be pinned down: lint currently returns 2 for error findings where 2 is documented as "parse error", so lint gets its own documented table (0/1/2/3) — a breaking change for CI consumers.
 
+
+## Notes
+
+**2026-08-03T17:53:06Z**
+
+**2026-08-03T17:53:06Z**
+
+Cause: Epic complete — all five children closed (sl-npi6 config loader, sl-j30s type-mismatch rule, sl-hysg lineage-cycle rule, sl-1u6r exit-code table and strict mode, sl-ay8a docs).
+Fix: Both detectors live in @satsuma/core (lint-type-mismatch.ts, lint-lineage-cycle.ts) with thin CLI wrappers, so the deferred LSP mirroring needs no re-implementation. PRD marked COMPLETE and the ROADMAP entry updated with what shipped and what stays deferred. (commit immediately after acbb3b96)

--- a/.tickets/sl-iffm.md
+++ b/.tickets/sl-iffm.md
@@ -24,3 +24,9 @@ Doc review 2026-07-31 settled four further points. (1) Config file is satsuma.co
 
 Cause: Epic complete — all five children closed (sl-npi6 config loader, sl-j30s type-mismatch rule, sl-hysg lineage-cycle rule, sl-1u6r exit-code table and strict mode, sl-ay8a docs).
 Fix: Both detectors live in @satsuma/core (lint-type-mismatch.ts, lint-lineage-cycle.ts) with thin CLI wrappers, so the deferred LSP mirroring needs no re-implementation. PRD marked COMPLETE and the ROADMAP entry updated with what shipped and what stays deferred. (commit immediately after acbb3b96)
+
+**2026-08-03T18:21:58Z**
+
+**2026-08-03T18:21:58Z**
+
+Decision records: ADR-046 (a command may publish its own exit-code table when the CLI-wide meanings contradict it — names the fmt/coverage precedent as a pattern and requires the non-collision argument to live on each constant), ADR-047 (lint policy detection in core beside semantic validation, with LintFinding kept distinct from SemanticDiagnostic — extends ADR-020/ADR-025 without superseding either), ADR-048 (a graph finding reports one strongly-connected component, not every cycle through it). No existing ADR superseded. ARCHITECTURE.md updated with the core lint modules and LintFinding. (commit immediately after 4d2372ec)

--- a/.tickets/sl-j30s.md
+++ b/.tickets/sl-j30s.md
@@ -1,6 +1,6 @@
 ---
 id: sl-j30s
-status: open
+status: closed
 deps: [sl-npi6]
 links: []
 created: 2026-07-31T13:14:15Z
@@ -24,3 +24,12 @@ Value-map arrows need no special case, and this is decidable today (doc review 2
 
 Minimal-snippet tests in core: STRING to DATE bare arrow warns naming both fields and types; same arrow with any transform body does not warn; an arrow bearing a `map { ... }` value map between differently-typed fields does not warn (locks the classification reasoning above); String vs STRING and parameterized vs bare base token do not warn; missing declared type does not warn; alias group in config suppresses an otherwise-mismatching pair; the rule contains no map-literal special case; CLI-level tests cover registration, severity and --json shape only; all suites pass locally.
 
+
+## Notes
+
+**2026-08-03T17:52:28Z**
+
+**2026-08-03T17:52:28Z**
+
+Cause: A bare arrow asserts its value passes through unchanged, but nothing in the toolchain compared the two ends' declared types, so a STRING -> DATE copy-paste or a schema edit that outran its mappings survived until a human read that arrow.
+Fix: Added detectTypeMismatches() in satsuma-core/src/lint-type-mismatch.ts — none-classified single-source arrows only, types compared on their upper-cased base token with lint.typeAliases groups layered on, silent on undeclared/unresolvable/ambiguous endpoints — plus a thin type-mismatch-direct-arrow wrapper in the CLI's lint-engine and a LintRuleContext carrying the config's alias groups to rules. 20 core tests lock the semantics including that value maps stay exempt through classification alone, with no map-literal branch. (commit immediately after acbb3b96)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
 - `tooling/tree-sitter-satsuma/`: tree-sitter grammar (318 corpus tests), generated parser artifacts, and queries
-- `tooling/satsuma-core/`: **the shared library every other package builds on** (675 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
+- `tooling/satsuma-core/`: **the shared library every other package builds on** (679 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
 - `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (1031 tests)
-- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio` (299 tests)
+- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio` (300 tests)
 - `tooling/satsuma-viz-model/`: the VizModel protocol contract (6 tests) — the payload shape the LSP produces and the viz component consumes, defined once so neither can drift
 - `tooling/satsuma-viz-backend/`: workspace indexing and VizModel assembly shared by the LSP and browser hosts (182 tests); also computes the field coverage the payload carries (ADR-042)
 - `tooling/satsuma-viz/`: the `satsuma-viz` Lit web component (128 tests) — overview graph and per-mapping detail view, embedded in the VS Code webview and the site playground

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
 - `tooling/tree-sitter-satsuma/`: tree-sitter grammar (318 corpus tests), generated parser artifacts, and queries
-- `tooling/satsuma-core/`: **the shared library every other package builds on** (578 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
-- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (994 tests)
+- `tooling/satsuma-core/`: **the shared library every other package builds on** (675 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
+- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (1031 tests)
 - `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio` (299 tests)
 - `tooling/satsuma-viz-model/`: the VizModel protocol contract (6 tests) — the payload shape the LSP produces and the viz component consumes, defined once so neither can drift
 - `tooling/satsuma-viz-backend/`: workspace indexing and VizModel assembly shared by the LSP and browser hosts (182 tests); also computes the field coverage the payload carries (ADR-042)

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -402,6 +402,22 @@ Every arrow the CLI returns carries one of three classifications:
 | `[nl]` | Has a transform body; all pipe-step content is NL | Read it and interpret intent |
 | `[nl-derived]` | Implicit arrow from NL `@ref` | Synthetic — verify the referenced field exists |
 
+**When you author a mapping, the classification is a claim you are making.** A bare
+`src -> tgt` asserts the value passes through *unchanged* — including its type — and
+`satsuma lint` checks that assertion against both declared types
+(`type-mismatch-direct-arrow`). Adding a transform body, even one NL string like
+`{ "parse as ISO-8601" }`, suppresses the check: you have said something happens
+here, and the CLI leaves judging it to a reader. So write the transform body
+whenever a conversion is intended, rather than leaving a bare arrow between two
+different types — an honest bare arrow is one you would be happy for a linter to
+verify.
+
+Two more authoring rules `lint` enforces: an arrow onto a record needs either a
+record source or child arrows saying which fields it fills
+(`unenumerated-record-target`), and mappings must not form a cycle across distinct
+schemas (`lineage-cycle`). Mapping a schema to *itself* is fine and expected — that
+is how an increment is expressed.
+
 ### Composing workflows
 
 **Whole-workspace reasoning:** Call `satsuma graph <entry-file>.stm --json` to load the entire workspace topology for that file's import-reachable graph in one call — nodes (schemas, mappings, metrics, fragments, transforms), field-level edges with transform classification, and schema-level topology. Use `--schema-only` for topology-only queries, `--namespace <ns>` to scope, `--no-nl` to reduce payload size. The `unresolved_nl` section lists all NL arrows requiring interpretation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,63 @@ rendered spelling into core's existing `{ type: "STRING", isList: true }` shape.
 Use `classifyFieldDecl` with `assertNever` when handling every variant
 exhaustively. No Satsuma syntax, CLI JSON field, LSP payload, or VizModel field
 has changed.
+### BREAKING: `satsuma lint` publishes its own exit-code table (`sl-1u6r`)
+
+**Any CI job keying off lint's exit codes needs to be re-read.** `lint` previously
+returned `2` both for error-severity findings and for failing to run at all — an
+unreadable workspace, a bad path, an unusable `satsuma.config.yaml` — so a script
+could not tell a failing lint gate from a broken checkout. It now has its own
+table, following the `fmt --check` precedent:
+
+| Code | Meaning                                                                     |
+| ---- | --------------------------------------------------------------------------- |
+| `0`  | No findings, or warnings only without strict mode                           |
+| `1`  | Warnings present and strict mode active                                     |
+| `2`  | Error-severity findings present                                             |
+| `3`  | Lint could not run — unusable config, unknown rule id, unreadable workspace |
+
+What changed in practice:
+
+- **`2` no longer means "could not run".** `satsuma lint /nonexistent/path` exited
+  `2` and now exits `3`. A job that treated `2` as "the workspace has lint errors"
+  was previously also catching setup failures under that label; it now sees them
+  separately. `2` continues to mean error-severity findings, which is what it has
+  meant in practice all along.
+- **`1` is new, and opt-in.** Warnings remain advisory by default and still exit
+  `0`. They exit `1` only under `--strict` or `lint.strict: true`, so no existing
+  job changes behaviour by upgrading.
+
+`--strict` and `--no-strict` both exist and win over `lint.strict` in either
+direction, so a workspace can commit a gate and one job can still opt out. A
+suppressed rule produces no findings and therefore can never trigger a strict
+failure.
+
+### Two structural lint rules (`sl-j30s`, `sl-hysg`)
+
+**`satsuma lint` reports two new warnings.** Both are warning-severity and not
+fixable, so no existing exit code changes unless you also opt into strict mode.
+
+- **`type-mismatch-direct-arrow`** — a bare `src -> tgt` asserts the value passes
+  through unchanged, so connecting a `STRING` to a `DATE` is almost always a
+  mis-picked field, a schema edit that outran its mappings, or a missing transform.
+  Types are compared on their base token, case-insensitively: `String` matches
+  `STRING` and `VARCHAR(255)` matches `VARCHAR`. Nothing else is presumed
+  equivalent — declare your own equivalences in `lint.typeAliases`, which this rule
+  is the first consumer of. An arrow carrying _any_ transform body is never
+  type-checked, `map { … }` value maps included: a transform may legitimately change
+  type, and judging that is interpretation the CLI leaves to agents.
+- **`lineage-cycle`** — the schema-level mapping graph (the edges `satsuma lineage`
+  and `graph --compact` draw) contains a cycle. Self-mappings are excluded, since
+  that is how an increment is expressed. One finding is reported per
+  strongly-connected component rather than per elementary cycle, with a canonical
+  representative path, the mapping behind each hop, and the component members the
+  path does not visit — nothing is capped or truncated.
+
+Detection for both lives in `@satsuma/core`, so the LSP can mirror them as editor
+diagnostics without a second implementation.
+
+`lint.typeAliases` and `lint.strict` are now enforced, so the warnings the CLI
+printed to say they were inert are gone.
 
 ## v0.12.0 — 2026-08-03
 

--- a/HOW-DO-I.md
+++ b/HOW-DO-I.md
@@ -146,7 +146,16 @@ Run `satsuma validate pipeline.stm`. The CLI validates the entry file and its tr
 Run `satsuma lineage --from <schema> pipeline.stm`. For field-level edges: `satsuma arrows <schema.field>`.
 
 **How do I lint my Satsuma files?**
-Run `satsuma lint pipeline.stm`. Use `--fix` for auto-fixing. Use `--json` for CI integration.
+Run `satsuma lint pipeline.stm`. Use `--fix` for auto-fixing, `--json` for CI integration, and `--rules` to see what it checks. See the [rule table](SATSUMA-CLI.md#validate-vs-lint) for each rule's severity, fixability, and exemptions.
+
+**How do I make lint warnings fail my build?**
+Run `satsuma lint pipeline.stm --strict`, or commit `lint: { strict: true }` in `satsuma.config.yaml`. Warnings then exit 1, distinctly from exit 2 for error-severity findings and exit 3 for "lint could not run", so CI can tell a policy failure from a broken workspace. See [Lint exit codes](SATSUMA-CLI.md#lint-exit-codes).
+
+**How do I tell lint that two of my declared type names mean the same thing?**
+List them as a group under `lint.typeAliases` in `satsuma.config.yaml` — e.g. `- [STRING, TEXT, VARCHAR]`. Nothing is presumed equivalent by default beyond case and type parameters, so `type-mismatch-direct-arrow` reports `STRING -> TEXT` until you say otherwise. See [Workspace configuration](SATSUMA-CLI.md#workspace-configuration).
+
+**How do I stop lint reporting a rule I have decided not to follow?**
+Add its id to `lint.suppress` in `satsuma.config.yaml` (the persistent form of `--ignore`), or pass `--ignore <rules>` for one run. A suppressed rule produces no findings, so it cannot fail a `--strict` build either.
 
 **How do I find out which fields aren't mapped yet?**
 Run `satsuma coverage pipeline.stm --uncovered`. Read the **aggregate** section to decide a field is genuinely unmapped — the per-mapping section lists fields another mapping may already populate. See [SATSUMA-CLI.md](SATSUMA-CLI.md#coverage).

--- a/SATSUMA-CLI.md
+++ b/SATSUMA-CLI.md
@@ -100,9 +100,9 @@ Operations that check or compare workspace structure.
 
 `validate` checks **structural correctness**: parse errors, undefined references, missing schemas. It answers "is this workspace well-formed?"
 
-`lint` checks **policy and conventions**: duplicate definitions, hidden schema dependencies in NL text, unresolved NL `@ref` references. It answers "does this workspace follow best practices?" Some lint rules support `--fix` for safe, deterministic autofix.
+`lint` checks **policy and conventions**: duplicate definitions, hidden schema dependencies in NL text, unresolved NL `@ref` references, bare arrows connecting mismatched types, and cycles in the schema-level mapping graph. It answers "does this workspace follow best practices?" Some lint rules support `--fix` for safe, deterministic autofix.
 
-Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rules>` / `--ignore <rules>` (filter rules), `--config <path>` (config file, see [Workspace configuration](#workspace-configuration)), `--quiet` (exit code only), `--rules` (list available rules).
+Flags: `--json` (structured output), `--fix` (apply safe fixes), `--select <rules>` / `--ignore <rules>` (filter rules), `--config <path>` (config file, see [Workspace configuration](#workspace-configuration)), `--strict` / `--no-strict` (whether warnings fail the run), `--quiet` (exit code only), `--rules` (list available rules).
 
 A rule id that does not exist is an error wherever it is written — `--select`, `--ignore`, or the config file — and exits `3`. A typo that silently suppressed nothing would leave the author believing a rule was off.
 
@@ -112,6 +112,24 @@ A rule id that does not exist is an error wherever it is written — `--select`,
 | `unresolved-nl-ref`          | warning  | no      | `@ref` in NL does not resolve to any known identifier               |
 | `duplicate-definition`       | error    | no      | Named definition is declared more than once in a namespace          |
 | `unenumerated-record-target` | warning  | no      | Arrow targets a record without a record source or child arrows      |
+| `type-mismatch-direct-arrow` | warning  | no      | Bare arrow connects fields whose declared types differ              |
+| `lineage-cycle`              | warning  | no      | Schema-level mapping graph contains a cycle                         |
+
+#### type-mismatch-direct-arrow
+
+A **bare** arrow — `src -> tgt` with no transform body — asserts that the value passes through unchanged. Between a `STRING` and a `DATE` that cannot be true, and in practice it is a mis-picked field, a schema edit that outran its mappings, or a transform nobody wrote down. The message names both qualified field paths and both declared types, so `lint --json` consumers can group findings by type-pair.
+
+Types are compared on their **base token, case-insensitively**: `String` matches `STRING`, and everything from the first `(` onwards is ignored, so `VARCHAR(255)` matches `VARCHAR` and `UUID(pk)` matches `UUID`. Nothing else is presumed equivalent — declaring that `TEXT` is a `STRING` is a convention decision the CLI leaves to you, via `lint.typeAliases`.
+
+**An arrow carrying a transform body is never type-checked.** Any transform body means the author has said "something happens here", and judging whether that something preserves type is natural-language interpretation, which the CLI leaves to agents. This includes `map { … }` value maps, which convert values and so may legitimately change type. The rule is also silent when either side declares no type, when the path resolves to no declared field (that is `validate`'s `field-not-in-schema`), when the arrow has several sources (no one of them is _the_ type of the result), and when two source schemas declare the same unqualified field name with different types — qualify the path (`b.email -> email`) to get it checked.
+
+#### lineage-cycle
+
+The graph is the one `satsuma lineage` and `graph --compact` traverse: directed edges from each mapping's source schemas to its target schemas. Traversal in this toolchain is cycle-guarded, which means a cycle shows up only as lineage output that quietly omits an expected upstream hop — guarding is not reporting, and this rule is the report.
+
+**A self-mapping is never a cycle.** An edge whose source and target are the same schema is dropped before detection, because that is how an incremental load is expressed — a recorded product decision, not an implementation convenience (see `docs/product-owner/ROADMAP.md`). The exemption is per-edge, so a mapping with `source { a }` and `target { a, b }` still contributes `a -> b`.
+
+One finding is reported **per strongly-connected component**, not per elementary cycle: a densely cross-linked platform graph can hold combinatorially many cycles that all describe the same tangle, and untangling the component is what a reviewer does anyway. The finding shows a canonical representative path (entered at the component's lexicographically smallest schema, shortest cycle from there), the mapping responsible for each hop, and — when the component is larger than the path — the schemas the path does not visit. Nothing is truncated.
 
 ### Workspace configuration
 
@@ -135,13 +153,24 @@ lint:
   strict: false
 ```
 
-**Precedence — one rule.** Flags win over config, and the union of `--ignore` and `lint.suppress` is suppressed. The single exception: `--select` means "run exactly these", so a rule named on the command line runs even when the config suppresses it — naming a rule is an unambiguous instruction to run it.
+**Precedence — one rule.** Flags win over config, and the union of `--ignore` and `lint.suppress` is suppressed. The single exception: `--select` means "run exactly these", so a rule named on the command line runs even when the config suppresses it — naming a rule is an unambiguous instruction to run it. `--strict` / `--no-strict` follow the same rule, overriding `lint.strict` in either direction.
 
 Unrecognised settings are reported as warnings and ignored, so a config written for a newer CLI still runs. Anything that makes the file unusable — invalid YAML, a wrong-shaped setting, an unknown rule id — aborts the run with exit `3` rather than falling back to defaults: linting with rules the author did not ask for, and reporting success, is worse than refusing to lint.
 
-`lint.typeAliases` and `lint.strict` are accepted and validated now, but nothing consumes them yet — the CLI prints a warning saying so, so a config cannot look like an active gate when no code enforces it. Their consumers ship with the type-mismatch rule and strict-mode exit codes respectively.
+#### Lint exit codes
 
-Lint exit codes: `0` no error-severity findings, `2` error-severity findings present, `3` lint could not run.
+`lint` publishes its own exit-code table, following the `fmt --check` precedent of a command owning codes that mean something specific to it:
+
+| Code | Meaning                                                                     |
+| ---- | --------------------------------------------------------------------------- |
+| `0`  | No findings, or warnings only without strict mode                           |
+| `1`  | Warnings present and strict mode active                                     |
+| `2`  | Error-severity findings present                                             |
+| `3`  | Lint could not run — unusable config, unknown rule id, unreadable workspace |
+
+Errors outrank warnings: a workspace with both reports `2`, because fixing the errors comes first either way. Warnings stay advisory by default, so adding a config file — or a new warning-severity rule — cannot break an existing CI job. A suppressed rule produces no findings at all and so can never trigger a strict failure.
+
+> **Breaking change (v0.12.0).** Previously `2` doubled as "error-severity findings" _and_ "lint could not run", so a CI job could not tell a failing gate from a broken checkout. `2` now means only the former; "could not run" moved to `3`. See `CHANGELOG.md`.
 
 ### coverage
 
@@ -378,7 +407,7 @@ Cycles are handled gracefully — each field is visited at most once. NL-derived
 | 1    | Not found or no results         |
 | 2    | Parse error or filesystem error |
 
-Two commands add a code that means something specific to them, so a script can tell a failing gate from a broken run: `coverage --fail-under` exits `3` when measured coverage is below the threshold, and `lint` exits `3` when it could not run at all (see [Workspace configuration](#workspace-configuration)). They never collide in one invocation — `lint` has no threshold and `coverage` reads no rules.
+Two commands add codes that mean something specific to them, so a script can tell a failing gate from a broken run. `coverage --fail-under` exits `3` when measured coverage is below the threshold. **`lint` publishes its own table entirely** — see [Lint exit codes](#lint-exit-codes) — where `1` means "warnings under `--strict`", `2` means "the workspace has lint errors", and `3` means "lint could not run". The command-specific codes never collide in one invocation: `lint` has no threshold gate and takes no lookup argument that can fail to resolve, and `coverage` reads no lint rules.
 
 ## How Agents Use the CLI
 

--- a/adrs/adr-046-a-command-may-publish-its-own-exit-code-table.md
+++ b/adrs/adr-046-a-command-may-publish-its-own-exit-code-table.md
@@ -1,0 +1,113 @@
+# ADR-046 — A Command May Publish Its Own Exit-Code Table When the CLI-Wide Meanings Contradict It
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-1u6r)
+
+## Context
+
+The CLI publishes three exit codes for every command
+(`tooling/satsuma-cli/src/command-runner.ts`, documented in `SATSUMA-CLI.md`):
+`0` success, `1` not found or no results, `2` parse error or filesystem error.
+`command-runner.ts` is the single `process.exit` boundary, and the comment on
+`EXIT_PARSE_ERROR` states the intent plainly: collapse every "real problem" into
+one non-zero code so a script can write `if ! satsuma …; then`, and let `--json`
+draw finer distinctions.
+
+That works while a command's failure modes map onto those three meanings. `lint`
+has never fitted. It returned `EXIT_PARSE_ERROR` for **error-severity findings**
+— a workspace that parsed perfectly and was read without incident — so `2` meant
+two unrelated things depending on which command produced it, and in `lint`'s case
+the documented meaning was the one that never applied. A CI job could not tell a
+failing lint gate from an unreadable checkout: both exited `2`.
+
+`sl-1u6r` then asked for strict mode, where warnings fail the build. Under the
+CLI-wide table the only free code was `1`, "not found or no results" — which
+would have given `1` a third meaning while `2` still had two. Three codes, five
+meanings, none of them documented for this command.
+
+Three alternatives were considered. **Extending the CLI-wide table** with a
+global "policy findings present" code was rejected: the meaning is not general,
+and every command would inherit a code it can never return, which is how a
+shared table becomes noise. **Keeping `2` for both and distinguishing via
+`--json`** is the documented philosophy, and it is right for a human at a shell —
+but a merge gate reads the code, and asking CI to parse JSON to discover whether
+lint ran at all inverts the reason exit codes exist. **Adding a fourth CLI-wide
+code** was rejected for the same reason as the first: `1` and `3` would then mean
+different things in different commands anyway, which is the situation this ADR
+chooses to name explicitly rather than arrive at by accident.
+
+The precedent already existed and was undocumented as a pattern: `fmt --check`
+exits `1` for "a file would change" (`SATSUMA-CLI.md`), which is neither "not
+found" nor "no results", and `coverage --fail-under` exits `3` for "below
+threshold". Two commands had already stepped outside the table.
+
+## Decision
+
+**A command may publish its own exit-code table when the CLI-wide meanings would
+be wrong for its outcomes, provided the table is documented alongside the command
+and the codes it reuses cannot collide within a single invocation of that
+command.** The CLI-wide table remains the default and continues to govern every
+command that has not published one.
+
+`lint` publishes this table, in its command help, in `SATSUMA-CLI.md` under *Lint
+exit codes*, and in the module header of `tooling/satsuma-cli/src/commands/lint.ts`:
+
+| Code | Meaning                                                                     |
+| ---- | --------------------------------------------------------------------------- |
+| `0`  | No findings, or warnings only without strict mode                           |
+| `1`  | Warnings present and strict mode active                                     |
+| `2`  | Error-severity findings present                                             |
+| `3`  | Lint could not run — unusable config, unknown rule id, unreadable workspace |
+
+The mechanism has three parts. Each command-scoped code is a **named constant in
+`command-runner.ts`** whose doc-comment states which command owns it and why it
+does not collide — `EXIT_LINT_STRICT_WARNINGS = 1` is numerically
+`EXIT_NOT_FOUND`, and the argument for safety is that `lint` takes no lookup
+argument that can fail to resolve; `EXIT_LINT_CANNOT_RUN = 3` is numerically
+`EXIT_THRESHOLD_NOT_MET`, and `lint` has no threshold gate. The non-collision
+argument is part of the constant, not folklore. Second, the whole table is
+decided in **one function** — `lintExitCode(diagnostics, strict)` — so the
+precedence between errors, warnings and strict mode is readable in one place
+rather than distributed across the handler. Third, where a shared helper raises a
+CLI-wide code that the command's table assigns a different meaning, the command
+**remaps it at its own boundary**: `loadLintWorkspace()` catches
+`loadWorkspace`'s `EXIT_PARSE_ERROR` and rethrows it as `EXIT_LINT_CANNOT_RUN`,
+passing the message and stream through untouched. Shared helpers keep raising
+CLI-wide codes; the translation is the command's responsibility.
+
+Redefining a code a command already returns is a **breaking change** and must be
+called out in `CHANGELOG.md` as one. `lint`'s move of "could not run" off `2` is
+recorded there.
+
+## Consequences
+
+**Positive:**
+
+- A CI job can distinguish the three outcomes it actually needs to act on
+  differently: the gate failed on policy (`1`), the workspace has lint errors
+  (`2`), the run never happened (`3`). Under the previous scheme the last two
+  were indistinguishable.
+- `2` from `lint` now means exactly one thing, which is what it meant in
+  practice all along; the documentation and the behaviour agree for the first
+  time.
+- Strict mode was added without giving any code a second meaning.
+- The `fmt --check` and `coverage --fail-under` deviations stop being anomalies
+  and become instances of a named pattern, with a rule about when it is allowed.
+- The non-collision reasoning is recorded next to each constant, so a future
+  command tempted to reuse `EXIT_LINT_CANNOT_RUN` has to confront whether it
+  means the same thing.
+
+**Negative:**
+
+- "What does exit 3 mean?" no longer has a single answer for the CLI; a reader
+  must know which command produced it. This is the cost the ADR accepts, and it
+  is why the table must be documented with the command rather than only in code.
+- Two constants now share a numeric value with two others. Nothing prevents a
+  future command from returning `EXIT_LINT_STRICT_WARNINGS` by mistake, since the
+  type is `number`; the guard is the doc-comment, not the compiler.
+- Every published table is a compatibility surface. Changing `lint`'s codes again
+  breaks CI jobs a second time, so the table should be treated as settled.
+- The pattern is available to commands that do not need it. A command adding a
+  table because its author prefers finer codes, rather than because the CLI-wide
+  meanings are wrong, would erode the default without the justification this ADR
+  requires.

--- a/adrs/adr-047-policy-detection-in-core-beside-semantic-validation.md
+++ b/adrs/adr-047-policy-detection-in-core-beside-semantic-validation.md
@@ -1,0 +1,113 @@
+# ADR-047 — Lint Policy Detection Lives in Core Beside Semantic Validation, With Its Own Finding Type
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-j30s, sl-hysg)
+
+## Context
+
+ADR-020 put extraction in `satsuma-core` and left consumers as thin wiring.
+ADR-025 followed it for **semantic validation**: the rules and their
+orchestration live in `tooling/satsuma-core/src/validate.ts`, which returns
+`SemanticDiagnostic` records, and both the CLI and the LSP adapt their own index
+into core's structural `SemanticIndex` interfaces rather than re-implementing the
+rules.
+
+`lint` did not follow either. Every rule lived in
+`tooling/satsuma-cli/src/lint-engine.ts` — registry, detection and text fixes in
+one 680-line module — which was defensible while lint rules were about NL `@ref`
+hygiene that only the CLI surfaced. Feature 37 changed that. Both new rules,
+`type-mismatch-direct-arrow` and `lineage-cycle`, are natural editor diagnostics:
+an author writing a mapping in VS Code wants the squiggle at the moment the arrow
+is written, not on the next CI run. The precedent for what happens when detection
+sits in a consumer is `duplicate-definition`, which had to be mirrored into the
+LSP and, per `sl-rw3e`, drifted while it was.
+
+That settled *where* the detection goes. The open question was the **output
+type**. Core already had `SemanticDiagnostic` — `file`, `line`, `column`,
+`severity`, `rule`, `message` — which is structurally exactly what a lint rule
+needs to report, and reusing it would have avoided a second shape for the same
+six fields.
+
+Two alternatives were considered. **Reusing `SemanticDiagnostic`** was rejected on
+what the two types mean rather than on what they hold. A `validate` diagnostic
+asserts the workspace is *wrong*; a lint finding asserts it breaks a *policy* the
+workspace may legitimately have chosen — the distinction the `validate`/`lint`
+split exists to draw, and the reason only one of the two is suppressible through
+`satsuma.config.yaml`. One type for both would make a rule's suppressibility
+invisible in its signature, and would tie the LSP protocol boundary (which
+`SemanticDiagnostic` crosses) to any field lint later needs. **Returning
+structured facts and letting each consumer compose the message** was rejected
+because the message is where the rule's reasoning lives: `type-mismatch`'s
+message has to say which field, which type, and what to do about it, and two
+consumers phrasing that differently is the same drift the move to core is meant
+to prevent.
+
+## Decision
+
+**Detection for any lint rule that a second consumer will surface lives in
+`satsuma-core`, as a pure function over structural input interfaces, returning
+`LintFinding` — a type distinct from `SemanticDiagnostic`.** The consumer's rule
+is a wrapper that resolves its own workspace model into those inputs and maps the
+findings onto its diagnostic shape. Nothing else moves: the rule registry,
+suppression, `--select`/`--ignore`, and text fixes stay with the consumer, because
+fixes rewrite files on disk and core imports no Node built-ins.
+
+`LintFinding` is defined in `tooling/satsuma-core/src/lint-findings.ts` and
+carries the rule id, the severity **the rule itself defines**, a 1-indexed
+position, and the finished message. Severity is not a caller parameter: a rule's
+severity is part of its meaning, and letting a consumer choose it is how an editor
+and CI come to disagree about the same finding.
+
+Each detector follows ADR-025's input pattern — minimal structural interfaces
+that the CLI's `ExtractedWorkspace` records and the LSP's index satisfy by
+TypeScript duck typing, so neither package builds an adapter object — plus a
+**resolver callback** for anything requiring workspace identity.
+`DeclaredTypeSchemaResolver` and `LineageSchemaIdResolver` exist because
+canonicalizing an authored schema reference is the consumer's business (ADR-039),
+while what to *do* with the resolved schema is core's.
+
+The two detectors are `tooling/satsuma-core/src/lint-type-mismatch.ts` and
+`tooling/satsuma-core/src/lint-lineage-cycle.ts`. Their wrappers in
+`lint-engine.ts` are twelve lines each. Settings a rule needs from
+`satsuma.config.yaml` reach it through a `LintRuleContext` passed to every
+`check()` call, rather than being captured when the registry is built, so `RULES`
+stays a plain constant that `--rules` and the help text can list without a config
+in hand.
+
+Rule **semantics** are tested once, in core. Consumer tests cover registration,
+severity mapping and output shape only.
+
+## Consequences
+
+**Positive:**
+
+- The LSP can mirror both rules by writing an index adapter, with no rule logic
+  to re-implement and no opportunity for the editor and CI to disagree — the
+  `duplicate-definition` failure mode is closed before it opens.
+- A rule's severity and message are properties of the rule, so every consumer
+  reports the same finding in the same words.
+- The type of a detector's return value now says whether its findings are policy
+  or correctness, which is the same distinction `satsuma.config.yaml` acts on.
+- Rule semantics have one test home. `lint-type-mismatch.test.js` and
+  `lint-lineage-cycle.test.js` build their inputs from core's own extraction, so
+  a change to how types or arrow paths are extracted fails there rather than in a
+  consumer.
+- Detectors are pure functions over plain data, so a graph-theoretic rule can be
+  tested without a parser fixture or a filesystem.
+
+**Negative:**
+
+- Core now has two structurally identical diagnostic types. A reader
+  encountering both must read the header of `lint-findings.ts` to learn why, and
+  a future contributor may reasonably propose merging them.
+- Each detector needs its own structural input interfaces and resolver callback,
+  which is more surface than a function taking `ExtractedWorkspace` directly, and
+  the interfaces must be kept in step with the records that satisfy them —
+  duck typing means a renamed field on `ArrowRecord` fails at the wrapper, not at
+  the detector.
+- Lint is now split across two packages: detection in core, registry and fixes in
+  the CLI. Adding a rule means touching both, and reading how lint works means
+  reading both.
+- The split is only justified for rules a second consumer will surface. A
+  CLI-only rule put in core would pay this cost for nothing, so the boundary
+  needs judgement per rule rather than a blanket "all rules in core".

--- a/adrs/adr-048-one-finding-per-tangle-not-per-instance.md
+++ b/adrs/adr-048-one-finding-per-tangle-not-per-instance.md
@@ -1,0 +1,93 @@
+# ADR-048 — A Graph Finding Reports One Tangle, Not Every Instance of It
+
+**Status:** Accepted
+**Date:** 2026-08-03 (sl-hysg)
+
+## Context
+
+`lineage-cycle` reports cycles in the schema-level mapping graph — the same edges
+`satsuma lineage` and `graph --compact` draw, from each mapping's source schemas
+to its target schemas. The rule exists because every traversal in this toolchain
+is cycle-guarded, so an unintended cycle shows up only as lineage output that
+quietly omits an expected upstream hop. Guarding is not reporting.
+
+Feature 37's PRD originally specified **elementary-cycle enumeration**: find every
+distinct simple cycle and report each one, with a truncation cap to stop the
+output running away. That is the obvious reading of "report the cycles", and the
+cap is the obvious defence.
+
+The cap is the tell. Elementary-cycle enumeration (Johnson's algorithm) is
+*output-exponential* — the number of simple cycles in a graph is not bounded by
+any polynomial in its size. Six mappings among three schemas, each pair linked
+both ways, already yield cycles `a→b→a`, `a→c→a`, `b→c→b`, `a→b→c→a` and
+`a→c→b→a`; a platform entry point pulling in a few dozen cross-linked schemas
+yields combinatorially many. Every one of them describes the *same* tangle of
+mappings, and the reviewer's task for all of them is identical: work out which
+arrow points the wrong way. A cap does not fix that. It caps a list whose entries
+were already redundant, and it does so silently — the reviewer sees ten cycles,
+fixes them, and has no idea whether the eleventh was the informative one.
+
+The alternative considered and rejected was **enumeration with deduplication** —
+enumerate elementary cycles, then collapse ones sharing a mapping. That still pays
+the exponential cost before collapsing, and the collapsing rule ("same tangle") is
+just a strongly-connected component computed the expensive way.
+
+## Decision
+
+**A finding about graph structure reports one finding per strongly-connected
+component, not one per cycle through it.** For `lineage-cycle`
+(`tooling/satsuma-core/src/lint-lineage-cycle.ts`): compute the SCCs of the schema
+graph with Tarjan's algorithm; every component of two or more nodes is exactly one
+finding. No cap, no truncation, and no scale guard — the number of findings is
+bounded by the number of schemas.
+
+Because a component is reported by a single *representative* cycle, that
+representative must be **canonical**, or the same tangle would be described
+differently depending on which file loaded first and a CI diff of lint output
+would show phantom changes. The canonicalisation is: enter the component at its
+lexicographically smallest schema id, and walk the shortest cycle from there via
+breadth-first search over **sorted** adjacency lists. Sorted adjacency plus
+first-discovery predecessors makes the walk a function of the graph alone, not of
+insertion order. `MIN_CYCLIC_COMPONENT_SIZE = 2` is the threshold, and single-node
+components can never qualify because self-mapping edges are dropped at
+graph-build time — the recorded product decision that a schema mapped to itself
+represents an increment, not a cycle.
+
+A representative hides what it does not traverse, so the finding must say so
+explicitly. The message carries the representative path, the mapping responsible
+for **each** hop (all of them, when several mappings declare one edge), and — when
+the component holds more schemas than the path visits — those schemas by name
+("component also includes c, d"). A two-hop representative for a five-schema
+tangle must not read as a two-schema problem.
+
+## Consequences
+
+**Positive:**
+
+- Output size is bounded by the number of schemas rather than by the number of
+  cycles, so the rule is safe to run on a whole platform graph. The truncation cap
+  the PRD needed is not merely unnecessary — there is nothing left to truncate,
+  and so nothing is silently dropped.
+- One finding matches one unit of work. Untangling the component is what the
+  reviewer does; auditing each rotation through it is not.
+- Tarjan is linear in nodes and edges, against Johnson's output-exponential
+  behaviour.
+- The canonical representative makes lint output diffable across runs, which is
+  what lets a team review changes to it rather than re-reading it whole.
+
+**Negative:**
+
+- The finding is not a complete description of the graph. A reviewer who wants
+  every cycle must derive them from the component, and the rule will not produce
+  them. This is deliberate, and it is the main thing a future contributor might
+  reasonably want to reverse.
+- The message must carry the component's other members, because the path alone
+  understates the problem. That is prose doing work the output shape does not do
+  on its own, and a consumer rendering only the path would mislead.
+- Fixing one arrow inside a large component may leave it cyclic, so the finding
+  can reappear with a *different* representative path after a partial fix. The
+  reviewer sees a changed message rather than a resolved one, which reads as
+  progress being undone unless they understand the component model.
+- Tarjan's algorithm is implemented iteratively, with an explicit frame stack, to
+  survive a deep graph. That is more code than the recursive form and needs its
+  invariants explained in comments rather than being self-evident.

--- a/docs/developer/ARCHITECTURE.md
+++ b/docs/developer/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Satsuma Tooling Architecture
 
-> Last updated: 2026-08-03 — documented `FieldDecl` structural variants (ADR-045).
+> Last updated: 2026-08-03 — documented lint policy detection in core (ADR-047) and `FieldDecl` structural variants (ADR-045).
 
 This document is the canonical architecture reference for the Satsuma language tooling — the packages under `tooling/` that parse, analyse, format, validate, visualize, and provide IDE support for `.stm` files. The design is influenced by [rust-analyzer's architecture](https://rust-analyzer.github.io/book/contributing/architecture.html), adapted for a tree-sitter-backed DSL rather than a full programming language compiler.
 
@@ -149,10 +149,12 @@ graph LR
   PE["parse-errors.ts\ncollectParseErrors()\nParseError"]
   COV["coverage.ts · coverage-paths.ts\nFieldCoverageEntry\nSchemaCoverageResult\nbuildCoveredFieldPaths()\nschemaLocalFieldPath()"]
   VAL["validate.ts\nSemanticIndex · SemanticDiagnostic\ncollectSemanticDiagnostics()"]
+  LNT["lint-findings.ts · lint-type-mismatch.ts\nlint-lineage-cycle.ts\nLintFinding\ndetectTypeMismatches()\ndetectLineageCycles()"]
 
-  IDX --> TYPES & FD & NEVER & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & REF & PAR & PE & COV & VAL
+  IDX --> TYPES & FD & NEVER & GENCST & CST & CLS & CAN & META & EXT & SPR & NL & FMT & STR & REF & PAR & PE & COV & VAL & LNT
   FD --> TYPES
   EXT --> CST & CLS & CAN & META & FD & TYPES
+  LNT --> COV & REF & TYPES
   SPR --> EXT & TYPES
   NL --> SPR & TYPES
   COV --> REF
@@ -180,6 +182,7 @@ graph LR
 | `DefinitionLookup` | `nl-ref.ts` | Callback for @-ref resolution: `(name, ns) => { kind, fields? } \| null` |
 | `SemanticIndex` | `validate.ts` | Minimal structural interface accepted by `collectSemanticDiagnostics`; satisfied by CLI `ExtractedWorkspace` |
 | `SemanticDiagnostic` | `validate.ts` | `{ file, line, column, severity, rule, message }` — one semantic warning or error |
+| `LintFinding` | `lint-findings.ts` | Same six fields, deliberately a distinct type: a *policy* finding, suppressible via `satsuma.config.yaml`, where `SemanticDiagnostic` is a *correctness* one. See ADR-047 |
 | `FieldCoverageEntry` | `coverage.ts` | `{ path, mapped: boolean }` — coverage status for one field path |
 | `SchemaCoverageResult` | `coverage.ts` | Per-schema list of `FieldCoverageEntry` records |
 | `ParseError` | `parse-errors.ts` | `{ file, line, column, message }` — structural error from tree-sitter ERROR/MISSING nodes |
@@ -212,7 +215,7 @@ flowchart TD
   spreadBridge["spread-expand.ts<br/>EntityFieldLookup adapter<br/>ExtractedWorkspace -> core callbacks"]
   graphBuilder["graph-builder.ts<br/>schema-level graph for graph/lineage"]
   graphCommandBuilder["commands/graph-builder.ts<br/>rich schema + field graph"]
-  lintEngine["lint-engine.ts<br/>lint rule evaluation"]
+  lintEngine["lint-engine.ts<br/>lint rule registry, fixes,<br/>NL-hygiene rules; wraps core detectors"]
   semanticWarnings["semantic-warnings.ts<br/>validateSemanticWorkspace adapter"]
 
   core["@satsuma/core<br/>extract* · validateSemanticWorkspace<br/>nl-ref · spread expansion · parser"]

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -22,15 +22,15 @@ A paint-only coverage overlay on the viz overview, uncovered-field treatment in 
 
 **Source:** `features/36-viz-coverage-and-chain-view/PRD.md`
 
-### Feature 37 — Structural Lint Rules (not started)
+### Feature 37 — Structural Lint Rules (complete)
 
-Two warning-severity lint rules — `type-mismatch-direct-arrow` (bare arrows between fields of different declared types) and `lineage-cycle` (schema-level cycles) — plus a `satsuma.config.yaml` loader for type aliases, rule suppression, and strict mode. Six tickets, none started (epic `sl-iffm`). Independent of Features 36 and 38.
+Two warning-severity lint rules — `type-mismatch-direct-arrow` (bare arrows between fields of different declared types) and `lineage-cycle` (schema-level cycles) — plus a `satsuma.config.yaml` loader for type aliases, rule suppression, and strict mode. All five tickets closed (epic `sl-iffm`). Detection for both rules lives in `@satsuma/core`, so the deferred LSP mirroring needs no re-implementation.
 
-**Sequencing:** `sl-npi6` (the config loader) gates everything else — `sl-j30s`, `sl-hysg`, `sl-1u6r`, then `sl-ay8a` for docs.
+**Breaking change shipped:** lint now publishes its own exit-code table (0 clean or advisory warnings, 1 strict warnings, 2 error findings, 3 could not run). It previously returned `2` both for error findings and for failing to run, so CI consumers keying on the old codes must change — called out in `CHANGELOG.md`.
 
-**Breaking change to plan for:** lint gets its own documented exit-code table (0/1/2/3). It currently returns `2` for error findings where `2` is documented as "parse error", so CI consumers keying on today's codes will need to change.
+**Recorded decision the cycle rule honours:** self-mappings (same source and target schema) are legitimate — they represent increments — and do not count as cycles. See the note at the foot of this page. The exemption is applied per-edge, so `source { a } target { a, b }` still contributes `a -> b`.
 
-**Recorded decision this rule must honour:** self-mappings (same source and target schema) are legitimate — they represent increments — and do not count as cycles. See the note at the foot of this page.
+**Still deferred:** LSP diagnostics for both rules, a built-in type-compatibility matrix (users declare their own via `lint.typeAliases`), field-level cycle detection, and autofixes for either rule.
 
 **Source:** `features/37-lint-structural-rules/PRD.md`
 

--- a/features/37-lint-structural-rules/PRD.md
+++ b/features/37-lint-structural-rules/PRD.md
@@ -1,6 +1,6 @@
 # Feature 37 — Structural Lint Rules: Type Mismatch & Lineage Cycles
 
-> **Status: PROPOSED** (2026-07-31) — independent of Features 35/36; shares
+> **Status: COMPLETE** (2026-08-03) — independent of Features 35/36; shares
 > their motivation. Large multi-layer mapping specs — especially ones
 > reverse-engineered from spreadsheet workbooks — accumulate two classes of
 > silent structural defect that the current toolchain accepts without

--- a/tooling/satsuma-cli/package-lock.json
+++ b/tooling/satsuma-cli/package-lock.json
@@ -34,7 +34,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/satsuma-cli/src/command-runner.ts
+++ b/tooling/satsuma-cli/src/command-runner.ts
@@ -73,9 +73,22 @@ export const EXIT_PARSE_ERROR = 2;
 export const EXIT_THRESHOLD_NOT_MET = 3;
 
 /**
+ * `lint --strict` (or `lint.strict: true`): the workspace has warning-severity
+ * findings and the caller asked for warnings to fail the build.
+ *
+ * Numerically the same as {@link EXIT_NOT_FOUND} but command-scoped, and the two
+ * never collide: `lint` takes no lookup argument that can fail to resolve, so `1`
+ * from `lint` has exactly one meaning. This is the escalation half of lint's own
+ * exit-code table (PRD 37 R5); the advisory default still exits `0`, so adding a
+ * config file cannot break an existing CI job.
+ */
+export const EXIT_LINT_STRICT_WARNINGS = 1;
+
+/**
  * `lint`: the command could not run as instructed — an unusable
- * `satsuma.config.yaml`, or a rule id that does not exist named by
- * `--select`/`--ignore`/`lint.suppress`.
+ * `satsuma.config.yaml`, a rule id that does not exist named by
+ * `--select`/`--ignore`/`lint.suppress`, or a workspace that could not be
+ * resolved or read at all.
  *
  * Numerically the same as {@link EXIT_THRESHOLD_NOT_MET} but a different
  * meaning, which is intentional and command-scoped: `lint` publishes its own

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -4,19 +4,28 @@
  * Policy-oriented linting for Satsuma workspaces.  Surfaces workspace
  * hygiene and modelling convention issues as structured diagnostics.
  *
- * Exit codes:
- *   0 — no error-severity findings (warnings alone do not cause exit 2)
- *   1 — internal error (filesystem, parser crash, bad arguments)
- *   2 — error-severity lint findings present
- *   3 — lint could not run (unusable config, unknown rule id)
+ * **`lint` publishes its own exit-code table** (PRD 37 R5), following the
+ * `fmt --check` precedent of a command owning codes that mean something specific
+ * to it:
+ *
+ *   0 — no findings, or warnings only without strict mode
+ *   1 — warnings present and strict mode active
+ *   2 — error-severity findings present
+ *   3 — lint could not run (unusable config, unknown rule id, unreadable workspace)
+ *
+ * This is a breaking change for CI jobs keying off the previous codes, where `2`
+ * doubled as "could not run" — see CHANGELOG.md. The split is what makes a
+ * failing gate distinguishable from a broken setup: `2` now means "the workspace
+ * has lint errors" and nothing else.
  *
  * Flags:
- *   --json     machine-readable JSON output
- *   --fix      apply safe, deterministic fixes
- *   --select   run only listed rules (comma-separated)
- *   --ignore   skip listed rules (comma-separated)
- *   --config   path to satsuma.config.yaml (default ./satsuma.config.yaml)
- *   --quiet    exit code only
+ *   --json      machine-readable JSON output
+ *   --fix       apply safe, deterministic fixes
+ *   --select    run only listed rules (comma-separated)
+ *   --ignore    skip listed rules (comma-separated)
+ *   --config    path to satsuma.config.yaml (default ./satsuma.config.yaml)
+ *   --strict    make warnings exit non-zero (--no-strict forces advisory)
+ *   --quiet     exit code only
  *
  * Rule selection combines flags and config through
  * `resolveSuppressedRuleIds` — see its contract for the precedence rule.
@@ -28,18 +37,20 @@ import {
   SATSUMA_CONFIG_FILENAME,
   resolveSuppressedRuleIds,
   unknownRuleIds,
-  type SatsumaConfig,
 } from "@satsuma/core/config";
 import { loadWorkspace } from "../load-workspace.js";
+import type { LoadedWorkspace } from "../load-workspace.js";
 import { loadSatsumaConfig } from "../load-config.js";
 import {
   CommandError,
   runCommand,
+  EXIT_OK,
   EXIT_PARSE_ERROR,
   EXIT_LINT_CANNOT_RUN,
+  EXIT_LINT_STRICT_WARNINGS,
 } from "../command-runner.js";
 import { runLint, applyFixes, RULES } from "../lint-engine.js";
-import type { LintFix } from "../types.js";
+import type { LintDiagnostic, LintFix } from "../types.js";
 
 /** Every rule id the engine knows, used to reject typos wherever ids are named. */
 const KNOWN_RULE_IDS: readonly string[] = RULES.map((r) => r.id);
@@ -74,26 +85,41 @@ function assertKnownRuleIds(flag: string, ids: readonly string[]): void {
 }
 
 /**
- * Warn about settings this CLI version parses but does not yet act on.
+ * The code `lint` exits with, given the findings that survived fixing.
  *
- * `lint.strict` and `lint.typeAliases` are part of the config contract from the
- * start (the LSP and CI need a stable shape to write against) but their
- * consumers ship separately: strict-mode exit codes in `sl-1u6r`, type aliasing
- * with the `type-mismatch-direct-arrow` rule in `sl-j30s`. Accepting them in
- * silence would let an author believe a gate is active when nothing enforces it
- * — the exact failure the config was added to prevent.
+ * The whole of PRD 37 R5's table in one place, so the meaning of each code is
+ * readable rather than spread across the handler:
+ *
+ *   - errors outrank warnings — a workspace with both is reported as `2`,
+ *     because fixing the errors is the first thing to do either way;
+ *   - warnings escalate to `1` only under strict mode, so the advisory default
+ *     is preserved and adding a config file cannot break an existing CI job;
+ *   - suppressed rules need no special case: a suppressed rule produces no
+ *     findings at all, so it can never trigger a strict failure.
  */
-function warnInertSettings(
-  config: SatsumaConfig,
-  warn: ((message: string) => void) | undefined,
-): void {
-  if (!warn) return;
+function lintExitCode(diagnostics: readonly LintDiagnostic[], strict: boolean): number {
+  if (diagnostics.some((d) => d.severity === "error")) return EXIT_PARSE_ERROR;
+  if (strict && diagnostics.length > 0) return EXIT_LINT_STRICT_WARNINGS;
+  return EXIT_OK;
+}
 
-  if (config.lint.strict) {
-    warn("lint.strict is not enforced yet — warnings still exit 0 (see sl-1u6r).");
-  }
-  if (config.lint.typeAliases.length > 0) {
-    warn("lint.typeAliases has no consumer yet — no rule compares declared types (see sl-j30s).");
+/**
+ * Load the workspace, reporting a failure to load as `3` rather than `2`.
+ *
+ * `loadWorkspace` raises {@link EXIT_PARSE_ERROR} because that is the CLI-wide
+ * code for unreadable input, but under lint's own table `2` means "the workspace
+ * has lint errors". A CI job must be able to tell a failing gate from a broken
+ * checkout, so the code is remapped here — the message and stream the loader
+ * chose are passed through untouched.
+ */
+async function loadLintWorkspace(pathArg: string | undefined): Promise<LoadedWorkspace> {
+  try {
+    return await loadWorkspace(pathArg);
+  } catch (err: unknown) {
+    if (err instanceof CommandError && err.code === EXIT_PARSE_ERROR) {
+      throw new CommandError(err.message, EXIT_LINT_CANNOT_RUN, err.stream);
+    }
+    throw err;
   }
 }
 
@@ -106,15 +132,26 @@ export function register(program: Command): void {
     .option("--select <rules>", "run only listed rules (comma-separated)")
     .option("--ignore <rules>", "skip listed rules (comma-separated)")
     .option("--config <path>", `path to config (default ./${SATSUMA_CONFIG_FILENAME})`)
+    .option("--strict", "make warning-severity findings exit non-zero")
+    .option("--no-strict", "keep warnings advisory even when the config sets strict")
     .option("--quiet", "exit code only")
     .option("--rules", "list available lint rules and exit")
     .addHelpText(
       "after",
       `
 Rules:
-  hidden-source-in-nl  error    NL text references a schema not in the mapping's source/target list
-  unresolved-nl-ref    warning  @ reference in NL does not resolve to any known identifier
-  duplicate-definition error    Named definition is declared more than once in a namespace
+  hidden-source-in-nl        error    NL text references a schema not in the mapping's source/target list
+  unresolved-nl-ref          warning  @ reference in NL does not resolve to any known identifier
+  duplicate-definition       error    Named definition is declared more than once in a namespace
+  unenumerated-record-target warning  Arrow targets a record without a record source or child arrows
+  type-mismatch-direct-arrow warning  Bare arrow connects fields whose declared types differ
+  lineage-cycle              warning  Schema-level mapping graph contains a cycle
+
+  Exemptions worth knowing: type-mismatch-direct-arrow never checks an arrow that
+  carries a transform body (a transform may legitimately change type, and judging
+  that is NL interpretation the CLI leaves to agents), and lineage-cycle never
+  reports a self-mapping (same source and target schema — how an increment is
+  expressed).
 
 JSON shape (--json):
   {
@@ -123,10 +160,11 @@ JSON shape (--json):
     "summary":  {"files": int, "findings": int, "fixable": int, "fixed": int}
   }
 
-Exit codes:
-  0  no error-severity findings
+Exit codes (lint has its own table):
+  0  no findings, or warnings only without --strict
+  1  warnings present and --strict active
   2  error-severity findings present
-  3  lint could not run (unusable config, or an unknown rule id)
+  3  lint could not run (unusable config, unknown rule id, unreadable workspace)
 
 Configuration (${SATSUMA_CONFIG_FILENAME}, override with --config):
   lint:
@@ -136,11 +174,14 @@ Configuration (${SATSUMA_CONFIG_FILENAME}, override with --config):
 
   A missing config file is not an error. Suppression is the union of --ignore
   and lint.suppress, except that a rule named by --select always runs.
+  --strict / --no-strict win over lint.strict. Suppressed rules produce no
+  findings, so they can never trigger a strict failure.
 
 Examples:
   satsuma lint pipeline.stm                  # check conventions
   satsuma lint pipeline.stm --json           # structured diagnostics
   satsuma lint pipeline.stm --fix            # auto-fix fixable issues
+  satsuma lint pipeline.stm --strict         # fail CI on warnings too
   satsuma lint --rules                       # list available rules
   satsuma lint pipeline.stm --select hidden-source-in-nl  # run one rule only
   satsuma lint pipeline.stm --config ci.yaml # lint with a specific config`,
@@ -155,6 +196,11 @@ Examples:
             select?: string;
             ignore?: string;
             config?: string;
+            /**
+             * Tri-state: `undefined` when neither `--strict` nor `--no-strict`
+             * was passed, which is what lets the config supply the default.
+             */
+            strict?: boolean;
             quiet?: boolean;
             rules?: boolean;
           },
@@ -183,7 +229,8 @@ Examples:
             ...(opts.quiet ? {} : { onWarning: (m: string) => console.error(`Warning: ${m}`) }),
           });
 
-          warnInertSettings(config, opts.quiet ? undefined : (m) => console.error(`Warning: ${m}`));
+          // Flags win over config; `undefined` means neither flag was passed.
+          const strict = opts.strict ?? config.lint.strict;
 
           const suppressed = resolveSuppressedRuleIds({
             ...(select ? { select } : {}),
@@ -191,10 +238,12 @@ Examples:
             configSuppress: config.lint.suppress,
           });
 
-          const { files, index } = await loadWorkspace(pathArg);
+          const { files, index } = await loadLintWorkspace(pathArg);
           const fileCount = files.length;
 
-          const ruleOpts: { select?: string[]; ignore?: string[] } = {};
+          const ruleOpts: Parameters<typeof runLint>[1] = {
+            typeAliases: config.lint.typeAliases,
+          };
           if (select) ruleOpts.select = select;
           if (suppressed.size > 0) ruleOpts.ignore = [...suppressed];
 
@@ -233,13 +282,8 @@ Examples:
           }
 
           const findingCount = diagnostics.length;
-          const errorCount = diagnostics.filter((d) => d.severity === "error").length;
           const fixableCount = diagnostics.filter((d) => d.fixable).length;
-
-          // Soft exit code: lint uses 2 for "any error-severity finding"
-          // and 0 otherwise. Warning-severity rules never push the exit
-          // non-zero — that's documented in the command help.
-          const exitCode = errorCount > 0 ? EXIT_PARSE_ERROR : 0;
+          const exitCode = lintExitCode(diagnostics, strict);
 
           // --quiet: exit code only
           if (opts.quiet) {

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -8,15 +8,26 @@
  */
 
 import {
+  canonicalizeEntityRef,
   capitalize,
   createAuthoredEntityRef,
   createCanonicalEntityRef,
   createContainerQualifiedFieldRef,
   declaredFieldKind,
+  detectLineageCycles,
+  detectTypeMismatches,
   schemaLocalFieldPath,
   stripNLRefScopePrefix,
+  LINEAGE_CYCLE_RULE_ID,
+  TYPE_MISMATCH_RULE_ID,
 } from "@satsuma/core";
-import type { ArrowDeclarationKind } from "@satsuma/core";
+import type {
+  ArrowDeclarationKind,
+  DeclaredTypeSchemaResolver,
+  LineageSchemaIdResolver,
+  LintFinding,
+} from "@satsuma/core";
+import { expandDeclaredFields } from "./spread-expand.js";
 import {
   extractAtRefs,
   computeNLRefPosition,
@@ -25,7 +36,13 @@ import {
   isSchemaInMappingSources,
 } from "./nl-ref-extract.js";
 import { resolveCanonicalKey } from "./index-builder.js";
-import type { LintDiagnostic, LintFix, LintRule, ExtractedWorkspace } from "./types.js";
+import type {
+  LintDiagnostic,
+  LintFix,
+  LintRule,
+  LintRuleContext,
+  ExtractedWorkspace,
+} from "./types.js";
 
 // ── Rule registry ──────────────────────────────────────────────────────────
 
@@ -49,6 +66,16 @@ export const RULES: LintRule[] = [
     id: "unenumerated-record-target",
     description: "Arrow targets a record without a record source or child arrows",
     check: checkUnenumeratedRecordTarget,
+  },
+  {
+    id: TYPE_MISMATCH_RULE_ID,
+    description: "Bare arrow connects fields whose declared types differ",
+    check: checkTypeMismatchDirectArrow,
+  },
+  {
+    id: LINEAGE_CYCLE_RULE_ID,
+    description: "Schema-level mapping graph contains a cycle",
+    check: checkLineageCycle,
   },
 ];
 
@@ -606,11 +633,109 @@ function endpointKind(
   return null;
 }
 
+// ── Structural rules detected in core ──────────────────────────────────────
+//
+// Both rules below are thin adapters, by design (PRD 37 R3): the detection lives
+// in `@satsuma/core` because the LSP will mirror these as editor diagnostics, and
+// a second implementation would let the editor and CI disagree about the same
+// workspace. Everything these functions do is resolve `ExtractedWorkspace` into
+// the shapes core asks for.
+
+/**
+ * Report bare arrows whose two ends declare different types.
+ *
+ * Alias groups arrive from `satsuma.config.yaml` through {@link LintRuleContext}:
+ * nothing is presumed equivalent without them.
+ */
+function checkTypeMismatchDirectArrow(
+  index: ExtractedWorkspace,
+  context: LintRuleContext,
+): LintDiagnostic[] {
+  return detectTypeMismatches({
+    arrows: index.arrows,
+    mappings: index.mappings,
+    resolveSchema: makeDeclaredTypeResolver(index),
+    typeAliases: context.typeAliases,
+  }).map(toLintDiagnostic);
+}
+
+/** Report each cyclic tangle in the schema-level mapping graph. */
+function checkLineageCycle(index: ExtractedWorkspace): LintDiagnostic[] {
+  return detectLineageCycles({
+    mappings: index.mappings,
+    resolveSchemaId: makeLineageSchemaIdResolver(index),
+  }).map(toLintDiagnostic);
+}
+
+/**
+ * Adapt a core finding to a CLI diagnostic.
+ *
+ * `fixable: false` is not a placeholder: neither rule can be fixed
+ * mechanically. Correcting a type mismatch means choosing between the field, the
+ * type and a missing transform, and breaking a cycle means reversing an arrow —
+ * both are author judgements, so there is nothing safe for `--fix` to apply.
+ */
+function toLintDiagnostic(finding: LintFinding): LintDiagnostic {
+  return {
+    file: finding.file,
+    line: finding.line,
+    column: finding.column,
+    severity: finding.severity,
+    rule: finding.rule,
+    message: finding.message,
+    fixable: false,
+  };
+}
+
+/**
+ * Resolve a schema reference written in a mapping to its declared field tree,
+ * with fragment spreads inlined.
+ *
+ * Spreads are expanded because a spread field is a declared field of the
+ * consuming schema, and an arrow may perfectly well name one — leaving them out
+ * would make the rule silently skip every arrow that touched one.
+ */
+function makeDeclaredTypeResolver(index: ExtractedWorkspace): DeclaredTypeSchemaResolver {
+  return (writtenRef, mappingNamespace) => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, index.schemas);
+    if (!canonicalRef) return null;
+    const key = resolveCanonicalKey(canonicalRef);
+    const schema = index.schemas.get(key);
+    if (!schema) return null;
+    return {
+      schemaId: key,
+      canonicalRef,
+      fields: expandDeclaredFields(schema, schema.namespace ?? null, index),
+    };
+  };
+}
+
+/**
+ * Resolve a schema reference written in a mapping to the workspace key that
+ * identifies it — the graph's node id.
+ *
+ * Uses the same canonicalization as every other consumer so `orders` written
+ * inside `namespace crm` and `crm::orders` written outside it become one node.
+ */
+function makeLineageSchemaIdResolver(index: ExtractedWorkspace): LineageSchemaIdResolver {
+  return (writtenRef, mappingNamespace) => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, index.schemas);
+    if (!canonicalRef) return null;
+    const key = resolveCanonicalKey(canonicalRef);
+    return index.schemas.has(key) ? key : null;
+  };
+}
+
 // ── Engine ─────────────────────────────────────────────────────────────────
 
 interface LintOptions {
   select?: string[];
   ignore?: string[];
+  /**
+   * Declared-type equivalence groups from `lint.typeAliases`. Defaults to none,
+   * which is what a workspace with no config file gets.
+   */
+  typeAliases?: readonly (readonly string[])[];
 }
 
 /**
@@ -627,9 +752,11 @@ export function runLint(index: ExtractedWorkspace, opts: LintOptions = {}): Lint
     rules = rules.filter((r) => !set.has(r.id));
   }
 
+  const context: LintRuleContext = { typeAliases: opts.typeAliases ?? [] };
+
   const diagnostics: LintDiagnostic[] = [];
   for (const rule of rules) {
-    diagnostics.push(...rule.check(index));
+    diagnostics.push(...rule.check(index, context));
   }
 
   diagnostics.sort(

--- a/tooling/satsuma-cli/src/types.ts
+++ b/tooling/satsuma-cli/src/types.ts
@@ -242,10 +242,25 @@ export interface LintDiagnostic {
   fix?: LintFix;
 }
 
+/**
+ * Workspace settings a rule may need beyond the index itself.
+ *
+ * Passed to every rule rather than captured when the registry is built, so `RULES`
+ * stays a plain constant that `--rules` and the help text can list without a
+ * config in hand. Rules that need nothing from it ignore the parameter.
+ */
+export interface LintRuleContext {
+  /**
+   * Declared-type equivalence groups from `lint.typeAliases`, consumed by
+   * `type-mismatch-direct-arrow`. Empty when the workspace has no config.
+   */
+  typeAliases: readonly (readonly string[])[];
+}
+
 export interface LintRule {
   id: string;
   description: string;
-  check: (index: ExtractedWorkspace) => LintDiagnostic[];
+  check: (index: ExtractedWorkspace, context: LintRuleContext) => LintDiagnostic[];
 }
 
 export type RegisterFn = (rule: LintRule) => void;

--- a/tooling/satsuma-cli/test/bug-purge.test.ts
+++ b/tooling/satsuma-cli/test/bug-purge.test.ts
@@ -406,7 +406,7 @@ describe("sl-tslm: collectSemanticWarnings emits 'unresolved-nl-ref' to match li
 
 // ── sl-j8uk: Filesystem errors exit code 2 ────────────────────────────────
 
-describe("sl-j8uk: filesystem errors exit code 2", () => {
+describe("sl-j8uk: filesystem errors exit with a 'could not run' code, never 0", () => {
   it("summary exits 2 for nonexistent path", async () => {
     const { code } = await run("summary", "/nonexistent/path");
     assert.equal(code, 2);
@@ -422,9 +422,13 @@ describe("sl-j8uk: filesystem errors exit code 2", () => {
     assert.equal(code, 2);
   });
 
-  it("lint exits 2 for nonexistent path", async () => {
+  it("lint exits 3 for nonexistent path, because 2 now means 'the workspace has lint errors'", async () => {
+    // lint publishes its own exit-code table (PRD 37 R5, sl-1u6r), which is a
+    // deliberate break from the CLI-wide `2` the sibling cases above assert. A
+    // CI job must be able to tell a failing lint gate from an unreadable
+    // workspace, so "could not run" moved to 3.
     const { code } = await run("lint", "/nonexistent/path");
-    assert.equal(code, 2);
+    assert.equal(code, 3);
   });
 
   it("not-found schema still exits 1", async () => {

--- a/tooling/satsuma-cli/test/lint-command.test.ts
+++ b/tooling/satsuma-cli/test/lint-command.test.ts
@@ -1,0 +1,266 @@
+/**
+ * lint-command.test.ts — the `satsuma lint` command's own contract.
+ *
+ * Covers what only the command owns: its exit-code table (PRD 37 R5), strict-mode
+ * precedence between the flag and the config, and that the structural rules
+ * detected in `@satsuma/core` are registered and surface in `--json` with the
+ * right severity.
+ *
+ * Rule *semantics* are tested once in core — `lint-type-mismatch.test.js` and
+ * `lint-lineage-cycle.test.js`. Nothing here re-asserts which arrows mismatch or
+ * which graphs are cyclic; these cases only prove the wiring.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { run } from "./helpers.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = resolve(__dirname, "../dist/index.js");
+
+/** lint's own exit-code table (PRD 37 R5), named so the assertions read as prose. */
+const EXIT_CLEAN = 0;
+const EXIT_STRICT_WARNINGS = 1;
+const EXIT_ERROR_FINDINGS = 2;
+const EXIT_CANNOT_RUN = 3;
+
+/** Write `pipeline.stm` into a throwaway directory and return the directory. */
+function workspace(source: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "satsuma-lint-cmd-"));
+  writeFileSync(join(dir, "pipeline.stm"), source, "utf8");
+  return dir;
+}
+
+/** Lint the workspace's entry file with the given extra arguments. */
+function lint(dir: string, ...args: string[]) {
+  return run(CLI, "lint", join(dir, "pipeline.stm"), ...args);
+}
+
+/** A workspace with no findings of any kind. */
+const CLEAN = `
+schema src {
+  id  STRING
+}
+
+schema dst {
+  id  STRING
+}
+
+mapping copy {
+  source { src }
+  target { dst }
+  id -> id
+}
+`;
+
+/** A workspace whose only finding is a warning — a bare arrow between two types. */
+const WARNING_ONLY = `
+schema src {
+  id  STRING
+}
+
+schema dst {
+  id  INT
+}
+
+mapping copy {
+  source { src }
+  target { dst }
+  id -> id
+}
+`;
+
+/** A workspace with an error-severity finding: the same schema declared twice. */
+const ERROR_FINDING = `
+schema src {
+  id  STRING
+}
+
+schema src {
+  id  STRING
+}
+`;
+
+/** Two mappings pointing at each other — the `lineage-cycle` case. */
+const LINEAGE_CYCLE = `
+schema a {
+  id  STRING
+}
+
+schema b {
+  id  STRING
+}
+
+mapping a_to_b {
+  source { a }
+  target { b }
+  id -> id
+}
+
+mapping b_to_a {
+  source { b }
+  target { a }
+  id -> id
+}
+`;
+
+// ── Exit-code table ─────────────────────────────────────────────────────────
+
+describe("lint exit codes", () => {
+  it("exits 0 on a workspace with no findings", async () => {
+    // The baseline the other rows are read against.
+    const { code } = await lint(workspace(CLEAN));
+    assert.equal(code, EXIT_CLEAN);
+  });
+
+  it("exits 0 when there are warnings but strict mode is off", async () => {
+    // Warnings stay advisory by default (PRD 37 R5), so adding a rule — or a
+    // config file — can never break an existing CI job.
+    const { code, stdout } = await lint(workspace(WARNING_ONLY));
+    assert.match(stdout, /warning/);
+    assert.equal(code, EXIT_CLEAN);
+  });
+
+  it("exits 1 when warnings are present and --strict is active", async () => {
+    // The escalation CI users asked for: same findings, failing exit code.
+    const { code } = await lint(workspace(WARNING_ONLY), "--strict");
+    assert.equal(code, EXIT_STRICT_WARNINGS);
+  });
+
+  it("exits 2 for an error-severity finding, with or without --strict", async () => {
+    // Errors outrank warnings: a workspace with lint errors reports 2 either way,
+    // because fixing the errors is the first thing to do regardless.
+    const dir = workspace(ERROR_FINDING);
+    assert.equal((await lint(dir)).code, EXIT_ERROR_FINDINGS);
+    assert.equal((await lint(dir, "--strict")).code, EXIT_ERROR_FINDINGS);
+  });
+
+  it("exits 3 when the workspace cannot be read at all", async () => {
+    // This is the row that makes the table useful: 2 now means "the workspace has
+    // lint errors", so "lint never ran" needs its own code. A CI job must be able
+    // to tell a failing gate from a broken checkout.
+    const { code } = await run(CLI, "lint", "/nonexistent/pipeline.stm");
+    assert.equal(code, EXIT_CANNOT_RUN);
+  });
+
+  it("exits 3 for an unusable config even when --strict is set", async () => {
+    // "Could not run" beats every finding-based code: with a broken config the
+    // findings are not trustworthy, so reporting a gate result would be a lie.
+    const dir = workspace(WARNING_ONLY);
+    const configPath = join(dir, "broken.yaml");
+    writeFileSync(configPath, "lint:\n  strict: maybe\n", "utf8");
+
+    const { code } = await lint(dir, "--strict", "--config", configPath);
+    assert.equal(code, EXIT_CANNOT_RUN);
+  });
+
+  it("reports the same code with --quiet as it does with output", async () => {
+    // --quiet exists for CI, which reads only the code; if the two paths could
+    // disagree the flag would be a trap.
+    const dir = workspace(WARNING_ONLY);
+    const quiet = await lint(dir, "--strict", "--quiet");
+
+    assert.equal(quiet.stdout, "");
+    assert.equal(quiet.code, EXIT_STRICT_WARNINGS);
+  });
+});
+
+// ── Strict-mode precedence ──────────────────────────────────────────────────
+
+describe("strict mode precedence", () => {
+  /** A workspace holding a warning plus a config file setting `lint.strict`. */
+  function workspaceWithStrict(strict: boolean): string {
+    const dir = workspace(WARNING_ONLY);
+    writeFileSync(join(dir, "strict.yaml"), `lint:\n  strict: ${strict}\n`, "utf8");
+    return dir;
+  }
+
+  it("honours lint.strict from the config file", async () => {
+    // The persistent form of the flag: a workspace can commit its own gate
+    // without every CI invocation having to remember to pass --strict.
+    const dir = workspaceWithStrict(true);
+    const { code } = await lint(dir, "--config", join(dir, "strict.yaml"));
+    assert.equal(code, EXIT_STRICT_WARNINGS);
+  });
+
+  it("lets --strict override a config that turns strict off", async () => {
+    // Flags win over config (PRD 37 R4's single precedence rule), so a one-off
+    // strict run needs no config edit.
+    const dir = workspaceWithStrict(false);
+    const { code } = await lint(dir, "--config", join(dir, "strict.yaml"), "--strict");
+    assert.equal(code, EXIT_STRICT_WARNINGS);
+  });
+
+  it("lets --no-strict override a config that turns strict on", async () => {
+    // The same rule in the other direction: one job may want an advisory run
+    // against a workspace whose committed config gates on warnings.
+    const dir = workspaceWithStrict(true);
+    const { code } = await lint(dir, "--config", join(dir, "strict.yaml"), "--no-strict");
+    assert.equal(code, EXIT_CLEAN);
+  });
+
+  it("does not fail strictly on a rule that is suppressed", async () => {
+    // A suppressed rule produces no findings at all, so it can never trigger a
+    // strict failure. Were it otherwise, suppression and strictness together
+    // would be unusable.
+    const dir = workspace(WARNING_ONLY);
+    const { code } = await lint(dir, "--strict", "--ignore", "type-mismatch-direct-arrow");
+    assert.equal(code, EXIT_CLEAN);
+  });
+});
+
+// ── Registration of the core-detected rules ─────────────────────────────────
+
+describe("structural rules registration", () => {
+  it("lists both structural rules in --rules", async () => {
+    // `--rules` is the discoverability surface, and the same list validates
+    // --select/--ignore/lint.suppress ids — a rule missing from the registry
+    // would make its own id a typo.
+    const { stdout } = await run(CLI, "lint", "--rules");
+    assert.match(stdout, /type-mismatch-direct-arrow/);
+    assert.match(stdout, /lineage-cycle/);
+  });
+
+  it("reports a type mismatch as an unfixable warning in --json", async () => {
+    // Pins the JSON contract machine consumers read: id, severity, position, and
+    // fixable: false — the fix is an author judgement, so --fix must not offer one.
+    const { stdout, code } = await lint(workspace(WARNING_ONLY), "--json");
+    const finding = JSON.parse(stdout).findings.find(
+      (f: { rule: string }) => f.rule === "type-mismatch-direct-arrow",
+    );
+
+    assert.equal(finding.severity, "warning");
+    assert.equal(finding.fixable, false);
+    assert.equal(finding.column, 1);
+    assert.ok(finding.line > 0);
+    assert.equal(code, EXIT_CLEAN);
+  });
+
+  it("reports a lineage cycle as an unfixable warning in --json", async () => {
+    // Same contract for the second rule, which shares the wrapper that sets
+    // severity and fixability.
+    const { stdout } = await lint(workspace(LINEAGE_CYCLE), "--json");
+    const findings = JSON.parse(stdout).findings.filter(
+      (f: { rule: string }) => f.rule === "lineage-cycle",
+    );
+
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].severity, "warning");
+    assert.equal(findings[0].fixable, false);
+  });
+
+  it("runs only the named rule under --select", async () => {
+    // Proves the new ids participate in selection like every other rule, rather
+    // than being appended outside the filter.
+    const { stdout } = await lint(workspace(LINEAGE_CYCLE), "--json", "--select", "lineage-cycle");
+    const rules = new Set(
+      JSON.parse(stdout).findings.map((f: { rule: string }) => f.rule) as string[],
+    );
+
+    assert.deepEqual([...rules], ["lineage-cycle"]);
+  });
+});

--- a/tooling/satsuma-cli/test/load-config.test.ts
+++ b/tooling/satsuma-cli/test/load-config.test.ts
@@ -242,15 +242,46 @@ describe("satsuma lint --config", () => {
     assert.match(result.stderr, /unresolved-nl-ref/);
   });
 
-  it("warns that lint.strict is parsed but not yet enforced", async () => {
-    // strict: true with no enforcement would read as an active gate. Until
-    // sl-1u6r ships, the CLI must say so out loud.
-    const dir = workspaceWithFinding();
-    const configPath = join(dir, "strict.yaml");
-    writeFileSync(configPath, "lint:\n  strict: true\n", "utf8");
+  it("applies lint.typeAliases to the type-mismatch rule", async () => {
+    // The end-to-end proof that the alias section reaches the rule. Without it
+    // the config would parse a setting nothing consumed — the failure mode the
+    // config was added to prevent. Alias *semantics* are core's tests.
+    const dir = mkdtempSync(join(tmpdir(), "satsuma-lint-aliases-"));
+    writeFileSync(
+      join(dir, "pipeline.stm"),
+      [
+        "schema src {",
+        "  id  STRING",
+        "}",
+        "",
+        "schema dst {",
+        "  id  TEXT",
+        "}",
+        "",
+        "mapping `copy id` {",
+        "  source { `src` }",
+        "  target { `dst` }",
+        "",
+        "  id -> id",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const configPath = join(dir, "aliases.yaml");
+    writeFileSync(configPath, "lint:\n  typeAliases:\n    - [STRING, TEXT]\n", "utf8");
 
-    const result = await run(CLI, "lint", join(dir, "pipeline.stm"), "--config", configPath);
-    assert.match(result.stderr, /lint\.strict is not enforced yet/);
-    assert.equal(result.code, 0);
+    const withoutConfig = await run(CLI, "lint", join(dir, "pipeline.stm"), "--json");
+    assert.match(withoutConfig.stdout, /type-mismatch-direct-arrow/);
+
+    const withConfig = await run(
+      CLI,
+      "lint",
+      join(dir, "pipeline.stm"),
+      "--json",
+      "--config",
+      configPath,
+    );
+    assert.doesNotMatch(withConfig.stdout, /type-mismatch-direct-arrow/);
   });
 });

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -141,6 +141,22 @@ export {
   walkDescendants,
 } from "./cst-utils.js";
 export { classifyTransform, classifyArrow } from "./classify.js";
+export type { LintFinding } from "./lint-findings.js";
+export { TYPE_MISMATCH_RULE_ID, detectTypeMismatches } from "./lint-type-mismatch.js";
+export type {
+  DeclaredTypeField,
+  DeclaredTypeSchema,
+  DeclaredTypeSchemaResolver,
+  TypeMismatchArrow,
+  TypeMismatchInput,
+  TypeMismatchMapping,
+} from "./lint-type-mismatch.js";
+export { LINEAGE_CYCLE_RULE_ID, detectLineageCycles } from "./lint-lineage-cycle.js";
+export type {
+  LineageCycleInput,
+  LineageCycleMapping,
+  LineageSchemaIdResolver,
+} from "./lint-lineage-cycle.js";
 export {
   canonicalRef,
   canonicalEntityName,

--- a/tooling/satsuma-core/src/lint-findings.ts
+++ b/tooling/satsuma-core/src/lint-findings.ts
@@ -1,0 +1,42 @@
+/**
+ * lint-findings.ts — the shape a core lint detector reports.
+ *
+ * Owns the output contract shared by every structural lint rule whose detection
+ * logic lives in core (PRD 37 R3), so the CLI's `lint` command and the LSP's
+ * diagnostics can be fed from the same detector without either package owning
+ * the other's shape.
+ *
+ * It does **not** own severity policy per rule (each detector states its own,
+ * and the rationale belongs next to the rule), rule registration, suppression,
+ * or fixes — fixes are text rewrites and stay with the consumer that owns the
+ * file on disk.
+ *
+ * Why this is not {@link SemanticDiagnostic}: the two are structurally identical
+ * today, and deliberately separate. A `validate` diagnostic says the workspace is
+ * *wrong*; a lint finding says it breaks a *policy* the workspace may have chosen
+ * — the distinction the `lint`/`validate` split exists to draw, and the reason
+ * only one of the two is suppressible via `satsuma.config.yaml`. Keeping them
+ * apart also means a field one side later needs (lint fixability, for instance)
+ * does not widen a contract that crosses the LSP protocol boundary.
+ */
+
+/**
+ * One finding from a core lint detector.
+ *
+ * Positions are 1-indexed in both axes, matching {@link SemanticDiagnostic} and
+ * CLI output. LSP consumers subtract 1 from each.
+ */
+export interface LintFinding {
+  /** Rule id, e.g. `type-mismatch-direct-arrow`. Stable: CI and configs key off it. */
+  readonly rule: string;
+  /** Severity as the rule itself defines it — detectors never leave this to the caller. */
+  readonly severity: "error" | "warning";
+  /** Absolute path (CLI) or URI (LSP) of the file the finding is reported against. */
+  readonly file: string;
+  /** 1-indexed line of the declaration that triggered the finding. */
+  readonly line: number;
+  /** 1-indexed column; `1` for findings anchored to a whole declaration. */
+  readonly column: number;
+  /** Human-readable message, complete enough to act on without opening the file. */
+  readonly message: string;
+}

--- a/tooling/satsuma-core/src/lint-lineage-cycle.ts
+++ b/tooling/satsuma-core/src/lint-lineage-cycle.ts
@@ -1,0 +1,510 @@
+/**
+ * lint-lineage-cycle.ts — the `lineage-cycle` lint rule (PRD 37 R2).
+ *
+ * Owns one question about the schema-level mapping graph: does data flow in a
+ * loop? `a -> b` in one mapping and `b -> a` in another is occasionally
+ * intentional (a bidirectional sync spec) but more often a reversed arrow, or
+ * two mappings authored independently that disagree about direction. The symptom
+ * is subtle, because every traversal in the toolchain is already cycle-guarded:
+ * lineage output silently omits an expected upstream hop and nothing says why.
+ * Guarding is not reporting.
+ *
+ * Owns: the graph's edge semantics, the self-mapping exemption, one finding per
+ * strongly-connected component, and the canonical representative path. Does not
+ * own rule registration, suppression, or schema resolution.
+ *
+ * Edges are the same ones `satsuma lineage` and `graph --compact` draw — each
+ * mapping's source schemas to its target schemas — so a cycle this rule reports
+ * is a cycle those commands traverse.
+ */
+
+import type { LintFinding } from "./lint-findings.js";
+import { createAuthoredEntityRef } from "./reference-stages.js";
+import type { AuthoredEntityRef } from "./reference-stages.js";
+
+/** Rule id. Stable — CI jobs and `lint.suppress` entries key off it. */
+export const LINEAGE_CYCLE_RULE_ID = "lineage-cycle";
+
+// ── Structural inputs ───────────────────────────────────────────────────────
+
+/** A mapping, reduced to the edges it contributes and where to find it. */
+export interface LineageCycleMapping {
+  /** Mapping label, or null for an anonymous `mapping { … }` block. */
+  readonly name: string | null;
+  /** Namespace the mapping is declared in, or null/absent at file scope. */
+  readonly namespace?: string | null;
+  /** Absolute path or URI of the declaring file. */
+  readonly file: string;
+  /** 0-indexed declaration row, as extraction records it. */
+  readonly row: number;
+  /** Schema references from the `source {}` block, as written. */
+  readonly sources: readonly string[];
+  /** Schema references from the `target {}` block, as written. */
+  readonly targets: readonly string[];
+}
+
+/**
+ * Resolve a schema reference written in a mapping to its stable workspace id, or
+ * null when the workspace declares no such schema.
+ *
+ * The id is what the graph's nodes *are*, so it must be the same string for two
+ * mappings that spell one schema differently (`orders` inside `namespace crm`,
+ * `crm::orders` from outside). Getting that wrong splits one schema into two
+ * nodes and hides the cycle running between them.
+ *
+ * Unresolvable references drop their edge rather than becoming a node of their
+ * own: an invented node cannot participate in a real cycle, and `validate`
+ * already reports a mapping pointing at a schema that does not exist.
+ */
+export type LineageSchemaIdResolver = (
+  writtenRef: AuthoredEntityRef,
+  mappingNamespace: string | null,
+) => string | null;
+
+/** Everything {@link detectLineageCycles} reads. */
+export interface LineageCycleInput {
+  /** Mappings by index key. Only the values are read; the key itself is not used. */
+  readonly mappings: ReadonlyMap<string, LineageCycleMapping>;
+  /** See {@link LineageSchemaIdResolver}. */
+  readonly resolveSchemaId: LineageSchemaIdResolver;
+}
+
+// ── Detection ───────────────────────────────────────────────────────────────
+
+/**
+ * Report each cyclic tangle in the schema-level mapping graph, once.
+ *
+ * Severity is `warning`: a cross-schema cycle can be a deliberate bidirectional
+ * spec, so this is policy, not correctness — `validate` semantics are untouched.
+ * Not fixable: closing a cycle means reversing an arrow or splitting a schema,
+ * and only the author knows which.
+ *
+ * **One finding per strongly-connected component, not per elementary cycle.**
+ * Enumerating elementary cycles (Johnson) is output-exponential: a densely
+ * cross-linked platform graph holds combinatorially many cycles that all
+ * describe the same tangle of mappings, which is why the rule was originally
+ * specified with a truncation cap. An SCC *is* that tangle — its count is
+ * bounded by the number of schemas, so nothing is capped and nothing is
+ * truncated — and untangling the component is what the reviewer has to do
+ * anyway, rather than auditing each rotation through it. Settled in doc review
+ * 2026-07-31.
+ */
+export function detectLineageCycles(input: LineageCycleInput): LintFinding[] {
+  const graph = buildSchemaGraph(input);
+
+  const findings: LintFinding[] = [];
+  for (const component of stronglyConnectedComponents(graph)) {
+    // Self-edges were dropped at graph-build time, so a single-node component
+    // can never be cyclic and is never a finding.
+    if (component.length < MIN_CYCLIC_COMPONENT_SIZE) continue;
+    findings.push(describeCycle(component, graph));
+  }
+
+  return findings;
+}
+
+/**
+ * A component smaller than this cannot hold a cycle once self-edges are gone:
+ * two distinct schemas, each reaching the other, is the smallest real tangle.
+ */
+const MIN_CYCLIC_COMPONENT_SIZE = 2;
+
+// ── The schema graph ────────────────────────────────────────────────────────
+
+/** Where a mapping is, and what to call it in a message. */
+interface MappingSite {
+  /** Label for the message — anonymous blocks are named by position instead. */
+  readonly label: string;
+  /** Absolute path or URI of the declaring file. */
+  readonly file: string;
+  /** 1-indexed declaration line, ready to report. */
+  readonly line: number;
+}
+
+/**
+ * The schema-level graph: sorted adjacency plus, for every edge, the mappings
+ * that declare it.
+ *
+ * Adjacency lists and each edge's mapping list are sorted, which is what makes
+ * every walk below independent of the order the files were loaded in.
+ *
+ * Edge attribution is a map of maps rather than one map under a composite key.
+ * A backtick-quoted schema name may contain spaces, dots and colons, so any
+ * separator that joined two ids into one string could itself be part of an id
+ * and let two distinct edges collide.
+ */
+interface SchemaGraph {
+  /** Every node, sorted by id. */
+  readonly nodes: readonly string[];
+  /** Successors of each node, sorted by id. */
+  readonly successors: ReadonlyMap<string, readonly string[]>;
+  /** Mappings declaring each edge, as `from` → `to` → sites sorted by position. */
+  readonly edgeMappings: ReadonlyMap<string, ReadonlyMap<string, readonly MappingSite[]>>;
+}
+
+/** The mappings declaring the edge `from -> to`; empty when there is no such edge. */
+function edgeSites(graph: SchemaGraph, from: string, to: string): readonly MappingSite[] {
+  return graph.edgeMappings.get(from)?.get(to) ?? [];
+}
+
+/**
+ * Build the schema graph from the workspace's mappings.
+ *
+ * **Self-mapping edges are dropped here, before any cycle detection runs.** A
+ * mapping whose source and target are the same schema is legitimate — it is how
+ * an incremental load is expressed — and that is a recorded product decision,
+ * not an implementation convenience: *"self-mappings (same source and target
+ * schema) are OK — we can use that to represent things like increments, and
+ * DON'T cause graph cycles"* (`docs/product-owner/ROADMAP.md`).
+ *
+ * Note the exemption is per-*edge*, not per-mapping: a mapping with
+ * `source { a }` and `target { a, b }` still contributes `a -> b`.
+ */
+function buildSchemaGraph(input: LineageCycleInput): SchemaGraph {
+  const successorSets = new Map<string, Set<string>>();
+  const edgeMappings = new Map<string, Map<string, MappingSite[]>>();
+
+  for (const mapping of input.mappings.values()) {
+    const namespace = mapping.namespace ?? null;
+    const resolve = (ref: string): string | null =>
+      input.resolveSchemaId(createAuthoredEntityRef(ref), namespace);
+
+    const sources = mapping.sources.map(resolve).filter(isResolved);
+    const targets = mapping.targets.map(resolve).filter(isResolved);
+
+    for (const from of sources) {
+      for (const to of targets) {
+        if (from === to) continue; // the self-mapping exemption
+        recordEdge(successorSets, edgeMappings, from, to, mappingSite(mapping));
+      }
+    }
+  }
+
+  return {
+    nodes: [...successorSets.keys()].sort(),
+    successors: sortedAdjacency(successorSets),
+    edgeMappings: sortedEdgeMappings(edgeMappings),
+  };
+}
+
+/** Add one `from -> to` edge and credit `site` with declaring it. */
+function recordEdge(
+  successorSets: Map<string, Set<string>>,
+  edgeMappings: Map<string, Map<string, MappingSite[]>>,
+  from: string,
+  to: string,
+  site: MappingSite,
+): void {
+  // Both endpoints become nodes, so a node that only ever appears as a target
+  // still exists in the graph.
+  for (const node of [from, to]) {
+    if (!successorSets.has(node)) successorSets.set(node, new Set());
+  }
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- created just above
+  successorSets.get(from)!.add(to);
+
+  const outgoing = edgeMappings.get(from) ?? new Map<string, MappingSite[]>();
+  const sites = outgoing.get(to) ?? [];
+  sites.push(site);
+  outgoing.set(to, sites);
+  edgeMappings.set(from, outgoing);
+}
+
+/** Freeze adjacency into sorted arrays, the form every walk below relies on. */
+function sortedAdjacency(
+  successorSets: ReadonlyMap<string, Set<string>>,
+): ReadonlyMap<string, readonly string[]> {
+  const successors = new Map<string, readonly string[]>();
+  for (const [node, set] of successorSets) {
+    successors.set(node, [...set].sort());
+  }
+  return successors;
+}
+
+/** Sort each edge's mapping list so message text never depends on load order. */
+function sortedEdgeMappings(
+  edgeMappings: ReadonlyMap<string, Map<string, MappingSite[]>>,
+): ReadonlyMap<string, ReadonlyMap<string, readonly MappingSite[]>> {
+  for (const outgoing of edgeMappings.values()) {
+    for (const sites of outgoing.values()) {
+      sites.sort(compareMappingSites);
+    }
+  }
+  return edgeMappings;
+}
+
+/** Type guard narrowing away the nulls a failed schema resolution produces. */
+function isResolved(id: string | null): id is string {
+  return id !== null;
+}
+
+/** Name and locate a mapping for the message; anonymous blocks get their position. */
+function mappingSite(mapping: LineageCycleMapping): MappingSite {
+  const line = mapping.row + 1;
+  const qualified =
+    mapping.namespace && mapping.name ? `${mapping.namespace}::${mapping.name}` : mapping.name;
+  return {
+    label: qualified ?? `anonymous mapping at line ${line}`,
+    file: mapping.file,
+    line,
+  };
+}
+
+/** Order mapping sites by position, then label, so output never depends on load order. */
+function compareMappingSites(left: MappingSite, right: MappingSite): number {
+  return (
+    left.file.localeCompare(right.file) ||
+    left.line - right.line ||
+    left.label.localeCompare(right.label)
+  );
+}
+
+// ── Tarjan's strongly-connected components ──────────────────────────────────
+
+/**
+ * The graph's strongly-connected components — every maximal set of nodes each
+ * reachable from every other. Each returned component is sorted by id.
+ *
+ * Iterative rather than recursive: a platform entry point can pull in hundreds of
+ * schemas, and recursive Tarjan's stack depth is bounded by the longest path
+ * through them.
+ *
+ * Roots are visited in sorted order and each node's successors in sorted order,
+ * so the components — and the order they are returned in — are the same whatever
+ * order the mappings were indexed in.
+ */
+function stronglyConnectedComponents(graph: SchemaGraph): string[][] {
+  const search = new TarjanSearch(graph);
+  for (const root of graph.nodes) search.visit(root);
+  return search.components;
+}
+
+/** One frame of the explicit DFS stack: a node, and how far through its successors. */
+interface SearchFrame {
+  readonly node: string;
+  nextSuccessor: number;
+}
+
+/**
+ * Tarjan's algorithm, with the traversal state held as fields so the iterative
+ * DFS reads as three short steps (descend, note a back-edge, close a component)
+ * rather than one long loop.
+ *
+ * `index` is each node's discovery order; `lowLink` is the smallest discovery
+ * index reachable from its subtree. A node whose two are equal opened the
+ * component sitting above it on `stack`, which is Tarjan's central invariant.
+ */
+class TarjanSearch {
+  readonly components: string[][] = [];
+
+  private readonly index = new Map<string, number>();
+  private readonly lowLink = new Map<string, number>();
+  private readonly onStack = new Set<string>();
+  private readonly stack: string[] = [];
+  private nextIndex = 0;
+
+  constructor(private readonly graph: SchemaGraph) {}
+
+  /** Explore everything reachable from `root` that has not been visited yet. */
+  visit(root: string): void {
+    if (this.index.has(root)) return;
+
+    const frames: SearchFrame[] = [{ node: root, nextSuccessor: 0 }];
+    this.discover(root);
+
+    while (frames.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by the loop
+      const frame = frames[frames.length - 1]!;
+      const successors = this.graph.successors.get(frame.node) ?? [];
+
+      if (frame.nextSuccessor < successors.length) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds checked above
+        const successor = successors[frame.nextSuccessor]!;
+        frame.nextSuccessor += 1;
+
+        if (!this.index.has(successor)) {
+          this.discover(successor);
+          frames.push({ node: successor, nextSuccessor: 0 });
+        } else if (this.onStack.has(successor)) {
+          // A back-edge into the component currently under construction.
+          this.lower(frame.node, this.index.get(successor));
+        }
+        continue;
+      }
+
+      frames.pop();
+      // Carry this node's low-link up to its parent before closing it off.
+      const parent = frames[frames.length - 1];
+      if (parent) this.lower(parent.node, this.lowLink.get(frame.node));
+      if (this.lowLink.get(frame.node) === this.index.get(frame.node)) {
+        this.closeComponent(frame.node);
+      }
+    }
+  }
+
+  /** Assign a node its discovery index and push it onto the component stack. */
+  private discover(node: string): void {
+    this.index.set(node, this.nextIndex);
+    this.lowLink.set(node, this.nextIndex);
+    this.nextIndex += 1;
+    this.stack.push(node);
+    this.onStack.add(node);
+  }
+
+  /** Pull `node`'s low-link down to `candidate` when that reaches further back. */
+  private lower(node: string, candidate: number | undefined): void {
+    if (candidate === undefined) return;
+    this.lowLink.set(node, Math.min(this.lowLink.get(node) ?? candidate, candidate));
+  }
+
+  /** Pop the component `root` opened, up to and including `root` itself. */
+  private closeComponent(root: string): void {
+    const component: string[] = [];
+    for (;;) {
+      const member = this.stack.pop();
+      if (member === undefined) break;
+      this.onStack.delete(member);
+      component.push(member);
+      if (member === root) break;
+    }
+    this.components.push(component.sort());
+  }
+}
+
+// ── The representative cycle ────────────────────────────────────────────────
+
+/**
+ * Turn one cyclic component into a finding: a canonical path through it, the
+ * mapping responsible for each hop, and the members that path does not visit.
+ *
+ * The finding is reported against the mapping declaring the path's first edge.
+ * The reviewer's next question is always "which mapping do I look at?", so an
+ * editor jump should land on one of the answers rather than on a schema.
+ */
+function describeCycle(component: readonly string[], graph: SchemaGraph): LintFinding {
+  const path = representativeCycle(component, graph);
+  const hops = describeHops(path, graph);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- a cycle has at least one hop
+  const anchor = hops[0]!.site;
+
+  // Name the members the representative path does not pass through, so a large
+  // tangle is not misread as a two-schema problem.
+  const unvisited = component.filter((node) => !path.includes(node));
+  const alsoIncludes =
+    unvisited.length > 0 ? ` Component also includes ${unvisited.join(", ")}.` : "";
+
+  return {
+    rule: LINEAGE_CYCLE_RULE_ID,
+    severity: "warning",
+    file: anchor.file,
+    line: anchor.line,
+    column: 1,
+    message:
+      `Lineage cycle: ${path.join(" -> ")}. ` +
+      `Edges: ${hops.map((hop) => hop.description).join(", ")}.` +
+      alsoIncludes,
+  };
+}
+
+/**
+ * A deterministic shortest cycle through the component, entered at its
+ * lexicographically smallest member.
+ *
+ * Returns the node sequence with the entry node repeated at the end
+ * (`a -> b -> a`), so the path reads as a loop.
+ *
+ * Canonicalisation matters because the finding is a *representative*: without a
+ * fixed entry point and a fixed walk, the same tangle would be described
+ * differently depending on which file happened to load first, and a CI diff of
+ * lint output would show phantom changes. Entry is the smallest id; the walk is
+ * a breadth-first search over sorted adjacency, which discovers nodes in a fully
+ * determined order and so picks the same shortest path on every run.
+ */
+function representativeCycle(component: readonly string[], graph: SchemaGraph): string[] {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- callers pass a non-empty component
+  const entry = component[0]!; // components arrive sorted, so this is the smallest id
+  const { distance, predecessor } = breadthFirstSearch(entry, new Set(component), graph);
+
+  // Close the loop through whichever member reaches the entry soonest. Ties go
+  // to the smallest id, which iterating the sorted component already gives us.
+  let closest: string | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (const node of component) {
+    const reachesEntry = (graph.successors.get(node) ?? []).includes(entry);
+    const nodeDistance = distance.get(node);
+    if (!reachesEntry || nodeDistance === undefined) continue;
+    if (nodeDistance < closestDistance) {
+      closest = node;
+      closestDistance = nodeDistance;
+    }
+  }
+
+  // A component of two or more nodes is strongly connected, so some member
+  // reaches the entry by construction; the fallback only keeps the types honest.
+  if (closest === null) return [entry, entry];
+
+  const path: string[] = [];
+  for (let node: string | undefined = closest; node !== undefined; node = predecessor.get(node)) {
+    path.unshift(node);
+    if (node === entry) break;
+  }
+  path.push(entry);
+  return path;
+}
+
+/** Shortest-path distances and BFS-tree predecessors from `entry`, within `members`. */
+function breadthFirstSearch(
+  entry: string,
+  members: ReadonlySet<string>,
+  graph: SchemaGraph,
+): { distance: Map<string, number>; predecessor: Map<string, string> } {
+  const distance = new Map<string, number>([[entry, 0]]);
+  const predecessor = new Map<string, string>();
+  const queue: string[] = [entry];
+
+  for (let head = 0; head < queue.length; head += 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guarded by the loop
+    const node = queue[head]!;
+    for (const successor of graph.successors.get(node) ?? []) {
+      if (!members.has(successor) || distance.has(successor)) continue;
+      distance.set(successor, (distance.get(node) ?? 0) + 1);
+      predecessor.set(successor, node);
+      queue.push(successor);
+    }
+  }
+
+  return { distance, predecessor };
+}
+
+/** One hop of the representative path, with the mapping that declares it. */
+interface CycleHop {
+  /** Where to report the finding when this is the path's first hop. */
+  readonly site: MappingSite;
+  /** Message fragment: the edge, and the mapping responsible for it. */
+  readonly description: string;
+}
+
+/**
+ * Attribute every hop of the path to the mapping that declares it.
+ *
+ * An edge can be declared by more than one mapping — two mappings can both read
+ * `a` and write `b` — and all of them are named, because hiding the others would
+ * send the reviewer to fix one arrow and leave the cycle standing.
+ */
+function describeHops(path: readonly string[], graph: SchemaGraph): CycleHop[] {
+  const hops: CycleHop[] = [];
+
+  for (let i = 0; i + 1 < path.length; i += 1) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds fixed by the loop
+    const from = path[i]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- bounds fixed by the loop
+    const to = path[i + 1]!;
+    const sites = edgeSites(graph, from, to);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- every path edge came from a mapping
+    const site = sites[0]!;
+    const labels = sites.map((s) => `'${s.label}'`).join(" and ");
+    hops.push({ site, description: `${from} -> ${to} (mapping ${labels})` });
+  }
+
+  return hops;
+}

--- a/tooling/satsuma-core/src/lint-type-mismatch.ts
+++ b/tooling/satsuma-core/src/lint-type-mismatch.ts
@@ -1,0 +1,396 @@
+/**
+ * lint-type-mismatch.ts — the `type-mismatch-direct-arrow` lint rule (PRD 37 R1).
+ *
+ * Owns one question: when an arrow says "this value passes through unchanged",
+ * do the two ends agree about what type that value is? A bare `src -> tgt`
+ * between a `STRING` and a `DATE` is almost always a mis-picked field, a schema
+ * edit that outran its mappings, or a transform nobody wrote down — and until
+ * this rule existed, nothing in the toolchain remarked on it.
+ *
+ * Owns: which arrows carry a type assertion, how two declared types are compared
+ * (base token, case-insensitively, plus the author's own alias groups), and the
+ * message. Does not own rule registration, suppression, or how the config is
+ * read — those belong to the consumer and to satsuma-config.ts respectively.
+ *
+ * **The rule is deliberately narrow.** It fires only where the spec's own
+ * classification says an assertion was made, and stays silent everywhere the
+ * answer would be a guess. Every exemption below is a decision, not an omission.
+ */
+
+import { schemaLocalFieldPath } from "./coverage-paths.js";
+import type { LintFinding } from "./lint-findings.js";
+import { createAuthoredEntityRef, createContainerQualifiedFieldRef } from "./reference-stages.js";
+import type { AuthoredEntityRef, CanonicalEntityRef, SchemaLocalPath } from "./reference-stages.js";
+import type { TypeAliasGroup } from "./satsuma-config.js";
+import type { Classification } from "./types.js";
+
+/** Rule id. Stable — CI jobs and `lint.suppress` entries key off it. */
+export const TYPE_MISMATCH_RULE_ID = "type-mismatch-direct-arrow";
+
+// ── Structural inputs ───────────────────────────────────────────────────────
+//
+// The minimal shapes the detector needs. The CLI's `ExtractedWorkspace` records
+// and the LSP's index satisfy them by structural typing, so neither package has
+// to build an adapter object — the same arrangement validate.ts uses.
+
+/** A declared field, as far as this rule is concerned: a name, a type, children. */
+export interface DeclaredTypeField {
+  /** Field name as declared, Satsuma backtick quoting already stripped. */
+  readonly name: string;
+  /**
+   * Declared type text exactly as authored (`STRING`, `DECIMAL(10,2)`,
+   * `UUID(pk)`, or `record` for a record body). Absent or empty means the author
+   * declared no type, which this rule treats as "nothing to compare".
+   */
+  readonly type?: string;
+  /** Nested declarations for record / `list_of record` fields. */
+  readonly children?: readonly DeclaredTypeField[];
+}
+
+/** One schema resolved for type comparison. */
+export interface DeclaredTypeSchema {
+  /**
+   * Stable id to name this schema by in messages (`crm::customers`, or the bare
+   * key for a global schema). Consumers pass their own workspace key so the
+   * message quotes the spelling the rest of their output uses.
+   */
+  readonly schemaId: string;
+  /**
+   * Unique workspace identity, used to strip a qualified prefix off an arrow
+   * path (`crm_customers.email -> email`). Obtained by canonicalizing the
+   * authored reference against the consumer's index.
+   */
+  readonly canonicalRef: CanonicalEntityRef;
+  /** Top-level declared fields, with fragment spreads already inlined. */
+  readonly fields: readonly DeclaredTypeField[];
+}
+
+/**
+ * Resolve a schema reference as written in a `source {}` / `target {}` block to
+ * its declared fields, or null when the workspace declares no such schema.
+ *
+ * Unresolvable references are skipped rather than reported: `validate` already
+ * flags a mapping pointing at a schema that does not exist, and a lint rule
+ * repeating it would double-report one mistake.
+ */
+export type DeclaredTypeSchemaResolver = (
+  writtenRef: AuthoredEntityRef,
+  mappingNamespace: string | null,
+) => DeclaredTypeSchema | null;
+
+/** The mapping an arrow sits in — only its schema references matter here. */
+export interface TypeMismatchMapping {
+  /** Namespace the mapping is declared in, or null/absent at file scope. */
+  readonly namespace?: string | null;
+  /** Schema references from the `source {}` block, as written. */
+  readonly sources: readonly string[];
+  /** Schema references from the `target {}` block, as written. */
+  readonly targets: readonly string[];
+}
+
+/** An arrow, reduced to what decides whether it asserts type identity. */
+export interface TypeMismatchArrow {
+  /** Mapping label, or the consumer's synthetic key for an anonymous mapping. */
+  readonly mapping: string | null;
+  /** Namespace the arrow's mapping is declared in, or null at file scope. */
+  readonly namespace: string | null;
+  /** Source paths, already made absolute against any enclosing container. */
+  readonly sources: readonly string[];
+  /** Target path, already made absolute against any enclosing container. */
+  readonly target: string | null;
+  /** Transform classification — `none` is the whole applicability criterion. */
+  readonly classification: Classification;
+  /** Absolute path or URI of the declaring file. */
+  readonly file: string;
+  /** 0-indexed declaration row, as extraction records it. */
+  readonly line: number;
+}
+
+/** Everything {@link detectTypeMismatches} reads. */
+export interface TypeMismatchInput {
+  /**
+   * Every arrow in the workspace, once each. A rule that visited an index keyed
+   * by field would report one arrow once per field it names.
+   */
+  readonly arrows: readonly TypeMismatchArrow[];
+  /**
+   * Mappings by index key — `ns::label` inside a namespace, the bare label
+   * otherwise. Matches how {@link TypeMismatchArrow.mapping} and
+   * {@link TypeMismatchArrow.namespace} combine, which is core's existing
+   * convention (validate.ts uses the same key).
+   */
+  readonly mappings: ReadonlyMap<string, TypeMismatchMapping>;
+  /** See {@link DeclaredTypeSchemaResolver}. */
+  readonly resolveSchema: DeclaredTypeSchemaResolver;
+  /**
+   * Alias groups from `lint.typeAliases`. Nothing is presumed equivalent
+   * without them: deciding on the author's behalf that `TEXT` is a `STRING` is
+   * a convention decision this feature explicitly does not make (PRD 37, Out of
+   * Scope).
+   */
+  readonly typeAliases?: readonly TypeAliasGroup[];
+}
+
+// ── Detection ───────────────────────────────────────────────────────────────
+
+/**
+ * Report bare arrows whose two ends declare different types.
+ *
+ * Findings are in arrow order, one per offending arrow. Severity is `warning`:
+ * a mismatch can be intentional (the author knows the target column is a string
+ * holding a date), so this is policy, not correctness — `validate` semantics are
+ * untouched.
+ */
+export function detectTypeMismatches(input: TypeMismatchInput): LintFinding[] {
+  const aliasGroups = indexAliasGroups(input.typeAliases ?? []);
+  const findings: LintFinding[] = [];
+
+  for (const arrow of input.arrows) {
+    // Applicability: only arrows the spec classifies `none`.
+    //
+    // Any transform body classifies `nl`, and judging whether an NL transform
+    // preserves type is interpretation the CLI leaves to agents (PRD 37 R1).
+    // `nl-derived` arrows are synthetic — inferred from an NL `@ref` — so they
+    // carry no authored assertion at all.
+    //
+    // **A `map { … }` value map needs no branch of its own, and must not get
+    // one.** `map_literal` is a `pipe_step`, and `classifyTransform` returns
+    // `nl` for any non-empty pipe chain, so a value-map arrow is already
+    // excluded here. A future refactor that classified map literals separately
+    // would silently start type-checking value maps — which convert values and
+    // so may legitimately change type. `type-mismatch-direct-arrow.test.js`
+    // locks that.
+    if (arrow.classification !== "none") continue;
+
+    // A single source only. A bare `first, last -> full_name` asserts something
+    // about the combination, and no one of its sources is *the* type of the
+    // result — picking one to compare would invent an assertion the author did
+    // not make. Derived arrows (`-> tgt` with no source path) land here too.
+    if (arrow.sources.length !== 1 || !arrow.target) continue;
+
+    const mapping = input.mappings.get(mappingIndexKey(arrow));
+    if (!mapping) continue;
+    const namespace = mapping.namespace ?? null;
+
+    const source = resolveDeclaredType(
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- length checked above
+      arrow.sources[0]!,
+      mapping.sources,
+      namespace,
+      input.resolveSchema,
+      aliasGroups,
+    );
+    const target = resolveDeclaredType(
+      arrow.target,
+      mapping.targets,
+      namespace,
+      input.resolveSchema,
+      aliasGroups,
+    );
+
+    // Silent skips: either side undeclared, unresolvable, or ambiguous across
+    // several participating schemas. All three mean the rule does not know what
+    // the author asserted, and guessing is how a lint rule loses its audience.
+    if (!source || !target) continue;
+    if (typesAgree(source.token, target.token, aliasGroups)) continue;
+
+    findings.push({
+      rule: TYPE_MISMATCH_RULE_ID,
+      severity: "warning",
+      file: arrow.file,
+      line: arrow.line + 1,
+      column: 1,
+      message:
+        `Bare arrow '${source.qualifiedPath} -> ${target.qualifiedPath}' connects declared type ` +
+        `${source.declaredType} to ${target.declaredType}. A bare arrow asserts the value passes ` +
+        `through unchanged — add a transform body if a conversion is intended, correct the field ` +
+        `reference, or declare the types as equivalent in lint.typeAliases.`,
+    });
+  }
+
+  return findings;
+}
+
+/** Index key for the mapping an arrow belongs to (`ns::label`, or the bare label). */
+function mappingIndexKey(arrow: TypeMismatchArrow): string {
+  return arrow.namespace ? `${arrow.namespace}::${arrow.mapping}` : (arrow.mapping ?? "");
+}
+
+// ── Resolving one endpoint's declared type ──────────────────────────────────
+
+/** What one end of an arrow turned out to declare. */
+interface EndpointType {
+  /** `schemaId.localPath` — how the message names this end. */
+  readonly qualifiedPath: string;
+  /** Declared type text as authored, for the message. */
+  readonly declaredType: string;
+  /** Normalized token, for the comparison. */
+  readonly token: string;
+}
+
+/**
+ * The declared type of an arrow path, resolved against the schemas on its side
+ * of the mapping — or null when this rule must stay silent.
+ *
+ * Null covers four distinct silences, all deliberate:
+ *
+ *  - no participating schema declares the path (`validate`'s territory);
+ *  - the path resolves but the author declared no type for it;
+ *  - the schema itself is unresolvable;
+ *  - **two participating schemas declare the path with different types.** A bare
+ *    `email -> email` in a mapping whose two sources both declare `email` names
+ *    no particular one of them, so which type the author meant is unknowable.
+ *    Reporting the first match would make the finding depend on source order.
+ *
+ * A schema whose fragment spreads are unresolved needs no special case: an
+ * unexpanded spread makes paths *fail* to resolve, and failing to resolve is
+ * already a silent skip. That is the opposite of `unenumerated-record-target`,
+ * which reasons about a field's *absence* and so must exclude such schemas.
+ */
+function resolveDeclaredType(
+  path: string,
+  schemaRefs: readonly string[],
+  mappingNamespace: string | null,
+  resolveSchema: DeclaredTypeSchemaResolver,
+  aliasGroups: AliasGroupIndex,
+): EndpointType | null {
+  let resolved: EndpointType | null = null;
+
+  for (const writtenRef of schemaRefs) {
+    const schema = resolveSchema(createAuthoredEntityRef(writtenRef), mappingNamespace);
+    if (!schema) continue;
+
+    const localPath = localiseAgainst(path, writtenRef, schema, schemaRefs);
+    if (localPath === null) continue;
+
+    const declaredType = findDeclaredType(localPath, schema.fields);
+    if (!declaredType) continue;
+
+    const candidate: EndpointType = {
+      qualifiedPath: `${schema.schemaId}.${localPath}`,
+      declaredType,
+      token: baseTypeToken(declaredType),
+    };
+
+    if (!resolved) {
+      resolved = candidate;
+      continue;
+    }
+    // Ambiguous across schemas: silence unless they agree about the type.
+    if (!typesAgree(resolved.token, candidate.token, aliasGroups)) return null;
+  }
+
+  return resolved;
+}
+
+/**
+ * Reduce an authored arrow path to one local to `schema`, or null when it names
+ * a different participating schema.
+ *
+ * Delegates the prefix rules to `schemaLocalFieldPath` so this rule and coverage
+ * cannot disagree about which schema a qualified path belongs to — including the
+ * shadowing case where a schema declares a top-level field named like another
+ * schema (ADR-041).
+ */
+function localiseAgainst(
+  path: string,
+  writtenRef: string,
+  schema: DeclaredTypeSchema,
+  allSchemaRefs: readonly string[],
+): SchemaLocalPath | null {
+  const topLevelNames = new Set(schema.fields.map((f) => f.name));
+  return schemaLocalFieldPath(
+    createContainerQualifiedFieldRef(path),
+    createAuthoredEntityRef(writtenRef),
+    schema.canonicalRef,
+    allSchemaRefs.filter((r) => r !== writtenRef).map(createAuthoredEntityRef),
+    (name) => topLevelNames.has(name),
+  );
+}
+
+/**
+ * The declared type text at a schema-local dotted path, or null when the schema
+ * declares no such path or declares it without a type.
+ */
+function findDeclaredType(
+  path: SchemaLocalPath,
+  fields: readonly DeclaredTypeField[],
+): string | null {
+  let level: readonly DeclaredTypeField[] | undefined = fields;
+  let found: DeclaredTypeField | undefined;
+
+  for (const segment of path.split(".")) {
+    found = level?.find((f) => f.name === segment);
+    if (!found) return null;
+    level = found.children;
+  }
+
+  const declared = found?.type?.trim();
+  return declared ? declared : null;
+}
+
+// ── Comparing two declared types ────────────────────────────────────────────
+
+/**
+ * The token two declared types are compared on: the part before any `(`,
+ * upper-cased.
+ *
+ * Two business rules, both from PRD 37 R1:
+ *
+ *  - **Case is not type information.** `String` and `STRING` are one type
+ *    spelled two ways, and a workspace assembled from several spreadsheets will
+ *    contain both.
+ *  - **Parameters are not compared.** Declared lengths and precision
+ *    (`VARCHAR(255)` vs `VARCHAR(64)`) do not count as mismatches at the
+ *    granularity this rule judges. Satsuma also spells constraint flags inside
+ *    the same parentheses (`UUID(pk)` — sl-vryu), which are not type
+ *    information at all, so stripping the parenthesised part is the only
+ *    reading that does not produce false positives on both.
+ */
+function baseTypeToken(declaredType: string): string {
+  const parameterStart = declaredType.indexOf("(");
+  const base = parameterStart >= 0 ? declaredType.slice(0, parameterStart) : declaredType;
+  return base.trim().toUpperCase();
+}
+
+/**
+ * A normalized type token to the alias groups it belongs to.
+ *
+ * A token can be in several groups (a workspace may declare both a
+ * `STRING`/`TEXT` group and a `TEXT`/`CLOB` one), so membership is a set of
+ * group indices and two tokens are equivalent when the sets intersect. Groups
+ * are never flattened into one pool — that would make `STRING` equivalent to
+ * `INT` in any workspace declaring both a string group and an integer group.
+ */
+type AliasGroupIndex = ReadonlyMap<string, ReadonlySet<number>>;
+
+/** Build the {@link AliasGroupIndex} for the workspace's configured alias groups. */
+function indexAliasGroups(groups: readonly TypeAliasGroup[]): AliasGroupIndex {
+  const index = new Map<string, Set<number>>();
+
+  groups.forEach((group, groupIndex) => {
+    for (const declaredType of group) {
+      const token = baseTypeToken(declaredType);
+      if (token.length === 0) continue;
+      const memberships = index.get(token) ?? new Set<number>();
+      memberships.add(groupIndex);
+      index.set(token, memberships);
+    }
+  });
+
+  return index;
+}
+
+/** True when two normalized type tokens are equal or share an alias group. */
+function typesAgree(left: string, right: string, aliasGroups: AliasGroupIndex): boolean {
+  if (left === right) return true;
+
+  const leftGroups = aliasGroups.get(left);
+  const rightGroups = aliasGroups.get(right);
+  if (!leftGroups || !rightGroups) return false;
+
+  for (const groupIndex of leftGroups) {
+    if (rightGroups.has(groupIndex)) return true;
+  }
+  return false;
+}

--- a/tooling/satsuma-core/test/lint-lineage-cycle.test.js
+++ b/tooling/satsuma-core/test/lint-lineage-cycle.test.js
@@ -1,0 +1,404 @@
+/**
+ * lint-lineage-cycle.test.js — semantics of the `lineage-cycle` rule.
+ *
+ * This suite owns what the rule *means*: which edges the schema graph has, the
+ * self-mapping exemption, that a tangle is reported once rather than once per
+ * rotation through it, and that the representative path is canonical. The CLI's
+ * suite covers only registration and the `--json` shape.
+ *
+ * Snippets are parsed with the real grammar and fed through core's own
+ * extraction, so the graph under test is built from the same mapping records a
+ * consumer supplies.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initParser,
+  getParser,
+  canonicalizeEntityRef,
+  detectLineageCycles,
+  extractMappings,
+  extractSchemas,
+  LINEAGE_CYCLE_RULE_ID,
+} from "@satsuma/core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+const TEST_FILE = "/w/test.stm";
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+/** Index key convention shared by core and the CLI: `ns::name`, or the bare name. */
+function indexKey(namespace, name, row) {
+  const label = name ?? `<anon>@${TEST_FILE}:${row}`;
+  return namespace ? `${namespace}::${label}` : label;
+}
+
+/**
+ * Build a {@link LineageCycleInput} from Satsuma source.
+ *
+ * `order` optionally permutes the mapping records before they are indexed, which
+ * is how the determinism cases simulate a different file-load order without
+ * rewriting the snippet.
+ */
+function inputFor(source, order = (records) => records) {
+  const root = getParser().parse(source).rootNode;
+
+  const schemas = new Map();
+  for (const schema of extractSchemas(root)) {
+    if (schema.name) {
+      schemas.set(schema.namespace ? `${schema.namespace}::${schema.name}` : schema.name, schema);
+    }
+  }
+
+  const mappings = new Map();
+  for (const mapping of order([...extractMappings(root)])) {
+    mappings.set(indexKey(mapping.namespace, mapping.name, mapping.row), {
+      ...mapping,
+      file: TEST_FILE,
+    });
+  }
+
+  const resolveSchemaId = (writtenRef, mappingNamespace) => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, schemas);
+    if (!canonicalRef) return null;
+    return canonicalRef.startsWith("::") ? canonicalRef.slice(2) : canonicalRef;
+  };
+
+  return { mappings, resolveSchemaId };
+}
+
+/** Findings for a snippet. */
+function findingsFor(source, order) {
+  return detectLineageCycles(inputFor(source, order));
+}
+
+/** Declare `names` as empty schemas — the graph only cares that they resolve. */
+function schemas(...names) {
+  return names.map((name) => `schema ${name} { id INT }`).join("\n");
+}
+
+/** A mapping named `name` moving data from `from` to `to`. */
+function mapping(name, from, to) {
+  return `
+mapping ${name} {
+  source { ${from} }
+  target { ${to} }
+  id -> id
+}
+`;
+}
+
+// ── The two-schema cycle ────────────────────────────────────────────────────
+
+describe("a cycle between two schemas", () => {
+  const TWO_SCHEMA_CYCLE = [
+    schemas("a", "b"),
+    mapping("a_to_b", "a", "b"),
+    mapping("b_to_a", "b", "a"),
+  ].join("\n");
+
+  it("reports exactly one warning for the pair, not one per mapping", () => {
+    // Two mappings participate but there is one tangle to untangle. Reporting per
+    // mapping would double the noise for every cycle in the workspace.
+    const findings = findingsFor(TWO_SCHEMA_CYCLE);
+
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].rule, LINEAGE_CYCLE_RULE_ID);
+    assert.equal(findings[0].severity, "warning");
+    assert.equal(findings[0].column, 1);
+  });
+
+  it("shows the cycle as a path that returns to where it started", () => {
+    // The path is the finding's whole value: a reviewer needs to see the loop,
+    // not a set of schema names. It is entered at the smallest id, so `a` first.
+    assert.match(findingsFor(TWO_SCHEMA_CYCLE)[0].message, /Lineage cycle: a -> b -> a\./);
+  });
+
+  it("names the mapping responsible for each hop", () => {
+    // The reviewer's next question is always "which mapping do I look at?" — a
+    // path of schema names alone does not answer it.
+    const { message } = findingsFor(TWO_SCHEMA_CYCLE)[0];
+
+    assert.match(message, /a -> b \(mapping 'a_to_b'\)/);
+    assert.match(message, /b -> a \(mapping 'b_to_a'\)/);
+  });
+
+  it("anchors the finding on the mapping declaring the path's first hop", () => {
+    // So an editor jump lands on a mapping the reader can change, rather than on
+    // a schema declaration that is not the problem.
+    const firstHopLine =
+      TWO_SCHEMA_CYCLE.split("\n").findIndex((l) => l.includes("mapping a_to_b")) + 1;
+    const finding = findingsFor(TWO_SCHEMA_CYCLE)[0];
+
+    assert.equal(finding.file, TEST_FILE);
+    assert.equal(finding.line, firstHopLine);
+  });
+
+  it("names every mapping declaring one edge, not just the first", () => {
+    // Two mappings can both read `a` and write `b`. Naming one would send the
+    // reviewer to fix a single arrow and leave the cycle standing.
+    const { message } = findingsFor(
+      [
+        schemas("a", "b"),
+        mapping("first_a_to_b", "a", "b"),
+        mapping("second_a_to_b", "a", "b"),
+        mapping("b_to_a", "b", "a"),
+      ].join("\n"),
+    )[0];
+
+    assert.match(message, /a -> b \(mapping 'first_a_to_b' and 'second_a_to_b'\)/);
+  });
+});
+
+// ── The self-mapping exemption ──────────────────────────────────────────────
+
+describe("self-mappings", () => {
+  it("reports nothing for a mapping whose source and target are the same schema", () => {
+    // Regression-locks the recorded product decision: "self-mappings (same source
+    // and target schema) are OK — we can use that to represent things like
+    // increments, and DON'T cause graph cycles" (docs/product-owner/ROADMAP.md).
+    assert.deepEqual(findingsFor([schemas("a"), mapping("increment", "a", "a")].join("\n")), []);
+  });
+
+  it("still records the other edges of a mapping that also maps a schema to itself", () => {
+    // The exemption is per-*edge*, not per-mapping: `source { a } target { a, b }`
+    // drops `a -> a` but keeps `a -> b`, so a cycle running through `b` is real.
+    const findings = findingsFor(
+      [
+        schemas("a", "b"),
+        mapping("increment_and_load", "a", "a, b"),
+        mapping("b_to_a", "b", "a"),
+      ].join("\n"),
+    );
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].message, /Lineage cycle: a -> b -> a\./);
+  });
+});
+
+// ── One finding per component ───────────────────────────────────────────────
+
+describe("one finding per strongly-connected component", () => {
+  it("reports a three-schema cycle once", () => {
+    // `a -> b -> c -> a` is one tangle however many mappings draw it.
+    const findings = findingsFor(
+      [
+        schemas("a", "b", "c"),
+        mapping("a_to_b", "a", "b"),
+        mapping("b_to_c", "b", "c"),
+        mapping("c_to_a", "c", "a"),
+      ].join("\n"),
+    );
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].message, /Lineage cycle: a -> b -> c -> a\./);
+  });
+
+  it("reports a densely tangled component once, however many rotations it holds", () => {
+    // A component holding several elementary cycles (a-b-a, a-c-a, b-c-b, a-b-c-a …)
+    // is one tangle. Enumerating elementary cycles is output-exponential, which is
+    // why SCC-per-finding replaced the truncation cap the rule was first specified
+    // with (doc review 2026-07-31).
+    const findings = findingsFor(
+      [
+        schemas("a", "b", "c"),
+        mapping("a_to_b", "a", "b"),
+        mapping("b_to_a", "b", "a"),
+        mapping("a_to_c", "a", "c"),
+        mapping("c_to_a", "c", "a"),
+        mapping("b_to_c", "b", "c"),
+        mapping("c_to_b", "c", "b"),
+      ].join("\n"),
+    );
+
+    assert.equal(findings.length, 1);
+  });
+
+  it("names the component members the representative path does not visit", () => {
+    // The shortest cycle through a large component can be two hops long, which on
+    // its own would read as a two-schema problem. The remaining members are named
+    // so nothing in the tangle is hidden.
+    const { message } = findingsFor(
+      [
+        schemas("a", "b", "c", "d"),
+        mapping("a_to_b", "a", "b"),
+        mapping("b_to_a", "b", "a"),
+        mapping("b_to_c", "b", "c"),
+        mapping("c_to_d", "c", "d"),
+        mapping("d_to_a", "d", "a"),
+      ].join("\n"),
+    )[0];
+
+    assert.match(message, /Lineage cycle: a -> b -> a\./);
+    assert.match(message, /Component also includes c, d\./);
+  });
+
+  it("reports two independent cycles separately", () => {
+    // Two disjoint components are two unrelated problems, and collapsing them into
+    // one finding would hide one of them.
+    const findings = findingsFor(
+      [
+        schemas("a", "b", "y", "z"),
+        mapping("a_to_b", "a", "b"),
+        mapping("b_to_a", "b", "a"),
+        mapping("y_to_z", "y", "z"),
+        mapping("z_to_y", "z", "y"),
+      ].join("\n"),
+    );
+
+    assert.equal(findings.length, 2);
+    assert.deepEqual(
+      findings.map((f) => f.message.match(/Lineage cycle: ([^.]+)\./)[1]),
+      ["a -> b -> a", "y -> z -> y"],
+    );
+  });
+
+  it("reports nothing for an acyclic chain", () => {
+    // A layered pipeline is the normal case; the rule must be silent on it or it
+    // is unusable. Also guards against a bug where every node became its own
+    // one-member component finding.
+    assert.deepEqual(
+      findingsFor(
+        [
+          schemas("raw", "clean", "mart"),
+          mapping("stage", "raw", "clean"),
+          mapping("publish", "clean", "mart"),
+        ].join("\n"),
+      ),
+      [],
+    );
+  });
+});
+
+// ── Determinism ─────────────────────────────────────────────────────────────
+
+describe("stability of the representative path", () => {
+  const THREE_SCHEMA_CYCLE = [
+    schemas("a", "b", "c"),
+    mapping("a_to_b", "a", "b"),
+    mapping("b_to_c", "b", "c"),
+    mapping("c_to_a", "c", "a"),
+  ].join("\n");
+
+  it("describes the same cycle whatever order the mappings were indexed in", () => {
+    // A CI diff of lint output must not change because a file loaded in a
+    // different order. Entry at the smallest id plus a breadth-first walk over
+    // sorted adjacency is what guarantees it.
+    const declared = findingsFor(THREE_SCHEMA_CYCLE);
+    const reversed = findingsFor(THREE_SCHEMA_CYCLE, (records) => [...records].reverse());
+    const rotated = findingsFor(THREE_SCHEMA_CYCLE, (records) => [
+      records[2],
+      records[0],
+      records[1],
+    ]);
+
+    assert.equal(declared.length, 1);
+    assert.deepEqual(reversed, declared);
+    assert.deepEqual(rotated, declared);
+  });
+
+  it("enters the cycle at its lexicographically smallest schema", () => {
+    // Canonical entry is what makes the path a *representative* rather than an
+    // artefact of which mapping happened to be visited first.
+    const { message } = findingsFor(
+      [schemas("m", "z"), mapping("z_to_m", "z", "m"), mapping("m_to_z", "m", "z")].join("\n"),
+    )[0];
+
+    assert.match(message, /Lineage cycle: m -> z -> m\./);
+  });
+
+  it("picks the shortest cycle through the entry schema", () => {
+    // `a -> b -> a` and `a -> b -> c -> a` both pass through `a`; the shorter one
+    // is the more readable representative, and choosing by length keeps the choice
+    // independent of edge insertion order.
+    const { message } = findingsFor(
+      [
+        schemas("a", "b", "c"),
+        mapping("a_to_b", "a", "b"),
+        mapping("b_to_c", "b", "c"),
+        mapping("c_to_a", "c", "a"),
+        mapping("b_to_a", "b", "a"),
+      ].join("\n"),
+    )[0];
+
+    assert.match(message, /Lineage cycle: a -> b -> a\./);
+  });
+});
+
+// ── Graph construction edge cases ───────────────────────────────────────────
+
+describe("building the schema graph", () => {
+  it("treats a schema referred to by two spellings as one node", () => {
+    // Inside `namespace crm` a mapping writes `orders`; from outside it writes
+    // `crm::orders`. Resolving to one id is what makes the cycle between them
+    // visible — two nodes would hide it entirely.
+    const findings = findingsFor(`
+namespace crm {
+  schema orders { id INT }
+  schema invoices { id INT }
+
+  mapping orders_to_invoices {
+    source { orders }
+    target { invoices }
+    id -> id
+  }
+}
+
+mapping invoices_to_orders {
+  source { crm::invoices }
+  target { crm::orders }
+  id -> id
+}
+`);
+
+    assert.equal(findings.length, 1);
+    assert.match(
+      findings[0].message,
+      /Lineage cycle: crm::invoices -> crm::orders -> crm::invoices\./,
+    );
+  });
+
+  it("drops an edge whose schema the workspace does not declare", () => {
+    // An undeclared reference is `validate`'s finding. Inventing a node for it
+    // could only ever produce a cycle that does not exist.
+    assert.deepEqual(
+      findingsFor(
+        [
+          schemas("a"),
+          mapping("a_to_ghost", "a", "ghost"),
+          mapping("ghost_to_a", "ghost", "a"),
+        ].join("\n"),
+      ),
+      [],
+    );
+  });
+
+  it("names an anonymous mapping by its position", () => {
+    // An anonymous `mapping { … }` block has no label, and a finding that omitted
+    // it would leave one hop of the cycle unattributed.
+    const source = `
+${schemas("a", "b")}
+mapping {
+  source { a }
+  target { b }
+  id -> id
+}
+${mapping("b_to_a", "b", "a")}
+`;
+    const anonLine = source.split("\n").findIndex((l) => l.trim() === "mapping {") + 1;
+
+    assert.match(
+      findingsFor(source)[0].message,
+      new RegExp(`anonymous mapping at line ${anonLine}`),
+    );
+  });
+});

--- a/tooling/satsuma-core/test/lint-type-mismatch.test.js
+++ b/tooling/satsuma-core/test/lint-type-mismatch.test.js
@@ -1,0 +1,427 @@
+/**
+ * lint-type-mismatch.test.js — semantics of the `type-mismatch-direct-arrow` rule.
+ *
+ * This suite owns what the rule *means*: which arrows carry a type assertion,
+ * when two declared types count as the same, and every case where the rule must
+ * stay silent. The CLI's own suite covers only registration, severity and the
+ * `--json` shape — the invariants here are tested once, at this level.
+ *
+ * Inputs are the smallest snippet that exercises each case, parsed with the real
+ * grammar and fed through core's own extraction, so a change to how types or
+ * arrow paths are extracted surfaces here rather than in a consumer.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before } from "node:test";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  initParser,
+  getParser,
+  canonicalizeEntityRef,
+  detectTypeMismatches,
+  extractArrowRecords,
+  extractMappings,
+  extractSchemas,
+  TYPE_MISMATCH_RULE_ID,
+} from "@satsuma/core";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
+
+const TEST_FILE = "/w/test.stm";
+
+before(async () => {
+  await initParser(WASM_PATH);
+});
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+/** Index key convention shared by core and the CLI: `ns::name`, or the bare name. */
+function indexKey(namespace, name) {
+  return namespace ? `${namespace}::${name}` : name;
+}
+
+/**
+ * Build a {@link TypeMismatchInput} from Satsuma source.
+ *
+ * Deliberately mirrors what the CLI's index-builder produces — schemas keyed by
+ * namespace-qualified name, arrows carrying their declaring file, a resolver that
+ * canonicalizes the reference as written in the mapping — so these tests exercise
+ * the same contract the real consumer satisfies.
+ */
+function inputFor(source, typeAliases = []) {
+  const tree = getParser().parse(source);
+  const root = tree.rootNode;
+
+  const schemas = new Map();
+  for (const schema of extractSchemas(root)) {
+    if (schema.name) schemas.set(indexKey(schema.namespace, schema.name), schema);
+  }
+
+  const mappings = new Map();
+  for (const mapping of extractMappings(root)) {
+    mappings.set(indexKey(mapping.namespace, mapping.name), mapping);
+  }
+
+  const arrows = extractArrowRecords(root).map((arrow) => ({ ...arrow, file: TEST_FILE }));
+
+  const resolveSchema = (writtenRef, mappingNamespace) => {
+    const canonicalRef = canonicalizeEntityRef(writtenRef, mappingNamespace, schemas);
+    if (!canonicalRef) return null;
+    const key = canonicalRef.startsWith("::") ? canonicalRef.slice(2) : canonicalRef;
+    const schema = schemas.get(key);
+    if (!schema) return null;
+    return { schemaId: key, canonicalRef, fields: schema.fields };
+  };
+
+  return { arrows, mappings, resolveSchema, typeAliases };
+}
+
+/** Findings for a snippet, with the alias groups a config would supply. */
+function findingsFor(source, typeAliases = []) {
+  return detectTypeMismatches(inputFor(source, typeAliases));
+}
+
+/** The smallest workspace with one bare arrow between two declared types. */
+function bareArrowBetween(sourceType, targetType) {
+  return `
+schema customers {
+  signup ${sourceType}
+}
+
+schema profiles {
+  signup_date ${targetType}
+}
+
+mapping load {
+  source { customers }
+  target { profiles }
+  signup -> signup_date
+}
+`;
+}
+
+// ── The finding itself ──────────────────────────────────────────────────────
+
+describe("reporting a mismatch", () => {
+  it("warns on a bare arrow whose two ends declare different types", () => {
+    // The rule's whole purpose: `STRING -> DATE` with no transform asserts the
+    // value passes through unchanged, which cannot be true of two different types.
+    const findings = findingsFor(bareArrowBetween("STRING", "DATE"));
+
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].rule, TYPE_MISMATCH_RULE_ID);
+    assert.equal(findings[0].severity, "warning");
+    assert.equal(findings[0].file, TEST_FILE);
+    assert.equal(findings[0].column, 1);
+  });
+
+  it("names both qualified field paths and both declared types in the message", () => {
+    // `lint --json` consumers group findings by type-pair, and a reviewer must be
+    // able to act without opening the file — so all four facts must be present.
+    const [finding] = findingsFor(bareArrowBetween("STRING", "DATE"));
+
+    assert.match(finding.message, /customers\.signup/);
+    assert.match(finding.message, /profiles\.signup_date/);
+    assert.match(finding.message, /STRING/);
+    assert.match(finding.message, /DATE/);
+  });
+
+  it("reports the finding against the arrow's own 1-indexed line", () => {
+    // The arrow is the thing to change, not the schema or the mapping header.
+    // Extraction records rows 0-indexed; a finding that forgot to add one would
+    // send every editor jump one line high.
+    const source = bareArrowBetween("STRING", "DATE");
+    const [finding] = findingsFor(source);
+    const arrowLine = source.split("\n").findIndex((l) => l.includes("signup -> signup_date")) + 1;
+
+    assert.equal(finding.line, arrowLine);
+  });
+
+  it("checks a nested arrow's absolute path, not just top-level fields", () => {
+    // Nested arrow paths are made absolute against their container during
+    // extraction, so the rule gets `address.postcode` and can resolve its type.
+    // Without that, every mismatch inside a record body would go unreported.
+    const findings = findingsFor(`
+schema src {
+  addr record {
+    postcode INT
+  }
+}
+
+schema dst {
+  address record {
+    postcode STRING
+  }
+}
+
+mapping load {
+  source { src }
+  target { dst }
+  addr -> address {
+    .postcode -> .postcode
+  }
+}
+`);
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].message, /src\.addr\.postcode/);
+    assert.match(findings[0].message, /dst\.address\.postcode/);
+  });
+});
+
+// ── Applicability: only arrows that assert type identity ────────────────────
+
+describe("arrows that assert nothing about type", () => {
+  it("exempts an arrow with a transform body", () => {
+    // Any transform body means the author said "something happens here", and
+    // judging whether that something preserves type is NL interpretation the CLI
+    // leaves to agents (PRD 37 R1).
+    const findings = findingsFor(`
+schema customers { signup STRING }
+schema profiles { signup_date DATE }
+
+mapping load {
+  source { customers }
+  target { profiles }
+  signup -> signup_date { parse as ISO-8601 }
+}
+`);
+
+    assert.deepEqual(findings, []);
+  });
+
+  it("exempts a value-map arrow without any map-literal special case", () => {
+    // Locks the reasoning that makes value maps exempt *structurally*: a
+    // `map { … }` is a pipe_step, so the arrow classifies `nl`, so the rule's
+    // `none`-only criterion already skips it. A future refactor that classified
+    // map literals separately would silently start type-checking value maps —
+    // which convert values and so may legitimately change type. This test fails
+    // the moment that classification changes, which is the warning we want.
+    const source = `
+schema customers { status INT }
+schema profiles { status STRING }
+
+mapping load {
+  source { customers }
+  target { profiles }
+  status -> status { map { 1 -> "active", 2 -> "closed" } }
+}
+`;
+    const { arrows } = inputFor(source);
+    const valueMapArrow = arrows.find((a) => a.target === "status");
+
+    assert.equal(valueMapArrow.classification, "nl");
+    assert.deepEqual(findingsFor(source), []);
+  });
+
+  it("exempts a multi-source bare arrow", () => {
+    // `first, last -> full_name` asserts something about the combination; no one
+    // of its sources is *the* type of the result, so picking one to compare would
+    // invent an assertion the author never made.
+    const findings = findingsFor(`
+schema people {
+  first STRING
+  last STRING
+}
+
+schema profiles { full_name INT }
+
+mapping load {
+  source { people }
+  target { profiles }
+  first, last -> full_name
+}
+`);
+
+    assert.deepEqual(findings, []);
+  });
+});
+
+// ── Silence: when the rule cannot know what was asserted ────────────────────
+
+describe("cases the rule must stay silent about", () => {
+  it("says nothing when either side declares no type", () => {
+    // A field with no declared type gives the rule nothing to compare. Demanding
+    // one is a different rule than this one.
+    assert.deepEqual(
+      findingsFor(`
+schema customers { signup }
+schema profiles { signup_date DATE }
+
+mapping load {
+  source { customers }
+  target { profiles }
+  signup -> signup_date
+}
+`),
+      [],
+    );
+  });
+
+  it("says nothing when the arrow path is not declared in any participating schema", () => {
+    // An arrow naming a field that does not exist is `validate`'s finding
+    // (`field-not-in-schema`). Reporting it again here would double-report one
+    // mistake under two rule ids.
+    assert.deepEqual(
+      findingsFor(`
+schema customers { signup STRING }
+schema profiles { signup_date DATE }
+
+mapping load {
+  source { customers }
+  target { profiles }
+  typo -> signup_date
+}
+`),
+      [],
+    );
+  });
+
+  it("says nothing when two source schemas declare the same field with different types", () => {
+    // A bare `email -> email` in a two-source mapping names no particular source,
+    // so which type the author meant is unknowable. Reporting the first match
+    // would make the finding depend on the order of the `source { }` list.
+    assert.deepEqual(
+      findingsFor(`
+schema a { email STRING }
+schema b { email INT }
+schema out { email STRING }
+
+mapping load {
+  source { a, b }
+  target { out }
+  email -> email
+}
+`),
+      [],
+    );
+  });
+
+  it("still reports a qualified path when a sibling source shadows the field name", () => {
+    // The ambiguity above is about *unqualified* paths. Qualifying the source
+    // (`b.email`) removes the ambiguity, and the rule must then compare the type
+    // the author actually pointed at — otherwise a multi-source mapping could
+    // never be checked at all.
+    const findings = findingsFor(`
+schema a { email STRING }
+schema b { email INT }
+schema out { email STRING }
+
+mapping load {
+  source { a, b }
+  target { out }
+  b.email -> email
+}
+`);
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].message, /b\.email/);
+    assert.match(findings[0].message, /INT/);
+  });
+});
+
+// ── Normalization: what counts as the same declared type ────────────────────
+
+describe("comparing declared types", () => {
+  it("treats case differences as one type", () => {
+    // A workspace assembled from several spreadsheets will spell one type both
+    // ways; case is not type information.
+    assert.deepEqual(findingsFor(bareArrowBetween("String", "STRING")), []);
+  });
+
+  it("compares parameterized types on their base token", () => {
+    // Declared lengths and precision do not count as mismatches at the
+    // granularity this rule judges (PRD 37 R1).
+    assert.deepEqual(findingsFor(bareArrowBetween("VARCHAR(255)", "VARCHAR")), []);
+    assert.deepEqual(findingsFor(bareArrowBetween("DECIMAL(10,2)", "DECIMAL(12,4)")), []);
+  });
+
+  it("ignores constraint flags spelled inside the type parentheses", () => {
+    // Satsuma puts constraint flags in the same parentheses as parameters
+    // (`UUID(pk)`, sl-vryu). Those are not type information, so an arrow between
+    // `UUID(pk)` and `UUID` must not be reported.
+    assert.deepEqual(findingsFor(bareArrowBetween("UUID(pk)", "UUID")), []);
+  });
+
+  it("still reports two genuinely different base tokens", () => {
+    // Guards the normalization above from over-reaching: stripping parameters
+    // must not collapse distinct types onto each other.
+    assert.equal(findingsFor(bareArrowBetween("VARCHAR(255)", "DECIMAL(10,2)")).length, 1);
+  });
+});
+
+// ── Alias groups from satsuma.config.yaml ───────────────────────────────────
+
+describe("configured type aliases", () => {
+  it("accepts a pair declared equivalent by an alias group", () => {
+    // Nothing is presumed equivalent by default — deciding that `TEXT` is a
+    // `STRING` is a convention decision this feature does not make (PRD 37, Out
+    // of Scope). `lint.typeAliases` is how the author makes it.
+    assert.equal(findingsFor(bareArrowBetween("STRING", "TEXT")).length, 1);
+    assert.deepEqual(findingsFor(bareArrowBetween("STRING", "TEXT"), [["STRING", "TEXT"]]), []);
+  });
+
+  it("matches alias members case-insensitively and on their base token", () => {
+    // A group written `[string, varchar]` must alias `VARCHAR(255)` too, or the
+    // author has to enumerate every parameterization they happen to have used.
+    assert.deepEqual(
+      findingsFor(bareArrowBetween("STRING", "VARCHAR(255)"), [["string", "varchar"]]),
+      [],
+    );
+  });
+
+  it("keeps separate alias groups separate", () => {
+    // Flattening groups into one pool would make `STRING` equivalent to `INT` in
+    // any workspace that declared both a string group and a numeric group — the
+    // exact failure `TypeAliasGroup` is modelled per-group to prevent.
+    const aliases = [
+      ["STRING", "TEXT"],
+      ["INT", "BIGINT"],
+    ];
+
+    assert.deepEqual(findingsFor(bareArrowBetween("TEXT", "STRING"), aliases), []);
+    assert.equal(findingsFor(bareArrowBetween("TEXT", "BIGINT"), aliases).length, 1);
+  });
+
+  it("bridges two groups that share a member", () => {
+    // A token may legitimately belong to several groups; membership is compared
+    // as an intersection, so `TEXT` in both groups makes each of its partners
+    // equivalent to it — but not to each other.
+    const aliases = [
+      ["STRING", "TEXT"],
+      ["TEXT", "CLOB"],
+    ];
+
+    assert.deepEqual(findingsFor(bareArrowBetween("STRING", "TEXT"), aliases), []);
+    assert.deepEqual(findingsFor(bareArrowBetween("CLOB", "TEXT"), aliases), []);
+    assert.equal(findingsFor(bareArrowBetween("STRING", "CLOB"), aliases).length, 1);
+  });
+});
+
+// ── Namespaces ──────────────────────────────────────────────────────────────
+
+describe("namespaced workspaces", () => {
+  it("resolves schemas a namespaced mapping refers to by their bare name", () => {
+    // Inside `namespace crm`, a mapping writes `customers` for what the index
+    // keys as `crm::customers`. If the resolver were handed the wrong namespace
+    // the schema would not resolve and the mismatch would go silently unreported.
+    const findings = findingsFor(`
+namespace crm {
+  schema customers { signup STRING }
+  schema profiles { signup_date DATE }
+
+  mapping load {
+    source { customers }
+    target { profiles }
+    signup -> signup_date
+  }
+}
+`);
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].message, /crm::customers\.signup/);
+    assert.match(findings[0].message, /crm::profiles\.signup_date/);
+  });
+});

--- a/tooling/satsuma-lsp/package-lock.json
+++ b/tooling/satsuma-lsp/package-lock.json
@@ -30,7 +30,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/satsuma-viz-backend/package-lock.json
+++ b/tooling/satsuma-viz-backend/package-lock.json
@@ -24,7 +24,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/satsuma-viz-harness/package-lock.json
+++ b/tooling/satsuma-viz-harness/package-lock.json
@@ -25,7 +25,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/satsuma-viz-model/package-lock.json
+++ b/tooling/satsuma-viz-model/package-lock.json
@@ -22,7 +22,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/satsuma-viz/package-lock.json
+++ b/tooling/satsuma-viz/package-lock.json
@@ -27,7 +27,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/tooling/vscode-satsuma/package-lock.json
+++ b/tooling/vscode-satsuma/package-lock.json
@@ -29,7 +29,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "web-tree-sitter": "^0.26.11"
+        "web-tree-sitter": "^0.26.11",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/node": "^26.1.2",


### PR DESCRIPTION
Closes Feature 37 (epic `sl-iffm`): `sl-j30s`, `sl-hysg`, `sl-1u6r`, `sl-ay8a`.

Two structural lint rules, detected in `@satsuma/core` so the LSP can mirror them
later without re-implementation, plus the exit-code table lint needed before
strict mode could ship.

## `type-mismatch-direct-arrow` (`sl-j30s`)

A bare `src -> tgt` asserts the value passes through unchanged, so connecting a
`STRING` to a `DATE` is almost always a mis-picked field, a schema edit that
outran its mappings, or a transform nobody wrote down. Nothing in the toolchain
remarked on it before.

`detectTypeMismatches()` fires only on `none`-classified single-source arrows.
Types compare on their upper-cased base token: case is not type information, and
everything from the first `(` is dropped — so `VARCHAR(255)` matches `VARCHAR`,
and the same rule handles Satsuma's constraint-flag spelling `UUID(pk)`.
`lint.typeAliases` groups layer on as intersecting membership sets, so a workspace
declaring both a string group and an int group never makes `STRING` equal `INT`.
This is the first consumer of that config section.

The rule is silent when either side declares no type, when the path resolves to no
declared field (that is `validate`'s `field-not-in-schema`), when the arrow has
several sources (no one of them is *the* type of the result), and when two source
schemas declare the same unqualified name with different types — qualifying the
path (`b.email -> email`) makes it checkable again.

**Value maps get no branch, and must not get one.** `map { … }` is a `pipe_step`,
so the arrow classifies `nl` and is already excluded by the `none`-only criterion.
A test asserts that classification directly, so a refactor splitting map literals
out fails there rather than silently starting to type-check conversions.

## `lineage-cycle` (`sl-hysg`)

Every traversal here is cycle-guarded, so an unintended cycle surfaced only as
lineage output that quietly omitted an expected upstream hop. Guarding is not
reporting.

`detectLineageCycles()` builds the same schema-level edges `lineage` and
`graph --compact` draw, drops self-mapping edges first — the recorded roadmap
decision, applied **per edge**, so `source { a }` with `target { a, b }` still
contributes `a -> b` — then reports one finding per strongly-connected component
via iterative Tarjan. The representative path is canonical (entry at the
component's smallest id, shortest cycle from there over sorted adjacency), each
hop is attributed to every mapping declaring it, and members the path does not
visit are named so a two-hop representative for a five-schema tangle cannot read
as a two-schema problem.

## Lint exit codes (`sl-1u6r`) — ⚠️ BREAKING for CI

`lint` returned `2` both for error-severity findings and for failing to run, so it
contradicted the CLI-wide table's "parse or filesystem error" and a job could not
tell a failing gate from a broken checkout. Strict mode would have given `1` a
third meaning. `lint` now publishes its own table:

| Code | Meaning |
| ---- | ------- |
| `0` | No findings, or warnings only without strict mode |
| `1` | Warnings present and strict mode active |
| `2` | Error-severity findings present |
| `3` | Lint could not run — unusable config, unknown rule id, unreadable workspace |

`--strict` / `--no-strict` override `lint.strict` in either direction. A
suppressed rule produces no findings and so can never fail a strict build.
`loadLintWorkspace()` remaps the loader's `2` to `3` at the command boundary,
leaving shared helpers raising CLI-wide codes.

**What a CI consumer must check:** a job treating `2` as "the workspace has lint
errors" was also silently catching setup failures under that label and now sees
them as `3`. `1` is new but opt-in — warnings still exit `0` by default, so no
existing job changes behaviour by upgrading.

## ADRs

- **ADR-046** — a command may publish its own exit-code table when the CLI-wide
  meanings would be wrong for its outcomes. Names the existing `fmt --check` and
  `coverage --fail-under` deviations as instances of a pattern, and requires each
  command-scoped constant to carry its own non-collision argument.
- **ADR-047** — lint policy detection lives in core beside semantic validation,
  with `LintFinding` kept distinct from `SemanticDiagnostic`. Extends ADR-020 and
  ADR-025 without superseding either.
- **ADR-048** — a graph finding reports one strongly-connected component, not
  every cycle through it.

No existing ADR is superseded.

## Docs

`SATSUMA-CLI.md` gains both rules in the table plus a subsection per rule covering
every exemption with its rationale and the roadmap citation, and the exit-code
table the CLI-wide section now points at. `AI-AGENT-REFERENCE.md` tells authors
what a bare arrow claims (baked into `satsuma agent-reference` at build time).
`HOW-DO-I.md` gains four lint questions. `ARCHITECTURE.md` gains the core lint
modules. `CHANGELOG.md` calls out the break. PRD marked COMPLETE, ROADMAP updated.

## Incidental

- The dependent packages' lockfiles were missing core's `yaml` dependency added
  by `sl-npi6`; `npm run install:all` fixed them and they are included.
- Core/CLI test counts in `AGENTS.md` were stale (578/994 → 675/1031).

## Verification

Core 675 tests, CLI 1031 tests, `scripts/run-repo-checks.sh` green — it ran again
in the pre-commit hook for both commits. Two existing tests changed by design:
`bug-purge.test.ts`'s "lint exits 2 for nonexistent path" now asserts `3` with the
reason, and `load-config.test.ts`'s "lint.strict is parsed but not yet enforced"
was replaced by an end-to-end check that `lint.typeAliases` reaches the rule.

## Note on commit shape

The implementation landed as one commit rather than one per ticket: the three
tickets share `lint.ts` and `lint-engine.ts`, the exit-code table is an acceptance
criterion of both `sl-1u6r` and `sl-ay8a`, and either rule alone would still have
needed the `LintRuleContext` plumbing. Any split would have been a state that
failed its own tests. The ADRs are a second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
