### PR TITLE
fix(viz): resolve hovered-arrow paths absolutely, and highlight NL @ref sources

### DIFF
--- a/.tickets/sl-d7fz.md
+++ b/.tickets/sl-d7fz.md
@@ -1,6 +1,6 @@
 ---
 id: sl-d7fz
-status: open
+status: closed
 deps: []
 links: [sl-rj78]
 created: 2026-08-05T09:27:33Z
@@ -21,3 +21,10 @@ Screenshot: bug-reports/source-nlref-not-highlighted.png. Related to sl-rj78 (ne
 
 Hovering/selecting a computed-arrow row highlights every source field named by an @ref in its NL transform text, across every source schema on screen. Regression test using a computed arrow with multiple @-refs spanning more than one source schema.
 
+
+## Notes
+
+**2026-08-05T11:41:23Z**
+
+Cause: `_sourceHighlightFields` only ever highlighted fields listed in `ArrowEntry.sourceFields`, which is always empty for a computed arrow by design (the value comes from the pipe chain) — nothing parsed the transform's NL text for @refs the way `highlightAtRefs` does for display styling, so a computed arrow's source fields never highlighted.
+Fix: `_sourceHighlightFields` now extracts @refs from the hovered arrow's transform text (core's `extractAtRefs`) and resolves each one against every on-screen source schema with the same `resolveSchemaLocalFieldPath` used for declared `sourceFields`. Regression test added in field-coverage.test.js. (commit immediately after 7273d0da)

--- a/.tickets/sl-rj78.md
+++ b/.tickets/sl-rj78.md
@@ -1,6 +1,6 @@
 ---
 id: sl-rj78
-status: open
+status: closed
 deps: []
 links: [sl-d7fz]
 created: 2026-08-05T09:26:38Z
@@ -23,3 +23,10 @@ Screenshot: bug-reports/nested-field-not-highlighted-in-source.png
 
 Hovering/selecting an arrow row inside a flatten/each highlights the correct nested source field(s) in the sources pane, at any nesting depth. Regression test using a nested-iteration fixture (e.g. examples/nested-iteration).
 
+
+## Notes
+
+**2026-08-05T11:41:23Z**
+
+Cause: `_sourceHighlightFields`/`_targetHighlightFields`'s `_hoveredArrow` branch resolved `ArrowEntry.sourceFields`/`targetField` raw — the authored, container-relative paths (e.g. ".adults") — instead of the absolute paths every other resolution surface in the file uses, so a doubly-nested arrow's path only matched a declared field by coincidence when there was no nesting.
+Fix: added `_resolveHoveredArrow`, which re-walks `forEachMappingArrow` and matches the hovered arrow by object identity to recover its already-qualified absolute paths, and used it in both getters. Regression test added in field-coverage.test.js. (commit immediately after 7273d0da)

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 190,
-    "satsuma-viz": 167,
+    "satsuma-viz": 170,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -49,6 +49,16 @@ const sapUri = libraryUri("sap-po-to-mfcs/pipeline.stm");
 const ffgUri = libraryUri("filter-flatten-governance/filter-flatten-governance.stm");
 /** buy-to-om-order contract fixture — used for compact card expansion tests. */
 const buyToOmUri = libraryUri("contracts/buy-to-om-order.stm");
+/** Nested each/flatten fixture — doubly-nested arrows (sl-rj78). */
+const nestedIterationUri = libraryUri("nested-iteration/pipeline.stm");
+/**
+ * Governance fixture's own mapping — a two-source join (crm_customers,
+ * finance_transactions) with computed arrows whose NL text names source
+ * fields by @ref rather than by a declared source path (sl-d7fz). Distinct
+ * from `ffgUri`, which points at the sibling entry point file in the same
+ * directory.
+ */
+const governanceUri = libraryUri("filter-flatten-governance/governance.stm");
 
 /**
  * Open a specific named mapping by clicking its overview mapping card.
@@ -953,6 +963,76 @@ test.describe("Hover highlighting between arrows and field rows", () => {
 
     const sourceField = detail.locator(
       "[data-testid='mapping-detail-opportunity-ingestion-source-schema-card-sfdc-opportunity-field-amount']",
+    );
+    await expect(sourceField).toHaveClass(/\bhl\b/);
+  });
+});
+
+test.describe("Hover highlighting resolves nested arrow paths (sl-rj78)", () => {
+  test("hovering a doubly-nested arrow row highlights the correct source and target field, not nothing", async ({
+    page,
+  }) => {
+    // The `dispatch manifest` mapping nests `each lines -> .lines` inside
+    // `each orders -> orders`, so `.sku -> .sku`'s authored paths are relative
+    // to TWO levels of container. Pre-fix, the `_hoveredArrow` branch matched
+    // those raw paths (".sku") against the schemas' declared fields directly,
+    // which only succeeds by coincidence when there is no nesting — here it
+    // matches nothing, so hovering the row lit up neither card.
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, nestedIterationUri);
+    const detail = await openMappingByName(page, "dispatch-manifest");
+
+    await detail
+      .locator(
+        "[data-testid='mapping-detail-dispatch-manifest-arrow-row-each-orders-each-lines-sku']",
+      )
+      .hover();
+
+    const sourceField = detail.locator(
+      "[data-testid='mapping-detail-dispatch-manifest-source-schema-card-warehouse-dispatch-events-field-orders-lines-sku']",
+    );
+    const targetField = detail.locator(
+      "[data-testid='mapping-detail-dispatch-manifest-target-schema-card-dispatch-manifest-json-field-orders-lines-sku']",
+    );
+
+    await expect(sourceField).toHaveClass(/\bhl\b/);
+    await expect(targetField).toHaveClass(/\bhl\b/);
+  });
+});
+
+test.describe("Hover highlighting resolves @refs in NL transforms (sl-d7fz)", () => {
+  test("hovering a computed arrow highlights the source field its NL text names by @ref", async ({
+    page,
+  }) => {
+    // `customer 360 assembly` joins crm_customers and finance_transactions.
+    // `-> total_transaction_amt`'s NL transform names its source purely via
+    // `@finance_transactions.amount` — a computed arrow has no declared
+    // source path at all (viz-model.ts's extractComputedArrow), so nothing
+    // but parsing the transform text itself can find the field to highlight.
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, governanceUri);
+    const detail = await openMappingByName(page, "customer-360-assembly");
+
+    await detail
+      .locator(
+        "[data-testid='mapping-detail-customer-360-assembly-arrow-row-total-transaction-amt']",
+      )
+      .hover();
+
+    const sourceField = detail.locator(
+      "[data-testid='mapping-detail-customer-360-assembly-source-schema-card-finance-transactions-field-amount']",
     );
     await expect(sourceField).toHaveClass(/\bhl\b/);
   });

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -16,9 +16,10 @@ import {
   resolveSchemaLocalFieldPath,
   scopeWithin,
 } from "../field-coverage.js";
-import type { ContainerScope } from "../field-coverage.js";
+import type { ContainerScope, MappingArrowVisit } from "../field-coverage.js";
 import { highlightAtRefs } from "../markdown.js";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
+import { extractAtRefs } from "@satsuma/core/nl-ref";
 import type { SchemaCoverage } from "../field-coverage.js";
 
 function sanitizeTestIdSegment(value: string): string {
@@ -389,6 +390,27 @@ export class SzMappingDetail extends LitElement {
     if (e.fieldName) this._hoveredArrow = null;
   }) as EventListener;
 
+  /**
+   * Absolute paths for `_hoveredArrow`, resolved by re-running the same walk
+   * every other resolution surface uses and matching on object identity.
+   *
+   * `_hoveredArrow` is set straight from `ArrowEntry.sourceFields`/`targetField`
+   * on mouseenter, which are authored paths — `.adults` under a `flatten`
+   * heading, not `transects.sightings.adults`. Resolving against a schema's
+   * declared fields needs the absolute form, the same requirement that sent
+   * `_isArrowHighlighted` through `qualifyChildArrowPath` two functions below.
+   * Re-walking here (rather than caching a scope alongside `_hoveredArrow`)
+   * keeps this getter as the only place besides `_isArrowHighlighted` that
+   * knows arrows need qualifying before resolution (sl-rj78).
+   */
+  private _resolveHoveredArrow(m: MappingBlock): MappingArrowVisit | null {
+    let found: MappingArrowVisit | null = null;
+    forEachMappingArrow(m, (entry) => {
+      if (entry.arrow === this._hoveredArrow) found = entry;
+    });
+    return found;
+  }
+
   /** Compute which source fields should be highlighted. */
   private get _sourceHighlightFields(): Map<string, Set<string>> {
     const result = new Map<string, Set<string>>();
@@ -399,12 +421,20 @@ export class SzMappingDetail extends LitElement {
     );
 
     if (this._hoveredArrow) {
+      const hovered = this._resolveHoveredArrow(m);
+      const sourceFields = hovered?.sourceFields ?? this._hoveredArrow.sourceFields;
+      // A computed arrow's NL transform names its sources by @ref rather than
+      // by ArrowEntry.sourceFields — the pipe chain produces the value, so
+      // extraction leaves sourceFields empty (viz-model.ts's extractComputedArrow).
+      // Parsing the same text highlightAtRefs highlights for display finds the
+      // fields those @refs actually name (sl-d7fz).
+      const atRefs = extractAtRefs(this._hoveredArrow.transform?.text ?? "").map((r) => r.ref);
       for (const sr of m.sourceRefs) {
         const fields = new Set<string>();
         const schema = sourceSchemaById.get(sr);
         if (!schema) continue;
-        for (const sf of this._hoveredArrow.sourceFields) {
-          const localPath = resolveSchemaLocalFieldPath(sf, schema, m.sourceRefs);
+        for (const fieldRef of [...sourceFields, ...atRefs]) {
+          const localPath = resolveSchemaLocalFieldPath(fieldRef, schema, m.sourceRefs);
           if (localPath) fields.add(localPath);
         }
         if (fields.size > 0) result.set(sr, fields);
@@ -428,9 +458,9 @@ export class SzMappingDetail extends LitElement {
 
     if (this._hoveredArrow) {
       if (!targetSchema) return new Set();
-      const localPath = resolveSchemaLocalFieldPath(this._hoveredArrow.targetField, targetSchema, [
-        m.targetRef,
-      ]);
+      const hovered = this._resolveHoveredArrow(m);
+      const targetField = hovered?.targetField ?? this._hoveredArrow.targetField;
+      const localPath = resolveSchemaLocalFieldPath(targetField, targetSchema, [m.targetRef]);
       return localPath ? new Set([localPath]) : new Set();
     }
 

--- a/tooling/satsuma-viz/test/field-coverage.test.js
+++ b/tooling/satsuma-viz/test/field-coverage.test.js
@@ -280,6 +280,86 @@ describe("sz-mapping-detail hover lookups recurse into nestedEach (sl-fm0q)", ()
     );
     assert.deepEqual([...targets], ["lines.discounts.code"]);
   });
+
+  // sl-rj78: hovering the ROW ITSELF (rather than a card field) went through a
+  // separate `_hoveredArrow` branch that resolved ArrowEntry.sourceFields/
+  // targetField raw — the authored, container-relative paths (".code") — instead
+  // of the absolute paths the two lookups above already resolve correctly.
+  // ".code" only matches a schema's declared field by coincidence when there is
+  // no nesting, so hovering a doubly-nested row highlighted nothing.
+  it("highlights the nested source and target fields when hovering the arrow row itself", async () => {
+    const detail = await makeDetail();
+    detail._hoveredArrow = detail.mapping.eachBlocks[0].nestedEach[0].arrows[0];
+    assert.deepEqual(
+      [...(detail._sourceHighlightFields.get("order") ?? [])],
+      ["items.discounts.code"],
+    );
+    assert.deepEqual([...detail._targetHighlightFields], ["lines.discounts.code"]);
+  });
+});
+
+// ── A computed arrow's sources are named by @ref, not by sourceFields (sl-d7fz) ──
+//
+// `-> tgt = "NL text with @refs"` is extracted with `sourceFields: []` by design
+// (viz-model.ts's extractComputedArrow: the pipe chain produces the value, there
+// is no declared source path). Hovering such a row highlighted the target field
+// only — the transform text visibly colors its @refs (markdown.ts's
+// highlightAtRefs), but nothing parsed them to find the source fields they name.
+
+describe("hovering a computed arrow highlights the fields its NL transform @refs (sl-d7fz)", () => {
+  const crmCustomers = schema("crm_customers", [field("first_name"), field("last_name")]);
+  const billing = schema("billing", [field("company_name")]);
+  const customer = schema("customer", [field("full_name")]);
+
+  const computedArrow = {
+    sourceFields: [],
+    targetField: "full_name",
+    transform: {
+      kind: "nl",
+      text:
+        'Concat @crm_customers.first_name + " " + @crm_customers.last_name. ' +
+        "If both are null, use @company_name instead.",
+      steps: [],
+    },
+    metadata: [],
+    comments: [],
+    location: loc,
+  };
+
+  async function makeDetail() {
+    const m = await import("../dist/satsuma-viz.js");
+    const detail = new m.SzMappingDetail();
+    detail.mapping = {
+      id: "m",
+      sourceRefs: ["crm_customers", "billing"],
+      targetRef: "customer",
+      arrows: [computedArrow],
+      eachBlocks: [],
+      flattenBlocks: [],
+      nestedArrows: [],
+      sourceBlock: null,
+      notes: [],
+      comments: [],
+      location: loc,
+    };
+    detail.sourceSchemas = [crmCustomers, billing];
+    detail.targetSchema = customer;
+    detail._hoveredArrow = computedArrow;
+    return detail;
+  }
+
+  it("highlights dotted @refs against the source schema they explicitly qualify", async () => {
+    const detail = await makeDetail();
+    assert.deepEqual(
+      [...(detail._sourceHighlightFields.get("crm_customers") ?? [])],
+      ["first_name", "last_name"],
+    );
+  });
+
+  it("highlights a bare @ref against whichever on-screen source schema declares that field", async () => {
+    const detail = await makeDetail();
+    assert.deepEqual([...(detail._sourceHighlightFields.get("billing") ?? [])], ["company_name"]);
+  });
 });
 
 // ── Element-relative paths inside containers (3cdd-yavi) ─────────────────────


### PR DESCRIPTION
## Summary
- `sz-mapping-detail`'s `_hoveredArrow` highlighting branch resolved `ArrowEntry.sourceFields`/`targetField` raw — the authored, container-relative paths (e.g. `.adults`) — instead of the absolute paths every other resolution surface in the file already uses (`forEachMappingArrow`). A doubly-nested arrow row's raw path only matched a declared field by coincidence when there was no nesting, so hovering it highlighted nothing (sl-rj78).
- A computed arrow (`-> tgt = "NL text with @refs"`) has an empty `sourceFields` by design — the pipe chain produces the value. Nothing parsed the transform text for `@ref`s the way `highlightAtRefs` does for display styling, so hovering such a row never highlighted its source fields (sl-d7fz).
- Fix: added `_resolveHoveredArrow`, which re-walks `forEachMappingArrow` and matches the hovered arrow by object identity to recover its already-qualified absolute paths; used in both `_sourceHighlightFields` and `_targetHighlightFields`. `_sourceHighlightFields` also now extracts `@ref`s from the hovered arrow's transform text (core's `extractAtRefs`) and resolves each against every on-screen source schema with the same `resolveSchemaLocalFieldPath` used for declared fields.

Closes sl-rj78, sl-d7fz.

## Test plan
- [x] Added regression tests in `tooling/satsuma-viz/test/field-coverage.test.js`: hovering a doubly-nested arrow row now highlights the correct absolute source/target fields; hovering a computed arrow highlights fields named by dotted and bare `@ref`s across multiple on-screen source schemas.
- [x] `turbo run test --filter=@satsuma/viz` — 170/170 passing (was 167)
- [x] `tsc --noEmit` in `tooling/satsuma-viz` — clean
- [x] `./scripts/run-repo-checks.sh` (full pre-commit suite: lint, workspace build, all workspace tests, corpus/smoke tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)