### PR TITLE
fix: remove stray gitlink at .claude/worktrees/agent-afe95143

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ site/_site/
 site/satsuma-diaries/
 site/playground/
 .worktrees/
+.claude/worktrees/
 .claude/*.local.md
 .claude/*.local.json
 .claude/settings.local.json


### PR DESCRIPTION
## Summary

A Claude Code agent's isolated worktree got accidentally staged as a gitlink (mode `160000`) back in commit `0c96d191` (Feature 26), with no `.gitmodules` entry to back it. Every CI job's `actions/checkout` post-job cleanup step has been emitting a harmless but noisy warning ever since:

```
fatal: No url found for submodule path '.claude/worktrees/agent-afe95143' in .gitmodules
```

Removes the stray gitlink and adds `.claude/worktrees/` to `.gitignore` so it can't recur.

## Test plan

- [x] `git ls-tree HEAD .claude/worktrees/` — empty
- [x] Full `scripts/run-repo-checks.sh` (pre-commit hook) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)