### PR TITLE
fix(viz): highlight @refs in join and filter descriptions (sl-yhlj)

### DIFF
--- a/.tickets/sl-yhlj.md
+++ b/.tickets/sl-yhlj.md
@@ -1,6 +1,6 @@
 ---
 id: sl-yhlj
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-05T09:25:20Z
@@ -18,4 +18,20 @@ Screenshot: bug-reports/atrefs-in-join-not-highlighted.png
 ## Acceptance Criteria
 
 Join and filter descriptions render @refs through highlightAtRefs, consistent with NL transform text and arrow notes. Add a fixture/unit test covering a join description containing an @ref.
+
+## Notes
+
+**2026-08-06T13:34:00Z**
+
+Cause: `sz-mapping-detail.ts` interpolated `sb.joinDescription` and each filter
+string directly into the Lit template instead of routing them through
+`unsafeHTML(highlightAtRefs(...))`, the pipeline every other @ref-bearing
+surface (NL transform text, arrow notes) already used.
+Fix: wrapped both the join-description and filter render paths in
+`unsafeHTML(highlightAtRefs(...))`; added a unit suite
+(`mapping-detail-join-filter-refs.test.js`) that resolves the `unsafeHTML`
+directive to prove the join/filter markup actually contains
+`<span class="at-ref">`, and extended the existing Playwright "completed
+orders (multi-source join)" test to assert a rendered `span.at-ref` inside the
+join row (commit immediately after 15d143ee).
 

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 191,
-    "satsuma-viz": 178,
+    "satsuma-viz": 181,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -710,6 +710,16 @@ test.describe("Mapping detail — completed orders (multi-source join)", () => {
     // user-authored and not stable enough for a separate testid hook.
     await expect(detail).toContainText("WHERE @order_events.order_status = completed");
 
+    // sl-yhlj: the join description's @refs (@order_events.customer.customer_id,
+    // @customer_profiles.customer_id, @order_events.order_status) must render
+    // through the same highlightAtRefs pipeline as NL transform text, not as
+    // plain unstyled text. Locate the join row by its distinguishing text and
+    // assert at least one <span class="at-ref"> landed inside it.
+    const joinRow = detail
+      .locator(".mapping-meta-row")
+      .filter({ hasText: "WHERE @order_events.order_status = completed" });
+    expect(await joinRow.locator("span.at-ref").count()).toBeGreaterThanOrEqual(1);
+
     // NOTE: as of sl-ny3r the mapping detail header does not render
     // MappingBlock.notes — only schema notes and arrow notes are rendered.
     // The mapping-level note remains an open viz gap (tracked separately);

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -690,7 +690,8 @@ export class SzMappingDetail extends LitElement {
               ? html`
                   <div class="mapping-meta-row">
                     <span class="meta-tag wrap"
-                      ><span class="label">join</span> ${sb.joinDescription}</span
+                      ><span class="label">join</span>
+                      ${unsafeHTML(highlightAtRefs(sb.joinDescription))}</span
                     >
                   </div>
                 `
@@ -699,7 +700,9 @@ export class SzMappingDetail extends LitElement {
           ${(sb?.filters ?? []).map(
             (f) => html`
               <div class="mapping-meta-row">
-                <span class="meta-tag wrap"><span class="label">filter</span> ${f}</span>
+                <span class="meta-tag wrap"
+                  ><span class="label">filter</span> ${unsafeHTML(highlightAtRefs(f))}</span
+                >
               </div>
             `,
           )}

--- a/tooling/satsuma-viz/test/mapping-detail-join-filter-refs.test.js
+++ b/tooling/satsuma-viz/test/mapping-detail-join-filter-refs.test.js
@@ -1,0 +1,131 @@
+/**
+ * mapping-detail-join-filter-refs.test.js — @refs inside a mapping's join and
+ * filter descriptions must be highlighted the same way NL transform text and
+ * arrow notes are (sl-yhlj).
+ *
+ * Before this fix, `sz-mapping-detail` interpolated `sb.joinDescription` and
+ * each filter string directly into the template, so an `@schema.field` token
+ * inside them rendered as plain text while the identical token in a transform
+ * or note rendered inside a styled `<span class="at-ref">`. These tests prove
+ * the join/filter render paths now go through the same `highlightAtRefs`
+ * pipeline by resolving the `unsafeHTML` directive's committed markup — the
+ * one thing a plain-text-substitution serializer (as used by
+ * mapping-detail-arrow-table.test.js) cannot observe.
+ */
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+
+const LOC = { uri: "file:///test.stm", line: 0, character: 0 };
+
+/**
+ * A mapping block whose only interesting field is `sourceBlock` — the join
+ * description and filter list under test. Every other container defaults to
+ * empty, matching the "nothing else going on" shape these tests need.
+ */
+function mappingBlock(sourceBlock) {
+  return {
+    id: "consumer",
+    sourceRefs: ["src"],
+    targetRef: "tgt",
+    arrows: [],
+    eachBlocks: [],
+    flattenBlocks: [],
+    nestedArrows: [],
+    sourceBlock,
+    metadata: [],
+    notes: [],
+    comments: [],
+    location: LOC,
+  };
+}
+
+/**
+ * Render the detail view's markup as text, resolving both plain lit `html`
+ * template results AND `unsafeHTML()` directive results.
+ *
+ * `unsafeHTML(str)` does not commit its HTML at template-construction time —
+ * calling it just returns a directive marker (`{_$litDirective$, values}`).
+ * The actual escaped-and-@ref-wrapped markup only exists once that
+ * directive's `render()` method runs, which is what lit-html's part-committing
+ * machinery does inside a real DOM. Since dom-shim.js is not a full DOM (see
+ * its module comment), there is no shadow root to read `innerHTML` from, so
+ * this helper drives the directive class directly to get the same string a
+ * browser would commit — the smallest step beyond plain-value serialization
+ * that still proves the join/filter text passed through highlightAtRefs.
+ */
+function renderText(detail) {
+  const serialize = (value) => {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.map(serialize).join("");
+    if (value && typeof value === "object" && "_$litDirective$" in value) {
+      const DirectiveClass = value._$litDirective$;
+      // PartType.CHILD (2) — the only part type unsafeHTML's constructor accepts.
+      const instance = new DirectiveClass({ type: 2 });
+      return serialize(instance.render(...value.values));
+    }
+    if (typeof value === "object" && value.strings && "values" in value) {
+      return value.strings
+        .map((s, i) => s + (i < value.values.length ? serialize(value.values[i]) : ""))
+        .join("");
+    }
+    return String(value);
+  };
+  return serialize(detail.render());
+}
+
+/** A detail view bound to `mapping`, with no schema cards to either side. */
+async function makeDetail(mapping) {
+  const mod = await import("../dist/satsuma-viz.js");
+  const detail = new mod.SzMappingDetail();
+  detail.mapping = mapping;
+  detail.sourceSchemas = [];
+  detail.targetSchema = null;
+  return detail;
+}
+
+describe("join description @ref highlighting (sl-yhlj)", () => {
+  it("wraps an @ref inside the join description in a styled span, not plain text", async () => {
+    // Mirrors the shape of examples/filter-flatten-governance's `completed
+    // orders` mapping: a join description naming a source field by @ref.
+    const sourceBlock = {
+      schemas: ["order_events", "customer_profiles"],
+      joinDescription: "Join on customer_id WHERE @order_events.order_status = completed",
+      filters: [],
+    };
+    const text = renderText(await makeDetail(mappingBlock(sourceBlock)));
+
+    assert.match(text, /<span class="at-ref">@order_events\.order_status<\/span>/);
+    // The surrounding prose must survive untouched — only the @ref token
+    // itself gets wrapped, not the whole join description.
+    assert.match(text, /Join on customer_id WHERE/);
+  });
+
+  it("HTML-escapes the join description before highlighting, same as NL transform text", async () => {
+    // highlightAtRefs escapes first (see markdown.ts) so a join description
+    // that happens to contain `<`/`>` cannot inject markup. Proves the
+    // join/filter call sites inherited that safety, not just the highlighting.
+    const sourceBlock = {
+      schemas: ["a"],
+      joinDescription: "@a.x < @a.y",
+      filters: [],
+    };
+    const text = renderText(await makeDetail(mappingBlock(sourceBlock)));
+
+    assert.match(text, /&lt;/);
+    assert.doesNotMatch(text, /@a\.x < @a\.y/);
+  });
+});
+
+describe("filter description @ref highlighting (sl-yhlj)", () => {
+  it("wraps an @ref inside a filter description in a styled span, not plain text", async () => {
+    const sourceBlock = {
+      schemas: ["orders"],
+      joinDescription: null,
+      filters: ["@orders.status = active"],
+    };
+    const text = renderText(await makeDetail(mappingBlock(sourceBlock)));
+
+    assert.match(text, /<span class="at-ref">@orders\.status<\/span>/);
+  });
+});


### PR DESCRIPTION
## Summary
- `sz-mapping-detail.ts` interpolated a mapping's join description and filter strings directly into the template instead of routing them through `unsafeHTML(highlightAtRefs(...))`, the pipeline NL transform text and arrow notes already use — so `@schema.field` refs inside a join/filter condition rendered as plain text instead of the styled `at-ref` span.
- Fixed both call sites to go through `highlightAtRefs`, consistent with the rest of the mapping detail view.

## Test plan
- [x] New unit suite `mapping-detail-join-filter-refs.test.js` resolves the `unsafeHTML` directive to prove the join/filter markup contains `<span class="at-ref">` around the ref, plus an HTML-escaping safety test.
- [x] Extended the existing Playwright "completed orders (multi-source join)" test to assert a real `span.at-ref` renders inside the join row in a browser (per repo convention, a paint/visual change needs browser proof, not just unit-level checks).
- [x] Full `@satsuma/viz` unit suite green (181 passed).
- [x] Full `@satsuma/viz-harness` Playwright suite run twice via the sentinel workflow: 123 passed both times. One unrelated test in `view-persistence.test.ts` (chain view) failed a different sub-case each run — confirmed pre-existing flake, not caused by this change.
- [x] `./scripts/run-repo-checks.sh` green (lint, all package tests/typechecks, tree-sitter corpus, smoke tests).

Closes sl-yhlj.

🤖 Generated with [Claude Code](https://claude.com/claude-code)