### PR TITLE
docs: close Feature 39 and preserve research follow-ons

### DIFF
--- a/.tickets/gcsc-qka8.md
+++ b/.tickets/gcsc-qka8.md
@@ -1,6 +1,6 @@
 ---
 id: gcsc-qka8
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-03T14:12:53Z
@@ -11,8 +11,15 @@ tags: [feature-39, tooling]
 ---
 # Feature 39: correctness by default
 
-Deliver Feature 39 from features/39-correctness-by-default/PRD.md: move stable CST, path/ref, coverage, typecheck, lint, and FieldDecl invariants from prose and string conventions into compiler- and test-enforced contracts. This epic tracks the independently valuable roadmap stages; optional investigations I1 and I2 are not completion gates.
+Deliver Feature 39 from archive/features/39-correctness-by-default/PRD.md: move stable CST, path/ref, coverage, typecheck, lint, and FieldDecl invariants from prose and string conventions into compiler- and test-enforced contracts. This epic tracks the independently valuable roadmap stages; optional investigations I1 and I2 are not completion gates.
 
 ## Acceptance Criteria
 
 R1-R8 are delivered through linked child tickets with their PRD acceptance tests passing; every child records its cause/fix note and passing relevant automated tests before closure; the feature PRD ticket map and status are reconciled when the epic closes; optional I1/I2 investigations do not block completion.
+
+## Notes
+
+**2026-08-04T10:50:29Z**
+
+Cause: All R1–R8 delivery tickets were closed, but the epic and PRD still said in progress, the PRD remained under active features, and the product roadmap still described Feature 39 as an unscheduled proposal without preserving its two optional research follow-ons.
+Fix: Marked Feature 39 implemented, archived its PRD, moved the shipped outcome into the roadmap, and recorded I1/I2 as explicitly deferred research; the complete repository check suite passes (commit immediately after 08cf0d9d).

--- a/archive/features/39-correctness-by-default/PRD.md
+++ b/archive/features/39-correctness-by-default/PRD.md
@@ -1,22 +1,29 @@
 # Feature 39 — Correctness by Default
 
-> **Status: IN PROGRESS** (started 2026-08-03 with R1, `gcsc-ejb2`) — raised
-> after reviewing the mechanism behind recent defect clusters. The recurring
-> problem is broader
-> than either “bad specification” or “bad implementation”: important rules have
-> lived in prose, string conventions, or examples, so the build could confirm
-> that code matched its tests without confirming that the rule was complete,
-> internally consistent, or expressed at the right abstraction boundary.
+> **Status: IMPLEMENTED** (2026-08-04) — all R1–R8 delivery work completed
+> under epic `gcsc-qka8`; all 19 child tickets are closed with their relevant
+> automated checks recorded. Archived 2026-08-04. The optional I1 bounded-model
+> and I2 compositional-semantics investigations remain deliberately deferred in
+> `docs/product-owner/ROADMAP.md`; they are research follow-ons, not unfinished
+> Feature 39 scope.
+>
+> The feature was raised after reviewing the mechanism behind recent defect
+> clusters. The recurring problem is broader than either “bad specification” or
+> “bad implementation”: important rules had lived in prose, string conventions,
+> or examples, so the build could confirm that code matched its tests without
+> confirming that the rule was complete, internally consistent, or expressed at
+> the right abstraction boundary.
 >
 > **State this revision was checked against:** `main` at `c53619b1`. The CST
 > comparison counts below were originally measured at `4d17c505`; the two later
 > commits only added and amended this PRD, so those counts are unchanged.
 >
-> **Recommendation.** Proceed, but as a sequence of independently valuable
+> **Outcome.** The feature landed as a sequence of independently valuable
 > hardening tasks rather than one all-or-nothing programme. Generated CST types,
-> generated-input coverage checks, domain-specific path/ref types, and build-gate
-> repairs are the delivery scope. Formal modelling and a compositional semantic
-> account are useful follow-on investigations; they do not gate completion.
+> generated-input coverage checks, domain-specific path/ref types, build-gate
+> repairs, type-aware linting, and `FieldDecl` variants formed the delivered
+> scope. Formal modelling and a compositional semantic account remain useful
+> follow-on investigations; they do not gate completion.
 >
 > **What this feature is not.** It changes no Satsuma syntax or runtime protocol,
 > and proposes no rewrite or verified-code extraction. Those approaches target a
@@ -437,8 +444,9 @@ ADR-041. Prose is sufficient; mechanised proof is out of scope.
 
 ## Ticket Map
 
-Feature epic: `gcsc-qka8`. R1 through R6 and R8 now have concrete tickets; the
-remaining rows retain the agreed ticket shape until scheduled.
+Feature epic: `gcsc-qka8`. Every R1–R8 delivery ticket is closed. I1 and I2 were
+never completion gates and remain unscheduled research follow-ons in the product
+roadmap.
 
 | Work | Ticket shape | Depends on |
 |---|---|---|
@@ -464,7 +472,7 @@ remaining rows retain the agreed ticket shape until scheduled.
 | I1 bounded consistency model | optional spike | Feature 38 epic closed |
 | I2 compositional semantics proposal | optional spike | Feature 38 epic closed |
 
-The best first slice is **R1 + the core portion of R2**: it is mechanical,
-independent of coverage semantics, and turns a grammar rename or typo into a
-compiler error. In parallel scheduling, R6 and the R3 semantic generator can
-start immediately because they touch different surfaces.
+**Historical delivery sequence.** The first slice was R1 plus the core portion
+of R2: it was mechanical, independent of coverage semantics, and turned a
+grammar rename or typo into a compiler error. R6 and the R3 semantic generator
+then proceeded independently because they touched different surfaces.

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -8,7 +8,10 @@ Feature specs live in `features/` while active and move to `archive/features/` o
 
 ## Active Feature Specs
 
-The three specs currently in `features/`. Everything numbered 01–35 and Feature 38 has shipped and is archived (see [Shipped Features](#shipped-features)).
+Features 36, 40, and 41 are active. Feature 37 is complete and remains in
+`features/` pending its own archival closeout. Everything numbered 01–35 plus
+Features 38 and 39 has shipped and is archived (see
+[Shipped Features](#shipped-features)).
 
 ### Feature 36 — Viz Coverage Overlay and Field Chain View (not started)
 
@@ -34,26 +37,13 @@ Two warning-severity lint rules — `type-mismatch-direct-arrow` (bare arrows be
 
 **Source:** `features/37-lint-structural-rules/PRD.md`
 
-### Feature 39 — Correctness by Default (proposed, no tickets yet)
-
-Moves the invariants this toolchain documents in prose into the build: node-kind types generated from `node-types.json` so a grammar rename cannot silently change behaviour, branded path and ref types so `sl-joeq`'s name-for-path confusion is unrepresentable, generated-input properties for the ADR-034–041 coverage rules, a naive reference model to differentially test against, and type-aware linting across the four packages that currently have none.
-
-**Why it matters:** the recent defect clusters were *specification* defects — `sl-joeq`, `sl-qead` (which forced ADR-041 to amend ADR-035), ADR-038 constraining ADR-037 — where the code correctly implemented a rule that was wrong or absent, and a green suite said so. Feature 38 decided those rules; this feature makes them machine-checked so they cannot quietly stop holding.
-
-**Ready now:** R1 (generated node-kind types) is small, mechanical, blocks two other requirements, and touches nothing Feature 38 is changing. R5 and the R6 lint rollout follow.
-
-**Newly unblocked by Feature 38:** R2, R3 and R4 can now build on the settled coverage semantics, and the R7 rule-consistency and R8 denotational-spec spikes can begin now that epic `sl-j6g9` is closed.
-
-**Source:** `features/39-correctness-by-default/PRD.md`
-
----
-
 ## Shipped Features
 
 Delivered and moved to `archive/features/`. Recent work, most recent first:
 
 | Feature | Shipped | What landed |
 | --- | --- | --- |
+| 39 — Correctness by default | 2026-08-04 | Generated CST contracts, opaque path/ref stages, generated coverage and formatter properties, an independent coverage oracle, enforced typecheck and type-aware lint gates, and structural `FieldDecl` variants |
 | 38 — Hierarchical field coverage | 2026-08-03 | Path-correct nested coverage, container tri-state, whole-subtree arrow semantics, leaf-only ratios, and parity across the CLI, LSP, VS Code, and viz consumers (ADR-035–041) |
 | 35 — Workspace coverage command | 2026-08-01 | `satsuma coverage` with per-mapping/per-schema/workspace rollups, a stable `--json` contract, and a `--fail-under` CI gate on exit code 3; `computeMappingCoverage` relocated into `@satsuma/core` |
 | 34 — Live editor UX polish | 2026-06-10 | All eight R1–R8 fixes to the public playground chrome and edit-loop behaviour (ADR-029, ADR-030) |
@@ -67,6 +57,25 @@ Two open tickets are follow-ups to archived features rather than outstanding sco
 ---
 
 ## Concrete Deferred Work
+
+### Correctness Research Follow-ons (Feature 39)
+
+Feature 39 deliberately left two research spikes outside its delivery gate:
+
+- **Bounded consistency model:** time-box an Alloy or Z3 model of the settled
+  ADR-034–041 coverage rules and report either a small counterexample or no
+  counterexample within the stated bound.
+- **Compositional semantics proposal:** propose a semantic domain and
+  interpretation for multi-source joins, filtering, `each`, and `flatten`, then
+  assess whether ADR-037, ADR-038, and ADR-041 can be derived from it.
+
+**Why deferred:** Both investigations may improve confidence in the language's
+semantic foundations, but neither is required for the compiler- and
+test-enforced contracts Feature 39 delivered. They are intentionally
+time-boxed research, not unfinished implementation.
+
+**Source:** `archive/features/39-correctness-by-default/PRD.md` (Follow-on
+Investigations)
 
 ### Excel-to-Satsuma Full Skill (Feature 04, Phases 1-5)
 


### PR DESCRIPTION
## Summary
- mark Feature 39 implemented and archive its PRD
- move Feature 39 into the roadmap’s shipped list
- preserve the I1 bounded-model and I2 compositional-semantics research as explicitly deferred work
- close epic gcsc-qka8

## Testing
- `./scripts/run-repo-checks.sh`

Closes gcsc-qka8