### PR TITLE
feat(viz): add coverage overlay and field-chain foundation

### DIFF
--- a/.tickets/sl-5m9x.md
+++ b/.tickets/sl-5m9x.md
@@ -1,6 +1,6 @@
 ---
 id: sl-5m9x
-status: open
+status: in_progress
 deps: [sl-gsxu, sl-4qvp]
 links: []
 created: 2026-07-31T13:13:41Z

--- a/.tickets/sl-5m9x.md
+++ b/.tickets/sl-5m9x.md
@@ -1,6 +1,6 @@
 ---
 id: sl-5m9x
-status: in_progress
+status: closed
 deps: [sl-gsxu, sl-4qvp]
 links: []
 created: 2026-07-31T13:13:41Z
@@ -22,3 +22,10 @@ Overlay is paint-only: card sizes and ELK layout identical between modes so togg
 
 Toggle renders correct percentages on a fixture with one fully-mapped and one half-mapped schema, matching satsuma coverage --json values; layout geometry unchanged between modes (snapshot comparison); works from both self-computed (core in browser) and host-supplied models; light+dark rendering verified; unit tests pass locally.
 
+
+## Notes
+
+**2026-08-04T15:40:00Z**
+
+Cause: Overview cards already received core coverage for detail rendering, but compact cards discarded it and had no paint-only mode or host aggregate input.
+Fix: Added an off-by-default coverage toggle, host-supplied aggregate adapter, exact ratio and percentage badge with proportional themed header fill, and fixture-backed 100%/50% tests that preserve the existing layout object. (commit immediately after c8a7eb47)

--- a/.tickets/sl-jcs6.md
+++ b/.tickets/sl-jcs6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-jcs6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-07-31T13:13:41Z
@@ -24,3 +24,10 @@ Parity test uses a checked-in golden, not a live CLI call (doc review 2026-07-31
 
 Model type exported with doc-commented fields; backend builder unit-tested against minimal .stm snippets including an nl-derived hop; golden parity test asserts builder output matches the committed field-lineage --json fixture, with a documented regeneration script under scripts/; viz-backend has no dependency on satsuma-cli; viz-model and viz-backend suites pass locally.
 
+
+## Notes
+
+**2026-08-04T15:27:25Z**
+
+Cause: The viz protocol had no field-chain contract, and browser hosts had no adapter from their in-memory document workspace to core’s shared field-edge builder and traversal.
+Fix: Added a CLI-compatible, doc-commented FieldChainModel, a browser-portable in-memory backend builder with NL-derived hops and import scoping, plus a checked-in CLI golden and explicit regeneration script. (commit immediately after c4bc1709)

--- a/scripts/regenerate-field-chain-golden.mjs
+++ b/scripts/regenerate-field-chain-golden.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Regenerate viz-backend's field-chain parity fixture from the published CLI.
+ *
+ * Usage (from the repository root):
+ *   npm --prefix tooling/satsuma-cli run build
+ *   node scripts/regenerate-field-chain-golden.mjs
+ *
+ * The backend test reads the checked-in JSON and never executes or depends on
+ * satsuma-cli. Running this explicit maintainer script is the only bridge: a CLI
+ * contract change becomes a reviewable golden diff before the browser adapter
+ * is updated to match it.
+ */
+
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const fixturePath = path.join(
+  repositoryRoot,
+  "tooling/satsuma-viz-backend/test/fixtures/field-chain.stm",
+);
+const goldenPath = path.join(
+  repositoryRoot,
+  "tooling/satsuma-viz-backend/test/fixtures/field-chain.json",
+);
+const cliPath = path.join(repositoryRoot, "tooling/satsuma-cli/dist/index.js");
+
+const result = spawnSync(
+  process.execPath,
+  [cliPath, "field-lineage", "curated.id", fixturePath, "--json"],
+  { cwd: repositoryRoot, encoding: "utf8" },
+);
+
+if (result.status !== 0) {
+  process.stderr.write(result.stderr || result.stdout);
+  process.exit(result.status ?? 1);
+}
+
+// Parse before writing so an accidental diagnostic on stdout cannot corrupt
+// the fixture while still looking like successful command output.
+const fieldChain = JSON.parse(result.stdout);
+writeFileSync(goldenPath, `${JSON.stringify(fieldChain, null, 2)}\n`, "utf8");
+process.stdout.write(`Updated ${path.relative(repositoryRoot, goldenPath)}\n`);

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 300,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 190,
-    "satsuma-viz": 137,
+    "satsuma-viz": 145,
     "vscode-satsuma": 46
   }
 }

--- a/test-stats.json
+++ b/test-stats.json
@@ -5,8 +5,8 @@
     "satsuma-core": 697,
     "satsuma-cli": 1052,
     "satsuma-lsp": 300,
-    "satsuma-viz-model": 6,
-    "satsuma-viz-backend": 186,
+    "satsuma-viz-model": 7,
+    "satsuma-viz-backend": 190,
     "satsuma-viz": 137,
     "vscode-satsuma": 46
   }

--- a/tooling/satsuma-viz-backend/package.json
+++ b/tooling/satsuma-viz-backend/package.json
@@ -23,6 +23,10 @@
     "./coverage": {
       "types": "./dist/coverage.d.ts",
       "default": "./dist/coverage.js"
+    },
+    "./field-chain": {
+      "types": "./dist/field-chain.d.ts",
+      "default": "./dist/field-chain.js"
     }
   },
   "scripts": {

--- a/tooling/satsuma-viz-backend/src/field-chain.ts
+++ b/tooling/satsuma-viz-backend/src/field-chain.ts
@@ -1,0 +1,174 @@
+/**
+ * field-chain.ts — build a field traversal from an in-memory workspace.
+ *
+ * This is the browser-side adapter around core's single field-edge builder and
+ * traversal. It owns import scoping, workspace-to-core projection, and the
+ * current endpoint-ambiguity policy; it does not implement lineage semantics or
+ * depend on the CLI. The result is the exact JSON shape the CLI publishes.
+ */
+
+import {
+  buildFieldEdges,
+  createAuthoredFieldRef,
+  createCanonicalFieldEndpoint,
+  extractArrowRecords,
+  extractMappings,
+  extractNLRefData,
+  resolveAllNLRefs,
+  resolveFieldEndpoint,
+  traceFieldLineage,
+} from "@satsuma/core";
+import type {
+  CanonicalFieldEndpoint,
+  FieldArrowLike,
+  FieldLineageDirection,
+  MappingSourcesTargets,
+  NLRefDataItem,
+} from "@satsuma/core";
+import type { FieldChainModel } from "@satsuma/viz-model";
+import { buildInMemoryWorkspace } from "./in-memory-workspace";
+import type { SourceDocument } from "./in-memory-workspace";
+import { createScopedIndex, getImportReachableUris, resolveDefinition } from "./workspace-index";
+import type { WorkspaceIndex } from "./workspace-index";
+import { createWorkspaceDefinitionLookup } from "./workspace-definition-lookup";
+
+/** Default mapping-hop limit, matching `satsuma field-lineage`. */
+export const DEFAULT_FIELD_CHAIN_DEPTH = 10;
+
+/** Controls the directions and mapping-hop limit of one chain build. */
+export interface BuildFieldChainOptions {
+  /** Maximum mapping hops from the focus field; defaults to 10. */
+  depth?: number;
+  /** Side or sides of the focus field to include; defaults to both. */
+  direction?: FieldLineageDirection;
+}
+
+/** Convert a host field reference to the canonical serialized form. */
+function canonicalFocusField(field: string): CanonicalFieldEndpoint {
+  return createCanonicalFieldEndpoint(field.includes("::") ? field : `::${field}`);
+}
+
+/** Stable mapping index key shared by extracted arrows, mappings, and NL refs. */
+function mappingKey(namespace: string | null, name: string | null): string {
+  return namespace ? `${namespace}::${name ?? ""}` : (name ?? "");
+}
+
+/** Resolve an authored schema ref to the WorkspaceIndex key it denotes. */
+function resolveSchemaKey(
+  authored: string,
+  namespace: string | null,
+  workspace: WorkspaceIndex,
+): string {
+  if (authored.startsWith("::")) return authored.slice(2);
+  if (authored.includes("::")) return authored;
+
+  const schema = resolveDefinition(workspace, authored, namespace).find(
+    (definition) => definition.kind === "schema",
+  );
+  if (!schema) return authored;
+  return schema.namespace ? `${schema.namespace}::${authored}` : authored;
+}
+
+/**
+ * Endpoint policy shared with today's CLI output.
+ *
+ * A bare token that is also a declared schema is still the unresolved
+ * `r0-7w76` ambiguity. Until that decision lands, both published paths read it
+ * as a field of the primary schema; keeping the rule labelled here prevents a
+ * browser adapter from silently choosing the other interpretation.
+ */
+function resolveEndpoint(authored: string, schemas: readonly string[]): CanonicalFieldEndpoint {
+  const resolution = resolveFieldEndpoint(createAuthoredFieldRef(authored), schemas);
+  switch (resolution.kind) {
+    case "field":
+      return resolution.endpoint;
+    case "schema-root-or-field":
+      return resolution.asField;
+    case "unqualifiable":
+      return canonicalFocusField(resolution.authored);
+  }
+}
+
+/** Semantic edge inputs extracted from the import-reachable document graph. */
+interface ChainInputs {
+  /** Authored arrows in stable document order, each labelled with its URI. */
+  arrows: FieldArrowLike[];
+  /** Mapping source and target schemas keyed by qualified mapping name. */
+  mappings: Map<string, MappingSourcesTargets>;
+  /** NL text records awaiting workspace-aware resolution. */
+  nlRefData: NLRefDataItem[];
+}
+
+/** Extract and qualify the core inputs for one import-reachable workspace. */
+function collectChainInputs(
+  reachableUris: Set<string>,
+  treesByUri: ReturnType<typeof buildInMemoryWorkspace>["treesByUri"],
+  workspace: WorkspaceIndex,
+): ChainInputs {
+  const arrows: FieldArrowLike[] = [];
+  const mappings = new Map<string, MappingSourcesTargets>();
+  const nlRefData: NLRefDataItem[] = [];
+
+  for (const uri of reachableUris) {
+    const tree = treesByUri.get(uri);
+    if (!tree) continue;
+
+    for (const mapping of extractMappings(tree.rootNode)) {
+      const key = mappingKey(mapping.namespace, mapping.name);
+      mappings.set(key, {
+        sources: mapping.sources.map((source) =>
+          resolveSchemaKey(source, mapping.namespace, workspace),
+        ),
+        targets: mapping.targets.map((target) =>
+          resolveSchemaKey(target, mapping.namespace, workspace),
+        ),
+        namespace: mapping.namespace,
+      });
+    }
+
+    arrows.push(...extractArrowRecords(tree.rootNode).map((arrow) => ({ ...arrow, file: uri })));
+    nlRefData.push(
+      ...extractNLRefData(tree.rootNode).map((reference) => ({ ...reference, file: uri })),
+    );
+  }
+
+  return { arrows, mappings, nlRefData };
+}
+
+/**
+ * Build a CLI-compatible field chain from host-supplied source documents.
+ *
+ * Only documents reachable from `entryUri` through imports contribute edges.
+ * The function reads no filesystem or process state and is safe in the browser;
+ * callers must initialise core's WASM parser before invoking it.
+ */
+export function buildFieldChainFromSources(
+  entryUri: string,
+  documents: SourceDocument[],
+  focusField: string,
+  options: BuildFieldChainOptions = {},
+): FieldChainModel {
+  const field = canonicalFocusField(focusField);
+  const { index, treesByUri } = buildInMemoryWorkspace(documents);
+  if (!treesByUri.has(entryUri)) return { field, upstream: [], downstream: [] };
+
+  const reachableUris = getImportReachableUris(entryUri, index);
+  const workspace = createScopedIndex(index, reachableUris);
+  const inputs = collectChainInputs(reachableUris, treesByUri, workspace);
+  const lookup = createWorkspaceDefinitionLookup(
+    workspace,
+    (key) => inputs.mappings.get(key) ?? null,
+  );
+  const nlRefs = resolveAllNLRefs(inputs.nlRefData, lookup);
+  const edges = buildFieldEdges({
+    arrows: inputs.arrows,
+    mappingSides: (key) => inputs.mappings.get(key) ?? null,
+    nlRefs,
+    resolveEndpoint,
+  }).edges;
+
+  return traceFieldLineage(edges, field, {
+    depth: options.depth ?? DEFAULT_FIELD_CHAIN_DEPTH,
+    direction: options.direction ?? "both",
+  });
+}

--- a/tooling/satsuma-viz-backend/src/in-memory-workspace.ts
+++ b/tooling/satsuma-viz-backend/src/in-memory-workspace.ts
@@ -1,0 +1,51 @@
+/**
+ * in-memory-workspace.ts — parse and index host-supplied Satsuma documents.
+ *
+ * This module owns the shared first half of every browser-side workspace
+ * operation: parse each source once, retain its tree, and build the portable
+ * WorkspaceIndex. Model assembly and field-chain traversal consume that result;
+ * document loading and persistence remain host concerns.
+ */
+
+import { getParser } from "@satsuma/core";
+import type { Tree } from "./parser-utils";
+import { createWorkspaceIndex, indexFile } from "./workspace-index";
+import type { WorkspaceIndex } from "./workspace-index";
+
+/** One in-memory Satsuma document keyed by the URI under which it is indexed. */
+export interface SourceDocument {
+  /** URI used for workspace identity and relative import resolution. */
+  uri: string;
+  /** Raw Satsuma source text parsed by the shared WASM parser. */
+  source: string;
+}
+
+/** Parsed trees and the index assembled from the same document snapshot. */
+export interface InMemoryWorkspace {
+  /** Workspace definitions, references, and imports across all documents. */
+  index: WorkspaceIndex;
+  /** Parsed tree for each document whose parse produced a tree. */
+  treesByUri: Map<string, Tree>;
+}
+
+/**
+ * Parse and index a document snapshot without reading the filesystem.
+ *
+ * The caller must initialise core's parser first. A document whose parser call
+ * returns null is omitted; web-tree-sitter only does so when parsing is halted
+ * through a callback, which Satsuma hosts do not install.
+ */
+export function buildInMemoryWorkspace(documents: SourceDocument[]): InMemoryWorkspace {
+  const parser = getParser();
+  const index = createWorkspaceIndex();
+  const treesByUri = new Map<string, Tree>();
+
+  for (const document of documents) {
+    const tree = parser.parse(document.source);
+    if (!tree) continue;
+    treesByUri.set(document.uri, tree);
+    indexFile(index, document.uri, tree);
+  }
+
+  return { index, treesByUri };
+}

--- a/tooling/satsuma-viz-backend/src/index.ts
+++ b/tooling/satsuma-viz-backend/src/index.ts
@@ -11,3 +11,4 @@ export * from "./workspace-index";
 export * from "./viz-model";
 export * from "./model-from-sources";
 export * from "./coverage";
+export * from "./field-chain";

--- a/tooling/satsuma-viz-backend/src/model-from-sources.ts
+++ b/tooling/satsuma-viz-backend/src/model-from-sources.ts
@@ -18,31 +18,17 @@
  * caller before use; it parses via the shared `getParser()` singleton.
  */
 
-import { getParser } from "@satsuma/core";
-import type { Tree } from "./parser-utils";
 import {
-  createWorkspaceIndex,
-  indexFile,
   getImportReachableUris,
   getUnresolvedImportPaths,
   createScopedIndex,
 } from "./workspace-index";
 import { buildVizModel, mergeVizModels } from "./viz-model";
 import type { VizModel } from "./viz-model";
+import { buildInMemoryWorkspace } from "./in-memory-workspace";
+import type { SourceDocument } from "./in-memory-workspace";
 
-/** One in-memory Satsuma document keyed by the URI under which it is indexed. */
-export interface SourceDocument {
-  /**
-   * The document's URI. Must be a `file:///` URI in the same form the import
-   * resolver produces, so cross-file `import`s between documents resolve and
-   * `WorkspaceIndex.indexedFiles.has(...)` matches (feature 33 §1a). The Node
-   * server derives this from the filesystem path; the browser derives it from
-   * the library entry's virtual path.
-   */
-  uri: string;
-  /** Raw Satsuma source text — the single source of truth for parse + index. */
-  source: string;
-}
+export type { SourceDocument } from "./in-memory-workspace";
 
 /** Options controlling how the entry document's model is assembled. */
 export interface BuildModelOptions {
@@ -96,20 +82,9 @@ export function buildModelResultFromSources(
   documents: SourceDocument[],
   options: BuildModelOptions = {},
 ): BuildModelResult {
-  const parser = getParser();
-  const index = createWorkspaceIndex();
-
-  // Parse once per document and keep the trees so the lineage merge below does
-  // not re-parse the same sources it already indexed.
-  const treesByUri = new Map<string, Tree>();
-  for (const doc of documents) {
-    const tree = parser.parse(doc.source);
-    // web-tree-sitter returns Tree | null; null only arises when parsing is
-    // halted via a callback, which we never do here.
-    if (!tree) continue;
-    treesByUri.set(doc.uri, tree);
-    indexFile(index, doc.uri, tree);
-  }
+  // Model and chain builders share one parse/index pipeline so their import
+  // scope and URI identity cannot diverge.
+  const { index, treesByUri } = buildInMemoryWorkspace(documents);
 
   const entryTree = treesByUri.get(entryUri);
   if (!entryTree) return { model: emptyModel(entryUri), unresolvedImports: [] };

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -11,7 +11,6 @@ import { child, children, labelText, stringText } from "./parser-utils";
 import { attachMappingCoverage } from "./coverage";
 import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 import { findReferences, resolveDefinition } from "./workspace-index";
-import type { DefinitionLookup } from "@satsuma/core";
 import {
   extractAtRefs,
   classifyRef,
@@ -27,6 +26,7 @@ import {
   renderFieldDeclType,
 } from "@satsuma/core";
 import type { MetaEntry, FieldDecl, SpreadEntity } from "@satsuma/core";
+import { createWorkspaceDefinitionLookup, fieldInfoToDecl } from "./workspace-definition-lookup";
 
 // ---------- VizModel protocol types ----------
 
@@ -345,17 +345,6 @@ function definitionToSpreadEntity(def: DefinitionEntry): SpreadEntity {
     hasSpreads: (def.spreads?.length ?? 0) > 0,
     spreads: def.spreads ?? [],
   };
-}
-
-/** Convert an indexed FieldInfo to core's FieldDecl for spread expansion input. */
-function fieldInfoToDecl(fi: FieldInfo): FieldDecl {
-  return fieldDeclFromRenderedType({
-    name: fi.name,
-    type: fi.type ?? "",
-    startRow: fi.range.start.line,
-    children: fi.children.map(fieldInfoToDecl),
-    ...(fi.spreads ? { spreads: fi.spreads } : {}),
-  });
 }
 
 /** Convert a SchemaCard to core's SpreadEntity interface for spread expansion. */
@@ -779,47 +768,6 @@ function extractConstraintsFromMeta(entries: MetaEntry[]): string[] {
 
 // ---------- Mapping extraction ----------
 
-/** Build a DefinitionLookup from the LSP WorkspaceIndex for NL @-ref resolution. */
-function makeVizLookup(wsIndex: WorkspaceIndex): DefinitionLookup {
-  return {
-    hasSchema: (key) => wsIndex.definitions.get(key)?.some((d) => d.kind === "schema") ?? false,
-    getSchema: (key) => {
-      const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "schema");
-      if (!def) return null;
-      return {
-        fields: def.fields.map(fieldInfoToDecl),
-        hasSpreads: false,
-      };
-    },
-    hasFragment: (key) => wsIndex.definitions.get(key)?.some((d) => d.kind === "fragment") ?? false,
-    getFragment: (key) => {
-      const def = wsIndex.definitions.get(key)?.find((d) => d.kind === "fragment");
-      if (!def) return null;
-      return {
-        fields: def.fields.map(fieldInfoToDecl),
-        hasSpreads: false,
-      };
-    },
-    hasTransform: (key) =>
-      wsIndex.definitions.get(key)?.some((d) => d.kind === "transform") ?? false,
-    getMapping: () => null,
-    iterateSchemas: function* () {
-      for (const [key, defs] of wsIndex.definitions) {
-        const schemaDef = defs.find((d) => d.kind === "schema");
-        if (schemaDef) {
-          yield [
-            key,
-            {
-              fields: schemaDef.fields.map(fieldInfoToDecl),
-              hasSpreads: false,
-            },
-          ];
-        }
-      }
-    },
-  };
-}
-
 /** Resolve NL @-refs in a transform against the workspace index. */
 function resolveTransformAtRefs(
   transform: ReturnType<typeof extractTransform>,
@@ -829,7 +777,7 @@ function resolveTransformAtRefs(
   wsIndex: WorkspaceIndex,
 ): ResolvedAtRef[] {
   if (!transform.text) return [];
-  const lookup = makeVizLookup(wsIndex);
+  const lookup = createWorkspaceDefinitionLookup(wsIndex);
   const ctx = { sources, targets, namespace };
   return extractAtRefs(transform.text).map((br) => {
     // br.raw keeps backtick quoting so literal names with "." / "::"

--- a/tooling/satsuma-viz-backend/src/workspace-definition-lookup.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-definition-lookup.ts
@@ -1,0 +1,68 @@
+/**
+ * workspace-definition-lookup.ts — adapt WorkspaceIndex to core NL resolution.
+ *
+ * Both VizModel assembly and field-chain construction resolve natural-language
+ * `@ref`s. This module owns their one DefinitionLookup adapter so schema field
+ * projection and mapping lookup semantics stay identical across both builders.
+ */
+
+import { fieldDeclFromRenderedType } from "@satsuma/core";
+import type { DefinitionLookup, FieldDecl, MappingSourcesTargets } from "@satsuma/core";
+import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
+
+/** Convert an indexed field tree to core's semantic field-declaration shape. */
+export function fieldInfoToDecl(field: FieldInfo): FieldDecl {
+  return fieldDeclFromRenderedType({
+    name: field.name,
+    type: field.type ?? "",
+    startRow: field.range.start.line,
+    children: field.children.map(fieldInfoToDecl),
+    ...(field.spreads ? { spreads: field.spreads } : {}),
+  });
+}
+
+/** Optional mapping-side lookup used while resolving refs inside a mapping. */
+export type MappingSidesLookup = (mappingKey: string) => MappingSourcesTargets | null;
+
+/**
+ * Create core's narrow lookup over a workspace index.
+ *
+ * `mappingSides` is omitted while VizModel resolves one transform with an
+ * explicit context. Field-chain construction supplies it because
+ * `resolveAllNLRefs` obtains each ref's context by mapping key.
+ */
+export function createWorkspaceDefinitionLookup(
+  workspace: WorkspaceIndex,
+  mappingSides: MappingSidesLookup = () => null,
+): DefinitionLookup {
+  return {
+    hasSchema: (key) =>
+      workspace.definitions.get(key)?.some((definition) => definition.kind === "schema") ?? false,
+    getSchema: (key) => {
+      const definition = workspace.definitions
+        .get(key)
+        ?.find((candidate) => candidate.kind === "schema");
+      if (!definition) return null;
+      return { fields: definition.fields.map(fieldInfoToDecl), hasSpreads: false };
+    },
+    hasFragment: (key) =>
+      workspace.definitions.get(key)?.some((definition) => definition.kind === "fragment") ?? false,
+    getFragment: (key) => {
+      const definition = workspace.definitions
+        .get(key)
+        ?.find((candidate) => candidate.kind === "fragment");
+      if (!definition) return null;
+      return { fields: definition.fields.map(fieldInfoToDecl), hasSpreads: false };
+    },
+    hasTransform: (key) =>
+      workspace.definitions.get(key)?.some((definition) => definition.kind === "transform") ??
+      false,
+    getMapping: mappingSides,
+    iterateSchemas: function* () {
+      for (const [key, definitions] of workspace.definitions) {
+        const schema = definitions.find((definition) => definition.kind === "schema");
+        if (schema) yield [key, { fields: schema.fields.map(fieldInfoToDecl), hasSpreads: false }];
+      }
+    },
+  };
+}

--- a/tooling/satsuma-viz-backend/test/field-chain.test.js
+++ b/tooling/satsuma-viz-backend/test/field-chain.test.js
@@ -1,0 +1,122 @@
+/**
+ * field-chain.test.js — browser-side field lineage over in-memory sources.
+ *
+ * The semantic walk is core's and is tested there. These tests pin the backend
+ * adapter: import scoping, endpoint qualification, NL resolution, and parity
+ * with the CLI's checked-in JSON contract.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { before, describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { initTestParser } = require("./helper");
+const { buildFieldChainFromSources } = require("../dist/field-chain");
+
+const FIXTURE_DIRECTORY = path.join(__dirname, "fixtures");
+const FIXTURE_URI = "file:///field-chain.stm";
+
+before(async () => {
+  await initTestParser();
+});
+
+/** Build a field chain from one virtual document. */
+function chainFrom(source, field, options) {
+  return buildFieldChainFromSources(
+    "file:///workspace.stm",
+    [{ uri: "file:///workspace.stm", source }],
+    field,
+    options,
+  );
+}
+
+describe("field-chain model builder", () => {
+  it("qualifies the focus and preserves ordered upstream and downstream hops", () => {
+    // A browser host starts with the schema card's unprefixed qualifiedId. The
+    // adapter must produce the same canonical names and BFS order as the CLI.
+    const result = chainFrom(
+      `
+schema a { id string }
+schema b { id string }
+schema c { id string }
+mapping ab { source { a } target { b } id -> id }
+mapping bc { source { b } target { c } id -> id }
+`,
+      "b.id",
+    );
+
+    assert.deepEqual(result, {
+      field: "::b.id",
+      upstream: [{ field: "::a.id", via_mapping: "::ab", classification: "none" }],
+      downstream: [{ field: "::c.id", via_mapping: "::bc", classification: "none" }],
+    });
+  });
+
+  it("adds a distinct nl-derived hop for a field referenced only in prose", () => {
+    // A resolved @ref is an implicit dependency that cannot be reconstructed
+    // from declared arrow endpoints. Losing it is the critical adapter failure.
+    const result = chainFrom(
+      `
+schema source_data {
+  id string
+  audit string
+}
+schema target_data { id string }
+mapping load {
+  source { source_data }
+  target { target_data }
+  id -> id { "checked against @source_data.audit" }
+}
+`,
+      "target_data.id",
+    );
+
+    assert.deepEqual(result.upstream, [
+      { field: "::source_data.id", via_mapping: "::load", classification: "nl" },
+      {
+        field: "::source_data.audit",
+        via_mapping: "::load",
+        classification: "nl-derived",
+      },
+    ]);
+  });
+
+  it("limits traversal by mapping depth while retaining the nearest hop", () => {
+    // The public builder must forward its limit to core; silently ignoring it
+    // would make a wide workspace expensive and contradict the CLI contract.
+    const result = chainFrom(
+      `
+schema a { id string }
+schema b { id string }
+schema c { id string }
+mapping ab { source { a } target { b } id -> id }
+mapping bc { source { b } target { c } id -> id }
+`,
+      "c.id",
+      { depth: 1, direction: "upstream" },
+    );
+
+    assert.deepEqual(result.upstream, [
+      { field: "::b.id", via_mapping: "::bc", classification: "none" },
+    ]);
+    assert.deepEqual(result.downstream, []);
+  });
+});
+
+describe("field-chain CLI parity golden", () => {
+  it("matches checked-in field-lineage --json output byte-for-value", () => {
+    // The golden is regenerated explicitly by scripts/regenerate-field-chain-golden.mjs.
+    // This test deliberately makes no live CLI call or package dependency.
+    const source = fs.readFileSync(path.join(FIXTURE_DIRECTORY, "field-chain.stm"), "utf8");
+    const expected = JSON.parse(
+      fs.readFileSync(path.join(FIXTURE_DIRECTORY, "field-chain.json"), "utf8"),
+    );
+    const actual = buildFieldChainFromSources(
+      FIXTURE_URI,
+      [{ uri: FIXTURE_URI, source }],
+      "curated.id",
+    );
+
+    assert.deepEqual(actual, expected);
+  });
+});

--- a/tooling/satsuma-viz-backend/test/fixtures/field-chain.json
+++ b/tooling/satsuma-viz-backend/test/fixtures/field-chain.json
@@ -1,0 +1,27 @@
+{
+  "field": "::curated.id",
+  "upstream": [
+    {
+      "field": "::staged.id",
+      "via_mapping": "::curate_records",
+      "classification": "nl"
+    },
+    {
+      "field": "::raw.audit_code",
+      "via_mapping": "::curate_records",
+      "classification": "nl-derived"
+    },
+    {
+      "field": "::raw.id",
+      "via_mapping": "::stage_records",
+      "classification": "none"
+    }
+  ],
+  "downstream": [
+    {
+      "field": "::published.id",
+      "via_mapping": "::publish_records",
+      "classification": "none"
+    }
+  ]
+}

--- a/tooling/satsuma-viz-backend/test/fixtures/field-chain.stm
+++ b/tooling/satsuma-viz-backend/test/fixtures/field-chain.stm
@@ -1,0 +1,37 @@
+schema raw {
+  id string
+  audit_code string
+}
+
+schema staged {
+  id string
+}
+
+schema curated {
+  id string
+}
+
+schema published {
+  id string
+}
+
+mapping stage_records {
+  source { raw }
+  target { staged }
+
+  id -> id
+}
+
+mapping curate_records {
+  source { staged, raw }
+  target { curated }
+
+  staged.id -> id { "validate against @raw.audit_code" }
+}
+
+mapping publish_records {
+  source { curated }
+  target { published }
+
+  id -> id
+}

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -19,17 +19,52 @@
  * core's, verbatim, so a consumer reading them cannot be reading a re-derivation.
  */
 
-import type { MappingCoverageResult } from "@satsuma/core";
+import type { CanonicalFieldEndpoint, Classification, MappingCoverageResult } from "@satsuma/core";
 
 // Coverage types are part of this contract, so a consumer needs no second
 // import to read the payload it just received.
 export type {
+  AggregateCoverage,
+  AggregateSchemaCoverage,
+  CoverageTotals,
   MappingCoverageResult,
   SchemaCoverageResult,
   FieldCoverageEntry,
   FieldCoverageState,
   CoverageTier,
 } from "@satsuma/core";
+
+// ---------- Field chain traversal ----------
+
+/**
+ * One field reached while tracing away from a focus field.
+ *
+ * This is deliberately byte-compatible with `satsuma field-lineage --json`.
+ * `field` is a canonical `[namespace]::schema.path` endpoint, so it carries its
+ * owning schema without adding a second serialized name that could drift; use
+ * core's `fieldEndpointSchema()` when a renderer needs that owner separately.
+ */
+export interface FieldChainHop {
+  /** Canonical field reference, including the schema that owns the field. */
+  field: CanonicalFieldEndpoint;
+  /** Canonical mapping reference through which this field was reached. */
+  via_mapping: string;
+  /** Whether the connection is direct, transformed NL, or inferred from an NL `@ref`. */
+  classification: Classification;
+}
+
+/**
+ * Browser-ready field traversal: ordered ancestors, the focus field, then
+ * ordered descendants. Both hop arrays use core's stable breadth-first order.
+ */
+export interface FieldChainModel {
+  /** Canonical field at the centre of the traversal. */
+  field: CanonicalFieldEndpoint;
+  /** Upstream fields, nearest first, with cycles and depth limits guarded by core. */
+  upstream: FieldChainHop[];
+  /** Downstream fields, nearest first, with cycles and depth limits guarded by core. */
+  downstream: FieldChainHop[];
+}
 
 // ---------- Top-level document model ----------
 

--- a/tooling/satsuma-viz-model/test/model.test.js
+++ b/tooling/satsuma-viz-model/test/model.test.js
@@ -36,6 +36,20 @@ describe("CONSTRAINT_TAGS", () => {
 });
 
 describe("VizModel fixture validation", () => {
+  it("accepts the CLI-compatible field chain contract", () => {
+    // The later Lit chain renderer and host-supplied LSP payload both depend on
+    // this exact field/via_mapping/classification shape staying serializable.
+    /** @type {import("@satsuma/viz-model").FieldChainModel} */
+    const chain = {
+      field: "::staged.id",
+      upstream: [{ field: "::raw.id", via_mapping: "::stage", classification: "none" }],
+      downstream: [{ field: "::curated.id", via_mapping: "::curate", classification: "nl" }],
+    };
+
+    assert.equal(chain.upstream[0].field, "::raw.id");
+    assert.equal(chain.downstream[0].via_mapping, "::curate");
+  });
+
   it("accepts a minimal VizModel shape with schema, fields, and comments", () => {
     // Validates the core VizModel → NamespaceGroup → SchemaCard → FieldEntry
     // chain. The renderer accesses namespaces[0].schemas[0].fields directly;

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -106,6 +106,8 @@ export class SzSchemaCard extends LitElement {
     }
 
     .header {
+      position: relative;
+      overflow: hidden;
       display: flex;
       align-items: center;
       gap: 8px;
@@ -119,6 +121,21 @@ export class SzSchemaCard extends LitElement {
       color: var(--sz-text-on-accent);
       cursor: pointer;
       user-select: none;
+    }
+
+    /* Coverage changes paint only this inset layer; the header's box model and
+       therefore every overview-layout coordinate remain untouched (sl-5m9x). */
+    .coverage-fill {
+      position: absolute;
+      inset: 0 auto 0 0;
+      width: var(--sz-coverage-percent, 0%);
+      background: var(--sz-coverage-fill);
+      pointer-events: none;
+    }
+
+    .header > :not(.coverage-fill) {
+      position: relative;
+      z-index: 1;
     }
 
     /* Without a namespace pill row the header is the top of the card and
@@ -151,6 +168,17 @@ export class SzSchemaCard extends LitElement {
     .header-count {
       font-size: 11px;
       opacity: 0.85;
+      flex-shrink: 0;
+    }
+
+    .coverage-badge {
+      padding: 1px 5px;
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-coverage-badge-bg);
+      color: var(--sz-text-on-accent);
+      font-size: 10px;
+      font-weight: 700;
+      line-height: 1.4;
       flex-shrink: 0;
     }
 
@@ -563,6 +591,10 @@ export class SzSchemaCard extends LitElement {
    *  Shows namespace::name in header when schema has a namespace (qualifiedId contains ::). */
   @property({ type: Boolean })
   compact = false;
+
+  /** Show aggregate coverage in a compact overview header. */
+  @property({ type: Boolean, attribute: "coverage-overlay", reflect: true })
+  coverageOverlay = false;
 
   @property({ type: String, attribute: "namespace-label" })
   namespaceLabel: string | null = null;
@@ -1029,11 +1061,27 @@ export class SzSchemaCard extends LitElement {
     const totalFields = this._leafCount(s);
     const metaPills = s.metadata.filter((m) => m.key !== "note");
     const isReport = this._isReport(s);
+    const coverage = this._coverage();
+    const coverageText = coverage
+      ? `${coverage.totals.covered}/${coverage.totals.total}`
+      : "Coverage unavailable";
+    const coverageTitle = coverage
+      ? this._coverageTitle(coverage.totals, coverage.containers)
+      : "Coverage not computed for this schema";
 
     return html`
       <div>
         ${this._renderNamespacePill()}
-        <div class="header ${isReport ? "report" : ""}" @click=${this._onHeaderClick}>
+        <div
+          class="header ${isReport ? "report" : ""}"
+          data-coverage-overlay=${this.coverageOverlay ? "on" : "off"}
+          data-coverage-percent=${coverage?.totals.pct ?? ""}
+          style=${
+            this.coverageOverlay && coverage ? `--sz-coverage-percent: ${coverage.totals.pct}%` : ""
+          }
+          @click=${this._onHeaderClick}
+        >
+          ${this.coverageOverlay && coverage ? html`<span class="coverage-fill"></span>` : ""}
           ${this._headerIcon(isReport)}
           <span class="header-name">${displayName}</span>
           <span
@@ -1042,7 +1090,22 @@ export class SzSchemaCard extends LitElement {
             @click=${this._onToggleClick}
             >&#9660;</span
           >
-          <span class="header-count">${totalFields} fields</span>
+          <span
+            class="header-count"
+            data-testid=${`${this.testIdPrefix}-header-count`}
+            data-coverage-available=${coverage !== null}
+            title=${this.coverageOverlay ? coverageTitle : `${totalFields} leaf fields`}
+            >${this.coverageOverlay ? coverageText : `${totalFields} fields`}</span
+          >
+          ${
+            this.coverageOverlay && coverage
+              ? html`<span
+                  class="coverage-badge"
+                  data-testid=${`${this.testIdPrefix}-coverage-percent`}
+                  >${coverage.totals.pct}%</span
+                >`
+              : ""
+          }
         </div>
         ${
           metaPills.length > 0

--- a/tooling/satsuma-viz/src/field-coverage.ts
+++ b/tooling/satsuma-viz/src/field-coverage.ts
@@ -40,6 +40,7 @@ import type {
   NestedArrowBlock,
   SchemaCard,
   VizModel,
+  AggregateCoverage,
 } from "./model.js";
 
 /**
@@ -326,13 +327,38 @@ export function mappingSchemaCoverage(
  * - **Otherwise** → the union of every referencing mapping's entries, seeded with
  *   that same all-uncovered list so the card's own field tree fixes the
  *   denominator and the row order.
+ *
+ * When `aggregate` is supplied by a host, its workspace-wide core verdicts are
+ * used instead of inspecting per-mapping payloads. Source and target entries
+ * for the same schema are unioned because an overview card represents the
+ * schema across both roles.
  */
-export function buildCoverageIndex(model: VizModel): Map<string, SchemaCoverage> {
+export function buildCoverageIndex(
+  model: VizModel,
+  aggregate: AggregateCoverage | null = null,
+): Map<string, SchemaCoverage> {
   const mappings = model.namespaces.flatMap((ns) => ns.mappings);
   const index = new Map<string, SchemaCoverage>();
 
   for (const ns of model.namespaces) {
     for (const schema of ns.schemas) {
+      const uncovered = uncoveredFieldCoverage(
+        toCoverageFields(schema.fields),
+        schema.location.uri,
+      );
+
+      // Browser and editor hosts may already have workspace-wide coverage from
+      // the backend. Prefer that serializable contract when supplied: it is the
+      // authoritative union and avoids asking the component to rediscover it
+      // from whichever mappings happen to be present in this render payload.
+      if (aggregate) {
+        const supplied = aggregate.schemas
+          .filter((entry) => entry.schemaId === schema.qualifiedId)
+          .map((entry) => entry.fields);
+        index.set(schema.qualifiedId, unionFieldCoverage([uncovered, ...supplied]));
+        continue;
+      }
+
       const referencing = mappings.filter((m) => referencesSchema(m, schema.qualifiedId));
 
       // Unknown beats partial: if anything that touches this schema could not be
@@ -343,7 +369,7 @@ export function buildCoverageIndex(model: VizModel): Map<string, SchemaCoverage>
         continue;
       }
 
-      const lists = [uncoveredFieldCoverage(toCoverageFields(schema.fields), schema.location.uri)];
+      const lists = [uncovered];
       for (const mapping of referencing) {
         for (const covered of mapping.coverage?.schemas ?? []) {
           if (covered.schemaId === schema.qualifiedId) lists.push(covered.fields);

--- a/tooling/satsuma-viz/src/model.ts
+++ b/tooling/satsuma-viz/src/model.ts
@@ -26,6 +26,7 @@ export type {
   MetadataEntry,
   SourceBlockInfo,
   SourceLocation,
+  AggregateCoverage,
 } from "@satsuma/viz-model";
 
 export { CONSTRAINT_TAGS } from "@satsuma/viz-model";

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -7,6 +7,7 @@ import type {
   NamespaceGroup,
   MappingBlock,
   SchemaCard,
+  AggregateCoverage,
 } from "./model.js";
 import {
   computeLayout,
@@ -23,7 +24,7 @@ import type { SchemaCoverage } from "./field-coverage.js";
 import { metricAsSchemaCard } from "./metric-adapter.js";
 
 export { VizModel } from "./model.js";
-export type { NamespaceGroup } from "./model.js";
+export type { AggregateCoverage, NamespaceGroup } from "./model.js";
 
 import type { SzCompactToggledDetail } from "./components/sz-schema-card.js";
 
@@ -897,6 +898,19 @@ export class SatsumaViz extends LitElement {
   model: VizModel | null = null;
 
   /**
+   * Optional workspace-wide coverage supplied by a host. When present it is
+   * preferred to the per-mapping coverage embedded in {@link model}; both
+   * shapes are computed by `@satsuma/core`, so the component only selects and
+   * renders verdicts rather than deriving coverage semantics itself.
+   */
+  @property({ type: Object, attribute: false })
+  coverageModel: AggregateCoverage | null = null;
+
+  /** Whether overview cards display the coverage overlay. Defaults off. */
+  @property({ type: Boolean, attribute: "coverage-overlay", reflect: true })
+  coverageOverlay = false;
+
+  /**
    * Visual theme. Reflected to the `theme` attribute so the
    * `:host([theme="dark"])` overrides in tokens.css apply — this is the *only*
    * switching mechanism for the palette. Consumers (VS Code webview, harness)
@@ -1087,6 +1101,12 @@ export class SatsumaViz extends LitElement {
       void this._runLayout();
     }
 
+    // Coverage payload changes are presentation-only. Refreshing this index
+    // must not invoke ELK or replace its node coordinates (sl-5m9x).
+    if (changed.has("coverageModel") && this.model) {
+      this._refreshCoverageIndex();
+    }
+
     if (
       changed.has("_layout") ||
       changed.has("_overviewLayout") ||
@@ -1205,7 +1225,7 @@ export class SatsumaViz extends LitElement {
     const mergedModel = this._buildMergedModel();
 
     // Coverage index for card rendering, over the same model that is laid out.
-    this._coverageBySchema = buildCoverageIndex(mergedModel);
+    this._coverageBySchema = buildCoverageIndex(mergedModel, this.coverageModel);
 
     try {
       const [detail, overview] = await Promise.all([
@@ -1217,6 +1237,11 @@ export class SatsumaViz extends LitElement {
     } catch {
       this._layoutError = true;
     }
+  }
+
+  /** Rebuild card coverage without touching either layout result. */
+  private _refreshCoverageIndex(): void {
+    this._coverageBySchema = buildCoverageIndex(this._buildMergedModel(), this.coverageModel);
   }
 
   /** Merge the primary model with any expanded cross-file models. */
@@ -1476,6 +1501,21 @@ export class SatsumaViz extends LitElement {
         ${
           !inDetail
             ? html`<button
+                  class="toolbar-btn"
+                  data-testid="toolbar-toggle-coverage"
+                  ?data-active=${this.coverageOverlay}
+                  aria-pressed=${this.coverageOverlay ? "true" : "false"}
+                  @click=${this._toggleCoverageOverlay}
+                  title="Show or hide aggregate field coverage"
+                >
+                  Coverage
+                </button>
+                <div class="toolbar-sep"></div>`
+            : ""
+        }
+        ${
+          !inDetail
+            ? html`<button
                 class="toolbar-btn"
                 data-testid="toolbar-fit"
                 @click=${this._fit}
@@ -1559,6 +1599,11 @@ export class SatsumaViz extends LitElement {
     this._selectedMapping = null;
     this._selectedMappingKey = null;
     this._resetPanZoom();
+  }
+
+  /** Toggle the visual overlay without recomputing graph geometry. */
+  private _toggleCoverageOverlay(): void {
+    this.coverageOverlay = !this.coverageOverlay;
   }
 
   private _resetPanZoom() {
@@ -1786,6 +1831,8 @@ export class SatsumaViz extends LitElement {
                     data-testid=${`overview-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
                     .testIdPrefix=${`overview-schema-card-${sanitizeTestIdSegment(s.qualifiedId)}`}
                     .schema=${s}
+                    .coverage=${this._coverageBySchema.get(s.qualifiedId) ?? null}
+                    .coverageOverlay=${this.coverageOverlay}
                     .namespaceLabel=${ns.name}
                     .compactExpanded=${this._compactExpandedIds.has(s.qualifiedId)}
                     compact

--- a/tooling/satsuma-viz/src/tokens.css
+++ b/tooling/satsuma-viz/src/tokens.css
@@ -14,6 +14,8 @@
   --sz-row-active-bg: rgba(45, 42, 38, 0.06);
   --sz-accent-wash: rgba(242, 145, 61, 0.12);
   --sz-green-wash: rgba(90, 158, 111, 0.12);
+  --sz-coverage-fill: rgba(29, 109, 67, 0.68);
+  --sz-coverage-badge-bg: #1D6D43;
   --sz-warning-border-soft: rgba(196, 93, 34, 0.2);
   --sz-warning-border-strong: rgba(196, 93, 34, 0.3);
   --sz-question-border-soft: rgba(124, 107, 174, 0.2);
@@ -89,6 +91,8 @@
   --sz-row-active-bg: rgba(255, 255, 255, 0.08);
   --sz-accent-wash: rgba(242, 168, 96, 0.16);
   --sz-green-wash: rgba(109, 191, 130, 0.16);
+  --sz-coverage-fill: rgba(37, 120, 76, 0.72);
+  --sz-coverage-badge-bg: #25784C;
   --sz-warning-border-soft: rgba(224, 112, 64, 0.28);
   --sz-warning-border-strong: rgba(224, 112, 64, 0.4);
   --sz-question-border-soft: rgba(160, 140, 200, 0.24);

--- a/tooling/satsuma-viz/test/coverage-overlay.test.js
+++ b/tooling/satsuma-viz/test/coverage-overlay.test.js
@@ -1,0 +1,60 @@
+/**
+ * coverage-overlay.test.js — Overview coverage is an opt-in paint layer.
+ *
+ * These tests pin the parent component's toggle contract and the key geometry
+ * invariant: changing coverage visibility re-renders existing nodes without
+ * asking ELK for a new layout or replacing its coordinates.
+ */
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+/** Serialize a Lit template with interpolated values in source order. */
+function renderText(template) {
+  const serialize = (value) => {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.map(serialize).join("");
+    if (typeof value === "object" && value.strings && "values" in value) {
+      return value.strings
+        .map(
+          (part, index) =>
+            part + (index < value.values.length ? serialize(value.values[index]) : ""),
+        )
+        .join("");
+    }
+    return String(value);
+  };
+  return serialize(template);
+}
+
+describe("overview coverage toggle (sl-5m9x)", () => {
+  it("defaults off and exposes a reflected public property", async () => {
+    // Existing embeds must retain their current overview until a user opts in;
+    // reflection also makes the mode observable to hosts and CSS automation.
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    const options = mod.SatsumaViz.elementProperties.get("coverageOverlay");
+    assert.equal(viz.coverageOverlay, false);
+    assert.equal(options?.reflect, true);
+    assert.equal(options?.attribute, "coverage-overlay");
+  });
+
+  it("toggles from the overview toolbar without replacing layout geometry", async () => {
+    // Overlay state changes card text and paint only. Preserving the exact
+    // layout object proves the toggle does not invoke the async ELK pipeline.
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    const layout = { width: 10, height: 10, nodes: [], edges: [] };
+    viz._overviewLayout = layout;
+
+    const before = renderText(viz._renderToolbar([]));
+    assert.match(before, /data-testid="toolbar-toggle-coverage"/);
+    assert.match(before, /aria-pressed="?false/);
+
+    viz._toggleCoverageOverlay();
+
+    assert.equal(viz.coverageOverlay, true);
+    assert.equal(viz._overviewLayout, layout);
+    assert.match(renderText(viz._renderToolbar([])), /aria-pressed="?true/);
+  });
+});

--- a/tooling/satsuma-viz/test/coverage-parity.test.js
+++ b/tooling/satsuma-viz/test/coverage-parity.test.js
@@ -33,6 +33,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const WASM_PATH = resolve(__dirname, "../../tree-sitter-satsuma/tree-sitter-satsuma.wasm");
 /** Fixtures live in the CLI package because its suite asserts on them too. */
 const FIXTURES = resolve(__dirname, "../../satsuma-cli/test/fixtures");
+const VIZ_FIXTURES = resolve(__dirname, "fixtures");
 
 /** @type {typeof import("../dist/satsuma-viz.js")} */
 let viz;
@@ -88,6 +89,40 @@ function coverageOf(fixtureName, schemaId, role = "target") {
     containers: countContainerStates(entries),
   };
 }
+
+/** Aggregate overview totals from a local viz fixture's browser-built model. */
+function overviewCoverageOf(fixtureName, schemaId) {
+  const file = resolve(VIZ_FIXTURES, fixtureName);
+  const uri = `file://${file}`;
+  const tree = getParser().parse(readFileSync(file, "utf8"));
+  const index = createWorkspaceIndex();
+  indexFile(index, uri, tree);
+  const model = buildVizModel(uri, tree, index);
+  const fields = viz.buildCoverageIndex(model).get(schemaId);
+  return summarizeFieldCoverage(fields);
+}
+
+describe("coverage overlay fixture (sl-5m9x)", () => {
+  it("reports the CLI-compatible 100% and 50% aggregate figures", () => {
+    // This is the component's self-computed path: core coverage embedded by the
+    // browser-portable backend, then unioned by the overview selector. The two
+    // exact figures are the same values `satsuma coverage --json` reports.
+    assert.deepEqual(overviewCoverageOf("coverage-overlay.stm", "complete"), {
+      covered: 2,
+      coveredDeclared: 2,
+      coveredNl: 0,
+      total: 2,
+      pct: 100,
+    });
+    assert.deepEqual(overviewCoverageOf("coverage-overlay.stm", "halfway"), {
+      covered: 1,
+      coveredDeclared: 1,
+      coveredNl: 0,
+      total: 2,
+      pct: 50,
+    });
+  });
+});
 
 describe("viz coverage equals satsuma coverage (sl-5nsv)", () => {
   it("agrees leaf for leaf on a record body materialised by a fragment spread", () => {

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -452,4 +452,37 @@ describe("absent coverage stays unavailable, distinct from 0/N", () => {
       [["z", "uncovered"]],
     );
   });
+
+  it("prefers host-supplied aggregate coverage over an absent mapping result", () => {
+    // Browser and editor hosts can send core's aggregate payload separately
+    // from VizModel. That authoritative result must remain usable even when a
+    // compact model omits per-mapping coverage entirely.
+    const aggregate = {
+      schemas: [
+        {
+          schemaId: "s",
+          role: "source",
+          mappings: ["m"],
+          fields: [
+            { path: "a", uri: loc.uri, mapped: true, state: "covered", tier: "declared" },
+            { path: "b", uri: loc.uri, mapped: false, state: "uncovered" },
+          ],
+          totals: { covered: 1, coveredDeclared: 1, coveredNl: 0, total: 2, pct: 50 },
+        },
+      ],
+      namespaces: [],
+      workspace: {
+        source: { covered: 1, coveredDeclared: 1, coveredNl: 0, total: 2, pct: 50 },
+        target: { covered: 0, coveredDeclared: 0, coveredNl: 0, total: 0, pct: 0 },
+      },
+    };
+    const index = mod.buildCoverageIndex(modelWith([uncomputed()], [src]), aggregate);
+    assert.deepEqual(
+      index.get("s").map((entry) => [entry.path, entry.state]),
+      [
+        ["a", "covered"],
+        ["b", "uncovered"],
+      ],
+    );
+  });
 });

--- a/tooling/satsuma-viz/test/fixtures/coverage-overlay.stm
+++ b/tooling/satsuma-viz/test/fixtures/coverage-overlay.stm
@@ -1,0 +1,17 @@
+// Overlay fixture: target schemas with exact 100% and 50% aggregate coverage.
+schema raw { id STRING name STRING }
+schema complete { id STRING name STRING }
+schema halfway { id STRING name STRING }
+
+mapping load_complete {
+  source { raw }
+  target { complete }
+  id -> id
+  name -> name
+}
+
+mapping load_halfway {
+  source { raw }
+  target { halfway }
+  id -> id
+}

--- a/tooling/satsuma-viz/test/schema-card-coverage.test.js
+++ b/tooling/satsuma-viz/test/schema-card-coverage.test.js
@@ -99,14 +99,65 @@ function renderText(card) {
  * `null` — "not computed" — is the default, so a case that forgets to supply
  * verdicts cannot accidentally assert against zeroes.
  */
-async function makeCard(fields, coverage = null, { compact = false } = {}) {
+async function makeCard(
+  fields,
+  coverage = null,
+  { compact = false, coverageOverlay = false } = {},
+) {
   const mod = await import("../dist/satsuma-viz.js");
   const card = new mod.SzSchemaCard();
   card.schema = schemaCard(fields);
   card.coverage = coverage;
   card.compact = compact;
+  card.coverageOverlay = coverageOverlay;
   return card;
 }
+
+describe("sz-schema-card compact coverage overlay (sl-5m9x)", () => {
+  it("shows exact mapped counts and percentage with proportional header fill", async () => {
+    // A 1/2 result must expose the same 50% in text and paint width: text keeps
+    // the overlay accessible without colour, while the CSS variable changes
+    // paint only and cannot alter the card's measured geometry.
+    const card = await makeCard(
+      [leaf("mapped"), leaf("gap")],
+      entries(["mapped", "covered", "declared"], ["gap", "uncovered"]),
+      { compact: true, coverageOverlay: true },
+    );
+    const text = renderText(card);
+    assert.match(text, /header-count[^>]*>1\/2</);
+    assert.match(text, /coverage-badge[^>]*[\s\S]*50%/);
+    assert.match(text, /data-coverage-percent="?50/);
+    assert.match(text, /--sz-coverage-percent: 50%/);
+    assert.match(text, /class="coverage-fill"/);
+  });
+
+  it("renders complete coverage as exactly 100 percent", async () => {
+    // Exact completion must not be rounded from a near-complete value; core's
+    // percentage contract reserves 100 for genuinely complete coverage.
+    const card = await makeCard(
+      [leaf("a"), leaf("b")],
+      entries(["a", "covered", "declared"], ["b", "covered", "nl"]),
+      { compact: true, coverageOverlay: true },
+    );
+    const text = renderText(card);
+    assert.match(text, /header-count[^>]*>2\/2</);
+    assert.match(text, /coverage-badge[^>]*[\s\S]*100%/);
+  });
+
+  it("keeps the existing field count when the overlay is off", async () => {
+    // Off is the backward-compatible default: supplying coverage alone must
+    // not change overview card text or add the proportional fill layer.
+    const card = await makeCard(
+      [leaf("a"), leaf("b")],
+      entries(["a", "covered", "declared"], ["b", "uncovered"]),
+      { compact: true },
+    );
+    const text = renderText(card);
+    assert.match(text, /2 fields/);
+    assert.doesNotMatch(text, /coverage-badge/);
+    assert.doesNotMatch(text, /class="coverage-fill"/);
+  });
+});
 
 // The figure named in sl-hcan: one scalar beside a three-leaf record, with a
 // single leaf of that record covered.

--- a/tooling/satsuma-viz/test/theme.test.js
+++ b/tooling/satsuma-viz/test/theme.test.js
@@ -71,6 +71,15 @@ describe("theme token parity", () => {
 
     assert.deepEqual(missing, [], `Missing dark token overrides: ${missing.join(", ")}`);
   });
+
+  it("defines a coverage fill for both light and dark palettes", () => {
+    // The overlay is a first-class themed surface, not a literal colour in the
+    // card component; each palette needs an explicit contrast-tuned value.
+    const { light, dark } = getTokensByBlock();
+    assert.ok(light.has("--sz-coverage-fill"));
+    assert.ok(dark.has("--sz-coverage-fill"));
+    assert.notEqual(light.get("--sz-coverage-fill"), dark.get("--sz-coverage-fill"));
+  });
 });
 
 describe("satsuma-viz theme property", () => {


### PR DESCRIPTION
## Summary

- add the shared, CLI-compatible field-chain protocol and browser-portable viz-backend builder
- add a checked-in CLI golden plus regeneration script for traversal parity
- add the off-by-default overview coverage overlay with host aggregate input, exact percentage badges, proportional header fill, and stable geometry
- close sl-jcs6 and sl-5m9x

## Validation

- full repository pre-commit suite passed for both commits
- @satsuma/viz-model: 7 tests passed
- @satsuma/viz-backend: 190 tests passed
- @satsuma/viz: 145 tests passed
- coverage fixture verified with satsuma coverage --json at 100% and 50%
- ADR review completed; existing ADR-018, ADR-026, ADR-027, ADR-029, and ADR-042 already govern these changes