### PR TITLE
Generate test-stats.json instead of hardcoding test/CLI-command counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,55 @@ jobs:
           name: test-results-parser
           path: test-results/parser.xml
 
+  test-stats:
+    name: Test stats freshness
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "22"
+
+      - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            node_modules
+            tooling/satsuma-cli/node_modules
+            tooling/satsuma-cli/src/generated
+            tooling/satsuma-cli/dist
+            tooling/satsuma-core/node_modules
+            tooling/satsuma-scenario-gen/node_modules
+            tooling/satsuma-core/dist
+            tooling/satsuma-viz-backend/node_modules
+            tooling/satsuma-viz-backend/dist
+            tooling/satsuma-viz-model/node_modules
+            tooling/satsuma-viz-model/dist
+            tooling/satsuma-viz/node_modules
+            tooling/satsuma-viz/dist
+            tooling/tree-sitter-satsuma/node_modules
+            tooling/tree-sitter-satsuma/build
+            tooling/tree-sitter-satsuma/tree-sitter-satsuma.wasm
+            tooling/vscode-satsuma/node_modules
+            tooling/satsuma-lsp/node_modules
+          key: workspace-${{ github.sha }}
+
+      # Default mode (no --from-logs): this job spawns each tracked package's
+      # own test command itself, rather than reading logs the pre-commit hook
+      # captured locally — CI has no local-hook cost constraint to optimize
+      # for, so it can just recompute the numbers from a clean checkout.
+      - name: Regenerate test-stats.json
+        run: node scripts/generate-test-stats.mjs
+
+      - name: Check test-stats.json is up to date
+        run: |
+          if ! git diff --exit-code test-stats.json; then
+            echo "::error::test-stats.json is out of date. Run 'node scripts/generate-test-stats.mjs' and commit the result."
+            echo "If this keeps happening, check 'git config core.hooksPath' prints '.githooks'."
+            exit 1
+          fi
+
   vscode-extension:
     name: VS Code extension
     needs: install

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -45,6 +45,9 @@ jobs:
           TAG="${{ steps.version.outputs.tag }}"
           echo "{\"version\":\"$TAG\",\"version_tag\":\"$TAG\"}" > site/_data/site.json
 
+      - name: Copy test stats for Eleventy
+        run: cp test-stats.json site/_data/stats.json
+
       - name: Copy diary entries and generate manifest
         run: |
           mkdir -p site/satsuma-diaries/content

--- a/.tickets/sl-if0c.md
+++ b/.tickets/sl-if0c.md
@@ -1,0 +1,19 @@
+---
+id: sl-if0c
+status: open
+deps: [sl-k7po]
+links: []
+created: 2026-08-04T09:54:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-unr3
+---
+# Point README.md, AGENTS.md, and PROJECT-OVERVIEW.md at test-stats.json instead of hardcoding counts
+
+Three living docs hardcode the same kind of numbers and will drift the same way: README.md's Current Status bullet ('a tree-sitter parser (318 corpus tests...)'), AGENTS.md's Repository Layout bullets (satsuma-core '679 tests', satsuma-cli '1031 tests', satsuma-lsp '300 tests', satsuma-viz-model '6 tests', satsuma-viz-backend '182 tests', satsuma-viz '128 tests', satsuma-viz-harness '99 tests' -- leave this one as prose, it's the deliberately-manual Playwright package, not generated -- and vscode-satsuma '34 tests', plus the tree-sitter-satsuma bullet's '318 corpus tests'), and docs/product-owner/PROJECT-OVERVIEW.md's 'Tree-sitter parser (318 corpus tests)' line. Drop the specific numbers from each bullet's prose and add one link to test-stats.json per doc (near the top of README's Current Status section and AGENTS.md's Repository Layout section) rather than restating every number inline. tooling/vscode-satsuma/README.md's '296 tests' code-comment and site/examples.njk's example count were found during research but are out of scope for this ticket (flagged as follow-ups, not fixed here).
+
+## Acceptance Criteria
+
+README.md, AGENTS.md (this repo's CLAUDE.md), and docs/product-owner/PROJECT-OVERVIEW.md contain no hardcoded parser/CLI/LSP/per-package test count and no hardcoded CLI command count; each links to test-stats.json instead. npm run lint:md passes.
+

--- a/.tickets/sl-if0c.md
+++ b/.tickets/sl-if0c.md
@@ -1,6 +1,6 @@
 ---
 id: sl-if0c
-status: open
+status: closed
 deps: [sl-k7po]
 links: []
 created: 2026-08-04T09:54:30Z
@@ -17,3 +17,14 @@ Three living docs hardcode the same kind of numbers and will drift the same way:
 
 README.md, AGENTS.md (this repo's CLAUDE.md), and docs/product-owner/PROJECT-OVERVIEW.md contain no hardcoded parser/CLI/LSP/per-package test count and no hardcoded CLI command count; each links to test-stats.json instead. npm run lint:md passes.
 
+
+## Notes
+
+**2026-08-04T10:42:16Z**
+
+## Notes
+
+**2026-08-04T12:00:00Z**
+
+Cause: README.md, AGENTS.md, and docs/product-owner/PROJECT-OVERVIEW.md each hand-typed the same parser/CLI/per-package test counts, which drifted independently of the real numbers and of each other.
+Fix: Removed the hardcoded counts from those three docs' bullets and added one link per doc to the generated test-stats.json (satsuma-viz-harness's manual-Playwright count left untouched, as it is not covered by the generator). (commit immediately after 20e63bb9)

--- a/.tickets/sl-k7po.md
+++ b/.tickets/sl-k7po.md
@@ -1,0 +1,30 @@
+---
+id: sl-k7po
+status: closed
+deps: []
+links: []
+created: 2026-08-04T09:54:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-unr3
+---
+# Add scripts/generate-test-stats.mjs to compute and write test-stats.json
+
+Write a Node ESM script that produces test-stats.json at repo root: {cliCommands, parserCorpusTests, packages: {satsuma-core, satsuma-cli, satsuma-lsp, satsuma-viz-model, satsuma-viz-backend, satsuma-viz, vscode-satsuma}}. cliCommands is counted structurally via ast-grep ('program.command($ARG)' over tooling/satsuma-cli/src/commands/*.ts --json, array length -- verified gives 23 today, matching cli.njk not index.njk's stale 22). parserCorpusTests is parsed from tree-sitter's own 'Total parses: N; successful parses: N; ...' summary line. Per-package counts are parsed from Node's built-in test runner summary line ('tests N', printed by 'node --test' regardless of reporter -- verified today: satsuma-core prints 'tests 689'). Support two input modes behind the same parsing logic: (1) default -- spawn each package's npm test itself and parse its stdout; (2) '--from-logs <dir>' -- read already-captured log files named after each package instead of re-running anything (needed by the pre-commit hook wiring in a dependent ticket, so that hook stays near-zero extra cost). satsuma-viz-harness (Playwright) is deliberately excluded -- it already has a documented human-in-the-loop-only run process (see AGENTS.md's Playwright section) and is not run by scripts/run-repo-checks.sh today. No timestamp field in the JSON -- diffs should only ever reflect a real count change.
+
+## Acceptance Criteria
+
+node scripts/generate-test-stats.mjs (no flags) runs every package's tests and writes a correct test-stats.json matching current reality. node scripts/generate-test-stats.mjs --from-logs <dir-of-precomputed-logs> produces an identical result without spawning any test command. Script has its own test coverage for the parsing logic (summary-line regex extraction, ast-grep command counting) using small fixture strings/dirs, not by depending on the real repo's live counts. npm run lint passes.
+
+
+## Notes
+
+**2026-08-04T10:05:12Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: README/AGENTS.md/PROJECT-OVERVIEW.md/site all hardcoded test and CLI-command counts with no generation mechanism, so they drifted (confirmed: satsuma-core actually has 689 tests vs AGENTS.md's stated 679; site/cli.njk said 22 CLI commands while site/learn.njk said 23).
+Fix: Added scripts/generate-test-stats.mjs, which writes test-stats.json (cliCommands, parserCorpusTests, per-package test counts) from each tool's own summary output — Node's built-in test runner's "tests N" line, tree-sitter's "Total parses: N" line, and the built CLI's own --help command list (excluding commander's auto-appended help entry). Supports a --from-logs mode so a caller that already captured test output doesn't need to re-run anything. Verified byte-identical output between default (spawn) and --from-logs modes, and idempotent across repeated runs. (commit immediately after 8e69721c)

--- a/.tickets/sl-lzqk.md
+++ b/.tickets/sl-lzqk.md
@@ -1,0 +1,19 @@
+---
+id: sl-lzqk
+status: open
+deps: [sl-k7po]
+links: []
+created: 2026-08-04T09:54:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-unr3
+---
+# Wire test-stats.json generation into the pre-commit hook
+
+scripts/run-repo-checks.sh already runs every package's tests once per commit. Tee the output of each relevant step (satsuma-core/viz-model/viz parallel block, satsuma-cli, vscode-satsuma+lsp parallel block, tree-sitter wasm corpus block which already captures its output in a shell variable) into per-package log files under a scratch dir, in addition to the existing terminal output -- 'cmd 2>&1 | tee $LOG_DIR/name.log', relying on the script's existing 'set -euo pipefail' so tee doesn't mask failures. As the final step (only after every check has passed), run 'node scripts/generate-test-stats.mjs --from-logs $LOG_DIR' and 'git add test-stats.json' so the regenerated file rides along in the commit that's about to be created, matching how a formatter's re-staged output would work in a pre-commit hook. Do not change what run-repo-checks.sh tests or its pass/fail semantics -- only add log capture and the final generation+stage step.
+
+## Acceptance Criteria
+
+Committing a change on a machine with the hook installed regenerates test-stats.json (if any count actually changed) and includes it in the same commit automatically, with no user action needed. Re-running the hook with no code changes produces a byte-identical test-stats.json (no spurious diff/re-stage). Measured wall-clock time of the hook does not meaningfully increase (log capture via tee, no test suite is run twice).
+

--- a/.tickets/sl-lzqk.md
+++ b/.tickets/sl-lzqk.md
@@ -1,6 +1,6 @@
 ---
 id: sl-lzqk
-status: open
+status: closed
 deps: [sl-k7po]
 links: []
 created: 2026-08-04T09:54:30Z
@@ -17,3 +17,14 @@ scripts/run-repo-checks.sh already runs every package's tests once per commit. T
 
 Committing a change on a machine with the hook installed regenerates test-stats.json (if any count actually changed) and includes it in the same commit automatically, with no user action needed. Re-running the hook with no code changes produces a byte-identical test-stats.json (no spurious diff/re-stage). Measured wall-clock time of the hook does not meaningfully increase (log capture via tee, no test suite is run twice).
 
+
+## Notes
+
+**2026-08-04T10:33:36Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: test-stats.json needed to stay fresh on every commit without doubling local test run time, and without treating run-repo-checks.sh's existing graceful skips (corpus check on a wasm-less tree-sitter-cli; packages it doesn't exercise locally like satsuma-viz-backend) as "the count is zero".
+Fix: Teed each relevant step's output to a per-package log in a scratch dir (satsuma-core/viz-model/viz, satsuma-cli, vscode-satsuma+lsp, tree-sitter's already-captured wasm output), then run generate-test-stats.mjs --from-logs as the final step and git add the result into the commit being made. Added resolvePackageCountFromLog/resolveCorpusTestCountFromLog so a missing or skipped log falls back to the previously committed value instead of throwing or zeroing. Verified end-to-end: full run-repo-checks.sh run regenerates a byte-identical test-stats.json with correct fallbacks for satsuma-viz-backend and the corpus count. (commit immediately after e79db9ba)

--- a/.tickets/sl-mo1e.md
+++ b/.tickets/sl-mo1e.md
@@ -1,6 +1,6 @@
 ---
 id: sl-mo1e
-status: open
+status: closed
 deps: [sl-k7po]
 links: []
 created: 2026-08-04T09:54:30Z
@@ -17,3 +17,14 @@ Add a job to .github/workflows/ci.yml (needs: install, so it can reuse the cache
 
 A PR that changes a package's test count without updating test-stats.json fails this CI job with an actionable error message. A PR where test-stats.json is already correct passes. npm run lint:yaml passes on the modified workflow file.
 
+
+## Notes
+
+**2026-08-04T10:45:50Z**
+
+## Notes
+
+**2026-08-04T11:00:00Z**
+
+Cause: test-stats.json regenerates only via the pre-commit hook, so a hook that's uninstalled, bypassed with --no-verify, or a manual edit to the file could still land on main without CI ever catching the drift.
+Fix: added a `test-stats` job to .github/workflows/ci.yml (needs: install, reusing the shared workspace cache block) that runs `node scripts/generate-test-stats.mjs` in default mode and fails with an actionable ::error:: on `git diff --exit-code test-stats.json`, mirroring the parser job's existing generate-then-diff pattern (commit immediately after 20e63bb9).

--- a/.tickets/sl-mo1e.md
+++ b/.tickets/sl-mo1e.md
@@ -1,0 +1,19 @@
+---
+id: sl-mo1e
+status: open
+deps: [sl-k7po]
+links: []
+created: 2026-08-04T09:54:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-unr3
+---
+# Add a CI job that fails if test-stats.json has drifted
+
+Add a job to .github/workflows/ci.yml (needs: install, so it can reuse the cached node_modules/dist) that runs 'node scripts/generate-test-stats.mjs' directly (default mode, not --from-logs -- CI has no local-hook cost constraint, and this mirrors the existing tree-sitter job's own 'generate then git diff --exit-code' pattern) and then 'git diff --exit-code test-stats.json'. On failure, print a clear ::error:: pointing at the likely cause (hook not installed -- see 'git config core.hooksPath' -- or hook bypassed with --no-verify) and telling the developer to run the script and commit the result, matching the existing '::error::Generated parser sources are out of date...' message style used by the parser job.
+
+## Acceptance Criteria
+
+A PR that changes a package's test count without updating test-stats.json fails this CI job with an actionable error message. A PR where test-stats.json is already correct passes. npm run lint:yaml passes on the modified workflow file.
+

--- a/.tickets/sl-unr3.md
+++ b/.tickets/sl-unr3.md
@@ -1,6 +1,6 @@
 ---
 id: sl-unr3
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T09:53:53Z

--- a/.tickets/sl-unr3.md
+++ b/.tickets/sl-unr3.md
@@ -1,0 +1,18 @@
+---
+id: sl-unr3
+status: open
+deps: []
+links: []
+created: 2026-08-04T09:53:53Z
+type: epic
+priority: 2
+assignee: Thorben Louw
+---
+# Generated test-stats.json replaces hardcoded test/command counts
+
+README, AGENTS.md, PROJECT-OVERVIEW.md, and the website (site/*.njk) all hardcode test counts (parser corpus tests, per-package test counts) and the CLI command count. These drift constantly and are already internally inconsistent (site/cli.njk says 22 CLI commands, site/learn.njk says 23; AGENTS.md says satsuma-core has 679 tests, it actually has 689). Replace every hardcoded number with a single generated test-stats.json at repo root, kept fresh by the pre-commit hook (near-zero extra cost, reusing output the hook already produces) and verified by a CI drift check. The website bakes the numbers in at build time from this file; README/AGENTS.md/PROJECT-OVERVIEW.md link to it instead of hardcoding.
+
+## Acceptance Criteria
+
+test-stats.json exists at repo root and is the single source of truth. No file changed by this epic contains a hardcoded parser/CLI/LSP test count or CLI command count. Pre-commit hook keeps it fresh with no measurable extra test run. CI fails if it drifts from a fresh computation. Website stats sections render the same numbers as test-stats.json with no cross-page inconsistency.
+

--- a/.tickets/sl-ypu1.md
+++ b/.tickets/sl-ypu1.md
@@ -1,6 +1,6 @@
 ---
 id: sl-ypu1
-status: open
+status: closed
 deps: [sl-k7po]
 links: []
 created: 2026-08-04T09:54:30Z
@@ -17,3 +17,14 @@ site/_data/site.json is already written by .github/workflows/deploy-site.yml jus
 
 site/_data/stats.json is produced by deploy-site.yml from the repo-root test-stats.json. Every stat this epic covers in index.njk, cli.njk, vscode.njk, and learn.njk reads from {{ stats.* }} -- grep for the literal old numbers (22, 23, 296, 315, 879, 293, 987, 318) in those 4 template files' stat/count contexts finds none left hardcoded. A local Eleventy build (cd site && npx @11ty/eleventy) succeeds and the built HTML shows the current real counts.
 
+
+## Notes
+
+**2026-08-04T10:44:56Z**
+
+## Notes
+
+**2026-08-04T12:00:00Z**
+
+Cause: The site's four static pages hardcoded CLI-command and per-package test counts by hand, so they drifted from reality and even disagreed with each other (cli.njk said 22 commands, learn.njk said 23).
+Fix: Added a deploy-site.yml step that copies the repo-root test-stats.json into site/_data/stats.json (committed a real snapshot for local builds too), and replaced every in-scope hardcoded count in index.njk/cli.njk/vscode.njk/learn.njk with {{ stats.* }} lookups; left front-matter description/og_description prose non-numeric since Eleventy front matter isn't template-rendered here. (commit immediately after 20e63bb9)

--- a/.tickets/sl-ypu1.md
+++ b/.tickets/sl-ypu1.md
@@ -1,0 +1,19 @@
+---
+id: sl-ypu1
+status: open
+deps: [sl-k7po]
+links: []
+created: 2026-08-04T09:54:30Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: sl-unr3
+---
+# Bake test-stats.json into the website build and fix the site's own count inconsistencies
+
+site/_data/site.json is already written by .github/workflows/deploy-site.yml just before 'cd site && npx @11ty/eleventy' runs (the precedent for injecting build-time data into Eleventy). Add one step there that copies the repo-root test-stats.json (already fresh and CI-gated by the time a release triggers this workflow) to site/_data/stats.json. Replace every hardcoded number this epic covers in site/index.njk (the 4-stat block: CLI Commands/Parser Tests/CLI Tests/LSP Tests; the '23 commands . 987 tests' and 'Full LSP . 296 tests' card captions), site/cli.njk (meta description's '22 deterministic...commands', 'All 22 CLI commands with usage patterns', the '23 commands available' terminal mock line, the 'All 23 commands' heading), site/vscode.njk (the 'LSP Tests' stat-bar number), and site/learn.njk ('Explore all 23 commands') with '{{ stats.* }}' template expressions reading from the new data file. Do not touch site/vscode.njk's '8' Commands or '11' LSP Capabilities stats or site/examples.njk's example count -- those aren't test/CLI-command counts and are out of scope for this epic. Confirm the previously-contradictory 22-vs-23 CLI command mentions across cli.njk/learn.njk now agree because they both read the same field.
+
+## Acceptance Criteria
+
+site/_data/stats.json is produced by deploy-site.yml from the repo-root test-stats.json. Every stat this epic covers in index.njk, cli.njk, vscode.njk, and learn.njk reads from {{ stats.* }} -- grep for the literal old numbers (22, 23, 296, 315, 879, 293, 987, 318) in those 4 template files' stat/count contexts finds none left hardcoded. A local Eleventy build (cd site && npx @11ty/eleventy) succeeds and the built HTML shows the current real counts.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 
 ## Repository Layout
 
+Current per-package test counts and the CLI command count are tracked in [`test-stats.json`](test-stats.json).
+
 - `docs/developer/SATSUMA-V2-SPEC.md`: authoritative language specification (v2)
 - `docs/product-owner/PROJECT-OVERVIEW.md`: product vision, motivation, and roadmap
 - `SATSUMA-CLI.md`: CLI command reference
@@ -21,16 +23,16 @@ All tooling is parser-backed. Downstream tools should be built on the tree-sitte
 - `useful-prompts/`: self-contained system prompts for web LLMs (Excel-to-Satsuma, Satsuma-to-Excel)
 - `skills/`: Agent Skills following the [agentskills.io](https://agentskills.io) standard (Excel-to-Satsuma conversion skill, Satsuma-to-Excel export skill)
 - `scripts/`: utility scripts used during development
-- `tooling/tree-sitter-satsuma/`: tree-sitter grammar (318 corpus tests), generated parser artifacts, and queries
-- `tooling/satsuma-core/`: **the shared library every other package builds on** (679 tests) — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
+- `tooling/tree-sitter-satsuma/`: tree-sitter grammar, generated parser artifacts, and queries
+- `tooling/satsuma-core/`: **the shared library every other package builds on** — parsing, extraction, validation, formatting, NL `@ref` resolution, and the single definition of coverage semantics. Logic that more than one consumer needs belongs here; see [Core vs Consumer Packages](#core-vs-consumer-packages)
 - `tooling/satsuma-scenario-gen/`: **test-only** generator of semantic Satsuma scenarios shared by every package's property suites — builds scenarios as plain data, renders them to source, and states the ground truth that follows by construction. Must never depend on `@satsuma/core` (core's tests depend on it, so the reverse edge would be a cycle); the adapters that drive production pipelines live in each consumer's test tree
-- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis (1031 tests)
-- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio` (300 tests)
-- `tooling/satsuma-viz-model/`: the VizModel protocol contract (6 tests) — the payload shape the LSP produces and the viz component consumes, defined once so neither can drift
-- `tooling/satsuma-viz-backend/`: workspace indexing and VizModel assembly shared by the LSP and browser hosts (182 tests); also computes the field coverage the payload carries (ADR-042)
-- `tooling/satsuma-viz/`: the `satsuma-viz` Lit web component (128 tests) — overview graph and per-mapping detail view, embedded in the VS Code webview and the site playground
+- `tooling/satsuma-cli/`: TypeScript CLI tool for workspace extraction, validation, and structural analysis
+- `tooling/satsuma-lsp/`: editor-agnostic Language Server (semantic tokens, diagnostics, go-to-definition, find-references, completions, hover, rename, code lens, folding, document symbols); runnable standalone via `npx satsuma-lsp --stdio`
+- `tooling/satsuma-viz-model/`: the VizModel protocol contract — the payload shape the LSP produces and the viz component consumes, defined once so neither can drift
+- `tooling/satsuma-viz-backend/`: workspace indexing and VizModel assembly shared by the LSP and browser hosts; also computes the field coverage the payload carries (ADR-042)
+- `tooling/satsuma-viz/`: the `satsuma-viz` Lit web component — overview graph and per-mapping detail view, embedded in the VS Code webview and the site playground
 - `tooling/satsuma-viz-harness/`: Playwright harness for the viz component (99 tests) — human-in-the-loop, see [Viz harness Playwright tests](#viz-harness-playwright-tests-human-in-the-loop-workflow)
-- `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp` (34 tests)
+- `tooling/vscode-satsuma/`: VS Code extension (LSP client, commands, webview panels) and TextMate grammar; delegates language intelligence to `satsuma-lsp`
 
 ## Platform Lineage Entry Point
 

--- a/README.md
+++ b/README.md
@@ -284,11 +284,13 @@ Start with Lesson 01 or jump to a [suggested reading path](lessons/README.md#sug
 
 ## Current Status
 
+Current parser/CLI/LSP test counts and CLI command count are tracked in [`test-stats.json`](test-stats.json).
+
 What exists today:
 
 - the Satsuma v2 language specification
 - a canonical example corpus (25 `.stm` files covering major integration patterns)
-- a tree-sitter parser (318 corpus tests, all examples parse clean)
+- a tree-sitter parser (all examples parse clean)
 - a TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - a VS Code extension with an LSP server (go-to-definition, find-references, completions, hover, rename, code lens, semantic tokens, diagnostics, folding, document symbols, formatting) and TextMate grammar

--- a/docs/product-owner/PROJECT-OVERVIEW.md
+++ b/docs/product-owner/PROJECT-OVERVIEW.md
@@ -246,10 +246,12 @@ How we'll know Satsuma is working:
 
 ### What exists today
 
+Current parser/CLI/LSP test counts and CLI command count are tracked in [`test-stats.json`](../../test-stats.json).
+
 - Formal language specification ([SATSUMA-V2-SPEC.md](../developer/SATSUMA-V2-SPEC.md))
 - Canonical example library covering major integration patterns (16 `.stm` files)
 - AI-oriented quick reference and compact grammar for prompts ([AI-AGENT-REFERENCE.md](../../AI-AGENT-REFERENCE.md))
-- Tree-sitter parser (318 corpus tests)
+- Tree-sitter parser
 - TypeScript CLI (`satsuma`) with commands for structural extraction, analysis, validation, formatting, and diff — see [SATSUMA-CLI.md](../../SATSUMA-CLI.md)
 - `satsuma fmt` — opinionated, zero-config formatter (CLI + VS Code Format Document)
 - `satsuma lint` with 3 policy rules and `--fix` support

--- a/scripts/generate-test-stats.mjs
+++ b/scripts/generate-test-stats.mjs
@@ -62,6 +62,31 @@ export function parseCorpusTestCount(output) {
   return Number(match[1]);
 }
 
+/** Same as parseCorpusTestCount, but returns null instead of throwing — for callers with a fallback. */
+export function tryParseCorpusTestCount(output) {
+  const match = output.match(CORPUS_SUMMARY_PATTERN);
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * Resolves the corpus test count from a captured log that may be a real run
+ * or a deliberate skip (see collectCorpusTestCount's doc comment for why a
+ * skip is expected, not an error). Falls back to the previous test-stats.json
+ * value on a skip; throws if there is no previous value to fall back to.
+ */
+export function resolveCorpusTestCountFromLog(output, previousStats) {
+  const parsed = tryParseCorpusTestCount(output);
+  if (parsed !== null) {
+    return parsed;
+  }
+  if (previousStats?.parserCorpusTests === undefined) {
+    throw new Error(
+      "tree-sitter's corpus check was skipped this run and there is no previous test-stats.json to fall back to",
+    );
+  }
+  return previousStats.parserCorpusTests;
+}
+
 /**
  * Counts commands from the CLI's own `--help` output — the shipped source of
  * truth, rather than a count of `.command(...)` call sites in the source
@@ -108,14 +133,10 @@ export const TRACKED_PACKAGES = [
 
 // ── Collection ──────────────────────────────────────────────────────────
 
-function readCapturedLog(logDir, name) {
+/** Returns a captured log's contents, or null if run-repo-checks.sh never teed that step (e.g. a package it doesn't exercise locally). */
+function readCapturedLogIfPresent(logDir, name) {
   const logPath = path.join(logDir, `${name}.log`);
-  if (!fs.existsSync(logPath)) {
-    throw new Error(
-      `Expected a captured log at ${logPath} — did scripts/run-repo-checks.sh skip teeing this step's output?`,
-    );
-  }
-  return fs.readFileSync(logPath, "utf8");
+  return fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : null;
 }
 
 function runNpmScript(packageKey, npmScript) {
@@ -125,25 +146,77 @@ function runNpmScript(packageKey, npmScript) {
   });
 }
 
-function collectPackageCounts(fromLogsDir) {
+/**
+ * Resolves one package's test count from a captured log that may not exist —
+ * run-repo-checks.sh doesn't run every tracked package locally (it's the
+ * fast local gate, not the full CI matrix). No log means no fresh count this
+ * run; keep the last committed value rather than treat "the local hook
+ * doesn't exercise this package" as "the count is zero".
+ */
+export function resolvePackageCountFromLog(output, previousCount, key) {
+  if (output === null) {
+    if (previousCount === undefined) {
+      throw new Error(
+        `No captured log for ${key} and no previous test-stats.json value to fall back to`,
+      );
+    }
+    return previousCount;
+  }
+  return parseNodeTestCount(output);
+}
+
+function collectPackageCounts(fromLogsDir, previousStats) {
   const packages = {};
   for (const { key, npmScript } of TRACKED_PACKAGES) {
-    const output = fromLogsDir ? readCapturedLog(fromLogsDir, key) : runNpmScript(key, npmScript);
-    packages[key] = parseNodeTestCount(output);
+    packages[key] = fromLogsDir
+      ? resolvePackageCountFromLog(
+          readCapturedLogIfPresent(fromLogsDir, key),
+          previousStats?.packages?.[key],
+          key,
+        )
+      : parseNodeTestCount(runNpmScript(key, npmScript));
   }
   return packages;
 }
 
-function collectCorpusTestCount(fromLogsDir) {
-  // `npm run test`, not a bare `tree-sitter test --wasm`: the globally
-  // resolved tree-sitter-cli binary may lack the wasm feature, but the
-  // project's own devDependency (resolved by the npm script via
-  // node_modules/.bin) always has it — the same reason AGENTS.md tells
-  // humans to run this suite through `npm test`, not the CLI directly.
-  const output = fromLogsDir
-    ? readCapturedLog(fromLogsDir, "tree-sitter-satsuma")
-    : runNpmScript("tree-sitter-satsuma", "test");
-  return parseCorpusTestCount(output);
+/**
+ * In --from-logs mode, the captured log is whatever run-repo-checks.sh's own
+ * corpus step produced — and that step deliberately SKIPs (rather than
+ * fails) when the globally resolved tree-sitter-cli lacks the wasm feature,
+ * relying on the JS integration tests to cover the corpus instead. A skip
+ * means no fresh count is available this run; keep the last committed value
+ * rather than treat "the hook chose not to run this" as "the count is zero".
+ * Default (spawn) mode has no such gap — it always runs through the
+ * project's own wasm-capable local binary — so it always parses for real.
+ */
+function collectCorpusTestCount(fromLogsDir, previousStats) {
+  if (!fromLogsDir) {
+    // `npm run test`, not a bare `tree-sitter test --wasm`: the globally
+    // resolved tree-sitter-cli binary may lack the wasm feature, but the
+    // project's own devDependency (resolved by the npm script via
+    // node_modules/.bin) always has it — the same reason AGENTS.md tells
+    // humans to run this suite through `npm test`, not the CLI directly.
+    return parseCorpusTestCount(runNpmScript("tree-sitter-satsuma", "test"));
+  }
+
+  const output = readCapturedLogIfPresent(fromLogsDir, "tree-sitter-satsuma");
+  if (output === null) {
+    if (previousStats?.parserCorpusTests === undefined) {
+      throw new Error(
+        "No captured log for tree-sitter-satsuma and no previous test-stats.json value to fall back to",
+      );
+    }
+    return previousStats.parserCorpusTests;
+  }
+  return resolveCorpusTestCountFromLog(output, previousStats);
+}
+
+/** Reads the currently committed test-stats.json, if any — the fallback source when a run-repo-checks.sh step was skipped rather than run. */
+function readPreviousStats() {
+  if (!fs.existsSync(STATS_PATH)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(STATS_PATH, "utf8"));
 }
 
 /** Always introspects the already-built CLI directly — cheap, no test suite involved, identical in both run modes. */
@@ -172,13 +245,14 @@ function parseFromLogsArg(argv) {
 
 function main() {
   const fromLogsDir = parseFromLogsArg(process.argv.slice(2));
+  const previousStats = readPreviousStats();
 
   // Package tests run (or their logs are read) before the CLI is introspected:
   // satsuma-cli's own "test" script rebuilds dist/ via npm's automatic pretest
   // hook, so by the time collectCliCommandCount() runs, dist/index.js is fresh
   // in both run modes (run-repo-checks.sh also builds it explicitly first).
-  const packages = collectPackageCounts(fromLogsDir);
-  const parserCorpusTests = collectCorpusTestCount(fromLogsDir);
+  const packages = collectPackageCounts(fromLogsDir, previousStats);
+  const parserCorpusTests = collectCorpusTestCount(fromLogsDir, previousStats);
   const cliCommands = collectCliCommandCount();
 
   writeStats(buildStats({ cliCommands, parserCorpusTests, packages }));

--- a/scripts/generate-test-stats.mjs
+++ b/scripts/generate-test-stats.mjs
@@ -1,0 +1,195 @@
+/**
+ * Computes the CLI command count and every tracked package's test count, and
+ * writes them to test-stats.json at the repo root.
+ *
+ * That file is the single source of truth README.md, AGENTS.md, and the
+ * website (site/_data/stats.json, copied from it at deploy time) read from,
+ * instead of each hardcoding a number that immediately starts drifting.
+ *
+ * Two ways to gather the numbers, behind the same parsing logic:
+ *   - default: spawn each package's own test command and parse its output.
+ *   - `--from-logs <dir>`: read output already captured elsewhere. The
+ *     pre-commit hook (scripts/run-repo-checks.sh) tees its own test run
+ *     into per-package log files, so this mode adds no second test run.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const STATS_PATH = path.join(REPO_ROOT, "test-stats.json");
+const CLI_ENTRY_POINT = path.join(REPO_ROOT, "tooling/satsuma-cli/dist/index.js");
+
+// ── Parsing ─────────────────────────────────────────────────────────────
+// All three counts are read from a tool's own summary output rather than
+// re-derived by scanning source — the running tool is the most authoritative
+// (and cheapest) source of truth available for each number.
+
+/**
+ * Node's built-in test runner (used by every package in this repo — there is
+ * no vitest/jest) prints this exact line regardless of which reporter is
+ * active: "ℹ tests N" for the default spec reporter, "# tests N" for the tap
+ * reporter used in CI. Anchoring to the start of the line means a test
+ * *named* "tests" can never be mistaken for the summary.
+ */
+const NODE_TEST_SUMMARY_PATTERN = /^(?:ℹ|#)\s+tests\s+(\d+)\s*$/m;
+
+/** tree-sitter's `test --wasm` ends every run with this exact summary line. */
+const CORPUS_SUMMARY_PATTERN = /Total parses:\s*(\d+);/;
+
+/** Commander auto-appends this to every program's command list; it isn't a Satsuma CLI command. */
+const COMMANDER_HELP_ENTRY_PATTERN = /^help\s/;
+
+/** Extracts the test count from a package's `node --test` output. Throws on unrecognized output rather than silently recording zero. */
+export function parseNodeTestCount(output) {
+  const match = output.match(NODE_TEST_SUMMARY_PATTERN);
+  if (!match) {
+    throw new Error("Could not find a node --test summary line ('tests N') in the given output");
+  }
+  return Number(match[1]);
+}
+
+/** Extracts the corpus test count from tree-sitter's `test --wasm` output. */
+export function parseCorpusTestCount(output) {
+  const match = output.match(CORPUS_SUMMARY_PATTERN);
+  if (!match) {
+    throw new Error(
+      "Could not find tree-sitter's 'Total parses: N' summary line in the given output",
+    );
+  }
+  return Number(match[1]);
+}
+
+/**
+ * Counts commands from the CLI's own `--help` output — the shipped source of
+ * truth, rather than a count of `.command(...)` call sites in the source
+ * (which would double-count comments/examples and needs the build fresh
+ * anyway). Excludes commander's auto-appended `help [command]` entry.
+ */
+export function parseCliCommandCount(helpText) {
+  const commandsSection = helpText.split(/^Commands:\s*$/m)[1];
+  if (!commandsSection) {
+    throw new Error("CLI --help output has no 'Commands:' section");
+  }
+  return commandsSection
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !COMMANDER_HELP_ENTRY_PATTERN.test(line)).length;
+}
+
+/** Assembles the exact test-stats.json shape from already-parsed numbers. No timestamp field: a re-run with unchanged counts must produce a byte-identical file. */
+export function buildStats({ cliCommands, parserCorpusTests, packages }) {
+  return { cliCommands, parserCorpusTests, packages };
+}
+
+// ── Package registry ───────────────────────────────────────────────────
+
+/**
+ * Packages whose test count is tracked. `tooling/satsuma-viz-harness` is
+ * deliberately absent — it's Playwright, run only through the human-in-the-
+ * loop watcher documented in AGENTS.md, never by a plain `npm test`, so
+ * there is no automatic run to source a count from.
+ */
+export const TRACKED_PACKAGES = [
+  { key: "satsuma-core", npmScript: "test" },
+  { key: "satsuma-cli", npmScript: "test" },
+  { key: "satsuma-lsp", npmScript: "test" },
+  { key: "satsuma-viz-model", npmScript: "test" },
+  { key: "satsuma-viz-backend", npmScript: "test" },
+  { key: "satsuma-viz", npmScript: "test" },
+  // vscode-satsuma's "test" script also runs vscode-tmgrammar-test grammar
+  // fixture/golden checks, which print no "tests N" summary of their own.
+  // test:unit is the slice that does, and is the count this package has
+  // always meant by its test count.
+  { key: "vscode-satsuma", npmScript: "test:unit" },
+];
+
+// ── Collection ──────────────────────────────────────────────────────────
+
+function readCapturedLog(logDir, name) {
+  const logPath = path.join(logDir, `${name}.log`);
+  if (!fs.existsSync(logPath)) {
+    throw new Error(
+      `Expected a captured log at ${logPath} — did scripts/run-repo-checks.sh skip teeing this step's output?`,
+    );
+  }
+  return fs.readFileSync(logPath, "utf8");
+}
+
+function runNpmScript(packageKey, npmScript) {
+  return execFileSync("npm", ["run", npmScript], {
+    cwd: path.join(REPO_ROOT, "tooling", packageKey),
+    encoding: "utf8",
+  });
+}
+
+function collectPackageCounts(fromLogsDir) {
+  const packages = {};
+  for (const { key, npmScript } of TRACKED_PACKAGES) {
+    const output = fromLogsDir ? readCapturedLog(fromLogsDir, key) : runNpmScript(key, npmScript);
+    packages[key] = parseNodeTestCount(output);
+  }
+  return packages;
+}
+
+function collectCorpusTestCount(fromLogsDir) {
+  // `npm run test`, not a bare `tree-sitter test --wasm`: the globally
+  // resolved tree-sitter-cli binary may lack the wasm feature, but the
+  // project's own devDependency (resolved by the npm script via
+  // node_modules/.bin) always has it — the same reason AGENTS.md tells
+  // humans to run this suite through `npm test`, not the CLI directly.
+  const output = fromLogsDir
+    ? readCapturedLog(fromLogsDir, "tree-sitter-satsuma")
+    : runNpmScript("tree-sitter-satsuma", "test");
+  return parseCorpusTestCount(output);
+}
+
+/** Always introspects the already-built CLI directly — cheap, no test suite involved, identical in both run modes. */
+function collectCliCommandCount() {
+  const helpText = execFileSync("node", [CLI_ENTRY_POINT, "--help"], { encoding: "utf8" });
+  return parseCliCommandCount(helpText);
+}
+
+function writeStats(stats) {
+  fs.writeFileSync(STATS_PATH, `${JSON.stringify(stats, null, 2)}\n`);
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────────
+
+function parseFromLogsArg(argv) {
+  const flagIndex = argv.indexOf("--from-logs");
+  if (flagIndex === -1) {
+    return null;
+  }
+  const dir = argv[flagIndex + 1];
+  if (!dir) {
+    throw new Error("--from-logs requires a directory argument");
+  }
+  return dir;
+}
+
+function main() {
+  const fromLogsDir = parseFromLogsArg(process.argv.slice(2));
+
+  // Package tests run (or their logs are read) before the CLI is introspected:
+  // satsuma-cli's own "test" script rebuilds dist/ via npm's automatic pretest
+  // hook, so by the time collectCliCommandCount() runs, dist/index.js is fresh
+  // in both run modes (run-repo-checks.sh also builds it explicitly first).
+  const packages = collectPackageCounts(fromLogsDir);
+  const parserCorpusTests = collectCorpusTestCount(fromLogsDir);
+  const cliCommands = collectCliCommandCount();
+
+  writeStats(buildStats({ cliCommands, parserCorpusTests, packages }));
+  console.log(`Wrote ${STATS_PATH}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/generate-test-stats.test.mjs
+++ b/scripts/generate-test-stats.test.mjs
@@ -14,6 +14,8 @@ import {
   parseCliCommandCount,
   parseCorpusTestCount,
   parseNodeTestCount,
+  resolveCorpusTestCountFromLog,
+  resolvePackageCountFromLog,
 } from "./generate-test-stats.mjs";
 
 test("reads the node --test summary line printed by the default spec reporter", () => {
@@ -71,6 +73,46 @@ test("throws when --help output has no Commands section", () => {
     () => parseCliCommandCount("Usage: satsuma\n\nOptions:\n  -h, --help\n"),
     /Commands:/,
   );
+});
+
+test("falls back to the previous count when run-repo-checks.sh's corpus step was skipped (no wasm feature)", () => {
+  // run-repo-checks.sh treats a wasm-feature-less tree-sitter-cli as a
+  // deliberate skip, not a failure — a skip must not be read as "0 tests".
+  const skippedOutput = "[tree-sitter corpus] SKIP — tree-sitter-cli built without wasm feature\n";
+  const previousStats = { cliCommands: 23, parserCorpusTests: 318, packages: {} };
+  assert.equal(resolveCorpusTestCountFromLog(skippedOutput, previousStats), 318);
+});
+
+test("prefers a fresh count over the previous one when the corpus step actually ran", () => {
+  const output = "Total parses: 320; successful parses: 320; failed parses: 0;\n";
+  const previousStats = { cliCommands: 23, parserCorpusTests: 318, packages: {} };
+  assert.equal(resolveCorpusTestCountFromLog(output, previousStats), 320);
+});
+
+test("throws on a skipped corpus step with no previous test-stats.json to fall back to", () => {
+  // Otherwise a skip on the very first run would silently write parserCorpusTests: undefined.
+  assert.throws(
+    () => resolveCorpusTestCountFromLog("SKIP\n", null),
+    /no previous test-stats\.json/,
+  );
+});
+
+test("falls back to a package's previous count when run-repo-checks.sh doesn't exercise it locally", () => {
+  // The local hook is a fast gate, not the full CI matrix — some tracked
+  // packages (e.g. satsuma-viz-backend) have no captured log at all.
+  assert.equal(resolvePackageCountFromLog(null, 182, "satsuma-viz-backend"), 182);
+});
+
+test("throws when a package has neither a captured log nor a previous count", () => {
+  assert.throws(
+    () => resolvePackageCountFromLog(null, undefined, "satsuma-viz-backend"),
+    /No captured log for satsuma-viz-backend/,
+  );
+});
+
+test("parses a package's real captured log instead of falling back, when one exists", () => {
+  const output = "ℹ tests 1049\n";
+  assert.equal(resolvePackageCountFromLog(output, 1031, "satsuma-cli"), 1049);
 });
 
 test("assembles test-stats.json with no volatile fields, so an unchanged rerun is byte-identical", () => {

--- a/scripts/generate-test-stats.test.mjs
+++ b/scripts/generate-test-stats.test.mjs
@@ -1,0 +1,87 @@
+/**
+ * Contract tests for the parsing logic behind test-stats.json generation.
+ *
+ * These test the pure parsing/assembly functions against small fixture
+ * strings, not the real repo's live counts — the script's correctness is
+ * "does it read a tool's summary output right", not "what number does the
+ * CLI happen to report today".
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildStats,
+  parseCliCommandCount,
+  parseCorpusTestCount,
+  parseNodeTestCount,
+} from "./generate-test-stats.mjs";
+
+test("reads the node --test summary line printed by the default spec reporter", () => {
+  const output = "✔ some test (1ms)\nℹ tests 689\nℹ suites 177\nℹ pass 689\nℹ fail 0\n";
+  assert.equal(parseNodeTestCount(output), 689);
+});
+
+test("reads the node --test summary line printed by the tap reporter used in CI", () => {
+  const output = "ok 1 - some test\n# tests 679\n# pass 679\n# fail 0\n";
+  assert.equal(parseNodeTestCount(output), 679);
+});
+
+test("does not mistake a test named 'tests' for the summary line", () => {
+  // A passing test whose own name/diagnostic text contains the word "tests"
+  // must not be read as the run's total — only the anchored summary line at
+  // the start of a line counts.
+  const output = "✔ counts all tests correctly (1ms)\nℹ tests 42\n";
+  assert.equal(parseNodeTestCount(output), 42);
+});
+
+test("throws rather than silently recording zero when the summary line is missing", () => {
+  // A truncated or unrecognized reporter output must fail loudly, not write
+  // a wrong count into test-stats.json.
+  assert.throws(() => parseNodeTestCount("some unrelated output\n"), /summary line/);
+});
+
+test("reads tree-sitter's 'Total parses' summary line", () => {
+  const output =
+    "    318. ✓ Two map entries on one line still require a comma\n\n" +
+    "Total parses: 318; successful parses: 318; failed parses: 0; success percentage: 100.00%; average speed: 5033 bytes/ms\n";
+  assert.equal(parseCorpusTestCount(output), 318);
+});
+
+test("throws when tree-sitter's summary line is missing", () => {
+  assert.throws(() => parseCorpusTestCount("no summary here\n"), /Total parses/);
+});
+
+test("counts real CLI commands and excludes commander's auto-appended help entry", () => {
+  // The exact off-by-one this parser must not reintroduce: commander always
+  // appends a synthetic "help [command]" line that is not a Satsuma command.
+  const helpText =
+    "Usage: satsuma [options] [command]\n\n" +
+    "Options:\n" +
+    "  -V, --version  output the version number\n\n" +
+    "Commands:\n" +
+    "  summary [options] [path]  Summarise a Satsuma file\n" +
+    "  fmt [options] [path]      Format Satsuma files\n" +
+    "  help [command]            display help for command\n";
+  assert.equal(parseCliCommandCount(helpText), 2);
+});
+
+test("throws when --help output has no Commands section", () => {
+  // Defends against silently reporting 0 commands for a broken or unbuilt CLI.
+  assert.throws(
+    () => parseCliCommandCount("Usage: satsuma\n\nOptions:\n  -h, --help\n"),
+    /Commands:/,
+  );
+});
+
+test("assembles test-stats.json with no volatile fields, so an unchanged rerun is byte-identical", () => {
+  const stats = buildStats({
+    cliCommands: 23,
+    parserCorpusTests: 318,
+    packages: { "satsuma-core": 689 },
+  });
+  assert.deepEqual(stats, {
+    cliCommands: 23,
+    parserCorpusTests: 318,
+    packages: { "satsuma-core": 689 },
+  });
+});

--- a/scripts/run-repo-checks.sh
+++ b/scripts/run-repo-checks.sh
@@ -33,6 +33,14 @@ run_parallel() {
 
 cd "$ROOT_DIR"
 
+# Every package's test output below is teed into this directory as it runs,
+# so the "generate test-stats.json" step at the end can read the real counts
+# straight out of a check that already ran — no second test run just to
+# source a number for test-stats.json. Removed on exit so a failed hook run
+# never leaves a stale log around to be misread by a later invocation.
+STATS_LOG_DIR="$(mktemp -d)"
+trap 'rm -rf "$STATS_LOG_DIR"' EXIT
+
 # Verify Python lint tools are available before running any checks.
 # Install with: pip install yamllint ruff
 for tool in yamllint ruff; do
@@ -55,9 +63,9 @@ run_step "scenario generator tests" npm --prefix tooling/satsuma-scenario-gen te
 # the ones defending against a mapping that silently renders no lines at all —
 # would only have failed after a push.
 run_parallel "satsuma-core + satsuma-viz-model + satsuma-viz tests" \
-  "npm --prefix tooling/satsuma-core test" \
-  "npm --prefix tooling/satsuma-viz-model test" \
-  "npm --prefix tooling/satsuma-viz test"
+  "npm --prefix tooling/satsuma-core test 2>&1 | tee '$STATS_LOG_DIR/satsuma-core.log'" \
+  "npm --prefix tooling/satsuma-viz-model test 2>&1 | tee '$STATS_LOG_DIR/satsuma-viz-model.log'" \
+  "npm --prefix tooling/satsuma-viz test 2>&1 | tee '$STATS_LOG_DIR/satsuma-viz.log'"
 
 # `npm --prefix tooling/satsuma-cli test` below already runs test:typecheck via
 # npm's implicit pretest hook, but make it an explicit, separately labelled
@@ -66,7 +74,8 @@ run_parallel "satsuma-core + satsuma-viz-model + satsuma-viz tests" \
 # resolves several test files' imports against `dist/` (the built output),
 # which only `pretest`'s build steps guarantee are present and current.
 run_step "satsuma-cli test:typecheck" npm --prefix tooling/satsuma-cli run pretest
-run_step "satsuma-cli tests" npm --prefix tooling/satsuma-cli test
+run_step "satsuma-cli tests" bash -c \
+  "npm --prefix tooling/satsuma-cli test 2>&1 | tee '$STATS_LOG_DIR/satsuma-cli.log'"
 
 # ADR-022: CLI accepts files, not directories. Check each example entry file.
 run_step "satsuma fmt --check examples" bash -c '
@@ -93,8 +102,8 @@ run_step "satsuma fmt --check examples" bash -c '
 
 run_step "vscode-satsuma validate" npm --prefix tooling/vscode-satsuma run validate
 run_parallel "vscode-satsuma tests + LSP" \
-  "npm --prefix tooling/vscode-satsuma test" \
-  "npm --prefix tooling/satsuma-lsp test"
+  "npm --prefix tooling/vscode-satsuma test 2>&1 | tee '$STATS_LOG_DIR/vscode-satsuma.log'" \
+  "npm --prefix tooling/satsuma-lsp test 2>&1 | tee '$STATS_LOG_DIR/satsuma-lsp.log'"
 
 run_step "generated CST contract is current" \
   npm --prefix tooling/tree-sitter-satsuma run check:cst-symbols
@@ -105,6 +114,10 @@ run_step "tree-sitter generate" npm --prefix tooling/tree-sitter-satsuma run gen
 # Gracefully skip if unavailable; JS integration tests cover the corpus via the
 # WASM parser already built by the previous generate step.
 _wasm_test_output="$(cd "$ROOT_DIR/tooling/tree-sitter-satsuma" && tree-sitter test --wasm 2>&1)" || _wasm_test_exit=$?
+# Captured as-is, skip message or real "Total parses: N" summary alike — the
+# stats generator below knows how to fall back on a skip (see
+# resolveCorpusTestCountFromLog in generate-test-stats.mjs).
+printf '%s\n' "$_wasm_test_output" >"$STATS_LOG_DIR/tree-sitter-satsuma.log"
 if echo "$_wasm_test_output" | grep -q "does not include the wasm feature"; then
   printf '[tree-sitter corpus] SKIP — tree-sitter-cli built without wasm feature (JS tests cover corpus)\n'
 elif [ "${_wasm_test_exit:-0}" -ne 0 ]; then
@@ -132,3 +145,10 @@ if command -v satsuma &>/dev/null; then
 else
   printf '\n[smoke tests] SKIP — satsuma not on PATH. Install it first (e.g. npm install -g tooling/satsuma-cli/).\n'
 fi
+
+# Last step, and only reached once every check above has passed: refresh
+# test-stats.json from the logs just captured (no second test run) and stage
+# it so the regenerated file rides along in the commit being made — the same
+# way a formatter's re-staged output would.
+run_step "generate test-stats.json" node scripts/generate-test-stats.mjs --from-logs "$STATS_LOG_DIR"
+git add test-stats.json

--- a/site/_data/stats.json
+++ b/site/_data/stats.json
@@ -1,0 +1,13 @@
+{
+  "cliCommands": 23,
+  "parserCorpusTests": 318,
+  "packages": {
+    "satsuma-core": 689,
+    "satsuma-cli": 1049,
+    "satsuma-lsp": 300,
+    "satsuma-viz-model": 6,
+    "satsuma-viz-backend": 186,
+    "satsuma-viz": 137,
+    "vscode-satsuma": 46
+  }
+}

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -1,9 +1,9 @@
 ---
 layout: default.njk
 title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
-description: "The Satsuma CLI gives AI agents 22 deterministic, parser-backed commands to slice, query, and validate Satsuma workspaces. Humans use it for formatting, validation, and linting."
+description: "The Satsuma CLI gives AI agents many deterministic, parser-backed commands to slice, query, and validate Satsuma workspaces. Humans use it for formatting, validation, and linting."
 og_title: "Satsuma CLI &mdash; Agent Tooling for Structural Extraction"
-og_description: "Give your AI agent 23 commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
+og_description: "Give your AI agent many commands to extract structure, trace lineage, and validate Satsuma workspaces. Humans get formatting, linting, and validation."
 nav_id: cli
 permalink: cli.html
 ---
@@ -14,13 +14,13 @@ permalink: cli.html
         <div>
           <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-6">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-            23 commands &middot; 987 tests
+            {{ stats.cliCommands }} commands &middot; {{ stats.packages['satsuma-cli'] }} tests
           </div>
           <h1 class="text-4xl sm:text-5xl font-extrabold text-charcoal leading-tight mb-6">
             The agent's <span class="text-orange">toolkit</span> for Satsuma
           </h1>
           <p class="text-lg text-warm-gray leading-relaxed mb-4">
-            The Satsuma CLI is built for AI agents. 22 parser-backed commands let your agent slice workspaces, trace lineage, extract metadata, and pull NL intent &mdash; all from the parse tree, with 100% deterministic results.
+            The Satsuma CLI is built for AI agents. {{ stats.cliCommands }} parser-backed commands let your agent slice workspaces, trace lineage, extract metadata, and pull NL intent &mdash; all from the parse tree, with 100% deterministic results.
           </p>
           <p class="text-warm-gray leading-relaxed mb-4">
             Humans use it too &mdash; <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">validate</code>, <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">fmt</code>, and <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">lint</code> are your day-to-day workflow commands. But the CLI's real power is as the structural backbone your agent reasons on top of.
@@ -121,7 +121,7 @@ permalink: cli.html
             </div>
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-              <span class="text-sm text-warm-gray">All 22 CLI commands with usage patterns</span>
+              <span class="text-sm text-warm-gray">All {{ stats.cliCommands }} CLI commands with usage patterns</span>
             </div>
             <div class="flex items-start gap-2">
               <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
@@ -606,7 +606,7 @@ permalink: cli.html
 
 <span class="prompt">$</span> satsuma <span class="flag">--help</span>
 <span class="output">satsuma &lt;command&gt; [options]</span>
-<span class="output">23 commands available</span></pre>
+<span class="output">{{ stats.cliCommands }} commands available</span></pre>
         </div>
         <details class="mt-4 text-sm">
           <summary class="cursor-pointer text-warm-gray hover:text-charcoal transition-colors font-medium">Latest unstable build (from main)</summary>
@@ -636,7 +636,7 @@ permalink: cli.html
   <section id="command-reference" class="py-16 lg:py-24">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12 reveal">
-        <h2 class="text-3xl font-bold text-charcoal mb-3">All 23 commands</h2>
+        <h2 class="text-3xl font-bold text-charcoal mb-3">All {{ stats.cliCommands }} commands</h2>
         <p class="text-warm-gray max-w-2xl mx-auto">Complete reference for every command in the CLI. See the <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-CLI.md" target="_blank" class="text-orange hover:underline">full reference on GitHub</a> for detailed usage and examples.</p>
       </div>
 

--- a/site/index.njk
+++ b/site/index.njk
@@ -242,7 +242,7 @@ permalink: index.html
             <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
           </div>
           <h3 class="text-lg font-bold text-charcoal mb-2">Machine-Parseable</h3>
-          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with 318 corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
+          <p class="text-warm-gray text-sm leading-relaxed">Tree-sitter grammar with {{ stats.parserCorpusTests }} corpus tests. Every CLI command produces 100% deterministically correct results from the parse tree.</p>
         </div>
         <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
           <div class="w-12 h-12 bg-charcoal rounded-xl flex items-center justify-center mb-4">
@@ -267,19 +267,19 @@ permalink: index.html
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-8">
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-orange mb-1">22</div>
+          <div class="text-4xl font-extrabold text-orange mb-1">{{ stats.cliCommands }}</div>
           <div class="text-sm text-warm-gray font-medium">CLI Commands</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-green mb-1">315</div>
+          <div class="text-4xl font-extrabold text-green mb-1">{{ stats.parserCorpusTests }}</div>
           <div class="text-sm text-warm-gray font-medium">Parser Tests</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-orange mb-1">879</div>
+          <div class="text-4xl font-extrabold text-orange mb-1">{{ stats.packages['satsuma-cli'] }}</div>
           <div class="text-sm text-warm-gray font-medium">CLI Tests</div>
         </div>
         <div class="stat-item text-center">
-          <div class="text-4xl font-extrabold text-green mb-1">293</div>
+          <div class="text-4xl font-extrabold text-green mb-1">{{ stats.packages['satsuma-lsp'] }}</div>
           <div class="text-sm text-warm-gray font-medium">LSP Tests</div>
         </div>
       </div>
@@ -455,7 +455,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">Satsuma CLI</h3>
-              <p class="text-sm text-warm-gray">23 commands &middot; 987 tests</p>
+              <p class="text-sm text-warm-gray">{{ stats.cliCommands }} commands &middot; {{ stats.packages['satsuma-cli'] }} tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">
@@ -482,7 +482,7 @@ permalink: index.html
             </div>
             <div>
               <h3 class="text-xl font-bold text-charcoal">VS Code Extension</h3>
-              <p class="text-sm text-warm-gray">Full LSP &middot; 296 tests</p>
+              <p class="text-sm text-warm-gray">Full LSP &middot; {{ stats.packages['satsuma-lsp'] }} tests</p>
             </div>
           </div>
           <div class="space-y-3 mb-6">

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -97,7 +97,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
             <pre><code class="font-mono text-charcoal">satsuma validate my-mapping.stm</code></pre>
           </div>
           <p class="text-warm-gray text-sm leading-relaxed mb-3">The parser checks syntax, reference resolution, and structural correctness. Zero errors means you are ready to go. The VS Code extension also shows diagnostics in real time as you type.</p>
-          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all 23 commands &rarr;</a>
+          <a href="cli.html" class="text-orange text-sm font-semibold hover:underline">Explore all {{ stats.cliCommands }} commands &rarr;</a>
         </div>
       </div>
     </div>

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -50,7 +50,7 @@ permalink: vscode.html
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">296</div>
+          <div class="text-2xl font-bold text-green">{{ stats.packages['satsuma-lsp'] }}</div>
           <div class="text-sm text-warm-gray">LSP Tests</div>
         </div>
         <div class="stat-item">

--- a/test-stats.json
+++ b/test-stats.json
@@ -3,7 +3,7 @@
   "parserCorpusTests": 318,
   "packages": {
     "satsuma-core": 689,
-    "satsuma-cli": 1049,
+    "satsuma-cli": 1052,
     "satsuma-lsp": 300,
     "satsuma-viz-model": 6,
     "satsuma-viz-backend": 186,

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,7 +2,7 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 689,
+    "satsuma-core": 694,
     "satsuma-cli": 1052,
     "satsuma-lsp": 300,
     "satsuma-viz-model": 6,

--- a/test-stats.json
+++ b/test-stats.json
@@ -1,0 +1,13 @@
+{
+  "cliCommands": 23,
+  "parserCorpusTests": 318,
+  "packages": {
+    "satsuma-core": 689,
+    "satsuma-cli": 1049,
+    "satsuma-lsp": 300,
+    "satsuma-viz-model": 6,
+    "satsuma-viz-backend": 186,
+    "satsuma-viz": 137,
+    "vscode-satsuma": 46
+  }
+}


### PR DESCRIPTION
## Summary

README, AGENTS.md, PROJECT-OVERVIEW.md, and the website all hardcoded test/CLI-command counts that drift constantly — the site was already internally inconsistent (`site/cli.njk` said 22 CLI commands, `site/learn.njk` said 23), and AGENTS.md's per-package counts were stale by 10-18 tests in several places.

- **sl-k7po** — `scripts/generate-test-stats.mjs` computes `cliCommands` (from the built CLI's own `--help` output), `parserCorpusTests` (tree-sitter's own `Total parses: N` summary line), and each tracked package's test count (Node's built-in test runner's `tests N` summary line — every package here uses `node --test`, no vitest/jest), and writes them to `test-stats.json` at the repo root.
- **sl-lzqk** — wired into `scripts/run-repo-checks.sh` (the pre-commit hook): each relevant step's output is teed to a log, and a final step regenerates `test-stats.json` from those logs (`--from-logs`) and stages it into the commit — no second test run, near-zero extra cost. Falls back to the previously committed value for a package the hook doesn't exercise locally (e.g. `satsuma-viz-backend`) or when the corpus check gracefully skips (wasm-less `tree-sitter-cli`), rather than misreading a skip as zero.
- **sl-mo1e** — new CI job (`test-stats`) that runs the generator fresh and fails with an actionable `::error::` if `test-stats.json` has drifted, mirroring the existing parser job's "generate and diff" pattern.
- **sl-ypu1** — `deploy-site.yml` copies `test-stats.json` to `site/_data/stats.json` before the Eleventy build; `index.njk`/`cli.njk`/`vscode.njk`/`learn.njk` now read `{{ stats.* }}` instead of hardcoding numbers, fixing the site's internal 22-vs-23 inconsistency.
- **sl-if0c** — README.md, AGENTS.md, and PROJECT-OVERVIEW.md drop their hardcoded counts and link to `test-stats.json` instead.

## Test plan

- [x] `scripts/generate-test-stats.test.mjs` — 15 unit tests on the parsing/fallback logic (summary-line extraction, CLI `--help` parsing minus commander's auto-appended `help` entry, fallback-on-skip/missing-log behavior)
- [x] Full local run of `scripts/run-repo-checks.sh` (the pre-commit hook) confirms `test-stats.json` regenerates correctly and idempotently
- [x] `npm run lint` (js/md/yaml/python) passes on the merged tree
- [x] `node scripts/generate-test-stats.mjs` + `git diff --exit-code test-stats.json` confirms no drift
- [x] `cd site && npx @11ty/eleventy` builds cleanly; built HTML shows real numbers with no leaked `{{ stats.* }}` template syntax
- [x] Every commit on this branch went through the full pre-commit hook (no `--no-verify`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>