### PR TITLE
docs: scope Feature 42 — npm workspaces + Turborepo build orchestration

### DIFF
--- a/.tickets/mbt-0f7t.md
+++ b/.tickets/mbt-0f7t.md
@@ -1,0 +1,22 @@
+---
+id: mbt-0f7t
+status: open
+deps: [mbt-pumv]
+links: []
+created: 2026-08-04T11:08:48Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R3: Verify vscode-satsuma extension packaging survives workspace hoisting
+
+vsce/extension packaging is sensitive to node_modules layout (hoisted vs nested), and this is the one package where that risk is concrete rather than hypothetical. After R2 lands, confirm vscode-satsuma still builds (npm run build) and packages correctly under the hoisted workspaces node_modules layout, and that the existing cli-pack-smoke-test-style global install check still passes.
+
+## Acceptance Criteria
+
+- vscode-satsuma builds successfully (client + server + webview) under the workspaces-hoisted node_modules
+- Extension packages correctly (vsce package or equivalent) with all expected files bundled into the .vsix
+- Existing vscode-extension CI job (fixture/golden tests, validate, build) passes unchanged
+- Any packaging breakage found is fixed before this ticket closes -- R2 is not considered done until this passes
+

--- a/.tickets/mbt-45v2.md
+++ b/.tickets/mbt-45v2.md
@@ -1,0 +1,23 @@
+---
+id: mbt-45v2
+status: open
+deps: [mbt-npy0]
+links: []
+created: 2026-08-04T11:08:48Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R5: Wire Turborepo into CI
+
+Route CI's existing per-package job/matrix steps in .github/workflows/ci.yml through turbo run <task> --filter=... so a package whose inputs are unchanged is skipped (cache hit) rather than always re-executed. Persist .turbo via actions/cache. Measure and record the before/after CI wall-clock delta against the R1 baseline. Keep the existing per-package job/matrix structure -- do not restructure the job graph in this ticket unless investigation shows it's required.
+
+## Acceptance Criteria
+
+- CI steps use turbo run --filter for build/test/lint tasks
+- .turbo cache is persisted across CI runs via actions/cache
+- A scoped test (no-op change under one package only, e.g. tooling/satsuma-viz) demonstrates turbo reports other packages as cached/skipped in CI
+- Before/after CI wall-clock time recorded and compared against the R1 baseline
+- All existing CI checks (Tree-sitter parser, VS Code extension, etc.) still pass and gate PRs as before
+

--- a/.tickets/mbt-5l7g.md
+++ b/.tickets/mbt-5l7g.md
@@ -1,0 +1,14 @@
+---
+id: mbt-5l7g
+status: open
+deps: []
+links: []
+created: 2026-08-04T11:08:06Z
+type: epic
+priority: 2
+assignee: Thorben Louw
+---
+# Feature 42: npm workspaces + Turborepo build orchestration
+
+Cut CI wall-clock time and local full-suite execution time by consolidating the 10 tooling/* packages onto npm workspaces (single lockfile, hoisted deps) and layering Turborepo on top for dependency-graph build ordering and local content-hash caching. See features/42-monorepo-build-tooling/PRD.md and ADR-049.
+

--- a/.tickets/mbt-foes.md
+++ b/.tickets/mbt-foes.md
@@ -1,0 +1,22 @@
+---
+id: mbt-foes
+status: open
+deps: []
+links: []
+created: 2026-08-04T11:08:17Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R1: Investigation spike — hoisting audit and CI baseline for workspaces migration
+
+Audit shared-dependency versions across all ten tooling/*/package.json files for hoisting conflicts (typescript, eslint, c8, web-tree-sitter, ...). Inventory every install-order-sensitive script: satsuma-cli's prepare -> build:core/build:viz-backend chain and the --ignore-scripts workaround in ci:all, and tree-sitter-satsuma's deliberate node-gyp skip (ADR-002). Capture the current CI baseline wall-clock time (install job + total pipeline) so later tickets have a measured before/after.
+
+## Acceptance Criteria
+
+- Findings note lists any shared-dependency version conflicts found (or states none found)
+- Findings note lists every install-order-sensitive script and confirms tree-sitter-satsuma's native-build skip is unaffected by hoisting
+- Baseline CI wall-clock timing (install job + full pipeline) recorded for comparison in R2 and R5
+- ADR-049 already covers the architectural decision (workspaces + Turborepo, local-only cache) -- no new ADR needed from this ticket unless the audit surfaces a blocker that changes that decision
+

--- a/.tickets/mbt-i81o.md
+++ b/.tickets/mbt-i81o.md
@@ -1,0 +1,22 @@
+---
+id: mbt-i81o
+status: open
+deps: [mbt-45v2]
+links: []
+created: 2026-08-04T11:08:48Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R6: Update docs for workspaces + Turborepo install/build flow
+
+Update AGENTS.md, HOW-DO-I.md, and docs/developer/AGENT-CONTRIBUTIONS.md worktree setup instructions to reflect the new single-command workspaces install and Turborepo-driven build/test flow. Remove references to the old per-package install:all chain and the --ignore-scripts workaround.
+
+## Acceptance Criteria
+
+- AGENTS.md's worktree setup / install:all instructions match the new commands
+- AGENT-CONTRIBUTIONS.md's worktree checklist (npm run install:all step) matches the new flow
+- HOW-DO-I.md updated if it references the old install/build process
+- No remaining doc references to the removed --ignore-scripts workaround or the old hand-sequenced build order
+

--- a/.tickets/mbt-npy0.md
+++ b/.tickets/mbt-npy0.md
@@ -1,0 +1,23 @@
+---
+id: mbt-npy0
+status: open
+deps: [mbt-0f7t]
+links: []
+created: 2026-08-04T11:08:48Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R4: Introduce Turborepo pipeline for build/test/lint
+
+Add a root turbo.json defining per-package build, test, test:coverage, and lint tasks with dependsOn: ["^build"] wiring that expresses the cross-package build order (core -> viz-model/viz-backend -> tree-sitter WASM -> cli/viz/lsp/vscode) exactly once. This replaces the two hand-maintained copies of that order: the root package.json script chain and the install job in .github/workflows/ci.yml. Adopt Turborepo's local content-hash cache (.turbo) -- no remote/hosted cache per ADR-049.
+
+## Acceptance Criteria
+
+- turbo.json defines build/test/test:coverage/lint pipelines with correct dependsOn wiring
+- Running turbo run build from a clean workspace produces the same build order/outputs as the current hand-sequenced install:all chain
+- The --ignore-scripts workaround for satsuma-cli's install is no longer needed (Turborepo topologically builds dependencies first)
+- .turbo local cache demonstrably skips a re-build/re-test of a package whose inputs are unchanged
+- All existing tests pass unchanged
+

--- a/.tickets/mbt-pumv.md
+++ b/.tickets/mbt-pumv.md
@@ -1,0 +1,24 @@
+---
+id: mbt-pumv
+status: open
+deps: [mbt-foes]
+links: []
+created: 2026-08-04T11:08:25Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: mbt-5l7g
+---
+# R2: Migrate tooling/* packages to npm workspaces
+
+Add "workspaces": ["tooling/*"] to the root package.json. Replace file:../X cross-package references (see satsuma-cli, satsuma-viz-backend, satsuma-viz-model, satsuma-viz, satsuma-viz-harness, satsuma-lsp, vscode-satsuma package.json files) with workspace-resolved version ranges. Consolidate the 11 existing package-lock.json files (root + 9 of 10 tooling/* packages; site/ stays independent) into one root lockfile. Rewrite install:all/ci:all/clean:all in the root package.json. Update ci.yml's cache step(s) to key on the root lockfile hash with restore-keys instead of workspace-${{ github.sha }}.
+
+## Acceptance Criteria
+
+- One root package-lock.json covers all tooling/* packages; site/ keeps its own
+- file:../X references removed from every tooling/*/package.json
+- install:all/ci:all/clean:all reduced to workspace-aware commands
+- CI cache step uses the lockfile hash as key with restore-keys fallback
+- All existing tests pass unchanged in every tooling/* package
+- Depends on R1's findings (no unresolved hoisting conflicts, ordering scripts accounted for)
+

--- a/adrs/adr-049-npm-workspaces-and-turborepo.md
+++ b/adrs/adr-049-npm-workspaces-and-turborepo.md
@@ -1,0 +1,115 @@
+# ADR-049 — npm Workspaces + Turborepo for Monorepo Build Orchestration
+
+**Status:** Accepted
+**Date:** 2026-08-04 (feature 42)
+
+## Context
+
+The repository's ten `tooling/*` packages are each installed independently:
+every package that depends on another declares it via
+`"@satsuma/core": "file:../satsuma-core"`-style references in its own
+`package.json`, and each package carries its own `package-lock.json` — 11
+lockfiles in total across the root, `site/`, and nine of the ten `tooling/*`
+packages. This is a hand-rolled emulation of what workspaces do natively: one
+package manually re-declares a local sibling as a dependency instead of the
+tool resolving it by name.
+
+The manual scheme is fragile in a way that has already required its own
+workaround. `satsuma-cli`'s `prepare` script runs `build:core &&
+build:viz-backend`, which would fire mid-install — before `@satsuma/core` and
+`@satsuma/viz-backend` have their own dependencies installed — if not for
+`ci:all` explicitly installing the CLI with `--ignore-scripts`. The correct
+build order (install → build core → build viz-model/viz-backend → build
+tree-sitter WASM → build cli/viz/lsp/vscode) is instead re-derived by hand in
+two places that must be kept in sync: the root `package.json`'s
+`install:all`/`ci:all` scripts, and the `install` job in
+`.github/workflows/ci.yml`. Nothing enforces they match; they have already
+needed independent fixes (see the "prebuild ran before WASM existed" comment
+on `ci.yml`).
+
+The lockfile sprawl has a measurable cost: a dependency shared across
+packages (`typescript`, `eslint`, `c8`, …) must be bumped independently in
+each lockfile, which is the most plausible explanation for why prior
+dependabot cleanup rounds needed 8–25 separate PRs per batch rather than one
+PR per shared dependency. Separately, CI's cache step
+(`actions/cache/restore`, keyed on `workspace-${{ github.sha }}` with no
+`restore-keys`) is a guaranteed miss on every commit, and every job restores
+the full cache blob for all ten packages regardless of which subset it
+actually needs. There is also no mechanism, locally or in CI, that skips a
+package whose inputs haven't changed — a commit touching only
+`tooling/satsuma-viz` still runs the full CLI, parser, and LSP suites.
+
+Two alternatives were considered and set aside. Switching package managers
+(pnpm or yarn workspaces) was rejected: no blocker specific to npm was found
+during investigation that a package-manager switch would solve and npm
+workspaces would not, and a package-manager migration is strictly larger and
+riskier than the problem requires. Nx was considered as the task-orchestration
+layer instead of Turborepo: Nx's project-graph visualization and generator
+tooling solve problems this repository doesn't have, whereas the actual need
+— topological build ordering plus content-hash task caching — is exactly
+Turborepo's `dependsOn` pipeline model. A hosted/remote Turborepo cache
+(Vercel Remote Cache or a self-hosted equivalent) was also considered and
+deferred: it would improve cross-run and cross-contributor cache-hit rates
+further, but introduces a new external service (or infrastructure to
+operate) that isn't justified until local caching is measured and found
+insufficient.
+
+## Decision
+
+Adopt npm workspaces for the ten `tooling/*` packages. The root
+`package.json` declares `"workspaces": ["tooling/*"]`; the `file:../X`
+cross-package references are replaced with workspace-resolved version
+ranges that npm links automatically by package name; one root
+`package-lock.json` replaces the current 11 for these packages. `site/` is a
+separate deployable and is explicitly excluded from the workspaces array —
+it keeps its own lockfile.
+
+Adopt Turborepo on top of the workspaces tree. A root `turbo.json` defines
+per-package `build`, `test`, `test:coverage`, and `lint` tasks, with
+`dependsOn: ["^build"]` wiring that expresses the cross-package build order
+exactly once — replacing both hand-maintained copies (the root
+`package.json` script chain and the `install` job in `ci.yml`). Turborepo's
+cache is local-only for this iteration: results are cached by content hash
+in `.turbo`, persisted across CI runs via `actions/cache`, with no
+remote/hosted cache service introduced. CI's existing per-package job/matrix
+structure in `ci.yml` is retained; individual steps are routed through
+`turbo run <task> --filter=...` so that a package whose inputs are unchanged
+is skipped (cache hit) rather than always re-executed, both in CI and
+locally.
+
+## Consequences
+
+**Positive:**
+
+- One lockfile replaces 11 for the `tooling/*` packages; a shared-dependency
+  bump becomes one PR instead of a batch spread across many lockfiles.
+- Cross-package build order is expressed once, as data (`turbo.json`'s
+  `dependsOn` graph), rather than as two hand-written script chains that can
+  silently drift apart.
+- A commit touching only one package's source no longer forces every other
+  package's full test suite to re-run, in CI or locally.
+- The `--ignore-scripts` workaround for `satsuma-cli`'s install, and the
+  class of ordering bug behind the "prebuild ran before WASM existed"
+  comment, are eliminated by construction: Turborepo topologically runs a
+  dependency's `build` before a dependent's task, so there is no window
+  where a `prepare`/`postinstall` script can fire out of order.
+
+**Negative:**
+
+- The migration touches every package's `package.json` plus the CI workflow
+  in one logical change; this is mitigated by landing the workspaces
+  consolidation (R1–R3) and the Turborepo introduction (R4–R6) as separate
+  PRs rather than one.
+- `vscode-satsuma`'s extension packaging (`vsce`) is known to be sensitive to
+  `node_modules` layout; hoisting must be verified not to break it before the
+  migration is considered complete — this is tracked as its own gating step
+  (feature 42, R3), not assumed safe.
+- Local-only caching means CI runners get a weaker cache-hit rate than a
+  remote cache would provide, since GitHub-hosted runners are ephemeral
+  beyond what `actions/cache` persists. This is an accepted tradeoff for this
+  iteration, not a limitation of Turborepo itself — a remote cache remains
+  available as a future addition if measurements show local caching is
+  insufficient.
+- `tooling/tree-sitter-satsuma`'s deliberate skip of a native/node-gyp build
+  (ADR-002) must be re-verified under the hoisted `node_modules` layout, to
+  confirm hoisting does not reintroduce a native build attempt.

--- a/features/42-monorepo-build-tooling/PRD.md
+++ b/features/42-monorepo-build-tooling/PRD.md
@@ -1,0 +1,209 @@
+# Feature 42 — npm Workspaces + Turborepo Task Orchestration
+
+> **Status: PROPOSED** (raised 2026-08-04) — raised while investigating CI and
+> local full-suite execution time.
+>
+> **State this PRD was checked against:** `main` at `b95cae5a`
+> (branch `fix/wasi-sdk-ci-cache`).
+>
+> **Recommendation.** Proceed in two phases that are each independently
+> shippable: consolidate the ten `tooling/*` packages onto npm workspaces
+> first (R1–R3), then layer Turborepo's dependency graph and content-hash
+> cache on top (R4–R6). Phase one alone already fixes a real, measured cost
+> (lockfile sprawl); phase two is where the CI/local wall-clock win actually
+> lands.
+>
+> **What this feature is not.** It changes no Satsuma language syntax, no CLI
+> output, no test assertions, and no published package's runtime behavior.
+> It does not adopt a remote/hosted cache (see Non-goals) and does not
+> replace npm with pnpm or yarn.
+
+## Goal
+
+Cut CI wall-clock time and local full-suite execution time by removing two
+sources of unnecessary, repeated work:
+
+1. Ten packages are installed independently (separate `node_modules`,
+   separate lockfiles) instead of once with hoisted, deduplicated
+   dependencies.
+2. Cross-package builds are ordered by hand-written npm script chains
+   instead of a dependency graph, and every push re-runs every package's
+   full test suite regardless of what changed.
+
+## Background — measured state
+
+### Ten packages, ten lockfiles, one hand-rolled linking scheme
+
+Every `tooling/*` package that depends on another already declares it via
+`file:../<package>` in its own `package.json` — this repo is manually
+emulating what workspaces do natively:
+
+| Package | Depends on (via `file:../X`) |
+|---|---|
+| `@satsuma/core` | `@satsuma/scenario-gen` |
+| `@satsuma/viz-model` | `@satsuma/core` |
+| `@satsuma/viz-backend` | `@satsuma/core`, `@satsuma/viz-model`, `@satsuma/scenario-gen` |
+| `@satsuma/viz` | `@satsuma/core`, `@satsuma/viz-model`, `@satsuma/viz-backend`, `@satsuma/scenario-gen` |
+| `@satsuma/viz-harness` | `@satsuma/core`, `@satsuma/viz-model`, `@satsuma/viz-backend` |
+| `@satsuma/lsp` | `@satsuma/core`, `@satsuma/viz-model`, `@satsuma/viz-backend` |
+| `satsuma-cli` | `@satsuma/core`, `@satsuma/scenario-gen`, `@satsuma/viz-backend` |
+| `vscode-satsuma` | `@satsuma/core`, `@satsuma/lsp` |
+
+Each package also carries its own `package-lock.json` — 11 in total
+(`.` root, `site/`, and 9 of the 10 `tooling/*` packages), plus a 12th
+inside `.worktrees/gcsc-qka8/`. A dependency shared across packages
+(`typescript`, `eslint`, `c8`, …) is bumped independently in each lockfile,
+which is the most likely explanation for why prior dependabot cleanup
+rounds needed 8–25 separate PRs per batch (see memory:
+`dependabot-batch-2026-07-13`, `-07-22`, `-07-31`) rather than one PR per
+shared dependency.
+
+### Build order is hand-sequenced, and the sequencing is fragile enough to need a workaround
+
+`ci:all` in the root `package.json` installs the CLI with
+`npm ci --ignore-scripts --prefix tooling/satsuma-cli` — deliberately, because
+`satsuma-cli`'s own `prepare` script runs `build:core && build:viz-backend`
+(`tooling/satsuma-cli/package.json`), which would otherwise fire mid-install,
+before `@satsuma/core` and `@satsuma/viz-backend` have their own dependencies
+installed. The correct order is instead re-derived by hand in two places that
+must be kept in sync:
+
+- `install:all` / `ci:all` (root `package.json`): install → build core →
+  build viz-backend → build tree-sitter WASM → copy WASM into CLI dist +
+  `tsc` → build viz → …
+- the `install` job in `.github/workflows/ci.yml` (lines 23–44): the same
+  sequence, repeated.
+
+Nothing enforces that these two copies of the build order stay identical;
+they have already needed independent maintenance (see the `prebuild ran
+before WASM existed` comment on `ci.yml:38`).
+
+### CI caching restores everything, for every job, keyed on nothing reusable
+
+Every job in `ci.yml` (`lint`, `satsuma-cli`, `parser`, `vscode-extension`,
+`cli-pack-smoke-test`, `smoke-tests`, `stm-to-excel-skill`, the
+`tooling-modules` matrix) restores the *same* full cache blob — all ten
+packages' `node_modules` plus every build output — via
+`actions/cache/restore` keyed on `workspace-${{ github.sha }}`, with no
+`restore-keys` fallback. Two consequences:
+
+1. Every commit is a guaranteed cache miss in the `install` job (the key
+   never matches a prior run), so `ci:all`'s nine separate `npm ci` calls
+   run from scratch on every push.
+2. Jobs that only need a subset of packages (e.g. `parser` needs none of
+   `vscode-satsuma`'s dependencies) still pay to restore the entire blob.
+
+### No affected-only execution, locally or in CI
+
+A commit that only touches `tooling/satsuma-viz` still runs the full
+`tooling-modules` matrix, the full CLI suite (1031 tests), the full parser
+corpus (318 tests), and the full LSP suite (300 tests) — there is no
+mechanism, locally or in CI, that skips a package whose inputs did not
+change.
+
+## Non-goals
+
+- No change to Satsuma language semantics, CLI/LSP/viz output, or any test
+  assertion — this feature must not "make CI green" by weakening a check.
+- No migration off npm (staying on npm workspaces; pnpm/yarn are out of
+  scope unless R1 surfaces a concrete blocker only they solve).
+- No remote/hosted Turborepo cache (Vercel Remote Cache or self-hosted) in
+  this iteration — confirmed out of scope for now. Local `.turbo` cache,
+  persisted across CI runs via `actions/cache`, is in scope and is expected
+  to deliver most of the win without adding a third-party service or new
+  infra to operate. Revisit as a follow-on feature if local caching proves
+  insufficient.
+- No change to how `tooling/tree-sitter-satsuma` skips its native/node-gyp
+  build (ADR-002) — R1 must confirm hoisting doesn't reintroduce a native
+  build attempt, not change the existing skip.
+
+## Success criteria
+
+- A single root lockfile replaces the current 11 (excluding `site/`, which
+  is a separate deployable and stays independent).
+- `install:all` / `ci:all` collapse from nine sequential `npm ci`/`npm
+  install --prefix` calls to one workspace-aware install.
+- The hand-sequenced build order (core → viz-backend → WASM → CLI → viz)
+  is expressed once, as a Turborepo `dependsOn` graph, and deleted from
+  both `package.json` scripts and `ci.yml` — no second copy to drift out of
+  sync.
+- CI's `install` job cache is keyed on the (now single) lockfile hash with
+  `restore-keys`, so an unrelated commit hits a warm cache instead of a
+  guaranteed miss.
+- A commit touching only one package's source does not re-run another,
+  unaffected package's test suite in CI — verified by a scoped test (make a
+  no-op change under `tooling/satsuma-viz` only, confirm `turbo run test`
+  reports the other packages as cached/skipped).
+- `vscode-satsuma` still builds and packages correctly (`vsce package` or
+  equivalent, plus the existing `cli-pack-smoke-test`-style install smoke
+  check) after the `node_modules` layout changes — this is the specific
+  regression risk flagged during scoping.
+- `tooling/tree-sitter-satsuma`'s WASM-only build path (no native/node-gyp
+  build, per ADR-002) is unchanged after hoisting.
+- Baseline CI wall-clock time (`install` job + total pipeline) is captured
+  before R2 lands, so the improvement from R2 and again from R4–R5 is a
+  measured delta, not a claim.
+- All existing tests pass unchanged; no test is skipped, weakened, or
+  deleted to make this migration land.
+
+## Proposed rollout
+
+Each ticket should be independently mergeable and independently valuable —
+R1–R3 (workspaces) must not be blocked on R4–R6 (Turborepo) being ready.
+
+1. **R1 — Investigation spike.** Audit shared-dependency versions across all
+   ten `package.json` files for hoisting conflicts (`typescript`, `eslint`,
+   `c8`, `web-tree-sitter`, …); inventory every install-order-sensitive
+   script (`satsuma-cli`'s `prepare` → `build:core`/`build:viz-backend`,
+   `tree-sitter-satsuma`'s node-gyp skip); capture the CI baseline timing
+   named in Success criteria. Output: a short findings note and, since
+   adopting workspaces is an architectural decision, an ADR draft (see
+   `/adr-draft`).
+2. **R2 — Migrate to npm workspaces.** Add `"workspaces"` to the root
+   `package.json`; replace `file:../X` cross-package deps with
+   workspace-resolved version ranges; consolidate to one root lockfile;
+   rewrite `install:all`/`ci:all`/`clean:all`; update `ci.yml`'s cache
+   step(s) to key on the root lockfile hash with `restore-keys`.
+3. **R3 — Verify `vscode-satsuma` packaging.** Confirm the extension still
+   builds and packages correctly under hoisted `node_modules` before
+   treating R2 as done; this is the one package where layout-sensitivity is
+   a known risk, not a hypothetical.
+4. **R4 — Introduce Turborepo.** Add `turbo.json` with per-package
+   `build`/`test`/`test:coverage`/`lint` pipeline entries and `dependsOn:
+   ["^build"]` wiring that replaces the hand-sequenced chain from
+   Background; adopt Turborepo's local content-hash cache.
+5. **R5 — Wire Turborepo into CI.** Replace or augment the existing
+   per-package job/matrix structure in `ci.yml` with `turbo run test
+   --filter=...`-style invocations (exact shape TBD in R4/R5 — may keep the
+   existing matrix and let Turborepo's cache short-circuit unaffected
+   packages within each job, rather than restructuring the workflow's job
+   graph); persist `.turbo` via `actions/cache`; measure and record the
+   before/after wall-clock delta against the R1 baseline.
+6. **R6 — Docs.** Update `AGENTS.md`, `HOW-DO-I.md`, and the worktree setup
+   instructions (`npm run install:all` references) to match the new
+   single-command install and Turborepo-driven build/test flow.
+
+## Risks
+
+- **`vscode-satsuma` packaging** is sensitive to `node_modules` layout
+  (hoisted vs. nested); explicitly gated by R3 rather than assumed safe.
+- **Migration review surface** touches every package's `package.json` plus
+  the root CI workflow in one logical change — recommend a dedicated
+  worktree per this repo's convention, and landing R1–R3 as their own PR
+  before starting R4.
+- **`tree-sitter-satsuma`'s deliberate native-build skip** (ADR-002) must
+  survive hoisting; R1 confirms this before R2 changes anything.
+- **Two copies of the build order** (`package.json` scripts and `ci.yml`)
+  currently exist because nothing enforces they match; until R4 lands, R2
+  still has to keep both in sync manually — R2 does not fix this on its
+  own, only R4 does.
+
+## Open questions
+
+- Exact CI restructuring in R5 (replace the job/matrix structure vs. keep
+  it and let Turborepo's cache do the skipping within existing jobs) is
+  left to be decided once R4's pipeline shape is concrete, rather than
+  fixed here.
+- Whether local-only Turborepo caching (this iteration's scope) delivers
+  enough of the win to make a future remote-cache feature unnecessary, or
+  whether it becomes a follow-on ask once R5's measurements are in.


### PR DESCRIPTION
## Summary

- Scopes CI/local test-time reduction as **Feature 42**: consolidate the ten `tooling/*` packages onto npm workspaces (single lockfile, replacing the current 11), then layer Turborepo on top for dependency-graph build ordering and a local content-hash cache — no remote/hosted cache in this iteration.
- Records the decision as **ADR-049** (npm Workspaces + Turborepo for Monorepo Build Orchestration). No existing ADR is superseded.
- Adds six sequenced tk tickets under the `mbt-5l7g` epic:
  - `mbt-foes` (R1) — investigation spike: hoisting audit + CI baseline
  - `mbt-pumv` (R2) — migrate to npm workspaces
  - `mbt-0f7t` (R3) — verify `vscode-satsuma` packaging survives hoisting
  - `mbt-npy0` (R4) — introduce Turborepo pipeline
  - `mbt-45v2` (R5) — wire Turborepo into CI
  - `mbt-i81o` (R6) — update docs
  - Only R1 is `ready`; each subsequent ticket depends on the one before it.

This PR is docs/planning only — no code, workflow, or dependency changes. See `features/42-monorepo-build-tooling/PRD.md` for the full measured-state writeup (11 lockfiles, the `--ignore-scripts` build-order workaround, the no-`restore-keys` CI cache, no affected-only test execution).

## Test plan

- [x] Pre-commit hook (`scripts/run-repo-checks.sh`) ran and passed: lint (JS/MD/YAML/Python), release-metadata tests, scenario-gen tests, tree-sitter corpus + fixture tests, smoke tests — all green, since this change touches no source.
- [x] `tk dep tree` confirms the R1→R2→R3→R4→R5→R6 chain and `tk ready` shows only R1 unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)