### PR TITLE
perf(ci): persist Turborepo's cache and cache the two longest jobs (Feature 42, R5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,17 @@ jobs:
           path: ~/.cache/tree-sitter
           key: wasi-sdk-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
+      # Turborepo's content-hash cache for the build tasks. See the note on the
+      # matching step in the `test-stats` job for why the key is namespaced per
+      # job rather than shared. This is what makes a commit that changes one
+      # package stop rebuilding the other ten.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .turbo
+          key: turbo-install-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-install-${{ runner.os }}-
+
       # One workspace-aware install, then one ordered build. Both orders used to
       # be spelled out step by step here, in a second copy of what the root
       # package.json already said (feature 42, R2 reduced that to one shell
@@ -147,23 +158,31 @@ jobs:
         working-directory: tooling/satsuma-scenario-gen
         run: npm test
 
-      # `npm run pretest` until R4 deleted that hook. What it added over
-      # test:typecheck was a build of this package and its siblings, and the
-      # `install` job — which this one `needs` — has already run one ordered
-      # build of the whole workspace and saved its output under this commit's
-      # SHA. The typecheck still needs its own step, because the c8 invocation
-      # below fires no npm script hook (sl-851u).
-      - name: Typecheck the CLI test sources
-        run: npm run test:typecheck
+      # Per-job Turborepo cache — see the note in the `test-stats` job for why the
+      # key is namespaced rather than shared.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .turbo
+          key: turbo-cli-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-cli-${{ runner.os }}-
 
+      # A named task, so nothing can bypass it the way npm's implicit `pretest`
+      # hook was bypassed by any command that was not literally `npm test`
+      # (sl-851u).
+      - name: Typecheck the CLI test sources
+        working-directory: ${{ github.workspace }}
+        run: npx turbo run test:typecheck --filter=satsuma-cli
+
+      # A Turborepo task rather than the c8 invocation this step used to spell out
+      # inline: a raw command cannot be cached, and this job was the pipeline's
+      # second-longest at 135s, almost always re-running a suite whose inputs had
+      # not changed. Its declared outputs are the coverage report and the JUnit
+      # XML, both now inside the package, so a cache hit restores everything the
+      # upload steps below look for. --filter builds its dependencies first.
       - name: Run CLI tests with coverage
-        run: |
-          mkdir -p ../../test-results
-          npx c8 --reporter=text --reporter=lcov --reporter=json-summary \
-            node --import tsx/esm --import ./test/setup.ts --test \
-            --test-reporter=spec --test-reporter-destination=stdout \
-            --test-reporter=junit --test-reporter-destination=../../test-results/cli.xml \
-            'test/**/*.test.ts'
+        working-directory: ${{ github.workspace }}
+        run: npx turbo run test:coverage --filter=satsuma-cli
 
       - name: Post coverage summary
         if: always()
@@ -183,7 +202,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-results-cli
-          path: test-results/cli.xml
+          path: tooling/satsuma-cli/test-results/cli.xml
 
       - name: Upload coverage report
         if: always()
@@ -335,12 +354,45 @@ jobs:
           restore-keys: |
             workspace-
 
-      # Default mode (no --from-logs): this job spawns each tracked package's
-      # own test command itself, rather than reading logs the pre-commit hook
-      # captured locally — CI has no local-hook cost constraint to optimize
-      # for, so it can just recompute the numbers from a clean checkout.
+      # See the matching step in the `install` job. Needed here because the
+      # `turbo run test` below builds the grammar WASM as a dependency.
+      - name: Cache wasi-sdk toolchain
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.cache/tree-sitter
+          key: wasi-sdk-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      # Turborepo's content-hash cache, namespaced to this job. A local cache is
+      # not shared between jobs (no remote cache — ADR-049), so a single repo-wide
+      # key would have every job racing to save and overwriting the others'
+      # entries. Per-job keys let this job accumulate exactly the task entries it
+      # runs and hit them on the next push; the restore-keys prefix is what
+      # carries them across commits.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .turbo
+          key: turbo-test-stats-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-test-stats-${{ runner.os }}-
+
+      # This job was the pipeline's longest at 150s, and all of it was
+      # re-execution: it spawned every tracked package's suite from scratch purely
+      # to count tests. Turborepo already captures each `test` task's output at
+      # tooling/<package>/.turbo/turbo-test.log and replays it on a cache hit, and
+      # the generator reads those logs directly — so on a commit that changes one
+      # package, only that package's suite actually runs and the rest are replayed.
+      #
+      # @satsuma/viz-harness is excluded for the same reason `test:all` excludes
+      # it: its `test` is Playwright. tree-sitter-satsuma is *not* excluded here,
+      # unlike in `test:all`, because its corpus summary is where parserCorpusTests
+      # comes from and nothing else in this job would produce it.
+      - name: Build and test the workspace
+        run: |
+          npx turbo run build compile
+          npx turbo run test --filter='!@satsuma/viz-harness'
+
       - name: Regenerate test-stats.json
-        run: node scripts/generate-test-stats.mjs
+        run: node scripts/generate-test-stats.mjs --from-logs
 
       - name: Check test-stats.json is up to date
         run: |
@@ -390,6 +442,16 @@ jobs:
         with:
           path: ~/.cache/tree-sitter
           key: wasi-sdk-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      # Per-job Turborepo cache — see the note in the `test-stats` job. This job
+      # builds seven packages through the filter below, so an unchanged
+      # dependency chain is a cache hit rather than a rebuild.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .turbo
+          key: turbo-vscode-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-vscode-${{ runner.os }}-
 
       # Four separate steps until R4 — build the grammar WASM, build the
       # extension, build satsuma-cli "(needed by LSP formatting provider)",

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 # Turborepo's local content-hash cache and per-task log files. Local only —
 # no remote cache is configured (ADR-049).
 .turbo/
+
+# JUnit XML that CI uploads as an artifact. Written inside the owning package
+# since feature 42's R5, so Turborepo can declare it as a task output — a path
+# at the repo root cannot be one, and an undeclared output means a cache hit
+# restores no XML for the upload step to find.
+test-results/
 .DS_Store
 log.html
 __pycache__/

--- a/.tickets/mbt-45v2.md
+++ b/.tickets/mbt-45v2.md
@@ -1,6 +1,6 @@
 ---
 id: mbt-45v2
-status: open
+status: closed
 deps: [mbt-npy0]
 links: []
 created: 2026-08-04T11:08:48Z
@@ -118,3 +118,59 @@ Two consequences for how this ticket is done:
    `turbo-<job>-<os>-` restore-key) lets each job accumulate exactly the task
    entries it runs and hit them on the next push. The cost is that the first run
    after this lands is no faster, and build outputs are stored once per job.
+
+**2026-08-04T19:14:15Z**
+
+Measured "after". All five acceptance criteria met; closing.
+
+**Wall clock, all like-for-like full pipelines:**
+
+| | Total | Install | Test stats | Satsuma CLI |
+|---|---|---|---|---|
+| R1 baseline | 4m35s | 1m34s | — | — |
+| post-R2/R3 | 4m37s | 58s | — | — |
+| post-R4 (main c2d447b4) | 4m18s | 61s | 150s | 135s |
+| R5 cold cache (run 30941702833) | **3m36s** | 41s | 110s | 148s |
+| R5 warm cache (run 30942106375) | **1m56s** | <=31s | 39s | 32s |
+
+**55% off the post-R4 baseline, 58% off the R1 baseline.**
+
+Cold is already 42s faster, before any cache exists: `turbo run test` parallelises
+what generate-test-stats.mjs used to spawn sequentially (150s -> 110s), and the
+install job dropped 61s -> 41s. The CLI job is the one that got *slower* cold
+(135s -> 148s), as expected — it now builds its dependency chain through
+`--filter` and pays turbo's overhead, and its win only appears warm.
+
+**Scoped-change evidence** (the criterion asking that an unaffected package's
+suite not re-run). Commit 44d0ee9b appended a comment to one @satsuma/viz source
+file and nothing else. satsuma-cli does not depend on @satsuma/viz, and its job
+reported:
+
+```
+##[group]satsuma-cli:test:coverage
+ℹ tests 1061
+ Tasks:    6 successful, 6 total
+Cached:    6 cached, 6 total
+  Time:    571ms >>> FULL TURBO
+```
+
+All 1061 tests reported from a replayed log, none executed, in 571ms against
+59.8s of real work. `satsuma-cli:test:typecheck` was likewise 6/6 cached in 89ms.
+That probe commit was reverted in the commit immediately after 44d0ee9b; it exists
+in history only as the evidence above.
+
+**All 28 checks green on both runs**, so nothing was weakened to get the number.
+
+Two things deliberately left, neither on the critical path:
+
+- The new longest job is `Satsuma-to-Excel skill` at 70s. It installs the CLI
+  globally from a packed tarball and runs pytest, so Turborepo cannot cache it —
+  a different kind of work, not a caching gap.
+- `tooling-modules` (12-36s per shard) and the LSP's coverage run inside the
+  vscode job are still raw commands. Converting them means giving each a
+  package-local output path as satsuma-cli's JUnit XML got; worth doing only when
+  one of them is the pole, which it is not.
+
+Also settled here: the `restore-keys: workspace-` fallback concern raised from
+R4's review. It stays, because it is now much less load-bearing — the jobs that
+matter verify their own inputs through turbo rather than trusting the blob.

--- a/.tickets/mbt-45v2.md
+++ b/.tickets/mbt-45v2.md
@@ -74,3 +74,47 @@ Also carried forward for measurement: R4 changed no job structure, so the expect
 before/after here is still against the 4m37s full-pipeline figure recorded above.
 R4's own run (30937118776, 28 checks green after the build:all fix) is the new
 "before" for this ticket.
+
+**2026-08-04T18:58:28Z**
+
+Measured "before" for this ticket — a main run, like-for-like with the earlier
+figures.
+
+main @ c2d447b4 (run 30940705927, immediately after R4 merged), all 28 checks
+green: **4m18s** end to end (18:53:10 -> 18:57:28). Install job 61s.
+
+Progression: R1 baseline 4m35s -> post-R2/R3 4m37s -> post-R4 4m18s. R4's ~19s
+came from deleting the vscode job's four hand-ordered build steps, not from any
+caching, which R4 did not add to CI.
+
+Where the time actually goes (per-job, from run 30940255914 on main):
+
+| Job | Duration |
+|---|---|
+| Test stats freshness | 150s |
+| Satsuma CLI | 135s |
+| Satsuma-to-Excel skill | 74s |
+| Install dependencies | 61s |
+| Smoke tests (BDD) | 48s |
+| VS Code extension | 41s |
+| Lint | 41s |
+| Tree-sitter parser | 39s |
+| everything else | <=29s |
+
+The pipeline is install (61s) then the longest downstream job, so the number to
+move is `Test stats freshness` at 150s, with `Satsuma CLI` at 135s right behind.
+Both are pure re-execution: test-stats re-runs *every* package's suite from
+scratch purely to count tests, and the CLI job re-runs a suite whose inputs
+usually have not changed.
+
+Two consequences for how this ticket is done:
+
+1. **No job graph restructuring is required** — the ticket's own instruction.
+   Both poles are fixed by making each job's work cacheable and persisting
+   `.turbo`, not by moving work between jobs.
+2. **Cache keys must be per-job.** A local cache is not shared between jobs, so a
+   single repo-wide key would have jobs racing to save and each overwriting the
+   others' entries. Namespacing on the job (`turbo-<job>-<os>-<sha>` with a
+   `turbo-<job>-<os>-` restore-key) lets each job accumulate exactly the task
+   entries it runs and hit them on the next push. The cost is that the first run
+   after this lands is no faster, and build outputs are stored once per job.

--- a/scripts/generate-test-stats.mjs
+++ b/scripts/generate-test-stats.mjs
@@ -8,9 +8,11 @@
  *
  * Two ways to gather the numbers, behind the same parsing logic:
  *   - default: spawn each package's own test command and parse its output.
- *   - `--from-logs <dir>`: read output already captured elsewhere. The
- *     pre-commit hook (scripts/run-repo-checks.sh) tees its own test run
- *     into per-package log files, so this mode adds no second test run.
+ *   - `--from-logs [dir]`: read output a caller already produced, adding no
+ *     second test run. Turborepo writes one log per `test` task it runs (and
+ *     replays it on a cache hit), which is where almost every count comes from;
+ *     the optional directory is for a caller with output of its own to
+ *     contribute, as scripts/run-repo-checks.sh has for the tree-sitter corpus.
  */
 
 import { execFileSync } from "node:child_process";
@@ -134,10 +136,33 @@ export const TRACKED_PACKAGES = [
 
 // ── Collection ──────────────────────────────────────────────────────────
 
-/** Returns a captured log's contents, or null if run-repo-checks.sh never teed that step (e.g. a package it doesn't exercise locally). */
+/**
+ * A package's already-captured test output, or null if nothing captured it.
+ *
+ * Two places are consulted, in order:
+ *
+ *   1. `<logDir>/<name>.log`, for a caller that captured the output itself.
+ *      scripts/run-repo-checks.sh uses this for the tree-sitter corpus, whose
+ *      step is bespoke: it runs `tree-sitter test --wasm` directly so it can
+ *      skip gracefully when the resolved binary lacks the wasm feature, and
+ *      that skip message is what the log has to carry.
+ *   2. `tooling/<name>/.turbo/turbo-test.log`, which Turborepo writes for every
+ *      `test` task it runs and replays on a cache hit. Since R4 this is where
+ *      almost every count comes from, and it is why neither the hook nor CI has
+ *      to run a package's suite a second time to count it.
+ *
+ * `logDir` is optional: a caller with nothing of its own to contribute passes
+ * nothing and gets Turborepo's logs alone.
+ */
 function readCapturedLogIfPresent(logDir, name) {
-  const logPath = path.join(logDir, `${name}.log`);
-  return fs.existsSync(logPath) ? fs.readFileSync(logPath, "utf8") : null;
+  const candidates = [
+    ...(logDir ? [path.join(logDir, `${name}.log`)] : []),
+    path.join(REPO_ROOT, "tooling", name, ".turbo", "turbo-test.log"),
+  ];
+  for (const logPath of candidates) {
+    if (fs.existsSync(logPath)) return fs.readFileSync(logPath, "utf8");
+  }
+  return null;
 }
 
 function runNpmScript(packageKey, npmScript) {
@@ -166,12 +191,12 @@ export function resolvePackageCountFromLog(output, previousCount, key) {
   return parseNodeTestCount(output);
 }
 
-function collectPackageCounts(fromLogsDir, previousStats) {
+function collectPackageCounts(capture, previousStats) {
   const packages = {};
   for (const { key, npmScript } of TRACKED_PACKAGES) {
-    packages[key] = fromLogsDir
+    packages[key] = capture.fromLogs
       ? resolvePackageCountFromLog(
-          readCapturedLogIfPresent(fromLogsDir, key),
+          readCapturedLogIfPresent(capture.logDir, key),
           previousStats?.packages?.[key],
           key,
         )
@@ -190,8 +215,8 @@ function collectPackageCounts(fromLogsDir, previousStats) {
  * Default (spawn) mode has no such gap — it always runs through the
  * project's own wasm-capable local binary — so it always parses for real.
  */
-function collectCorpusTestCount(fromLogsDir, previousStats) {
-  if (!fromLogsDir) {
+function collectCorpusTestCount(capture, previousStats) {
+  if (!capture.fromLogs) {
     // `npm run test`, not a bare `tree-sitter test --wasm`: the globally
     // resolved tree-sitter-cli binary may lack the wasm feature, but the
     // project's own devDependency (resolved by the npm script via
@@ -200,7 +225,7 @@ function collectCorpusTestCount(fromLogsDir, previousStats) {
     return parseCorpusTestCount(runNpmScript("tree-sitter-satsuma", "test"));
   }
 
-  const output = readCapturedLogIfPresent(fromLogsDir, "tree-sitter-satsuma");
+  const output = readCapturedLogIfPresent(capture.logDir, "tree-sitter-satsuma");
   if (output === null) {
     if (previousStats?.parserCorpusTests === undefined) {
       throw new Error(
@@ -232,16 +257,30 @@ function writeStats(stats) {
 
 // ── CLI entry point ─────────────────────────────────────────────────────
 
-function parseFromLogsArg(argv) {
+/**
+ * How this run gets its numbers.
+ *
+ * `--from-logs` selects captured mode, and its directory argument is optional:
+ * a caller that captured nothing of its own (CI, which lets Turborepo capture
+ * everything) passes the bare flag. Without the flag the run is authoritative
+ * and spawns each suite itself.
+ *
+ * The flag is deliberately explicit rather than inferred from whether Turborepo
+ * logs happen to exist. A turbo log is current for the inputs that produced it,
+ * but it survives a later source edit, so trusting one that no caller just
+ * refreshed could report a count for code that has since changed.
+ *
+ * @returns {{fromLogs: boolean, logDir: string|null}}
+ */
+function parseCaptureMode(argv) {
   const flagIndex = argv.indexOf("--from-logs");
   if (flagIndex === -1) {
-    return null;
+    return { fromLogs: false, logDir: null };
   }
-  const dir = argv[flagIndex + 1];
-  if (!dir) {
-    throw new Error("--from-logs requires a directory argument");
-  }
-  return dir;
+  const next = argv[flagIndex + 1];
+  // A following token is a directory unless it is itself a flag.
+  const logDir = next && !next.startsWith("--") ? next : null;
+  return { fromLogs: true, logDir };
 }
 
 /**
@@ -256,23 +295,23 @@ function parseFromLogsArg(argv) {
  * exactly as CI's failure message tells them to, would commit a cliCommands
  * count one short and be told by CI that their file is out of date.
  *
- * --from-logs mode does not need this: it reads output that a caller
- * (scripts/run-repo-checks.sh) already produced after its own build step.
+ * Captured mode does not need this: it reads output a caller already produced
+ * after its own build step.
  */
 function buildWorkspace() {
   execFileSync("npm", ["run", "build:all"], { cwd: REPO_ROOT, stdio: "inherit" });
 }
 
 function main() {
-  const fromLogsDir = parseFromLogsArg(process.argv.slice(2));
+  const capture = parseCaptureMode(process.argv.slice(2));
   const previousStats = readPreviousStats();
 
-  if (!fromLogsDir) {
+  if (!capture.fromLogs) {
     buildWorkspace();
   }
 
-  const packages = collectPackageCounts(fromLogsDir, previousStats);
-  const parserCorpusTests = collectCorpusTestCount(fromLogsDir, previousStats);
+  const packages = collectPackageCounts(capture, previousStats);
+  const parserCorpusTests = collectCorpusTestCount(capture, previousStats);
   const cliCommands = collectCliCommandCount();
 
   writeStats(buildStats({ cliCommands, parserCorpusTests, packages }));

--- a/scripts/run-repo-checks.sh
+++ b/scripts/run-repo-checks.sh
@@ -33,31 +33,19 @@ run_parallel() {
 
 cd "$ROOT_DIR"
 
-# The "generate test-stats.json" step at the end reads each package's test
-# output out of a check that already ran, rather than running the suites a
-# second time just to source a number. Turborepo captures that output itself,
-# one file per task at tooling/<package>/.turbo/turbo-<task>.log, and replays it
-# on a cache hit — so this directory is filled by copying those logs in under
-# the names the generator expects (see collect_turbo_test_logs below) instead of
-# by teeing every step as it runs. Removed on exit so a failed hook run never
-# leaves a stale log around to be misread by a later invocation.
+# The "generate test-stats.json" step at the end reads each package's test output
+# out of a check that already ran, rather than running the suites a second time
+# just to source a number. Almost all of it comes from Turborepo, which writes one
+# log per `test` task at tooling/<package>/.turbo/turbo-test.log and replays it on
+# a cache hit — the generator reads those itself.
+#
+# This directory carries the one count Turborepo cannot supply here: the
+# tree-sitter corpus. That step is bespoke (see below) because it has to skip
+# gracefully when the resolved tree-sitter binary lacks the wasm feature, so its
+# output — skip message or real summary — is captured here instead. Removed on
+# exit so a failed hook run never leaves a stale log to be misread later.
 STATS_LOG_DIR="$(mktemp -d)"
 trap 'rm -rf "$STATS_LOG_DIR"' EXIT
-
-# scripts/generate-test-stats.mjs --from-logs expects <dir>/<package>.log, keyed
-# on the package's directory name under tooling/. Turborepo's own per-task log
-# is already exactly the output the generator parses, so this just renames.
-# A missing log is not an error: the generator keeps the previously committed
-# count for any package this run did not exercise, which is the correct answer
-# for the packages test:all deliberately excludes.
-collect_turbo_test_logs() {
-  for log in "$ROOT_DIR"/tooling/*/.turbo/turbo-test.log; do
-    [ -f "$log" ] || continue
-    local package_dir
-    package_dir="$(basename "$(dirname "$(dirname "$log")")")"
-    cp -f "$log" "$STATS_LOG_DIR/$package_dir.log"
-  done
-}
 
 # Verify Python lint tools are available before running any checks.
 # Install with: pip install yamllint ruff
@@ -110,7 +98,6 @@ run_step "scenario generator tests" npx turbo run test --filter=@satsuma/scenari
 # parallelism (two run_parallel groups), and the typecheck steps that npm's
 # implicit `pretest` hook would otherwise have decided for us.
 run_step "workspace tests" npm run test:all
-collect_turbo_test_logs
 
 # ADR-022: CLI accepts files, not directories. Check each example entry file.
 run_step "satsuma fmt --check examples" bash -c '

--- a/tooling/satsuma-cli/package.json
+++ b/tooling/satsuma-cli/package.json
@@ -44,7 +44,7 @@
     "dev": "tsc --watch",
     "pack": "npm run build && node scripts/pack.js",
     "test": "node --import tsx/esm --import ./test/setup.ts --test 'test/**/*.test.ts'",
-    "test:coverage": "c8 --reporter=text --reporter=lcov node --import tsx/esm --import ./test/setup.ts --test 'test/**/*.test.ts'",
+    "test:coverage": "mkdir -p test-results && c8 --reporter=text --reporter=lcov --reporter=json-summary node --import tsx/esm --import ./test/setup.ts --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test-results/cli.xml 'test/**/*.test.ts'",
     "test:typecheck": "tsc --project tsconfig.test.json"
   },
   "dependencies": {

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -2766,6 +2766,3 @@ declare global {
     navigate: SzNavigateEvent;
   }
 }
-
-// Scoped-change probe for mbt-45v2. Reverted in the next commit — see that
-// commit message and the ticket note for the CI evidence it produced.

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -2766,3 +2766,6 @@ declare global {
     navigate: SzNavigateEvent;
   }
 }
+
+// Scoped-change probe for mbt-45v2. Reverted in the next commit — see that
+// commit message and the ticket note for the CI evidence it produced.

--- a/turbo.json
+++ b/turbo.json
@@ -96,9 +96,25 @@
       "dependsOn": ["build", "^build", "compile"]
     },
 
+    // ci.yml runs this rather than spelling a c8 invocation out inline, because a
+    // raw command cannot be cached and the CLI's suite was the pipeline's
+    // second-longest job at 135s — almost always re-running a suite whose inputs
+    // had not changed (feature 42, R5).
+    //
+    // `test-results/**` is here because satsuma-cli's flavour of this script also
+    // emits the JUnit XML that CI uploads. A separate `test:ci` task was tried
+    // first and rejected: two tasks in one package both claiming `coverage/**`
+    // is the same latent hazard mbt-oy6n exists for, where a cache restore
+    // silently decides which task's version of a shared directory survives. One
+    // task, one output set.
+    //
+    // Both outputs must live inside the package to be declarable at all. The
+    // JUnit file used to be written to the repo root's test-results/, which
+    // cannot be a package's output — a cache hit would have restored the coverage
+    // report and left no XML for the upload step to find.
     "test:coverage": {
       "dependsOn": ["build", "^build", "compile"],
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**", "test-results/**"]
     },
 
     // ── Package-specific overrides ───────────────────────────────────────────


### PR DESCRIPTION
Part of mbt-45v2. **Draft in spirit** — the point of this PR is a measured
before/after, and the "after" needs two runs to exist, because the first run with
a new cache key is a guaranteed miss. Numbers to follow in a comment.

## Measured first

main @ `c2d447b4` (immediately after R4), all 28 checks green: **4m18s**.
Progression: R1 baseline 4m35s → post-R2/R3 4m37s → post-R4 4m18s.

The pipeline is `install` (61s) then the longest downstream job:

| Job | Duration |
|---|---|
| **Test stats freshness** | **150s** |
| **Satsuma CLI** | **135s** |
| Satsuma-to-Excel skill | 74s |
| Install dependencies | 61s |
| Smoke tests (BDD) | 48s |
| VS Code extension | 41s |
| Lint | 41s |
| Tree-sitter parser | 39s |
| everything else | ≤29s |

Both poles are pure re-execution, so — per this ticket's own instruction — **no
job graph restructuring**. They just needed their work made cacheable.

## Test stats freshness (150s)

It spawned every tracked package's suite from scratch purely to count tests.
Turborepo already writes each `test` task's output to
`tooling/<package>/.turbo/turbo-test.log` and replays it on a cache hit, so the
job now runs `turbo run test` and the generator reads those logs. A commit
touching one package runs one suite.

That needed one change in `generate-test-stats.mjs`: `--from-logs`' directory
argument becomes optional, and a missing per-package log falls back to
Turborepo's own. The hook's bash loop that copied those logs into a temp
directory is **deleted** — it was doing by hand what the generator can now do
itself. The directory argument survives for the one count Turborepo cannot
supply locally: the tree-sitter corpus, whose step is bespoke so it can skip
gracefully when the resolved binary lacks the wasm feature.

The flag stays explicit rather than being inferred from whether turbo logs happen
to exist. A turbo log is current for the inputs that produced it, but it survives
a later source edit — trusting one no caller just refreshed could report a count
for code that has since changed.

## Satsuma CLI (135s)

It spelled its c8 invocation out inline, and a raw command cannot be cached. It's
now `turbo run test:coverage --filter=satsuma-cli`, with the JUnit XML moved
**inside the package** so it can be a declared output: a repo-root path cannot
be one, and an undeclared output means a cache hit restores the coverage report
and leaves no XML for the upload step to find.

Verified locally: **59.8s cold → 445ms on a hit**, with both `coverage/` and
`test-results/cli.xml` restored, and coverage at 92.88% (threshold 90).

A separate `test:ci` task was tried first and rejected: two tasks in one package
both claiming `coverage/**` is the same latent hazard **mbt-oy6n** exists for,
where a cache restore silently decides which task's version of a shared
directory survives. One task, one output set.

## Why the cache keys are per-job

A local cache isn't shared between jobs (no remote cache — ADR-049), so a single
repo-wide key would have every job racing to save and overwriting the others'
entries. `turbo-<job>-<os>-<sha>` with a `turbo-<job>-<os>-` restore-key lets
each job accumulate exactly the entries it runs and hit them on the next push.
Two costs, both accepted: the first run after this lands is no faster, and build
outputs are stored once per job.

Added to `install`, `test-stats`, `satsuma-cli` and `vscode-extension` — the four
jobs that run turbo. Deliberately **not** `lint`: that's a root task hashing the
whole repo (so it over-invalidates by design, see turbo.json), and a key that
almost never hits isn't worth a cache step.

## Still open in this ticket

- The scoped-change demonstration (no-op change under one package, confirm the
  others report cached in CI) — needs the cache warm, so it comes after the first
  merged run.
- `tooling-modules` matrix and the LSP's coverage run are still raw commands.
  They're 12–41s and off the critical path; converting them is only worth it once
  the two poles are gone and something else is the pole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)