### PR TITLE
fix(ci): cache wasi-sdk toolchain across CI/release/deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,17 @@ jobs:
         working-directory: tooling/satsuma-viz-backend
         run: npm run build
 
+      # tree-sitter build --wasm downloads a ~119MB wasi-sdk toolchain into
+      # ~/.cache/tree-sitter on every invocation unless it's already present.
+      # Keyed on the lockfile that pins tree-sitter-cli (which hardcodes the
+      # wasi-sdk version it fetches), so a version bump there — and only
+      # that — invalidates the cache (sl-wz2h).
+      - name: Cache wasi-sdk toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: wasi-sdk-${{ runner.os }}-${{ hashFiles('tooling/tree-sitter-satsuma/package-lock.json') }}
+
       - name: Build tree-sitter WASM (needed by CLI and VS Code)
         working-directory: tooling/tree-sitter-satsuma
         run: node_modules/.bin/tree-sitter build --wasm . -o tree-sitter-satsuma.wasm
@@ -336,6 +347,14 @@ jobs:
       - name: Build satsuma-cli (needed by LSP formatting provider)
         working-directory: tooling/satsuma-cli
         run: npm run build
+
+      # See the matching step in the `install` job — same rationale for
+      # caching the wasi-sdk toolchain instead of re-downloading it here.
+      - name: Cache wasi-sdk toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: wasi-sdk-${{ runner.os }}-${{ hashFiles('tooling/tree-sitter-satsuma/package-lock.json') }}
 
       - name: Build tree-sitter WASM for LSP tests
         working-directory: tooling/tree-sitter-satsuma

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -60,6 +60,17 @@ jobs:
       - name: Install tooling packages (playground build)
         run: npm run ci:all
 
+      # tree-sitter build --wasm downloads a ~119MB wasi-sdk toolchain into
+      # ~/.cache/tree-sitter on every invocation unless it's already present.
+      # Keyed on the lockfile that pins tree-sitter-cli (which hardcodes the
+      # wasi-sdk version it fetches), so a version bump there — and only
+      # that — invalidates the cache (sl-wz2h).
+      - name: Cache wasi-sdk toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: wasi-sdk-${{ runner.os }}-${{ hashFiles('tooling/tree-sitter-satsuma/package-lock.json') }}
+
       - name: Build tree-sitter WASM (the playground's in-browser parser)
         working-directory: tooling/tree-sitter-satsuma
         run: node_modules/.bin/tree-sitter build --wasm . -o tree-sitter-satsuma.wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Install all dependencies
         run: npm run ci:all
 
+      # tree-sitter build --wasm downloads a ~119MB wasi-sdk toolchain into
+      # ~/.cache/tree-sitter on every invocation unless it's already present.
+      # Keyed on the lockfile that pins tree-sitter-cli (which hardcodes the
+      # wasi-sdk version it fetches), so a version bump there — and only
+      # that — invalidates the cache (sl-wz2h).
+      - name: Cache wasi-sdk toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: wasi-sdk-${{ runner.os }}-${{ hashFiles('tooling/tree-sitter-satsuma/package-lock.json') }}
+
       - name: Build WASM parser
         run: cd tooling/tree-sitter-satsuma && node_modules/.bin/tree-sitter build --wasm . -o tree-sitter-satsuma.wasm
 

--- a/.tickets/sl-wz2h.md
+++ b/.tickets/sl-wz2h.md
@@ -1,0 +1,27 @@
+---
+id: sl-wz2h
+status: closed
+deps: []
+links: []
+created: 2026-08-04T10:28:48Z
+type: chore
+priority: 2
+assignee: Thorben Louw
+---
+# Cache wasi-sdk toolchain across CI/release/deploy workflows
+
+tree-sitter build --wasm downloads a ~119MB wasi-sdk-29 toolchain into ~/.cache/tree-sitter on every invocation because none of ci.yml, deploy-site.yml, or release.yml persist that cache directory across runs. It happens twice per CI run (install job + vscode-extension job) and once each in deploy-site.yml and release.yml.
+
+## Acceptance Criteria
+
+actions/cache added before each 'tree-sitter build --wasm' step (ci.yml install job, ci.yml vscode-extension job, deploy-site.yml deploy job, release.yml artifacts job), keyed on hashFiles(tooling/tree-sitter-satsuma/package-lock.json) so a tree-sitter-cli version bump (which pins the wasi-sdk download URL) invalidates the cache rather than silently reusing a stale SDK.
+
+
+## Notes
+
+**2026-08-04T10:31:14Z**
+
+**2026-08-04T00:00:00Z**
+
+Cause: `tree-sitter build --wasm` downloads a ~119MB wasi-sdk-29 toolchain into `~/.cache/tree-sitter` on every invocation; none of `ci.yml`, `deploy-site.yml`, or `release.yml` persisted that directory across runs, so it re-downloaded on every job that builds the WASM parser (twice per CI run, once each for deploy-site and release).
+Fix: added an `actions/cache` step before each of the 4 `tree-sitter build --wasm` invocations, caching `~/.cache/tree-sitter` keyed on `hashFiles('tooling/tree-sitter-satsuma/package-lock.json')` so a `tree-sitter-cli` version bump (which pins the wasi-sdk download URL) invalidates the cache rather than reusing a mismatched SDK (commit immediately after 8e69721c).


### PR DESCRIPTION
## Summary
- `tree-sitter build --wasm` downloads a ~119MB wasi-sdk toolchain into `~/.cache/tree-sitter` on every invocation, and nothing persisted that directory across CI runs — it re-downloaded on every job that builds the WASM parser (twice per CI run in `ci.yml`, plus once each in `deploy-site.yml` and `release.yml`).
- Added an `actions/cache` step before each of the 4 `tree-sitter build --wasm` calls, keyed on `hashFiles('tooling/tree-sitter-satsuma/package-lock.json')` — that lockfile pins the `tree-sitter-cli` version, which hardcodes the wasi-sdk download URL, so a version bump there (and only there) invalidates the cache instead of silently reusing a mismatched SDK.
- Closes sl-wz2h.

## Test plan
- [x] `npm run lint:yaml` (yamllint 1.38.0, matches `requirements-dev.txt` pin) passes on all three edited workflow files
- [x] Validated YAML parses via `js-yaml`
- [x] Full local pre-commit suite (lint, unit/property/coverage tests, smoke tests) passed before this commit was authored
- [ ] Confirm the new cache step actually produces a hit on the next CI run after this merges (first run on this PR will still be a cold miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)