### PR TITLE
feat(viz): field chain view rendering (sl-4czz)

### DIFF
--- a/.tickets/sl-4czz.md
+++ b/.tickets/sl-4czz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-4czz
-status: in_progress
+status: closed
 deps: [sl-jcs6]
 links: []
 created: 2026-07-31T13:13:41Z
@@ -22,3 +22,15 @@ Entry points: field action in expanded cards and detail view (trace this field) 
 
 Three-mapping chain fixture renders all hops in order with correct labels and classifications; nl-derived hop distinct; namespace fan collapse and expand works; depth-limit affordance shown; hop refocus and mapping-label navigation work; edit-while-in-chain-view preserves state; unit tests pass locally.
 
+
+## Notes
+
+**2026-08-05T10:46:11Z**
+
+## Notes
+
+**2026-08-05T00:00:00Z**
+
+Cause: PRD 36 R4 had no chain-view rendering; the viz-model/backend traversal existed (sl-jcs6) but nothing painted it, and the "trace field" entry point (sz-schema-card's lineage icon) dispatched an event nobody consumed.
+
+Fix: added sz-chain-view.ts (a new left-to-right rail component: upstream columns furthest-first, focus card, downstream columns, namespace-fan collapse >3 hops, classification badges incl. a new nl-derived convention, depth-limit affordance). Wired satsuma-viz.ts with a "chain" view mode, a host-facing openFieldChain(model) API, Feature-34-R1-style reconciliation (re-requests a retrace via the existing field-lineage event on model edits; falls back to overview if the field no longer exists), and mapping-label navigation via a new chain-open-mapping event. Also closed a real gap found while implementing the depth-limit requirement: neither core's traceFieldLineage nor the CLI's field-lineage --json exposed any depth signal, so added per-hop depth and a maxDepth cap to FieldLineageResult/FieldChainModel (additive, golden fixture regenerated) — user-approved approach. (commit immediately after 0876998c)

--- a/.tickets/sl-4czz.md
+++ b/.tickets/sl-4czz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-4czz
-status: open
+status: in_progress
 deps: [sl-jcs6]
 links: []
 created: 2026-07-31T13:13:41Z

--- a/AI-AGENT-REFERENCE.md
+++ b/AI-AGENT-REFERENCE.md
@@ -387,10 +387,16 @@ JSON shape for `field-lineage --json`:
 ```json
 {
   "field":      "::schema.field",
-  "upstream":   [{"field": "::src.f", "via_mapping": "::m", "classification": "none"}, ...],
-  "downstream": [{"field": "::tgt.f", "via_mapping": "::m", "classification": "nl-derived"}, ...]
+  "maxDepth":   10,
+  "upstream":   [{"field": "::src.f", "via_mapping": "::m", "classification": "none", "depth": 1}, ...],
+  "downstream": [{"field": "::tgt.f", "via_mapping": "::m", "classification": "nl-derived", "depth": 1}, ...]
 }
 ```
+
+`maxDepth` echoes the `--depth` you requested. Each hop's `depth` is its hop
+distance from the focus field; a hop whose depth equals `maxDepth` sits
+exactly on the traversal boundary — it may have further neighbours that were
+never traced, not a confirmed dead end.
 
 ### Transform classification
 

--- a/docs/product-owner/ROADMAP.md
+++ b/docs/product-owner/ROADMAP.md
@@ -14,11 +14,11 @@ shipped and is archived (see [Shipped Features](#shipped-features)).
 
 ### Feature 36 — Viz Coverage Overlay and Field Chain View (in progress)
 
-A paint-only coverage overlay on the viz overview, uncovered-field treatment in cards and detail views, and a chain view rendering one field's full upstream/downstream lineage. Seven tickets under epic `sl-3de8`; two closed (`sl-jcs6` chain traversal model, `sl-5m9x` overlay toggle), five open.
+A paint-only coverage overlay on the viz overview, uncovered-field treatment in cards and detail views, and a chain view rendering one field's full upstream/downstream lineage. Seven tickets under epic `sl-3de8`; three closed (`sl-jcs6` chain traversal model, `sl-5m9x` overlay toggle, `sl-4czz` chain view rendering), four open.
 
-**Ready now:** `sl-4czz` (chain view rendering) and `sl-twe8` (uncovered-field treatment) follow from the two closed tickets. `sl-iwlv`, `sl-1ml2`, and `sl-nswc` remain.
+**Ready now:** `sl-twe8` (uncovered-field treatment) and `sl-iwlv` (VS Code webview wiring, unblocked now that `sl-4czz` has landed). `sl-1ml2` and `sl-nswc` remain; `sl-nswc` (the harness Playwright suite) still waits on both `sl-twe8` and `sl-iwlv`.
 
-**Prerequisite worth pulling in:** `3cdd-yavi` — viz-backend does not qualify relative child-arrow paths against their container, so coverage lookups and edge ports silently drop every relative-path arrow. That directly undermines the overlay.
+**Landed alongside `sl-4czz`:** neither core's field-lineage traversal nor the CLI's `field-lineage --json` carried any depth signal, so the chain view's "depth limit reached" affordance could not be shown honestly. Added an additive `depth` (per hop) and `maxDepth` (traversal cap) to the shared CLI/browser JSON contract.
 
 **Deferred by decision:** public-playground exposure of coverage is out of scope and gets its own future feature (`sl-1ml2`).
 

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 300,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 190,
-    "satsuma-viz": 145,
+    "satsuma-viz": 167,
     "integration-tests": 3,
     "vscode-satsuma": 46
   }

--- a/tooling/satsuma-cli/src/commands/field-lineage.ts
+++ b/tooling/satsuma-cli/src/commands/field-lineage.ts
@@ -48,9 +48,15 @@ The field reference is <schema>.<field>. Namespace-qualified names work
 JSON output shape:
   {
     "field": "::schema.field",
-    "upstream":   [{ "field": "::src.f", "via_mapping": "::m", "classification": "none" }, ...],
-    "downstream": [{ "field": "::tgt.f", "via_mapping": "::m", "classification": "none" }, ...]
+    "maxDepth": 10,
+    "upstream":   [{ "field": "::src.f", "via_mapping": "::m", "classification": "none", "depth": 1 }, ...],
+    "downstream": [{ "field": "::tgt.f", "via_mapping": "::m", "classification": "none", "depth": 1 }, ...]
   }
+
+  "maxDepth" echoes the requested --depth. Each hop's "depth" is its hop
+  distance from the focus field; a hop with depth equal to maxDepth sits
+  exactly on the traversal boundary and may have further neighbours that
+  --depth excluded.
 
 Examples:
   satsuma field-lineage s2.a                     # full upstream + downstream

--- a/tooling/satsuma-core/src/field-lineage.ts
+++ b/tooling/satsuma-core/src/field-lineage.ts
@@ -156,6 +156,15 @@ export interface FieldLineageHop {
   via_mapping: string;
   /** Classification of the edge used for the hop. */
   classification: Classification;
+  /**
+   * Mapping-hop distance from the focus field (1 for its direct neighbours).
+   * A hop with `depth === options.depth` sits exactly at the traversal's
+   * depth cap: because BFS is depth-exact (see `traceDirection`), any further
+   * neighbours it may have were never visited. Consumers use this to render
+   * an honest "depth limit reached" affordance rather than presenting such a
+   * hop as a confirmed dead end (no-silent-truncation rule).
+   */
+  depth: number;
 }
 
 /** Published field-lineage payload shared by CLI and browser hosts. */
@@ -166,6 +175,14 @@ export interface FieldLineageResult {
   upstream: FieldLineageHop[];
   /** Breadth-first descendants of the focus field. */
   downstream: FieldLineageHop[];
+  /**
+   * The traversal's requested depth cap (the `depth` this result was built
+   * with). Consumers compare a hop's own `depth` against this value to tell a
+   * boundary hop (may have further, untraced neighbours) from a genuine dead
+   * end reached before the cap — the per-hop `depth` field alone cannot make
+   * that distinction.
+   */
+  maxDepth: number;
 }
 
 /** Which side or sides of a field should be traversed. */
@@ -351,6 +368,7 @@ function traceDirection(
         field: next,
         via_mapping: canonicalMappingRef(edge.mapping),
         classification: edge.classification,
+        depth: item.depth + 1,
       });
       queue.push({ field: next, depth: item.depth + 1 });
     }
@@ -383,5 +401,5 @@ export function traceFieldLineage(
     options.direction === "upstream"
       ? []
       : traceDirection(stableEdges, start, options.depth, "downstream");
-  return { field: start, upstream, downstream };
+  return { field: start, upstream, downstream, maxDepth: options.depth };
 }

--- a/tooling/satsuma-core/test/field-lineage.test.js
+++ b/tooling/satsuma-core/test/field-lineage.test.js
@@ -176,13 +176,14 @@ describe("traceFieldLineage", () => {
     assert.deepEqual(traceFieldLineage(edges, b, { depth: 10, direction: "both" }), {
       field: "::b.id",
       upstream: [
-        { field: "::a.id", via_mapping: "::a_to_b", classification: "none" },
-        { field: "::c.id", via_mapping: "::cycle", classification: "none" },
+        { field: "::a.id", via_mapping: "::a_to_b", classification: "none", depth: 1 },
+        { field: "::c.id", via_mapping: "::cycle", classification: "none", depth: 1 },
       ],
       downstream: [
-        { field: "::c.id", via_mapping: "ns::b_to_c", classification: "nl" },
-        { field: "::d.id", via_mapping: "::b_to_d", classification: "nl-derived" },
+        { field: "::c.id", via_mapping: "ns::b_to_c", classification: "nl", depth: 1 },
+        { field: "::d.id", via_mapping: "::b_to_d", classification: "nl-derived", depth: 1 },
       ],
+      maxDepth: 10,
     });
   });
 
@@ -192,10 +193,11 @@ describe("traceFieldLineage", () => {
     assert.deepEqual(traceFieldLineage(edges, b, { depth: 1, direction: "upstream" }), {
       field: "::b.id",
       upstream: [
-        { field: "::a.id", via_mapping: "::a_to_b", classification: "none" },
-        { field: "::c.id", via_mapping: "::cycle", classification: "none" },
+        { field: "::a.id", via_mapping: "::a_to_b", classification: "none", depth: 1 },
+        { field: "::c.id", via_mapping: "::cycle", classification: "none", depth: 1 },
       ],
       downstream: [],
+      maxDepth: 1,
     });
   });
 
@@ -241,18 +243,23 @@ describe("traceFieldLineage", () => {
     // `leaf` is three hops away only through hub's two-hop side, so it appears
     // if and only if hub was claimed at its shortest depth. Full ordered compare
     // also pins breadth-first emission order and one hop per reached field.
+    // `leaf` also sits exactly on the requested depth cap (3), equal to
+    // `result.maxDepth`: consumers compare a hop's `depth` against `maxDepth`
+    // to render the "may continue beyond here" affordance instead of
+    // presenting a boundary hop as a confirmed dead end.
     const result = traceFieldLineage(downstreamDiamond, start, {
       depth: 3,
       direction: "downstream",
     });
 
     assert.deepEqual(result.downstream, [
-      { field: "::near.id", via_mapping: "::start_to_near", classification: "none" },
-      { field: "::detour.id", via_mapping: "::start_to_detour", classification: "none" },
-      { field: "::hub.id", via_mapping: "::near_to_hub", classification: "none" },
-      { field: "::relay.id", via_mapping: "::detour_to_relay", classification: "none" },
-      { field: "::leaf.id", via_mapping: "::hub_to_leaf", classification: "none" },
+      { field: "::near.id", via_mapping: "::start_to_near", classification: "none", depth: 1 },
+      { field: "::detour.id", via_mapping: "::start_to_detour", classification: "none", depth: 1 },
+      { field: "::hub.id", via_mapping: "::near_to_hub", classification: "none", depth: 2 },
+      { field: "::relay.id", via_mapping: "::detour_to_relay", classification: "none", depth: 2 },
+      { field: "::leaf.id", via_mapping: "::hub_to_leaf", classification: "none", depth: 3 },
     ]);
+    assert.equal(result.maxDepth, 3);
   });
 
   it("reaches the field on the depth boundary above a two-path field upstream", () => {
@@ -273,11 +280,16 @@ describe("traceFieldLineage", () => {
     });
 
     assert.deepEqual(result.upstream, [
-      { field: "::near.id", via_mapping: "::near_to_sink", classification: "none" },
-      { field: "::detour.id", via_mapping: "::detour_to_sink", classification: "none" },
-      { field: "::hub.id", via_mapping: "::hub_to_near", classification: "none" },
-      { field: "::relay.id", via_mapping: "::relay_to_detour", classification: "none" },
-      { field: "::ancestor.id", via_mapping: "::ancestor_to_hub", classification: "none" },
+      { field: "::near.id", via_mapping: "::near_to_sink", classification: "none", depth: 1 },
+      { field: "::detour.id", via_mapping: "::detour_to_sink", classification: "none", depth: 1 },
+      { field: "::hub.id", via_mapping: "::hub_to_near", classification: "none", depth: 2 },
+      { field: "::relay.id", via_mapping: "::relay_to_detour", classification: "none", depth: 2 },
+      {
+        field: "::ancestor.id",
+        via_mapping: "::ancestor_to_hub",
+        classification: "none",
+        depth: 3,
+      },
     ]);
   });
 

--- a/tooling/satsuma-viz-backend/src/field-chain.ts
+++ b/tooling/satsuma-viz-backend/src/field-chain.ts
@@ -149,8 +149,9 @@ export function buildFieldChainFromSources(
   options: BuildFieldChainOptions = {},
 ): FieldChainModel {
   const field = canonicalFocusField(focusField);
+  const maxDepth = options.depth ?? DEFAULT_FIELD_CHAIN_DEPTH;
   const { index, treesByUri } = buildInMemoryWorkspace(documents);
-  if (!treesByUri.has(entryUri)) return { field, upstream: [], downstream: [] };
+  if (!treesByUri.has(entryUri)) return { field, maxDepth, upstream: [], downstream: [] };
 
   const reachableUris = getImportReachableUris(entryUri, index);
   const workspace = createScopedIndex(index, reachableUris);
@@ -168,7 +169,7 @@ export function buildFieldChainFromSources(
   }).edges;
 
   return traceFieldLineage(edges, field, {
-    depth: options.depth ?? DEFAULT_FIELD_CHAIN_DEPTH,
+    depth: maxDepth,
     direction: options.direction ?? "both",
   });
 }

--- a/tooling/satsuma-viz-backend/test/field-chain.test.js
+++ b/tooling/satsuma-viz-backend/test/field-chain.test.js
@@ -47,8 +47,9 @@ mapping bc { source { b } target { c } id -> id }
 
     assert.deepEqual(result, {
       field: "::b.id",
-      upstream: [{ field: "::a.id", via_mapping: "::ab", classification: "none" }],
-      downstream: [{ field: "::c.id", via_mapping: "::bc", classification: "none" }],
+      maxDepth: 10,
+      upstream: [{ field: "::a.id", via_mapping: "::ab", classification: "none", depth: 1 }],
+      downstream: [{ field: "::c.id", via_mapping: "::bc", classification: "none", depth: 1 }],
     });
   });
 
@@ -72,11 +73,12 @@ mapping load {
     );
 
     assert.deepEqual(result.upstream, [
-      { field: "::source_data.id", via_mapping: "::load", classification: "nl" },
+      { field: "::source_data.id", via_mapping: "::load", classification: "nl", depth: 1 },
       {
         field: "::source_data.audit",
         via_mapping: "::load",
         classification: "nl-derived",
+        depth: 1,
       },
     ]);
   });
@@ -84,6 +86,8 @@ mapping load {
   it("limits traversal by mapping depth while retaining the nearest hop", () => {
     // The public builder must forward its limit to core; silently ignoring it
     // would make a wide workspace expensive and contradict the CLI contract.
+    // maxDepth must echo the caller's limit, not the core default, so a host
+    // renderer can tell a boundary hop from a genuine dead end.
     const result = chainFrom(
       `
 schema a { id string }
@@ -97,9 +101,10 @@ mapping bc { source { b } target { c } id -> id }
     );
 
     assert.deepEqual(result.upstream, [
-      { field: "::b.id", via_mapping: "::bc", classification: "none" },
+      { field: "::b.id", via_mapping: "::bc", classification: "none", depth: 1 },
     ]);
     assert.deepEqual(result.downstream, []);
+    assert.equal(result.maxDepth, 1);
   });
 });
 

--- a/tooling/satsuma-viz-backend/test/fixtures/field-chain.json
+++ b/tooling/satsuma-viz-backend/test/fixtures/field-chain.json
@@ -4,24 +4,29 @@
     {
       "field": "::staged.id",
       "via_mapping": "::curate_records",
-      "classification": "nl"
+      "classification": "nl",
+      "depth": 1
     },
     {
       "field": "::raw.audit_code",
       "via_mapping": "::curate_records",
-      "classification": "nl-derived"
+      "classification": "nl-derived",
+      "depth": 1
     },
     {
       "field": "::raw.id",
       "via_mapping": "::stage_records",
-      "classification": "none"
+      "classification": "none",
+      "depth": 2
     }
   ],
   "downstream": [
     {
       "field": "::published.id",
       "via_mapping": "::publish_records",
-      "classification": "none"
+      "classification": "none",
+      "depth": 1
     }
-  ]
+  ],
+  "maxDepth": 10
 }

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -51,6 +51,13 @@ export interface FieldChainHop {
   via_mapping: string;
   /** Whether the connection is direct, transformed NL, or inferred from an NL `@ref`. */
   classification: Classification;
+  /**
+   * Mapping-hop distance from the focus field. A hop whose depth equals the
+   * traversal's requested depth sits on the boundary and may have further
+   * neighbours that were never visited — renderers use this to show an
+   * explicit "depth limit reached" affordance rather than a silent cutoff.
+   */
+  depth: number;
 }
 
 /**
@@ -60,6 +67,13 @@ export interface FieldChainHop {
 export interface FieldChainModel {
   /** Canonical field at the centre of the traversal. */
   field: CanonicalFieldEndpoint;
+  /**
+   * The traversal's requested depth cap. A hop whose `depth` equals this
+   * value sits on the boundary and may have further, untraced neighbours —
+   * compare the two to render an honest "depth limit reached" affordance
+   * rather than a silent cutoff.
+   */
+  maxDepth: number;
   /** Upstream fields, nearest first, with cycles and depth limits guarded by core. */
   upstream: FieldChainHop[];
   /** Downstream fields, nearest first, with cycles and depth limits guarded by core. */

--- a/tooling/satsuma-viz/src/components/sz-chain-view.ts
+++ b/tooling/satsuma-viz/src/components/sz-chain-view.ts
@@ -1,0 +1,462 @@
+/**
+ * sz-chain-view.ts — the "biography of one field": a left-to-right rail.
+ *
+ * Renders a {@link FieldChainModel} (PRD 36 R3) as ordered upstream hops,
+ * then the focus field anchored in the centre, then ordered downstream hops.
+ * This component only renders; it never traces lineage itself — the model is
+ * always supplied by a host (`satsuma-viz`'s `openFieldChain`, ultimately fed
+ * by `@satsuma/viz-backend` in the browser or the LSP in VS Code), matching
+ * the same host-supplied-model contract already used for the coverage
+ * overlay (PRD 36 R1). It owns none of the app-level view-mode switching or
+ * back navigation — those live in `satsuma-viz.ts`, alongside the equivalent
+ * machinery for the mapping detail view.
+ */
+import { LitElement, html, css, type TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+// Narrow submodule imports, not the package root: the root barrel re-exports
+// parser/extraction code that needs Node's tree-sitter bindings, which
+// esbuild cannot bundle into this browser component (mirrors
+// sz-mapping-detail.ts's @satsuma/core/extract import).
+import { fieldEndpointPath, fieldEndpointSchema } from "@satsuma/core/reference-stages";
+import type { CanonicalFieldEndpoint } from "@satsuma/core/reference-stages";
+import type { Classification } from "@satsuma/core/types";
+import type { FieldChainHop, FieldChainModel } from "../model.js";
+import { SzFieldLineageEvent } from "../satsuma-viz.js";
+
+/**
+ * A namespace group within one depth column is collapsed to a summary chip
+ * once it holds more than this many hops (PRD 36 R4: "collapse by namespace
+ * with expand-on-click", user decision on PRD open question 2). Chosen as the
+ * largest fan that still reads comfortably as a single column of cards
+ * without scrolling past the viewport on a typical review screen.
+ */
+const NAMESPACE_GROUP_COLLAPSE_THRESHOLD = 3;
+
+/** One direction's hops bucketed into left-to-right columns by hop distance. */
+interface ChainColumn {
+  depth: number;
+  hops: FieldChainHop[];
+}
+
+/** One namespace's hops within a single column, before collapse is decided. */
+interface NamespaceGroup {
+  namespace: string | null;
+  hops: FieldChainHop[];
+}
+
+/** A hop's field decomposed for display and for re-dispatching a trace request. */
+interface EndpointParts {
+  namespace: string | null;
+  schemaName: string;
+  fieldPath: string;
+}
+
+/** Split a canonical field endpoint into namespace, schema name, and field path. */
+function splitEndpoint(endpoint: CanonicalFieldEndpoint): EndpointParts {
+  const schemaRef = fieldEndpointSchema(endpoint);
+  const separator = schemaRef.indexOf("::");
+  return {
+    namespace: separator === 0 ? null : schemaRef.slice(0, separator),
+    schemaName: schemaRef.slice(separator + 2),
+    fieldPath: fieldEndpointPath(endpoint) ?? "",
+  };
+}
+
+/** The `qualifiedId` spelling (no leading `::`) that SchemaCard and events use. */
+function qualifiedIdOf(parts: EndpointParts): string {
+  return parts.namespace ? `${parts.namespace}::${parts.schemaName}` : parts.schemaName;
+}
+
+/** Drop a global mapping's leading `::` for a compact display label. */
+function shortMappingName(viaMapping: string): string {
+  return viaMapping.startsWith("::") ? viaMapping.slice(2) : viaMapping;
+}
+
+/** Bucket hops by hop distance, ascending, so each depth becomes one rail column. */
+function toColumns(hops: readonly FieldChainHop[]): ChainColumn[] {
+  const byDepth = new Map<number, FieldChainHop[]>();
+  for (const hop of hops) {
+    const bucket = byDepth.get(hop.depth);
+    if (bucket) bucket.push(hop);
+    else byDepth.set(hop.depth, [hop]);
+  }
+  return [...byDepth.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([depth, columnHops]) => ({ depth, hops: columnHops }));
+}
+
+/** Group one column's hops by the namespace of the field they reach. */
+function toNamespaceGroups(hops: readonly FieldChainHop[]): NamespaceGroup[] {
+  const byNamespace = new Map<string, NamespaceGroup>();
+  for (const hop of hops) {
+    const { namespace } = splitEndpoint(hop.field);
+    const key = namespace ?? "";
+    const group = byNamespace.get(key);
+    if (group) group.hops.push(hop);
+    else byNamespace.set(key, { namespace, hops: [hop] });
+  }
+  return [...byNamespace.values()];
+}
+
+/** Mapping label click — asks the host to resolve and open that mapping's detail view. */
+export class SzChainOpenMappingEvent extends Event {
+  readonly viaMapping: string;
+  constructor(viaMapping: string) {
+    super("chain-open-mapping", { bubbles: true, composed: true });
+    this.viaMapping = viaMapping;
+  }
+}
+
+@customElement("sz-chain-view")
+export class SzChainView extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      font-family: var(--sz-font-sans);
+    }
+
+    .chain-rail {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+      padding: 16px 8px;
+      width: max-content;
+      min-width: 100%;
+    }
+
+    .chain-column {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .chain-group {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .chain-group-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--sz-text-muted);
+    }
+
+    .chain-group-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      border: 1px dashed var(--sz-card-border-strong);
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-namespace-bg);
+      color: var(--sz-text-muted);
+      font-family: inherit;
+      font-size: 12px;
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+
+    .chain-group-chip:hover {
+      background: var(--sz-row-hover-bg);
+      color: var(--sz-text);
+    }
+
+    .hop-card {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      min-width: 160px;
+      padding: 8px 10px;
+      border: 1px solid var(--sz-card-border);
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-card-bg);
+      box-shadow: var(--sz-card-shadow);
+    }
+
+    .focus-card {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 4px;
+      min-width: 180px;
+      padding: 12px 14px;
+      border: 2px solid var(--sz-orange);
+      border-radius: var(--sz-card-radius);
+      background: var(--sz-accent-wash);
+      flex-shrink: 0;
+    }
+
+    .hop-via {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11px;
+    }
+
+    .hop-mapping {
+      border: none;
+      background: transparent;
+      color: var(--sz-text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 0;
+      cursor: pointer;
+      text-decoration: underline dotted;
+    }
+
+    .hop-mapping:hover {
+      color: var(--sz-orange-dark);
+    }
+
+    .classification-badge {
+      border-radius: var(--sz-badge-radius);
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 5px;
+    }
+
+    /* Declared, transformed arrow (classification "nl") — same green as the
+     * dashed NL edge stroke used elsewhere in the overview/detail views. */
+    .classification-badge.nl {
+      background: var(--sz-green-wash);
+      color: var(--sz-green);
+    }
+
+    /* Implicit hop inferred from an @ref in prose, not a declared arrow — the
+     * one classification with no rendering precedent elsewhere in this
+     * package (sl-4czz design note). Reuses the "question" palette: an
+     * inferred connection carries the same "read the prose to be sure"
+     * caveat as an open question on a field. */
+    .classification-badge.nl-derived {
+      background: var(--sz-question-bg);
+      color: var(--sz-question-icon);
+    }
+
+    .hop-field {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      border: none;
+      background: transparent;
+      font-family: inherit;
+      padding: 0;
+      cursor: pointer;
+      text-align: left;
+    }
+
+    .hop-field:hover .hop-schema,
+    .hop-field:hover .hop-path {
+      color: var(--sz-orange-dark);
+    }
+
+    .focus-card .hop-schema,
+    .focus-card .hop-path {
+      cursor: default;
+    }
+
+    .hop-namespace {
+      font-size: 10px;
+      color: var(--sz-text-muted);
+    }
+
+    .hop-schema {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--sz-text);
+    }
+
+    .hop-path {
+      font-family: var(--sz-font-mono);
+      font-size: 12px;
+      color: var(--sz-text-muted);
+    }
+
+    /* Depth-limit affordance (sl-4czz): reuses the "warning" palette because,
+     * like a warning badge, it flags that the picture may be incomplete —
+     * this hop sits exactly on the traversal's depth cap and may have
+     * further, untraced neighbours (no-silent-truncation rule). */
+    .depth-limit-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 3px;
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-warning-bg);
+      color: var(--sz-warning-icon);
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 5px;
+    }
+
+    .chain-empty {
+      padding: 24px;
+      color: var(--sz-text-muted);
+      font-size: 13px;
+    }
+  `;
+
+  /** The traversal to render, supplied by the host. Null renders nothing but an empty state. */
+  @property({ type: Object })
+  chain: FieldChainModel | null = null;
+
+  /**
+   * Namespace groups the user has expanded past their default collapse
+   * (`${direction}:${depth}:${namespace}` keys). Intentionally never pruned
+   * against `chain` changes: re-collapsing a group the user just opened, the
+   * moment a host refreshes the chain after an edit, would be surprising.
+   */
+  @state()
+  private _expandedGroups = new Set<string>();
+
+  override render() {
+    if (!this.chain) {
+      return html`<div class="chain-empty" data-testid="chain-empty">No field selected</div>`;
+    }
+
+    // Upstream renders furthest-first so hop distance increases moving away
+    // from the focus card, matching the downstream rail's natural order.
+    const upstreamColumns = toColumns(this.chain.upstream).reverse();
+    const downstreamColumns = toColumns(this.chain.downstream);
+
+    return html`
+      <div class="chain-rail" data-testid="chain-view">
+        ${upstreamColumns.map((column) => this._renderColumn(column, "upstream"))}
+        ${this._renderFocus(this.chain.field)}
+        ${downstreamColumns.map((column) => this._renderColumn(column, "downstream"))}
+      </div>
+    `;
+  }
+
+  private _renderFocus(field: CanonicalFieldEndpoint): TemplateResult {
+    const parts = splitEndpoint(field);
+    return html`
+      <div class="focus-card" data-testid="chain-focus">
+        ${parts.namespace ? html`<span class="hop-namespace">${parts.namespace}</span>` : ""}
+        <span class="hop-schema">${parts.schemaName}</span>
+        <span class="hop-path">${parts.fieldPath}</span>
+      </div>
+    `;
+  }
+
+  private _renderColumn(column: ChainColumn, direction: "upstream" | "downstream") {
+    const groups = toNamespaceGroups(column.hops);
+    // Composed as one JS string, then bound as a single interpolation: an
+    // attribute mixing literal text with more than one `${}` slot serializes
+    // as separate string/value runs under the tests' template-flattening
+    // helper (and every sibling component already follows this rule).
+    const testId = `chain-column-${direction}-${column.depth}`;
+    return html`
+      <div class="chain-column" data-testid=${testId}>
+        ${groups.map((group) => this._renderGroup(group, direction, column.depth))}
+      </div>
+    `;
+  }
+
+  private _renderGroup(group: NamespaceGroup, direction: "upstream" | "downstream", depth: number) {
+    const key = `${direction}:${depth}:${group.namespace ?? ""}`;
+    const collapsed =
+      group.hops.length > NAMESPACE_GROUP_COLLAPSE_THRESHOLD && !this._expandedGroups.has(key);
+
+    if (collapsed) {
+      const testId = `chain-group-${key}`;
+      return html`
+        <button
+          class="chain-group-chip"
+          data-testid=${testId}
+          @click=${() => this._expandGroup(key)}
+        >
+          ${group.namespace ?? "global"} (${group.hops.length} fields) &#9656;
+        </button>
+      `;
+    }
+
+    return html`
+      <div class="chain-group">
+        ${group.namespace ? html`<span class="chain-group-label">${group.namespace}</span>` : ""}
+        ${group.hops.map((hop) => this._renderHop(hop, direction))}
+      </div>
+    `;
+  }
+
+  private _renderHop(hop: FieldChainHop, direction: "upstream" | "downstream") {
+    const parts = splitEndpoint(hop.field);
+    const qualifiedId = qualifiedIdOf(parts);
+    const atDepthLimit = this.chain !== null && hop.depth === this.chain.maxDepth;
+    const cardTestId = `chain-hop-${direction}-${hop.depth}`;
+    const mappingTestId = `chain-hop-mapping-${direction}-${hop.depth}`;
+    const fieldTestId = `chain-hop-field-${direction}-${hop.depth}`;
+    const depthLimitTestId = `chain-depth-limit-${direction}-${hop.depth}`;
+    const mappingTitle = `Open mapping ${hop.via_mapping}`;
+    const fieldTitle = `Trace ${qualifiedId}.${parts.fieldPath}`;
+
+    return html`
+      <div class="hop-card" data-testid=${cardTestId} data-classification=${hop.classification}>
+        <div class="hop-via">
+          <button
+            class="hop-mapping"
+            data-testid=${mappingTestId}
+            title=${mappingTitle}
+            @click=${() => this._openMapping(hop.via_mapping)}
+          >
+            ${shortMappingName(hop.via_mapping)}
+          </button>
+          ${this._renderClassificationBadge(hop.classification)}
+        </div>
+        <button
+          class="hop-field"
+          data-testid=${fieldTestId}
+          title=${fieldTitle}
+          @click=${() => this._focusField(qualifiedId, parts.fieldPath)}
+        >
+          ${parts.namespace ? html`<span class="hop-namespace">${parts.namespace}</span>` : ""}
+          <span class="hop-schema">${parts.schemaName}</span>
+          <span class="hop-path">${parts.fieldPath}</span>
+        </button>
+        ${
+          atDepthLimit
+            ? html`<span
+                class="depth-limit-badge"
+                data-testid=${depthLimitTestId}
+                title="Depth limit reached — this hop may have further, untraced neighbours"
+                >&#8942; depth limit</span
+              >`
+            : ""
+        }
+      </div>
+    `;
+  }
+
+  private _renderClassificationBadge(classification: Classification) {
+    if (classification === "none") return "";
+    if (classification === "nl") {
+      return html`<span class="classification-badge nl" title="Declared arrow with a transform"
+        >NL</span
+      >`;
+    }
+    return html`<span
+      class="classification-badge nl-derived"
+      title="Inferred from an @ref in natural-language text — not a declared arrow"
+      >NL-derived</span
+    >`;
+  }
+
+  private _expandGroup(key: string) {
+    this._expandedGroups = new Set(this._expandedGroups).add(key);
+  }
+
+  private _focusField(schemaId: string, fieldName: string) {
+    this.dispatchEvent(new SzFieldLineageEvent(schemaId, fieldName));
+  }
+
+  private _openMapping(viaMapping: string) {
+    this.dispatchEvent(new SzChainOpenMappingEvent(viaMapping));
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "sz-chain-view": SzChainView;
+  }
+}

--- a/tooling/satsuma-viz/src/model.ts
+++ b/tooling/satsuma-viz/src/model.ts
@@ -27,6 +27,8 @@ export type {
   SourceBlockInfo,
   SourceLocation,
   AggregateCoverage,
+  FieldChainModel,
+  FieldChainHop,
 } from "@satsuma/viz-model";
 
 export { CONSTRAINT_TAGS } from "@satsuma/viz-model";

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -8,6 +8,7 @@ import type {
   MappingBlock,
   SchemaCard,
   AggregateCoverage,
+  FieldChainModel,
 } from "./model.js";
 import {
   computeLayout,
@@ -19,9 +20,16 @@ import {
 import { SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 import tokens from "./tokens.css";
 import { renderMarkdown } from "./markdown.js";
-import { buildCoverageIndex, mappingSchemaCoverage } from "./field-coverage.js";
+import { buildCoverageIndex, mappingSchemaCoverage, schemaHasFieldPath } from "./field-coverage.js";
 import type { SchemaCoverage } from "./field-coverage.js";
 import { metricAsSchemaCard } from "./metric-adapter.js";
+// Imported from the narrow reference-stages submodule, not the package root:
+// the root barrel re-exports parser/extraction code that needs Node's tree-
+// sitter bindings, which esbuild cannot bundle for this browser component
+// (mirrors sz-mapping-detail.ts's @satsuma/core/extract import).
+import { fieldEndpointPath, fieldEndpointSchema } from "@satsuma/core/reference-stages";
+import type { CanonicalFieldEndpoint } from "@satsuma/core/reference-stages";
+import { SzChainOpenMappingEvent } from "./components/sz-chain-view.js";
 
 export { VizModel } from "./model.js";
 export type { AggregateCoverage, NamespaceGroup } from "./model.js";
@@ -33,6 +41,7 @@ export { SzSchemaCard } from "./components/sz-schema-card.js";
 export type { SzCompactToggledDetail } from "./components/sz-schema-card.js";
 export { SzMetricCard } from "./components/sz-metric-card.js";
 export { SzFragmentCard } from "./components/sz-fragment-card.js";
+export { SzChainView, SzChainOpenMappingEvent } from "./components/sz-chain-view.js";
 export { SzEdgeLayer } from "./edges/sz-edge-layer.js";
 export { SzOverviewEdgeLayer, SzOpenMappingEvent } from "./edges/sz-overview-edge-layer.js";
 export { SzMappingDetail } from "./components/sz-mapping-detail.js";
@@ -182,7 +191,8 @@ export class SzFieldLineageEvent extends Event {
 }
 
 export type VizAutomationReadyState = "empty" | "loading" | "ready" | "fallback";
-export type VizAutomationRenderMode = "empty" | "overview" | "detail" | "fallback";
+export type VizAutomationRenderMode = "empty" | "overview" | "detail" | "chain" | "fallback";
+export type VizViewMode = "overview" | "detail" | "chain";
 
 export interface VizAutomationState {
   /** Stable renderer readiness state for browser automation. */
@@ -190,7 +200,7 @@ export interface VizAutomationState {
   /** Which major UI surface is currently rendered. */
   renderMode: VizAutomationRenderMode;
   /** Current user-facing view mode. */
-  viewMode: "overview" | "detail";
+  viewMode: VizViewMode;
 }
 
 export function sanitizeTestIdSegment(value: string): string {
@@ -221,11 +231,18 @@ export function describeVizAutomationState(args: {
   hasModel: boolean;
   hasOverviewLayout: boolean;
   hasDetailLayout: boolean;
+  /** Whether a chain model is currently loaded — chain mode has no ELK layout to wait on. */
+  hasChainModel: boolean;
   layoutError: boolean;
-  viewMode: "overview" | "detail";
+  viewMode: VizViewMode;
 }): VizAutomationState {
   if (!args.hasModel) {
     return { readyState: "empty", renderMode: "empty", viewMode: args.viewMode };
+  }
+  if (args.viewMode === "chain") {
+    return args.hasChainModel
+      ? { readyState: "ready", renderMode: "chain", viewMode: args.viewMode }
+      : { readyState: "loading", renderMode: "empty", viewMode: args.viewMode };
   }
   if (args.layoutError) {
     return { readyState: "fallback", renderMode: "fallback", viewMode: args.viewMode };
@@ -927,7 +944,16 @@ export class SatsumaViz extends LitElement {
   reduceMotion = false;
 
   @state()
-  private _viewMode: "overview" | "detail" = "overview";
+  private _viewMode: VizViewMode = "overview";
+
+  /**
+   * Chain view's currently displayed traversal, supplied by the host via
+   * {@link openFieldChain} — the component never computes lineage itself
+   * (PRD 36 open question 3, resolved REUSE). Null whenever `_viewMode` is
+   * not `"chain"`.
+   */
+  @state()
+  private _chainModel: FieldChainModel | null = null;
 
   @state()
   private _layout: LayoutResult | null = null;
@@ -1083,6 +1109,13 @@ export class SatsumaViz extends LitElement {
       this._viewMode = "detail";
       this._resetPanZoom();
     }) as EventListener);
+    // A chain-view hop's mapping label carries only a canonical mapping
+    // reference (no MappingBlock object survives the chain-model boundary),
+    // so this resolves it against the currently loaded model rather than
+    // reusing the "open-mapping" contract, which expects the object itself.
+    this.addEventListener("chain-open-mapping", ((e: SzChainOpenMappingEvent) => {
+      this._openMappingByRef(e.viaMapping);
+    }) as EventListener);
   }
 
   override disconnectedCallback() {
@@ -1179,10 +1212,86 @@ export class SatsumaViz extends LitElement {
       }
     }
 
-    // No surviving selection (first load, or the mapping was renamed/deleted).
+    // Chain view has no analogue of "the object still exists in the new
+    // model" — a FieldChainModel is a host-supplied traversal, not something
+    // reconstructible from VizModel alone. So instead of rebinding locally,
+    // ask the host to retrace: re-dispatching the same "field-lineage"
+    // request the original entry point used lets the host recompute against
+    // the fresh model and call openFieldChain() again (Feature 34 R1). The
+    // stale _chainModel keeps rendering until that response arrives.
+    if (this._viewMode === "chain" && this._chainModel) {
+      if (this._chainFieldStillExists(model, this._chainModel.field)) {
+        const { namespace, schemaName, fieldPath } = this._splitEndpointForReconcile(
+          this._chainModel.field,
+        );
+        const schemaId = namespace ? `${namespace}::${schemaName}` : schemaName;
+        this.dispatchEvent(new SzFieldLineageEvent(schemaId, fieldPath));
+        return;
+      }
+    }
+
+    // No surviving selection (first load, or the mapping/field was renamed
+    // or deleted).
     this._viewMode = "overview";
     this._selectedMapping = null;
     this._selectedMappingKey = null;
+    this._chainModel = null;
+  }
+
+  /** Whether a chain focus field's owning schema and path still exist in `model`. */
+  private _chainFieldStillExists(model: VizModel, endpoint: CanonicalFieldEndpoint): boolean {
+    const { namespace, schemaName, fieldPath } = this._splitEndpointForReconcile(endpoint);
+    const qualifiedId = namespace ? `${namespace}::${schemaName}` : schemaName;
+    for (const ns of model.namespaces) {
+      const schema = ns.schemas.find((s) => s.qualifiedId === qualifiedId);
+      if (schema) return fieldPath === "" || schemaHasFieldPath(schema, fieldPath);
+    }
+    return false;
+  }
+
+  /** Decompose a canonical field endpoint without importing the full chain-view module. */
+  private _splitEndpointForReconcile(endpoint: CanonicalFieldEndpoint): {
+    namespace: string | null;
+    schemaName: string;
+    fieldPath: string;
+  } {
+    const schemaRef = fieldEndpointSchema(endpoint);
+    const separator = schemaRef.indexOf("::");
+    return {
+      namespace: separator === 0 ? null : schemaRef.slice(0, separator),
+      schemaName: schemaRef.slice(separator + 2),
+      fieldPath: fieldEndpointPath(endpoint) ?? "",
+    };
+  }
+
+  /**
+   * Enter or refresh chain view with a host-computed traversal.
+   *
+   * The component never traces lineage itself (PRD 36 open question 3,
+   * resolved REUSE): a host listens for the bubbling "field-lineage" event —
+   * fired by a schema card's or mapping detail's field action, by a chain
+   * hop click, or by this component re-requesting a refresh after a model
+   * edit — computes the traversal via `@satsuma/viz-backend` or the LSP, and
+   * calls this method with the result.
+   */
+  openFieldChain(model: FieldChainModel): void {
+    this._chainModel = model;
+    this._viewMode = "chain";
+    this._resetPanZoom();
+  }
+
+  /** Resolve a chain hop's mapping reference against the current model and open its detail view. */
+  private _openMappingByRef(viaMapping: string): void {
+    if (!this.model) return;
+    const key = viaMapping.startsWith("::") ? `_::${viaMapping.slice(2)}` : viaMapping;
+    for (const ns of this.model.namespaces) {
+      for (const m of ns.mappings) {
+        if (this._mappingKey(m) === key) {
+          this._openOverviewMapping(m);
+          return;
+        }
+      }
+    }
   }
 
   /** Stable cross-rebuild key for a mapping; see _selectedMappingKey. */
@@ -1304,6 +1413,7 @@ export class SatsumaViz extends LitElement {
       hasModel: Boolean(this.model),
       hasOverviewLayout: Boolean(this._overviewLayout),
       hasDetailLayout: Boolean(this._layout),
+      hasChainModel: Boolean(this._chainModel),
       layoutError: this._layoutError,
       viewMode: this._viewMode,
     });
@@ -1331,6 +1441,36 @@ export class SatsumaViz extends LitElement {
 
     const filtered = this._filterNamespaces(namespaces);
     const toggleClasses = `${this._schemaOnly ? "schema-only" : ""} ${!this._showNotes ? "hide-notes" : ""}`;
+
+    // Chain view: a simple left-to-right rail, independent of the ELK
+    // overview/detail layouts computed below — it renders as soon as a host
+    // has supplied a chain model, whatever state those layouts are in.
+    if (this._viewMode === "chain") {
+      return html`
+        ${this._renderToolbar(namespaces)}
+        <div class="view-content">
+          <div
+            class="viewport"
+            data-testid="viz-viewport"
+            @wheel=${this._onWheel}
+            @mousedown=${this._onMouseDown}
+            @mousemove=${this._onMouseMove}
+            @mouseup=${this._onMouseUp}
+            @mouseleave=${this._onMouseUp}
+          >
+            <div
+              class="viewport-inner"
+              style="transform: translate(${this._panX}px, ${this._panY}px) scale(${this._zoom});"
+            >
+              <sz-chain-view .chain=${this._chainModel}></sz-chain-view>
+            </div>
+            <div class="zoom-indicator ${this._zoomIndicatorVisible ? "visible" : ""}">
+              ${Math.round(this._zoom * 100)}%
+            </div>
+          </div>
+        </div>
+      `;
+    }
 
     // If layout hasn't computed yet, show loading
     if (!this._layout && !this._overviewLayout && !this._layoutError) {
@@ -1471,6 +1611,8 @@ export class SatsumaViz extends LitElement {
     );
     const hasNamespaces = namedNs.length > 0;
     const inDetail = this._viewMode === "detail";
+    const inChain = this._viewMode === "chain";
+    const inOverview = this._viewMode === "overview";
 
     return html`
       <div class="toolbar">
@@ -1483,7 +1625,20 @@ export class SatsumaViz extends LitElement {
                 <div class="toolbar-sep"></div>
                 <span class="toolbar-title">${this._selectedMapping?.id ?? "Mapping Detail"}</span>
               `
-            : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`
+            : inChain
+              ? html`
+                  <button
+                    class="toolbar-btn"
+                    data-testid="toolbar-chain-back"
+                    @click=${this._backToOverview}
+                    title="Back to overview"
+                  >
+                    &#9664; Overview
+                  </button>
+                  <div class="toolbar-sep"></div>
+                  <span class="toolbar-title">${this._chainFocusTitle()}</span>
+                `
+              : html`<span class="toolbar-title">&#9673; Mapping Viz</span>`
         }
         <div class="toolbar-sep"></div>
         <button
@@ -1499,7 +1654,7 @@ export class SatsumaViz extends LitElement {
         </button>
         <div class="toolbar-sep"></div>
         ${
-          !inDetail
+          inOverview
             ? html`<button
                   class="toolbar-btn"
                   data-testid="toolbar-toggle-coverage"
@@ -1514,7 +1669,7 @@ export class SatsumaViz extends LitElement {
             : ""
         }
         ${
-          !inDetail
+          inOverview
             ? html`<button
                 class="toolbar-btn"
                 data-testid="toolbar-fit"
@@ -1534,7 +1689,7 @@ export class SatsumaViz extends LitElement {
           &#8635; Refresh
         </button>
         ${
-          !inDetail
+          inOverview
             ? html`<button
                 class="toolbar-btn"
                 data-testid="toolbar-export"
@@ -1546,7 +1701,7 @@ export class SatsumaViz extends LitElement {
             : ""
         }
         ${
-          hasNamespaces && !inDetail
+          hasNamespaces && inOverview
             ? html`
                 <div class="toolbar-sep"></div>
                 <select
@@ -1567,7 +1722,7 @@ export class SatsumaViz extends LitElement {
             : ""
         }
         ${
-          this._getSourceFiles().length > 1 && !inDetail
+          this._getSourceFiles().length > 1 && inOverview
             ? html`
                 <div class="toolbar-sep"></div>
                 <select
@@ -1594,10 +1749,21 @@ export class SatsumaViz extends LitElement {
     `;
   }
 
+  /** Toolbar title for chain view: the focus field's qualified name. */
+  private _chainFocusTitle(): string {
+    if (!this._chainModel) return "Field Chain";
+    const { namespace, schemaName, fieldPath } = this._splitEndpointForReconcile(
+      this._chainModel.field,
+    );
+    const schemaId = namespace ? `${namespace}::${schemaName}` : schemaName;
+    return `Chain: ${schemaId}.${fieldPath}`;
+  }
+
   private _backToOverview() {
     this._viewMode = "overview";
     this._selectedMapping = null;
     this._selectedMappingKey = null;
+    this._chainModel = null;
     this._resetPanZoom();
   }
 
@@ -2090,6 +2256,7 @@ export class SatsumaViz extends LitElement {
       hasModel: Boolean(this.model),
       hasOverviewLayout: Boolean(this._overviewLayout),
       hasDetailLayout: Boolean(this._layout),
+      hasChainModel: Boolean(this._chainModel),
       layoutError: this._layoutError,
       viewMode: this._viewMode,
     });

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -16,6 +16,7 @@ describe("viz automation helpers", () => {
         hasModel: true,
         hasOverviewLayout: false,
         hasDetailLayout: false,
+        hasChainModel: false,
         layoutError: false,
         viewMode: "overview",
       }),
@@ -30,6 +31,7 @@ describe("viz automation helpers", () => {
         hasModel: true,
         hasOverviewLayout: true,
         hasDetailLayout: true,
+        hasChainModel: false,
         layoutError: false,
         viewMode: "overview",
       }),
@@ -44,10 +46,43 @@ describe("viz automation helpers", () => {
         hasModel: true,
         hasOverviewLayout: false,
         hasDetailLayout: false,
+        hasChainModel: false,
         layoutError: true,
         viewMode: "overview",
       }),
       { readyState: "fallback", renderMode: "fallback", viewMode: "overview" },
+    );
+  });
+
+  it("reports loading state for chain view before a host has supplied a chain model", async () => {
+    // Chain view has no ELK layout to wait on — its own readiness signal is
+    // whether openFieldChain() has been called yet, not hasOverviewLayout.
+    const mod = await import("../dist/satsuma-viz.js");
+    assert.deepEqual(
+      mod.describeVizAutomationState({
+        hasModel: true,
+        hasOverviewLayout: true,
+        hasDetailLayout: true,
+        hasChainModel: false,
+        layoutError: false,
+        viewMode: "chain",
+      }),
+      { readyState: "loading", renderMode: "empty", viewMode: "chain" },
+    );
+  });
+
+  it("reports ready chain state once a chain model has been supplied", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    assert.deepEqual(
+      mod.describeVizAutomationState({
+        hasModel: true,
+        hasOverviewLayout: true,
+        hasDetailLayout: true,
+        hasChainModel: true,
+        layoutError: false,
+        viewMode: "chain",
+      }),
+      { readyState: "ready", renderMode: "chain", viewMode: "chain" },
     );
   });
 

--- a/tooling/satsuma-viz/test/sz-chain-view.test.js
+++ b/tooling/satsuma-viz/test/sz-chain-view.test.js
@@ -1,0 +1,189 @@
+// sz-chain-view.test.js — the field-chain rail rendering (sl-4czz, PRD 36 R4).
+//
+// The component only paints a host-supplied FieldChainModel; it never traces
+// lineage itself. These tests pin: column ordering (furthest-first moving away
+// from the focus card), the classification badge invented for this feature
+// (no prior rendering precedent existed for "nl-derived"), the depth-limit
+// affordance that makes truncation explicit rather than silent, namespace-fan
+// collapse/expand, and the two events a host must handle to complete the
+// "trace this field" and "open this mapping" interactions.
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+/** Flatten a Lit TemplateResult tree into plain text, the same way sibling test files do. */
+function serialize(t) {
+  if (t == null || typeof t !== "object") return String(t ?? "");
+  if (Array.isArray(t)) return t.map(serialize).join(" ");
+  if (t.strings && t.values) {
+    return [...t.strings, ...t.values.map(serialize)].join(" ");
+  }
+  return "";
+}
+
+const hop = (field, viaMapping, classification, depth) => ({
+  field,
+  via_mapping: viaMapping,
+  classification,
+  depth,
+});
+
+describe("sz-chain-view", () => {
+  it("renders an empty state when no chain is supplied", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    const serialized = serialize(view.render());
+    assert.match(serialized, /chain-empty/);
+  });
+
+  it("renders the focus field's namespace, schema, and path", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    view.chain = { field: "crm::orders.id", maxDepth: 5, upstream: [], downstream: [] };
+    const serialized = serialize(view.render());
+    assert.match(serialized, /chain-focus/);
+    assert.match(serialized, /crm/);
+    assert.match(serialized, /orders/);
+    assert.match(serialized, /\bid\b/);
+  });
+
+  it("orders upstream columns furthest-first so hop distance increases moving away from the focus card", async () => {
+    // Depth 2 must appear before depth 1 in the upstream rail so the reader's
+    // eye moves focus -> near -> far in the same left-to-right direction the
+    // downstream rail already reads in.
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    view.chain = {
+      field: "::orders.id",
+      maxDepth: 5,
+      upstream: [
+        hop("::customers.id", "::load_customers", "none", 1),
+        hop("::legacy.id", "::migrate", "none", 2),
+      ],
+      downstream: [],
+    };
+    const serialized = serialize(view.render());
+    assert.ok(
+      serialized.indexOf("chain-column-upstream-2") < serialized.indexOf("chain-column-upstream-1"),
+      "expected the depth-2 column before the depth-1 column",
+    );
+  });
+
+  describe("classification badge", () => {
+    it("renders no badge for a direct, undeclared-transform hop", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      assert.equal(view._renderClassificationBadge("none"), "");
+    });
+
+    it("labels a declared arrow with a transform as NL", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      const serialized = serialize(view._renderClassificationBadge("nl"));
+      assert.match(serialized, /classification-badge nl"/);
+      assert.match(serialized, /\bNL\b/);
+    });
+
+    it("distinctly labels an @ref-inferred hop as NL-derived, not just NL", async () => {
+      // This classification had zero rendering precedent anywhere in the
+      // package before this feature — reviewers must be able to tell an
+      // inferred hop from a declared one at a glance.
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      const serialized = serialize(view._renderClassificationBadge("nl-derived"));
+      assert.match(serialized, /nl-derived/);
+      assert.match(serialized, /NL-derived/);
+    });
+  });
+
+  it("flags only the hop sitting exactly on the requested depth cap, not shallower hops", async () => {
+    // maxDepth: 2. The depth-1 hops are confirmed nearer hops; the depth-2
+    // hop sits on the boundary and may have further, untraced neighbours.
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    view.chain = {
+      field: "::orders.id",
+      maxDepth: 2,
+      upstream: [
+        hop("::customers.id", "::load_customers", "none", 1),
+        hop("::legacy.id", "::migrate", "nl-derived", 2),
+      ],
+      downstream: [hop("::invoices.order_id", "::bill", "none", 1)],
+    };
+    const serialized = serialize(view.render());
+    assert.match(serialized, /chain-depth-limit-upstream-2/);
+    assert.doesNotMatch(serialized, /chain-depth-limit-upstream-1/);
+    assert.doesNotMatch(serialized, /chain-depth-limit-downstream-1/);
+  });
+
+  describe("namespace-fan collapse", () => {
+    const wideChain = {
+      field: "::orders.id",
+      maxDepth: 5,
+      upstream: [
+        hop("crm::a.id", "crm::m1", "none", 1),
+        hop("crm::b.id", "crm::m1", "none", 1),
+        hop("crm::c.id", "crm::m1", "none", 1),
+        hop("crm::d.id", "crm::m1", "none", 1),
+      ],
+      downstream: [],
+    };
+
+    it("collapses a namespace group of more than three hops to a summary chip", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = wideChain;
+      const serialized = serialize(view.render());
+      assert.match(serialized, /chain-group-upstream:1:crm/);
+      assert.doesNotMatch(serialized, /chain-hop-field-upstream-1/);
+    });
+
+    it("expands a collapsed group on request, revealing its individual hop cards", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = wideChain;
+      view._expandGroup("upstream:1:crm");
+      const serialized = serialize(view.render());
+      assert.match(serialized, /chain-hop-field-upstream-1/);
+    });
+
+    it("never collapses a group of three or fewer hops", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = {
+        field: "::orders.id",
+        maxDepth: 5,
+        upstream: [hop("crm::a.id", "crm::m1", "none", 1), hop("crm::b.id", "crm::m1", "none", 1)],
+        downstream: [],
+      };
+      const serialized = serialize(view.render());
+      assert.match(serialized, /chain-hop-field-upstream-1/);
+      assert.doesNotMatch(serialized, /chain-group-upstream:1:crm/);
+    });
+  });
+
+  it("dispatches a field-lineage request when a hop's field is clicked, for the host to retrace", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    const received = [];
+    view.addEventListener("field-lineage", (e) => received.push(e));
+
+    view._focusField("crm::customers", "email");
+
+    assert.equal(received.length, 1);
+    assert.equal(received[0].schemaId, "crm::customers");
+    assert.equal(received[0].fieldName, "email");
+  });
+
+  it("dispatches chain-open-mapping when a hop's mapping label is clicked", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const view = new mod.SzChainView();
+    const received = [];
+    view.addEventListener("chain-open-mapping", (e) => received.push(e));
+
+    view._openMapping("crm::load_customers");
+
+    assert.equal(received.length, 1);
+    assert.equal(received[0].viaMapping, "crm::load_customers");
+  });
+});

--- a/tooling/satsuma-viz/test/view-state.test.js
+++ b/tooling/satsuma-viz/test/view-state.test.js
@@ -12,18 +12,29 @@ import * as assert from "node:assert/strict";
 
 const loc = { uri: "file:///test.stm", line: 1, character: 0 };
 
-const schema = (id, qualifiedId = id) => ({
+const schema = (id, qualifiedId = id, fields = []) => ({
   id,
   qualifiedId,
   kind: "schema",
   label: null,
-  fields: [],
+  fields,
   notes: [],
   comments: [],
   metadata: [],
   location: loc,
   hasExternalLineage: false,
   spreads: [],
+});
+
+const field = (name) => ({
+  name,
+  type: "STRING",
+  constraints: [],
+  metadata: [],
+  notes: [],
+  comments: [],
+  children: [],
+  location: loc,
 });
 
 const mapping = (id, sourceRefs = ["src"], targetRef = "tgt") => ({
@@ -130,4 +141,147 @@ describe("view-state reconciliation across model updates", () => {
     assert.equal(viz._viewMode, "overview");
     assert.equal(viz._selectedMapping, null);
   });
+});
+
+describe("openFieldChain (sl-4czz)", () => {
+  it("enters chain view with the host-supplied traversal", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    const chain = { field: "::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+
+    viz.openFieldChain(chain);
+
+    assert.equal(viz._viewMode, "chain");
+    assert.equal(viz._chainModel, chain);
+  });
+});
+
+describe("chain view reconciliation across model updates (sl-4czz)", () => {
+  /** Build a viz instance in chain view, as if the host had just traced `focusField`. */
+  async function vizInChainView(oldModel, chain) {
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    viz.model = oldModel;
+    viz.openFieldChain(chain);
+    return viz;
+  }
+
+  it("re-requests a retrace of the same field when its schema and path still exist", async () => {
+    // Chain data cannot be reconstructed from VizModel alone (it is a
+    // host-supplied traversal), so surviving a model edit means asking the
+    // host to recompute it — not rebinding locally, unlike mapping detail.
+    const oldModel = model(
+      namespace(null, { schemas: [schema("orders", "orders", [field("id")])] }),
+    );
+    const chain = { field: "::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+    const viz = await vizInChainView(oldModel, chain);
+    const received = [];
+    viz.addEventListener("field-lineage", (e) => received.push(e));
+
+    viz._reconcileViewState(
+      model(namespace(null, { schemas: [schema("orders", "orders", [field("id")])] })),
+    );
+
+    assert.equal(viz._viewMode, "chain");
+    assert.equal(received.length, 1);
+    assert.equal(received[0].schemaId, "orders");
+    assert.equal(received[0].fieldName, "id");
+  });
+
+  it("falls back to the overview when the focus field's schema no longer exists", async () => {
+    const oldModel = model(
+      namespace(null, { schemas: [schema("orders", "orders", [field("id")])] }),
+    );
+    const chain = { field: "::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+    const viz = await vizInChainView(oldModel, chain);
+
+    viz._reconcileViewState(model(namespace(null, { schemas: [] })));
+
+    assert.equal(viz._viewMode, "overview");
+    assert.equal(viz._chainModel, null);
+  });
+
+  it("falls back to the overview when the schema survives but the field was removed", async () => {
+    const oldModel = model(
+      namespace(null, { schemas: [schema("orders", "orders", [field("id")])] }),
+    );
+    const chain = { field: "::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+    const viz = await vizInChainView(oldModel, chain);
+
+    viz._reconcileViewState(
+      model(namespace(null, { schemas: [schema("orders", "orders", [field("total")])] })),
+    );
+
+    assert.equal(viz._viewMode, "overview");
+    assert.equal(viz._chainModel, null);
+  });
+
+  it("does not match a same-named schema from a different namespace", async () => {
+    const oldModel = model(
+      namespace("crm", { schemas: [schema("orders", "crm::orders", [field("id")])] }),
+    );
+    const chain = { field: "crm::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+    const viz = await vizInChainView(oldModel, chain);
+
+    viz._reconcileViewState(
+      model(
+        namespace("billing", { schemas: [schema("orders", "billing::orders", [field("id")])] }),
+      ),
+    );
+
+    assert.equal(viz._viewMode, "overview");
+  });
+});
+
+describe("chain hop mapping-label navigation (sl-4czz)", () => {
+  // _openMappingByRef is exercised directly rather than via a dispatched
+  // "chain-open-mapping" event: the internal listener that routes the event
+  // to it is registered in connectedCallback(), which the dom-shim never
+  // fires for an unattached element — the same reason every other case in
+  // this file drives _reconcileViewState directly instead of a model-change
+  // event.
+  it("opens the mapping detail view for a global mapping referenced by a chain hop", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    const m = mapping("load_orders");
+    viz.model = model(namespace(null, { mappings: [m] }));
+
+    viz._openMappingByRef("::load_orders");
+
+    assert.equal(viz._viewMode, "detail");
+    assert.equal(viz._selectedMapping, m);
+  });
+
+  it("opens the mapping detail view for a namespaced mapping referenced by a chain hop", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    const m = mapping("load_orders");
+    viz.model = model(namespace("crm", { mappings: [m] }));
+
+    viz._openMappingByRef("crm::load_orders");
+
+    assert.equal(viz._viewMode, "detail");
+    assert.equal(viz._selectedMapping, m);
+  });
+
+  it("does nothing when the referenced mapping is not in the currently loaded model", async () => {
+    // A cross-file chain hop's mapping may live outside the loaded document;
+    // silently doing nothing is preferable to a crash or a wrong navigation.
+    const mod = await import("../dist/satsuma-viz.js");
+    const viz = new mod.SatsumaViz();
+    viz.model = model(namespace(null, { mappings: [mapping("load_orders")] }));
+
+    viz._openMappingByRef("::not_loaded");
+
+    assert.equal(viz._viewMode, "overview");
+    assert.equal(viz._selectedMapping, null);
+  });
+
+  // The connectedCallback() listener that routes a dispatched
+  // "chain-open-mapping" event to _openMappingByRef is not separately
+  // exercised: this package's dom-shim provides no `window`/ResizeObserver,
+  // so connectedCallback() throws outside a real browser. The cases above
+  // cover _openMappingByRef's resolution logic directly, matching how every
+  // other case in this file drives _reconcileViewState rather than a
+  // dispatched model-change event.
 });


### PR DESCRIPTION
## Summary
- Adds `sz-chain-view`, a left-to-right rail rendering a field's full upstream/downstream lineage (PRD 36 R4): columns ordered by hop distance, namespace-fan collapse past 3 hops, classification badges (declared / NL / NL-derived — the last had no prior rendering precedent in this package), and an explicit "depth limit reached" affordance instead of silent truncation.
- `satsuma-viz` gains a `"chain"` view mode, a host-facing `openFieldChain(model)` API (the component never traces lineage itself — a host such as `@satsuma/viz-backend` or the LSP supplies the model), edit-preserving reconciliation matching the Feature 34 R1 guarantee, and mapping-label navigation via a new `chain-open-mapping` event.
- Prerequisite fix: neither core's `traceFieldLineage` nor the CLI's `field-lineage --json` exposed any depth signal, so the depth-limit affordance couldn't be shown honestly. Added an additive `depth` (per hop) and `maxDepth` (traversal cap) to the shared CLI/browser JSON contract, regenerated the viz-backend golden fixture.
- Entry points reuse `sz-schema-card`'s existing field-lineage icon (already present in both the overview's expanded cards and, since mapping-detail embeds `sz-schema-card`, the detail view too) — nothing new needed there.
- Updates `docs/product-owner/ROADMAP.md`: 3/7 Feature 36 tickets now closed, `sl-iwlv` (VS Code webview wiring) unblocked.

Closes `sl-4czz`.

## Test plan
- [x] `turbo run build test --filter=@satsuma/core --filter=satsuma-cli --filter=@satsuma/viz-model --filter=@satsuma/viz-backend --filter=@satsuma/viz` — all green (core 697, cli 1061, viz-model 7, viz-backend 190, viz 167 tests)
- [x] `turbo run build --filter=vscode-satsuma --filter=@satsuma/viz-harness` and `turbo run test --filter=vscode-satsuma --filter=@satsuma/lsp` — build/tests green (Playwright harness suite intentionally not run here — needs the human-in-the-loop watcher)
- [x] Pre-commit hook (`scripts/run-repo-checks.sh`) passed on both commits: lint, tree-sitter corpus, smoke tests, BDD scenarios
- [ ] `@satsuma/viz-harness` Playwright suite for the chain view is deferred to `sl-nswc`, still blocked on `sl-twe8`/`sl-iwlv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)