### PR TITLE
chore(viz-harness): add /viz-dev command and document local UI preview

### DIFF
--- a/.claude/commands/viz-dev.md
+++ b/.claude/commands/viz-dev.md
@@ -1,0 +1,77 @@
+---
+name: viz-dev
+description: >
+  Build the satsuma-viz-harness dev server and its dependencies, then start it
+  locally so the user can open the current viz UI in a browser. Use whenever
+  the user asks to "run the viz", "see the current UI", "preview the viz
+  component", "start the viz dev server", or similar — this is for a live,
+  interactive look at the component, not the Playwright test harness (that
+  workflow is documented separately in AGENTS.md).
+---
+
+# Run the viz dev server
+
+Builds `@satsuma/viz-harness` and its dependencies (`@satsuma/core`,
+`@satsuma/viz-model`, `@satsuma/viz-backend`, `@satsuma/viz`, the tree-sitter
+grammar WASM) via Turborepo, then starts the harness's own Node HTTP server so
+the user can open the production `<satsuma-viz>` component — with the fixture
+picker over the `examples/**` corpus — in a real browser.
+
+This is distinct from the Playwright sentinel workflow in AGENTS.md
+("Viz harness Playwright tests"): that workflow drives an automated headless
+browser for regression tests. This command starts a plain dev server for a
+human to look at in their own browser — no Playwright, no sentinel file.
+
+## Steps
+
+1. **Set turbo's sandbox env vars** (harmless if already set, required in the
+   agent sandbox — see AGENTS.md "Running Turborepo in the agent sandbox"):
+
+   ```bash
+   export TURBO_CONFIG_DIR_PATH="$SCRATCHPAD/turbo-config"
+   export VERCEL_CONFIG_DIR_PATH="$SCRATCHPAD/vercel-config"
+   ```
+
+2. **Free port 3333** if a stale server is already listening on it:
+
+   ```bash
+   kill "$(lsof -ti:3333)" 2>/dev/null || true
+   ```
+
+3. **Build the harness and every dependency it needs**, in dependency order:
+
+   ```bash
+   npx turbo run build --filter=@satsuma/viz-harness
+   ```
+
+4. **Start the server in the background** (it must keep running for the user
+   to browse it — do not run it in the foreground):
+
+   ```bash
+   node tooling/satsuma-viz-harness/dist/server.js > "$SCRATCHPAD/viz-dev-server.log" 2>&1 &
+   disown
+   ```
+
+5. **Confirm it came up**, then hand the URL to the user:
+
+   ```bash
+   sleep 1
+   curl -sf -o /dev/null -w "HTTP %{http_code}\n" http://localhost:3333/
+   ```
+
+   If the curl fails, read `$SCRATCHPAD/viz-dev-server.log` for the error
+   (most likely a stale build — re-run step 3) rather than guessing.
+
+6. Tell the user to open **http://localhost:3333** in their browser. Do not
+   try to open a browser yourself — the agent sandbox cannot launch one; the
+   user opens the URL manually.
+
+## Notes
+
+- The server only serves static assets and a small fixtures API — all model
+  building happens client-side in the browser (feature 33; see the harness
+  README's "The playground" section). There is nothing further to configure.
+- If the user edits `satsuma-viz`, `viz-backend`, `viz-model`, or `core`
+  source while the server is running, re-run this command (steps 3–5) to
+  rebuild and restart — the server does not hot-reload.
+- To stop the server later: `kill "$(lsof -ti:3333)"`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,7 @@ editing a package's `dependencies`/`devDependencies`, nothing else (ADR-049).
 | Coverage for every package that reports it | `npm run test:coverage` |
 | The repo-level scripts' own tests | `npm run test:scripts` |
 | Everything the pre-commit hook runs | `./scripts/run-repo-checks.sh` |
+| Preview the current viz UI locally | `npx turbo run build --filter=@satsuma/viz-harness && npm --prefix tooling/satsuma-viz-harness run dev`, then open <http://localhost:3333> — see [tooling/satsuma-viz-harness/README.md](tooling/satsuma-viz-harness/README.md#running-the-dev-server-locally-live-preview-not-playwright). Claude Code users can just run `/viz-dev`. |
 
 `--filter` takes a package's **declared name**, not its directory:
 `@satsuma/core`, `@satsuma/lsp`, `satsuma-cli`, `tree-sitter-satsuma`. It pulls in

--- a/tooling/satsuma-viz-harness/README.md
+++ b/tooling/satsuma-viz-harness/README.md
@@ -33,6 +33,43 @@ either.
 
 ---
 
+## Running the dev server locally (live preview, not Playwright)
+
+Sometimes you just want to look at the current `<satsuma-viz>` UI in a real
+browser — not run the Playwright regression suite. This starts the harness's
+own Node HTTP server (`src/server.ts`), which serves the harness web UI (a
+fixture picker over `examples/**` plus the production viz component) at
+**<http://localhost:3333>**.
+
+```bash
+# One-time (or after changing core/viz-model/viz-backend/viz source):
+npx turbo run build --filter=@satsuma/viz-harness
+
+# Start the server:
+npm --prefix tooling/satsuma-viz-harness run dev
+```
+
+Then open <http://localhost:3333> in your browser. The server does not
+hot-reload — after further source changes, stop it (`Ctrl-C`, or
+`kill "$(lsof -ti:3333)"`), re-run the turbo build, and start it again.
+
+Note `npm run dev` here runs this package's own `build` script first, which
+only rebuilds *this* package's bundle from already-built dependencies — it
+does not build `@satsuma/core`, `@satsuma/viz`, etc. themselves. Run the
+`turbo run build` step above whenever a dependency changed, not just this
+package.
+
+Claude Code users: the `/viz-dev` command (`.claude/commands/viz-dev.md`)
+automates all of the above, including the agent-sandbox Turborepo env vars
+(see AGENTS.md "Running Turborepo in the agent sandbox") and confirming the
+server actually came up before handing you the URL.
+
+This is unrelated to the sentinel-file Playwright workflow described below —
+that workflow drives an automated headless browser for regression tests, not
+a human-facing preview.
+
+---
+
 ## The playground (server-free live editor)
 
 `npm run build:playground` emits `dist/playground/` — a flat, static bundle


### PR DESCRIPTION
## Summary
- Add a `/viz-dev` Claude Code slash command that builds `@satsuma/viz-harness` and its dependencies via Turborepo and starts the dev server in the background, confirming it's up before handing back the URL.
- Document the equivalent plain `npm`/`turbo` commands for any developer in `tooling/satsuma-viz-harness/README.md`, in a new "Running the dev server locally (live preview, not Playwright)" section.
- Add a row to the `AGENTS.md` build/test table pointing at both.

This is purely additive documentation/tooling — no production code changed.

## Test plan
- [x] `./scripts/run-repo-checks.sh` (via pre-commit hook) ran clean on commit — lint, typecheck, and full test suite all green.
- [x] Manually verified the dev server starts and serves the viz UI at `http://localhost:3333`.