### PR TITLE
fix(viz): five UI bugs — card corners, toggle target, toolbar overflow, arrow-table absences

### DIFF
--- a/.tickets/sl-6g23.md
+++ b/.tickets/sl-6g23.md
@@ -1,6 +1,6 @@
 ---
 id: sl-6g23
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-05T09:26:57Z
@@ -21,3 +21,12 @@ Screenshot: bug-reports/only-click-in-arrow-expands-contracts.png
 
 Clicking the arrow OR the field-count text toggles expand/collapse. Clicking the name/icon still navigates and does not toggle. The existing sl-tw0r regression test (combined-handler navigate-on-expand) still passes.
 
+
+## Notes
+
+**2026-08-06T12:42:15Z**
+
+**2026-08-06T12:42:00Z**
+
+Cause: only `.header-toggle` (a ~12px glyph plus padding) was wired to `_onToggleClick`, so the expand/collapse target on a compact overview card was far smaller than the header region a reader aims at.
+Fix: `.header-count` now shares the same `_onToggleClick` handler (and a pointer cursor) in both the compact and full card renders — the handler split sl-tw0r requires is untouched, and a new harness case asserts the count click stays navigation-silent while the header name still navigates (commit immediately after 5f59ffc6).

--- a/.tickets/sl-jetk.md
+++ b/.tickets/sl-jetk.md
@@ -1,6 +1,6 @@
 ---
 id: sl-jetk
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-03T12:30:45Z
@@ -24,3 +24,12 @@ Root cause: satsuma-viz/src/components/sz-mapping-detail.ts _renderArrowTable (l
 - A test covers the empty case using a minimal report/model mapping snippet (not the whole example file).
 - The non-empty case is unchanged.
 
+
+## Notes
+
+**2026-08-06T12:42:27Z**
+
+**2026-08-06T12:42:00Z**
+
+Cause: `_renderArrowTable` always emitted `<thead>` and its four column headers, and `<tbody>` received nothing when arrows, eachBlocks, flattenBlocks and nestedArrows were all empty — the legitimate report/model consumer shape.
+Fix: an `_hasNoArrows` branch renders a stated empty state ('This mapping declares no field-level arrows — it maps whole schemas only') and no table at all. Covered by render-output tests in @satsuma/viz and by the reports-and-models consumers in the harness; note that EVERY mapping in that fixture is arrow-free, so the control case uses sfdc's opportunity-ingestion (commit immediately after 5f59ffc6).

--- a/.tickets/sl-k7i4.md
+++ b/.tickets/sl-k7i4.md
@@ -1,6 +1,6 @@
 ---
 id: sl-k7i4
-status: open
+status: closed
 deps: []
 links: [lgc-4bxl]
 created: 2026-08-03T12:30:52Z
@@ -24,3 +24,12 @@ Sourceless arrows are a first-class construct, so they deserve a first-class pre
 - A test asserts the marker for a minimal sourceless-arrow snippet.
 - Arrows that do have sources are unchanged.
 
+
+## Notes
+
+**2026-08-06T12:42:27Z**
+
+**2026-08-06T12:42:00Z**
+
+Cause: the Source cell rendered `a.sourceFields.map(...)` unconditionally, so a target-only arrow (empty `sourceFields`) produced an empty cell — visually identical to a source path the viz had failed to resolve.
+Fix: an empty `sourceFields` renders a muted italic 'derived' marker with an explanatory title, carrying its own `.source-derived` class rather than `.field-ref` so it cannot read as a field name or pick up path highlighting. Asserted on sfdc's `is_closed` row in the harness (commit immediately after 5f59ffc6).

--- a/.tickets/sl-yedr.md
+++ b/.tickets/sl-yedr.md
@@ -1,6 +1,6 @@
 ---
 id: sl-yedr
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-05T09:25:42Z
@@ -21,3 +21,12 @@ Screenshot: bug-reports/namespaced-cards-lose-rounded-corners-on-expand.png
 
 Expanded (compact-expanded) namespaced compact cards keep rounded top corners, matching non-namespaced cards. Playwright/visual test on a namespaced card in the expanded state, both themes.
 
+
+## Notes
+
+**2026-08-06T12:42:05Z**
+
+**2026-08-06T12:42:00Z**
+
+Cause: `.header:first-child` was the only rule giving a compact card its top rounding once `:host([compact-expanded])` drops the host's overflow clip, and a namespaced card's pill row sits above the header, so the header is not first and no rule fired.
+Fix: the pill row's geometry moved from an inline style into a `.namespace-pill-row` class that carries the same top-rounding fallback under `:first-child`; covered in chrome-layout.test.ts in both themes, and proved to fail without the fix (commit immediately after 5f59ffc6).

--- a/.tickets/sl-zsv6.md
+++ b/.tickets/sl-zsv6.md
@@ -1,6 +1,6 @@
 ---
 id: sl-zsv6
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-03T12:30:34Z
@@ -24,3 +24,12 @@ This is the viz component's own toolbar, so it affects the VS Code webview and t
 - A Playwright assertion covers it: at 1440x900 with the source pane open on ns-platform.stm, the title element's scrollHeight equals a single line height and the last toolbar control's right edge is within the toolbar's client box.
 - Verified in both light and dark themes.
 
+
+## Notes
+
+**2026-08-06T12:42:16Z**
+
+**2026-08-06T12:42:00Z**
+
+Cause: `.toolbar` is a flex row with no wrap, and `.toolbar-title` was the only item that could shrink (buttons and selects are nowrap), so the title wrapped to two lines while the trailing file filter was pushed past the toolbar's right edge.
+Fix: the title takes `white-space: nowrap`, `flex-shrink: 0` and ellipsis truncation capped at the row width; the toolbar takes `flex-wrap: wrap` with a row gap, so overflow becomes a second row rather than a hidden control. Asserted at 1440x900 with the source pane open on ns-platform.stm in both themes (commit immediately after 5f59ffc6).

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 191,
-    "satsuma-viz": 172,
+    "satsuma-viz": 178,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-harness/test/chrome-layout.test.ts
+++ b/tooling/satsuma-viz-harness/test/chrome-layout.test.ts
@@ -115,22 +115,27 @@ test.describe("Namespaced compact card corners when expanded (sl-yedr)", () => {
       await expect(card).toHaveAttribute("compact-expanded", "");
 
       // The pill row is the top of the card, so it is the element whose corners
-      // a reader sees. Assert both halves of that claim: it sits flush with the
-      // card's top edge, and it paints the card radius rather than 0.
+      // a reader sees. Assert both halves of that claim: it sits at the very top
+      // of the card's content box, and it paints the card radius rather than 0.
       const geometry = await card.evaluate((host) => {
         const row = host.shadowRoot?.querySelector<HTMLElement>("[data-testid$='-namespace-pill']");
         if (!row) throw new Error("namespace pill row not rendered");
         const style = getComputedStyle(row);
+        const hostStyle = getComputedStyle(host);
         return {
-          cardTop: host.getBoundingClientRect().top,
-          rowTop: row.getBoundingClientRect().top,
+          // The row starts inside the host's 1px border, so the offset to compare
+          // against is the border width — not zero.
+          topOffset:
+            row.getBoundingClientRect().top -
+            host.getBoundingClientRect().top -
+            parseFloat(hostStyle.borderTopWidth),
           topLeft: style.borderTopLeftRadius,
           topRight: style.borderTopRightRadius,
-          cardRadius: getComputedStyle(host).getPropertyValue("--sz-card-radius").trim(),
+          cardRadius: hostStyle.getPropertyValue("--sz-card-radius").trim(),
         };
       });
 
-      expect(geometry.rowTop).toBeCloseTo(geometry.cardTop, 0);
+      expect(geometry.topOffset).toBeCloseTo(0, 0);
       // Equal to the shared card-radius token, not merely non-zero: that is what
       // "matching non-namespaced cards" means, and it fails loudly if the token
       // and the fallback rule ever diverge.

--- a/tooling/satsuma-viz-harness/test/chrome-layout.test.ts
+++ b/tooling/satsuma-viz-harness/test/chrome-layout.test.ts
@@ -1,0 +1,141 @@
+/**
+ * chrome-layout.test.ts — Playwright tests for two pieces of viz chrome whose
+ * defects are only observable once the component is painted at a real width.
+ *
+ *  - sl-zsv6: the toolbar is a flex row of controls that all hold their own
+ *    width. Narrower than its contents, it pushed the trailing file filter past
+ *    its right edge and wrapped the title onto two lines instead. Neither is
+ *    visible to a unit test: both are consequences of flex resolution in a
+ *    laid-out box.
+ *
+ *  - sl-yedr: a compact card's top rounding comes from the host's overflow clip,
+ *    which `:host([compact-expanded])` deliberately lifts. The header carries a
+ *    fallback rule, but only fires as `:first-child` — so a namespaced card,
+ *    whose pill row sits above the header, rendered square top corners when
+ *    expanded. Only a browser resolves which rule won and what radius the
+ *    painted element actually has.
+ *
+ * Both are checked in light and dark: the fixes are geometry, so a theme must
+ * not change them, and a token-driven radius that resolved in one palette only
+ * would be exactly the kind of regression this file exists to catch.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { libraryUri } from "./harness-env";
+
+/**
+ * The multi-namespace platform entry point — the fixture that renders the most
+ * toolbar controls (both the namespace and the file filter appear, because it
+ * has namespaces AND imports across files) and the only one whose overview
+ * cards carry namespace pills. Both bugs were reported against it.
+ */
+const nsPlatformUri = libraryUri("namespaces/ns-platform.stm");
+
+/**
+ * The viewport the bugs were reported at. The harness's own default is 1280px
+ * wide; sl-zsv6 was observed at 1440x900 with the source pane open, which is
+ * the narrower viz column of the two, so this is the tighter of the two cases.
+ */
+const REPORTED_VIEWPORT = { width: 1440, height: 900 };
+
+/** Load a fixture through the picker and wait for the viz to report ready. */
+async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
+  await page.locator("#fixture-picker-btn").click();
+  await page.locator(`.fixture-item[data-uri="${fixtureUri}"]`).click();
+  await page.locator("[data-testid='viz-root']").waitFor({ state: "visible" });
+  await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+    "data-ready-state",
+    "ready",
+    { timeout: 20_000 },
+  );
+}
+
+test.describe("Toolbar layout at the reported viewport (sl-zsv6)", () => {
+  for (const theme of ["light", "dark"] as const) {
+    test(`the title stays on one line and every control stays inside the toolbar (${theme})`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(REPORTED_VIEWPORT);
+      await page.goto(`/?theme=${theme}`);
+      await loadFixture(page, nsPlatformUri);
+
+      // The source pane is open (the harness default) — the reported condition,
+      // and the one that leaves the viz its narrowest column.
+      await expect(page.locator("#source-editor")).toBeVisible();
+
+      // A span renders one client rect per line box, so a wrapped title has two.
+      // This is the direct form of "the title does not wrap": it does not depend
+      // on knowing the font's line height.
+      const titleLineBoxes = await page
+        .locator("satsuma-viz .toolbar-title")
+        .evaluate((el) => el.getClientRects().length);
+      expect(titleLineBoxes, "toolbar title wrapped onto more than one line").toBe(1);
+
+      // The file filter is the last control in the toolbar for this fixture, so
+      // it is the one that used to overflow. Every control must sit within the
+      // toolbar's own content box — the toolbar is allowed to grow taller
+      // (it wraps deliberately), never to hide a control past its right edge.
+      const overflow = await page.locator("satsuma-viz .toolbar").evaluate((toolbar) => {
+        const box = toolbar.getBoundingClientRect();
+        return [...toolbar.children]
+          .map((child) => {
+            const r = child.getBoundingClientRect();
+            return { right: r.right, bottom: r.bottom, cls: child.className };
+          })
+          .filter((r) => r.right > box.right + 1 || r.bottom > box.bottom + 1);
+      });
+      expect(overflow, "toolbar controls painted outside the toolbar box").toEqual([]);
+
+      // And the filter is genuinely reachable, not merely inside a zero-size box.
+      const filter = page.locator("[data-testid='toolbar-file-filter']");
+      await expect(filter).toBeVisible();
+      const filterBox = await filter.boundingBox();
+      expect(filterBox?.width ?? 0).toBeGreaterThan(0);
+    });
+  }
+});
+
+test.describe("Namespaced compact card corners when expanded (sl-yedr)", () => {
+  for (const theme of ["light", "dark"] as const) {
+    test(`an expanded namespaced card keeps its rounded top corners (${theme})`, async ({
+      page,
+    }) => {
+      await page.goto(`/?theme=${theme}`);
+      await loadFixture(page, nsPlatformUri);
+
+      // Any namespaced card exercises the rule; the `raw` layer's cards are the
+      // fixture's sources and always present.
+      const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-raw-']").first();
+      const pillRow = card.locator("[data-testid$='-namespace-pill']");
+      await expect(pillRow).toBeVisible();
+
+      await card.locator(".header-toggle").click();
+      // The reflected attribute is what lifts the host's overflow clip, so the
+      // fallback rounding matters only once it is present.
+      await expect(card).toHaveAttribute("compact-expanded", "");
+
+      // The pill row is the top of the card, so it is the element whose corners
+      // a reader sees. Assert both halves of that claim: it sits flush with the
+      // card's top edge, and it paints the card radius rather than 0.
+      const geometry = await card.evaluate((host) => {
+        const row = host.shadowRoot?.querySelector<HTMLElement>("[data-testid$='-namespace-pill']");
+        if (!row) throw new Error("namespace pill row not rendered");
+        const style = getComputedStyle(row);
+        return {
+          cardTop: host.getBoundingClientRect().top,
+          rowTop: row.getBoundingClientRect().top,
+          topLeft: style.borderTopLeftRadius,
+          topRight: style.borderTopRightRadius,
+          cardRadius: getComputedStyle(host).getPropertyValue("--sz-card-radius").trim(),
+        };
+      });
+
+      expect(geometry.rowTop).toBeCloseTo(geometry.cardTop, 0);
+      // Equal to the shared card-radius token, not merely non-zero: that is what
+      // "matching non-namespaced cards" means, and it fails loudly if the token
+      // and the fallback rule ever diverge.
+      expect(geometry.topLeft).toBe(geometry.cardRadius);
+      expect(geometry.topRight).toBe(geometry.cardRadius);
+    });
+  }
+});

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -1869,6 +1869,45 @@ test.describe("Compact card expansion in overview", () => {
     await expect(card.locator("[data-testid$='-field-id']")).toHaveCount(0);
   });
 
+  test("clicking the field-count text toggles the fields, like the arrow (sl-6g23)", async ({
+    page,
+  }) => {
+    // The arrow glyph alone was a ~12px hit target on a compact card, so the
+    // count next to it joined the toggle's target (sl-6g23). Only a real click
+    // on the rendered span proves the listener is wired to that element; a
+    // handler-level test would pass whether or not it reached the DOM.
+    const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-buy-order']");
+    const count = card.locator(".header-count");
+
+    await count.click();
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Symmetric: the count collapses as well as expands.
+    await count.click();
+    await expect(card.locator("[data-testid$='-field-id']")).toHaveCount(0);
+  });
+
+  test("the field-count click expands without navigating (sl-tw0r still holds)", async ({
+    page,
+  }) => {
+    // Widening the toggle's hit area must not widen navigation's. sl-tw0r's
+    // rule is that anything wired to expand is navigation-silent, or a host
+    // that opens documents on navigate (VS Code) yanks the editor away the
+    // moment a card is expanded — so the new target needs the same guard the
+    // arrow has.
+    await page.evaluate(() => window.__satsumaHarness.clearEvents());
+
+    const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-buy-order']");
+    await card.locator(".header-count").click();
+    await expect(card.locator("[data-testid$='-field-id']").first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    expect(await recordedEvents(page, "navigate")).toEqual([]);
+  });
+
   test("expanding grows the canvas and collapsing shrinks it back (symmetric re-layout)", async ({
     page,
   }) => {

--- a/tooling/satsuma-viz-harness/test/mapping-detail-arrow-states.test.ts
+++ b/tooling/satsuma-viz-harness/test/mapping-detail-arrow-states.test.ts
@@ -51,9 +51,16 @@ async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
   );
 }
 
-/** Open a mapping's detail view by clicking its overview card. */
+/**
+ * Open a mapping's detail view from its overview card.
+ *
+ * `dispatchEvent` rather than a pointer click, following minimap.test.ts: on
+ * these fixtures the bottom-anchored minimap overlays part of the canvas and
+ * intercepts pointer events on whichever card sits beneath it. Reaching the
+ * detail view is the precondition here, not the subject.
+ */
 async function openMapping(page: Page, mappingId: string) {
-  await page.locator(`[data-testid='overview-mapping-card-${mappingId}']`).click();
+  await page.locator(`[data-testid='overview-mapping-card-${mappingId}']`).dispatchEvent("click");
   const detail = page.locator(`[data-testid='mapping-detail-${mappingId}']`).first();
   await expect(detail).toBeVisible({ timeout: 10_000 });
   return detail;
@@ -76,13 +83,17 @@ test.describe("A consumer mapping with no field arrows (sl-jetk)", () => {
     await expect(detail.locator("[data-testid$='-arrow-table']")).toHaveCount(0);
   });
 
-  test("still renders the full arrow table for a mapping that has arrows", async ({ page }) => {
-    // The same fixture's `_customer_risk_report_pipeline` does declare arrows,
-    // so it proves the empty branch is reached by emptiness and not by the
-    // report/model shape in general.
+  test("still renders the full arrow table for a mapping that does declare arrows", async ({
+    page,
+  }) => {
+    // The control case, and it needs a different fixture: EVERY mapping in
+    // reports-and-models is a whole-schema consumer, so nothing in that file can
+    // show the empty branch being reached by emptiness rather than by the
+    // report/model shape in general. sfdc's opportunity-ingestion is the
+    // canonical arrow-carrying mapping.
     await openHarnessInSingleFileMode(page);
-    await loadFixture(page, reportsUri);
-    const detail = await openMapping(page, "customer-risk-report-pipeline");
+    await loadFixture(page, sfdcUri);
+    const detail = await openMapping(page, "opportunity-ingestion");
 
     await expect(detail.locator("[data-testid$='-arrow-table']")).toBeVisible();
     await expect(detail.locator("[data-testid$='-arrow-table-empty']")).toHaveCount(0);

--- a/tooling/satsuma-viz-harness/test/mapping-detail-arrow-states.test.ts
+++ b/tooling/satsuma-viz-harness/test/mapping-detail-arrow-states.test.ts
@@ -1,0 +1,125 @@
+/**
+ * mapping-detail-arrow-states.test.ts — Playwright tests for the two arrow-table
+ * states that stand in for absence, painted in a real browser.
+ *
+ * The rendering decisions themselves are covered as render output in
+ * `@satsuma/viz`'s `mapping-detail-arrow-table.test.js`, against minimal model
+ * fixtures. What only a browser can answer is whether the states appear at all
+ * for the corpus mappings that motivated them, and whether the elements are
+ * visible rather than merely present in the shadow tree:
+ *
+ *  - sl-jetk: `reports-and-models/pipeline.stm`'s consumer mappings are the
+ *    documented demonstration of report/model consumers, and every one of them
+ *    declares source and target schemas with no field arrows.
+ *  - sl-k7i4: `sfdc-to-snowflake/pipeline.stm`'s `-> is_closed { "..." }` is the
+ *    corpus's canonical target-only arrow, sitting in a Source column otherwise
+ *    full of real field paths — the exact context in which a blank cell read as
+ *    a rendering failure.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+import { libraryUri } from "./harness-env";
+
+/** Report/model consumers — mappings that declare no field arrows at all. */
+const reportsUri = libraryUri("reports-and-models/pipeline.stm");
+/** The canonical single-file pipeline, home of the `is_closed` derived arrow. */
+const sfdcUri = libraryUri("sfdc-to-snowflake/pipeline.stm");
+
+/**
+ * Open the harness in single-file mode, so each fixture renders exactly the
+ * mappings its own file declares (lineage mode pulls in imported files too).
+ */
+async function openHarnessInSingleFileMode(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForFunction(() => {
+    const harness = window.__satsumaHarness;
+    if (!harness?.setViewMode) return false; // app.js not evaluated yet
+    harness.setViewMode("single");
+    return true;
+  });
+}
+
+/** Load a fixture through the picker and wait for the viz to report ready. */
+async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
+  await page.locator("#fixture-picker-btn").click();
+  await page.locator(`.fixture-item[data-uri="${fixtureUri}"]`).click();
+  await page.locator("[data-testid='viz-root']").waitFor({ state: "visible" });
+  await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+    "data-ready-state",
+    "ready",
+    { timeout: 20_000 },
+  );
+}
+
+/** Open a mapping's detail view by clicking its overview card. */
+async function openMapping(page: Page, mappingId: string) {
+  await page.locator(`[data-testid='overview-mapping-card-${mappingId}']`).click();
+  const detail = page.locator(`[data-testid='mapping-detail-${mappingId}']`).first();
+  await expect(detail).toBeVisible({ timeout: 10_000 });
+  return detail;
+}
+
+test.describe("A consumer mapping with no field arrows (sl-jetk)", () => {
+  test("shows the stated empty state instead of a bare column header", async ({ page }) => {
+    // `_weekly_sales_dashboard_report` declares two source schemas and one
+    // target and nothing else. The panel must explain that, because a header
+    // row above an empty body is what a failed load looks like.
+    await openHarnessInSingleFileMode(page);
+    await loadFixture(page, reportsUri);
+    const detail = await openMapping(page, "weekly-sales-dashboard-report");
+
+    const empty = detail.locator("[data-testid$='-arrow-table-empty']");
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText("no field-level arrows");
+
+    // No table at all — not a table with the empty state tucked underneath it.
+    await expect(detail.locator("[data-testid$='-arrow-table']")).toHaveCount(0);
+  });
+
+  test("still renders the full arrow table for a mapping that has arrows", async ({ page }) => {
+    // The same fixture's `_customer_risk_report_pipeline` does declare arrows,
+    // so it proves the empty branch is reached by emptiness and not by the
+    // report/model shape in general.
+    await openHarnessInSingleFileMode(page);
+    await loadFixture(page, reportsUri);
+    const detail = await openMapping(page, "customer-risk-report-pipeline");
+
+    await expect(detail.locator("[data-testid$='-arrow-table']")).toBeVisible();
+    await expect(detail.locator("[data-testid$='-arrow-table-empty']")).toHaveCount(0);
+  });
+});
+
+test.describe("A sourceless derived arrow's Source cell (sl-k7i4)", () => {
+  test("renders a visible derived marker where the source path would be", async ({ page }) => {
+    // The marker must be painted inside the row for `is_closed`, in the Source
+    // column, alongside rows that do carry real paths — the mixed column is the
+    // whole reason a blank cell was unreadable.
+    await openHarnessInSingleFileMode(page);
+    await loadFixture(page, sfdcUri);
+    const detail = await openMapping(page, "opportunity-ingestion");
+
+    // Row test ids are `mapping-detail-{mappingId}-arrow-row-{targetField}`; the
+    // marker hangs off its row's id (see _renderArrowRow).
+    const marker = detail.locator(
+      "[data-testid='mapping-detail-opportunity-ingestion-arrow-row-is-closed-source-derived']",
+    );
+    await expect(marker).toBeVisible();
+    await expect(marker).toHaveText("derived");
+
+    // The neighbouring rows are unchanged: a real source path still renders as
+    // a field path, so the marker is a substitute for absence only.
+    await expect(
+      detail
+        .locator(
+          "[data-testid='mapping-detail-opportunity-ingestion-arrow-row-amount-usd'] .field-ref",
+        )
+        .first(),
+    ).toBeVisible();
+
+    // Distinguishable from a field path by more than its text: the marker is
+    // deliberately not a `.field-ref`, so it cannot be read as a field named
+    // "derived" and never picks up the highlight styling for real paths.
+    const isFieldRef = await marker.evaluate((el) => el.classList.contains("field-ref"));
+    expect(isFieldRef).toBe(false);
+  });
+});

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -179,6 +179,16 @@ export class SzMappingDetail extends LitElement {
       border-bottom: 2px solid var(--sz-card-border);
     }
 
+    /* Stated empty state for a mapping with no field arrows (sl-jetk). Muted
+       and italic so it reads as an explanation, not as table content. */
+    .arrow-table-empty {
+      padding: 10px 12px;
+      font-size: 12px;
+      font-style: italic;
+      line-height: 1.5;
+      color: var(--sz-text-muted);
+    }
+
     .arrow-table td {
       padding: 5px 12px;
       border-bottom: 1px solid var(--sz-card-border);
@@ -231,6 +241,16 @@ export class SzMappingDetail extends LitElement {
 
     .source-ref-item {
       display: block;
+    }
+
+    /* Marker for an arrow with no source field (sl-k7i4). Deliberately not a
+       .field-ref: sans-serif, italic and muted so it cannot be misread as a
+       field path, and so highlight styling for real paths never applies to it. */
+    .source-derived {
+      font-family: var(--sz-font-sans);
+      font-size: 11px;
+      font-style: italic;
+      color: var(--sz-text-muted);
     }
 
     .transform-cell {
@@ -700,7 +720,36 @@ export class SzMappingDetail extends LitElement {
     `;
   }
 
+  /**
+   * True when the mapping declares no field-level arrows in any form.
+   *
+   * Report and model consumers legitimately declare `source {schemas}` and
+   * `target {schema}` and nothing else, so this is a valid mapping shape rather
+   * than a missing-data case — see {@link _renderArrowTable}.
+   */
+  private _hasNoArrows(m: MappingBlock): boolean {
+    return (
+      m.arrows.length === 0 &&
+      m.eachBlocks.length === 0 &&
+      m.flattenBlocks.length === 0 &&
+      m.nestedArrows.length === 0
+    );
+  }
+
   private _renderArrowTable(m: MappingBlock) {
+    // A mapping with no arrows used to render the four column headers over an
+    // empty <tbody>, which reads as a half-loaded panel (sl-jetk). Headers head
+    // rows; with no rows, say what the mapping declares instead.
+    if (this._hasNoArrows(m)) {
+      return html`
+        <div class="mapping-header" style="padding: 0;">
+          <div class="arrow-table-empty" data-testid=${`${this.testIdPrefix}-arrow-table-empty`}>
+            This mapping declares no field-level arrows — it maps whole schemas only.
+          </div>
+        </div>
+      `;
+    }
+
     return html`
       <div class="mapping-header" style="padding: 0;">
         <table class="arrow-table" data-testid=${`${this.testIdPrefix}-arrow-table`}>
@@ -759,11 +808,24 @@ export class SzMappingDetail extends LitElement {
       >
         <td>
           <div class="source-ref-list">
-            ${a.sourceFields.map(
-              (sourceField) => html`
-                <span class="field-ref source-ref-item">${sourceField}</span>
-              `,
-            )}
+            ${
+              a.sourceFields.length === 0
+                ? // A target-only arrow (`-> is_closed { "..." }`) has no source
+                  // field by design. An empty cell was indistinguishable from a
+                  // source path the viz had failed to resolve (sl-k7i4), so name
+                  // the construct instead.
+                  html`<span
+                    class="source-derived"
+                    data-testid=${`${rowTestId}-source-derived`}
+                    title="No source field: this target is derived from the transform"
+                    >derived</span
+                  >`
+                : a.sourceFields.map(
+                    (sourceField) => html`
+                      <span class="field-ref source-ref-item">${sourceField}</span>
+                    `,
+                  )
+            }
           </div>
         </td>
         <td><span class="arrow-icon">&#x2192;</span></td>

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -146,6 +146,35 @@ export class SzSchemaCard extends LitElement {
       border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
     }
 
+    /* The namespace pill row, when present, is the top of the card — so the
+       header is no longer :first-child and the rule above cannot fire. This
+       row therefore owns the top rounding for a namespaced card; without it
+       such a card's top corners went square the moment compact-expanded
+       dropped the host's clip (sl-yedr). Pinned to the shared
+       NAMESPACE_PILL_HEIGHT the overview layout reserves for this row. */
+    .namespace-pill-row {
+      height: ${NAMESPACE_PILL_HEIGHT}px;
+      box-sizing: border-box;
+      display: flex;
+      align-items: end;
+      padding: 0 12px;
+      background: var(--sz-orange);
+    }
+
+    .namespace-pill-row:first-child {
+      border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
+    }
+
+    .namespace-pill-chip {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 700;
+      padding: 1px 8px;
+      border-radius: 999px;
+      background: var(--sz-namespace-pill-chip-bg);
+      color: var(--sz-orange-dark);
+    }
+
     .header.report {
       background: var(--sz-report);
     }
@@ -169,6 +198,14 @@ export class SzSchemaCard extends LitElement {
       font-size: 11px;
       opacity: 0.85;
       flex-shrink: 0;
+      /* Part of the toggle's click target, not the navigate target: the arrow
+         glyph alone is a poor Fitts's-law target on a compact overview card
+         (sl-6g23). The count is the one other header element whose meaning is
+         "the fields", so it toggles them; the name and icon still navigate.
+         Padding only — no margin offset — so the header's fixed-height box and
+         every coordinate the ELK layout derives from it stay untouched. */
+      cursor: pointer;
+      padding: 4px 0;
     }
 
     .coverage-badge {
@@ -654,15 +691,15 @@ export class SzSchemaCard extends LitElement {
     // The namespace pill is the only visual marker that distinguishes a
     // namespaced schema card from a vanilla one. Expose a stable test id
     // (sl-3c2w) so Playwright can assert qualified namespace rendering
-    // without text matching against a positioned <span>. The row is pinned
-    // to the shared NAMESPACE_PILL_HEIGHT the layout reserves for it.
+    // without text matching against a positioned <span>. Row geometry and the
+    // top rounding live in `.namespace-pill-row` (see the styles above) rather
+    // than in an inline style, because only a stylesheet rule can react to the
+    // row being :first-child (sl-yedr).
     return html`<div
-      style="height:${NAMESPACE_PILL_HEIGHT}px;box-sizing:border-box;display:flex;align-items:end;padding:0 12px;background:var(--sz-orange);"
+      class="namespace-pill-row"
       data-testid=${`${this.testIdPrefix}-namespace-pill`}
     >
-      <span
-        data-testid=${`${this.testIdPrefix}-namespace-label`}
-        style="display:inline-block;font-size:10px;font-weight:700;padding:1px 8px;border-radius:999px;background:var(--sz-namespace-pill-chip-bg);color:var(--sz-orange-dark);"
+      <span class="namespace-pill-chip" data-testid=${`${this.testIdPrefix}-namespace-label`}
         >${this.namespaceLabel}</span
       >
     </div>`;
@@ -710,6 +747,7 @@ export class SzSchemaCard extends LitElement {
                what is known, where "0/N" would assert completeness nobody
                measured (ADR-042). -->
           <span
+            @click=${this._onToggleClick}
             class="header-count"
             data-testid=${`${this.testIdPrefix}-header-count`}
             data-coverage-available=${coverage !== null}
@@ -1091,6 +1129,7 @@ export class SzSchemaCard extends LitElement {
             >&#9660;</span
           >
           <span
+            @click=${this._onToggleClick}
             class="header-count"
             data-testid=${`${this.testIdPrefix}-header-count`}
             data-coverage-available=${coverage !== null}
@@ -1129,12 +1168,14 @@ export class SzSchemaCard extends LitElement {
   }
 
   // Header clicks carry two distinct intents that used to be conflated on one
-  // handler: the toggle arrow expands/collapses, the rest of the header
-  // navigates to the schema source. Hosts that open documents on navigate
+  // handler: the toggle arrow and the field count expand/collapse, the name and
+  // icon navigate to the schema source. Hosts that open documents on navigate
   // (VS Code) made the combined handler unusable — expanding a card yanked
-  // the editor to the source file and hid the panel (sl-tw0r).
+  // the editor to the source file and hid the panel (sl-tw0r). The two handlers
+  // must therefore stay separate; widening the toggle's hit area (sl-6g23)
+  // means adding elements to THIS handler, never merging the two.
 
-  /** Arrow click: expand/collapse only — never navigate. */
+  /** Arrow or field-count click: expand/collapse only — never navigate. */
   private _onToggleClick(e: Event) {
     // Stop the click before the header's navigate handler sees it.
     e.stopPropagation();

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -505,6 +505,14 @@ export class SatsumaViz extends LitElement {
       display: flex;
       align-items: center;
       gap: 2px;
+      /* Wrap deliberately rather than overflow. Every control here holds its
+         own width (buttons and selects are nowrap), so a single-line toolbar
+         narrower than its contents pushed the trailing file filter past the
+         right edge and out of reach (sl-zsv6). Wrapping keeps every control
+         inside the toolbar's box at any width; the toolbar simply gets taller,
+         which the flex column below it absorbs. */
+      flex-wrap: wrap;
+      row-gap: 4px;
       padding: 6px 12px;
       background: var(--sz-card-bg);
       border-bottom: 1px solid var(--sz-card-border);
@@ -521,6 +529,18 @@ export class SatsumaViz extends LitElement {
       color: var(--sz-text);
       margin-right: 12px;
       padding: 4px 0;
+      /* The title was the only flex item that could absorb the toolbar's
+         overflow, so it broke onto two lines while the controls kept their
+         width (sl-zsv6). It stays on one line; a title too long for the row
+         ellipsizes instead of wrapping. */
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      /* Never shrink below the title's own width — the controls wrap instead —
+         but never grow past the row either, so a very long mapping id in the
+         detail view ellipsizes rather than widening the toolbar. */
+      flex-shrink: 0;
+      max-width: 100%;
     }
 
     .toolbar-sep {

--- a/tooling/satsuma-viz/test/mapping-detail-arrow-table.test.js
+++ b/tooling/satsuma-viz/test/mapping-detail-arrow-table.test.js
@@ -1,0 +1,157 @@
+/**
+ * mapping-detail-arrow-table.test.js — what the arrow table renders for the two
+ * mapping shapes that carry no ordinary source → target row.
+ *
+ * Both shapes are first-class Satsuma constructs that used to render as absence:
+ *
+ *   - A consumer mapping (report/model) declares `source {}` and `target {}` and
+ *     no arrows at all. The table printed its four column headers over an empty
+ *     body, which reads as a half-loaded panel (sl-jetk).
+ *   - A target-only arrow (`-> is_closed { "..." }`) has no source field. Its
+ *     Source cell was blank, indistinguishable from a source path the viz had
+ *     failed to resolve (sl-k7i4).
+ *
+ * These cases are written against the component's render output because that is
+ * where the decision lives — the model already carries the empty `sourceFields`
+ * and empty block arrays faithfully. Whether the resulting element is *painted*
+ * as intended is a browser question, covered by the viz harness's
+ * `mapping-detail-arrow-states.test.ts`.
+ */
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+const LOC = { uri: "file:///test.stm", line: 0, character: 0 };
+
+/** An arrow entry in the viz model's shape; `sourceFields` is the axis under test. */
+function arrow(sourceFields, targetField) {
+  return {
+    sourceFields,
+    targetField,
+    transform: null,
+    metadata: [],
+    comments: [],
+    location: LOC,
+  };
+}
+
+/**
+ * A mapping block carrying nothing but the arrows under test.
+ *
+ * Every container list defaults to empty, so a case that passes no arrows is
+ * exactly the no-field-arrows consumer shape (sl-jetk) with no further setup.
+ */
+function mappingBlock(arrows = []) {
+  return {
+    id: "consumer",
+    sourceRefs: ["src"],
+    targetRef: "tgt",
+    arrows,
+    eachBlocks: [],
+    flattenBlocks: [],
+    nestedArrows: [],
+    sourceBlock: null,
+    metadata: [],
+    notes: [],
+    comments: [],
+    location: LOC,
+  };
+}
+
+/**
+ * Render the detail view and return its markup as text, with template values
+ * interleaved in source order — the same serialization the schema-card tests
+ * use, so a value substituted into an attribute or a cell is visible here.
+ */
+function renderText(detail) {
+  const serialize = (value) => {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.map(serialize).join("");
+    if (typeof value === "object" && value.strings && "values" in value) {
+      return value.strings
+        .map((s, i) => s + (i < value.values.length ? serialize(value.values[i]) : ""))
+        .join("");
+    }
+    return String(value);
+  };
+  return serialize(detail.render());
+}
+
+/** A detail view bound to `mapping`, with no schema cards to either side. */
+async function makeDetail(mapping) {
+  const mod = await import("../dist/satsuma-viz.js");
+  const detail = new mod.SzMappingDetail();
+  detail.mapping = mapping;
+  detail.sourceSchemas = [];
+  detail.targetSchema = null;
+  return detail;
+}
+
+describe("arrow table for a mapping with no field arrows (sl-jetk)", () => {
+  it("states that the mapping maps whole schemas instead of heading nothing", async () => {
+    // The empty state must SAY what the mapping declares. A reader seeing a
+    // header row with no rows beneath it cannot tell a legitimate consumer
+    // mapping from a panel that failed to load.
+    const text = renderText(await makeDetail(mappingBlock()));
+
+    assert.match(text, /arrow-table-empty/);
+    assert.match(text, /no field-level arrows/);
+  });
+
+  it("omits the column headers when there are no rows to head", async () => {
+    // Column headers are only meaningful over rows. Asserting the header text
+    // is absent (not merely that the empty state is present) is what pins the
+    // fix: an empty state rendered *underneath* a bare header would still be
+    // the reported bug.
+    const text = renderText(await makeDetail(mappingBlock()));
+
+    assert.doesNotMatch(text, /<th>Source<\/th>/);
+    assert.doesNotMatch(text, /<th>Transform<\/th>/);
+    assert.doesNotMatch(text, /<th>Target<\/th>/);
+  });
+
+  it("keeps the table and its headers as soon as one arrow exists", async () => {
+    // The empty branch must be reached only by the genuinely empty mapping —
+    // one arrow returns the full table, headers included.
+    const text = renderText(await makeDetail(mappingBlock([arrow(["a"], "b")])));
+
+    assert.match(text, /<th>Source<\/th>/);
+    assert.match(text, /<th>Target<\/th>/);
+    assert.doesNotMatch(text, /arrow-table-empty/);
+  });
+});
+
+describe("Source cell of a sourceless derived arrow (sl-k7i4)", () => {
+  it("names the derived construct rather than leaving the cell blank", async () => {
+    // `-> is_closed { "..." }` is a target-only arrow: the value comes from the
+    // transform, not from a source field. The cell must say so, because a blank
+    // cell is what a dropped source path also looks like.
+    const text = renderText(await makeDetail(mappingBlock([arrow([], "is_closed")])));
+
+    assert.match(text, /source-derived/);
+    assert.match(text, /derived</);
+    // The marker explains itself on hover, so the meaning does not depend on
+    // the reader already knowing the construct.
+    assert.match(text, /title="No source field: this target is derived from the transform"/);
+  });
+
+  it("styles the marker as prose, never as a field path", async () => {
+    // Sharing `.field-ref` would make the marker read as a field literally
+    // named "derived" and would pick up the highlight treatment meant for real
+    // paths. The marker must therefore carry its own class only.
+    const text = renderText(await makeDetail(mappingBlock([arrow([], "is_closed")])));
+    const sourceCell = text.slice(0, text.indexOf("arrow-icon"));
+
+    assert.doesNotMatch(sourceCell, /field-ref/);
+  });
+
+  it("leaves an arrow that does have a source field untouched", async () => {
+    // The marker is a substitute for absence, not a decoration: an arrow with a
+    // real source renders that path as a field-ref and no marker.
+    const text = renderText(await makeDetail(mappingBlock([arrow(["Amount"], "amount_usd")])));
+
+    assert.match(text, /field-ref source-ref-item/);
+    assert.match(text, /Amount/);
+    assert.doesNotMatch(text, /source-derived/);
+  });
+});


### PR DESCRIPTION
Five open viz UI bugs, each small and self-contained. All five are presentation-only changes inside `satsuma-viz` — no coverage, model or extraction logic is touched, and nothing here is a core concern another consumer would duplicate.

| Ticket | Defect | Fix |
|---|---|---|
| sl-yedr (P2) | A namespaced compact card's top corners went square when expanded | The namespace pill row owns the top rounding; the header's `:first-child` fallback could never fire when a pill row sat above it |
| sl-6g23 | Expand/collapse target was the ~12px arrow glyph alone | The field count joins the toggle's target, wired to the **same** handler — sl-tw0r's toggle/navigate split is untouched |
| sl-zsv6 | Toolbar title wrapped to two lines; trailing file filter clipped | The title holds one line and ellipsizes; the toolbar wraps deliberately, so no control escapes its box at any width |
| sl-jetk | A mapping with no field arrows rendered a bare column header over an empty body | A stated empty state, and no headers — headers head rows |
| sl-k7i4 | A sourceless derived arrow rendered a blank Source cell | A muted `derived` marker, deliberately not a `.field-ref` |

## Testing

Four of the five alter what gets *painted* or what a *gesture* triggers, so unit tests cannot settle them — CSS rule precedence, flex resolution in a laid-out box, and whether a listener reached the rendered span are only observable in a browser. All are covered in the Playwright harness:

- `chrome-layout.test.ts` (new) — sl-zsv6 and sl-yedr on `ns-platform.stm`, the fixture both were filed against, in light and dark.
- `mapping-detail-arrow-states.test.ts` (new) — sl-jetk and sl-k7i4 against the corpus mappings that motivated them.
- `harness.test.ts` — two cases in the existing compact-card block for sl-6g23, including the navigation-silence guard sl-tw0r requires.

sl-jetk and sl-k7i4 additionally have render-output unit tests in `@satsuma/viz` against minimal model fixtures, since *which element renders with what text* is decided there.

**Harness: 124 passed.** Every new case was then re-run against the reverted fixes: 8 of the 9 fail, each for its own reason (`0px` corner radius, controls painted outside the toolbar box, fields never appearing on a count click, no empty state, no derived marker). The ninth is a control case that correctly passes either way.

Two defects the harness caught in the *specs* themselves are described in the third commit — the pill row starts inside the host's 1px border, and every mapping in `reports-and-models` is arrow-free, so sl-jetk's control case cannot come from that fixture.

`./scripts/run-repo-checks.sh` is green (it ran via the pre-commit hook on all three commits). No ADR: these are localised presentation fixes with no architectural decision behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
