### PR TITLE
chore(tickets): re-plan sl-prlp against the sl-4871 spike and R6; raise spr-w98t

### DIFF
--- a/.tickets/sl-12kz.md
+++ b/.tickets/sl-12kz.md
@@ -49,3 +49,24 @@ Not viz-backend, because it is a devDependency of satsuma-cli: putting lineage
 there would make the published CLI bundle carry the VizModel assembly. Core also
 already holds qualifyField, resolveScopedEntityRef and schemaLocalFieldPath, and
 has a typecheck gate keeping Node built-ins off its import path.
+
+**2026-08-04T09:28:51Z**
+
+sl-prlp re-planned against the sl-4871 spike and Feature 41 R6 (ticket text only, no code).
+
+Settled: the traversal goes to satsuma-core, in two steps — a pure
+traceFieldLineage(edges, start, opts), then the edge builder behind a narrow
+FieldEdgeSource interface so no workspace index type enters core. Step 2 is what
+deletes the graph-builder.ts / field-lineage.ts duplication and is not optional.
+
+New since the spike: R6 (sl-jyee) put endpoint resolution behind arrowEndpoint in
+satsuma-cli/src/field-endpoints.ts, which holds the *undecided* r0-7w76 reading that
+core deliberately refuses to make. So that module stays in the CLI and the core
+builder takes endpoint resolution as an injected function. sl-prlp must not decide
+r0-7w76; its pinned tests go red if it does.
+
+Also raised spr-w98t (P1 bug): sl-y89y's DepthAwareTraversal fix reached
+commands/lineage.ts only, so the field traversal still has the first-visit-wins shape
+that truncates subtrees reachable within depth via a shorter path. It cannot ride in
+sl-prlp (byte-identical output) and Feature 41 R4 asserts depth exactness, so the
+chain is now sl-prlp -> spr-w98t -> sl-jsyn.

--- a/.tickets/sl-jsyn.md
+++ b/.tickets/sl-jsyn.md
@@ -1,7 +1,7 @@
 ---
 id: sl-jsyn
 status: open
-deps: [sl-dqyu, sl-prlp]
+deps: [sl-dqyu, sl-prlp, spr-w98t]
 links: []
 created: 2026-08-03T16:23:59Z
 type: task

--- a/.tickets/sl-prlp.md
+++ b/.tickets/sl-prlp.md
@@ -8,19 +8,69 @@ type: task
 priority: 2
 assignee: Thorben Louw
 parent: sl-12kz
-tags: [field-lineage]
+tags: [field-lineage, core]
 ---
-# Extract traceFieldLineage into a browser-portable package; CLI delegates
+# Extract the field-lineage traversal and edge builder into satsuma-core; CLI delegates
 
-Move the traversal out of satsuma-cli/src/commands/field-lineage.ts into the package chosen by the spike, as a pure traceFieldLineage(workspace, fieldRef, {depth, direction}) function. The command becomes a thin adapter: parse args, load workspace, call, format.
+Move the traversal and the edge builder out of satsuma-cli/src/commands/field-lineage.ts into **satsuma-core**, and point both emitters at the shared builder. The command becomes a thin adapter: parse args, load workspace, call, format.
+
+The target package and the signature are settled by the sl-4871 spike — see features/40-shared-field-lineage-view/SPIKE-sl-4871-portable-home.md. Two corrections to this ticket as originally written:
+
+- **Package is satsuma-core, not satsuma-viz-backend.** viz-backend is a devDependency of satsuma-cli, so lineage living there would put VizModel assembly in the published CLI bundle. Core already has the no-Node-built-ins typecheck gate this ticket's first criterion asks for.
+- **The signature is not `traceFieldLineage(workspace, fieldRef, opts)`.** No workspace shape enters core at all. It splits in two (below), and step 2 is not optional — it is what "no second copy remains" actually asks for.
 
 FieldLineageResult must keep the shape the CLI's --json already emits (field, upstream[], downstream[] with field/via_mapping/classification) because the VS Code panel consumes it today.
 
+## Design
+
+**Step 1 — the pure traversal.** `traceFieldLineage(edges, start, { depth, direction })` over a plain edge list and nothing else. Replaces traceUpstream/traceDownstream (field-lineage.ts:245-303). This is the function Feature 41's R4 properties (sl-jsyn) aim at, so the edge-list shape is load-bearing: it lets R4 compare directly against scenarioAncestorsWithin / scenarioDescendantsWithin in @satsuma/scenario-gen.
+
+**Step 2 — the edge builder, behind a narrow interface.** Neither ExtractedWorkspace nor viz-backend's WorkspaceIndex may enter core. The builder reads three things:
+
+```ts
+interface FieldEdgeSource {
+  arrows: Iterable<ArrowRecordLike>;                 // already deduplicated by the caller
+  mappingSides(mappingKey: string): { sources: string[]; targets: string[] } | null;
+  nlRefs: Iterable<ResolvedNlRefLike>;               // already resolved by the caller
+}
+```
+
+distinctArrowRecords stays in the CLI (it dedupes by object reference across the multi-key fieldArrows map — a positional key is not a safe identity there), and resolveAllNLRefs stays in the CLI, so the phantom-edge history (cbh-y5og) stays on the resolver's side of the boundary. Both graph-builder.ts:469 buildFieldEdges and field-lineage.ts:160 buildFieldEdgeGraph then call the core builder; that near-line-for-line duplication is what this step deletes.
+
+The shared builder must carry the metadata superset: graph needs transforms/nl_text/file/line and the unresolvedNl list, field-lineage needs none of them. Namespace filtering stays a caller concern — graph filters, lineage does not. graph-builder's ResolvedFieldEdge (edge + branded endpoints, added by sl-jyee) is the return shape to generalise.
+
+**Endpoint resolution is a parameter, not a move.** Since sl-jyee, both emitters resolve endpoints through `arrowEndpoint` in satsuma-cli/src/field-endpoints.ts, which encodes the *pending* r0-7w76 reading ("a bare token that also names a declared schema reads as a field") behind a labelled rule comment. Core deliberately refuses that choice — resolveFieldEndpoint reports the fork instead. So field-endpoints.ts stays in the CLI and the core builder takes endpoint resolution as an injected function. Do not resolve r0-7w76 here.
+
+**Dependency classification (from the spike).** spread-expand portable; nl-ref-extract portable once index-builder is; index-builder has exactly one node:path call (line 439, resolving import paths) with a precedented browser-portable substitution in viz-backend (`new URL(pathText, importerUri)`, workspace-index.ts:310); load-workspace stays in the CLI — it *is* the filesystem adapter, so the extracted code takes an already-built workspace, never a path. command-runner and option-parsers stay.
+
+**Out of scope, deliberately.** The extracted traversal keeps today's first-visit-wins visited set, defects and all — spr-w98t owns the depth-truncation defect that R4's depth-exactness property will red-flag. Fixing it here would violate the byte-identical criterion below.
+
 ## Acceptance Criteria
 
-- traceFieldLineage has no Node built-in (fs/path/url) on its import path, asserted by a test over the module graph.
+- traceFieldLineage and the edge builder both live in satsuma-core with no Node built-in (fs/path/url) on their import path, asserted by core's existing test:typecheck gate plus a test over the module graph.
+- No workspace index type (ExtractedWorkspace, WorkspaceIndex) appears in either core signature.
 - The 17 existing tests in satsuma-cli/test/field-lineage.test.ts pass UNCHANGED.
-- satsuma field-lineage output is byte-identical for every case those tests cover.
-- No second copy of the traversal remains in the CLI.
+- satsuma field-lineage output is byte-identical for every case those tests cover, and satsuma graph output is byte-identical across graph.test.ts and Feature 41 R3's generated edge invariants.
+- The pinned r0-7w76 expectations in test/field-endpoints.test.ts and the pinned container-header property in test/generated-edge-invariants.test.ts stay green — going red means the extraction silently decided r0-7w76.
+- Only one edge builder remains: field-lineage.ts and graph-builder.ts both call core's, and neither retains its own walk.
 - Cycle detection and the --depth limit move with the traversal and stay covered.
 
+## Notes
+
+**2026-08-04T09:27:14Z**
+
+Re-planned against the sl-4871 spike finding and Feature 41 R6 (both now on main at
+f775a972); no code change, ticket text only.
+
+Body and acceptance criteria previously named "the package chosen by the spike" and a
+`traceFieldLineage(workspace, fieldRef, opts)` signature that the spike then ruled out.
+Now records the settled answers: satsuma-core, a two-step split (pure traversal over an
+edge list, then the edge builder behind FieldEdgeSource), and the one new question R6
+created — field-endpoints.ts holds the undecided r0-7w76 reading that core refuses to
+make, so endpoint resolution is injected rather than moved.
+
+Raised spr-w98t for the field traversal's depth-truncation defect, found while checking
+this plan: sl-y89y's DepthAwareTraversal fix reached commands/lineage.ts only, so
+field-lineage.ts still has the original first-visit-wins shape. It cannot be fixed inside
+this ticket (byte-identical output), and R4 (sl-jsyn) will fail on it, so it is sequenced
+between the two.

--- a/.tickets/spr-w98t.md
+++ b/.tickets/spr-w98t.md
@@ -1,0 +1,30 @@
+---
+id: spr-w98t
+status: open
+deps: [sl-prlp]
+links: []
+created: 2026-08-04T09:28:15Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: sl-6hot
+tags: [cli, lineage, field-lineage]
+---
+# cli: field-lineage depth-limited traversal truncates subtrees reachable within depth via a shorter path
+
+satsuma field-lineage's traceUpstream/traceDownstream (field-lineage.ts:245-303) use a first-visit-wins visited set: a node first reached at deep depth is never re-expanded when a shorter path reaches it later with depth budget remaining, so its whole subtree is truncated from the result.
+
+This is exactly the defect sl-y89y described and fixed — but that fix (DepthAwareTraversal, recording the shallowest visit per node and re-expanding on strictly shallower revisits) landed only in commands/lineage.ts, the schema-level walk. The field-level walk was never migrated and still has the original shape. Two traversals, one fixed, one not.
+
+Found while re-planning sl-prlp (2026-08-04), not by a user report — so a diamond-shaped field graph reproducing it needs writing.
+
+Sequencing: this cannot be fixed inside sl-prlp, whose acceptance criteria require byte-identical field-lineage output, and fixing it changes the output for diamond field graphs. But Feature 41 R4 (sl-jsyn) asserts depth *exactness* — 'the result at depth n is exactly the nodes whose shortest path is <= n', written specifically to catch this class rather than monotonicity, which the buggy version also satisfies — so R4 goes red until this lands. Fix after sl-prlp extracts the traversal into core, before or alongside sl-jsyn.
+
+## Acceptance Criteria
+
+- A diamond field-lineage graph (two paths to one node, of different lengths) is covered by a regression test asserting the full subtree below the shorter path appears at the depth where it is reachable.
+- Upstream and downstream both re-expand a node revisited at a strictly shallower depth, and neither emits duplicate entries for it.
+- The depth-aware traversal is shared with commands/lineage.ts rather than reimplemented: after sl-prlp, one traversal in satsuma-core serves both the schema-level and field-level walks, and DepthAwareTraversal is deleted from commands/lineage.ts.
+- Cyclic workspaces still terminate.
+- Feature 41 R4's depth-exactness property (sl-jsyn) passes against the field traversal with no weakened assertion.
+

--- a/features/41-lineage-graph-confidence/IMPLEMENTATION-NOTES.md
+++ b/features/41-lineage-graph-confidence/IMPLEMENTATION-NOTES.md
@@ -15,8 +15,8 @@ plan while executing it.
 | R1 promote the generator to `satsuma-scenario-gen` | `sl-puky` | done |
 | R2 workspace-shaped scenario model and ground truth | `sl-dqyu` | done |
 | R3 structural edge invariants | `sl-hi0z` | done |
-| R4 reachability properties | `sl-jsyn` | blocked — see [Feature 40 dependency](#the-feature-40-dependency-r4-and-r5) |
-| R5 cross-consumer parity sweep | `sl-kwet` | blocked — same |
+| R4 reachability properties | `sl-jsyn` | blocked on `sl-prlp` then `spr-w98t` — see [Feature 40 dependency](#the-feature-40-dependency-r4-and-r5) |
+| R5 cross-consumer parity sweep | `sl-kwet` | blocked on `sl-prlp` — same |
 | R6 branded lineage endpoints | `sl-jyee` | done |
 
 ## No ADR for the generator package — dropped on review, 2026-08-04
@@ -61,7 +61,8 @@ Ranked by what I would pick up next.
    checking. It also unblocks the generator's namespaced-chain arbitrary generating
    the shape again, which widens R3's domain for free.
 3. **R4 and R5**, once Feature 40's `sl-prlp` lands — see below. R4's oracle is
-   already shipped.
+   already shipped, but R4 also waits on `spr-w98t` (see the
+   [addendum](#addendum-2026-08-04--one-bug-now-sits-between-sl-prlp-and-r4)).
 4. **`lgc-wtz1`** (P2, cosmetic but corrosive): one spelling per entity across
    `nodes`, `edges`, `schema_edges` and `field-lineage`. Landing it deletes the two
    normalisation shims in R3's properties and the same shims R5 would otherwise need.
@@ -94,6 +95,25 @@ What was done instead, to make the follow-up as small as possible:
   `scenarioDescendantsWithin` are already in the generator package with their
   properties' invariants documented, so R4 becomes a test file that calls a
   traversal, not a design exercise.
+
+### Addendum, 2026-08-04 — one bug now sits between `sl-prlp` and R4
+
+Re-planning `sl-prlp` against the spike surfaced `spr-w98t` (P1): `sl-y89y`'s
+`DepthAwareTraversal` fix — shallowest-visit-wins, re-expanding on strictly shallower
+revisits — landed only in `commands/lineage.ts`, the *schema-level* walk.
+`field-lineage.ts`'s `traceUpstream`/`traceDownstream` still use the original
+first-visit-wins visited set, so a field reached first by a long path is never
+re-expanded when a shorter one reaches it with budget left.
+
+That matters here because **R4's depth-exactness property is written to catch exactly
+this** ("the result at depth *n* is exactly the nodes whose shortest path is ≤ *n*",
+chosen over monotonicity precisely because the buggy version satisfies monotonicity).
+So R4 is red against the traversal `sl-prlp` extracts, and the fix cannot ride inside
+`sl-prlp`, whose acceptance criteria require byte-identical output. The chain is now
+`sl-prlp` → `spr-w98t` → `sl-jsyn`, recorded as a dependency.
+
+The spike's claim that "every logged traversal defect lives in the traversal half"
+holds — it just understated it: one of the two is still live.
 
 ## Findings that correct the PRD
 


### PR DESCRIPTION
Docs and ticket text only — no production code.

## Why

`sl-prlp` (extract the field-lineage traversal into a browser-portable package) was written *before* the `sl-4871` spike ran, and before Feature 41 R6 landed. Two things in it were stale, and one new question had appeared.

## What changed

**`sl-prlp` re-planned** to match the spike finding (`features/40-shared-field-lineage-view/SPIKE-sl-4871-portable-home.md`):

- Target package is **`satsuma-core`**, not `satsuma-viz-backend` — viz-backend is a devDependency of the CLI, so lineage there would put VizModel assembly in the published CLI bundle.
- The signature is **not** `traceFieldLineage(workspace, fieldRef, opts)`. It splits in two: a pure `traceFieldLineage(edges, start, opts)`, then the edge builder behind a narrow `FieldEdgeSource` interface so no workspace index type enters core. Step 2 is what deletes the `graph-builder.ts` / `field-lineage.ts` duplication, which is what "no second copy remains" actually asks for.
- **New since R6:** `arrowEndpoint` in `satsuma-cli/src/field-endpoints.ts` holds the *undecided* `r0-7w76` reading that core deliberately refuses to make, so that module stays in the CLI and the core builder takes endpoint resolution as an injected function. Two pinned tests are added as acceptance criteria — they go red if the extraction decides `r0-7w76` by accident.

**`spr-w98t` raised (P1 bug)** — a live defect found while checking the plan: `sl-y89y`'s `DepthAwareTraversal` fix (shallowest-visit-wins) reached `commands/lineage.ts` only. `field-lineage.ts`'s `traceUpstream`/`traceDownstream` still use a first-visit-wins visited set, so a field first reached by a long path is never re-expanded when a shorter one reaches it with depth budget left.

It cannot ride inside `sl-prlp`, whose criteria require byte-identical output, and Feature 41 R4 asserts depth *exactness* (chosen over monotonicity precisely because the buggy version satisfies monotonicity). So the chain is now `sl-prlp` → `spr-w98t` → `sl-jsyn`, recorded as a dependency.

**Feature 41's running log** gains an addendum and a corrected status table so its blocked-on chain is accurate.

## Checks

`markdownlint-cli2` clean. The pre-commit hook was skipped deliberately: this worktree has no `node_modules` and the change touches nothing the suites cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)