### PR TITLE
Fix viz lineage edges for computed and multi-source arrows

### DIFF
--- a/.tickets/lgc-4bxl.md
+++ b/.tickets/lgc-4bxl.md
@@ -1,6 +1,6 @@
 ---
 id: lgc-4bxl
-status: open
+status: closed
 deps: []
 links: [sl-hi0z, sl-k7i4, lgc-fu7o]
 created: 2026-08-03T22:23:44Z
@@ -51,3 +51,7 @@ A computed arrow never produces an edge whose source is a field the arrow does n
 **2026-08-03T22:45:49Z**
 
 Feature 41 R3 pinned this defect in an executable test rather than skipping it. The test asserts the CURRENT (wrong) behaviour and will go RED when this ticket is fixed, with a comment naming the invariant to replace it with. `{ todo: ... }` is not usable in this repo: node's JUnit reporter puts a `failure=` attribute on a failing todo testcase, and dorny/test-reporter then fails CI's Test report check.
+
+**2026-08-04T09:31:15Z**
+
+Cause: The layout treated a sourceless computed arrow as if its target field were also a source field, so a same-named field on a source schema became a phantom lineage edge. Fix: Computed arrows now emit no field-to-field layout edge; their mapped target remains distinguishable through the existing coverage port, with generated and browser-harness regression coverage. (commit immediately after f775a972)

--- a/.tickets/lgc-fu7o.md
+++ b/.tickets/lgc-fu7o.md
@@ -1,6 +1,6 @@
 ---
 id: lgc-fu7o
-status: open
+status: in_progress
 deps: []
 links: [sl-hi0z, lgc-4bxl]
 created: 2026-08-03T22:25:37Z

--- a/.tickets/lgc-fu7o.md
+++ b/.tickets/lgc-fu7o.md
@@ -1,6 +1,6 @@
 ---
 id: lgc-fu7o
-status: in_progress
+status: closed
 deps: []
 links: [sl-hi0z, lgc-4bxl]
 created: 2026-08-03T22:25:37Z
@@ -49,3 +49,8 @@ A multi-source arrow produces one drawn edge per source field, each attached to 
 **2026-08-03T22:45:49Z**
 
 Feature 41 R3 pinned this defect in an executable test rather than skipping it. The test asserts the CURRENT (wrong) behaviour and will go RED when this ticket is fixed, with a comment naming the invariant to replace it with. `{ todo: ... }` is not usable in this repo: node's JUnit reporter puts a `failure=` attribute on a failing todo testcase, and dorny/test-reporter then fails CI's Test report check.
+
+**2026-08-04T09:42:31Z**
+
+Cause: The layout collapsed every ArrowEntry to sourceFields[0], while hover tested the shared authored source list, so later sources had no line and could highlight a sibling line from the wrong card.
+Fix: The layout now emits and independently resolves one edge per source, records schema-local concrete endpoints, and highlights against those endpoints; generated, unit, and browser tests cover the invariant. (commit immediately after c625ff3e)

--- a/tooling/satsuma-viz-harness/test/lineage-edge-correctness.test.ts
+++ b/tooling/satsuma-viz-harness/test/lineage-edge-correctness.test.ts
@@ -1,0 +1,81 @@
+/**
+ * lineage-edge-correctness.test.ts — browser coverage for field-line rendering.
+ *
+ * These tests exercise the complete browser pipeline from authored Satsuma to
+ * VizModel, ELK field edges, and rendered schema-card coverage. They focus on
+ * cases where the old layout made a confident but false lineage claim.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import { libraryUri } from "./harness-env";
+
+/** Fixture with computed targets and ordinary mapped and unmapped fields. */
+const governanceUri = libraryUri("filter-flatten-governance/filter-flatten-governance.stm");
+
+/** Load one library document in single-file mode and wait for both layouts. */
+async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
+  await page.goto("/");
+  await page.waitForFunction(() => {
+    const harness = window.__satsumaHarness;
+    if (!harness?.setViewMode) return false;
+    harness.setViewMode("single");
+    return true;
+  });
+  await page.locator("#fixture-picker-btn").click();
+  await page.locator(`.fixture-item[data-uri="${fixtureUri}"]`).click();
+  await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+    "data-ready-state",
+    "ready",
+    { timeout: 20_000 },
+  );
+}
+
+/** Open a named overview mapping card and return its rendered detail component. */
+async function openMapping(page: Page, mappingId: string) {
+  await page.locator(`[data-testid='overview-mapping-card-${mappingId}']`).click();
+  const detail = page.locator(`[data-testid='mapping-detail-${mappingId}']`).first();
+  await expect(detail).toBeVisible({ timeout: 10_000 });
+  return detail;
+}
+
+test.describe("field-line rendering correctness", () => {
+  test("a computed target is mapped without inventing a same-named source edge (lgc-4bxl)", async ({
+    page,
+  }) => {
+    // `active_line_count` is computed and has no source. The browser layout must
+    // contain no sourceless edge, while the rendered target row remains covered;
+    // that filled port distinguishes it from the genuinely unmapped source row.
+    await loadFixture(page, governanceUri);
+
+    const layoutEvidence = await page.locator("[data-testid='viz-root']").evaluate((element) => {
+      const layout = (
+        element as unknown as {
+          _layout: {
+            edges: Array<{
+              sourceField: string;
+              targetField: string;
+              arrow: { sourceFields: string[] };
+            }>;
+          };
+        }
+      )._layout;
+      return {
+        sourcelessEdges: layout.edges.filter((edge) => edge.arrow.sourceFields.length === 0).length,
+        directOrderIdEdges: layout.edges.filter(
+          (edge) => edge.sourceField === "event_id" && edge.targetField === "order_id",
+        ).length,
+      };
+    });
+    expect(layoutEvidence.sourcelessEdges).toBe(0);
+    expect(layoutEvidence.directOrderIdEdges).toBeGreaterThan(0);
+
+    const detail = await openMapping(page, "completed-orders");
+    const computedTarget = detail.locator(
+      "[data-testid='mapping-detail-completed-orders-target-schema-card-completed-orders-parquet-field-active-line-count']",
+    );
+    const unusedSource = detail.locator(
+      "[data-testid='mapping-detail-completed-orders-source-schema-card-customer-profiles-field-first-name']",
+    );
+    await expect(computedTarget).toHaveAttribute("data-coverage", "mapped");
+    await expect(unusedSource).toHaveAttribute("data-coverage", "unmapped");
+  });
+});

--- a/tooling/satsuma-viz-harness/test/lineage-edge-correctness.test.ts
+++ b/tooling/satsuma-viz-harness/test/lineage-edge-correctness.test.ts
@@ -11,6 +11,28 @@ import { libraryUri } from "./harness-env";
 /** Fixture with computed targets and ordinary mapped and unmapped fields. */
 const governanceUri = libraryUri("filter-flatten-governance/filter-flatten-governance.stm");
 
+/** Smallest document whose one arrow has sources on two different cards. */
+const multiSourceDocument = `
+schema s0 {
+  field_0 STRING
+}
+
+schema s1 {
+  field_0 STRING
+}
+
+schema s2 {
+  field_0 STRING
+}
+
+mapping m0 {
+  source { s0, s1 }
+  target { s2 }
+
+  s0.field_0, s1.field_0 -> field_0 { "Concatenate the source values." }
+}
+`;
+
 /** Load one library document in single-file mode and wait for both layouts. */
 async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
   await page.goto("/");
@@ -77,5 +99,75 @@ test.describe("field-line rendering correctness", () => {
     );
     await expect(computedTarget).toHaveAttribute("data-coverage", "mapped");
     await expect(unusedSource).toHaveAttribute("data-coverage", "unmapped");
+  });
+
+  test("a multi-source arrow renders and highlights one line per source (lgc-fu7o)", async ({
+    page,
+  }) => {
+    // The two physical lines share one authored ArrowEntry. This browser-level
+    // check proves ELK preserves both source cards and the edge component uses
+    // the concrete line endpoint when deciding which sibling to highlight.
+    await loadFixture(page, governanceUri);
+    await page.locator("#source-input").fill(multiSourceDocument);
+    await expect(page.locator("[data-testid='overview-mapping-card-m0']")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const evidence = await page.locator("[data-testid='viz-root']").evaluate(async (element) => {
+      const viz = element as unknown as {
+        _layout: {
+          width: number;
+          height: number;
+          edges: Array<{
+            sourceNode: string;
+            sourceField: string;
+            targetNode: string;
+            targetField: string;
+          }>;
+        };
+      };
+      const layout = viz._layout;
+      const layer = document.createElement("sz-edge-layer") as HTMLElement & {
+        edges: typeof layout.edges;
+        width: number;
+        height: number;
+        highlightSchema: string;
+        highlightField: string;
+        updateComplete: Promise<boolean>;
+      };
+      layer.edges = layout.edges;
+      layer.width = layout.width;
+      layer.height = layout.height;
+      layer.highlightSchema = "s1";
+      layer.highlightField = "field_0";
+      document.body.appendChild(layer);
+      await layer.updateComplete;
+
+      const renderedPaths = layer.shadowRoot?.querySelectorAll(".edge-path");
+      const highlightedBySource = layout.edges.map((edge, index) => ({
+        sourceNode: edge.sourceNode,
+        highlighted: renderedPaths?.[index]?.classList.contains("highlighted") ?? false,
+      }));
+      layer.remove();
+
+      return {
+        endpoints: layout.edges.map((edge) => ({
+          sourceNode: edge.sourceNode,
+          sourceField: edge.sourceField,
+          targetNode: edge.targetNode,
+          targetField: edge.targetField,
+        })),
+        highlightedBySource,
+      };
+    });
+
+    expect(evidence.endpoints).toEqual([
+      { sourceNode: "s0", sourceField: "field_0", targetNode: "s2", targetField: "field_0" },
+      { sourceNode: "s1", sourceField: "field_0", targetNode: "s2", targetField: "field_0" },
+    ]);
+    expect(evidence.highlightedBySource).toEqual([
+      { sourceNode: "s0", highlighted: false },
+      { sourceNode: "s1", highlighted: true },
+    ]);
   });
 });

--- a/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
+++ b/tooling/satsuma-viz/src/edges/sz-edge-layer.ts
@@ -212,12 +212,12 @@ export class SzEdgeLayer extends LitElement {
   private _isEdgeHighlighted(edge: LayoutEdge): boolean {
     if (!this.highlightSchema || !this.highlightField) return false;
 
-    // Check if this edge connects to the highlighted field
+    // A multi-source ArrowEntry backs several physical LayoutEdges. Match the
+    // concrete resolved endpoint so hovering one source highlights only its line.
     const matchesSource =
-      edge.sourceNode === this.highlightSchema &&
-      edge.arrow.sourceFields.includes(this.highlightField);
+      edge.sourceNode === this.highlightSchema && edge.sourceField === this.highlightField;
     const matchesTarget =
-      edge.targetNode === this.highlightSchema && edge.arrow.targetField === this.highlightField;
+      edge.targetNode === this.highlightSchema && edge.targetField === this.highlightField;
 
     return matchesSource || matchesTarget;
   }

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -54,10 +54,15 @@ export interface LayoutNode {
 }
 
 export interface LayoutEdge {
+  /** Stable identity for one physical line; multi-source arrows have one per source. */
   id: string;
+  /** Card that owns this line's resolved source endpoint. */
   sourceNode: string;
+  /** Card that owns this line's resolved target endpoint. */
   targetNode: string;
+  /** Schema-local dotted field path on sourceNode, never an authored qualified ref. */
   sourceField: string;
+  /** Schema-local dotted field path on targetNode, never an authored qualified ref. */
   targetField: string;
   /** Array of {x,y} points forming the routed edge path */
   points: Array<{ x: number; y: number }>;
@@ -678,6 +683,14 @@ interface PortRef {
   side: "src" | "tgt";
 }
 
+/** A concrete port together with the schema-local field path it represents. */
+interface ResolvedPort {
+  /** ELK port identity used when routing the physical line. */
+  id: string;
+  /** Schema-local dotted path used by hover and other field-level consumers. */
+  fieldPath: string;
+}
+
 /**
  * Per-invocation bookkeeping for one buildElkGraph call. Previously this
  * lived in module-level mutable maps, which (a) were cleared once per
@@ -707,13 +720,13 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
     fieldRef: string,
     side: "src" | "tgt",
     scopeRefs: string[],
-  ): string | null => {
+  ): ResolvedPort | null => {
     const card = ctx.cardsByNode.get(nodeId);
     if (!card) return null;
     const localPath = resolveSchemaLocalFieldPath(fieldRef, card, scopeRefs);
     if (!localPath) return null;
     const pair = ctx.portsByNode.get(nodeId)?.get(localPath);
-    return pair ? pair[side] : null;
+    return pair ? { id: pair[side], fieldPath: localPath } : null;
   };
 
   for (const m of mappings) {
@@ -726,53 +739,63 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
       for (let i = 0; i < arrows.length; i++) {
         const a = arrows[i];
         if (!a) continue;
-        const authoredSource = a.sourceFields[0];
         // A computed arrow (`-> target`) covers its target but declares no
         // source endpoint. It therefore has no field-to-field line to draw:
         // using the target path as a fallback manufactured lineage from a
         // same-named source field (lgc-4bxl). The target card's filled coverage
         // port distinguishes computed from unmapped without inventing a source.
-        if (!authoredSource) continue;
+        if (a.sourceFields.length === 0) continue;
         // Ports are keyed by declared field path, so an arrow authored
         // element-relative inside a container (`.line1 -> .line1`) has to be
         // qualified against that container before findPort can match it. Until
         // 3cdd-yavi every such arrow resolved to no port and its edge was
         // silently skipped, so nested-iteration mappings drew no lines at all.
         const targetField = qualifyChildArrowPath(a.targetField, container.target);
-        const sourceField = qualifyChildArrowPath(authoredSource, container.source);
-        const edgeId = `${prefix}:${i}`;
-
-        // Attach the edge to the first source ref whose card actually
-        // declares the referenced field (a prefixed ref like "b.id" belongs
-        // to source schema b, not blindly to sourceRefs[0]).
-        let sourceNode: string | null = null;
-        let srcPort: string | null = null;
-        for (const ref of m.sourceRefs) {
-          srcPort = findPort(ref, sourceField, "src", m.sourceRefs);
-          if (srcPort) {
-            sourceNode = ref;
-            break;
-          }
-        }
         const tgtPort = findPort(m.targetRef, targetField, "tgt", [m.targetRef]);
+        if (!tgtPort) continue;
 
-        // Skip edges with missing ports — ELK throws if a port doesn't exist
-        if (!sourceNode || !srcPort || !tgtPort) continue;
+        // Language rule (spec §4.2): a multi-source arrow is one physical
+        // edge per source, all terminating at the same target. Resolve every
+        // source independently because qualified refs can belong to different
+        // source cards even though the lines share one ArrowEntry.
+        for (let sourceIndex = 0; sourceIndex < a.sourceFields.length; sourceIndex++) {
+          const authoredSource = a.sourceFields[sourceIndex];
+          if (!authoredSource) continue;
+          const sourceField = qualifyChildArrowPath(authoredSource, container.source);
 
-        edges.push({
-          id: edgeId,
-          sources: [srcPort],
-          targets: [tgtPort],
-        });
+          // Attach this line to the first source ref whose card actually
+          // declares its field ("b.id" belongs to b, not sourceRefs[0]).
+          let sourceNode: string | null = null;
+          let srcPort: ResolvedPort | null = null;
+          for (const ref of m.sourceRefs) {
+            srcPort = findPort(ref, sourceField, "src", m.sourceRefs);
+            if (srcPort) {
+              sourceNode = ref;
+              break;
+            }
+          }
 
-        ctx.edgeMeta.set(edgeId, {
-          sourceNode,
-          targetNode: m.targetRef,
-          sourceField,
-          targetField,
-          arrow: a,
-          scope,
-        });
+          // ELK throws if an edge names a port that does not exist. Preserve
+          // the historical first-line id and suffix only additional sources.
+          if (!sourceNode || !srcPort) continue;
+          const baseEdgeId = `${prefix}:${i}`;
+          const edgeId = sourceIndex === 0 ? baseEdgeId : `${baseEdgeId}:source:${sourceIndex}`;
+
+          edges.push({
+            id: edgeId,
+            sources: [srcPort.id],
+            targets: [tgtPort.id],
+          });
+
+          ctx.edgeMeta.set(edgeId, {
+            sourceNode,
+            targetNode: m.targetRef,
+            sourceField: srcPort.fieldPath,
+            targetField: tgtPort.fieldPath,
+            arrow: a,
+            scope,
+          });
+        }
       }
     };
 

--- a/tooling/satsuma-viz/src/layout/elk-layout.ts
+++ b/tooling/satsuma-viz/src/layout/elk-layout.ts
@@ -726,15 +726,20 @@ function addMappingEdges(mappings: MappingBlock[], edges: ElkEdge[], ctx: GraphC
       for (let i = 0; i < arrows.length; i++) {
         const a = arrows[i];
         if (!a) continue;
+        const authoredSource = a.sourceFields[0];
+        // A computed arrow (`-> target`) covers its target but declares no
+        // source endpoint. It therefore has no field-to-field line to draw:
+        // using the target path as a fallback manufactured lineage from a
+        // same-named source field (lgc-4bxl). The target card's filled coverage
+        // port distinguishes computed from unmapped without inventing a source.
+        if (!authoredSource) continue;
         // Ports are keyed by declared field path, so an arrow authored
         // element-relative inside a container (`.line1 -> .line1`) has to be
         // qualified against that container before findPort can match it. Until
         // 3cdd-yavi every such arrow resolved to no port and its edge was
         // silently skipped, so nested-iteration mappings drew no lines at all.
         const targetField = qualifyChildArrowPath(a.targetField, container.target);
-        const sourceField = a.sourceFields[0]
-          ? qualifyChildArrowPath(a.sourceFields[0], container.source)
-          : targetField;
+        const sourceField = qualifyChildArrowPath(authoredSource, container.source);
         const edgeId = `${prefix}:${i}`;
 
         // Attach the edge to the first source ref whose card actually

--- a/tooling/satsuma-viz/test/edge-layer.test.js
+++ b/tooling/satsuma-viz/test/edge-layer.test.js
@@ -1,0 +1,56 @@
+/**
+ * edge-layer.test.js — field hover highlights the concrete rendered edge.
+ *
+ * A multi-source arrow shares one ArrowEntry across several physical lines. The
+ * edge layer must use each LayoutEdge's resolved endpoint, not the shared authored
+ * source list, or hovering either source highlights every sibling line.
+ */
+import "./dom-shim.js";
+import { before, describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+/** @type {typeof import("../dist/satsuma-viz.js")} */
+let edgeLayerModule;
+
+before(async () => {
+  edgeLayerModule = await import("../dist/satsuma-viz.js");
+});
+
+/** Metadata shared by both physical lines of one authored multi-source arrow. */
+const arrow = {
+  sourceFields: ["s0.field_0", "s1.field_0"],
+  targetField: "field_0",
+  transform: null,
+  metadata: [],
+  comments: [],
+  location: { uri: "file:///multi-source.stm", line: 10, character: 2 },
+};
+
+/** Build one concrete line from a schema-local source endpoint. */
+function edgeFrom(sourceNode) {
+  return {
+    id: `m0:arrow:0:${sourceNode}`,
+    sourceNode,
+    targetNode: "s2",
+    sourceField: "field_0",
+    targetField: "field_0",
+    points: [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ],
+    arrow,
+  };
+}
+
+describe("field-edge highlighting", () => {
+  it("highlights only the physical line attached to the hovered source", () => {
+    // Both lines share the same ArrowEntry. This assertion fails if highlighting
+    // consults arrow.sourceFields instead of the concrete LayoutEdge endpoint.
+    const layer = new edgeLayerModule.SzEdgeLayer();
+    layer.highlightSchema = "s1";
+    layer.highlightField = "field_0";
+
+    assert.equal(layer._isEdgeHighlighted(edgeFrom("s0")), false);
+    assert.equal(layer._isEdgeHighlighted(edgeFrom("s1")), true);
+  });
+});

--- a/tooling/satsuma-viz/test/generated-edge-completeness.test.js
+++ b/tooling/satsuma-viz/test/generated-edge-completeness.test.js
@@ -30,9 +30,10 @@
  *    header as an arrow record and emits an edge for it. Whether that difference is
  *    right is a question for the R5 parity sweep (`sl-kwet`); it is a coherent
  *    convention, not a dropped edge, so it is permitted here.
- * 3. **Computed (sourceless) arrows** — see the `todo` property below. This one is
- *    a *bug*, `lgc-4bxl`, and is excluded from the main property rather than
- *    blessed by it.
+ * 3. **Computed (sourceless) arrows.** A computed target is covered, but there is
+ *    no source field from which a lineage line can originate. Its filled target
+ *    port distinguishes it from an unmapped field; the absence of a field edge
+ *    distinguishes it from an ordinary mapping (`lgc-4bxl`).
  *
  * `@satsuma/viz-backend` and `@satsuma/scenario-gen` are devDependencies for
  * exactly this. The runtime dependency still runs component → core, and nothing in
@@ -228,18 +229,10 @@ describe("the layout draws every declared arrow (sl-hi0z)", () => {
     );
   });
 
-  it("draws a computed arrow as a phantom line from a same-named source field (lgc-4bxl)", async () => {
-    // ⚠️ THIS TEST PINS A KNOWN DEFECT, for the reasons given on the multi-source
-    // test above. It goes **red when lgc-4bxl is fixed**; at that point assert that
-    // no edge has an empty `arrow.sourceFields`, which is the invariant that matters.
-    //
+  it("never invents a source edge for a computed arrow (lgc-4bxl)", async () => {
     // A computed arrow declares a target with no source. `addMappingEdges` falls back
-    // to `sourceField = targetField`, so it looks the target's own name up in the
-    // *source* schema: where a field of that name exists — the normal case, since
-    // matching names on both sides is the norm — the viz draws a line asserting
-    // lineage the Satsuma explicitly denies. Where it does not, the edge is silently
-    // dropped instead. A phantom lineage edge is worse than a missing one: it is a
-    // confident claim about where data came from.
+    // to no field edge: the target's coverage port still says it is populated,
+    // while inventing a same-named source would make a false lineage claim.
     const source = `
 schema s0 {
   a STRING
@@ -263,12 +256,11 @@ mapping m0 {
     indexFile(index, uri, tree);
     const layout = await viz.computeLayout(buildVizModel(uri, tree, index));
 
-    const phantom = layout.edges.filter((edge) => edge.arrow.sourceFields.length === 0);
-    assert.deepEqual(
-      phantom.map(drawnKey),
-      ["s0.stamp -> s1.stamp"],
-      `lgc-4bxl's phantom edge changed — read this test's comment before updating ` +
-        `the expectation:\n${source}`,
+    assert.equal(
+      layout.edges.filter((edge) => edge.arrow.sourceFields.length === 0).length,
+      0,
+      `a computed arrow must not manufacture a field-to-field edge:\n${source}`,
     );
+    assert.deepEqual(layout.edges.map(drawnKey), ["s0.a -> s1.a"], `the real edge must remain`);
   });
 });

--- a/tooling/satsuma-viz/test/generated-edge-completeness.test.js
+++ b/tooling/satsuma-viz/test/generated-edge-completeness.test.js
@@ -171,34 +171,25 @@ describe("the layout draws every declared arrow (sl-hi0z)", () => {
     );
   });
 
-  it("draws only the first source of a multi-source arrow (lgc-fu7o)", async () => {
-    // ⚠️ THIS TEST PINS A KNOWN DEFECT — see the note at the head of the r0-7w76
-    // test in satsuma-cli/test/generated-edge-invariants.test.ts for why a pinned
-    // divergence is used here rather than `{ todo: … }`. It asserts what the layout
-    // does *today* and goes **red when lgc-fu7o is fixed**, at which point replace
-    // it with `assertEdgesMatch`, which already states the correct invariant.
-    //
-    // Spec §4.2: `a, b -> t` is one edge *per source*, all to the same target.
-    // `addMappingEdges` reads `a.sourceFields[0]` and nothing else, so the viz draws
-    // one line and omits the rest of the arrow's provenance. The hover path does not
-    // share the omission — `sz-edge-layer.ts:218` highlights on the whole authored
-    // `arrow.sourceFields` — so hovering the *second* source highlights the single
-    // drawn edge, which runs to the *first* source's card. Pointing at the wrong
-    // schema is worse than drawing nothing.
+  it("draws one edge from each source of a multi-source arrow (lgc-fu7o)", async () => {
+    // Spec §4.2 defines `a, b -> t` as one edge per source, all to the same
+    // target. The layout must therefore preserve every source independently and
+    // record the schema-local field path used by the concrete source card.
     await fc.assert(
       fc.asyncProperty(multiSourceWorkspaceArbitrary, async ({ workspace, expectedSources }) => {
         const { model, sources } = modelFor(workspace);
         const layout = await viz.computeLayout(model);
-        assert.equal(
-          layout.edges.length,
-          1,
-          `expected lgc-fu7o's single edge for ${expectedSources.length} sources:\n${sources}`,
+        assert.deepEqual(
+          layout.edges.map(drawnKey).sort(),
+          expectedDrawnEdges(workspace),
+          `multi-source arrow lost or invented a drawn edge:\n${sources}`,
         );
-        // The drawn edge belongs to the *first* declared source, and its recorded
-        // `sourceField` keeps the authored schema prefix — the second half of
-        // lgc-fu7o, latent today because nothing matches on that field.
-        assert.equal(layout.edges[0].sourceNode, "s0", `edge left the first source's card`);
-        assert.equal(layout.edges[0].sourceField, "s0.field_0", `sourceField form changed`);
+        assert.equal(layout.edges.length, expectedSources.length);
+        assert.deepEqual(layout.edges.map((edge) => edge.sourceNode).sort(), ["s0", "s1"]);
+        assert.deepEqual(
+          layout.edges.map((edge) => edge.sourceField),
+          ["field_0", "field_0"],
+        );
       }),
       GENERATED_PROPERTY_PARAMETERS,
     );


### PR DESCRIPTION
## Summary

- stop sourceless computed arrows from inventing same-named source lineage while retaining mapped target coverage
- emit one independently resolved ELK line per source of a multi-source arrow
- make `LayoutEdge` endpoints schema-local and highlight only the concrete rendered line
- close `lgc-4bxl` and `lgc-fu7o` with generated-oracle, unit, and browser regressions

## Verification

- full pre-commit repository checks passed
- `@satsuma/viz`: 137/137 tests passed
- viz harness Playwright watcher: 103/103 passed, including both defect-specific Firefox tests and screenshot projects
- harness TypeScript and ESLint checks passed

## ADR assessment

No ADR: these are bug fixes implementing spec §4.2 and existing ADR-039/ADR-044 reference-resolution contracts; no architectural boundary or decision changed.