### PR TITLE
fix(core): resolve global targets from namespaced mappings

### DIFF
--- a/.tickets/lgc-3f13.md
+++ b/.tickets/lgc-3f13.md
@@ -1,6 +1,6 @@
 ---
 id: lgc-3f13
-status: open
+status: closed
 deps: []
 links: [sl-dqyu, sl-hi0z]
 created: 2026-08-03T22:08:38Z
@@ -41,3 +41,9 @@ This is the schema-level twin of r0-7w76: an endpoint emitted for a name nothing
 
 The repro above validates clean and reports the global 's1' as the target in graph nodes, graph schema_edges, graph edges and lineage. Targets are resolved the same way sources are — against the index, honouring current-namespace-then-global — rather than pre-qualified during extraction. ExtractedMapping's contract states which spelling targets carry, and every consumer of mapping.targets is checked against the change (graph-builder, field-lineage, lineage, schema-graph, viz-backend, LSP). Feature 41's generator drops its avoidance of the shape and the namespaced chain arbitrary generates it again.
 
+
+## Notes
+
+**2026-08-04T10:12:52Z**
+
+Cause: extractMappings pre-qualified bare target references with their enclosing namespace even though extraction has no workspace index, erasing the distinction needed for current-namespace-then-global resolution. Fix: preserve target references exactly as authored, restore namespaced-to-global cases in the scenario generator, and add validate, graph, lineage, core extraction, and NL-ref regressions (commit immediately after 8e69721c).

--- a/features/41-lineage-graph-confidence/IMPLEMENTATION-NOTES.md
+++ b/features/41-lineage-graph-confidence/IMPLEMENTATION-NOTES.md
@@ -56,14 +56,10 @@ Ranked by what I would pick up next.
    *not* in this PR because `sl-hi0z` says to record such findings against their own
    ticket rather than fix them here, and because changing what the viz draws deserves
    the Playwright harness and a look at the picture.
-2. **Fix `lgc-3f13`** (P1, core). Bigger blast radius: it changes what
-   `ExtractedMapping.targets` contains, so every consumer of that field needs
-   checking. It also unblocks the generator's namespaced-chain arbitrary generating
-   the shape again, which widens R3's domain for free.
-3. **R4 and R5**, once Feature 40's `sl-prlp` lands — see below. R4's oracle is
+2. **R4 and R5**, once Feature 40's `sl-prlp` lands — see below. R4's oracle is
    already shipped, but R4 also waits on `spr-w98t` (see the
    [addendum](#addendum-2026-08-04--one-bug-now-sits-between-sl-prlp-and-r4)).
-4. **`lgc-wtz1`** (P2, cosmetic but corrosive): one spelling per entity across
+3. **`lgc-wtz1`** (P2, cosmetic but corrosive): one spelling per entity across
    `nodes`, `edges`, `schema_edges` and `field-lineage`. Landing it deletes the two
    normalisation shims in R3's properties and the same shims R5 would otherwise need.
 
@@ -280,8 +276,13 @@ namespace ns_a {
 edges point at `ns_a::s1.field_0`; and `lineage --from ns_a::s0` reports the data
 flowing into a schema that does not exist. This is the *schema-level* twin of
 `r0-7w76`, and it is exactly what R3's endpoint-existence property is for. The
-generator avoids the shape for now (`mappingNamespace`, with the ticket referenced)
-so R3 is not red for a defect it did not cause.
+generator initially avoided the shape so R3 was not red for a defect it did not
+cause.
+
+**Resolved 2026-08-04 (`lgc-3f13`).** `ExtractedMapping.sources` and `targets` now
+both retain their authored spelling; index-aware consumers resolve both sides with
+the mapping namespace. The generator workaround is gone, so namespaced chains can
+again target file-scope schemas and all R2/R3 properties cover the shape.
 
 **`lgc-wtz1` (P2) — `graph --json` spells the same entity two ways.** `nodes[].id`
 and `schema_edges[]` use the index-key form (`raw`), while `edges[]` uses the

--- a/tooling/satsuma-cli/test/fixtures/namespaced-global-target.stm
+++ b/tooling/satsuma-cli/test/fixtures/namespaced-global-target.stm
@@ -1,0 +1,15 @@
+schema s1 {
+  field_0 STRING
+}
+
+namespace ns_a {
+  schema s0 {
+    field_0 STRING
+  }
+
+  mapping m0 {
+    source { s0 }
+    target { s1 }
+    field_0 -> field_0
+  }
+}

--- a/tooling/satsuma-cli/test/namespaced-global-target.test.ts
+++ b/tooling/satsuma-cli/test/namespaced-global-target.test.ts
@@ -1,0 +1,64 @@
+/**
+ * namespaced-global-target.test.ts — regression coverage for lgc-3f13.
+ *
+ * A bare entity reference inside a namespace resolves locally first and then at
+ * file scope. These command-level checks keep validation, graph assembly, field
+ * endpoints, and lineage traversal aligned on that one resolution rule.
+ */
+
+import assert from "node:assert/strict";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+import { run as runCli } from "./helpers.js";
+
+const CLI = resolve(import.meta.dirname, "../dist/index.js");
+const FIXTURE = resolve(import.meta.dirname, "fixtures/namespaced-global-target.stm");
+
+/** Run the built CLI against the minimal lgc-3f13 fixture. */
+const run = (...args: string[]) => runCli(CLI, ...args, FIXTURE);
+
+describe("a namespaced mapping targeting a global schema (lgc-3f13)", () => {
+  it("validates without inventing a namespace-local target", async () => {
+    // A bare target must fall back to the global schema when no declaration with
+    // that name exists in the mapping's namespace.
+    const { stdout, stderr, code } = await run("validate");
+    assert.equal(code, 0, `${stdout}\n${stderr}`);
+    assert.doesNotMatch(`${stdout}\n${stderr}`, /undefined-ref|ns_a::s1/);
+  });
+
+  it("uses the declared global schema in every graph surface", async () => {
+    // Nodes, schema edges, and field edges must agree on the existing `s1`
+    // identity; `ns_a::s1` would be an endpoint with no declaration or node.
+    const { stdout, stderr, code } = await run("graph", "--json");
+    assert.equal(code, 0, stderr);
+    const graph = JSON.parse(stdout);
+    assert.ok(graph.nodes.some((node: { id: string }) => node.id === "s1"));
+    assert.ok(
+      graph.schema_edges.some(
+        (edge: { from: string; to: string }) => edge.from === "ns_a::m0" && edge.to === "s1",
+      ),
+    );
+    assert.ok(
+      graph.edges.some(
+        (edge: { from: string | null; to: string | null }) =>
+          edge.from === "ns_a::s0.field_0" && edge.to === "::s1.field_0",
+      ),
+    );
+    assert.doesNotMatch(stdout, /ns_a::s1/);
+  });
+
+  it("traces downstream into the declared global schema", async () => {
+    // Schema lineage is assembled from the same resolved mapping endpoints as
+    // graph output and must therefore reach `s1`, never a phantom `ns_a::s1`.
+    const { stdout, stderr, code } = await run("lineage", "--from", "ns_a::s0", "--json");
+    assert.equal(code, 0, stderr);
+    const lineage = JSON.parse(stdout);
+    assert.ok(lineage.nodes.some((node: { name: string }) => node.name === "s1"));
+    assert.ok(
+      lineage.edges.some(
+        (edge: { from: string; to: string }) => edge.from === "ns_a::m0" && edge.to === "s1",
+      ),
+    );
+    assert.doesNotMatch(stdout, /ns_a::s1/);
+  });
+});

--- a/tooling/satsuma-core/src/extract.ts
+++ b/tooling/satsuma-core/src/extract.ts
@@ -444,7 +444,15 @@ export function extractMetrics(rootNode: SyntaxNode): ExtractedMetric[] {
 export interface ExtractedMapping {
   name: string | null;
   namespace: string | null;
+  /** Entity references exactly as authored in the `source` block. */
   sources: string[];
+  /**
+   * Entity references exactly as authored in the `target` block.
+   *
+   * Extraction has no workspace index, so a bare name cannot yet be identified
+   * as namespace-local or global. Consumers must resolve it relative to
+   * {@link namespace}, using current-namespace-then-global lookup.
+   */
   targets: string[];
   arrowCount: number;
   /** 0-indexed row from CST startPosition. */
@@ -487,20 +495,11 @@ export function extractMappings(rootNode: SyntaxNode): ExtractedMapping[] {
         allDescendants(body, "nested_arrow").length;
     }
 
-    // Targets are namespace-qualified here; sources are intentionally left as
-    // authored. Extraction has no workspace knowledge to decide whether a bare
-    // source name is namespace-local or global, so resolution-time consumers
-    // qualify them against the index instead (core resolveRef's
-    // contextSchemaKey, the CLI's resolveScopedEntityRef — sl-98cz).
-    const qualifiedTargets = targets.map((t) =>
-      namespace && !t.includes("::") ? `${namespace}::${t}` : t,
-    );
-
     return {
       name,
       namespace,
       sources,
-      targets: qualifiedTargets,
+      targets,
       arrowCount,
       row: node.startPosition.row,
       startColumn: node.startPosition.column,

--- a/tooling/satsuma-core/test/extract.test.js
+++ b/tooling/satsuma-core/test/extract.test.js
@@ -1034,10 +1034,10 @@ describe("extractSchemas — namespace propagation (sl-cvs2)", () => {
 // ── extractMappings with namespaces ─────────────────────────────────────────
 
 describe("extractMappings — namespaced mapping with qualified ref (sl-cvs2)", () => {
-  it("preserves a fully-qualified source ref and qualifies the bare target ref", () => {
-    // Validates the namespace-resolution rule: an explicit ns::name source ref keeps its
-    // qualifier verbatim, while an unqualified target inside a namespaced mapping
-    // is auto-qualified with the enclosing namespace.
+  it("preserves source and target refs exactly as authored", () => {
+    // Extraction has no workspace index, so it cannot know whether a bare target
+    // is namespace-local or global. Both sides must retain that authored spelling
+    // for resolution-time consumers to apply current-namespace-then-global lookup.
     const qualName = n("qualified_name", [ident("pos"), ident("stores")], "pos::stores");
     const srcEntry = sourceRef(qualName);
     const tgtEntry = sourceRef(ident("hub_store"));
@@ -1048,7 +1048,7 @@ describe("extractMappings — namespaced mapping with qualified ref (sl-cvs2)", 
     const result = extractMappings(root);
     assert.equal(result[0].namespace, "vault");
     assert.deepEqual(result[0].sources, ["pos::stores"]);
-    assert.deepEqual(result[0].targets, ["vault::hub_store"]);
+    assert.deepEqual(result[0].targets, ["hub_store"]);
   });
 });
 

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -328,20 +328,17 @@ describe("resolveRef()", () => {
     assert.equal(r.resolvedTo.kind, "field");
   });
 
-  // sl-98cz: extraction records source/target lists exactly as authored, so a
-  // namespaced mapping's bare source name ("customers") arrives unqualified
-  // while the index keys the schema "crm::customers". resolveRef must try the
-  // namespace-qualified form before giving up, or every bare @field ref against
-  // a namespaced source schema becomes a false unresolved-nl-ref warning.
+  // sl-98cz, lgc-3f13: extraction records both source and target lists exactly as
+  // authored. resolveRef must try the namespace-qualified form before giving up,
+  // or every bare @field ref against a namespaced schema becomes a false warning.
 
   it("resolves a bare field against an unqualified source name inside a namespace (sl-98cz)", () => {
     const lookup = makeLookup({
       "crm::customers": { fields: [{ name: "account_id" }], hasSpreads: false },
       "crm::tgt": { fields: [{ name: "id" }], hasSpreads: false },
     });
-    // The ticket repro: sources raw, targets pre-qualified (extractMappings
-    // qualifies only targets), both fields must resolve symmetrically.
-    const ctx = { sources: ["customers"], targets: ["crm::tgt"], namespace: "crm" };
+    // Both refs arrive raw from extraction and must resolve symmetrically.
+    const ctx = { sources: ["customers"], targets: ["tgt"], namespace: "crm" };
     const src = resolveRef("account_id", ctx, lookup);
     assert.equal(src.resolved, true);
     assert.equal(src.resolvedTo.name, "crm::customers.account_id");

--- a/tooling/satsuma-scenario-gen/src/workspace-arbitraries.js
+++ b/tooling/satsuma-scenario-gen/src/workspace-arbitraries.js
@@ -109,7 +109,7 @@ function chainWorkspace(length, namespaces = []) {
     mappings.push(
       mappingDecl({
         name: mappingName(hop),
-        namespace: mappingNamespace(nsOf(hop), nsOf(hop + 1)),
+        namespace: nsOf(hop),
         sources: [ref(hop)],
         targets: [ref(hop + 1)],
         arrows: leaves().map((leaf) =>
@@ -119,28 +119,6 @@ function chainWorkspace(length, namespaces = []) {
     );
   }
   return { schemas, mappings, ref };
-}
-
-/**
- * Which namespace a hop's mapping is declared in, given its two schemas'.
- *
- * A mapping sits in its source schema's namespace — *unless* either schema is at
- * file scope, in which case it is declared at file scope too.
- *
- * That exception is a deliberate hole in the generated domain, and it is working
- * around **`lgc-3f13`**: a namespaced mapping whose target is a global schema has
- * that target pre-qualified during extraction (`extract.ts:490-497`), so the whole
- * toolchain then reports `ns::name` for a schema nothing declares — an invented
- * endpoint in `graph`, in `lineage`, and a spurious `undefined-ref` from
- * `validate`. Generating the shape would leave every property in this feature red
- * for a defect it did not cause and does not own.
- *
- * Cross-*namespace* hops are unaffected and are still generated: those targets are
- * written `ns::name` by the author, so there is nothing to pre-qualify. Remove this
- * function when `lgc-3f13` is fixed.
- */
-function mappingNamespace(sourceNamespace, targetNamespace) {
-  return sourceNamespace !== null && targetNamespace !== null ? sourceNamespace : null;
 }
 
 /** Wrap declarations into a single-file workspace whose entry file holds them all. */


### PR DESCRIPTION
## Summary

- preserve mapping target references exactly as authored during core extraction
- resolve bare names at index-aware consumer boundaries using current namespace then global fallback
- restore namespaced-to-global generated scenarios and add validate, graph, and lineage regressions

## Testing

- full pre-commit repository gate
- 1,052 CLI tests
- 689 core tests
- 300 LSP tests
- 39 tree-sitter Python tests with 1,172 fixture subtests
- 50 BDD smoke tests

Closes lgc-3f13