### PR TITLE
fix(cli): compute lint --rules id column width from the registry (sl-n4rb)

### DIFF
--- a/.tickets/sl-n4rb.md
+++ b/.tickets/sl-n4rb.md
@@ -1,0 +1,40 @@
+---
+id: sl-n4rb
+status: closed
+deps: []
+links: []
+created: 2026-08-03T18:41:49Z
+type: bug
+priority: 4
+assignee: Thorben Louw
+tags: [cli, lint]
+---
+# cli: lint --rules column alignment broken by 26-char rule ids
+
+`satsuma lint --rules` pads rule ids with a hard-coded `padEnd(24)` (commands/lint.ts), but `unenumerated-record-target` and `type-mismatch-direct-arrow` are both 26 characters, so their description column is pushed out of alignment with the other four rows.
+
+Introduced by sl-j30s / sl-hysg, which added the two long ids. Cosmetic only — no behaviour change.
+
+Observed:
+
+```
+  duplicate-definition     Named definition is declared more than once in a namespace
+  unenumerated-record-target Arrow targets a record without a record source or child arrows
+  type-mismatch-direct-arrow Bare arrow connects fields whose declared types differ
+```
+
+## Design
+
+Derive the column width from the registry instead of hard-coding it: `Math.max(...RULES.map(r => r.id.length)) + 1`, extracted to a named constant with a comment saying it is computed so a new rule id cannot break the table again. That removes the magic number the repo's own readability rules disallow rather than just widening it.
+
+## Acceptance Criteria
+
+--rules output aligns for every registered rule id; the width is computed from RULES rather than hard-coded; a test asserts alignment holds for the longest id so a future long id cannot silently regress it.
+
+
+## Notes
+
+**2026-08-03T18:57:29Z**
+
+Cause: `lint --rules` padded rule ids with a hard-coded `padEnd(24)`, which sl-j30s/sl-hysg outgrew by adding two 26-character ids.
+Fix: derive the id column width from the RULES registry (`RULE_ID_COLUMN_WIDTH`) and add a test asserting every description starts at the same column, so a future long id cannot regress the table (commit immediately after a5c221b7).

--- a/tooling/satsuma-cli/src/commands/lint.ts
+++ b/tooling/satsuma-cli/src/commands/lint.ts
@@ -55,6 +55,13 @@ import type { LintDiagnostic, LintFix } from "../types.js";
 /** Every rule id the engine knows, used to reject typos wherever ids are named. */
 const KNOWN_RULE_IDS: readonly string[] = RULES.map((r) => r.id);
 
+/**
+ * Width of the id column in `--rules`, computed from the registry rather than
+ * hard-coded so that registering a rule with a longer id cannot knock the
+ * description column out of alignment (sl-n4rb).
+ */
+const RULE_ID_COLUMN_WIDTH = Math.max(...KNOWN_RULE_IDS.map((id) => id.length));
+
 /** Split a comma-separated rule-id flag value, dropping incidental whitespace. */
 function parseRuleList(value: string): string[] {
   return value
@@ -208,7 +215,7 @@ Examples:
           // --rules: list available rules and exit
           if (opts.rules) {
             for (const r of RULES) {
-              console.log(`  ${r.id.padEnd(24)} ${r.description}`);
+              console.log(`  ${r.id.padEnd(RULE_ID_COLUMN_WIDTH)} ${r.description}`);
             }
             return;
           }

--- a/tooling/satsuma-cli/test/lint-command.test.ts
+++ b/tooling/satsuma-cli/test/lint-command.test.ts
@@ -225,6 +225,22 @@ describe("structural rules registration", () => {
     assert.match(stdout, /lineage-cycle/);
   });
 
+  it("aligns every --rules description at the same column, including the longest id", async () => {
+    // The id column width is derived from the registry, so registering a rule
+    // with a longer id than any existing one must not push its description out
+    // of line (sl-n4rb: a hard-coded padEnd(24) broke the two 26-char ids).
+    const { stdout } = await run(CLI, "lint", "--rules");
+    const descriptionColumns = new Set(
+      stdout
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        // The description starts after the id and the run of padding spaces.
+        .map((line) => line.length - line.replace(/^\s+\S+\s+/, "").length),
+    );
+
+    assert.equal(descriptionColumns.size, 1, `descriptions not aligned:\n${stdout}`);
+  });
+
   it("reports a type mismatch as an unfixable warning in --json", async () => {
     // Pins the JSON contract machine consumers read: id, severity, position, and
     // fixable: false — the fix is an author judgement, so --fix must not offer one.


### PR DESCRIPTION
Closes sl-n4rb.

`satsuma lint --rules` padded rule ids with a hard-coded `padEnd(24)`. The two
structural rules added in sl-j30s / sl-hysg (`unenumerated-record-target`,
`type-mismatch-direct-arrow`) are 26 characters, so their descriptions sat out
of alignment with the other four rows. Cosmetic, no behaviour change.

The fix derives the width from the `RULES` registry rather than widening the
magic number, so registering a longer rule id in future cannot break the table
again — and it removes a magic value the repo's own readability rules disallow.

Before:

```
  duplicate-definition     Named definition is declared more than once in a namespace
  unenumerated-record-target Arrow targets a record without a record source or child arrows
  type-mismatch-direct-arrow Bare arrow connects fields whose declared types differ
```

After:

```
  duplicate-definition       Named definition is declared more than once in a namespace
  unenumerated-record-target Arrow targets a record without a record source or child arrows
  type-mismatch-direct-arrow Bare arrow connects fields whose declared types differ
```

## Testing

- New test asserts every `--rules` row starts its description at the same
  column. Verified it is a real guard: it fails when `padEnd(24)` is restored
  and passes with the computed width.
- Full `satsuma-cli` suite: 1032 pass, 0 fail.
- Pre-commit repo checks green.

No ADR needed — this reverses an oversight inside an existing decision rather
than making a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)