### PR TITLE
test(viz-harness): prove uncovered-field treatment in overview cards

### DIFF
--- a/.tickets/sl-twe8.md
+++ b/.tickets/sl-twe8.md
@@ -1,6 +1,6 @@
 ---
 id: sl-twe8
-status: open
+status: closed
 deps: [sl-5m9x]
 links: []
 created: 2026-07-31T13:13:41Z
@@ -22,3 +22,10 @@ Presentation only — reuse the existing field-coverage.ts covered-set computati
 
 Uncovered fields visually distinct in both views in light and dark themes; covered-set values unchanged from existing field-coverage.ts behaviour (no semantic drift); unit tests pass locally.
 
+
+## Notes
+
+**2026-08-05T14:04:41Z**
+
+Cause: PRD 36 R2's uncovered-field treatment was already delivered as a side effect of sl-f0x6 (the port-dot tri-state fix) — sz-schema-card's _renderField is shared verbatim by expanded overview cards, standalone cards, and the mapping detail view's source/target columns, so the shape-based mapped/partial/unmapped/unknown dot (muted colour, not colour alone) already renders in every context this ticket names. The only real gap was proof: the harness only ever mounted that markup via the mapping detail view (one mapping's own coverage verdicts); nothing had exercised it via the overview's expanded compact card, which feeds the aggregate coverage unioned across every mapping referencing the schema (buildCoverageIndex) — a distinct data path never rendered in a real browser.
+Fix: no component code changed. Added two theme-parameterised Playwright specs (light/dark) to the "Field coverage indicators" describe block in tooling/satsuma-viz-harness/test/harness.test.ts, using the filter-flatten-governance fixture's order_events schema (read by two mappings, so its aggregate genuinely differs from either mapping's own view) to prove covered/partial/uncovered port dots render distinctly in the overview's expanded card, mirroring sl-f0x6's mapping-detail proof. Ground truth for which leaves are uncovered in the aggregate was confirmed via `satsuma coverage --json` against the fixture before writing the assertions. Full harness suite (107 tests) green. (commit immediately after de30d6ba)

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -905,6 +905,58 @@ test.describe("Field coverage indicators", () => {
       expect(appearances.partial).toMatch(/gradient/);
     });
   }
+
+  // sl-twe8: the test above proves the port dot is drawn distinctly in the
+  // mapping detail view, which renders one mapping's own verdicts. The
+  // overview's expanded compact card reuses the exact same <sz-schema-card>
+  // markup, but feeds it the *aggregate* coverage unioned across every
+  // mapping that references the schema (buildCoverageIndex) — a different
+  // data path that has never been exercised in a real browser. order_events
+  // is read by both mappings in this fixture, so its aggregate differs from
+  // either mapping's own view: `tag_ids` and the deeply nested
+  // `line_items.discount_lines.discount_amount` are the only two leaves
+  // nothing anywhere maps (confirmed via `satsuma coverage --json` against
+  // this fixture), which makes `line_items` itself a genuine partial
+  // container — the case worth proving here.
+  for (const theme of ["light", "dark"] as const) {
+    test(`uncovered-field treatment renders distinctly in an expanded overview card (${theme})`, async ({
+      page,
+    }) => {
+      await page.goto(`/?theme=${theme}`);
+      await page.waitForFunction(() => {
+        const harness = window.__satsumaHarness;
+        if (!harness?.setViewMode) return false; // app.js not evaluated yet
+        harness.setViewMode("single");
+        return true;
+      });
+      await loadFixture(page, ffgUri);
+
+      const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-order-events']");
+      await card.locator(".header-toggle").click();
+
+      const cardPrefix = "overview-schema-card-order-events";
+      const row = (path: string) => card.locator(`[data-testid='${cardPrefix}-field-${path}']`);
+
+      await expect(row("event-id")).toBeVisible({ timeout: 5_000 });
+      await expect(row("event-id")).toHaveAttribute("data-coverage-state", "covered");
+      await expect(row("tag-ids")).toHaveAttribute("data-coverage-state", "uncovered");
+      await expect(row("line-items")).toHaveAttribute("data-coverage-state", "partial");
+      await expect(row("line-items-discount-lines-discount-amount")).toHaveAttribute(
+        "data-coverage-state",
+        "uncovered",
+      );
+
+      const appearances = {
+        covered: await portAppearance(card, `${cardPrefix}-field-event-id`),
+        partial: await portAppearance(card, `${cardPrefix}-field-line-items`),
+        uncovered: await portAppearance(card, `${cardPrefix}-field-tag-ids`),
+      };
+      // Pairwise distinct, same requirement as the mapping-detail case above —
+      // this time proven against the aggregate data path instead.
+      expect(new Set(Object.values(appearances)).size, JSON.stringify(appearances)).toBe(3);
+      expect(appearances.partial).toMatch(/gradient/);
+    });
+  }
 });
 
 test.describe("Hover highlighting between arrows and field rows", () => {


### PR DESCRIPTION
## Summary
- Closes sl-twe8 (PRD 36 R2 — uncovered-field treatment in expanded schema cards and the mapping detail view).
- No component code changed: the shape-based, theme-safe coverage port dot (mapped/partial/unmapped/unknown) was already delivered by sl-f0x6, and the mapping detail view already reuses `sz-schema-card` wholesale, so the treatment already rendered in every context this ticket names.
- The real gap was proof, not behaviour: the harness had only ever mounted that markup via the mapping detail view (one mapping's own coverage verdicts). Nothing had exercised the overview's expanded compact card, which feeds `sz-schema-card` the *aggregate* coverage unioned across every mapping referencing a schema (`buildCoverageIndex`) — a distinct data path never rendered in a real browser.
- Added two theme-parameterised Playwright specs (light/dark) to the "Field coverage indicators" describe block, using the `filter-flatten-governance` fixture's `order_events` schema (read by two mappings, so its aggregate genuinely differs from either mapping's own view) to prove covered/partial/uncovered port dots render distinctly there too. Ground truth for the fixture's aggregate coverage was confirmed via `satsuma coverage --json` before writing assertions.

## Test plan
- [x] `npm run test:all` — green (no code changes, no regressions)
- [x] `npm run lint` — green
- [x] Full `satsuma-viz-harness` Playwright suite (107 tests) — green via the watcher sentinel protocol, including the 2 new specs
- [x] Pre-commit hook (`scripts/run-repo-checks.sh`) ran clean on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)