### PR TITLE
test(viz-harness): Playwright coverage for coverage overlay and chain view (sl-nswc)

### DIFF
--- a/.tickets/sl-nswc.md
+++ b/.tickets/sl-nswc.md
@@ -1,6 +1,6 @@
 ---
 id: sl-nswc
-status: open
+status: closed
 deps: [sl-5m9x, sl-twe8, sl-4czz, sl-iwlv]
 links: []
 created: 2026-07-31T13:13:41Z
@@ -22,3 +22,12 @@ Runs only via the sentinel-file watcher protocol (agent sandbox cannot launch br
 
 All new specs pass and the full existing harness suite remains green via the watcher protocol; layout snapshot test in place; results confirmed from .playwright-results.txt.
 
+
+## Notes
+
+**2026-08-05T14:44:06Z**
+
+**2026-08-05T14:41:00Z**
+
+Cause: PRD 36 R5's harness Playwright suite didn't exist yet, and sz-chain-view.ts's own unit tests could only prove the rendering function's logic — the click path (a field row's lineage icon -> real chain view), the harness's own host wiring from "field-lineage" event to openFieldChain, and the real per-hop DOM addressability were all unverified in a browser. While building the fixture for the "≥2 upstream/≥2 downstream, nl-derived" requirement, found that sz-chain-view.ts's hop testids collided (direction+depth only) whenever a column held more than one ungrouped hop below the namespace-fan threshold — invisible to the existing unit tests because they only do substring matching on serialized templates, never a real DOM query.
+Fix: added seven new Playwright specs (harness.test.ts + view-persistence.test.ts) covering coverage-toggle on/off with badge values matching `satsuma coverage --json`, a coverage-mode layout-snapshot, chain-view rendering against examples/namespaces/ns-merging.stm (the only corpus fixture with a genuine multi-mapping fan on both sides), hop-click refocus, mapping-label navigation, and edit-while-in-chain-view preservation/fallback. Wired the harness's own "field-lineage" listener to `buildFieldChain` -> `openFieldChain` (previously it only recorded the event) so the real click path is exercised end-to-end. Fixed the testid collision in sz-chain-view.ts by appending a sanitized field-path suffix, with a new unit test pinning per-hop testid uniqueness. Full harness suite (114 tests) green via the watcher protocol; `run-repo-checks.sh` green. (commit immediately after b0e23830)

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 190,
-    "satsuma-viz": 170,
+    "satsuma-viz": 171,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-harness/src/client/app.ts
+++ b/tooling/satsuma-viz-harness/src/client/app.ts
@@ -36,8 +36,8 @@
  * `file-open`, and `file-save` events.
  */
 
-import { ensureParserReady, buildModel } from "./model-pipeline";
-import type { VizModel } from "./model-pipeline";
+import { ensureParserReady, buildModel, buildFieldChain } from "./model-pipeline";
+import type { VizModel, FieldChainModel } from "./model-pipeline";
 import { highlightSatsuma } from "./highlight";
 import { SatsumaEditor } from "./editor";
 import { DocumentLibrary, STARTER_SOURCE } from "./library";
@@ -421,7 +421,22 @@ function ensureVizElement(): HTMLElement {
     }
   });
   el.addEventListener("field-lineage", (e) => {
-    recordNormalizedEvent("field-lineage", e, normalizeFieldEvent);
+    const detail = recordNormalizedEvent(
+      "field-lineage",
+      e,
+      normalizeFieldEvent,
+    ) as HarnessFieldPayload | null;
+    // Trace the field and hand the result to the component's host-agnostic
+    // chain-view API (PRD 36 R3/R4): the harness plays the same "host computes,
+    // component renders" role VS Code and the LSP play in production.
+    if (detail?.fieldName && harness.fixture) {
+      const chain = buildFieldChain(
+        harness.fixture,
+        library.documents(),
+        `${detail.schemaId}.${detail.fieldName}`,
+      );
+      (el as unknown as { openFieldChain(model: FieldChainModel): void }).openFieldChain(chain);
+    }
   });
   el.addEventListener("open-mapping", (e) => {
     recordNormalizedEvent("open-mapping", e, normalizeOpenMappingEvent);

--- a/tooling/satsuma-viz-harness/src/client/model-pipeline.ts
+++ b/tooling/satsuma-viz-harness/src/client/model-pipeline.ts
@@ -14,15 +14,24 @@
  */
 
 import { initParser } from "@satsuma/core";
-import { buildModelResultFromSources } from "@satsuma/viz-backend";
+import { buildModelResultFromSources, buildFieldChainFromSources } from "@satsuma/viz-backend";
 import type {
   SourceDocument,
   BuildModelOptions,
   BuildModelResult,
   VizModel,
+  BuildFieldChainOptions,
 } from "@satsuma/viz-backend";
+import type { FieldChainModel } from "@satsuma/viz-model";
 
-export type { SourceDocument, BuildModelOptions, BuildModelResult, VizModel };
+export type {
+  SourceDocument,
+  BuildModelOptions,
+  BuildModelResult,
+  VizModel,
+  BuildFieldChainOptions,
+  FieldChainModel,
+};
 
 // The two WASM artifacts the parser needs. Both are served alongside the page:
 // the harness server serves them at the site root, and the static playground
@@ -78,4 +87,21 @@ export function buildModel(
   options?: BuildModelOptions,
 ): BuildModelResult {
   return buildModelResultFromSources(entryUri, documents, options);
+}
+
+/**
+ * Build a field chain (upstream/downstream lineage) for `focusField` — a
+ * "schema.field" reference in the same form the CLI's
+ * `field-lineage <schema.field>` argument takes — from in-memory `documents`.
+ * A thin pass-through to the core pipeline, mirroring `buildModel`'s role but
+ * for the chain-view entry point (PRD 36 R3/R4): the parser must already be
+ * initialised.
+ */
+export function buildFieldChain(
+  entryUri: string,
+  documents: SourceDocument[],
+  focusField: string,
+  options?: BuildFieldChainOptions,
+): FieldChainModel {
+  return buildFieldChainFromSources(entryUri, documents, focusField, options);
 }

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -59,6 +59,14 @@ const nestedIterationUri = libraryUri("nested-iteration/pipeline.stm");
  * directory.
  */
 const governanceUri = libraryUri("filter-flatten-governance/governance.stm");
+/**
+ * Namespace-merging fixture — the corpus's only field whose lineage genuinely
+ * spans multiple mappings on both sides with `nl-derived` hops mixed in
+ * (sl-nswc): `reporting::dept_budget_vs_actual.actual_spend` has 3 upstream
+ * hops at depth 1 and 4 at depth 2 (collapsing into a namespace-fan chip),
+ * plus 2 downstream hops. No other fixture in the harness reaches this shape.
+ */
+const nsMergingUri = libraryUri("namespaces/ns-merging.stm");
 
 /**
  * Open a specific named mapping by clicking its overview mapping card.
@@ -957,6 +965,264 @@ test.describe("Field coverage indicators", () => {
       expect(appearances.partial).toMatch(/gradient/);
     });
   }
+});
+
+// sl-nswc (PRD 36 R5): sl-5m9x's own unit tests (coverage-overlay.test.js,
+// schema-card-coverage.test.js) already prove the toggle property and geometry
+// invariant it pins survive a *simulated* DOM. What only a real browser can
+// prove is that the toolbar button the user actually clicks flips the overlay
+// on every schema card in one page, with the CLI's own numbers, and that the
+// paint-only promise ("toggling never reshuffles the diagram") holds for
+// bounding boxes Playwright reads off real rendered elements.
+test.describe("Coverage overlay toggle", () => {
+  test("toggle switches every schema card between field counts and covered/total ratios with percentage badges matching `satsuma coverage --json`", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, ffgUri);
+
+    const toggle = page.locator("[data-testid='toolbar-toggle-coverage']");
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    // order_events is read by two mappings in this fixture, so its aggregate
+    // (20/22, 90%) genuinely differs from either mapping's own coverage —
+    // the same case sl-twe8 used, confirmed via `satsuma coverage --json`
+    // against filter-flatten-governance.stm.
+    const orderEventsCount = page.locator(
+      "[data-testid='overview-schema-card-order-events-header-count']",
+    );
+    const orderEventsBadge = page.locator(
+      "[data-testid='overview-schema-card-order-events-coverage-percent']",
+    );
+    await expect(orderEventsCount).toHaveText("22 fields");
+    await expect(orderEventsBadge).toHaveCount(0);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    await expect(orderEventsCount).toHaveText("20/22");
+    await expect(orderEventsBadge).toHaveText("90%");
+
+    // customer_profiles (3/8, 37%) and completed_orders_parquet (15/15, 100%)
+    // pin the "one fully-mapped, one half-mapped schema" acceptance test from
+    // the PRD against the same fixture, so all three assertions are checked
+    // against one `satsuma coverage --json` run rather than three fixtures.
+    await expect(
+      page.locator("[data-testid='overview-schema-card-customer-profiles-header-count']"),
+    ).toHaveText("3/8");
+    await expect(
+      page.locator("[data-testid='overview-schema-card-customer-profiles-coverage-percent']"),
+    ).toHaveText("37%");
+    await expect(
+      page.locator(
+        "[data-testid='overview-schema-card-completed-orders-parquet-coverage-percent']",
+      ),
+    ).toHaveText("100%");
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-pressed", "false");
+    await expect(orderEventsCount).toHaveText("22 fields");
+    await expect(orderEventsBadge).toHaveCount(0);
+  });
+
+  test("toggling coverage mode does not change overview card geometry", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, ffgUri);
+
+    const before = await readOverviewCardBoxes(page);
+    await page.locator("[data-testid='toolbar-toggle-coverage']").click();
+    await expect(page.locator("[data-testid='toolbar-toggle-coverage']")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    const after = await readOverviewCardBoxes(page);
+
+    // Same cards, same boxes: the overlay repaints headers in place, it never
+    // triggers a relayout (PRD 36 R1's "paint-only" requirement).
+    expect(after).toEqual(before);
+  });
+});
+
+// sl-nswc (PRD 36 R4/R5): sl-4czz's own unit tests drive <sz-chain-view>
+// directly with hand-built FieldChainModel fixtures and can only prove the
+// rendering function is correct. They cannot prove the real entry point (a
+// click on a field row's lineage icon) reaches it, that the harness's own
+// host wiring (buildFieldChain -> openFieldChain, added alongside these
+// specs) produces a model matching the CLI, or that two sibling hops at the
+// same depth are genuinely two separate, clickable DOM elements — the exact
+// testid-collision defect a substring-matching unit test cannot observe
+// (fixed in sz-chain-view.ts alongside this suite).
+//
+// examples/namespaces/ns-merging.stm is the only fixture in the corpus whose
+// lineage genuinely fans out on both sides with `nl-derived` hops mixed in —
+// see the `nsMergingUri` doc comment above for the shape, confirmed via
+// `satsuma field-lineage reporting::dept_budget_vs_actual.actual_spend
+// examples/namespaces/ns-merging.stm --json` before writing these assertions.
+test.describe("Field chain view", () => {
+  /** Expand a namespaced overview card and return its field-row test-id prefix. */
+  async function expandOverviewCard(page: Page, qualifiedIdTestSegment: string): Promise<string> {
+    const cardPrefix = `overview-schema-card-${qualifiedIdTestSegment}`;
+    await page
+      .locator(`sz-schema-card[data-testid^='${cardPrefix}']`)
+      .locator(".header-toggle")
+      .click();
+    return cardPrefix;
+  }
+
+  test("tracing a field with multiple upstream and downstream mappings opens a chain view with nl-derived hops, including a collapsed namespace fan", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, nsMergingUri);
+
+    const cardPrefix = await expandOverviewCard(page, "reporting-dept-budget-vs-actual");
+    await page
+      .locator(`[data-testid='${cardPrefix}-field-actual-spend-lineage']`)
+      .click({ force: true });
+
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+      { timeout: 10_000 },
+    );
+    const focus = page.locator("[data-testid='chain-focus']");
+    await expect(focus).toContainText("dept_budget_vs_actual");
+    await expect(focus).toContainText("actual_spend");
+
+    // Depth 1 upstream: 3 hops (2 in the `staging` namespace, 1 in `source`),
+    // none exceeding the namespace-fan collapse threshold, so all three render
+    // as individually addressable hop cards — the exact shape the testid fix
+    // in sz-chain-view.ts makes possible.
+    const stgAmount = page.locator(
+      "[data-testid^='chain-hop-upstream-1-staging-stg-gl-entries-amount']",
+    );
+    const stgDepartment = page.locator(
+      "[data-testid^='chain-hop-upstream-1-staging-stg-gl-entries-department']",
+    );
+    const budgetFiscalYear = page.locator(
+      "[data-testid^='chain-hop-upstream-1-source-finance-budgets-fiscal-year']",
+    );
+    await expect(stgAmount).toHaveAttribute("data-classification", "nl");
+    await expect(stgDepartment).toHaveAttribute("data-classification", "nl-derived");
+    await expect(budgetFiscalYear).toHaveAttribute("data-classification", "nl-derived");
+
+    // Depth 2 upstream: 4 hops, all in `source` — over the collapse threshold,
+    // so they start as one summary chip until expanded (PRD 36 open question 2).
+    const depth2Chip = page.locator("[data-testid='chain-group-upstream:2:source']");
+    await expect(depth2Chip).toBeVisible();
+    await expect(depth2Chip).toContainText("4 fields");
+    await expect(
+      page.locator("[data-testid^='chain-hop-upstream-2-source-finance-gl-amount']"),
+    ).toHaveCount(0);
+    await depth2Chip.click();
+    await expect(
+      page.locator("[data-testid^='chain-hop-upstream-2-source-finance-gl-amount']"),
+    ).toHaveAttribute("data-classification", "none");
+
+    // Downstream: 2 hops, one column each, both nl-derived — the field this
+    // mapping computes flows into two further computed fields on the same
+    // record, neither backed by a declared arrow.
+    await expect(
+      page.locator(
+        "[data-testid^='chain-hop-downstream-1-reporting-dept-budget-vs-actual-variance']",
+      ),
+    ).toHaveAttribute("data-classification", "nl-derived");
+    await expect(
+      page.locator(
+        "[data-testid^='chain-hop-downstream-2-reporting-dept-budget-vs-actual-variance-pct']",
+      ),
+    ).toHaveAttribute("data-classification", "nl-derived");
+  });
+
+  test("clicking a hop's field re-focuses the chain view on that field", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, nsMergingUri);
+
+    const cardPrefix = await expandOverviewCard(page, "reporting-dept-budget-vs-actual");
+    await page
+      .locator(`[data-testid='${cardPrefix}-field-actual-spend-lineage']`)
+      .click({ force: true });
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+      { timeout: 10_000 },
+    );
+
+    await page
+      .locator("[data-testid^='chain-hop-field-upstream-1-staging-stg-gl-entries-amount']")
+      .click();
+
+    // Re-focused on staging::stg_gl_entries.amount: a fresh trace from that
+    // field's own perspective, not the original focus field's hop list.
+    const focus = page.locator("[data-testid='chain-focus']");
+    await expect(focus).toContainText("stg_gl_entries");
+    await expect(focus).toContainText("amount");
+    await expect(
+      page.locator("[data-testid^='chain-hop-upstream-1-source-finance-gl-amount']"),
+    ).toHaveAttribute("data-classification", "none");
+    await expect(
+      page.locator(
+        "[data-testid^='chain-hop-downstream-1-reporting-dept-budget-vs-actual-actual-spend']",
+      ),
+    ).toHaveAttribute("data-classification", "nl");
+  });
+
+  test("clicking a hop's mapping label opens that mapping's detail view", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, nsMergingUri);
+
+    const cardPrefix = await expandOverviewCard(page, "reporting-dept-budget-vs-actual");
+    await page
+      .locator(`[data-testid='${cardPrefix}-field-actual-spend-lineage']`)
+      .click({ force: true });
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+      { timeout: 10_000 },
+    );
+
+    await page
+      .locator("[data-testid^='chain-hop-mapping-upstream-1-staging-stg-gl-entries-amount']")
+      .click();
+
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "detail",
+    );
+    await expect(
+      page.locator("[data-testid^='mapping-detail-build-budget-vs-actual']").first(),
+    ).toBeVisible();
+  });
 });
 
 test.describe("Hover highlighting between arrows and field rows", () => {

--- a/tooling/satsuma-viz-harness/test/view-persistence.test.ts
+++ b/tooling/satsuma-viz-harness/test/view-persistence.test.ts
@@ -1,5 +1,6 @@
 /**
- * view-persistence.test.ts — the mapping detail view survives live edits (sl-2ksz).
+ * view-persistence.test.ts — the mapping detail view survives live edits (sl-2ksz),
+ * and the chain view does too (sl-nswc, PRD 36 R4's Feature-34-R1 guarantee).
  *
  * Live editing replaces the viz model on every debounced keystroke. Before the
  * fix, <satsuma-viz> reset itself to the overview whenever its model property
@@ -8,6 +9,17 @@
  *   1. An edit that keeps the selected mapping (same namespace + name)
  *      re-renders the detail view in place with the new model's content.
  *   2. An edit that renames the mapping falls back gracefully to the overview.
+ *
+ * The chain view's equivalent guarantee (_reconcileViewState in
+ * satsuma-viz.ts, "Feature 34 R1" cited by name) works differently: a
+ * FieldChainModel isn't reconstructible from a VizModel alone, so instead of
+ * rebinding locally the component re-dispatches the same "field-lineage"
+ * event the original entry point used, asking the host to retrace against
+ * the fresh model. That only round-trips through a real host — the harness's
+ * own app.ts wiring added alongside this suite (buildFieldChain ->
+ * openFieldChain) — so only a real browser proves the retrace actually
+ * happens, not just that the event was re-dispatched (which sz-chain-view's
+ * own unit tests already prove at the component level).
  */
 
 import { test, expect, type Page } from "@playwright/test";
@@ -112,5 +124,131 @@ test.describe("Detail view persistence across live edits", () => {
       "data-view-mode",
       "overview",
     );
+  });
+});
+
+/**
+ * Three schemas, two mappings, one traceable field (stg_customers.email):
+ * upstream to raw_customers.email, downstream to dim_customers.email.
+ * `emailTransform` lets an edit change the upstream arrow's classification
+ * without touching the chain's shape — the smallest edit that still proves a
+ * fresh trace happened, rather than a stale chain merely lingering onscreen.
+ */
+function chainDoc(emailTransform = "", emailFieldName = "email"): string {
+  return [
+    "schema raw_customers {",
+    "  id     ID           (pk)",
+    "  email  STRING(120)",
+    "}",
+    "",
+    "schema stg_customers {",
+    "  id             VARCHAR(20)   (pk)",
+    `  ${emailFieldName}  VARCHAR(120)`,
+    "}",
+    "",
+    "schema dim_customers {",
+    "  customer_key  VARCHAR(20)   (pk)",
+    "  email         VARCHAR(120)",
+    "}",
+    "",
+    "mapping stage_customers {",
+    "  source { raw_customers }",
+    "  target { stg_customers }",
+    "",
+    "  id -> id",
+    `  email -> ${emailFieldName}${emailTransform}`,
+    "}",
+    "",
+    "mapping load_dim_customers {",
+    "  source { stg_customers }",
+    "  target { dim_customers }",
+    "",
+    "  id -> customer_key",
+    `  ${emailFieldName} -> email`,
+    "}",
+    "",
+  ].join("\n");
+}
+
+test.describe("Chain view persistence across live edits", () => {
+  /** Open the harness in single-file mode, load a starting buffer, then replace it with `text`. */
+  async function openWithChainBuffer(page: Page, text: string): Promise<void> {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await page.locator("#fixture-picker-btn").click();
+    await page.locator(`.fixture-item[data-uri="${sfdcUri}"]`).click();
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-ready-state",
+      "ready",
+      { timeout: 20_000 },
+    );
+    await page.locator("#source-input").fill(text);
+    await expect(page.locator("[data-testid='overview-schema-card-stg-customers']")).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /** Expand stg_customers' compact card and click its email field's lineage icon. */
+  async function openEmailChain(page: Page): Promise<void> {
+    const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-stg-customers']");
+    await card.locator(".header-toggle").click();
+    await page
+      .locator("[data-testid='overview-schema-card-stg-customers-field-email-lineage']")
+      .click({ force: true });
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+      { timeout: 10_000 },
+    );
+  }
+
+  test("an edit that keeps the chain's focus field re-traces against the new model", async ({
+    page,
+  }) => {
+    await openWithChainBuffer(page, chainDoc());
+    await openEmailChain(page);
+
+    const upstreamHop = page.locator("[data-testid^='chain-hop-upstream-1-raw-customers-email']");
+    await expect(upstreamHop).toHaveAttribute("data-classification", "none");
+
+    // Add a transform to the upstream arrow — the focus field (stg_customers.email)
+    // is untouched, but the retrace must pick up the new classification, proving
+    // the host actually re-traced against the fresh model rather than the stale
+    // chain merely staying onscreen.
+    await page.locator("#source-input").fill(chainDoc(" { trim }"));
+
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+    );
+    await expect(page.locator("[data-testid='chain-focus']")).toContainText("stg_customers");
+    await expect(upstreamHop).toHaveAttribute("data-classification", "nl", { timeout: 10_000 });
+  });
+
+  test("an edit that removes the chain's focus field falls back to the overview", async ({
+    page,
+  }) => {
+    await openWithChainBuffer(page, chainDoc());
+    await openEmailChain(page);
+
+    // Renaming stg_customers.email deletes the field the chain is focused on
+    // (its schema survives, its path does not) — _chainFieldStillExists must
+    // say no, and the component must fall back rather than render a stale or
+    // broken trace.
+    await page.locator("#source-input").fill(chainDoc("", "email_address"));
+
+    await expect(
+      page.locator("[data-testid='overview-schema-card-stg-customers-field-email-address']"),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "overview",
+    );
+    await expect(page.locator("[data-testid='chain-view']")).toHaveCount(0);
   });
 });

--- a/tooling/satsuma-viz/src/components/sz-chain-view.ts
+++ b/tooling/satsuma-viz/src/components/sz-chain-view.ts
@@ -21,7 +21,7 @@ import { fieldEndpointPath, fieldEndpointSchema } from "@satsuma/core/reference-
 import type { CanonicalFieldEndpoint } from "@satsuma/core/reference-stages";
 import type { Classification } from "@satsuma/core/types";
 import type { FieldChainHop, FieldChainModel } from "../model.js";
-import { SzFieldLineageEvent } from "../satsuma-viz.js";
+import { SzFieldLineageEvent, sanitizeTestIdSegment } from "../satsuma-viz.js";
 
 /**
  * A namespace group within one depth column is collapsed to a summary chip
@@ -384,10 +384,18 @@ export class SzChainView extends LitElement {
     const parts = splitEndpoint(hop.field);
     const qualifiedId = qualifiedIdOf(parts);
     const atDepthLimit = this.chain !== null && hop.depth === this.chain.maxDepth;
-    const cardTestId = `chain-hop-${direction}-${hop.depth}`;
-    const mappingTestId = `chain-hop-mapping-${direction}-${hop.depth}`;
-    const fieldTestId = `chain-hop-field-${direction}-${hop.depth}`;
-    const depthLimitTestId = `chain-depth-limit-${direction}-${hop.depth}`;
+    // A column can hold more than one hop below the namespace-fan collapse
+    // threshold (e.g. two sibling fields on the same source schema at the
+    // same depth) — direction+depth alone collides for those, so the field
+    // itself breaks the tie. Regex-based unit tests only ever assert a
+    // testid's presence as a substring and cannot see a real DOM collision;
+    // only Playwright driving an actual click proves each hop is individually
+    // addressable (the same class of gap noted in AGENTS.md's viz-testing rule).
+    const hopId = sanitizeTestIdSegment(`${qualifiedId}.${parts.fieldPath}`);
+    const cardTestId = `chain-hop-${direction}-${hop.depth}-${hopId}`;
+    const mappingTestId = `chain-hop-mapping-${direction}-${hop.depth}-${hopId}`;
+    const fieldTestId = `chain-hop-field-${direction}-${hop.depth}-${hopId}`;
+    const depthLimitTestId = `chain-depth-limit-${direction}-${hop.depth}-${hopId}`;
     const mappingTitle = `Open mapping ${hop.via_mapping}`;
     const fieldTitle = `Trace ${qualifiedId}.${parts.fieldPath}`;
 

--- a/tooling/satsuma-viz/test/sz-chain-view.test.js
+++ b/tooling/satsuma-viz/test/sz-chain-view.test.js
@@ -160,6 +160,28 @@ describe("sz-chain-view", () => {
       assert.match(serialized, /chain-hop-field-upstream-1/);
       assert.doesNotMatch(serialized, /chain-group-upstream:1:crm/);
     });
+
+    // A substring-match assertion (as above) cannot tell one hit from two
+    // identical ones, so it would not have caught the two sibling hops here
+    // sharing a testid before the field-path suffix was added — only a real
+    // DOM query (Playwright) can prove a testid addresses exactly one
+    // element. This test asserts the property the substring checks cannot:
+    // real uniqueness of each rendered testid.
+    it("gives each ungrouped hop at the same depth its own distinct testid", async () => {
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = {
+        field: "::orders.id",
+        maxDepth: 5,
+        upstream: [hop("crm::a.id", "crm::m1", "none", 1), hop("crm::b.id", "crm::m1", "none", 1)],
+        downstream: [],
+      };
+      const testIds = [...serialize(view.render()).matchAll(/chain-hop-upstream-1-\S+/g)].map(
+        (m) => m[0],
+      );
+      assert.equal(testIds.length, 2);
+      assert.notEqual(testIds[0], testIds[1]);
+    });
   });
 
   it("dispatches a field-lineage request when a hop's field is clicked, for the host to retrace", async () => {


### PR DESCRIPTION
## Summary
- Closes sl-nswc, the last open ticket in Feature 36 (viz coverage overlay + field chain view epic, sl-3de8).
- Adds 7 new Playwright specs: coverage-toggle on/off with badge values matching `satsuma coverage --json`, a coverage-mode layout-snapshot (paint-only proof), chain-view rendering with upstream/downstream fan-out including an nl-derived hop, hop-click refocus, mapping-label navigation, and edit-while-in-chain-view preservation/fallback.
- Wires the harness's `field-lineage` event listener to `buildFieldChain`/`openFieldChain` (it previously only recorded the event), so the real click-to-chain-view path is exercised end-to-end for the first time.
- Fixes a real bug found while writing the fan-out test: `sz-chain-view.ts` computed hop testids from direction+depth only, which collided whenever a column held more than one ungrouped hop below the namespace-fan-collapse threshold — invisible to the existing unit tests, which only do substring matching on serialized templates and can't observe a real DOM testid collision. Fixed by appending a sanitized field-path suffix, with a new unit test pinning per-hop uniqueness.
- Adds `examples/namespaces/ns-merging.stm` as a harness fixture (`nsMergingUri`) — it's the only corpus fixture with a field whose lineage genuinely fans out on both sides with `nl-derived` hops mixed in.

## Test plan
- [x] `npm run test:all` — all packages green
- [x] `tsc --noEmit` on the harness package — clean
- [x] `eslint` on all changed files — clean
- [x] Full Playwright suite via the sentinel-file watcher protocol — 114/114 passed
- [x] `./scripts/run-repo-checks.sh` — green (also ran automatically via the pre-commit hook)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>