### PR TITLE
fix+redesign(site): audit fixes, real Kimball example, CLI/VS Code redesign

### DIFF
--- a/.tickets/saf-2re8.md
+++ b/.tickets/saf-2re8.md
@@ -1,6 +1,6 @@
 ---
 id: saf-2re8
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:43Z
@@ -18,3 +18,17 @@ Links to https://github.com/EqualExperts/satsuma-lang/blob/main/PROJECT-OVERVIEW
 
 The link in site/learn.njk's documentation-hub Tutorials card points to blob/main/docs/product-owner/PROJECT-OVERVIEW.md and resolves (spot check against the real repo path).
 
+
+## Notes
+
+**2026-08-04T21:14:17Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: site/learn.njk's Tutorials documentation-hub card linked to
+blob/main/PROJECT-OVERVIEW.md, which doesn't exist at the repo root -- the
+file lives at docs/product-owner/PROJECT-OVERVIEW.md.
+Fix: corrected the link target to the real path
+(commit immediately after 9a44adff).

--- a/.tickets/saf-3zn6.md
+++ b/.tickets/saf-3zn6.md
@@ -1,6 +1,6 @@
 ---
 id: saf-3zn6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:42Z
@@ -18,3 +18,29 @@ The Data & ML Engineers pathway's Example Walkthroughs blurb claims the examples
 
 site/learn.njk's Example Walkthroughs blurb only names patterns that actually exist in site/examples.njk (e.g. multi-source joins, namespace/platform modelling, governance metadata, merge strategies), or the missing patterns are added as real example cards instead (out of scope for this ticket unless trivial).
 
+
+## Notes
+
+**2026-08-04T21:14:17Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: learn.njk's Data & ML Engineers "Example Walkthroughs" blurb claimed
+the examples gallery includes SCD Type 2 and Kimball star schema patterns,
+but no such card existed in site/examples.njk -- the real content lived
+only in the separate docs/data-modelling/kimball/ directory (a full,
+well-written RetailCo Kimball model including a genuine SCD Type 2
+dim_customer.stm), never surfaced in the gallery itself. On review with the
+project owner, decided this warranted adding a real example rather than
+just softening the sentence, since the underlying content already exists
+and is high quality.
+Fix: added a "Kimball Star Schema (SCD Type 2)" card to the examples
+gallery (convention category) built from the real dim-customer.stm
+(dimension/scd 2/track/ignore metadata convention + a representative
+mapping), linking out to the full docs/data-modelling/kimball/ guide for
+the complete star schema. Updated the learn.njk sentence to accurately
+name what's in the gallery (multi-source joins, Kimball SCD Type 2, Data
+Vault hubs/satellites -- the last already existed in the "Enterprise
+Platform" card) (commit immediately after 9a44adff).

--- a/.tickets/saf-6eid.md
+++ b/.tickets/saf-6eid.md
@@ -1,0 +1,51 @@
+---
+id: saf-6eid
+status: closed
+deps: []
+links: []
+created: 2026-08-04T21:25:27Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, vscode, redesign]
+---
+# Redesign vscode.njk around user workflows, not LSP internals
+
+Replace the 'Core LSP Features' feature-inventory grid and the internals-flavoured stats bar with workflow-oriented sections (review without reading raw syntax, catch mistakes before a PR, see the whole workspace, trace a field, know what's mapped, navigate a big spec like code). This also resolves saf-8n85: the redesigned Interactive Visualization section will correctly describe the 3 real live webviews (Workspace Graph, Field-Level Lineage, Schema Lineage) instead of miscounting Mapping Coverage as one of them.
+
+## Acceptance Criteria
+
+vscode.njk no longer has a flat feature-capability grid; content is organized by user workflow. The visualization section names only real webviews. Screenshot gaps are flagged in the PR description for the project owner to fill.
+
+
+## Notes
+
+**2026-08-04T21:32:47Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: the page described the LSP as an internals inventory (Syntax
+Highlighting / Diagnostics / Navigation / IntelliSense / Document Structure /
+Format Document / CodeLens feature cards, plus a stats bar counting raw LSP
+capabilities and webview panels) rather than explaining what a user actually
+gets from installing it. On review with the project owner, decided this
+needed a structural rewrite, not a fact-fix: reorganise around workflows
+(read a mapping without knowing the grammar, catch mistakes before a PR, see
+the workspace then drill into a mapping, trace a schema's or a field's
+lineage, know what's mapped) so the extension's value is legible to a
+non-technical reviewer, not just an internals list for engineers.
+Fix: replaced the "Core LSP Features" / "Interactive Webviews" sections with
+workflow-oriented content; correctly names the 3 real live webviews
+(Workspace Graph + Mapping Detail as one panel, Field-Level Lineage, Schema
+Lineage via "Show Lineage From...") instead of miscounting Mapping Coverage
+(gutter markers, not a webview) as one of three -- this also resolves the
+webview-count discrepancy saf-8n85 tracked. Put a previously-unused
+screenshot (vscode-src-example.webp, showing CodeLens + syntax highlighting
++ Find References) to use for the first time. Flagged 4 further screenshot
+opportunities to the project owner (diagnostics/squiggles in action, the
+Field-Level Lineage webview, the Schema Lineage webview, and Mapping
+Coverage gutter markers + status bar) for a follow-up pass
+(commit immediately after 1518bacf).

--- a/.tickets/saf-8d61.md
+++ b/.tickets/saf-8d61.md
@@ -1,6 +1,6 @@
 ---
 id: saf-8d61
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:43Z
@@ -18,3 +18,20 @@ The #classification table documents five classifications (structural, nl, mixed,
 
 site/cli.njk's Transform Classification table shows only nl, none, and nl-derived, with descriptions matching tooling/satsuma-core/src/classify.ts's current behavior (presence check, not content analysis).
 
+
+## Notes
+
+**2026-08-04T21:14:17Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: the "Transform classification" table on site/cli.njk documented
+five classifications (structural, nl, mixed, none, nl-derived) when the
+codebase only emits three (nl, none, nl-derived) -- structural/mixed were
+removed before Feature 28. On review with the project owner, decided this
+detail is low-value CLI-internals content not worth keeping accurate on a
+marketing page, rather than worth fixing in place.
+Fix: removed the section entirely instead of correcting it
+(commit immediately after 9a44adff).

--- a/.tickets/saf-8n85.md
+++ b/.tickets/saf-8n85.md
@@ -1,6 +1,6 @@
 ---
 id: saf-8n85
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:43Z
@@ -18,3 +18,9 @@ tooling/vscode-satsuma has 4 webview panel implementations (viz, field-lineage, 
 
 site/vscode.njk's Interactive Visualization section describes the three real, live, command-reachable webviews (Workspace Graph, Field-Level Lineage, Schema Lineage) and no longer presents Mapping Coverage as a webview panel there. The dead LineagePanel code (tooling/vscode-satsuma/src/webview/lineage/) is either wired up to a command or removed -- flag as a follow-up ticket if removal is out of scope here, but at minimum the site copy must stop being wrong.
 
+
+## Notes
+
+**2026-08-04T21:25:27Z**
+
+Superseded by saf-vscode-redesign (see child ticket added under saf-dmvx): rather than patch the existing internals-listing copy to be merely accurate, the project owner asked for the whole VS Code page to be redesigned around user workflows. The webview miscount this ticket tracked is resolved as part of that redesign.

--- a/.tickets/saf-dmvx.md
+++ b/.tickets/saf-dmvx.md
@@ -1,6 +1,6 @@
 ---
 id: saf-dmvx
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:12Z
@@ -13,3 +13,26 @@ tags: [site, docs]
 
 Fix correctness issues found by an exhaustive audit of site/ (fabricated example snippets, self-contradicting claims, stale docs, dead link, numeric drift). See features/43-site-audit-fixes/PRD.md for full findings.
 
+
+## Notes
+
+**2026-08-04T21:33:51Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: exhaustive audit of site/ found fabricated example snippets, two
+self-contradicting claims, a stale internals table, a dead link, stats
+drift, an undersold real Kimball/SCD example, and internals-flavoured
+CLI/VS Code pages the project owner asked to be redesigned around
+workflows rather than feature inventories.
+Fix: all 11 child tickets closed across 4 commits on feat/site-audit-fixes
+(PR #485): fabricated snippets corrected against real fixtures, both
+self-contradictions resolved, low-value classification table removed
+outright, dead link fixed, stats.json synced, a real Kimball SCD-2 example
+added to the gallery, and both cli.njk and vscode.njk restructured around
+user/agent workflows instead of internals listings. Left open per the
+project owner: a UK-English copy pass and the "Diaries" nav placement
+question, neither scoped into this epic (commit immediately after
+9693dec1).

--- a/.tickets/saf-jha9.md
+++ b/.tickets/saf-jha9.md
@@ -1,6 +1,6 @@
 ---
 id: saf-jha9
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:42Z
@@ -18,3 +18,24 @@ Seven example cards show syntax/values that don't match the real examples/*.stm 
 
 Each of the 7 named snippets is re-derived from its real source file: same functions/fields/types/constraints as the file it claims to summarize (truncation for length is fine, incorrect content is not). Re-verify by re-reading the real file alongside the new snippet HTML for each of the 7 cards.
 
+
+## Notes
+
+**2026-08-04T21:01:39Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: 7 example cards on site/examples.njk showed hand-authored illustrative
+snippets that had drifted from the real examples/*.stm files they claim to
+summarize -- not just truncated for length, but fabricated (uuid_v5() call,
+a merged/renamed EDI field, an invented pk and wrong NUMBER->DECIMAL type on
+SAP fields) or using unsupported reference styles (backtick reference instead
+of @ref; now_utc() with parens the real file never uses; dropped/rewritten
+sources and NL text).
+Fix: re-derived all 7 snippets (db-to-db, sfdc-to-snowflake, edi-to-json,
+sap-po-to-mfcs, merge-strategies, governance, multi-source-hub) directly from
+their real source files so every field, type, constraint, and NL string shown
+is a verbatim (whitespace/truncation aside) subset of the actual fixture
+(commit immediately after e9fae41a).

--- a/.tickets/saf-lmb6.md
+++ b/.tickets/saf-lmb6.md
@@ -1,6 +1,6 @@
 ---
 id: saf-lmb6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:42Z
@@ -18,3 +18,19 @@ Front-matter description and og_description say 'Explore 16 canonical Satsuma ex
 
 site/examples.njk front-matter description and og_description state 20 examples and list all 6 real categories (database migration, legacy modernization, enterprise integration, platform modelling, conventions, governance), matching the rendered hero exactly.
 
+
+## Notes
+
+**2026-08-04T21:14:17Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: front-matter description/og_description said "16 canonical examples"
+across 5 categories while the rendered hero said 20/6; a Kimball SCD-2 card
+was added in this same pass (saf-3zn6), so the true count moved to 21.
+Fix: front-matter now states 21 examples across all 6 real categories
+(database migration, legacy modernisation, enterprise integration, platform
+modelling, conventions, governance), matching the hero and stat badge
+(commit immediately after 9a44adff).

--- a/.tickets/saf-s2dw.md
+++ b/.tickets/saf-s2dw.md
@@ -1,6 +1,6 @@
 ---
 id: saf-s2dw
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:42Z
@@ -18,3 +18,18 @@ Stats bar and section heading both say '8 commands', but only 7 command cards re
 
 The number of rendered command cards in the '8 commands at your fingertips' section equals the stated count of 8 (add the missing Clear Mapping Coverage card, or correct the stated number to match what's shown -- prefer adding the card since it's a real distinct command).
 
+
+## Notes
+
+**2026-08-04T21:01:39Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: site/vscode.njk stated "8 commands" (stats tile and section heading)
+but only 7 command cards were rendered in that section -- the real 8th
+registered command, satsuma.clearCoverage, had no card of its own (it was
+only mentioned in prose on the Show Mapping Coverage card).
+Fix: added a "Clear Mapping Coverage" card so the rendered count matches the
+stated count of 8 (commit immediately after e9fae41a).

--- a/.tickets/saf-s5q4.md
+++ b/.tickets/saf-s5q4.md
@@ -1,0 +1,42 @@
+---
+id: saf-s5q4
+status: closed
+deps: []
+links: []
+created: 2026-08-04T21:25:27Z
+type: task
+priority: 2
+assignee: Thorben Louw
+parent: saf-dmvx
+tags: [site, cli, redesign]
+---
+# Redesign cli.njk: agent-first, token-efficient framing; drop exhaustive command grid
+
+Reposition the CLI as a deterministic, token-efficient tool for agents (with fmt/validate/lint as the human daily-driver subset), and remove the 'All 23 commands' categorized card grid in favour of a short pointer to satsuma --help / SATSUMA-CLI.md for the exhaustive reference. This isn't meant to be an exhaustive docsite.
+
+## Acceptance Criteria
+
+cli.njk keeps the agent-workflow narratives (lineage, NL extraction, metadata/codegen, whole-workspace reasoning) and the day-to-day human commands section, but no longer lists every subcommand in a card grid. A compact callout links to satsuma --help output / SATSUMA-CLI.md instead.
+
+
+## Notes
+
+**2026-08-04T21:32:47Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: the "All 23 commands" section listed every subcommand in a
+categorized card grid, duplicating SATSUMA-CLI.md as an exhaustive reference
+on a marketing page -- the project owner called this out as not the point
+of the page and asked for an agent-first, token-efficient framing instead,
+pointing curious readers at `satsuma --help` / SATSUMA-CLI.md rather than
+listing everything in place.
+Fix: tightened the hero to explain token efficiency qualitatively (small
+deterministic JSON slices vs. loading whole files, no invented benchmark
+numbers) and that most commands exist for the agent, not the human. Replaced
+the exhaustive command grid with a compact "that's the shape of it" callout:
+one paragraph naming the command families, a styled `satsuma --help`
+terminal snippet, and a link to the full GitHub reference
+(commit immediately after 1518bacf).

--- a/.tickets/saf-xzkt.md
+++ b/.tickets/saf-xzkt.md
@@ -1,6 +1,6 @@
 ---
 id: saf-xzkt
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:43Z
@@ -18,3 +18,19 @@ site/_data/stats.json has drifted from the authoritative root test-stats.json: s
 
 site/_data/stats.json's packages object matches test-stats.json's packages object exactly, field for field, including adding integration-tests. Consider whether a build step should generate site/_data/stats.json from test-stats.json automatically to prevent future drift (note as a follow-up if out of scope for this ticket).
 
+
+## Notes
+
+**2026-08-04T21:14:17Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: site/_data/stats.json had drifted from the authoritative root
+test-stats.json across 5 package test counts and was missing the
+integration-tests package entirely.
+Fix: overwrote site/_data/stats.json's packages object to match
+test-stats.json exactly. No script yet regenerates this automatically --
+noted as a good follow-up (not scoped here) to stop future drift
+(commit immediately after 9a44adff).

--- a/.tickets/saf-z30z.md
+++ b/.tickets/saf-z30z.md
@@ -1,6 +1,6 @@
 ---
 id: saf-z30z
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-04T20:51:42Z
@@ -18,3 +18,21 @@ The Structural Primitives section lists a real 'coverage' command with --fail-un
 
 site/cli.njk no longer states that no coverage command exists, while still accurately noting there is no impact or audit command. The page is internally consistent when read start to end.
 
+
+## Notes
+
+**2026-08-04T21:01:39Z**
+
+## Notes
+
+**2026-08-04T00:00:00Z**
+
+Cause: site/cli.njk's Design Boundaries section claimed "There are no impact,
+coverage, or audit commands," while the Structural Primitives section on the
+same page documents a real coverage command with its own --fail-under flag --
+a direct self-contradiction.
+Fix: removed coverage from the "does not exist" list and added a clause
+clarifying that coverage is a real primitive (reports one schema's
+mapped/unmapped fields) that doesn't itself compose into impact analysis or
+an audit, which is still true and is why those two remain absent
+(commit immediately after e9fae41a).

--- a/site/_data/stats.json
+++ b/site/_data/stats.json
@@ -2,12 +2,13 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 689,
-    "satsuma-cli": 1049,
+    "satsuma-core": 697,
+    "satsuma-cli": 1061,
     "satsuma-lsp": 300,
-    "satsuma-viz-model": 6,
-    "satsuma-viz-backend": 186,
-    "satsuma-viz": 137,
+    "satsuma-viz-model": 7,
+    "satsuma-viz-backend": 190,
+    "satsuma-viz": 145,
+    "integration-tests": 3,
     "vscode-satsuma": 46
   }
 }

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -828,7 +828,7 @@ permalink: cli.html
             </div>
             <div>
               <h4 class="font-semibold text-charcoal mb-1">Does not compose analysis workflows</h4>
-              <p class="text-sm text-warm-gray">There are no <code class="font-mono text-xs">impact</code>, <code class="font-mono text-xs">coverage</code>, or <code class="font-mono text-xs">audit</code> commands. These are agent workflows built from primitives.</p>
+              <p class="text-sm text-warm-gray">There are no <code class="font-mono text-xs">impact</code> or <code class="font-mono text-xs">audit</code> commands. These are agent workflows built from primitives &mdash; including <code class="font-mono text-xs">coverage</code>, which reports one schema's mapped/unmapped fields but doesn't itself trace impact or run an audit.</p>
             </div>
           </div>
           <div class="flex items-start gap-4 p-4 bg-cream rounded-xl">

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -20,10 +20,10 @@ permalink: cli.html
             The agent's <span class="text-orange">toolkit</span> for Satsuma
           </h1>
           <p class="text-lg text-warm-gray leading-relaxed mb-4">
-            The Satsuma CLI is built for AI agents. {{ stats.cliCommands }} parser-backed commands let your agent slice workspaces, trace lineage, extract metadata, and pull NL intent &mdash; all from the parse tree, with 100% deterministic results.
+            The Satsuma CLI exists mainly so an AI agent doesn't have to load a whole workspace into its context window and guess. It answers precise structural questions &mdash; one field's lineage, every PII tag, the fields still unmapped &mdash; with small, deterministic JSON slices instead of raw files, so your agent spends its tokens reasoning, not re-parsing.
           </p>
           <p class="text-warm-gray leading-relaxed mb-4">
-            Humans use it too &mdash; <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">validate</code>, <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">fmt</code>, and <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">lint</code> are your day-to-day workflow commands. But the CLI's real power is as the structural backbone your agent reasons on top of.
+            Humans use it too &mdash; <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">validate</code>, <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">fmt</code>, and <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">lint</code> are your day-to-day workflow commands. But most of the {{ stats.cliCommands }} commands exist for the agent, not for you.
           </p>
           <p class="text-warm-gray leading-relaxed mb-8">
             <strong>The CLI extracts facts. The agent interprets them.</strong> It also powers the VS Code extension's diagnostics, lineage views, and code intelligence.
@@ -583,177 +583,44 @@ permalink: cli.html
     </div>
   </section>
 
-  <!-- Command Reference -->
+  <!-- Full Reference Pointer -->
   <section id="command-reference" class="py-16 lg:py-24">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="text-center mb-12 reveal">
-        <h2 class="text-3xl font-bold text-charcoal mb-3">All {{ stats.cliCommands }} commands</h2>
-        <p class="text-warm-gray max-w-2xl mx-auto">Complete reference for every command in the CLI. See the <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-CLI.md" target="_blank" class="text-orange hover:underline">full reference on GitHub</a> for detailed usage and examples.</p>
-      </div>
-
-      <!-- Workspace Extractors -->
-      <div class="mb-12">
-        <div class="mb-6 reveal">
-          <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-2">
-            Workspace Extractors
-          </div>
-          <p class="text-sm text-warm-gray">Block-level extraction &mdash; retrieve whole blocks or workspace-level summaries.</p>
+      <div class="grid lg:grid-cols-2 gap-12 items-center reveal">
+        <div>
+          <h2 class="text-3xl font-bold text-charcoal mb-3">That's the shape of it &mdash; not the whole list</h2>
+          <p class="text-warm-gray mb-4">
+            This page shows you how an agent strings commands together, not a catalogue of all {{ stats.cliCommands }}. They fall into a few families &mdash; block extractors like <code class="font-mono text-xs bg-code-bg px-1 rounded">summary</code> and <code class="font-mono text-xs bg-code-bg px-1 rounded">schema</code>, fine-grained primitives like <code class="font-mono text-xs bg-code-bg px-1 rounded">arrows</code> and <code class="font-mono text-xs bg-code-bg px-1 rounded">meta</code>, the one-shot <code class="font-mono text-xs bg-code-bg px-1 rounded">graph</code> export, and the human-facing analysis trio above &mdash; but the fastest way to get the exhaustive, always-current list is to ask the CLI itself.
+          </p>
+          <p class="text-warm-gray">
+            <code class="font-mono text-sm text-orange-dark bg-orange/10 px-1.5 py-0.5 rounded">satsuma agent-reference</code> gives your agent this same list with usage patterns baked in, so it rarely needs <code class="font-mono text-xs bg-code-bg px-1 rounded">--help</code> at all.
+          </p>
         </div>
+        <div class="terminal shadow-xl text-xs">
+          <div class="terminal-header">
+            <div class="terminal-dot red"></div>
+            <div class="terminal-dot yellow"></div>
+            <div class="terminal-dot green"></div>
+            <span class="text-xs text-gray-400 ml-2 font-mono">satsuma --help</span>
+          </div>
+          <pre>
+<span class="prompt">$</span> satsuma <span class="flag">--help</span>
 
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">summary</h4>
-            <p class="text-xs text-warm-gray">Workspace overview &mdash; schemas, mappings, metrics, and counts.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">schema</h4>
-            <p class="text-xs text-warm-gray">Full schema definition from the parse tree.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">metric</h4>
-            <p class="text-xs text-warm-gray">Full definition of a schema decorated with <code>metric</code> metadata — grain, slice, filter, and measure fields.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">mapping</h4>
-            <p class="text-xs text-warm-gray">Full mapping with all arrows and transforms.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">find --tag</h4>
-            <p class="text-xs text-warm-gray">Find all fields carrying a metadata tag (pii, encrypt, etc.).</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">lineage</h4>
-            <p class="text-xs text-warm-gray">Schema-level graph traversal, forward or backward.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">field-lineage</h4>
-            <p class="text-xs text-warm-gray">Full upstream and downstream lineage of a single field.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">where-used</h4>
-            <p class="text-xs text-warm-gray">All references to a schema, fragment, or transform.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">warnings</h4>
-            <p class="text-xs text-warm-gray">All <code class="font-mono text-xs">//!</code> and <code class="font-mono text-xs">//? </code> comments across the workspace.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">context</h4>
-            <p class="text-xs text-warm-gray">Keyword-ranked block extraction (heuristic fuzzy search).</p>
-          </div>
+<span class="output">satsuma &lt;command&gt; [options]</span>
+
+<span class="highlight">Workspace extractors</span>    <span class="output">summary, schema, mapping, metric, lineage, ...</span>
+<span class="highlight">Structural primitives</span>  <span class="output">arrows, nl, meta, fields, coverage, ...</span>
+<span class="highlight">Graph export</span>           <span class="output">graph --json | --compact | --schema-only</span>
+<span class="highlight">Analysis</span>               <span class="output">fmt, validate, lint, diff</span>
+<span class="highlight">Agent setup</span>            <span class="output">agent-reference</span>
+
+<span class="output"># {{ stats.cliCommands }} commands total — run --help on any of them for full usage</span></pre>
         </div>
       </div>
-
-      <!-- Structural Primitives -->
-      <div class="mb-12">
-        <div class="mb-6 reveal">
-          <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-green/10 text-green-dark text-sm font-medium rounded-full mb-2">
-            Structural Primitives
-          </div>
-          <p class="text-sm text-warm-gray">Fine-grained extraction &mdash; slice below block level for arrows, NL, metadata, and fields.</p>
-        </div>
-
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">arrows</h4>
-            <p class="text-xs text-warm-gray">All arrows for a field, with transform classification.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">nl</h4>
-            <p class="text-xs text-warm-gray">NL content &mdash; notes, transforms, comments &mdash; extracted verbatim.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">nl-refs</h4>
-            <p class="text-xs text-warm-gray">All <code class="font-mono text-xs">@ref</code> references inside NL transform bodies.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">meta</h4>
-            <p class="text-xs text-warm-gray">Metadata entries &mdash; tags, constraints, annotations.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">fields</h4>
-            <p class="text-xs text-warm-gray">Field list with types. Supports <code class="font-mono text-xs">--unmapped-by</code>.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">coverage</h4>
-            <p class="text-xs text-warm-gray">How much of each schema a mapping touches, counted in leaf fields. Gate CI with <code class="font-mono text-xs">--fail-under</code>.</p>
-          </div>
-          <div class="bg-cream rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">match-fields</h4>
-            <p class="text-xs text-warm-gray">Normalized name comparison between source and target schemas.</p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Graph -->
-      <div class="mb-12">
-        <div class="mb-6 reveal">
-          <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-charcoal/10 text-charcoal text-sm font-medium rounded-full mb-2">
-            Workspace Graph
-          </div>
-          <p class="text-sm text-warm-gray">Full semantic graph export in a single call.</p>
-        </div>
-
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">graph --json</h4>
-            <p class="text-xs text-warm-gray">Complete graph with nodes, edges, and field-level data flow.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">graph --compact</h4>
-            <p class="text-xs text-warm-gray">Schema-level adjacency list (minimal payload).</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">graph --schema-only</h4>
-            <p class="text-xs text-warm-gray">Topology only, omit field-level edges.</p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Analysis -->
-      <div class="mb-12">
-        <div class="mb-6 reveal">
-          <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-orange/10 text-orange-dark text-sm font-medium rounded-full mb-2">
-            Analysis
-          </div>
-          <p class="text-sm text-warm-gray">Formatting, validation, linting, and structural comparison.</p>
-        </div>
-
-        <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-4 reveal">
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">fmt</h4>
-            <p class="text-xs text-warm-gray">Opinionated, zero-config formatter. <code class="font-mono text-xs">--check</code> for CI.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">validate</h4>
-            <p class="text-xs text-warm-gray">Parse errors and semantic reference checks.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">lint</h4>
-            <p class="text-xs text-warm-gray">Policy checks with <code class="font-mono text-xs">--fix</code> autofix.</p>
-          </div>
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">diff</h4>
-            <p class="text-xs text-warm-gray">Structural comparison of two workspace snapshots.</p>
-          </div>
-        </div>
-      </div>
-
-      <!-- Agent Setup -->
-      <div>
-        <div class="mb-6 reveal">
-          <div class="inline-flex items-center gap-2 px-3 py-1.5 bg-charcoal/10 text-charcoal text-sm font-medium rounded-full mb-2">
-            Agent Setup
-          </div>
-          <p class="text-sm text-warm-gray">Bootstrap your AI agent.</p>
-        </div>
-
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
-          <div class="bg-white rounded-xl p-4 border border-charcoal/5">
-            <h4 class="font-bold text-charcoal mb-1 font-mono text-sm">agent-reference</h4>
-            <p class="text-xs text-warm-gray">Print the AI Agent Reference for embedding in agent instructions.</p>
-          </div>
-        </div>
+      <div class="mt-8 text-center reveal">
+        <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/SATSUMA-CLI.md" target="_blank" rel="noopener" class="text-orange font-semibold hover:underline">
+          Full command reference with usage and examples on GitHub &rarr;
+        </a>
       </div>
     </div>
   </section>

--- a/site/cli.njk
+++ b/site/cli.njk
@@ -538,55 +538,6 @@ permalink: cli.html
     </div>
   </section>
 
-  <!-- Transform Classification -->
-  <section id="classification" class="py-16 lg:py-24">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="max-w-3xl mx-auto reveal">
-        <h2 class="text-3xl font-bold text-charcoal mb-3">Transform classification</h2>
-        <p class="text-warm-gray mb-8">Every arrow the CLI returns carries a classification derived from CST node types. This tells the agent whether it needs to interpret the transform or can trust the syntax.</p>
-
-        <div class="bg-white rounded-2xl border border-charcoal/5 overflow-hidden">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-charcoal/5 bg-peach/50">
-                <th class="text-left px-6 py-3 font-semibold text-charcoal">Classification</th>
-                <th class="text-left px-6 py-3 font-semibold text-charcoal">Meaning</th>
-                <th class="text-left px-6 py-3 font-semibold text-charcoal">Agent action</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr class="border-b border-charcoal/5">
-                <td class="px-6 py-3"><code class="font-mono text-sm text-green-dark bg-green/10 px-2 py-0.5 rounded">structural</code></td>
-                <td class="px-6 py-3 text-warm-gray">Deterministic pipeline</td>
-                <td class="px-6 py-3 text-warm-gray">None &mdash; fully specified</td>
-              </tr>
-              <tr class="border-b border-charcoal/5">
-                <td class="px-6 py-3"><code class="font-mono text-sm text-orange-dark bg-orange/10 px-2 py-0.5 rounded">nl</code></td>
-                <td class="px-6 py-3 text-warm-gray">Natural-language string</td>
-                <td class="px-6 py-3 text-warm-gray">Read and interpret intent</td>
-              </tr>
-              <tr class="border-b border-charcoal/5">
-                <td class="px-6 py-3"><code class="font-mono text-sm text-charcoal bg-charcoal/10 px-2 py-0.5 rounded">mixed</code></td>
-                <td class="px-6 py-3 text-warm-gray">Pipeline steps + NL strings</td>
-                <td class="px-6 py-3 text-warm-gray">Review the NL portion</td>
-              </tr>
-              <tr class="border-b border-charcoal/5">
-                <td class="px-6 py-3"><code class="font-mono text-sm text-warm-gray bg-charcoal/5 px-2 py-0.5 rounded">none</code></td>
-                <td class="px-6 py-3 text-warm-gray">Bare <code class="font-mono text-xs">src -&gt; tgt</code></td>
-                <td class="px-6 py-3 text-warm-gray">None</td>
-              </tr>
-              <tr>
-                <td class="px-6 py-3"><code class="font-mono text-sm text-purple-700 bg-purple-50 px-2 py-0.5 rounded">nl-derived</code></td>
-                <td class="px-6 py-3 text-warm-gray">Implicit from <code class="font-mono text-xs">@ref</code></td>
-                <td class="px-6 py-3 text-warm-gray">Verify referenced field exists</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <!-- Installation -->
   <section id="install" class="py-16 lg:py-24 bg-white">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 reveal">

--- a/site/examples.njk
+++ b/site/examples.njk
@@ -1,9 +1,9 @@
 ---
 layout: default.njk
 title: "Examples — Satsuma"
-description: "Explore 16 canonical Satsuma examples covering database migration, legacy modernization, enterprise integration, platform modelling, and governance."
+description: "Explore 21 canonical Satsuma examples covering database migration, legacy modernisation, enterprise integration, platform modelling, conventions, and governance."
 og_title: "Examples — Satsuma"
-og_description: "Explore 16 canonical Satsuma examples covering database migration, legacy modernization, enterprise integration, platform modelling, and governance."
+og_description: "Explore 21 canonical Satsuma examples covering database migration, legacy modernisation, enterprise integration, platform modelling, conventions, and governance."
 nav_id: examples
 permalink: examples.html
 ---
@@ -16,12 +16,12 @@ permalink: examples.html
           <span class="text-transparent bg-clip-text bg-gradient-to-r from-orange to-orange-dark">Gallery</span>
         </h1>
         <p class="text-lg text-warm-gray leading-relaxed max-w-2xl mx-auto mb-8">
-          20 canonical examples covering real-world data mapping scenarios. From legacy mainframe migrations to modern platform architectures, each example is a complete, parser-validated <code class="font-mono text-sm bg-white/60 px-1.5 py-0.5 rounded">.stm</code> file you can use as a starting point.
+          21 canonical examples covering real-world data mapping scenarios. From legacy mainframe migrations to modern platform architectures, each example is a complete, parser-validated <code class="font-mono text-sm bg-white/60 px-1.5 py-0.5 rounded">.stm</code> file you can use as a starting point.
         </p>
         <div class="flex items-center justify-center gap-6 text-sm text-warm-gray">
           <span class="flex items-center gap-2">
             <svg class="w-4 h-4 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
-            20 examples
+            21 examples
           </span>
           <span class="flex items-center gap-2">
             <svg class="w-4 h-4 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A2 2 0 013 12V7a4 4 0 014-4z"/></svg>
@@ -902,6 +902,60 @@ permalink: examples.html
   avg_order_value        <span class="type">DECIMAL(10,2)</span>
   days_since_last_order  <span class="type">INTEGER</span>
   churn_probability      <span class="type">DECIMAL(5,4)</span>
+}</code></pre>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- kimball-star-schema.stm -->
+        <div class="example-item reveal" data-category="convention">
+          <div class="border border-charcoal/10 rounded-xl overflow-hidden hover:border-orange-light/50 transition-colors bg-cream/50">
+            <div class="p-6">
+              <div class="flex items-start justify-between mb-3">
+                <h3 class="text-lg font-bold text-charcoal">Kimball Star Schema (SCD Type 2)</h3>
+                <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/data-modelling/kimball/dim-customer.stm" target="_blank" rel="noopener"
+                   class="text-warm-gray hover:text-orange transition-colors flex-shrink-0 ml-3" title="View full file on GitHub">
+                  <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+                </a>
+              </div>
+              <p class="text-sm text-warm-gray mb-4">A conformed customer dimension fed by two source systems, using the free-form <code class="font-mono text-xs bg-white/60 px-1 py-0.5 rounded">dimension</code> / <code class="font-mono text-xs bg-white/60 px-1 py-0.5 rounded">scd 2</code> / <code class="font-mono text-xs bg-white/60 px-1 py-0.5 rounded">track</code> metadata convention that tells an LLM which fields to version on change. Part of a full RetailCo Kimball model &mdash; see the <a href="https://github.com/EqualExperts/satsuma-lang/tree/main/docs/data-modelling/kimball" target="_blank" rel="noopener" class="text-orange hover:underline">Kimball Dimensional Modelling</a> guide for the complete star schema (facts, other dimensions, and the LLM interpretation rules).</p>
+              <div class="flex flex-wrap gap-2 mb-4">
+                <span class="px-2.5 py-0.5 text-xs font-medium rounded-full bg-peach text-orange-dark">Kimball</span>
+                <span class="px-2.5 py-0.5 text-xs font-medium rounded-full bg-peach text-orange-dark">SCD Type 2</span>
+                <span class="px-2.5 py-0.5 text-xs font-medium rounded-full bg-peach text-orange-dark">conformed dimension</span>
+              </div>
+              <button class="example-toggle inline-flex items-center gap-1.5 text-sm font-medium text-orange hover:text-orange-dark transition-colors">
+                View snippet
+                <svg class="w-4 h-4 arrow transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+              </button>
+            </div>
+            <div class="example-content">
+              <div class="code-block rounded-none border-x-0 border-b-0">
+                <pre class="text-sm"><code class="stm"><span class="keyword">schema</span> <span class="field">dim_customer</span> (
+  <span class="annotation">dimension</span>,
+  <span class="annotation">conformed</span>,
+  <span class="annotation">scd</span> 2,
+  <span class="annotation">natural_key</span> customer_id,
+  <span class="annotation">track</span> {email, phone, loyalty_tier, preferred_store_id, first_name, last_name},
+  <span class="annotation">ignore</span> {last_login_channel, lifetime_order_count, lifetime_spend}
+) {
+  customer_id   <span class="type">VARCHAR(50)</span>   (<span class="constraint">required</span>)  <span class="comment">// Durable business key: SFDC ContactId</span>
+  first_name    <span class="type">VARCHAR(100)</span>
+  last_name     <span class="type">VARCHAR(100)</span>
+  email         <span class="type">VARCHAR(255)</span>  (<span class="constraint">pii</span>)
+  loyalty_tier  <span class="type">VARCHAR(20)</span>   (<span class="constraint">enum {bronze, silver, gold, platinum, diamond}</span>)
+  customer_segment <span class="type">VARCHAR(30)</span>
+}
+
+<span class="keyword">mapping</span> <span class="string">`sfdc to dim_customer`</span> {
+  <span class="keyword">source</span> { <span class="field">`loyalty_sfdc`</span> }
+  <span class="keyword">target</span> { <span class="field">`dim_customer`</span> }
+
+  ContactId <span class="operator">-></span> customer_id
+  FirstName <span class="operator">-></span> first_name { <span class="function">trim</span> | <span class="function">title_case</span> }
+  Email <span class="operator">-></span> email { <span class="function">trim</span> | <span class="function">lowercase</span> | <span class="function">validate_email</span> | <span class="function">null_if_invalid</span> }
+  LoyaltyTier <span class="operator">-></span> loyalty_tier { <span class="function">lowercase</span> }
 }</code></pre>
               </div>
             </div>

--- a/site/examples.njk
+++ b/site/examples.njk
@@ -86,7 +86,9 @@ permalink: examples.html
   <span class="keyword">source</span> { <span class="field">`legacy_sqlserver`</span> }
   <span class="keyword">target</span> { <span class="field">`postgres_db`</span> }
 
-  CUST_ID <span class="operator">-></span> customer_id { <span class="function">uuid_v5</span>(<span class="string">"6ba7b810-..."</span>, CUST_ID) }
+  CUST_ID <span class="operator">-></span> customer_id {
+    <span class="note-text">"Generate UUID v5 using namespace 6ba7b810-9dad-11d1-80b4-00c04fd430c8 and CUST_ID as name"</span>
+  }
   CUST_ID <span class="operator">-></span> legacy_customer_id
 
   CUST_TYPE <span class="operator">-></span> customer_type {
@@ -140,8 +142,8 @@ permalink: examples.html
   Name <span class="operator">-></span> opportunity_name
 
   Amount <span class="operator">-></span> amount_usd {
-    <span class="string">"Multiply by rate from `fx_spot_rates` using CurrencyIsoCode"</span>
-    | <span class="function">round</span>(2)
+    <span class="note-text">"Multiply by rate from <span class="at-ref">@fx_spot_rates</span> lookup using CurrencyIsoCode"</span>
+    | <span class="function">round</span> 2
   }
 
   StageName <span class="operator">-></span> pipeline_stage {
@@ -295,7 +297,13 @@ permalink: examples.html
   }
 
   LineItems <span class="keyword">list_of record</span> {
-    ITEMQTY   <span class="type">NUMBER(15)</span>       <span class="warning">//! 4 implied decimal places</span>
+    LINENUM   <span class="type">NUMBER(6)</span>
+    ITEMNO    <span class="type">CHAR(35)</span>         <span class="comment">// product identifier</span>
+  }
+
+  Quantities <span class="keyword">list_of record</span> (<span class="constraint">filter QUANTQUAL == <span class="string">"12"</span></span>) {
+    QUANTQUAL <span class="type">CHAR(3)</span>
+    QUANTITY  <span class="type">NUMBER(15)</span>       <span class="warning">//! 4 implied decimal places</span>
   }
 }</code></pre>
               </div>
@@ -386,11 +394,11 @@ permalink: examples.html
   WAERS    <span class="type">STRING(3)</span>   (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Document currency"</span></span>)
 
   Items <span class="keyword">list_of record</span> {
-    EBELP    <span class="type">STRING(5)</span>   (<span class="constraint">pk</span>, <span class="constraint">required</span>, <span class="constraint">note <span class="string">"Item number"</span></span>)
-    MATNR    <span class="type">STRING(18)</span>  (<span class="constraint">note <span class="string">"Material number"</span></span>)
-    MENGE    <span class="type">DECIMAL(13,3)</span> (<span class="constraint">required</span>)
-    NETPR    <span class="type">DECIMAL(11,2)</span> (<span class="constraint">note <span class="string">"Net price"</span></span>)
-    MEINS    <span class="type">STRING(3)</span>   (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Unit of measure"</span></span>)
+    EBELP    <span class="type">STRING(5)</span>   (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"PO line number"</span></span>)
+    MATNR    <span class="type">STRING(18)</span>  (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"SAP material number"</span></span>)
+    MENGE    <span class="type">NUMBER(13,3)</span> (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Ordered quantity"</span></span>)
+    NETPR    <span class="type">NUMBER(13,4)</span> (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Net price"</span></span>)
+    MEINS    <span class="type">STRING(3)</span>   (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Base unit of measure"</span></span>)
     WERKS    <span class="type">STRING(4)</span>   (<span class="constraint">required</span>, <span class="constraint">note <span class="string">"Plant"</span></span>)
   }
 }</code></pre>
@@ -424,21 +432,24 @@ permalink: examples.html
             <div class="example-content">
               <div class="code-block rounded-none border-x-0 border-b-0">
                 <pre class="text-sm"><code class="stm"><span class="keyword">mapping</span> <span class="string">`payments to analytics`</span> {
-  <span class="keyword">source</span> { <span class="field">`payment_gateway`</span> }
+  <span class="keyword">source</span> {
+    <span class="field">`payment_gateway`</span>,
+    <span class="field">`crm_system`</span>
+  }
   <span class="keyword">target</span> { <span class="field">`analytics_db`</span> }
 
   amount <span class="operator">-></span> total_spent {
-    <span class="string">"Sum all transactions where status = 'completed',
-     grouped by customer_email.
-     Join to crm_system on email to resolve customer_id."</span>
+    <span class="note-text">"Sum all transactions where <span class="at-ref">@status</span> = completed,
+     grouped by <span class="at-ref">@customer_email</span>.
+     Join to <span class="at-ref">@crm_system</span> on <span class="at-ref">@email</span> to resolve <span class="at-ref">@customer_id</span>."</span>
   }
 
   <span class="operator">-></span> transaction_count {
-    <span class="string">"Count transactions where status = 'completed', per customer."</span>
+    <span class="note-text">"Count transactions where <span class="at-ref">@status</span> = completed, per customer."</span>
   }
 
   <span class="operator">-></span> last_transaction_date {
-    <span class="string">"Max transaction timestamp where status = 'completed',
+    <span class="note-text">"Max transaction timestamp where <span class="at-ref">@status</span> = completed,
      per customer."</span>
   }
 }</code></pre>
@@ -726,7 +737,7 @@ permalink: examples.html
   customer_id <span class="operator">-></span> customer_id
   full_name   <span class="operator">-></span> full_name   { <span class="function">trim</span> | <span class="function">title_case</span> }
   email       <span class="operator">-></span> email       { <span class="function">trim</span> | <span class="function">lowercase</span> }
-  <span class="operator">-></span> updated_at  { <span class="function">now_utc</span>() }
+  <span class="operator">-></span> updated_at  { <span class="function">now_utc</span> }
 }
 
 <span class="keyword">mapping</span> <span class="string">`purchase events`</span> (<span class="annotation">merge</span> append) {
@@ -737,7 +748,7 @@ permalink: examples.html
   customer_id      <span class="operator">-></span> customer_id
   sku              <span class="operator">-></span> sku
   quantity         <span class="operator">-></span> quantity
-  <span class="operator">-></span> ingested_at { <span class="function">now_utc</span>() }
+  <span class="operator">-></span> ingested_at { <span class="function">now_utc</span> }
 }</code></pre>
               </div>
             </div>
@@ -776,12 +787,21 @@ permalink: examples.html
   <span class="annotation">retention</span> <span class="string">"7y"</span>
 ) {
   customer_id  <span class="type">UUID</span>         (<span class="constraint">pk</span>, <span class="constraint">required</span>)
-  email        <span class="type">STRING(255)</span>  (<span class="constraint">pii</span>, <span class="annotation">classification</span> <span class="string">"RESTRICTED"</span>,
-    <span class="annotation">encrypt</span> AES-256-GCM, <span class="annotation">mask</span> partial_email,
-    <span class="annotation">retention</span> <span class="string">"3y"</span>)
+  email        <span class="type">STRING(255)</span> (
+    <span class="constraint">pii</span>,
+    <span class="annotation">classification</span> <span class="string">"RESTRICTED"</span>,
+    <span class="annotation">encrypt</span> AES-256-GCM,
+    <span class="annotation">mask</span> partial_email,
+    <span class="annotation">retention</span> <span class="string">"3y"</span>,
+    <span class="constraint">note</span> <span class="string">"Email has a 3-year retention override per GDPR Art. 17 right-to-erasure."</span>
+  )
   first_name   <span class="type">STRING(100)</span>  (<span class="constraint">pii</span>, <span class="annotation">classification</span> <span class="string">"CONFIDENTIAL"</span>, <span class="annotation">mask</span> redact)
-  phone        <span class="type">STRING(20)</span>   (<span class="constraint">pii</span>, <span class="annotation">classification</span> <span class="string">"RESTRICTED"</span>,
-    <span class="annotation">encrypt</span> AES-256-GCM, <span class="annotation">mask</span> last_four)
+  phone        <span class="type">STRING(20)</span> (
+    <span class="constraint">pii</span>,
+    <span class="annotation">classification</span> <span class="string">"RESTRICTED"</span>,
+    <span class="annotation">encrypt</span> AES-256-GCM,
+    <span class="annotation">mask</span> last_four
+  )
 }</code></pre>
               </div>
             </div>

--- a/site/learn.njk
+++ b/site/learn.njk
@@ -213,7 +213,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
                 <svg class="w-4 h-4 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>
                 Example Walkthroughs
               </h4>
-              <p class="text-sm text-warm-gray mb-3">The examples gallery includes real-world patterns: multi-source joins, SCD Type 2, Kimball star schemas, and more.</p>
+              <p class="text-sm text-warm-gray mb-3">The examples gallery includes real-world patterns: multi-source joins, a Kimball SCD Type 2 dimension, Data Vault hubs and satellites, and more.</p>
               <a href="examples.html" class="inline-flex items-center gap-2 text-green font-semibold text-sm hover:underline">
                 Browse examples &rarr;
               </a>
@@ -611,7 +611,7 @@ code --install-extension vscode-satsuma-{{ site.version_tag }}.vsix</code></pre>
               </a>
             </li>
             <li>
-              <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/PROJECT-OVERVIEW.md" target="_blank" rel="noopener"
+              <a href="https://github.com/EqualExperts/satsuma-lang/blob/main/docs/product-owner/PROJECT-OVERVIEW.md" target="_blank" rel="noopener"
                  class="flex items-center gap-2 text-sm text-warm-gray hover:text-orange transition-colors group">
                 <svg class="w-4 h-4 text-orange/60 group-hover:text-orange flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
                 Project Overview &amp; Roadmap

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -23,7 +23,7 @@ permalink: vscode.html
           <span class="text-transparent bg-clip-text bg-gradient-to-r from-green to-green-dark">Extension</span>
         </h1>
         <p class="text-lg text-warm-gray leading-relaxed mb-8 max-w-xl">
-          Full language support for Satsuma: syntax highlighting, an LSP server with navigation and completions, real-time diagnostics, and interactive workspace visualization. All parser-backed.
+          Turns a plain-text <code class="font-mono text-base bg-code-bg px-1.5 py-0.5 rounded">.stm</code> file into something your whole team can work with directly: reviewable like a document, navigable like code, and visual wherever a diagram says more than an arrow &mdash; without giving up the Git-friendly plain text that makes Satsuma worth using in the first place.
         </p>
         <div class="flex flex-wrap gap-4">
           <a href="https://github.com/EqualExperts/satsuma-lang/releases/tag/{{ site.version_tag }}" target="_blank" rel="noopener"
@@ -48,7 +48,7 @@ permalink: vscode.html
   <!-- Stats Bar -->
   <section class="py-8 bg-white border-b border-charcoal/5">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-6 text-center">
+      <div class="grid grid-cols-3 gap-6 text-center">
         <div class="stat-item">
           <div class="text-2xl font-bold text-green">{{ stats.packages['satsuma-lsp'] }}</div>
           <div class="text-sm text-warm-gray">LSP Tests</div>
@@ -58,129 +58,144 @@ permalink: vscode.html
           <div class="text-sm text-warm-gray">Commands</div>
         </div>
         <div class="stat-item">
-          <div class="text-2xl font-bold text-green">11</div>
-          <div class="text-sm text-warm-gray">LSP Capabilities</div>
-        </div>
-        <div class="stat-item">
           <div class="text-2xl font-bold text-green">3</div>
-          <div class="text-sm text-warm-gray">Webview Panels</div>
+          <div class="text-sm text-warm-gray">Visual Views</div>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Core LSP Features -->
+  <!-- What Changes -->
   <section class="py-20 lg:py-28">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16 reveal">
-        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Full LSP, zero compromise</h2>
-        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Every feature is backed by the tree-sitter parser. No regex heuristics, no guesswork &mdash; deterministic, correct results as you type.</p>
+        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Everything a spreadsheet review used to need a screen-share for</h2>
+        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Satsuma files are plain text by design &mdash; version them, diff them, review them in a pull request. The extension is what makes that plain text feel as approachable as a spreadsheet, and considerably more powerful.</p>
       </div>
 
-      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6 reveal">
-
-        <!-- Syntax Highlighting -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/></svg>
-          </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">Syntax Highlighting</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">TextMate grammar for immediate highlighting of all Satsuma constructs &mdash; keywords, types, metadata, strings, comments, and operators.</p>
-          <p class="text-warm-gray text-sm leading-relaxed">Semantic tokens from the LSP override TextMate scopes for context-sensitive constructs: <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">source</code>/<code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">target</code> as keyword vs. field name, vocabulary tokens, and more.</p>
-        </div>
-
-        <!-- Diagnostics -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
-          </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">Real-time Diagnostics</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Parse errors</strong> &mdash; red squiggles as you type, powered by tree-sitter ERROR and MISSING nodes.</p>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Semantic warnings</strong> &mdash; yellow squiggles on save via <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">satsuma validate</code>: undefined schemas, duplicate names, broken imports.</p>
-          <p class="text-warm-gray text-sm leading-relaxed"><strong class="text-charcoal">Marker comments</strong> &mdash; <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">//!</code> warnings and <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">//?</code> questions surface in the Problems panel.</p>
-        </div>
-
-        <!-- Navigation -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
-          </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">Navigation</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Go-to-Definition</strong> (Ctrl+Click / F12) &mdash; jump to schema definitions, fragment blocks, imported definitions, and import file paths.</p>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Find References</strong> (Shift+F12) &mdash; locate all usages of a schema, fragment, or transform across the workspace.</p>
-          <p class="text-warm-gray text-sm leading-relaxed"><strong class="text-charcoal">Rename Symbol</strong> (F2) &mdash; rename across all files with duplicate detection. Handles namespace-qualified references.</p>
-        </div>
-
-        <!-- IntelliSense -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
-          </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">IntelliSense</h3>
-          <p class="text-warm-gray text-sm leading-relaxed">Context-aware completions for every position:</p>
-          <ul class="mt-2 space-y-1.5 text-sm text-warm-gray">
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Schema names in <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">source</code> / <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">target</code> blocks</li>
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Fragment and transform names after <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">...</code></li>
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Field names from source/target schemas in arrow paths</li>
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Metadata tokens: <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">pk</code>, <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">pii</code>, <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">scd</code>, <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">required</code>, etc.</li>
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Pipeline functions: <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">trim</code>, <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">lowercase</code>, <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">coalesce</code>, etc.</li>
-            <li class="flex items-start gap-2"><span class="text-orange mt-0.5">&#x2022;</span> Block names in <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">import { }</code> declarations</li>
+      <!-- Read it like a document -->
+      <div class="grid lg:grid-cols-2 gap-8 items-center mb-20 reveal">
+        <div>
+          <h3 class="text-2xl font-bold text-charcoal mb-3">Read it like a document, not a grammar</h3>
+          <p class="text-warm-gray mb-4">Syntax highlighting, hover tooltips, and an outline panel turn a mapping into something a product owner can scan without knowing the syntax. Inline CodeLens goes further &mdash; usage counts appear right above each block, so "is this field used anywhere?" is answered before you've clicked a thing.</p>
+          <ul class="space-y-2 text-sm text-warm-gray">
+            <li class="flex items-start gap-2">
+              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+              <span>CodeLens above every block: field counts, "used in N mappings," spread counts</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+              <span>Go-to-Definition and Find References (Ctrl+Click, Shift+F12) &mdash; jump straight to where something is defined or used</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+              <span>Rename Symbol (F2) across every file, with duplicate detection</span>
+            </li>
+            <li class="flex items-start gap-2">
+              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
+              <span>Format on save &mdash; one canonical style, same formatter as <code class="font-mono text-xs bg-code-bg px-1 rounded">satsuma fmt</code></span>
+            </li>
           </ul>
         </div>
-
-        <!-- Document Structure -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+        <div class="rounded-2xl overflow-hidden shadow-xl border border-charcoal/10">
+          <div class="bg-charcoal/5 px-5 py-3 flex items-center gap-2 border-b border-charcoal/10">
+            <span class="w-3 h-3 rounded-full bg-red-400/60"></span>
+            <span class="w-3 h-3 rounded-full bg-yellow-400/60"></span>
+            <span class="w-3 h-3 rounded-full bg-green/60"></span>
+            <span class="ml-3 text-xs text-warm-gray font-mono">CodeLens usage counts, a PII hint, and Find All References</span>
           </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">Document Structure</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Outline Panel</strong> &mdash; schemas, mappings, fragments, transforms, metrics, namespaces, and notes with nested fields.</p>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Breadcrumbs</strong> &mdash; automatic navigation breadcrumbs from document symbols.</p>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3"><strong class="text-charcoal">Code Folding</strong> &mdash; fold any block type: schema, mapping, fragment, transform, metric, note, namespace, each, flatten, map literal, metadata, nested arrow.</p>
-          <p class="text-warm-gray text-sm leading-relaxed"><strong class="text-charcoal">Hover</strong> &mdash; contextual info for blocks, fields, tags, spreads, arrow paths, and pipeline functions.</p>
+          <img
+            src="img/vscode-src-example.webp"
+            alt="Satsuma VS Code extension showing syntax highlighting, CodeLens usage counts above a schema, a PII hint, and a Find All References panel"
+            class="w-full h-auto block"
+            width="1200"
+            height="893"
+            loading="lazy"
+          >
         </div>
+      </div>
 
-        <!-- Format Document -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16"/></svg>
-          </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">Format Document</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">Opinionated, zero-config formatting. One canonical style for all Satsuma files &mdash; field column alignment, consistent spacing, normalised blank lines.</p>
-          <p class="text-warm-gray text-sm leading-relaxed">Trigger with <kbd class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded border border-charcoal/10">Shift+Alt+F</kbd> or enable format-on-save. Same formatter as <code class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded">satsuma fmt</code> in the CLI.</p>
+      <!-- See the whole workspace -->
+      <div class="mb-20 reveal">
+        <div class="max-w-3xl mx-auto text-center mb-8">
+          <h3 class="text-2xl font-bold text-charcoal mb-3">See the whole workspace, then drill into any mapping</h3>
+          <p class="text-warm-gray">The Workspace Graph lays out every schema, mapping, metric, and fragment as an interactive SVG &mdash; click any node to jump to its definition, filter by namespace, and it auto-refreshes on save. Click into a mapping and it opens the Mapping Detail view: source and target schemas side by side, with every field-level arrow and transform between them.</p>
         </div>
-
-        <!-- CodeLens -->
-        <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
-          <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">
-            <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+        <div class="space-y-8">
+          <div class="rounded-2xl overflow-hidden shadow-xl border border-charcoal/10">
+            <div class="bg-charcoal/5 px-5 py-3 flex items-center gap-2 border-b border-charcoal/10">
+              <span class="w-3 h-3 rounded-full bg-red-400/60"></span>
+              <span class="w-3 h-3 rounded-full bg-yellow-400/60"></span>
+              <span class="w-3 h-3 rounded-full bg-green/60"></span>
+              <span class="ml-3 text-xs text-warm-gray font-mono">Workspace Overview — schemas, mappings, and data flow at a glance</span>
+            </div>
+            <img
+              src="img/vscode-extension-overview.webp"
+              alt="Satsuma VS Code extension workspace overview showing schema nodes connected by mapping arrows with namespace grouping"
+              class="w-full h-auto block"
+              width="1400"
+              height="598"
+              loading="lazy"
+            >
           </div>
-          <h3 class="text-lg font-bold text-charcoal mb-2">CodeLens</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-3">Inline annotations above every block, giving you at-a-glance structural insight:</p>
-          <div class="space-y-2 text-sm">
-            <div class="flex items-center gap-2">
-              <code class="font-mono text-xs bg-code-bg px-2 py-1 rounded text-charcoal">schema</code>
-              <span class="text-warm-gray">N fields | used in M mappings</span>
+
+          <div class="rounded-2xl overflow-hidden shadow-xl border border-charcoal/10">
+            <div class="bg-charcoal/5 px-5 py-3 flex items-center gap-2 border-b border-charcoal/10">
+              <span class="w-3 h-3 rounded-full bg-red-400/60"></span>
+              <span class="w-3 h-3 rounded-full bg-yellow-400/60"></span>
+              <span class="w-3 h-3 rounded-full bg-green/60"></span>
+              <span class="ml-3 text-xs text-warm-gray font-mono">Mapping Detail — field-level arrows between source and target schemas</span>
             </div>
-            <div class="flex items-center gap-2">
-              <code class="font-mono text-xs bg-code-bg px-2 py-1 rounded text-charcoal">mapping</code>
-              <span class="text-warm-gray">source &rarr; target | N arrows</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <code class="font-mono text-xs bg-code-bg px-2 py-1 rounded text-charcoal">fragment</code>
-              <span class="text-warm-gray">spread in N places</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <code class="font-mono text-xs bg-code-bg px-2 py-1 rounded text-charcoal">transform</code>
-              <span class="text-warm-gray">used in N places</span>
-            </div>
-            <div class="flex items-center gap-2">
-              <code class="font-mono text-xs bg-code-bg px-2 py-1 rounded text-charcoal">metric</code>
-              <span class="text-warm-gray">sources: schema1, schema2</span>
-            </div>
+            <img
+              src="img/vscode-mapping-view-extension.webp"
+              alt="Satsuma VS Code extension mapping detail view showing source and target schema cards with field-level arrow connections"
+              class="w-full h-auto block"
+              width="1400"
+              height="603"
+              loading="lazy"
+            >
           </div>
         </div>
+      </div>
 
+      <!-- Remaining workflows: no screenshot yet -->
+      <div class="reveal">
+        <h3 class="text-2xl font-bold text-charcoal mb-8 text-center">And when you need to check something specific</h3>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+
+          <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
+            <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">
+              <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+            </div>
+            <h4 class="text-base font-bold text-charcoal mb-2">Catch mistakes before they reach a PR</h4>
+            <p class="text-warm-gray text-sm leading-relaxed">Red squiggles for parse errors as you type; yellow squiggles on save for undefined schemas, duplicate names, and broken imports. <code class="font-mono text-xs bg-code-bg px-1 rounded">//!</code> and <code class="font-mono text-xs bg-code-bg px-1 rounded">//?</code> marker comments surface in the Problems panel too.</p>
+          </div>
+
+          <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
+            <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
+              <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>
+            </div>
+            <h4 class="text-base font-bold text-charcoal mb-2">Trace a schema's lineage before you touch it</h4>
+            <p class="text-warm-gray text-sm leading-relaxed">"Show Lineage From..." picks a schema and renders its full forward or backward flow through the workspace &mdash; know what breaks before you change something.</p>
+          </div>
+
+          <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
+            <div class="w-12 h-12 bg-orange/10 rounded-xl flex items-center justify-center mb-4">
+              <svg class="w-6 h-6 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.447 2.724A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/></svg>
+            </div>
+            <h4 class="text-base font-bold text-charcoal mb-2">Trace one field through the entire pipeline</h4>
+            <p class="text-warm-gray text-sm leading-relaxed">Field-Level Lineage renders a horizontal, multi-hop chain &mdash; source.field &rarr; [transform] &rarr; target.field &mdash; with NL transforms styled distinctly, so you can see exactly where a value comes from.</p>
+          </div>
+
+          <div class="feature-card bg-white rounded-2xl p-6 border border-charcoal/5">
+            <div class="w-12 h-12 bg-green/10 rounded-xl flex items-center justify-center mb-4">
+              <svg class="w-6 h-6 text-green" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
+            </div>
+            <h4 class="text-base font-bold text-charcoal mb-2">Know what's mapped without reading the arrows</h4>
+            <p class="text-warm-gray text-sm leading-relaxed">Green and red gutter markers plus a status-bar percentage show mapped vs. unmapped target fields for the mapping under your cursor &mdash; no CLI, no counting by hand.</p>
+          </div>
+
+        </div>
       </div>
     </div>
   </section>
@@ -189,8 +204,8 @@ permalink: vscode.html
   <section class="py-20 lg:py-28 bg-white">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-16 reveal">
-        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">8 commands at your fingertips</h2>
-        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Access every command from the Command Palette (<kbd class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded border border-charcoal/10">Ctrl+Shift+P</kbd>). Each one integrates directly with the Satsuma CLI.</p>
+        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Every workflow above, one keystroke away</h2>
+        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Open the Command Palette (<kbd class="font-mono text-xs bg-code-bg px-1.5 py-0.5 rounded border border-charcoal/10">Ctrl+Shift+P</kbd>) and type "Satsuma" for all 8 commands. Each one runs the CLI for you and renders the result.</p>
       </div>
 
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 reveal">
@@ -274,139 +289,6 @@ permalink: vscode.html
           <p class="text-warm-gray text-xs leading-relaxed">Removes the gutter markers and status bar item added by <em>Show Mapping Coverage</em>.</p>
         </div>
       </div>
-    </div>
-  </section>
-
-  <!-- Interactive Webviews -->
-  <section class="py-20 lg:py-28">
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="text-center mb-16 reveal">
-        <h2 class="text-3xl sm:text-4xl font-bold text-charcoal mb-4">Interactive visualization</h2>
-        <p class="text-warm-gray text-lg max-w-2xl mx-auto">Three dedicated webview panels bring your mapping workspace to life, right inside VS Code.</p>
-      </div>
-
-      <div class="grid lg:grid-cols-3 gap-8 reveal">
-
-        <!-- Workspace Graph -->
-        <div class="feature-card bg-white rounded-2xl p-8 border border-charcoal/5">
-          <div class="w-14 h-14 gradient-green rounded-2xl flex items-center justify-center mb-6">
-            <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zm0 8a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zm12 0a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"/></svg>
-          </div>
-          <h3 class="text-xl font-bold text-charcoal mb-3">Workspace Graph</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">An interactive SVG diagram of your entire workspace, laid out by block type.</p>
-          <ul class="space-y-2 text-sm text-warm-gray">
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Schemas, mappings, metrics, and fragments as distinct node shapes</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Click any node to jump to its definition</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Namespace filter dropdown to focus on a single namespace</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Auto-refreshes on file save</span>
-            </li>
-          </ul>
-        </div>
-
-        <!-- Field-Level Lineage -->
-        <div class="feature-card bg-white rounded-2xl p-8 border border-charcoal/5">
-          <div class="w-14 h-14 gradient-orange rounded-2xl flex items-center justify-center mb-6">
-            <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l5.447 2.724A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/></svg>
-          </div>
-          <h3 class="text-xl font-bold text-charcoal mb-3">Field-Level Lineage</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">Trace a single field through the entire data pipeline with multi-hop chain visualization.</p>
-          <ul class="space-y-2 text-sm text-warm-gray">
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-orange flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Horizontal flow: source.field &rarr; [transform] &rarr; target.field</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-orange flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>NL transforms displayed with distinct styling</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-orange flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Click any node to navigate to the definition</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-orange flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Multi-hop chain tracing via <code class="font-mono text-xs bg-code-bg px-1 py-0.5 rounded">satsuma arrows</code></span>
-            </li>
-          </ul>
-        </div>
-
-        <!-- Mapping Coverage -->
-        <div class="feature-card bg-white rounded-2xl p-8 border border-charcoal/5">
-          <div class="w-14 h-14 gradient-green rounded-2xl flex items-center justify-center mb-6">
-            <svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
-          </div>
-          <h3 class="text-xl font-bold text-charcoal mb-3">Mapping Coverage</h3>
-          <p class="text-warm-gray text-sm leading-relaxed mb-4">See at a glance which target fields are mapped and which are missing.</p>
-          <ul class="space-y-2 text-sm text-warm-gray">
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Green gutter markers for mapped fields</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Red gutter markers for unmapped fields</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Status bar shows coverage percentage</span>
-            </li>
-            <li class="flex items-start gap-2">
-              <svg class="w-4 h-4 text-green flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/></svg>
-              <span>Works from cursor position inside any mapping block</span>
-            </li>
-          </ul>
-        </div>
-
-      </div>
-
-      <!-- Screenshots -->
-      <div class="mt-16 space-y-8 reveal">
-        <div class="rounded-2xl overflow-hidden shadow-xl border border-charcoal/10">
-          <div class="bg-charcoal/5 px-5 py-3 flex items-center gap-2 border-b border-charcoal/10">
-            <span class="w-3 h-3 rounded-full bg-red-400/60"></span>
-            <span class="w-3 h-3 rounded-full bg-yellow-400/60"></span>
-            <span class="w-3 h-3 rounded-full bg-green/60"></span>
-            <span class="ml-3 text-xs text-warm-gray font-mono">Workspace Overview — schemas, mappings, and data flow at a glance</span>
-          </div>
-          <img
-            src="img/vscode-extension-overview.webp"
-            alt="Satsuma VS Code extension workspace overview showing schema nodes connected by mapping arrows with namespace grouping"
-            class="w-full h-auto block"
-            width="1400"
-            height="598"
-            loading="lazy"
-          >
-        </div>
-
-        <div class="rounded-2xl overflow-hidden shadow-xl border border-charcoal/10">
-          <div class="bg-charcoal/5 px-5 py-3 flex items-center gap-2 border-b border-charcoal/10">
-            <span class="w-3 h-3 rounded-full bg-red-400/60"></span>
-            <span class="w-3 h-3 rounded-full bg-yellow-400/60"></span>
-            <span class="w-3 h-3 rounded-full bg-green/60"></span>
-            <span class="ml-3 text-xs text-warm-gray font-mono">Mapping Detail — field-level arrows between source and target schemas</span>
-          </div>
-          <img
-            src="img/vscode-mapping-view-extension.webp"
-            alt="Satsuma VS Code extension mapping detail view showing source and target schema cards with field-level arrow connections"
-            class="w-full h-auto block"
-            width="1400"
-            height="603"
-            loading="lazy"
-          >
-        </div>
-      </div>
-
     </div>
   </section>
 

--- a/site/vscode.njk
+++ b/site/vscode.njk
@@ -263,6 +263,16 @@ permalink: vscode.html
           </div>
           <p class="text-warm-gray text-xs leading-relaxed">Gutter markers and status bar showing mapped vs. unmapped fields with coverage percentage. Paired with <em>Clear Mapping Coverage</em> to remove the markers.</p>
         </div>
+
+        <div class="feature-card bg-cream rounded-xl p-5 border border-charcoal/5">
+          <div class="flex items-center gap-3 mb-2">
+            <div class="w-8 h-8 bg-orange/10 rounded-lg flex items-center justify-center flex-shrink-0">
+              <svg class="w-4 h-4 text-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </div>
+            <h3 class="font-semibold text-charcoal text-sm">Clear Mapping Coverage</h3>
+          </div>
+          <p class="text-warm-gray text-xs leading-relaxed">Removes the gutter markers and status bar item added by <em>Show Mapping Coverage</em>.</p>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

PR #485 merged early with only the PRD/tickets commit (`docs: PRD and
tickets for marketing site audit fixes`) — the four commits with the
actual fixes never made it into `main`. This PR carries those four commits
forward, rebased onto current `main`.

Closes the remaining work under epic `saf-dmvx` (already closed in
`.tickets/`, tracked here for the code):

1. **Fabricated example snippets fixed** (`saf-jha9`) + **two
   self-contradictions resolved** (`saf-z30z`, `saf-s2dw`) — 7 example
   cards on `examples.njk` re-derived from their real `examples/*.stm`
   files; `cli.njk`'s "no coverage command" claim and `vscode.njk`'s
   "8 commands" count both fixed to match what the page actually shows.
2. **Dead link, stats drift, stale counts, real Kimball example**
   (`saf-2re8`, `saf-xzkt`, `saf-lmb6`, `saf-3zn6`, `saf-8d61`) — fixed the
   `PROJECT-OVERVIEW.md` link, synced `_data/stats.json` with
   `test-stats.json`, corrected example/category counts, added a real
   "Kimball Star Schema (SCD Type 2)" example card sourced from the
   already-excellent `docs/data-modelling/kimball/dim-customer.stm` (rather
   than just softening the claim that referenced it), and removed the
   stale Transform Classification table instead of fixing it in place.
3. **CLI and VS Code pages redesigned** (`saf-s5q4`, `saf-6eid`, supersedes
   `saf-8n85`) — `vscode.njk` reorganized around user workflows instead of
   an LSP-internals feature inventory, correctly naming the 3 real webviews;
   `cli.njk` reframed around agent-first, token-efficient use, with the
   exhaustive 23-command grid replaced by a compact pointer to
   `satsuma --help` / `SATSUMA-CLI.md`.

See `features/43-site-audit-fixes/PRD.md` (already on `main`) for the full
audit findings this addresses.

## Screenshot follow-ups flagged (not blocking this PR)

Four workflow cards on the redesigned VS Code page are text-only pending
screenshots: diagnostics/squiggles in action, the Field-Level Lineage
webview, the Schema Lineage webview ("Show Lineage From..."), and Mapping
Coverage gutter markers + status bar percentage.

## Test plan

- [x] Each commit passed `scripts/run-repo-checks.sh` (pre-commit hook:
      lint, build, JS/Python tests, smoke tests) individually before this
      push — redone via `cherry-pick --no-commit` + `git commit` after
      discovering plain `git cherry-pick` doesn't trigger the hook in this
      setup.
- [x] Site builds cleanly with `npx @11ty/eleventy` and spot-checked output
      HTML for all fixed claims (command counts, example counts, fixed
      snippets, no dead references).