### PR TITLE
feat(viz): distinguish unknown-field from no-lineage in field-chain view (sv-embb)

### DIFF
--- a/.tickets/sv-embb.md
+++ b/.tickets/sv-embb.md
@@ -1,6 +1,6 @@
 ---
 id: sv-embb
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-06T13:20:10Z
@@ -22,3 +22,10 @@ A Playwright spec in harness.test.ts opens the chain view against a cyclic fixtu
 The chain view is captured light and dark in screenshots.spec.ts.
 Full harness Playwright suite green via the watch-and-test.sh sentinel protocol; run-repo-checks.sh green.
 
+
+## Notes
+
+**2026-08-06T14:01:09Z**
+
+Cause: buildFieldChainFromWorkspace/buildFieldChainFromSources returned an identical empty {upstream:[], downstream:[]} FieldChainModel whether the focus field's schema/path was genuinely undeclared or resolved fine with no lineage, so sz-chain-view (and any host) could not render the two cases differently, unlike the CLI's field-lineage.ts which throws EXIT_NOT_FOUND for the former.
+Fix: added an optional `resolved` flag to FieldChainModel (absent = true, matching every CLI-derived payload since the CLI never emits JSON for an unresolved field); buildFieldChainFromWorkspace now checks schema+field declaration (via a new spread-aware resolveSchemaFields in workspace-definition-lookup.ts, mirroring the CLI's expandEntityFields check) before tracing, returning resolved:false with empty upstream/downstream when the entry file can't load or the focus field can't be resolved; sz-chain-view renders a distinct "chain-unknown-field" state for resolved:false. Added unit tests for both new resolution branches (viz-backend, LSP), a hand-built-cyclic-model render test and an unknown-field render test in sz-chain-view.test.js, a new examples/lineage-cycle/pipeline.stm fixture (adapted from tooling/satsuma-cli/test/fixtures/lineage-cycle.stm) with a Playwright spec in harness.test.ts proving the cycle terminates with the CLI's own confirmed one-hop-per-direction shape, and light/dark chain-view screenshots in screenshots.spec.ts. Also fixed two pre-existing viz-harness Playwright flakes (openEmailChain in view-persistence.test.ts and the new cycle test itself) where a just-expanded schema card's field-lineage button sat outside the SVG canvas's current pan/zoom viewBox on small graphs — DOM-level "scroll into view" can't follow an SVG transform, so both now click the toolbar's Fit button first. (commit immediately after 15d143ee)

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ The CLI requires a `.stm` file entry point (not a directory). The workspace is d
 | [`edi-to-json/`](edi-to-json/) | `pipeline.stm` | EDI 856 ASN fixed-length messages to MFCS JSON for warehouse ingestion |
 | [`filter-flatten-governance/`](filter-flatten-governance/) | `filter-flatten-governance.stm` | Scalar lists, filter/flatten, and governance metadata annotations |
 | [`json-api-to-parquet/`](json-api-to-parquet/) | `pipeline.stm` | Commerce REST API order responses to Lakehouse Parquet |
+| [`lineage-cycle/`](lineage-cycle/) | `pipeline.stm` | Two schemas mapped into each other in both directions — a demo fixture proving field-lineage tracing terminates on a cycle, not a plausible pipeline |
 | [`merge-strategies/`](merge-strategies/) | `pipeline.stm` | All four merge strategies (upsert, append, soft delete, full refresh) |
 | [`metrics-platform/`](metrics-platform/) | `metrics.stm` | Business metrics (MRR, CLV, churn, conversion) as schema blocks with `(metric, ...)` metadata |
 | [`multi-hop-lineage/`](multi-hop-lineage/) | `pipeline.stm` | Artificial 7-schema, 6-hop chain with varying record nesting — a demo fixture for the field-chain viz, not a plausible pipeline |

--- a/examples/lineage-cycle/pipeline.stm
+++ b/examples/lineage-cycle/pipeline.stm
@@ -1,0 +1,26 @@
+// Deliberately artificial: two schemas mapped into each other in both
+// directions, so tracing either field's lineage walks straight into a cycle.
+// Exists only to prove the field-chain viz (and the CLI it mirrors) detects
+// the cycle and terminates instead of recursing forever — not a plausible
+// real-world pipeline. Adapted from
+// tooling/satsuma-cli/test/fixtures/lineage-cycle.stm (sv-embb).
+
+schema cycle_a {
+  id  INTEGER
+}
+
+schema cycle_b {
+  id  INTEGER
+}
+
+mapping a_to_b {
+  source { cycle_a }
+  target { cycle_b }
+  id -> id
+}
+
+mapping b_to_a {
+  source { cycle_b }
+  target { cycle_a }
+  id -> id
+}

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,12 +2,12 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 700,
-    "satsuma-cli": 1073,
+    "satsuma-core": 703,
+    "satsuma-cli": 1074,
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
-    "satsuma-viz-backend": 191,
-    "satsuma-viz": 181,
+    "satsuma-viz-backend": 196,
+    "satsuma-viz": 184,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-lsp/test/field-chain.test.js
+++ b/tooling/satsuma-lsp/test/field-chain.test.js
@@ -85,13 +85,21 @@ describe("satsuma/fieldChain — import graph traversal", () => {
     );
   });
 
-  it("returns an empty chain when the entry file itself cannot be loaded", () => {
+  it("returns an unresolved chain when the entry file itself cannot be loaded", () => {
     // Mirrors computeFullLineage's null-primary contract, adapted to
     // FieldChainModel's shape: no upstream/downstream rather than no model,
     // since a chain always names the focus field even when it finds nothing.
+    // Unresolved (sv-embb), not just empty: an unreadable entry file means the
+    // focus field's existence was never confirmed either.
     const index = createWorkspaceIndex();
     const model = buildFieldChainFromWorkspace("file:///missing.stm", index, () => null, "b.id");
-    assert.deepEqual(model, { field: "::b.id", maxDepth: 10, upstream: [], downstream: [] });
+    assert.deepEqual(model, {
+      field: "::b.id",
+      maxDepth: 10,
+      upstream: [],
+      downstream: [],
+      resolved: false,
+    });
   });
 
   it("forwards depth and direction options to the traversal", () => {

--- a/tooling/satsuma-viz-backend/src/field-chain.ts
+++ b/tooling/satsuma-viz-backend/src/field-chain.ts
@@ -16,16 +16,21 @@
 
 import {
   buildFieldEdges,
+  collectFieldNames,
   createAuthoredFieldRef,
   createCanonicalFieldEndpoint,
   extractArrowRecords,
   extractMappings,
   extractNLRefData,
+  fieldEndpointPath,
+  fieldEndpointSchema,
+  findFieldByPath,
   resolveAllNLRefs,
   resolveFieldEndpoint,
   traceFieldLineage,
 } from "@satsuma/core";
 import type {
+  CanonicalEntityRef,
   CanonicalFieldEndpoint,
   FieldArrowLike,
   FieldLineageDirection,
@@ -38,7 +43,10 @@ import { buildInMemoryWorkspace } from "./in-memory-workspace";
 import type { SourceDocument } from "./in-memory-workspace";
 import { createScopedIndex, getImportReachableUris, resolveDefinition } from "./workspace-index";
 import type { WorkspaceIndex } from "./workspace-index";
-import { createWorkspaceDefinitionLookup } from "./workspace-definition-lookup";
+import {
+  createWorkspaceDefinitionLookup,
+  resolveSchemaFields,
+} from "./workspace-definition-lookup";
 
 /** Returns a parse tree for a URI, from whichever source the host has, or null/undefined when unavailable. */
 export type TreeLoader = (uri: string) => Tree | null | undefined;
@@ -146,6 +154,35 @@ function collectChainInputs(
   return { arrows, mappings, nlRefData };
 }
 
+/** The WorkspaceIndex key a canonical entity ref denotes: `::x` names the global entry `x`. */
+function indexKeyOfSchema(schema: CanonicalEntityRef): string {
+  return schema.startsWith("::") ? schema.slice(2) : schema;
+}
+
+/**
+ * Whether `field` names a schema (and, if given, a field path within it) that
+ * `workspace` actually declares.
+ *
+ * Mirrors the CLI's `field-lineage` not-found check — schema lookup, then a
+ * dotted-path lookup with the same nested-leaf-name fallback
+ * `collectFieldNames` provides — so a browser or LSP host can tell "this
+ * field does not exist" apart from "this field exists but has no lineage"
+ * (sv-embb), the distinction `traceFieldLineage` alone cannot make: it walks
+ * edges from whatever endpoint it is given and has no notion of whether that
+ * endpoint was ever declared.
+ */
+function focusFieldIsDeclared(field: CanonicalFieldEndpoint, workspace: WorkspaceIndex): boolean {
+  const schemaKey = indexKeyOfSchema(fieldEndpointSchema(field));
+  const path = fieldEndpointPath(field);
+  if (path === null) {
+    return workspace.definitions.get(schemaKey)?.some((d) => d.kind === "schema") ?? false;
+  }
+
+  const fields = resolveSchemaFields(workspace, schemaKey);
+  if (!fields) return false;
+  return findFieldByPath(fields, path) !== null || collectFieldNames(fields).includes(path);
+}
+
 /**
  * Build a CLI-compatible field chain from an already-built workspace index.
  *
@@ -158,6 +195,12 @@ function collectChainInputs(
  * matching `satsuma coverage`'s and `vizFullLineage`'s scoping rule: "the
  * workspace" means the entry file's transitive import closure, not every file
  * a host happens to have loaded.
+ *
+ * `resolved` is omitted (meaning true) whenever `focusField` was actually
+ * found; it is `false`, with empty upstream/downstream, when the entry file
+ * cannot be loaded at all or `focusField` cannot be resolved against the
+ * traced workspace — the two cases a host cannot otherwise distinguish from a
+ * field that legitimately has no lineage.
  */
 export function buildFieldChainFromWorkspace(
   entryUri: string,
@@ -168,10 +211,16 @@ export function buildFieldChainFromWorkspace(
 ): FieldChainModel {
   const field = canonicalFocusField(focusField);
   const maxDepth = options.depth ?? DEFAULT_FIELD_CHAIN_DEPTH;
-  if (!loadTree(entryUri)) return { field, maxDepth, upstream: [], downstream: [] };
+  if (!loadTree(entryUri)) {
+    return { field, maxDepth, upstream: [], downstream: [], resolved: false };
+  }
 
   const reachableUris = getImportReachableUris(entryUri, workspace);
   const scoped = createScopedIndex(workspace, reachableUris);
+  if (!focusFieldIsDeclared(field, scoped)) {
+    return { field, maxDepth, upstream: [], downstream: [], resolved: false };
+  }
+
   const inputs = collectChainInputs(reachableUris, loadTree, scoped);
   const lookup = createWorkspaceDefinitionLookup(scoped, (key) => inputs.mappings.get(key) ?? null);
   const nlRefs = resolveAllNLRefs(inputs.nlRefData, lookup);

--- a/tooling/satsuma-viz-backend/src/workspace-definition-lookup.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-definition-lookup.ts
@@ -4,11 +4,25 @@
  * Both VizModel assembly and field-chain construction resolve natural-language
  * `@ref`s. This module owns their one DefinitionLookup adapter so schema field
  * projection and mapping lookup semantics stay identical across both builders.
+ * It also owns the one place a caller can ask "does this schema really declare
+ * this field, spreads included?" over a raw `WorkspaceIndex` — field-chain's
+ * focus-field existence check ({@link resolveSchemaFields}) needs the same
+ * fragment-spread expansion `resolveAndStripSpreads` runs for a full VizModel,
+ * without building one.
  */
 
-import { fieldDeclFromRenderedType } from "@satsuma/core";
-import type { DefinitionLookup, FieldDecl, MappingSourcesTargets } from "@satsuma/core";
-import type { FieldInfo, WorkspaceIndex } from "./workspace-index";
+import {
+  expandDeclaredFields,
+  fieldDeclFromRenderedType,
+  makeEntityRefResolver,
+} from "@satsuma/core";
+import type {
+  DefinitionLookup,
+  FieldDecl,
+  MappingSourcesTargets,
+  SpreadEntity,
+} from "@satsuma/core";
+import type { DefinitionEntry, FieldInfo, WorkspaceIndex } from "./workspace-index";
 
 /** Convert an indexed field tree to core's semantic field-declaration shape. */
 export function fieldInfoToDecl(field: FieldInfo): FieldDecl {
@@ -65,4 +79,49 @@ export function createWorkspaceDefinitionLookup(
       }
     },
   };
+}
+
+/** Convert an indexed schema or fragment definition to core's spread-expansion input shape. */
+function definitionToSpreadEntity(definition: DefinitionEntry): SpreadEntity {
+  return {
+    fields: definition.fields.map(fieldInfoToDecl),
+    hasSpreads: (definition.spreads?.length ?? 0) > 0,
+    spreads: definition.spreads ?? [],
+  };
+}
+
+/**
+ * The fully spread-expanded field tree `workspace` declares for `schemaKey`,
+ * or null when `schemaKey` names no schema.
+ *
+ * Only fragments spread fields into a schema, so the entity map built here
+ * covers fragment definitions alone — the same asymmetry `expandDeclaredFields`
+ * itself relies on (its `lookupFragment` callback is never asked to resolve a
+ * schema). Resolution is cross-file and cross-namespace because `workspace`
+ * already is: a caller that wants the fields visible from one entry point's
+ * import closure should pass the closure's scoped index, not the whole
+ * workspace, exactly as `buildFieldChainFromWorkspace` does for everything
+ * else it resolves.
+ */
+export function resolveSchemaFields(
+  workspace: WorkspaceIndex,
+  schemaKey: string,
+): FieldDecl[] | null {
+  const schema = workspace.definitions.get(schemaKey)?.find((d) => d.kind === "schema");
+  if (!schema) return null;
+
+  const fragments = new Map<string, SpreadEntity>();
+  for (const [key, definitions] of workspace.definitions) {
+    const fragment = definitions.find((d) => d.kind === "fragment");
+    if (fragment) fragments.set(key, definitionToSpreadEntity(fragment));
+  }
+
+  const resolveRef = makeEntityRefResolver(fragments);
+  const lookupFragment = (key: string) => fragments.get(key) ?? null;
+  return expandDeclaredFields(
+    definitionToSpreadEntity(schema),
+    schema.namespace,
+    resolveRef,
+    lookupFragment,
+  );
 }

--- a/tooling/satsuma-viz-backend/test/field-chain.test.js
+++ b/tooling/satsuma-viz-backend/test/field-chain.test.js
@@ -108,6 +108,59 @@ mapping bc { source { b } target { c } id -> id }
   });
 });
 
+describe("field-chain unknown-field resolution (sv-embb)", () => {
+  it("marks the chain unresolved when the focus field names no declared schema", () => {
+    // A typo'd or renamed schema must not be reported the same way as a
+    // resolved field with genuinely empty lineage — the CLI throws
+    // EXIT_NOT_FOUND for this case, so the browser/LSP builder must at least
+    // flag it distinctly rather than returning a look-alike empty chain.
+    const result = chainFrom("schema a { id string }", "nonexistent.id");
+
+    assert.equal(result.resolved, false);
+    assert.deepEqual(result.upstream, []);
+    assert.deepEqual(result.downstream, []);
+    assert.equal(result.field, "::nonexistent.id");
+  });
+
+  it("marks the chain unresolved when the schema exists but the field path does not", () => {
+    const result = chainFrom("schema a { id string }", "a.nonexistent");
+
+    assert.equal(result.resolved, false);
+    assert.deepEqual(result.upstream, []);
+    assert.deepEqual(result.downstream, []);
+  });
+
+  it("leaves the chain resolved (the key omitted) when the field genuinely has no lineage", () => {
+    // The positive case this feature must not regress: a real, declared field
+    // with no arrows touching it is "resolved, empty" — not "not found".
+    const result = chainFrom("schema a { id string }", "a.id");
+
+    assert.equal(result.resolved, undefined);
+    assert.deepEqual(result.upstream, []);
+    assert.deepEqual(result.downstream, []);
+  });
+
+  it("resolves a focus field that only exists because a fragment spread materialised it", () => {
+    // Spread expansion is not optional here: without it, every field a
+    // fragment contributes would be misreported as "not found" even though
+    // `satsuma coverage` and the schema card both already treat it as real.
+    const result = chainFrom(
+      `
+fragment address_fields { street string city string }
+schema tgt { id string address record { ...address_fields } }
+schema src { raw_city string }
+mapping load { source { src } target { tgt } raw_city -> address.city }
+`,
+      "tgt.address.city",
+    );
+
+    assert.equal(result.resolved, undefined);
+    assert.deepEqual(result.upstream, [
+      { field: "::src.raw_city", via_mapping: "::load", classification: "none", depth: 1 },
+    ]);
+  });
+});
+
 describe("field-chain CLI parity golden", () => {
   it("matches checked-in field-lineage --json output byte-for-value", () => {
     // The golden is regenerated explicitly by scripts/regenerate-field-chain-golden.mjs.

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -67,6 +67,17 @@ const governanceUri = libraryUri("filter-flatten-governance/governance.stm");
  * plus 2 downstream hops. No other fixture in the harness reaches this shape.
  */
 const nsMergingUri = libraryUri("namespaces/ns-merging.stm");
+/**
+ * Two schemas mapped into each other in both directions (sv-embb) — the only
+ * fixture in the corpus whose lineage graph is a genuine cycle, adapted from
+ * `tooling/satsuma-cli/test/fixtures/lineage-cycle.stm`. Tracing `cycle_a.id`
+ * confirmed via `satsuma field-lineage cycle_a.id
+ * examples/lineage-cycle/pipeline.stm --json` terminates at depth 1 in both
+ * directions: `upstream: [{ field: cycle_b.id, via_mapping: b_to_a }]`,
+ * `downstream: [{ field: cycle_b.id, via_mapping: a_to_b }]` — the shape
+ * these tests pin for the browser-rendered chain.
+ */
+const cycleUri = libraryUri("lineage-cycle/pipeline.stm");
 
 /**
  * Open a specific named mapping by clicking its overview mapping card.
@@ -84,6 +95,16 @@ async function openMappingByName(
   const detail = page.locator(`[data-testid='mapping-detail-${mappingId}']`).first();
   await expect(detail).toBeVisible({ timeout: 10_000 });
   return detail;
+}
+
+/** Expand an overview card and return its field-row test-id prefix. */
+async function expandOverviewCard(page: Page, qualifiedIdTestSegment: string): Promise<string> {
+  const cardPrefix = `overview-schema-card-${qualifiedIdTestSegment}`;
+  await page
+    .locator(`sz-schema-card[data-testid^='${cardPrefix}']`)
+    .locator(".header-toggle")
+    .click();
+  return cardPrefix;
 }
 
 /**
@@ -1081,16 +1102,6 @@ test.describe("Coverage overlay toggle", () => {
 // `satsuma field-lineage reporting::dept_budget_vs_actual.actual_spend
 // examples/namespaces/ns-merging.stm --json` before writing these assertions.
 test.describe("Field chain view", () => {
-  /** Expand a namespaced overview card and return its field-row test-id prefix. */
-  async function expandOverviewCard(page: Page, qualifiedIdTestSegment: string): Promise<string> {
-    const cardPrefix = `overview-schema-card-${qualifiedIdTestSegment}`;
-    await page
-      .locator(`sz-schema-card[data-testid^='${cardPrefix}']`)
-      .locator(".header-toggle")
-      .click();
-    return cardPrefix;
-  }
-
   test("tracing a field with multiple upstream and downstream mappings opens a chain view with nl-derived hops, including a collapsed namespace fan", async ({
     page,
   }) => {
@@ -1288,6 +1299,71 @@ test.describe("Field chain view", () => {
     }
     expect(connectorBox.x).toBeGreaterThanOrEqual(upstreamBox.x + upstreamBox.width - 1);
     expect(connectorBox.x + connectorBox.width).toBeLessThanOrEqual(focusBox.x + 1);
+  });
+});
+
+// sv-embb: sz-chain-view.test.js proves a hand-built cyclic FieldChainModel
+// renders without duplicate cards, but that model is authored by the test,
+// not produced by tracing a real cyclic mapping graph end to end through
+// @satsuma/viz-backend and the harness's host wiring. This test is the one
+// place that full path is exercised against an actual cycle: a hung Promise
+// or an infinite render loop here would time out the test rather than pass
+// silently, and the exact hop shown on each side is asserted against the
+// CLI's own `field-lineage --json` output for the same fixture (see the
+// `cycleUri` doc comment above), so a regression that broke cycle detection
+// but still terminated would still be caught.
+test.describe("Field chain view — cycle detection (sv-embb)", () => {
+  test("tracing a field in a two-schema mapping cycle terminates with one hop per direction", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, cycleUri);
+
+    const cardPrefix = await expandOverviewCard(page, "cycle-a");
+    // This fixture's two-schema graph is small enough that expanding a card
+    // can leave its field row outside the SVG canvas's current pan/zoom
+    // viewBox — a transform Playwright's DOM-level "scroll into view" cannot
+    // follow, unlike the richer fixtures the sibling tests above use. Re-fit
+    // before clicking, exactly as a human would with the toolbar's own button.
+    await page.locator("[data-testid='toolbar-fit']").click();
+    await page.locator(`[data-testid='${cardPrefix}-field-id-lineage']`).click({ force: true });
+
+    await expect(page.locator("[data-testid='viz-root']")).toHaveAttribute(
+      "data-view-mode",
+      "chain",
+      { timeout: 10_000 },
+    );
+    const focus = page.locator("[data-testid='chain-focus']");
+    await expect(focus).toContainText("cycle_a");
+    await expect(focus).toContainText("id");
+
+    // Exactly one hop card on each side — the cycle closes back onto the
+    // focus field after one step in either direction, and core's
+    // visited-field BFS must not walk around it a second time.
+    const upstreamHops = page.locator("[data-testid^='chain-hop-upstream-1-cycle-b']");
+    const downstreamHops = page.locator("[data-testid^='chain-hop-downstream-1-cycle-b']");
+    await expect(upstreamHops).toHaveCount(1);
+    await expect(downstreamHops).toHaveCount(1);
+
+    // Each side names the mapping that actually points that way around the
+    // cycle: b_to_a feeds cycle_a from upstream, a_to_b carries it onward.
+    await expect(
+      page.locator("[data-testid^='chain-hop-mapping-upstream-1-cycle-b']"),
+    ).toContainText("b_to_a");
+    await expect(
+      page.locator("[data-testid^='chain-hop-mapping-downstream-1-cycle-b']"),
+    ).toContainText("a_to_b");
+
+    // No further columns: a genuine second hop would put a
+    // chain-column-*-2 on the rail, which the cycle must never reach.
+    await expect(page.locator("[data-testid='chain-column-upstream-2']")).toHaveCount(0);
+    await expect(page.locator("[data-testid='chain-column-downstream-2']")).toHaveCount(0);
   });
 });
 

--- a/tooling/satsuma-viz-harness/test/screenshots.spec.ts
+++ b/tooling/satsuma-viz-harness/test/screenshots.spec.ts
@@ -90,6 +90,10 @@ const metricsUri = libraryUri("metrics-platform/metrics.stm");
 const reportsUri = libraryUri("reports-and-models/pipeline.stm");
 const ffgUri = libraryUri("filter-flatten-governance/filter-flatten-governance.stm");
 const sapUri = libraryUri("sap-po-to-mfcs/pipeline.stm");
+// The richest chain in the corpus: multiple upstream/downstream mappings,
+// nl-derived hops, and a collapsed namespace-fan chip all in one trace (see
+// harness.test.ts's "Field chain view" describe for the confirmed shape).
+const nsMergingUri = libraryUri("namespaces/ns-merging.stm");
 
 async function loadFixture(page: Page, fixtureUri: string): Promise<void> {
   await page.locator("#fixture-picker-btn").click();
@@ -122,6 +126,36 @@ async function openMapping(page: Page, mappingId: string): Promise<void> {
     .locator(`[data-testid='mapping-detail-${mappingId}']`)
     .first()
     .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+/** Expand an overview card and return its field-row test-id prefix (mirrors harness.test.ts). */
+async function expandOverviewCard(page: Page, qualifiedIdTestSegment: string): Promise<string> {
+  const cardPrefix = `overview-schema-card-${qualifiedIdTestSegment}`;
+  await page
+    .locator(`sz-schema-card[data-testid^='${cardPrefix}']`)
+    .locator(".header-toggle")
+    .click();
+  return cardPrefix;
+}
+
+/** Open the field-chain view for one field, via its overview card's lineage icon. */
+async function openFieldChain(
+  page: Page,
+  qualifiedIdTestSegment: string,
+  fieldTestSegment: string,
+): Promise<void> {
+  const cardPrefix = await expandOverviewCard(page, qualifiedIdTestSegment);
+  await page
+    .locator(`[data-testid='${cardPrefix}-field-${fieldTestSegment}-lineage']`)
+    .click({ force: true });
+  await page.locator("[data-testid='viz-root']").waitFor({ state: "attached" });
+  await page.waitForFunction(
+    () =>
+      document.querySelector("[data-testid='viz-root']")?.getAttribute("data-view-mode") ===
+      "chain",
+    null,
+    { timeout: 10_000 },
+  );
 }
 
 async function waitForReady(page: Page): Promise<void> {
@@ -318,6 +352,25 @@ for (const theme of THEMES) {
         theme,
         uiState: "detail:order-line-facts",
         step: `filter-flatten-detail-order-line-facts-${theme}`,
+      });
+    });
+
+    test(`namespaces-chain-view-${theme}`, async ({ page }) => {
+      // sv-embb: the field-chain view (PRD 36 R4) had no light/dark review
+      // shot at all — this fixture is the corpus's richest chain (multi-hop
+      // upstream/downstream, nl-derived hops, a collapsed namespace-fan chip),
+      // matching harness.test.ts's "Field chain view" describe.
+      await page.goto(`/?theme=${theme}`);
+      await setSingleFileMode(page);
+      await loadFixture(page, nsMergingUri);
+      await openFieldChain(page, "reporting-dept-budget-vs-actual", "actual-spend");
+      await capture(page, {
+        file: `namespaces-chain-view-${theme}.png`,
+        fixture: "namespaces/ns-merging.stm",
+        viewMode: "single",
+        theme,
+        uiState: "chain:reporting::dept_budget_vs_actual.actual_spend",
+        step: `namespaces-chain-view-${theme}`,
       });
     });
 

--- a/tooling/satsuma-viz-harness/test/view-persistence.test.ts
+++ b/tooling/satsuma-viz-harness/test/view-persistence.test.ts
@@ -197,6 +197,12 @@ test.describe("Chain view persistence across live edits", () => {
   async function openEmailChain(page: Page): Promise<void> {
     const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-stg-customers']");
     await card.locator(".header-toggle").click();
+    // This fixture's small three-schema graph can leave the just-expanded
+    // card's field row outside the SVG canvas's current pan/zoom viewBox — a
+    // transform Playwright's DOM-level "scroll into view" cannot follow
+    // (sv-embb, caught flaking on this exact interaction). Re-fit first,
+    // exactly as a human would with the toolbar's own button.
+    await page.locator("[data-testid='toolbar-fit']").click();
     await page
       .locator("[data-testid='overview-schema-card-stg-customers-field-email-lineage']")
       .click({ force: true });

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -78,6 +78,18 @@ export interface FieldChainModel {
   upstream: FieldChainHop[];
   /** Downstream fields, nearest first, with cycles and depth limits guarded by core. */
   downstream: FieldChainHop[];
+  /**
+   * False when `field`'s schema, or its path within that schema, could not be
+   * resolved against the traced workspace (a typo, a rename, or a field that
+   * never existed) — `upstream`/`downstream` are then always empty, and a
+   * renderer must show a distinct "field not found" state rather than
+   * treating this the same as a resolved field that genuinely has no
+   * lineage. Absent means true: `satsuma field-lineage` never emits a JSON
+   * chain for an unresolved field at all (it exits with `EXIT_NOT_FOUND`
+   * instead), so every payload derived from the CLI's output is resolved by
+   * construction and carries no need to say so.
+   */
+  resolved?: boolean;
 }
 
 // ---------- Top-level document model ----------

--- a/tooling/satsuma-viz/src/components/sz-chain-view.ts
+++ b/tooling/satsuma-viz/src/components/sz-chain-view.ts
@@ -329,6 +329,18 @@ export class SzChainView extends LitElement {
       color: var(--sz-text-muted);
       font-size: 13px;
     }
+
+    /* Unknown-field state (sv-embb): reuses the "warning" palette, like the
+     * depth-limit badge, because it flags a chain the reader should not read
+     * as "no lineage" — the focus field itself could not be resolved. */
+    .chain-unknown {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 24px;
+      color: var(--sz-warning-icon);
+      font-size: 13px;
+    }
   `;
 
   /** The traversal to render, supplied by the host. Null renders nothing but an empty state. */
@@ -347,6 +359,19 @@ export class SzChainView extends LitElement {
   override render() {
     if (!this.chain) {
       return html`<div class="chain-empty" data-testid="chain-empty">No field selected</div>`;
+    }
+
+    if (this.chain.resolved === false) {
+      // Composed as one string before binding: a lit template attribute or
+      // text node mixing literal text with more than one `${}` slot
+      // serializes as separate string/value runs under the tests'
+      // template-flattening helper (see `_renderColumn`'s testId for the same
+      // rule).
+      const parts = splitEndpoint(this.chain.field);
+      const message = `Field not found: ${qualifiedIdOf(parts)}.${parts.fieldPath}`;
+      return html`
+        <div class="chain-unknown" data-testid="chain-unknown-field">&#9888; ${message}</div>
+      `;
     }
 
     // Upstream renders furthest-first so hop distance increases moving away

--- a/tooling/satsuma-viz/test/sz-chain-view.test.js
+++ b/tooling/satsuma-viz/test/sz-chain-view.test.js
@@ -94,6 +94,65 @@ describe("sz-chain-view", () => {
     );
   });
 
+  describe("unknown-field state (sv-embb)", () => {
+    it("renders a distinct not-found state, not the empty-lineage rail, when resolved is false", async () => {
+      // sv-embb: a chain whose focus field could not be resolved must not
+      // look like a resolved field with no lineage — the rail (and its
+      // "chain-focus" card) must not render at all here.
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = {
+        field: "::orders.typo_field",
+        maxDepth: 10,
+        upstream: [],
+        downstream: [],
+        resolved: false,
+      };
+      const serialized = serialize(view.render());
+      assert.match(serialized, /chain-unknown-field/);
+      assert.match(serialized, /orders\.typo_field/);
+      assert.doesNotMatch(serialized, /chain-focus/);
+      assert.doesNotMatch(serialized, /chain-rail/);
+    });
+
+    it("renders the ordinary rail when resolved is absent, even for a genuinely empty chain", async () => {
+      // Guards the omitted-means-true convention: a resolved field with no
+      // lineage at all must still render the focus card, not the unknown
+      // state, or every childless field would look like a typo.
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = { field: "::orders.id", maxDepth: 10, upstream: [], downstream: [] };
+      const serialized = serialize(view.render());
+      assert.match(serialized, /chain-focus/);
+      assert.doesNotMatch(serialized, /chain-unknown-field/);
+    });
+  });
+
+  describe("cyclic chain rendering (sv-embb)", () => {
+    it("renders a hand-built cyclic FieldChainModel without duplicate hop cards", async () => {
+      // Core's traceFieldLineage dedupes by visited field before this
+      // component ever sees the result, so a cyclic mapping graph (a -> b ->
+      // a) surfaces as this exact shape: each field appears once, at its
+      // shortest-path depth. This pins that the component renders that shape
+      // as a finite, non-duplicated rail rather than assuming lineage data is
+      // always acyclic and re-walking it.
+      const mod = await import("../dist/satsuma-viz.js");
+      const view = new mod.SzChainView();
+      view.chain = {
+        field: "::cycle_a.id",
+        maxDepth: 10,
+        upstream: [hop("::cycle_b.id", "::b_to_a", "none", 1)],
+        downstream: [hop("::cycle_b.id", "::a_to_b", "none", 1)],
+      };
+      const serialized = serialize(view.render());
+      const hopCards = [...serialized.matchAll(/chain-hop-(?:up|down)stream-1-\S+/g)].map(
+        (m) => m[0],
+      );
+      assert.equal(hopCards.length, 2, "expected exactly one upstream and one downstream card");
+      assert.notEqual(hopCards[0], hopCards[1]);
+    });
+  });
+
   describe("classification badge", () => {
     it("renders no badge for a direct, undeclared-transform hop", async () => {
       const mod = await import("../dist/satsuma-viz.js");


### PR DESCRIPTION
## Summary

- `FieldChainModel` (viz-model) gains an optional `resolved` flag — absent (meaning true) whenever the focus field was actually found, matching every CLI-derived payload since `satsuma field-lineage` never emits JSON for an unresolved field (it exits `EXIT_NOT_FOUND` instead). Set to `false`, with empty `upstream`/`downstream`, only when the entry file can't load or the focus field can't be resolved.
- `buildFieldChainFromWorkspace` (viz-backend) now checks schema+field declaration before tracing, via a new spread-aware `resolveSchemaFields` helper in `workspace-definition-lookup.ts` — mirroring the CLI's `expandEntityFields` existence check, so a field only reachable through a fragment spread still resolves correctly.
- `sz-chain-view` renders a distinct `chain-unknown-field` state instead of silently falling back to the same empty rail a resolved-but-lineage-less field shows.
- Added `examples/lineage-cycle/pipeline.stm` (adapted from `tooling/satsuma-cli/test/fixtures/lineage-cycle.stm`) and a Playwright spec proving the chain view terminates on a mapping cycle with the exact shape confirmed against `satsuma field-lineage --json`, plus light/dark chain-view screenshots in `screenshots.spec.ts`.
- Fixed two pre-existing viz-harness Playwright flakes (`openEmailChain` in `view-persistence.test.ts`, and the new cycle test) where a just-expanded schema card's field-lineage button sat outside the SVG canvas's current pan/zoom viewBox on small graphs — DOM-level "scroll into view" can't follow an SVG transform, so both now click the toolbar's Fit button first.

Closes sv-embb (residual gap from Feature 40, superseded by Feature 36's `sz-chain-view`).

## Test plan

- [x] `npm run test:all` — all packages green
- [x] `./scripts/run-repo-checks.sh` — green (lint, corpus, smoke tests, test-stats regen)
- [x] Full viz-harness Playwright suite green via the watch-and-test.sh sentinel protocol (127 passed)
- [x] New unit tests: viz-backend (`focusFieldIsDeclared` — unknown schema, unknown field, spread-derived field, resolved-empty control), LSP (unresolved entry file), `sz-chain-view` (unknown-field render, cyclic-model render)
- [x] New Playwright spec: cycle detection against `examples/lineage-cycle/pipeline.stm`
- [x] New screenshots: `namespaces-chain-view-{light,dark}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)