### PR TITLE
docs: PRD and tickets for marketing site audit fixes

### DIFF
--- a/.tickets/saf-2re8.md
+++ b/.tickets/saf-2re8.md
@@ -1,0 +1,20 @@
+---
+id: saf-2re8
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:43Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, learn, links]
+---
+# Fix dead PROJECT-OVERVIEW.md link in site/learn.njk
+
+Links to https://github.com/EqualExperts/satsuma-lang/blob/main/PROJECT-OVERVIEW.md which 404s -- the file actually lives at docs/product-owner/PROJECT-OVERVIEW.md. See PRD Finding D.
+
+## Acceptance Criteria
+
+The link in site/learn.njk's documentation-hub Tutorials card points to blob/main/docs/product-owner/PROJECT-OVERVIEW.md and resolves (spot check against the real repo path).
+

--- a/.tickets/saf-3zn6.md
+++ b/.tickets/saf-3zn6.md
@@ -1,0 +1,20 @@
+---
+id: saf-3zn6
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:42Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, learn]
+---
+# Remove false SCD Type 2 / Kimball star schema claim from site/learn.njk
+
+The Data & ML Engineers pathway's Example Walkthroughs blurb claims the examples gallery includes 'multi-source joins, SCD Type 2, Kimball star schemas, and more' -- only the multi-source-joins part is true; grep of site/examples.njk finds zero matches for 'scd' or 'kimball'. See PRD Finding B.4.
+
+## Acceptance Criteria
+
+site/learn.njk's Example Walkthroughs blurb only names patterns that actually exist in site/examples.njk (e.g. multi-source joins, namespace/platform modelling, governance metadata, merge strategies), or the missing patterns are added as real example cards instead (out of scope for this ticket unless trivial).
+

--- a/.tickets/saf-8d61.md
+++ b/.tickets/saf-8d61.md
@@ -1,0 +1,20 @@
+---
+id: saf-8d61
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:43Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, cli]
+---
+# Update stale Transform Classification table in site/cli.njk
+
+The #classification table documents five classifications (structural, nl, mixed, none, nl-derived). tooling/satsuma-core/src/classify.ts and types.ts confirm 'structural' and 'mixed' were removed before/at Feature 28 -- Classification is now only 'nl' | 'none' | 'nl-derived'. The site documents a removed design as current behavior. See PRD Finding C.
+
+## Acceptance Criteria
+
+site/cli.njk's Transform Classification table shows only nl, none, and nl-derived, with descriptions matching tooling/satsuma-core/src/classify.ts's current behavior (presence check, not content analysis).
+

--- a/.tickets/saf-8n85.md
+++ b/.tickets/saf-8n85.md
@@ -1,0 +1,20 @@
+---
+id: saf-8n85
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:43Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, vscode]
+---
+# Reconcile 'Interactive Visualization: 3 Webview Panels' section in site/vscode.njk with real implementation
+
+tooling/vscode-satsuma has 4 webview panel implementations (viz, field-lineage, lineage, schema-lineage); 'lineage' (LineagePanel) is dead code never imported anywhere. The site's 3-webview showcase names Workspace Graph, Field-Level Lineage, and Mapping Coverage as its three -- but Mapping Coverage is gutter decorations + status bar (zero createWebviewPanel calls, confirmed by the page's own earlier Commands section calling it exactly that). The real third live webview, SchemaLineagePanel (opened by 'Show Lineage From...' / satsuma.showLineage), is never mentioned in that section. See PRD Finding F.
+
+## Acceptance Criteria
+
+site/vscode.njk's Interactive Visualization section describes the three real, live, command-reachable webviews (Workspace Graph, Field-Level Lineage, Schema Lineage) and no longer presents Mapping Coverage as a webview panel there. The dead LineagePanel code (tooling/vscode-satsuma/src/webview/lineage/) is either wired up to a command or removed -- flag as a follow-up ticket if removal is out of scope here, but at minimum the site copy must stop being wrong.
+

--- a/.tickets/saf-dmvx.md
+++ b/.tickets/saf-dmvx.md
@@ -1,0 +1,15 @@
+---
+id: saf-dmvx
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:12Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [site, docs]
+---
+# Marketing site audit fixes
+
+Fix correctness issues found by an exhaustive audit of site/ (fabricated example snippets, self-contradicting claims, stale docs, dead link, numeric drift). See features/43-site-audit-fixes/PRD.md for full findings.
+

--- a/.tickets/saf-jha9.md
+++ b/.tickets/saf-jha9.md
@@ -1,0 +1,20 @@
+---
+id: saf-jha9
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:42Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, examples]
+---
+# Fix fabricated example snippets in site/examples.njk
+
+Seven example cards show syntax/values that don't match the real examples/*.stm file they claim to summarize (beyond acceptable truncation): db-to-db (uuid_v5() call not in real file, which uses an NL string), sfdc-to-snowflake (backtick reference where real file uses @fx_spot_rates), edi-to-json (fabricated ITEMQTY field merging two distinct schema blocks), sap-po-to-mfcs (fabricated pk on EBELP, dropped required on MATNR, wrong type DECIMAL vs real NUMBER on MENGE/NETPR), merge-strategies (now_utc() with parens vs real bare now_utc), governance (metadata line-wrapping doesn't match real file or formatter output, drops a real note), multi-source-hub (drops one of two real sources, rewrites @ref text to ref-free prose). See PRD Finding A for exact line references.
+
+## Acceptance Criteria
+
+Each of the 7 named snippets is re-derived from its real source file: same functions/fields/types/constraints as the file it claims to summarize (truncation for length is fine, incorrect content is not). Re-verify by re-reading the real file alongside the new snippet HTML for each of the 7 cards.
+

--- a/.tickets/saf-lmb6.md
+++ b/.tickets/saf-lmb6.md
@@ -1,0 +1,20 @@
+---
+id: saf-lmb6
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:42Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, examples, seo]
+---
+# Fix stale example/category counts in site/examples.njk front-matter
+
+Front-matter description and og_description say 'Explore 16 canonical Satsuma examples' across 5 named categories; the rendered hero correctly says 20 examples / 6 categories (verified: 20 example-item cards, 6 distinct data-category values). The front-matter is stale from an earlier gallery size. See PRD Finding B.3.
+
+## Acceptance Criteria
+
+site/examples.njk front-matter description and og_description state 20 examples and list all 6 real categories (database migration, legacy modernization, enterprise integration, platform modelling, conventions, governance), matching the rendered hero exactly.
+

--- a/.tickets/saf-s2dw.md
+++ b/.tickets/saf-s2dw.md
@@ -1,0 +1,20 @@
+---
+id: saf-s2dw
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:42Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, vscode]
+---
+# Reconcile '8 commands' claim with rendered command cards in site/vscode.njk
+
+Stats bar and section heading both say '8 commands', but only 7 command cards render in that section (missing: Clear Mapping Coverage, a real 8th registered vscode command satsuma.clearCoverage). See PRD Finding B.2.
+
+## Acceptance Criteria
+
+The number of rendered command cards in the '8 commands at your fingertips' section equals the stated count of 8 (add the missing Clear Mapping Coverage card, or correct the stated number to match what's shown -- prefer adding the card since it's a real distinct command).
+

--- a/.tickets/saf-xzkt.md
+++ b/.tickets/saf-xzkt.md
@@ -1,0 +1,20 @@
+---
+id: saf-xzkt
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:43Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, data]
+---
+# Sync site/_data/stats.json with root test-stats.json
+
+site/_data/stats.json has drifted from the authoritative root test-stats.json: satsuma-core (689 vs 697), satsuma-cli (1049 vs 1061), satsuma-viz-model (6 vs 7), satsuma-viz-backend (186 vs 190), satsuma-viz (137 vs 145), and integration-tests (3) is missing entirely from the site's packages object. cliCommands, parserCorpusTests, satsuma-lsp, and vscode-satsuma are already correct. See PRD Finding E.
+
+## Acceptance Criteria
+
+site/_data/stats.json's packages object matches test-stats.json's packages object exactly, field for field, including adding integration-tests. Consider whether a build step should generate site/_data/stats.json from test-stats.json automatically to prevent future drift (note as a follow-up if out of scope for this ticket).
+

--- a/.tickets/saf-z30z.md
+++ b/.tickets/saf-z30z.md
@@ -1,0 +1,20 @@
+---
+id: saf-z30z
+status: open
+deps: []
+links: []
+created: 2026-08-04T20:51:42Z
+type: bug
+priority: 1
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, cli]
+---
+# Resolve self-contradicting 'coverage' command claim in site/cli.njk
+
+The Structural Primitives section lists a real 'coverage' command with --fail-under CI-gating behavior, but the Design Boundaries section on the same page claims 'There are no impact, coverage, or audit commands.' See PRD Finding B.1.
+
+## Acceptance Criteria
+
+site/cli.njk no longer states that no coverage command exists, while still accurately noting there is no impact or audit command. The page is internally consistent when read start to end.
+

--- a/features/43-site-audit-fixes/PRD.md
+++ b/features/43-site-audit-fixes/PRD.md
@@ -1,0 +1,206 @@
+# Feature 43 — Marketing Site Audit Fixes
+
+> **Status: PROPOSED** (raised 2026-08-04) — found during a full-site audit of
+> `site/` (the Eleventy-built marketing/docs site deployed at
+> `equalexperts.github.io/satsuma-lang`) requested by the project owner: an
+> exhaustive search for incorrect claims, invalid example syntax, dead links,
+> numeric drift, and content that should be removed, de-emphasized, or added.
+>
+> **State this PRD was checked against:** `main` at `db65476d`.
+>
+> **Method.** A 15-agent audit cross-checked every claim on `site/index.njk`,
+> `site/learn.njk`, `site/cli.njk`, `site/examples.njk`, and `site/vscode.njk`
+> against: the tree-sitter grammar (`tooling/tree-sitter-satsuma/grammar.js`),
+> the language spec (`docs/developer/SATSUMA-V2-SPEC.md`), the real files
+> under `examples/` that the site's illustrative snippets claim to summarize,
+> the real source of `tooling/vscode-satsuma` and `tooling/satsuma-lsp`, and
+> the repo-root `test-stats.json`. Several findings were confirmed by writing
+> minimal `.stm` repros and parsing them with the tree-sitter CLI.
+>
+> **What this feature is not.** It changes no Satsuma syntax, no grammar, and
+> no CLI/LSP/VS Code behavior. Every fix here is either a text/data correction
+> on the static site, or (for the fabricated example snippets) bringing the
+> site's illustrative code back in line with the real fixture files it claims
+> to summarize.
+
+## Goal
+
+Make every factual claim on the marketing site true, make every illustrative
+code snippet either an accurate excerpt of the real file it names or clearly
+labelled as illustrative-only, and remove or fix content that actively
+misleads a technical evaluator (self-contradicting claims, a removed feature
+still documented as current, a dead link).
+
+## Background — audit findings
+
+### A. Fabricated or incorrect example snippets (`site/examples.njk`)
+
+Several "View snippet" code blocks do not match the real `examples/*.stm`
+file they claim to summarize — beyond the acceptable truncation every card
+already does for length. These read as bugs, not simplifications, because
+they show syntax or values that are not just shortened but *wrong*:
+
+| Card | File | Problem |
+|---|---|---|
+| Legacy Customer Migration | `examples/db-to-db/pipeline.stm:106-108` | Snippet shows `uuid_v5("6ba7b810-...", CUST_ID)` as a structural function call. The real file uses an NL string instead: `"Generate UUID v5 using namespace 6ba7b810-9dad-11d1-80b4-00c04fd430c8 and CUST_ID as name"`. |
+| Salesforce to Snowflake | `examples/sfdc-to-snowflake/pipeline.stm:74` | Snippet shows an in-prose backtick reference: `` "Multiply by rate from `fx_spot_rates` using CurrencyIsoCode" ``. The real file uses an `@ref`: `"Multiply by rate from @fx_spot_rates lookup using CurrencyIsoCode"`. Per `SATSUMA-V2-SPEC.md:55` and ADR-036, `@ref` is the documented mechanism for in-string cross-references; a backtick-quoted name inside an `nl_string` is inert prose to the parser, not a real reference. |
+| EDI to JSON | `examples/edi-to-json/pipeline.stm:50-59` | Snippet shows `LineItems list_of record { ITEMQTY NUMBER(15) //! 4 implied decimal places }`. No `ITEMQTY` field exists anywhere in the file. The real `LineItems` record has `LINENUM`/`ITEMNO`/`ITEMTYPE`; the `NUMBER(15)` field with the decimal-places warning is `QUANTITY`, inside an entirely separate `Quantities` block. Two schema blocks were merged and a field renamed. |
+| SAP PO to MFCS | `examples/sap-po-to-mfcs/pipeline.stm:54-59` | Multiple fabrications in the `Items` block: adds a `pk` constraint to `EBELP` that the real schema doesn't have; drops `required` from `MATNR` (changes semantics from mandatory to optional) and rewrites its note; and uses `DECIMAL(13,3)`/`DECIMAL(11,2)` for `MENGE`/`NETPR` where the real file uses `NUMBER(13,3)`/`NUMBER(13,4)` — `DECIMAL` never appears anywhere in this example (it looks like content copied from the unrelated `xml-to-parquet` example). |
+| Merge Strategies | `examples/merge-strategies/pipeline.stm` | Snippet shows `now_utc()` with parentheses at both call sites; the real file uses the bare word `now_utc` (no parens) everywhere it appears. |
+| Governance Metadata | `examples/filter-flatten-governance/governance.stm` | Snippet packs two metadata entries per continuation line when a field's metadata wraps. Neither the real file nor the formatter's own multi-line output (`tooling/satsuma-core/src/format.ts:1334-1358`, one entry per line) does this. The snippet also drops a real `note` entry on the `email` field. |
+| Multi-Source Hub | `examples/multi-source/multi-source-hub.stm:68-76` | Snippet drops one of the mapping's two real sources (`crm_system`) and rewrites `@ref`-based NL text into ref-free prose, making a two-source join look single-source. |
+
+### B. Self-contradictions within a single page
+
+1. **`site/cli.njk`** lists a real `coverage` command in the "Structural
+   Primitives" section (with its own `--fail-under` CI-gating behavior
+   described) — then the "Design Boundaries" section on the *same page*
+   states: "There are no `impact`, `coverage`, or `audit` commands." The
+   `impact`/`audit` half of that claim is accurate; the `coverage` clause is
+   false and contradicts the page's own command reference above it.
+2. **`site/vscode.njk`** asserts "8 commands" twice (stats-bar tile and the
+   "8 commands at your fingertips" section heading), but only 7 command
+   cards are rendered in that section (missing: `clearCoverage`, which is a
+   real 8th registered command with no card of its own).
+3. **`site/examples.njk`** front-matter (`description`/`og_description`)
+   says "16 canonical examples" across 5 named categories; the page's own
+   rendered hero says "20 canonical examples" / "20 examples" / "6
+   categories." The rendered body is correct (20 example-item cards, 6
+   distinct categories) — the SEO meta text is stale from an earlier gallery
+   size.
+4. **`site/learn.njk`** (Data & ML Engineers pathway) claims "The examples
+   gallery includes real-world patterns: multi-source joins, SCD Type 2,
+   Kimball star schemas, and more," linking to `examples.html`. Neither
+   "SCD Type 2" nor "Kimball star schema" appears anywhere in
+   `site/examples.njk` (confirmed by grep) — only the multi-source-joins
+   part of that sentence is true. A reader following this link to find those
+   two named patterns will not find them.
+
+### C. Stale/removed-feature documentation
+
+**`site/cli.njk`**'s "Transform classification" table (the `#classification`
+section) documents five classifications: `structural`, `nl`, `mixed`, `none`,
+`nl-derived`. `tooling/satsuma-core/src/classify.ts` explicitly documents that
+`structural` and `mixed` "existed before Feature 28" and have been removed;
+`tooling/satsuma-core/src/types.ts:50` defines `Classification` as only
+`"nl" | "none" | "nl-derived"` — three values, not five. The site is
+describing a design that shipped and was later replaced, not the current
+behavior.
+
+### D. Broken / dead link
+
+`site/learn.njk` (the "Tutorials" documentation-hub card) links to
+`https://github.com/EqualExperts/satsuma-lang/blob/main/PROJECT-OVERVIEW.md`.
+That file does not exist at the repo root — it lives at
+`docs/product-owner/PROJECT-OVERVIEW.md`. The link 404s on GitHub.
+
+### E. Numeric drift — `site/_data/stats.json` vs. `test-stats.json`
+
+The repo-root `test-stats.json` is the authoritative source per `AGENTS.md`.
+`site/_data/stats.json` has drifted from it (`cliCommands`, `parserCorpusTests`,
+`satsuma-lsp`, and `vscode-satsuma` are still correct):
+
+| Field | site/_data/stats.json | test-stats.json (authoritative) |
+|---|---|---|
+| `packages.satsuma-core` | 689 | 697 |
+| `packages.satsuma-cli` | 1049 | 1061 |
+| `packages.satsuma-viz-model` | 6 | 7 |
+| `packages.satsuma-viz-backend` | 186 | 190 |
+| `packages.satsuma-viz` | 137 | 145 |
+| `packages.integration-tests` | *(absent)* | 3 |
+
+There is no script that regenerates `site/_data/stats.json` from
+`test-stats.json` automatically, which is why they drift every time
+package test counts change without someone remembering to update the site's
+copy by hand.
+
+### F. VS Code "3 Webview Panels" claim is right by accident
+
+`tooling/vscode-satsuma/src/webview/` has **four** panel implementations
+(`viz`, `field-lineage`, `lineage`, `schema-lineage`), not three. Of these,
+`webview/lineage/panel.ts` (`LineagePanel`, viewType `satsumaLineage`) is dead
+code — never imported by `extension.ts` or any command handler. The site's
+"Interactive Visualization" section (`site/vscode.njk` lines ~270-359)
+presents exactly three webviews as its headline "3 Webview Panels": Workspace
+Graph, Field-Level Lineage, and **Mapping Coverage**. But Mapping Coverage is
+implemented with `TextEditorDecorationType` + a status-bar item
+(`tooling/vscode-satsuma/src/commands/coverage.ts`) — it contains zero
+`createWebviewPanel` calls, and the CLI/VS Code page's own Commands section
+two subsections earlier correctly calls it "gutter markers and status bar,"
+never a webview. Meanwhile the real third live webview — `SchemaLineagePanel`
+(`webview/schema-lineage/panel.ts`), opened by the "Show Lineage From..."
+command (`satsuma.showLineage`) — is never mentioned in that section at all.
+Net effect: the showcase lists a non-webview feature as one of its three
+webviews and omits a real one.
+
+### G. Documentation-authority conflict (flagged per `AGENTS.md`'s own rule)
+
+`docs/developer/SATSUMA-V2-SPEC.md` — the file `AGENTS.md` designates as the
+*primary* authority for syntax questions — still describes the `namespace`
+block as a **future, unbuilt** feature ("**Future**: The `namespace` block
+... will scope definitions..."), even though `archive/features/15-namespaces/PRD.md`
+records it as `Status: COMPLETED (2026-03-20)` with full grammar support, and
+three site example cards (Namespace Basics, Namespace Merging, Enterprise
+Platform) showcase it working today. `AGENTS.md`'s own "Source of Truth"
+section says to "call out the mismatch explicitly" when docs conflict — this
+PRD is that callout. Fixing the spec itself is out of scope for this feature
+(it's a developer-doc gap, not a site-content bug) but is recorded here so a
+ticket can be raised against `docs/developer/SATSUMA-V2-SPEC.md` separately.
+
+## Non-goals for this feature
+
+The audit also surfaced softer editorial judgment calls that are **not**
+being turned into fix tickets here, only recorded for a maintainer decision:
+
+- **Unsubstantiated marketing numbers** ("40-60% smaller," "3-8x less token
+  usage," ">90% LLM-generates-valid-Satsuma" — the last one is lifted from
+  `docs/product-owner/PROJECT-OVERVIEW.md`'s *future target* success metrics,
+  not a measured result) repeated multiple times across `site/index.njk`.
+- **The "Diaries" top-level nav item** (a whimsical in-joke changelog
+  written by a fictional AI intern) sitting alongside Home/CLI/VS Code/
+  Examples/Learn, which may undercut credibility with the enterprise/data
+  engineering audience the rest of the site targets.
+- **Redundant pitch repetition** of the same 2-3 value props across the
+  homepage feature cards, homepage role cards, and nearly all of
+  `learn.njk`'s role sections.
+- **Missing content opportunities**: `satsuma-lsp` as a standalone
+  editor-agnostic server is never mentioned (only framed as a VS Code
+  dependency); the footer's "MIT License" text isn't a link to `LICENSE`;
+  no dedicated tool-comparison page (PROJECT-OVERVIEW.md already has a
+  considered comparison table); no public roadmap page derived from
+  `docs/product-owner/ROADMAP.md`; `satsuma-viz-model`/`satsuma-viz-backend`
+  (the shared engine behind both the VS Code webviews and the browser
+  playground) are never explained to a visitor; `satsuma.config.yaml`
+  (lint suppression, type aliases, strict mode) is undocumented on the CLI
+  page despite being real and documented in `SATSUMA-CLI.md`.
+
+These are intentionally left for the project owner to triage into a future
+feature rather than bundled into this correctness-focused pass.
+
+## Acceptance criteria
+
+- [ ] Every example snippet identified in Finding A renders syntax and
+      values that are a verbatim (whitespace/truncation aside) subset of its
+      real named source file — no invented functions, fields, types, or
+      constraints.
+- [ ] The `coverage` self-contradiction on `site/cli.njk` is resolved (the
+      Design Boundaries text no longer claims no `coverage` command exists).
+- [ ] `site/vscode.njk`'s "8 commands" claim and its rendered command-card
+      count agree (either add the missing card or correct the stated count).
+- [ ] `site/examples.njk`'s front-matter `description`/`og_description`
+      state the same example/category counts as the rendered hero.
+- [ ] `site/learn.njk` no longer promises example patterns (SCD Type 2,
+      Kimball star schema) that are not present in the examples gallery.
+- [ ] `site/cli.njk`'s Transform Classification table shows only the three
+      classifications the code actually emits (`nl`, `none`, `nl-derived`).
+- [ ] The dead `PROJECT-OVERVIEW.md` link in `site/learn.njk` points to its
+      real path.
+- [ ] `site/_data/stats.json` matches `test-stats.json` exactly, including
+      the previously-missing `integration-tests` entry.
+- [ ] `site/vscode.njk`'s "Interactive Visualization" section accurately
+      describes the three live, command-reachable webviews (Workspace
+      Graph, Field-Level Lineage, Schema Lineage) and no longer presents
+      Mapping Coverage as a webview panel; OR the stats-bar "3 Webview
+      Panels" / section framing is otherwise reconciled with reality.
+- [ ] The site builds and renders correctly after all changes (spot-check
+      with the Eleventy dev server).


### PR DESCRIPTION
## Summary

Adds `features/43-site-audit-fixes/PRD.md` and 9 tracked tickets capturing
findings from an exhaustive audit of `site/` (the marketing/docs site)
requested by the project owner: an agent-driven check of every claim on the
site against the actual grammar, the real example fixture files, the real
CLI/LSP/VS Code source, and `test-stats.json`.

No code changes in this PR — this is the PRD-first step per `AGENTS.md`
before the fix tickets are picked up.

**Highlights of what was found** (full detail in the PRD):
- 7 example snippets on `examples.njk` show syntax/values that don't match
  the real `examples/*.stm` file they claim to summarize (fabricated fields,
  wrong types, dropped constraints — not just truncation).
- `cli.njk` claims "there are no coverage commands" in one section while
  documenting a real `coverage` command with its own `--fail-under` flag in
  another section on the same page.
- `vscode.njk` states "8 commands" twice but only renders 7 command cards.
- `cli.njk`'s Transform Classification table documents `structural`/`mixed`
  classifications that were removed from the codebase before Feature 28.
- A dead link to `PROJECT-OVERVIEW.md` (real path is under `docs/product-owner/`).
- `site/_data/stats.json` has drifted from the authoritative root
  `test-stats.json` across 5 package test counts, and is missing the
  `integration-tests` package entirely.
- The VS Code page's "3 Webview Panels" showcase names a non-webview feature
  (Mapping Coverage) as one of the three and omits a real live webview
  (Schema Lineage).

## Tickets

Epic: `saf-dmvx` — Marketing site audit fixes

| Ticket | Title |
|---|---|
| `saf-jha9` | Fix fabricated example snippets in site/examples.njk |
| `saf-z30z` | Resolve self-contradicting 'coverage' command claim in site/cli.njk |
| `saf-s2dw` | Reconcile '8 commands' claim with rendered command cards in site/vscode.njk |
| `saf-lmb6` | Fix stale example/category counts in site/examples.njk front-matter |
| `saf-3zn6` | Remove false SCD Type 2 / Kimball star schema claim from site/learn.njk |
| `saf-8d61` | Update stale Transform Classification table in site/cli.njk |
| `saf-2re8` | Fix dead PROJECT-OVERVIEW.md link in site/learn.njk |
| `saf-xzkt` | Sync site/_data/stats.json with root test-stats.json |
| `saf-8n85` | Reconcile 'Interactive Visualization: 3 Webview Panels' section in site/vscode.njk |

Softer editorial findings (unsubstantiated marketing numbers, the "Diaries"
nav item, redundant pitch copy, missing content like a standalone-LSP
callout or a roadmap page) are recorded in the PRD's "Non-goals" section for
a maintainer to triage separately — not turned into tickets here.

## Test plan

- [x] `scripts/run-repo-checks.sh` (pre-commit hook) passed locally, including markdownlint on the new PRD.
- [ ] Maintainer reviews ticket scope/priority before work on `saf-*` tickets begins.