### PR TITLE
examples: add @refs to NL field notes for consistent documentation

### DIFF
--- a/examples/reports-and-models/pipeline.stm
+++ b/examples/reports-and-models/pipeline.stm
@@ -62,11 +62,11 @@ schema weekly_sales_dashboard (
   owner "analytics-team",
   note "Executive weekly sales overview — filters default to current quarter"
 ) {
-  total_revenue     DECIMAL(14,2) (note "Sum of fact_orders.net_amount for the period")
-  units_sold        INTEGER        (note "Count of fact_orders.quantity")
-  avg_order_value   DECIMAL(10,2) (note "total_revenue / number of distinct orders")
+  total_revenue     DECIMAL(14,2) (note "Sum of @fact_orders.net_amount for the period")
+  units_sold        INTEGER        (note "Count of @fact_orders.quantity")
+  avg_order_value   DECIMAL(10,2) (note "@total_revenue / number of distinct orders")
   top_product       VARCHAR(200) (note "Product with highest revenue in the period")
-  region            VARCHAR(50) (note "Dimension slicer from dim_product.region")
+  region            VARCHAR(50) (note "Dimension slicer from @dim_product.region")
   week_ending_date  DATE           (note "Last day of the reporting week")
 }
 
@@ -89,9 +89,9 @@ schema churn_predictor (
   refresh schedule "Sunday 02:00 UTC",
   note "Binary classifier predicting 90-day churn. Retrained weekly; promoted to production only if AUC > 0.82."
 ) {
-  customer_tenure_days   INTEGER (note "Days since dim_customer.signup_date")
-  order_count_30d        INTEGER (note "Orders in the last 30 days from fact_orders")
-  avg_order_value        DECIMAL(10,2) (note "Mean net_amount over customer lifetime")
+  customer_tenure_days   INTEGER (note "Days since @dim_customer.signup_date")
+  order_count_30d        INTEGER (note "Orders in the last 30 days from @fact_orders")
+  avg_order_value        DECIMAL(10,2) (note "Mean @net_amount over customer lifetime")
   days_since_last_order  INTEGER (note "Recency signal — days since most recent order")
   churn_probability      DECIMAL(5,4) (
     note "Model output: probability of churn in next 90 days"
@@ -122,7 +122,7 @@ schema customer_risk_report (
   customer_id        UUID           (required)
   customer_name      VARCHAR(200)   (pii)
   churn_probability  DECIMAL(5,4)   (note "From churn_predictor model output")
-  lifetime_revenue   DECIMAL(14,2) (note "Sum of all historical orders from fact_orders")
+  lifetime_revenue   DECIMAL(14,2) (note "Sum of all historical orders from @fact_orders")
   risk_tier          VARCHAR(20) (
     note "High / Medium / Low based on churn probability and LTV"
   )

--- a/examples/xml-to-parquet/pipeline.stm
+++ b/examples/xml-to-parquet/pipeline.stm
@@ -144,7 +144,7 @@ mapping `order headers` {
   Order.Totals.TotalAmount -> total_amount
 
   -> discount_codes {
-    "Collect `DiscountCode` values from the order discount entries, preserving source order.
+    "Collect @DiscountCode values from the order discount entries, preserving source order.
      Emit as a JSON array string. If no discounts, emit []."
   }
 


### PR DESCRIPTION
## Summary

Added `@`-prefix references to schema field notes that explain data provenance, making these cross-references tooling-detectable for lineage analysis and documentation generation.

### Changes

- **examples/reports-and-models/pipeline.stm**: 6 field notes updated
  - `total_revenue`: `@fact_orders.net_amount`
  - `units_sold`: `@fact_orders.quantity`
  - `avg_order_value`: `@total_revenue`
  - `region`: `@dim_product.region`
  - `customer_tenure_days`: `@dim_customer.signup_date`
  - `order_count_30d`: `@fact_orders`
  - `lifetime_revenue`: `@fact_orders`

- **examples/xml-to-parquet/pipeline.stm**: 1 notation standardized
  - `discount_codes`: Changed backtick \`DiscountCode\` to @DiscountCode for consistency

### Why This Matters

Field notes that explain data provenance should use @ref syntax for:
1. **Tooling traceability** — Semantic analyzers can detect and validate these references
2. **Lineage analysis** — Impact queries can follow the documented dependencies
3. **Documentation** — Export tools can resolve and render these references correctly

Per spec section 2.2: "@refs required inside NL strings for tooling to detect refs."

### Validation

✅ Both files validate without errors  
✅ All 318 tree-sitter corpus tests pass  
✅ All CLI validation tests pass

**Note:** There is a pre-existing test failure in `tooling/satsuma-viz/test/generated-edge-completeness.test.js` unrelated to these changes (verified by reverting and re-testing).

## Checklist

- [x] Examples validate cleanly
- [x] No new test failures introduced
- [x] Changes follow @ref convention documented in spec
- [x] Audit report created in scratchpad

---

Related: NL @ref audit of canonical examples and corpus (comprehensive scan completed)