### PR TITLE
test(core): pin field-lineage depth exactness (spr-w98t)

### DIFF
--- a/.tickets/spr-w98t.md
+++ b/.tickets/spr-w98t.md
@@ -1,6 +1,6 @@
 ---
 id: spr-w98t
-status: open
+status: closed
 deps: [sl-prlp]
 links: []
 created: 2026-08-04T09:28:15Z
@@ -28,3 +28,9 @@ Sequencing: this cannot be fixed inside sl-prlp, whose acceptance criteria requi
 - Cyclic workspaces still terminate.
 - Feature 41 R4's depth-exactness property (sl-jsyn) passes against the field traversal with no weakened assertion.
 
+
+## Notes
+
+**2026-08-04T12:26:54Z**
+
+Cause: The ticket inferred a depth-limit defect from a first-visit set, but field-lineage has always used FIFO breadth-first traversal, so every field is necessarily discovered at a shortest depth before any longer path can reach it. Fix: Added explicit downstream and upstream diamond contract tests proving shortest-path expansion, boundary-subtree inclusion, and unique output; no production change or shared traversal abstraction is required. (commit immediately after ec45cfba)

--- a/.tickets/spr-w98t.md
+++ b/.tickets/spr-w98t.md
@@ -34,3 +34,7 @@ Sequencing: this cannot be fixed inside sl-prlp, whose acceptance criteria requi
 **2026-08-04T12:26:54Z**
 
 Cause: The ticket inferred a depth-limit defect from a first-visit set, but field-lineage has always used FIFO breadth-first traversal, so every field is necessarily discovered at a shortest depth before any longer path can reach it. Fix: Added explicit downstream and upstream diamond contract tests proving shortest-path expansion, boundary-subtree inclusion, and unique output; no production change or shared traversal abstraction is required. (commit immediately after ec45cfba)
+
+**2026-08-04T13:20:00Z**
+
+Cause (review follow-up): the first diamond fixtures were too shallow to discriminate — mutating `queue.shift()` to `queue.pop()`, which reproduces exactly the depth-inexactness this ticket alleged, left them green, because a two-path field adjacent to the focus is enqueued at its shortest depth under any expansion order. Fix: rebuilt the fixtures as five-node diamonds whose boundary field is lost unless the two-path field is claimed by its two-hop side (all three cases now fail under the LIFO mutant), added an edge-order-independence case, and replaced the in-code comment that still named this ticket as pending work with the FIFO shortest-path invariant and why the CLI's schema walk needs its own shallowest-visit map. (commit immediately after fe26b465)

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,7 +2,7 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 696,
+    "satsuma-core": 697,
     "satsuma-cli": 1052,
     "satsuma-lsp": 300,
     "satsuma-viz-model": 6,

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,7 +2,7 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 694,
+    "satsuma-core": 696,
     "satsuma-cli": 1052,
     "satsuma-lsp": 300,
     "satsuma-viz-model": 6,

--- a/tooling/satsuma-core/src/field-lineage.ts
+++ b/tooling/satsuma-core/src/field-lineage.ts
@@ -325,8 +325,14 @@ function traceDirection(
   maxDepth: number,
   direction: Exclude<FieldLineageDirection, "both">,
 ): FieldLineageHop[] {
-  // This first-visit-wins set deliberately preserves current CLI output.
-  // spr-w98t owns replacing it with depth-aware revisits in a later change.
+  // Marking a field visited on enqueue is depth-exact *because* the queue is
+  // FIFO and every field edge is one hop: fields therefore leave the queue in
+  // non-decreasing depth order, so a field's first visit is always along a
+  // shortest path and its subtree is expanded with the full remaining budget.
+  // No shallower revisit can exist, so nothing needs re-expanding here. The
+  // CLI's schema-level walk needs an explicit shallowest-visit map instead,
+  // because it recurses depth-first and weights mapping nodes at zero depth —
+  // there a first visit really can be deeper than the shortest path.
   const visited = new Set<CanonicalFieldEndpoint>([start]);
   const queue: Array<{ field: CanonicalFieldEndpoint; depth: number }> = [
     { field: start, depth: 0 },
@@ -358,6 +364,10 @@ function traceDirection(
  * The function performs no workspace access and mutates neither its edges nor
  * options. Cycles terminate at the first visited field, matching the published
  * CLI behavior; `depth` counts mapping hops from `start`.
+ *
+ * Each direction is depth-exact: it contains exactly the fields whose shortest
+ * path from `start` is at most `depth` hops, each listed once and reached via a
+ * shortest-path edge. Callers may rely on that (Feature 41 R4 asserts it).
  */
 export function traceFieldLineage(
   edges: Iterable<FieldLineageEdge>,

--- a/tooling/satsuma-core/test/field-lineage.test.js
+++ b/tooling/satsuma-core/test/field-lineage.test.js
@@ -198,4 +198,63 @@ describe("traceFieldLineage", () => {
       downstream: [],
     });
   });
+
+  it("keeps the downstream subtree reachable through the shorter side of a diamond", () => {
+    // The longer branch is deliberately listed first. FIFO breadth-first
+    // traversal must still reach the leaf at depth two through the shortcut,
+    // and must report the shared join only once with its shortest-path edge.
+    const start = createCanonicalFieldEndpoint("::start.id");
+    const detour = createCanonicalFieldEndpoint("::detour.id");
+    const join = createCanonicalFieldEndpoint("::join.id");
+    const leaf = createCanonicalFieldEndpoint("::leaf.id");
+    const diamond = [
+      { from: start, to: detour, mapping: "start_to_detour", classification: "none" },
+      { from: detour, to: join, mapping: "detour_to_join", classification: "none" },
+      { from: join, to: leaf, mapping: "join_to_leaf", classification: "none" },
+      { from: start, to: join, mapping: "start_to_join", classification: "none" },
+    ];
+
+    const result = traceFieldLineage(diamond, start, {
+      depth: 2,
+      direction: "downstream",
+    });
+
+    assert.deepEqual(result.downstream, [
+      { field: "::detour.id", via_mapping: "::start_to_detour", classification: "none" },
+      { field: "::join.id", via_mapping: "::start_to_join", classification: "none" },
+      { field: "::leaf.id", via_mapping: "::join_to_leaf", classification: "none" },
+    ]);
+    assert.equal(new Set(result.downstream.map(({ field }) => field)).size, 3);
+  });
+
+  it("keeps the upstream subtree reachable through the shorter side of a diamond", () => {
+    // Reversing the same topology exercises the upstream endpoint selection.
+    // The ancestor is exactly three hops away through the shortcut and the
+    // shared start field must not be duplicated through the longer branch.
+    const ancestor = createCanonicalFieldEndpoint("::ancestor.id");
+    const start = createCanonicalFieldEndpoint("::start.id");
+    const detour = createCanonicalFieldEndpoint("::detour.id");
+    const join = createCanonicalFieldEndpoint("::join.id");
+    const sink = createCanonicalFieldEndpoint("::sink.id");
+    const diamond = [
+      { from: ancestor, to: start, mapping: "ancestor_to_start", classification: "none" },
+      { from: start, to: detour, mapping: "start_to_detour", classification: "none" },
+      { from: detour, to: join, mapping: "detour_to_join", classification: "none" },
+      { from: start, to: join, mapping: "start_to_join", classification: "none" },
+      { from: join, to: sink, mapping: "join_to_sink", classification: "none" },
+    ];
+
+    const result = traceFieldLineage(diamond, sink, {
+      depth: 3,
+      direction: "upstream",
+    });
+
+    assert.deepEqual(result.upstream, [
+      { field: "::join.id", via_mapping: "::join_to_sink", classification: "none" },
+      { field: "::detour.id", via_mapping: "::detour_to_join", classification: "none" },
+      { field: "::start.id", via_mapping: "::start_to_join", classification: "none" },
+      { field: "::ancestor.id", via_mapping: "::ancestor_to_start", classification: "none" },
+    ]);
+    assert.equal(new Set(result.upstream.map(({ field }) => field)).size, 4);
+  });
 });

--- a/tooling/satsuma-core/test/field-lineage.test.js
+++ b/tooling/satsuma-core/test/field-lineage.test.js
@@ -199,62 +199,117 @@ describe("traceFieldLineage", () => {
     });
   });
 
-  it("keeps the downstream subtree reachable through the shorter side of a diamond", () => {
-    // The longer branch is deliberately listed first. FIFO breadth-first
-    // traversal must still reach the leaf at depth two through the shortcut,
-    // and must report the shared join only once with its shortest-path edge.
-    const start = createCanonicalFieldEndpoint("::start.id");
-    const detour = createCanonicalFieldEndpoint("::detour.id");
-    const join = createCanonicalFieldEndpoint("::join.id");
-    const leaf = createCanonicalFieldEndpoint("::leaf.id");
-    const diamond = [
-      { from: start, to: detour, mapping: "start_to_detour", classification: "none" },
-      { from: detour, to: join, mapping: "detour_to_join", classification: "none" },
-      { from: join, to: leaf, mapping: "join_to_leaf", classification: "none" },
-      { from: start, to: join, mapping: "start_to_join", classification: "none" },
-    ];
+  // ── Depth exactness (spr-w98t) ────────────────────────────────────────────
+  //
+  // These fixtures pin the invariant that makes the traversal's mark-on-enqueue
+  // visited set safe: the result is exactly the fields whose *shortest* path is
+  // within the hop budget. The shape matters. A diamond whose two-path field is
+  // adjacent to the focus proves nothing — an adjacent field is enqueued at its
+  // shortest depth whatever order the walk expands in — so `hub` below sits two
+  // hops away, with `leaf`/`ancestor` one further hop out, exactly on the depth
+  // boundary. That boundary field is reachable within budget only if `hub` was
+  // claimed by its two-hop side; a walk that claims `hub` through the three-hop
+  // side loses the boundary field entirely and mislabels `hub`'s via_mapping.
+  // Authoring the short side first is deliberate: it is the order a depth-first
+  // (stack-based) walk gets wrong, so these cases fail if the queue stops being
+  // FIFO. Edge-order independence is asserted separately below.
 
-    const result = traceFieldLineage(diamond, start, {
-      depth: 2,
+  /** One direct field hop; classification is irrelevant to these topologies. */
+  const hop = (from, to, mapping) => ({ from, to, mapping, classification: "none" });
+
+  const start = createCanonicalFieldEndpoint("::start.id");
+  const sink = createCanonicalFieldEndpoint("::sink.id");
+  const near = createCanonicalFieldEndpoint("::near.id");
+  const detour = createCanonicalFieldEndpoint("::detour.id");
+  const relay = createCanonicalFieldEndpoint("::relay.id");
+  const hub = createCanonicalFieldEndpoint("::hub.id");
+  const leaf = createCanonicalFieldEndpoint("::leaf.id");
+  const ancestor = createCanonicalFieldEndpoint("::ancestor.id");
+
+  // start → near → hub → leaf              (hub at 2 hops, leaf at 3)
+  // start → detour → relay → hub           (hub at 3 hops the long way)
+  const downstreamDiamond = [
+    hop(start, near, "start_to_near"),
+    hop(near, hub, "near_to_hub"),
+    hop(start, detour, "start_to_detour"),
+    hop(detour, relay, "detour_to_relay"),
+    hop(relay, hub, "relay_to_hub"),
+    hop(hub, leaf, "hub_to_leaf"),
+  ];
+
+  it("reaches the field on the depth boundary below a two-path field downstream", () => {
+    // `leaf` is three hops away only through hub's two-hop side, so it appears
+    // if and only if hub was claimed at its shortest depth. Full ordered compare
+    // also pins breadth-first emission order and one hop per reached field.
+    const result = traceFieldLineage(downstreamDiamond, start, {
+      depth: 3,
       direction: "downstream",
     });
 
     assert.deepEqual(result.downstream, [
+      { field: "::near.id", via_mapping: "::start_to_near", classification: "none" },
       { field: "::detour.id", via_mapping: "::start_to_detour", classification: "none" },
-      { field: "::join.id", via_mapping: "::start_to_join", classification: "none" },
-      { field: "::leaf.id", via_mapping: "::join_to_leaf", classification: "none" },
+      { field: "::hub.id", via_mapping: "::near_to_hub", classification: "none" },
+      { field: "::relay.id", via_mapping: "::detour_to_relay", classification: "none" },
+      { field: "::leaf.id", via_mapping: "::hub_to_leaf", classification: "none" },
     ]);
-    assert.equal(new Set(result.downstream.map(({ field }) => field)).size, 3);
   });
 
-  it("keeps the upstream subtree reachable through the shorter side of a diamond", () => {
-    // Reversing the same topology exercises the upstream endpoint selection.
-    // The ancestor is exactly three hops away through the shortcut and the
-    // shared start field must not be duplicated through the longer branch.
-    const ancestor = createCanonicalFieldEndpoint("::ancestor.id");
-    const start = createCanonicalFieldEndpoint("::start.id");
-    const detour = createCanonicalFieldEndpoint("::detour.id");
-    const join = createCanonicalFieldEndpoint("::join.id");
-    const sink = createCanonicalFieldEndpoint("::sink.id");
-    const diamond = [
-      { from: ancestor, to: start, mapping: "ancestor_to_start", classification: "none" },
-      { from: start, to: detour, mapping: "start_to_detour", classification: "none" },
-      { from: detour, to: join, mapping: "detour_to_join", classification: "none" },
-      { from: start, to: join, mapping: "start_to_join", classification: "none" },
-      { from: join, to: sink, mapping: "join_to_sink", classification: "none" },
+  it("reaches the field on the depth boundary above a two-path field upstream", () => {
+    // The mirrored topology exercises the upstream endpoint selection: `ancestor`
+    // is three hops back only through hub's two-hop side.
+    const upstreamDiamond = [
+      hop(near, sink, "near_to_sink"),
+      hop(hub, near, "hub_to_near"),
+      hop(detour, sink, "detour_to_sink"),
+      hop(relay, detour, "relay_to_detour"),
+      hop(hub, relay, "hub_to_relay"),
+      hop(ancestor, hub, "ancestor_to_hub"),
     ];
 
-    const result = traceFieldLineage(diamond, sink, {
+    const result = traceFieldLineage(upstreamDiamond, sink, {
       depth: 3,
       direction: "upstream",
     });
 
     assert.deepEqual(result.upstream, [
-      { field: "::join.id", via_mapping: "::join_to_sink", classification: "none" },
-      { field: "::detour.id", via_mapping: "::detour_to_join", classification: "none" },
-      { field: "::start.id", via_mapping: "::start_to_join", classification: "none" },
-      { field: "::ancestor.id", via_mapping: "::ancestor_to_start", classification: "none" },
+      { field: "::near.id", via_mapping: "::near_to_sink", classification: "none" },
+      { field: "::detour.id", via_mapping: "::detour_to_sink", classification: "none" },
+      { field: "::hub.id", via_mapping: "::hub_to_near", classification: "none" },
+      { field: "::relay.id", via_mapping: "::relay_to_detour", classification: "none" },
+      { field: "::ancestor.id", via_mapping: "::ancestor_to_hub", classification: "none" },
     ]);
-    assert.equal(new Set(result.upstream.map(({ field }) => field)).size, 4);
+  });
+
+  it("claims a two-path field by its shortest side whichever side is authored first", () => {
+    // Depth exactness must not depend on edge-list order, which is an artifact of
+    // authoring order in the workspace. Emission order does vary with it, so this
+    // compares the reached fields and their via_mapping as an unordered map.
+    const longSideFirst = [
+      hop(start, detour, "start_to_detour"),
+      hop(detour, relay, "detour_to_relay"),
+      hop(relay, hub, "relay_to_hub"),
+      hop(start, near, "start_to_near"),
+      hop(near, hub, "near_to_hub"),
+      hop(hub, leaf, "hub_to_leaf"),
+    ];
+    const shortestPathEdges = (edges) =>
+      new Map(
+        traceFieldLineage(edges, start, { depth: 3, direction: "downstream" }).downstream.map(
+          ({ field, via_mapping }) => [field, via_mapping],
+        ),
+      );
+
+    assert.deepEqual(shortestPathEdges(longSideFirst), shortestPathEdges(downstreamDiamond));
+    assert.deepEqual(
+      shortestPathEdges(longSideFirst),
+      new Map([
+        ["::near.id", "::start_to_near"],
+        ["::detour.id", "::start_to_detour"],
+        ["::hub.id", "::near_to_hub"],
+        ["::relay.id", "::detour_to_relay"],
+        ["::leaf.id", "::hub_to_leaf"],
+      ]),
+    );
   });
 });


### PR DESCRIPTION
Closes spr-w98t.

## Summary

- records that spr-w98t was a false positive: field-lineage's traversal is a FIFO breadth-first walk over a unit-weight field graph, and it marks fields visited on enqueue, so a field's first visit is necessarily along a shortest path — a longer path cannot claim a field and truncate its subtree
- adds three depth-exactness contract tests (downstream boundary, upstream boundary, edge-order independence) over five-node diamonds
- corrects the in-code comment that still named spr-w98t as pending work, and publishes depth exactness on `traceFieldLineage`'s contract for Feature 41 R4 (sl-jsyn) to assert against
- refreshes the generated satsuma-core test count from 694 to 697

## Why the ticket was wrong

It assumed the field walk had the same shape as the schema walk. It doesn't:

| | shape | needs depth-aware revisits? |
|---|---|---|
| `satsuma-core/src/field-lineage.ts` (fields) | FIFO BFS, unit-weight edges, mark-on-enqueue | no — first visit is provably shortest |
| `satsuma-cli/src/commands/lineage.ts` (schemas) | recursive DFS, mapping/transform nodes weighted at **zero** depth | yes — `DepthAwareTraversal`, from sl-y89y |

So `DepthAwareTraversal` is genuinely required for the schema walk and genuinely unnecessary here. The acceptance criterion asking for one shared traversal is declined on that basis: the two walks do not have the same semantics to share. `traceFieldLineage` is the only field traversal in the repo (one CLI caller), so there is no unfixed sibling.

## Test fixtures: why they are shaped the way they are

The first version of these tests did not pin the invariant. Mutating `queue.shift()` to `queue.pop()` — which reproduces exactly the depth-inexactness the ticket alleged — left them **green**, because a two-path field adjacent to the focus field is enqueued at its shortest depth whatever order the walk expands in.

The fixtures are now five-node diamonds: a two-hop and a three-hop side meeting at `hub`, with a boundary field one hop beyond it and `depth: 3`. A walk that claims `hub` through the long side reports it at three hops and loses the boundary field entirely:

| traversal | reached (downstream, depth 3) |
|---|---|
| FIFO, as shipped | `near`, `detour`, `hub` via `::near_to_hub`, `relay`, **`leaf` via `::hub_to_leaf`** |
| LIFO mutant | `near`, `detour`, `relay`, `hub` via `::relay_to_hub` — **`leaf` dropped** |

All three new cases fail under the LIFO mutant and pass as shipped, so a later refactor that stops the queue being FIFO cannot land green.

## Production impact

None. No production code changed — only a comment and a doc-comment.

## Verification

- complete pre-commit repository gate passed
- satsuma-core: 697 passed; mutation-checked as above (3 fail / 4 pass under the LIFO mutant, 7 pass restored)
- satsuma-cli: 1052 passed
- Python tree-sitter checks: 39 passed plus 1172 subtests; CLI smoke tests: 50 passed
- lint, typechecks, viz, LSP, generated CST, and test-stats freshness checks passed

ADR assessment: no architectural decision; this PR adds contract coverage and closes an invalid bug premise.
