### PR TITLE
redesign(eval): add a markdown arm and a cheap probe to the Feature 44 protocol

### DIFF
--- a/.tickets/sl-3yzd.md
+++ b/.tickets/sl-3yzd.md
@@ -1,0 +1,30 @@
+---
+id: sl-3yzd
+status: open
+deps: [sl-x9m1]
+links: []
+created: 2026-08-05T09:29:28Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-qz3v
+tags: [eval, feature-44]
+---
+# Grade the probe by hand and record the go/no-go decision
+
+Grade T4 by set-F1 against the answer key and T5 by flagged-vs-silently-guessed plus false-positive rate. By hand - no graders, no judge.
+
+Evaluate against the PRD's pre-committed thresholds:
+- S+ >= 0.85 x M on tokens AND no quality separation on T5 -> STOP, correct the site copy downward without a full study
+- S+ <= 0.6 x M -> build the full protocol
+- in between -> build Phases 1-2, re-probe before the primary slice
+
+Also report: whether the 1-mapping cell showed S+ losing (the crossover), and an n estimate for the full run.
+
+## Acceptance Criteria
+
+- Go/no-go decision recorded as a PRD note with the measured ratios behind it
+- Crossover at the 1-mapping cell confirmed or refuted explicitly
+- An n recommendation for the full run, replacing the current guess of 5
+- A list of protocol bugs found, each either fixed in the PRD or raised as its own ticket
+

--- a/.tickets/sl-6ips.md
+++ b/.tickets/sl-6ips.md
@@ -1,0 +1,26 @@
+---
+id: sl-6ips
+status: open
+deps: []
+links: []
+created: 2026-08-05T09:30:11Z
+type: chore
+priority: 1
+assignee: Thorben Louw
+tags: [eval, feature-44, feature-45]
+---
+# Gate: Feature 45 shipped and released before the Feature 44 eval probe runs
+
+Feature 44's Phase 0.5 probe must not run until Feature 45 (agent-reference progressive disclosure) has shipped AND been released.
+
+Two reasons, both from features/45-agent-reference-progressive-disclosure/PRD.md:
+1. The probe charges AI-AGENT-REFERENCE.md's resident cost against the Satsuma arms. If the reference changes after the probe, the measured artifact is not the shipped one.
+2. F45 carries a 'no iteration against eval outcomes' Goodhart control. A probe running in parallel would put that under strain.
+
+This gate exists so tk does not surface the probe tickets as ready work early. Feature 45's own implementation tickets are not cut yet - closing this gate means F45 has shipped and released, however that work ends up being tracked.
+
+## Acceptance Criteria
+
+- Feature 45 is merged and included in a release
+- AI-AGENT-REFERENCE.md's shipped delivery mechanism and its measured resident token cost are known, so Feature 44 can charge the real figure rather than a bytes/4 estimate
+

--- a/.tickets/sl-jdho.md
+++ b/.tickets/sl-jdho.md
@@ -1,0 +1,27 @@
+---
+id: sl-jdho
+status: open
+deps: [sl-6ips]
+links: []
+created: 2026-08-05T09:29:28Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-qz3v
+tags: [eval, feature-44]
+---
+# Author the probe scenario and its answer keys
+
+Hand-author one ~10-mapping scenario and express it in each probe representation: .xlsx at P0 and P2, markdown at M0, and .stm. Also author a 1-mapping variant (the cell designed to make S+ lose).
+
+Write the T4 and T5 answer keys AT AUTHORING TIME, before any episode runs: T4 = the true downstream set for a chosen field; T5 = the list of planted ambiguities plus the unambiguous fields used for the false-positive rate.
+
+Reuse archive/features/04-excel-to-stm-skill/test-data/generate_test_spreadsheets.py for P0/P2 workbook construction.
+
+## Acceptance Criteria
+
+- Five artifacts exist for the 10-mapping scenario (X-P0, X-P2, M0, .stm) plus the 1-mapping variant
+- T4 and T5 answer keys committed, authored before any episode runs
+- Planted ambiguities are genuine (underspecified rounding, target field with no stated source, value map missing a case, implicit timezone), not typos
+- A note recording that the markdown arm is hand-authored and therefore at risk of summary drift - the reason probe results are non-publishable
+

--- a/.tickets/sl-qz3v.md
+++ b/.tickets/sl-qz3v.md
@@ -1,0 +1,27 @@
+---
+id: sl-qz3v
+status: open
+deps: [sl-jdho, sl-x9m1, sl-3yzd]
+links: []
+created: 2026-08-05T09:29:10Z
+type: epic
+priority: 1
+assignee: Thorben Louw
+tags: [eval, feature-44]
+---
+# Feature 44 Phase 0.5 — insight-first eval probe
+
+Run a cheap, hand-graded probe that returns a directional effect size for the Satsuma-vs-spreadsheet-vs-markdown comparison BEFORE building the Phase 1-3 machinery (MappingIntent, three renderers, totality test, blind pairing audit, deterministic graders).
+
+See features/44-token-and-task-eval/PRD.md, section 'Phase 0.5 - the probe that decides whether to build the machinery'.
+
+Blocked on Feature 45 (agent-reference progressive disclosure) shipping AND releasing, so the reference the probe charges against is the one that will actually be measured, and so F45's slicing design cannot be tuned against probe outcomes.
+
+Budget ~$8. Results are explicitly NON-PUBLISHABLE - not evidence, not pre-registered, never quoted on the site or in RESULTS.md.
+
+## Acceptance Criteria
+
+- All child tickets closed
+- A go/no-go decision recorded against the PRD's pre-committed kill thresholds
+- Probe numbers absent from site copy and RESULTS.md
+

--- a/.tickets/sl-x9m1.md
+++ b/.tickets/sl-x9m1.md
@@ -1,0 +1,27 @@
+---
+id: sl-x9m1
+status: open
+deps: [sl-jdho]
+links: []
+created: 2026-08-05T09:29:28Z
+type: task
+priority: 1
+assignee: Thorben Louw
+parent: sl-qz3v
+tags: [eval, feature-44]
+---
+# Run the five probe arms and record usage
+
+Run T4 and T5 across arms X-P0, X-P2, M0, S and S+ at n=2, one model, one harness. Then the 1-mapping variant.
+
+Record per episode: input/output/cache-read/cache-write tokens, turn count, and - for arm S+ - every satsuma invocation with flags, exit code and output size.
+
+Arm S must run with the CLI absent from PATH, asserted before the episode starts. satsuma context is excluded from arm S+; record any attempt to call it.
+
+## Acceptance Criteria
+
+- Transcripts and usage recorded for every episode
+- Arm-S CLI absence asserted, not merely requested
+- Arm-S+ invocation mix captured, including whether the agent used --json on aggregate commands
+- Spend stayed within the ~$8 probe budget
+

--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ This gives you the `satsuma` command on your PATH. Run `satsuma --help` to see
 available commands.
 
 > **Can't install the CLI or VS Code extension?** Satsuma is still useful
-> without any tooling. LLMs can read and generate `.stm` files directly — our
-> tests show 3–8x fewer tokens than equivalent spreadsheets or YAML — and
+> without any tooling. LLMs can read and generate `.stm` files directly, and
 > plain-text files version-control cleanly. See
 > **[Using Satsuma Without the CLI](docs/using-satsuma-without-cli.md)** for
 > workflows with web LLMs like ChatGPT, Gemini, or Claude.ai.

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -8,9 +8,13 @@ Feature specs live in `features/` while active and move to `archive/features/` o
 
 ## Active Feature Specs
 
-Features 36 and 40 are active. Everything numbered 01–35 plus Features
-37, 38, 39, 41, and 42 has shipped and is archived (see
-[Shipped Features](#shipped-features)).
+Features 36 and 40 are active, and Features 44 and 45 are proposed but not yet
+started. Everything numbered 01–35 plus Features 37, 38, 39, 41 and 42 has
+shipped and is archived (see [Shipped Features](#shipped-features)).
+
+Feature 43 (site audit fixes) has also shipped — all 11 `saf-*` tickets are closed
+— but its spec is still sitting in `features/` rather than `archive/features/`. It
+should be moved on the next tidy-up.
 
 ### Feature 36 — Viz Coverage Overlay and Field Chain View (not started)
 
@@ -24,12 +28,49 @@ A paint-only coverage overlay on the viz overview, uncovered-field treatment in 
 
 **Source:** `features/36-viz-coverage-and-chain-view/PRD.md`
 
+### Feature 45 — Progressive Disclosure for the AI Agent Reference (proposed)
+
+Restructure `AI-AGENT-REFERENCE.md` into canonical sections composed at build
+time, adding `satsuma agent-reference --section/--profile/--list` while keeping
+bare invocation byte-identical. Task-need analysis says slicing roughly halves the
+~7k-token resident cost. No tickets cut yet.
+
+**Sequencing:** this ships *before* Feature 44 hashes its protocol, so the eval
+measures the reference we intend to ship rather than one we are about to replace.
+Tracked by gate ticket `sl-6ips`.
+
+**Source:** `features/45-agent-reference-progressive-disclosure/PRD.md`
+
+### Feature 44 — Token and Task-Completion Eval (proposed)
+
+A pre-registered protocol replacing the site's "3-8x less token usage" and
+"40-60% smaller" claims with measured, CI-bounded numbers. Arms compare `.xlsx`,
+markdown, `.stm` alone, and `.stm` + CLI, all rendered mechanically from one
+neutral `MappingIntent` record so the comparison is genuinely paired.
+
+**Ready now:** nothing. The only unblocked ticket is the Feature 45 gate
+(`sl-6ips`); the Phase 0.5 probe epic (`sl-qz3v`) and its three children sit
+behind it.
+
+**Next step is deliberately cheap:** Phase 0.5 is a ~$8 hand-graded probe that
+returns a directional effect size *before* the `MappingIntent` machinery, the
+renderers, the graders and the pairing audit get built, with pre-committed kill
+thresholds. If the effect is inside noise, the honest outcome is to correct the
+site copy downward without running a full study.
+
+**Open for the project owner:** the run no longer fits its $100 cap once the
+markdown arm is included (~$118). Either drop the harness-invariance slice and run
+markdown at two rungs (~$98), or raise the cap.
+
+**Source:** `features/44-token-and-task-eval/PRD.md`
+
 ## Shipped Features
 
 Delivered and moved to `archive/features/`. Recent work, most recent first:
 
 | Feature | Shipped | What landed |
 | --- | --- | --- |
+| 43 — Marketing site audit fixes | 2026-08-05 | All 11 `saf-*` tickets: dead links, stats drift, fabricated example snippets, self-contradictions, and a reframe of `vscode.njk` around workflows and `cli.njk` around agents. Deliberately left the unsubstantiated "3-8x"/"40-60%"/">90%" numbers for Feature 44 to measure. Spec not yet moved to `archive/features/` |
 | 42 — Monorepo build tooling | 2026-08-04 | npm workspaces behind one root lockfile, a Turborepo task graph whose build order is derived from the manifests rather than written down, and a persisted content-hash cache (ADR-049). CI 4m35s → 1m56s warm; the eleven packages' `prebuild`/`pretest` sibling-build chains and `scripts/build-workspace.sh` are gone |
 | 39 — Correctness by default | 2026-08-04 | Generated CST contracts, opaque path/ref stages, generated coverage and formatter properties, an independent coverage oracle, enforced typecheck and type-aware lint gates, and structural `FieldDecl` variants |
 | 38 — Hierarchical field coverage | 2026-08-03 | Path-correct nested coverage, container tri-state, whole-subtree arrow semantics, leaf-only ratios, and parity across the CLI, LSP, VS Code, and viz consumers (ADR-035–041) |

--- a/features/44-token-and-task-eval/PRD.md
+++ b/features/44-token-and-task-eval/PRD.md
@@ -1,11 +1,38 @@
-# Feature 44 — Token and Task-Completion Eval: Satsuma vs. Spreadsheets
+# Feature 44 — Token and Task-Completion Eval: Satsuma vs. Spreadsheets and Markdown
 
-> **Status: PROPOSED** (raised 2026-08-04) — requested by the project owner to
-> put a reproducible measurement behind the site's quantitative claims about
-> agent token usage, and to find out whether a coding agent given a `.stm` spec
-> actually produces *better* work than one given the equivalent spreadsheet.
+> **Status: PROPOSED** (raised 2026-08-04, revised 2026-08-05) — requested by the
+> project owner to put a reproducible measurement behind the site's quantitative
+> claims about agent token usage, and to find out whether a coding agent given a
+> `.stm` spec actually produces *better* work than one given the equivalent
+> spreadsheet.
 >
-> **State this PRD was checked against:** `main` at `0579a037`.
+> **State this PRD was checked against:** `main` at `0579a037`; revision checked
+> against `177cabd9`.
+>
+> **Revision, 2026-08-05.** Five changes, after a review of this protocol against
+> the question a technical evaluator actually asks:
+>
+> 1. **Arm M (markdown) added as a billed behavioural arm** with its own M0/M1
+>    profiles. Beating spreadsheets answers the marketing question; markdown is
+>    what a sceptic substitutes for free, and the protocol was silent on it.
+>    Compactness is explicitly *not* the claim — see
+>    [What we actually claim over markdown](#what-we-actually-claim-over-markdown).
+> 2. **Phase 0.5 added** — a ~$8 hand-graded probe that returns a directional
+>    effect size *before* `MappingIntent`, the renderers, the totality test, the
+>    pairing audit and the graders get built, with pre-committed kill thresholds.
+> 3. **The cut order is corrected.** It previously put arm S second, contradicting
+>    this document's own claim that S vs. S+ is what makes the result attributable.
+>    Arms X, M, S and S+ are now uncuttable.
+> 4. **Arm S+ is documented as a behavioural distribution, not a fixed treatment**,
+>    because measured CLI output sizes show `--json` on aggregate commands costs
+>    *more* than reading the source files. Invocations are now recorded per episode.
+> 5. **T2 dropped** on the merits, and a context-boundary cell added, because
+>    prompt caching partially substitutes for the benefit arm S+ is meant to provide.
+>
+> The revision leaves the pairing design, grading approach, statistics and
+> pre-registration discipline intact — those were sound. It costs money: the run no
+> longer fits the $100 cap, and [Costed run plan](#costed-run-plan--100-hard-cap)
+> puts that choice to the project owner rather than silently absorbing it.
 >
 > **Direct antecedent.** `features/43-site-audit-fixes/PRD.md` (Non-goals)
 > records "3-8x less token usage", "40-60% smaller", and
@@ -18,10 +45,12 @@
 >
 > **What this feature delivers.** A pre-registered experimental protocol, the
 > paired-artifact generation design that makes the comparison valid, the graders,
-> the model/harness matrix, a costed run plan under a hard budget cap, and a
-> single-cell pilot proving the metrics are collectable. **It does not produce
-> the published numbers** — executing the full run and updating site copy is a
-> follow-on feature gated on this protocol being signed off.
+> the model/harness matrix, a costed run plan under a hard budget cap, a cheap
+> probe that decides whether the full run is worth building, and a single-cell
+> pilot proving the metrics are collectable. **It does not produce the published
+> numbers** — executing the full run and updating site copy is a follow-on feature
+> gated on this protocol being signed off. The one exception is `README.md:179`,
+> which asserts tests that do not exist and is corrected now rather than in Phase 4.
 >
 > **What this feature is not.** It changes no Satsuma syntax, no grammar, and no
 > CLI/LSP/VS Code/viz behaviour. It adds no package to the Turborepo task graph
@@ -33,8 +62,8 @@ Replace three unfalsifiable marketing numbers with three separately-measured,
 confidence-bounded, independently reproducible ones:
 
 1. **Static compactness** — how many fewer tokens a `.stm` spec is than the
-   same mapping expressed as a spreadsheet, and than the same mapping expressed
-   as YAML. Deterministic; no model involved.
+   same mapping expressed as a spreadsheet, as YAML, as JSON, and as a
+   field-level markdown table. Deterministic; no model involved.
 2. **Task cost** — how many tokens an agent *consumes* to complete a real
    mapping task from each representation. Behavioural; dominated by agent
    loops, not file size.
@@ -73,12 +102,12 @@ Picking the first and reporting the result would not be a measurement, it would
 be a rhetorical device. The protocol must pre-commit to a primary serialization
 and report the full range across all four, so the reader can see the bound.
 
-**The comparison has no controlled pairing.** For the two arms to differ *only*
+**The comparison has no controlled pairing.** For the arms to differ *only*
 in representation, they must encode the same mapping. There is currently no
 artifact in the repo of which that is true — see the next section, which is the
 core design problem this feature solves.
 
-## The central design problem: how the two arms get paired
+## The central design problem: how the arms get paired
 
 Both obvious approaches are contaminated, in opposite directions.
 
@@ -95,20 +124,24 @@ Both obvious approaches are contaminated, in opposite directions.
   information it didn't. Any measured advantage could be an artifact of the
   conversion step.
 
-### The design: one intent record, two total renderers
+### The design: one intent record, several total renderers
 
 Author the ground truth **once, in neither format**, as a machine-readable
-`MappingIntent` record; render both arms from it mechanically.
+`MappingIntent` record; render every arm from it mechanically.
 
 ```
-                    MappingIntent  (JSON — the only source of truth)
-                  ┌────────┴────────┐
-        render_stm│                 │render_xlsx (messiness profile 0|1|2)
-                  ▼                 ▼
-              Arm S / S+        Arm X            Arm Y (render_yaml, static only)
-                  └────────┬────────┘
-                           ▼
-                  same ground-truth key grades both
+                  MappingIntent  (JSON — the only source of truth)
+                                 │
+        ┌────────────────┬───────┴────────┬──────────────────────┐
+        │                │                │                      │
+   render_stm      render_xlsx      render_markdown      render_yaml / _json
+        │          (P0|P1|P2)         (M0|M1)              (static only)
+        ▼                ▼                ▼                      ▼
+    Arm S / S+        Arm X            Arm M               Arms Y / J
+        │                │                │
+        └────────────────┴────────────────┘
+                         ▼
+            one ground-truth key grades all three
 ```
 
 The repo already contains most of this. `tooling/satsuma-scenario-gen/` is
@@ -120,25 +153,59 @@ interprets Satsuma, and its one architectural rule is no dependency on
 - `satsuma-scenario-gen` gains a neutral **`MappingIntent` JSON serializer**
   alongside its existing Satsuma renderer. It stays pure string/JSON building
   and takes on no new dependency — in particular no xlsx writer.
-- The **xlsx, CSV and YAML renderers live in `evals/`** (Python, `openpyxl`),
-  reusing the workbook-construction approach already proven in
-  `skills/satsuma-to-excel/scripts/stm_to_excel.py`. This is the same
-  core-vs-consumer split `AGENTS.md` mandates: semantics in the shared
-  generator, format-specific I/O in the consumer.
+- The **xlsx, markdown, CSV, YAML and JSON renderers live in `evals/`** (Python,
+  `openpyxl` for the workbook), reusing the workbook-construction approach
+  already proven in `skills/satsuma-to-excel/scripts/stm_to_excel.py` and the
+  messiness primitives — header styling, fills, multi-tab layout — already in
+  `archive/features/04-excel-to-stm-skill/test-data/generate_test_spreadsheets.py`.
+  This is the same core-vs-consumer split `AGENTS.md` mandates: semantics in the
+  shared generator, format-specific I/O in the consumer.
 
 **Totality is the control, and it must be enforced, not assumed.** Every field
-of `MappingIntent` must be rendered by *both* renderers, or one arm is quietly
-handed less information than the other. Two mechanisms:
+of `MappingIntent` must be rendered by *every* behavioural renderer, or one arm
+is quietly handed less information than another. Two mechanisms:
 
 1. **Renderer totality test** — a schema-driven test asserting every
    `MappingIntent` field is reachable in each renderer's output. A new intent
    field with no rendering in one arm fails the suite.
-2. **Blind pairing audit** — an LLM reads *only* arm X, and separately *only*
-   arm S, and reconstructs the intent record from each. The two
+2. **Blind pairing audit** — an LLM reads *only* arm X, then *only* arm M, then
+   *only* arm S, and reconstructs the intent record from each. All three
    reconstructions must agree with each other, and with the true record, on
    every gradeable element except the deliberately planted ambiguities. A
    disagreement means the arms are not paired and the run is invalid. This is a
    go/no-go gate before any billed run, not a post-hoc diagnostic.
+
+**The markdown arm needs this control more than the xlsx arm does**, and the one
+real-world artifact we have proves why. `tmp/dmd_tb_branch.{xlsx,stm,md}`
+(untracked, client-derived, inspected locally on 2026-08-05 and not committable)
+is the only Satsuma/markdown pair in existence here — and **it is not a pair**.
+The `.stm` carries 15 schemas, **175 field-level arrows** and 79 natural-language
+transform bodies in 656 lines. The `.md` carries **zero field-level mappings** in
+146 lines: schema-level mermaid lineage, business rules summarised by *area*
+rather than by field, and an explicit self-description as a companion document
+*about* the `.stm`. Nothing could be implemented from it.
+
+Two conclusions, and they point in opposite directions:
+
+- The `.md` being 3.5× smaller than the `.stm` is **not** markdown winning on
+  compactness. It is a *genre convention*: asked to document a mapping of this
+  size in prose-plus-tables, the author produced a summary and silently dropped
+  the payload a mapping spec exists to carry. That failure mode — silent
+  omission, not visible mess — is markdown's characteristic risk, and it is the
+  most honest available answer to "why not just write markdown".
+- But it is **n = 1**, and that document was written as a companion to the `.stm`
+  rather than as a substitute for it, so it cannot be cited as evidence of
+  anything. What it does establish is a *methodological requirement*: a
+  hand-authored markdown baseline will drift toward summary, which would hand
+  Satsuma a win for entirely the wrong reason. Only a total `render_markdown`
+  over `MappingIntent`, gated by the totality test, produces a markdown arm
+  worth beating.
+
+**Registered prediction for the static markdown comparison:** a *total*
+field-level markdown table (175 rows of source, target, type and rule, for a spec
+of that size) will come out at roughly **parity** with `.stm`, not 3.5× smaller
+and not meaningfully larger. Registered in advance so that "Satsuma is more
+compact than markdown" cannot be quietly adopted as a finding if it isn't one.
 
 ### Messiness profiles: report the honest lower bound
 
@@ -160,17 +227,46 @@ trick.
 
 Results are reported **per profile**. The headline goes to P0.
 
+### Markdown gets the same treatment, for the same reason
+
+If the xlsx arm's headline is its Excel-favourable profile, the markdown arm's
+must be its markdown-favourable one. Anything else is the strawman the profile
+mechanism exists to prevent.
+
+| Profile | What the document looks like | Role |
+|---|---|---|
+| **M0 — tidy** | One field-level table per mapping with fixed columns (source, target, type, rule), consistent naming, rules stated per row | **Adversarially favourable to markdown.** The headline markdown comparison is bounded by this number |
+| **M1 — typical** | Per-author structure: some mappings as tables and some as prose bullets, rules interleaved with commentary, a shared conventions preamble the reader must apply, inconsistent heading depth | The realistic middle — what a mapping doc written by whoever wrote it actually looks like |
+
+The **M0↔M1 gap is itself a measurand**, not noise. It quantifies the
+convention-inference cost that Satsuma's fixed grammar removes, which is one of
+the three things we actually claim over markdown (below). A large gap is evidence
+for the claim; a small one is evidence against it.
+
+Note what M0 concedes: a tidy field-level markdown table is a genuinely good
+artifact, and the totality test forces it to carry everything the `.stm` carries.
+This arm is meant to be hard to beat.
+
 ## Arms
 
 Behavioural arms (cost 💰 = billed episodes; static-only arms are free):
 
 | Arm | Artifact | Agent tooling | 💰 | What it isolates |
 |---|---|---|---|---|
-| **X** | `.xlsx` at profile P0/P1/P2 | Python + `openpyxl`/`pandas`, file described as a mapping spec, free exploration | yes | The baseline the claim is made against |
-| **S** | `.stm` only | No `satsuma` CLI. `AI-AGENT-REFERENCE.md` in context | yes (reduced) | **The language alone** |
+| **X** | `.xlsx` at profile P0/P1/P2 | Python + `openpyxl`/`pandas`, file described as a mapping spec, free exploration | yes | The baseline the claim is made against — **the anchor arm** |
+| **M** | Markdown at profile M0/M1 | Read/Grep/Glob, file described as a mapping spec | yes | **The alternative a sceptic substitutes instead** |
+| **S** | `.stm` only | No `satsuma` CLI. `AI-AGENT-REFERENCE.md` in context | yes | **The language alone** |
 | **S+** | `.stm` | `satsuma` CLI on PATH + `AI-AGENT-REFERENCE.md` | yes | **Language + tooling** — the configuration actually shipped |
 | **Y** | YAML | — | no | The `40-60% smaller than YAML` claim (static only) |
+| **J** | JSON | — | no | The JSON half of the same claim (static only) |
 | **C** | CSV-per-sheet dump of X | — | no | Serialization sensitivity for the static claim |
+
+**Arm X is the anchor, not an optional extra.** Spreadsheets are the world
+Satsuma displaces and the baseline every published number is stated against, so X
+is the one arm whose removal ends the run rather than shrinking it. It also
+carries T5: real-world ambiguity lives in workbooks — merged cells, a free-text
+Notes column, semantics in fill colour — and ambiguity detection measured only
+against artifacts we authored ourselves measures our own planting.
 
 **S vs. S+ is the contrast that stops the result being uninterpretable.** The
 site makes two distinct claims — the format is compact (`index.njk:259`) and the
@@ -178,6 +274,102 @@ CLI gives agents structural queries instead of whole-file dumps
 (`cli.njk:156`). Run only S+ and you cannot attribute the effect to either. A
 sceptical technical evaluator will ask, and "we didn't separate them" is not an
 answer.
+
+### What we actually claim over markdown
+
+Arm M exists because Excel and markdown answer two different questions. Excel is
+the *status quo* Satsuma displaces; markdown is the *cheapest credible
+alternative*, the one a sceptical engineer substitutes at zero cost with the
+obvious retort — "we'll just write a well-structured markdown doc." An eval that
+beats spreadsheets and stays silent on markdown answers the marketing question
+and dodges the engineering one.
+
+Compactness is **not** the argument, and the PRD should say so before anything is
+measured. A total field-level markdown table is predicted to land at rough parity
+(above). The three things we do claim:
+
+1. **No convention inference.** Markdown structure is per-author: one writer's
+   Notes column is another's H3 section, and the agent re-derives the convention
+   for every new document. Satsuma's shape is fixed by grammar, so that cost is
+   paid once by the ecosystem rather than per document — and, more importantly,
+   does not vary with author quality. Measured by the **M0↔M1 gap**.
+2. **There is an oracle.** `validate` and `lint` give ground truth on structural
+   correctness; markdown admits no equivalent at any price. This is what kills
+   the agent's most expensive loop — re-reading the document to "check
+   carefully" — and it should surface in T1 and T5 as *quality* separation rather
+   than token separation.
+3. **Addressability.** Canonical entity IDs and stable field paths are what make
+   arm S+'s queries possible at all. This is a *precondition* for the tooling,
+   not a benefit of the surface syntax.
+
+Note that (2) and (3) are both really arguments that **the language exists to
+enable the tooling**. So register the uncomfortable outcome in advance: if arm S
+lands at parity with arm M, the finding is *the tooling is the product and the
+syntax is the enabling substrate*. That is a stronger and more defensible
+position than "our syntax is shorter" — it matches where the engineering effort
+actually went (grammar, core, CLI, LSP), and it cannot be neutralised by someone
+writing a tighter markdown convention. "Our syntax is 12% smaller" invites
+exactly that reply.
+
+### Arm S+ is a behavioural distribution, not a fixed treatment
+
+Measured on the installed CLI (**v0.12.0**, 2026-08-05) against
+`examples/sfdc-to-snowflake/` — 5,817 bytes for the whole three-file workspace
+including `examples/lib/` — and `examples/metrics-platform/` (10,922 bytes):
+
+| Invocation | Output bytes | vs. reading the workspace |
+|---|---|---|
+| `graph --compact` | 151 | **38× smaller** |
+| `validate` | 36 | — |
+| `field-lineage <f>` | 158 | — |
+| `arrows <f>` | 202 | — |
+| `mapping --compact` | 369 | — |
+| `fields <schema>` | 374 | — |
+| `summary` | 792 | 7× smaller |
+| `coverage` | 1,113 | 5× smaller |
+| `summary --json` | 2,740 | 2× smaller |
+| `graph --json` | 12,388 | **2.1× LARGER** |
+| `coverage --json` | 15,601 | **2.7× LARGER** |
+| `coverage --json` (metrics-platform) | 70,081 | **6.4× LARGER** |
+
+The savings live in the **text and `--compact`** forms plus the targeted
+primitives (`arrows`, `field-lineage`, `fields`, `meta`, `nl`, `validate`).
+`--json` on the *aggregate* commands (`graph`, `coverage`) costs substantially
+more than reading the source files. This inverts the common assumption — and the
+most frequent external recommendation about this CLI — that structured output is
+inherently cheaper for agents. It is cheaper only where the command is *narrowing*.
+
+Three consequences the protocol must absorb:
+
+1. **Arm S+'s token result is a property of the agent's invocation choices, not
+   of the CLI.** An agent that reaches for `graph --json` makes Satsuma+CLI lose
+   outright. The runner must therefore record **every `satsuma` invocation with
+   its flags, exit code and output size** per episode, and the write-up must
+   report the invocation mix alongside the headline. Without it, an S+ number is
+   uninterpretable in a second way — the first being S vs. S+ attribution.
+2. **This is a measurable property of the reference, which ties it to Feature
+   45.** `AI-AGENT-REFERENCE.md:456-458` already advises `--compact` to minimise
+   tokens, and `:439-461` is a 13-row situation→command decision table whose last
+   row says to read files directly for raw content. Whether the agent *follows*
+   that guidance is exactly the behavioural reference-delivery check this feature
+   already promises; and if progressive disclosure drops the slice carrying that
+   advice, S+ gets measurably worse. That is the sharpest available test of
+   Feature 45's design.
+3. **A free static deliverable, available today.** A per-command output-size table
+   across the corpus at each spec size is deterministic and needs no model spend.
+   It belongs with the other static measurements, and it is useful to agent and
+   skill authors regardless of what the behavioural run concludes.
+
+Two definitional consequences for the arms themselves:
+
+- **`satsuma context` is excluded from arm S+.** It is the CLI's only heuristic,
+  keyword-ranked command. Leaving it in turns the experiment into "our retrieval
+  heuristic vs. grep" rather than "semantic structure vs. plain text". The runner
+  records any attempt to call it as a protocol observation.
+- **Arm S's withholding is enforced, not requested.** An agent instructed not to
+  use a binary that is on `PATH` will use it. Arm S runs with the CLI absent from
+  `PATH` (or in a container without the package), and the runner asserts absence
+  before the episode starts.
 
 ### Satsuma pays for its own reference material
 
@@ -189,7 +381,7 @@ Omitting them would be indefensible.
 The consequence is worth stating up front because it likely reshapes the
 headline: on a small spec, Satsuma may well *lose* on total tokens, and only win
 past some workspace size. If so, the deliverable is a **break-even curve**
-(tokens vs. number of mappings, both arms plotted, crossover marked) rather than
+(tokens vs. number of mappings, all arms plotted, crossover marked) rather than
 a single multiple. That is a strictly better asset than "3-8x": it is
 defensible, it tells an evaluator where the technique pays off for *their*
 workspace, and it cannot be dismissed as cherry-picking. The run must therefore
@@ -265,14 +457,13 @@ This feature then measures the *restructured* reference. Two consequences:
 
 ## Tasks and how each is graded
 
-Five tasks. Three are graded **deterministically against the intent record**,
+Four tasks. Three are graded **deterministically against the intent record**,
 which is the single biggest lever on this eval's credibility: LLM-as-judge is
 the weakest link in any eval, and most of these don't need one.
 
 | # | Task | Primary grading | Judge? |
 |---|---|---|---|
 | **T1** | Generate a pipeline implementation (dbt model + SQL) for one mapping | Deterministic: does it parse; is every target field populated; does the derived field-level coverage match the intent record's | Yes — idiomaticity only |
-| **T2** | Enumerate data-quality test cases for the spec | Recall against the ground-truth constraint checklist (required, enum, pk uniqueness, referential integrity, filter boundaries) derived from the intent record | Light — "does this test actually test that constraint" |
 | **T3** | Generate synthetic test data | **Fully deterministic.** Programmatically validate rows against every intent constraint: types, enums, required, PII patterns, formats, defaults, filter predicates, cross-schema referential integrity | No |
 | **T4** | Impact analysis — "if `<field>` changes type, what breaks?" | **Fully deterministic.** Set-F1 against the true downstream set from the intent record's lineage | No |
 | **T5** | Ambiguity detection | **Fully deterministic.** Recall/precision over *K* ambiguities planted in the intent record by construction; false-positive rate over unambiguous fields | No |
@@ -289,7 +480,35 @@ too: an arm that flags everything is not better, so the false-positive rate over
 the unambiguous fields is reported alongside.
 
 T4 and T5 are also the **cheapest episodes** — short, no code generation — which
-is how five tasks fit inside the budget of four.
+is how four tasks fit inside the budget of three.
+
+**T2 (enumerate data-quality test cases) is dropped.** Settled 2026-08-05, and on
+its merits rather than under budget pressure: it overlaps T3 in what it exercises
+— both probe whether the arm recovered the constraint set — while being the only
+remaining task needing a judge for its primary grade. Dropping it removes the
+weakest measurement, not the cheapest one. The freed ~$13 funds arm M, the
+context-boundary cell, and a raised *n* on arm S. The IDs T3/T4/T5 keep their
+original numbers so that existing cross-references and Feature 45's PRD stay
+valid; the gap at T2 is deliberate and records the decision.
+
+### One cell must cross a context boundary
+
+Prompt caching **partially substitutes for the exact benefit arm S+ is supposed to
+provide.** Inside a single warm session, an agent re-reading a large `.stm` or
+re-dumping a sheet pays cache-read prices — roughly a tenth of fresh input, and
+roughly the cost that narrowing via the CLI is meant to eliminate. An S+ advantage
+measured entirely within one warm context therefore tests something narrower than
+the claim at `cli.njk:156`.
+
+Where caching cannot help is **across** a context boundary: a fresh session,
+a post-compaction continuation, a subagent fan-out. That is where precise
+retrieval should pay most, because rediscovery is re-paid at full price.
+
+Add one cell — **T4, 1 rung, n=3, at the 25-mapping spec size** where compaction
+is likeliest, ~$2 — and report the S+ advantage **with and without a boundary
+crossed**. If the effect exists only within a warm session, the honest claim is
+much narrower than the site currently makes, and we should be the ones to find
+that out.
 
 ### Judge protocol, where a judge is unavoidable
 
@@ -330,6 +549,36 @@ summarized as the **geometric mean** of per-instance ratios with a BCa bootstrap
 right-skewed and the ratio of means systematically overstates the effect. This
 is the single most common error in published comparisons of this kind. Paired
 significance by Wilcoxon signed-rank, with effect size.
+
+**Secondary paired ratios**, reported the same way: X/M (does structure beat prose
+at all), M/S+ (the sceptic's comparison), and S/S+ (the tooling decomposition).
+
+**Which comparisons carry a CI, and which do not.** The X-vs-S+ headline is
+powered for one; the decomposition arms are not, and the PRD must not let them
+inherit the headline's framing by proximity. Arm S at its funded slice yields on
+the order of a dozen episodes, which cannot support a bootstrap CI. Therefore:
+
+- **X vs. S+ and M vs. S+** are reported as `point estimate [95% CI]`.
+- **S vs. S+** is reported as a **directional decomposition with per-cell
+  observations shown**, explicitly labelled as underpowered for an interval. It
+  answers "which of the two factors dominates", not "by exactly how much".
+
+If the freed budget stretches far enough to raise arm S to *n* = 5 across both
+rungs, S vs. S+ is promoted to a CI-bounded figure and this paragraph is amended.
+What must not happen is a thin arm quietly reported as though it were a thick one.
+
+**Invocation mix.** For arm S+, report the distribution of `satsuma` subcommands
+and flags actually used per episode, and the share of S+ input tokens originating
+from CLI output versus file reads. See
+[Arm S+ is a behavioural distribution](#arm-s-is-a-behavioural-distribution-not-a-fixed-treatment)
+— without this, the S+ number cannot be attributed to the CLI's design rather
+than to one agent's habits.
+
+**Turn count is reported alongside tokens.** With caching, dollar cost and token
+count diverge; with tool-calling, both diverge from wall-clock and from the
+number of round-trips a user waits through. Turns are the honest latency proxy and
+the metric most sensitive to the round-trip overhead that should make Satsuma+CLI
+*lose* at small spec sizes.
 
 **Quality metrics** are proportions per arm, with the paired difference and its
 bootstrap CI; McNemar's test for the binary outcomes.
@@ -428,8 +677,8 @@ Costing unit: one **codegen-equivalent episode (CEE)** ≈ 150k input-equivalent
 measurements — the Excel arm is expected to run 1.5-2.5× the Satsuma arm, and
 the CEE figure is set at the higher end so the estimate errs expensive.
 
-Task sizes in CEE: T1 1.0, T2 0.6, T3 0.8, T4 0.25, T5 0.25 → **2.9 CEE per
-arm per model per repeat**.
+Task sizes in CEE: T1 1.0, T3 0.8, T4 0.25, T5 0.25 → **2.3 CEE per
+arm per model per repeat** (T2 dropped, see below).
 
 Cost of one CEE per rung, at the corrected August 2026 prices:
 
@@ -443,20 +692,35 @@ Cost of one CEE per rung, at the corrected August 2026 prices:
 
 | Slice | CEE | Est. |
 |---|---|---|
-| Primary: arms X vs S+, 5 tasks, 4 rungs, n=5, Pi | 29/rung | **$66** |
-| Secondary: arm S (language alone), T1+T4, 2 rungs, n=3 | 7.5 | **$2** |
+| Primary: arms X vs S+, 4 tasks, 4 rungs, n=5, Pi | 23/rung | **$53** |
+| Arm M (markdown), 4 tasks, 4 rungs, n=5, Pi | 23/rung | **$26** |
+| Secondary: arm S (language alone), T1+T4, 2 rungs, n=5 | 12.5 | **$4** |
+| Context-boundary cell: T4, 1 rung, n=3, 25 mappings | ~4 | **$2** |
 | Harness invariance: Claude Code + Codex, 1 rung, 2 tasks, 2 arms, n=3 | 15 | **$7** |
 | Reference-delivery check: 2 mechanisms, T1+T4, 1 rung, n=3 | 7.5 | **$4** |
 | Judge panel: 3 judges × 40 T1 outputs | 120 calls | **$5** |
-| Pairing audit + canary probes | — | **$3** |
-| Pilot (this feature's gate) | ~3 | **$5** |
-| Static arms (Y, C, tokenizer counts, delivery-mechanism baselines) | — | **~$0** |
-| | **Total** | **~$92** |
+| Pairing audit (now three arms) + canary probes | — | **$4** |
+| Phase 0.5 probe | ~6 | **$8** |
+| Pilot (Phase 3 gate) | ~3 | **$5** |
+| Static arms (Y, J, C, markdown, tokenizer counts, per-command output sizes) | — | **~$0** |
+| | **Total** | **~$118** |
 
-That is uncomfortably close to the cap, which makes the cut order below
-load-bearing rather than theoretical. **Dropping T2 brings the total to ~$79**
-(the primary slice falls from 29 to 23 CEE per rung) — see open decision 2,
-which is now a costed choice rather than a preference.
+**That is over the cap, and the cap is hard.** Two honest options, and the choice
+belongs to the project owner (open decision 2):
+
+- **Drop the harness-invariance slice (−$7) and reduce arm M to 2 rungs (−$13),
+  giving ~$98.** Arm M at the top and bottom rungs still tests the registered
+  capability-ladder prediction, which is the only thing the four-rung sweep buys.
+  This is the recommended cut: it keeps every arm alive and every comparison
+  interpretable.
+- **Raise the cap to $150.** The eval's whole purpose is replacing numbers that
+  are currently indefensible; $50 is cheap against publishing a wrong one. If the
+  answer matters enough to measure, it probably matters enough to measure properly.
+
+Arm M is not free, and the PRD should not pretend otherwise: adding the comparison
+a sceptic actually cares about costs about a quarter of the run. The judgement is
+that a defensible markdown number is worth more than a four-rung sweep of a
+harness-invariance check the PRD already refuses to generalise from.
 
 Note that Claude Code and Codex CLI may bill against a subscription rather than
 per-token, so the harness-invariance slice's marginal cash cost may be near
@@ -469,8 +733,18 @@ Controls on the cap:
 - A **running spend ledger** with a hard kill switch at the cap; a partial run
   is reported as partial, never silently truncated.
 - **Documented cut order** if the cap is approached: harness-invariance check
-  first, then the arm-S secondary slice, then T2, then n from 5 to 3. Anything
-  cut is named in the write-up.
+  first, then arm M from 4 rungs to 2, then the context-boundary cell, then *n*
+  from 5 to 3, then Excel profile P2, then P1. Anything cut is named in the
+  write-up.
+
+  **Four things are uncuttable: arms X, M, S and S+.** Removing any of them does
+  not shrink the run, it ends it — a budget squeeze that deletes arm S leaves the
+  expensive primary slice intact and *uninterpretable*, which is the worst
+  available outcome. The earlier version of this cut order put arm S second,
+  contradicting this document's own claim that S vs. S+ is what makes the result
+  attributable; that is corrected here. If the ledger cannot fund all four arms at
+  minimum viable *n*, the runner **aborts and reports a partial run** rather than
+  silently degrading to a comparison that cannot be interpreted.
 - A **tier-0 smoke config** (1 model, 1 harness, 2 tasks, n=1, ~$1) that any
   reader can run to reproduce the pipeline end to end without reproducing the
   spend.
@@ -492,14 +766,15 @@ scenarios give breadth and free ground truth, but are synthetic and may be
 unrealistic for judging code-generation quality. A small number of
 **hand-authored realistic scenarios** — expressed in the same `MappingIntent`
 form, so they get the same free ground truth — carry the tasks where realism
-matters (T1, T2).
+matters (T1, T3).
 
 ## Delivery phases
 
 | Phase | Content | Feature |
 |---|---|---|
 | **0** | This PRD — protocol, arms, tasks, graders, matrix, costing, pre-registration | **44** |
-| **1** | `MappingIntent` schema + both renderers + totality test + blind pairing audit passing | **44** |
+| **0.5** | **Insight-first probe** — hand-authored scenario, 5 arms, T4 + T5, hand-graded. Go/no-go on building Phases 1–3 at all | **44** |
+| **1** | `MappingIntent` schema + all three behavioural renderers + totality test + blind pairing audit passing | **44** |
 | **2** | Deterministic graders (T3/T4/T5) + static-compactness measurement (arms Y, C — no model spend) | **44** |
 | **3** | **Pilot gate:** one cell end to end (1 model, 1 harness, T1 + T4, n=3), proving usage is collectable, grading runs, and arms are paired | **44** |
 | **4** | Full run, statistics, `RESULTS.md`, published methodology page, **site copy updated to the measured numbers** | follow-on |
@@ -507,15 +782,114 @@ matters (T1, T2).
 Phase 4 is explicitly out of scope here and should be raised as its own feature
 once this protocol is signed off.
 
+### Phase 0.5 — the probe that decides whether to build the machinery
+
+As written before this revision, the earliest signal from this feature arrived at
+the Phase 3 pilot gate — behind Feature 45 shipping *and* releasing, plus
+`MappingIntent`, three total renderers, a schema-driven totality test, a blind
+three-arm pairing audit, and three deterministic graders. That is weeks of
+engineering before anyone knows whether the effect is 1.2× or 4×. Phase 0.5 buys
+that number first.
+
+**Design.** One hand-authored scenario of ~10 mappings, expressed by hand in each
+representation. Five arms, with **Excel as the anchor**:
+
+| Probe arm | Role |
+|---|---|
+| **X-P0** | The headline pair with S+. Tidy, adversarially favourable to Excel |
+| **X-P2** | The realism check — the P0↔P2 spread is the honest-bound question |
+| **M0** | The sceptic's substitute |
+| **S** | Language alone |
+| **S+** | Language + CLI — the shipped configuration |
+
+Two tasks: **T4** (impact analysis) and **T5** (ambiguity detection). *n* = 2. One
+model, one harness. **~$8.**
+
+**Why those two tasks:** both are gradeable **by hand against an answer key
+written when the scenario was authored** — T4 by set-F1 against the true
+downstream set, T5 by counting flags against the planted list. Neither needs
+`MappingIntent`, the renderers, the totality test, the pairing audit, or a judge.
+T1 is excluded because it needs the judge panel and derived coverage. T4 and T5
+are also where the S+ advantage should be most visible: `lineage`/`where-used`
+versus reconstructing traversals by hand, and the deterministic/NL split
+respectively.
+
+**Include a cell designed to lose.** Run the same probe at **1 mapping**, where
+the reference overhead and per-call round-trips should make S+ *lose* outright.
+Confirming the crossover exists at the small end costs almost nothing here and is
+the single most credible thing the eventual write-up can contain — it is the
+difference between a break-even curve and a marketing multiple.
+
+**What it is explicitly not.** Not evidence, not publishable, not pre-registered.
+Its scenario is hand-authored by us with no totality control, so its arms are
+**not paired** to the standard the registered run requires, and its markdown arm
+in particular is at risk of the summary drift documented above. Its numbers must
+never appear on the site or in `RESULTS.md`. That limitation is precisely why it
+is cheap, and precisely why it must not be allowed to grow.
+
+**Its three outputs.**
+
+1. A **go/no-go on building Phases 1–3**, against thresholds written before the
+   run:
+   - S+ ≥ 0.85 × M on tokens **and** no quality separation on T5 → **stop.** The
+     effect is inside run-to-run noise and no amount of harness rescues it. The
+     honest follow-up is to correct the site copy downward without a full study.
+   - S+ ≤ 0.6 × M → **build the full protocol.**
+   - In between → build Phases 1–2, then re-probe before committing the primary
+     slice.
+2. A directional effect size per arm pair, used to **size *n*** for the full run.
+   The current *n* = 5 is a guess; the probe replaces it with an estimate.
+3. A list of protocol bugs found cheaply: does the S+ agent actually *use* the
+   CLI, or ignore it; **does it fall into the `--json`-on-aggregate-commands trap**;
+   does it reach for `satsuma context`; is **turn count** rather than tokens the
+   thing that moves; is arm-S withholding actually enforced; do the hand-written
+   answer keys survive contact with real output.
+
+**Sequencing.** Phase 0.5 waits for **Feature 45 to ship and release**, so the
+reference it charges against is the one that will actually be measured, and so
+Feature 45's slicing design cannot be tuned against probe outcomes — that
+feature's "no iteration against eval outcomes" Goodhart control would otherwise
+come under strain. It still lands well before Phases 1–3, which is where the
+saving is.
+
+**Reuse rather than write from scratch.**
+`useful-prompts/excel-to-stm-prompt.md` (343 lines: full grammar, conventions,
+worked examples, a self-critique checklist, and it already emits ambiguity flags)
+is a ready-made no-CLI treatment for arms X and S. `testing-prompts/` holds 21
+per-command agent exercise prompts that are a realistic source of S+ task
+phrasings. `archive/features/04-excel-to-stm-skill/test-data/generate_test_spreadsheets.py`
+gives P0-grade workbook construction.
+
 ## Publishing commitment
 
 Registered in advance, as a condition of the measurement being worth anything:
 **the site copy follows the data.** If the measured ratio is 1.8×, the site says
 1.8×. If Satsuma loses below some spec size, the break-even point is published
-alongside the win. `site/index.njk:259` and `:524` are updated to the measured,
-dated, CI-bounded figure in Phase 4, and the unmeasured
-">90% LLM-generates-valid-Satsuma" claim is either measured or removed — it is
-currently a roadmap target being presented as a result.
+alongside the win. And if arm M comes out at parity, the site stops implying
+otherwise.
+
+**Every site that carries these numbers is updated, not just the two on the
+landing page.** A commitment that fixes two of eight leaves the claim in
+circulation:
+
+| Location | Claim |
+|---|---|
+| `README.md:179` | "**our tests show** 3–8x fewer tokens than equivalent spreadsheets or YAML" |
+| `site/index.njk:259` | "40-60% Smaller" / "3-8x less token usage" |
+| `site/index.njk:524` | "3–8x more compact than spreadsheets" |
+| `site/index.njk:654` | FAQ — "5–7 lines of YAML … 40–60% smaller than YAML" |
+| `docs/using-satsuma-without-cli.md:38-40` | "3–8x more compact than equivalent spreadsheets, YAML, or free-form docs" |
+| `docs/tutorials/data-engineer-tutorial.md:368` | "3-8x more compact than equivalent spreadsheets or YAML documents" |
+| `docs/product-owner/PROJECT-OVERVIEW.md:67`, `:202` | "40-60% smaller than equivalent YAML" (`:67` is phrased as a design goal, `:202` as a result) |
+| `docs/product-owner/PROJECT-OVERVIEW.md:237` | ">90% LLM-generates-valid-Satsuma" — a future target in a success-metrics list |
+
+`README.md:179` is the worst of the set and should be corrected **immediately,
+not in Phase 4**: it asserts that tests exist. They do not — there is no eval code
+anywhere in the repo, which is why this feature exists. Every other line above is
+an unsourced claim; that one is a false statement about our own repository.
+
+The `>90%` figure is either measured or removed. (`site/_site/` is generated
+output — only the `.njk` sources need editing.)
 
 The failure mode this commitment exists to prevent is running the experiment,
 disliking the answer, and quietly keeping the old number.
@@ -528,8 +902,10 @@ disliking the answer, and quietly keeping the old number.
 - **No claim about human comprehension.** This measures agents. "Faster for
   humans to scan" (`PROJECT-OVERVIEW.md:67`) needs a study with human subjects
   and is out of scope.
-- **No comparison against dbt, DBML, or other mapping DSLs.** Spreadsheets and
-  YAML only — those are what the claims name.
+- **No comparison against dbt, DBML, or other mapping DSLs.** Spreadsheets,
+  markdown, YAML and JSON only — the formats the claims name, plus the one a
+  sceptic substitutes for free. Other mapping DSLs are a different question
+  (competitive positioning, not agent cost) and need their own feature.
 - **No CI integration.** The eval never runs on PRs. Its results are committed
   artifacts, refreshed deliberately.
 - **No cross-harness generalisation claim** at this budget (see the matrix
@@ -542,23 +918,45 @@ disliking the answer, and quietly keeping the old number.
       lineage edges, and **deliberately planted ambiguities**.
 - [ ] `satsuma-scenario-gen` emits `MappingIntent` JSON, with no new dependency
       and no dependency on `@satsuma/core`.
-- [ ] Both renderers (`.stm`, `.xlsx`) implemented, with the xlsx renderer
-      supporting messiness profiles P0/P1/P2.
+- [ ] All three behavioural renderers (`.stm`, `.xlsx`, markdown) implemented,
+      with the xlsx renderer supporting messiness profiles P0/P1/P2 and the
+      markdown renderer supporting M0/M1.
 - [ ] **Renderer totality test passes**: every `MappingIntent` field is
-      demonstrably rendered in both arms; adding an unrendered field fails the
-      suite.
+      demonstrably rendered in all three behavioural arms; adding an unrendered
+      field fails the suite. The markdown renderer is covered by the same test —
+      its characteristic failure is silent omission, so it is the arm this test
+      most needs to guard.
 - [ ] **Blind pairing audit passes**: independent reconstructions from arm X
-      alone and arm S alone agree with each other and with the intent record on
-      every gradeable element except the planted ambiguities.
+      alone, arm M alone and arm S alone agree with each other and with the
+      intent record on every gradeable element except the planted ambiguities.
 - [ ] Deterministic graders for T3, T4 and T5 implemented and unit-tested,
       including negative tests proving each grader *fails* a deliberately wrong
       submission.
-- [ ] Judge rubrics for T1 (and T2's light check) written, with a worked example
-      per score band, and an agreement threshold committed.
+- [ ] Judge rubric for T1 written, with a worked example per score band, and an
+      agreement threshold committed.
 - [ ] Static-compactness measurement produces per-tokenizer, per-serialization,
-      per-spec-size numbers for arms S/X/Y/C — including the
+      per-spec-size numbers for arms S/X/M/Y/J/C — including the
       `AI-AGENT-REFERENCE.md` overhead charged to the Satsuma arm — with no
       model spend.
+- [ ] **Per-command CLI output-size table** produced across the corpus at each
+      spec size, with no model spend, documenting which invocations narrow and
+      which (`graph --json`, `coverage --json`) cost more than reading the source.
+- [ ] Runner records **every `satsuma` invocation** per episode with flags, exit
+      code and output size; the analysis reports the arm-S+ invocation mix and the
+      share of S+ input tokens originating from CLI output versus file reads.
+- [ ] **Arm S's CLI withholding is enforced and asserted** — the CLI is absent
+      from `PATH` for arm-S episodes and the runner verifies this before starting,
+      rather than instructing the agent not to use it.
+- [ ] `satsuma context` is excluded from arm S+, and any attempt to invoke it is
+      recorded as a protocol observation.
+- [ ] Context-boundary cell run, reporting the arm-S+ advantage with and without
+      a context boundary crossed.
+- [ ] **Phase 0.5 probe run and its go/no-go thresholds evaluated** before any
+      Phase 1 engineering begins, with its non-publishable status recorded in the
+      write-up and its numbers absent from `RESULTS.md` and the site.
+- [ ] `README.md:179` corrected immediately — it asserts tests that do not exist,
+      which is a false statement about this repository rather than an unsourced
+      claim.
 - [ ] **Reference-delivery baselines consumed from Feature 45** (which owns that
       measurement): the Satsuma arms use the shipped task-appropriate profile,
       and the resident overhead charged to them is Feature 45's measured figure,
@@ -593,11 +991,12 @@ disliking the answer, and quietly keeping the old number.
    prompt overhead, model-agnostic). The counter-argument is that Claude Code is
    what most of the audience actually uses, so a number measured on Pi may read
    as less relevant even if it is more valid. Validity vs. relatability.
-2. **Whether T2 survives.** Test-case enumeration overlaps T3 (test-data
-   generation) in what it exercises, and you named both. Keeping it puts the run
-   at ~$92 against a $100 cap; dropping it brings the run to ~$79 and frees
-   headroom for more repeats, which is the only thing that tightens the
-   headline's confidence interval.
+2. ~~**Whether T2 survives.**~~ **Settled 2026-08-05: dropped**, on the merits —
+   it overlapped T3 and was the last task needing a judge for its primary grade.
+   The live question it has been replaced by is **how to fit arm M under the cap**:
+   drop the harness-invariance slice and run arm M at 2 rungs instead of 4
+   (~$98, recommended), or raise the cap to $150. See
+   [Costed run plan](#costed-run-plan--100-hard-cap).
 3. **Hand-authored scenario count.** More realism costs authoring effort and
    risks our own bias in what we write; fewer means the marquee codegen task
    runs mostly on synthetic scenarios.
@@ -607,7 +1006,13 @@ disliking the answer, and quietly keeping the old number.
    baseline measurement moves there; this feature measures the restructured
    reference and must not hash its protocol until Feature 45 is released. See
    [But the overhead is a *variable*](#but-the-overhead-is-a-variable-not-a-constant--so-it-is-a-factor).
-5. **Whether the `>90% valid Satsuma` claim gets measured here or just pulled.**
+5. **Whether arm M is reported as a headline number or a footnote.** The measured
+   markdown ratio is the one a technical evaluator will look for, and the
+   registered prediction is that it lands near parity on static size with the
+   advantage showing up in *quality* instead. Publishing it prominently is the
+   honest choice and makes the whole write-up harder to dismiss; it also means the
+   site can no longer imply compactness-over-prose. Recommend headline.
+6. **Whether the `>90% valid Satsuma` claim gets measured here or just pulled.**
    Measuring it is a different experiment (generation validity, not
    comprehension cost) and would need its own arms. Recommend pulling it from
    the site in Phase 4 and giving it its own feature if it's wanted back.


### PR DESCRIPTION
## Why

Feature 44's protocol was strong where it mattered — the `MappingIntent` pairing design, deterministic grading, geometric-mean paired ratios, pre-registration discipline. But reviewing it against the question a technical evaluator actually asks turned up two gaps and one internal contradiction:

1. **It answered the marketing question, not the engineering one.** Markdown appeared exactly once in 614 lines, as a static serialization footnote, and Non-goals scoped it out as "spreadsheets and YAML only — those are what the claims name." Excel is the status quo Satsuma displaces; markdown is what a sceptic substitutes for free.
2. **The earliest signal arrived far too late** — behind Feature 45 shipping *and* releasing, plus `MappingIntent`, the renderers, a totality test, a blind pairing audit, and three graders. Weeks of engineering before anyone knew whether the effect was 1.2× or 4×.
3. **The cut order contradicted the document.** It put arm S second on the chopping block while the same PRD said S vs. S+ is "the contrast that stops the result being uninterpretable."

## What changed

- **Arm M (markdown)** becomes a billed behavioural arm with its own M0/M1 messiness profiles, mirroring the treatment the xlsx arm already had. Compactness is explicitly *not* the claim — the three claims are no convention inference (measured by the M0↔M1 gap), the existence of a `validate`/`lint` oracle, and addressability.
- **Phase 0.5** — a ~$8 hand-graded probe over five arms and the two hand-gradeable tasks (T4, T5), with kill thresholds committed in advance, run before any Phase 1 machinery. Includes a cell designed to *lose* at 1 mapping, to locate the crossover cheaply.
- **Cut order corrected**; arms X, M, S and S+ are uncuttable, and the runner aborts rather than degrading to an uninterpretable comparison.
- **Arm S+ documented as a behavioural distribution**, not a fixed treatment (see below). Invocations now recorded per episode.
- **T2 dropped** on the merits — it overlapped T3 and was the last task needing a judge for its primary grade — and a **context-boundary cell** added, because prompt caching partially substitutes for the benefit arm S+ is meant to provide.

## Two findings worth reading on their own

**Structured output is not inherently cheaper.** Measured on the installed CLI v0.12.0:

| Invocation | Output | vs. reading the workspace |
|---|---|---|
| `graph --compact` | 151 B | 38× smaller |
| `summary` | 792 B | 7× smaller |
| `graph --json` | 12,388 B | **2.1× larger** |
| `coverage --json` | 15,601 B | **2.7× larger** |
| `coverage --json` (metrics-platform) | 70,081 B | **6.4× larger** |

`--json` on the *aggregate* commands costs more than reading the source. So an agent reaching for `graph --json` makes Satsuma+CLI lose outright, which means arm S+'s number is a property of the agent's invocation choices. This also gives Feature 45 its sharpest test: `AI-AGENT-REFERENCE.md:456-458` already advises `--compact`, so dropping that slice should make S+ measurably worse.

**The one real-world Satsuma/markdown pair is not a pair.** A client-derived triple (untracked, inspected locally, not committable) has a `.stm` with 15 schemas, **175 field-level arrows** and 79 NL transform bodies — and a `.md` with **zero field-level mappings**: schema-level mermaid lineage plus rules summarised by *area*. The markdown being 3.5× smaller is not markdown winning on compactness; it's a summary that dropped the payload. That's the honest answer to "why not markdown", but it's n=1, so what it really establishes is a methodological requirement: a hand-authored markdown baseline drifts toward summary, and only a total `render_markdown` gated by the totality test produces an arm worth beating.

## Cost

The run no longer fits its $100 cap (~$118 with arm M, the boundary cell and the probe). The PRD puts that choice to the project owner — drop the harness-invariance slice and run markdown at two rungs (~$98, recommended), or raise the cap — rather than absorbing it silently. Arm M is about a quarter of the run; the PRD says so plainly.

## Also in here

- **`README.md:179` corrected now, not in Phase 4.** It said "*our tests show* 3–8x fewer tokens" — asserting tests that do not exist anywhere in the repo, which is a false statement about our own repository rather than an unsourced claim. The publishing commitment is also widened from 2 sites to all 8 that carry these numbers.
- **`ROADMAP.md`** was missing Features 43, 44 and 45 entirely; its shipped list stopped at 42. All three recorded, with Feature 43 noted as shipped-but-not-yet-archived.

## Tickets

Phase 0.5 only — Phases 1–3 stay ticketless until the probe returns a go.

- `sl-6ips` — gate: Feature 45 shipped and released (the only ready ticket)
- `sl-qz3v` — Phase 0.5 epic, blocked by its three children
- `sl-jdho` → `sl-x9m1` → `sl-3yzd` — author scenario + answer keys, run the arms, grade and decide

## Not an ADR

Assessed: this adds no package, no code and no interface, and changes no architectural boundary. The decisions it records (baseline includes markdown; four arms uncuttable; probe before machinery) are experiment-design decisions whose right home is the PRD itself. Existing ADRs cover coverage semantics, build tooling and serialization contracts — nothing here is of that kind.

## Verification

Docs-only change. `./scripts/run-repo-checks.sh` passes (exit 0), and the pre-commit hook ran the full suite on commit. Anchor links in the PRD verified to resolve against their headings; stale `T2`/"two arms" references swept.

Note: 9 untracked `viz:` bug tickets and a `bug-reports/` directory from parallel work were deliberately left unstaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)