### PR TITLE
chore: archive Feature 43, correct Feature 36 roadmap status

### DIFF
--- a/archive/features/43-site-audit-fixes/PRD.md
+++ b/archive/features/43-site-audit-fixes/PRD.md
@@ -1,6 +1,7 @@
 # Feature 43 — Marketing Site Audit Fixes
 
-> **Status: PROPOSED** (raised 2026-08-04) — found during a full-site audit of
+> **Status: IMPLEMENTED** (2026-08-05) — all 11 `saf-*` tickets closed (epic
+> `saf-dmvx`), PR #485. Found during a full-site audit of
 > `site/` (the Eleventy-built marketing/docs site deployed at
 > `equalexperts.github.io/satsuma-lang`) requested by the project owner: an
 > exhaustive search for incorrect claims, invalid example syntax, dead links,

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -9,18 +9,14 @@ Feature specs live in `features/` while active and move to `archive/features/` o
 ## Active Feature Specs
 
 Features 36 and 40 are active, and Features 44 and 45 are proposed but not yet
-started. Everything numbered 01–35 plus Features 37, 38, 39, 41 and 42 has
+started. Everything numbered 01–35 plus Features 37, 38, 39, 41, 42 and 43 has
 shipped and is archived (see [Shipped Features](#shipped-features)).
 
-Feature 43 (site audit fixes) has also shipped — all 11 `saf-*` tickets are closed
-— but its spec is still sitting in `features/` rather than `archive/features/`. It
-should be moved on the next tidy-up.
+### Feature 36 — Viz Coverage Overlay and Field Chain View (in progress)
 
-### Feature 36 — Viz Coverage Overlay and Field Chain View (not started)
+A paint-only coverage overlay on the viz overview, uncovered-field treatment in cards and detail views, and a chain view rendering one field's full upstream/downstream lineage. Seven tickets under epic `sl-3de8`; two closed (`sl-jcs6` chain traversal model, `sl-5m9x` overlay toggle), five open.
 
-A paint-only coverage overlay on the viz overview, uncovered-field treatment in cards and detail views, and a chain view rendering one field's full upstream/downstream lineage. Eight tickets, none started (epic `sl-3de8`).
-
-**Ready now:** its core dependencies (`sl-gsxu`, `sl-4qvp`) shipped with Feature 35, so `sl-jcs6` (chain traversal model) and `sl-5m9x` (overlay toggle) can both start. `sl-4czz`, `sl-twe8`, `sl-iwlv`, and `sl-nswc` follow from those.
+**Ready now:** `sl-4czz` (chain view rendering) and `sl-twe8` (uncovered-field treatment) follow from the two closed tickets. `sl-iwlv`, `sl-1ml2`, and `sl-nswc` remain.
 
 **Prerequisite worth pulling in:** `3cdd-yavi` — viz-backend does not qualify relative child-arrow paths against their container, so coverage lookups and edge ports silently drop every relative-path arrow. That directly undermines the overlay.
 
@@ -70,7 +66,7 @@ Delivered and moved to `archive/features/`. Recent work, most recent first:
 
 | Feature | Shipped | What landed |
 | --- | --- | --- |
-| 43 — Marketing site audit fixes | 2026-08-05 | All 11 `saf-*` tickets: dead links, stats drift, fabricated example snippets, self-contradictions, and a reframe of `vscode.njk` around workflows and `cli.njk` around agents. Deliberately left the unsubstantiated "3-8x"/"40-60%"/">90%" numbers for Feature 44 to measure. Spec not yet moved to `archive/features/` |
+| 43 — Marketing site audit fixes | 2026-08-05 | All 11 `saf-*` tickets: dead links, stats drift, fabricated example snippets, self-contradictions, and a reframe of `vscode.njk` around workflows and `cli.njk` around agents. Deliberately left the unsubstantiated "3-8x"/"40-60%"/">90%" numbers for Feature 44 to measure |
 | 42 — Monorepo build tooling | 2026-08-04 | npm workspaces behind one root lockfile, a Turborepo task graph whose build order is derived from the manifests rather than written down, and a persisted content-hash cache (ADR-049). CI 4m35s → 1m56s warm; the eleven packages' `prebuild`/`pretest` sibling-build chains and `scripts/build-workspace.sh` are gone |
 | 39 — Correctness by default | 2026-08-04 | Generated CST contracts, opaque path/ref stages, generated coverage and formatter properties, an independent coverage oracle, enforced typecheck and type-aware lint gates, and structural `FieldDecl` variants |
 | 38 — Hierarchical field coverage | 2026-08-03 | Path-correct nested coverage, container tri-state, whole-subtree arrow semantics, leaf-only ratios, and parity across the CLI, LSP, VS Code, and viz consumers (ADR-035–041) |

--- a/features/44-token-and-task-eval/PRD.md
+++ b/features/44-token-and-task-eval/PRD.md
@@ -34,7 +34,7 @@
 > longer fits the $100 cap, and [Costed run plan](#costed-run-plan--100-hard-cap)
 > puts that choice to the project owner rather than silently absorbing it.
 >
-> **Direct antecedent.** `features/43-site-audit-fixes/PRD.md` (Non-goals)
+> **Direct antecedent.** `archive/features/43-site-audit-fixes/PRD.md` (Non-goals)
 > records "3-8x less token usage", "40-60% smaller", and
 > ">90% LLM-generates-valid-Satsuma" as unsubstantiated marketing numbers, and
 > explicitly left them for the project owner to triage into a future feature.


### PR DESCRIPTION
## Summary
- Move `features/43-site-audit-fixes/` to `archive/features/` — all 11 `saf-*` tickets under epic `saf-dmvx` are closed (PR #485), so the spec is fully delivered.
- Update its `Status:` line to `IMPLEMENTED` and fix the cross-reference in `features/44-token-and-task-eval/PRD.md`.
- Correct `ROADMAP.md`'s stale claim that Feature 36 has "none started" — `sl-jcs6` and `sl-5m9x` are closed, 5 of 7 tickets remain.

## Test plan
- [x] Pre-commit hook ran full repo checks (lint, tests, smoke tests) — all green