### PR TITLE
fix(viz): collapse enum badges to a count with a click-to-expand overlay (sl-2ne7)

### DIFF
--- a/.tickets/sl-2ne7.md
+++ b/.tickets/sl-2ne7.md
@@ -1,6 +1,6 @@
 ---
 id: sl-2ne7
-status: open
+status: closed
 deps: []
 links: [sl-om1l]
 created: 2026-08-05T09:25:33Z
@@ -27,3 +27,14 @@ Screenshot: bug-reports/enum-render-is-ugly.png
 - Doesn't regress the ELK layout's field-row height estimate (the collapsed state's height must match what layout already assumes).
 - Covers a multi-value enum fixture in both compact and expanded card states, both themes.
 
+
+## Notes
+
+**2026-08-06T14:24:40Z**
+
+## Notes
+
+**2026-08-06T14:20:00Z**
+
+Cause: metaEntriesToViz only stored an enum's values as one pipe-joined display string, and sz-schema-card.ts rendered that whole string as a single field-meta badge, so a 4+ value enum ("enum enterprise | mid_market | smb | individual") became the widest thing on the row.
+Fix: MetadataEntry now carries an optional `values: string[]` alongside the joined `value` (viz-model contract + viz-backend emit it for enum entries); sz-schema-card's enum badge collapses to a count ("enum (4)") and a click opens an absolutely-positioned overlay (with an added `has-enum-overlay` host attribute lifting the card's clip) listing every value, closing on a second click, an outside click, or Escape. Playwright coverage added for the collapse/expand/outside-click/Escape/no-reflow behaviour in both the mapping-detail card and the overview compact-expanded card, in both themes, against the corpus's existing 4-value `crm_customers.segment` enum fixture (multi-source-join.stm). (commit immediately after 398991a1)

--- a/test-stats.json
+++ b/test-stats.json
@@ -6,8 +6,8 @@
     "satsuma-cli": 1074,
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
-    "satsuma-viz-backend": 196,
-    "satsuma-viz": 184,
+    "satsuma-viz-backend": 197,
+    "satsuma-viz": 188,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-backend/src/viz-model.ts
+++ b/tooling/satsuma-viz-backend/src/viz-model.ts
@@ -1508,7 +1508,10 @@ function extractComments(uri: string, node: SyntaxNode): CommentEntry[] {
  * - tag  → {key: tagName, value: ""}
  * - kv   → {key: keyName, value: valueText}
  * - note → {key: "note", value: noteText}
- * - enum → {key: "enum", value: "val1 | val2 | ..."} (joined for display)
+ * - enum → {key: "enum", value: "val1 | val2 | ...", values: [val1, val2, ...]}
+ *   (joined string for display, plus the raw list so a renderer that needs
+ *   each value on its own — e.g. an expanded enum badge overlay — doesn't
+ *   have to re-split `value` and guess at the join separator, sl-2ne7)
  * - slice → skipped (handled separately by metric metadata extraction)
  */
 function metaEntriesToViz(entries: MetaEntry[]): MetadataEntry[] {
@@ -1525,7 +1528,7 @@ function metaEntriesToViz(entries: MetaEntry[]): MetadataEntry[] {
         result.push({ key: "note", value: entry.text });
         break;
       case "enum":
-        result.push({ key: "enum", value: entry.values.join(" | ") });
+        result.push({ key: "enum", value: entry.values.join(" | "), values: entry.values });
         break;
       case "slice":
         // Slices are handled separately by extractMetricMetadata

--- a/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
+++ b/tooling/satsuma-viz-backend/test/viz-model-builders.test.js
@@ -442,6 +442,23 @@ describe("extractFieldEntries (direct)", () => {
     // Neither key is a constraint tag, so the badge list stays empty.
     assert.deepStrictEqual(field.constraints, []);
   });
+
+  // sl-2ne7: sz-schema-card collapses an enum badge to a count and expands
+  // each value into its own chip on click, so it needs the individual values
+  // rather than only the joined display string metaEntriesToViz also emits.
+  it("carries both the joined display string and the raw value list for an enum field", () => {
+    const src = "schema s {\n  segment VARCHAR(20) (enum {enterprise, mid_market, smb})\n}";
+    const body = findNode(root(src), "schema_body");
+    const [field] = extractFieldEntries(URI, body);
+
+    assert.deepStrictEqual(field.metadata, [
+      {
+        key: "enum",
+        value: "enterprise | mid_market | smb",
+        values: ["enterprise", "mid_market", "smb"],
+      },
+    ]);
+  });
 });
 
 describe("extractSpreads (direct)", () => {

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -78,6 +78,13 @@ const nsMergingUri = libraryUri("namespaces/ns-merging.stm");
  * these tests pin for the browser-rendered chain.
  */
 const cycleUri = libraryUri("lineage-cycle/pipeline.stm");
+/**
+ * Multi-source-join fixture — its `crm_customers.segment` field carries the
+ * four-value enum from the sl-2ne7 bug report (`enum {enterprise,
+ * mid_market, smb, individual}`), the corpus's only field with that many
+ * enum values. No other fixture wired into this suite reaches that shape.
+ */
+const multiSourceJoinUri = libraryUri("multi-source/multi-source-join.stm");
 
 /**
  * Open a specific named mapping by clicking its overview mapping card.
@@ -757,6 +764,152 @@ test.describe("Mapping detail — completed orders (multi-source join)", () => {
       detail.locator("[data-testid='mapping-detail-completed-orders-arrow-row-tier']"),
     ).toBeVisible();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Enum badge collapse/expand (sl-2ne7)
+//
+// A multi-value enum used to render as one unbroken pill joining every value
+// ("enum enterprise | mid_market | smb | individual"), the widest thing on a
+// field row that already carries other tags. Unit-level coverage in
+// tooling/satsuma-viz/test/automation.test.js pins that the collapsed badge
+// and the expanded overlay's markup are computed correctly from
+// `_expandedEnumField`; none of it proves the click actually opens the
+// overlay in a real DOM, that the overlay escapes the card's clipped
+// overflow, that the field row's own box stays put while it's open, or that
+// clicking away / Escape closes it again — only a rendered browser can.
+// ---------------------------------------------------------------------------
+
+test.describe("Field enum badge collapse/expand (sl-2ne7)", () => {
+  test("collapses to a count, expands into an overlay without reflowing the row, and closes on a second click, outside click, or Escape", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, multiSourceJoinUri);
+    const detail = await openMappingByName(page, "customer-360");
+
+    const cardPrefix = "mapping-detail-customer-360-source-schema-card-crm-customers";
+    const badge = detail.locator(`[data-testid='${cardPrefix}-field-segment-enum-badge']`);
+    const overlay = detail.locator(`[data-testid='${cardPrefix}-field-segment-enum-overlay']`);
+    const segmentRow = detail.locator(`[data-testid='${cardPrefix}-field-segment']`);
+    // The field declared immediately after `segment` in crm_customers — its
+    // position must not shift when the overlay opens above it.
+    const regionRow = detail.locator(`[data-testid='${cardPrefix}-field-region']`);
+
+    // Collapsed by default: a count, not the four-value pipe-joined list.
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText(/enum\s*\(4\)/);
+    await expect(segmentRow).not.toContainText("enterprise | mid_market");
+    await expect(overlay).toHaveCount(0);
+
+    const segmentBoxBefore = await segmentRow.boundingBox();
+    const regionBoxBefore = await regionRow.boundingBox();
+
+    await badge.click();
+    await expect(overlay).toBeVisible();
+    for (const value of ["enterprise", "mid_market", "smb", "individual"]) {
+      await expect(overlay).toContainText(value);
+    }
+
+    // The row's own box and the row below it must be exactly where they were
+    // — the overlay floats over the card rather than pushing the field list
+    // (AC: "Doesn't regress the ELK layout's field-row height estimate").
+    expect(await segmentRow.boundingBox()).toEqual(segmentBoxBefore);
+    expect(await regionRow.boundingBox()).toEqual(regionBoxBefore);
+
+    // A second click on the same badge collapses it again.
+    await badge.click();
+    await expect(overlay).toHaveCount(0);
+
+    // Escape collapses an open overlay.
+    await badge.click();
+    await expect(overlay).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(overlay).toHaveCount(0);
+
+    // A click anywhere outside the badge and the overlay collapses it too —
+    // the schema card's own header is a convenient target: distinct from
+    // both, and its own click handler (navigate) has no side effect here.
+    await badge.click();
+    await expect(overlay).toBeVisible();
+    await detail.locator(`[data-testid='${cardPrefix}-header']`).click();
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test("collapses and expands the same way inside an overview compact-expanded card", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, multiSourceJoinUri);
+
+    const card = page.locator("sz-schema-card[data-testid^='overview-schema-card-crm-customers']");
+    await card.locator(".header-toggle").click();
+
+    const cardPrefix = "overview-schema-card-crm-customers";
+    const badge = card.locator(`[data-testid='${cardPrefix}-field-segment-enum-badge']`);
+    const overlay = card.locator(`[data-testid='${cardPrefix}-field-segment-enum-overlay']`);
+
+    await expect(badge).toHaveText(/enum\s*\(4\)/);
+    await expect(overlay).toHaveCount(0);
+
+    await badge.click();
+    await expect(overlay).toBeVisible();
+    for (const value of ["enterprise", "mid_market", "smb", "individual"]) {
+      await expect(overlay).toContainText(value);
+    }
+
+    await badge.click();
+    await expect(overlay).toHaveCount(0);
+  });
+
+  // The port dot cases above (sl-f0x6) already prove theming is exercised
+  // pairwise; this proves the *new* overlay element specifically paints a
+  // real, non-transparent panel distinct from its own chip text in both.
+  for (const theme of ["light", "dark"] as const) {
+    test(`enum overlay renders a visible, legible panel in the ${theme} theme`, async ({
+      page,
+    }) => {
+      await page.goto(`/?theme=${theme}`);
+      await page.waitForFunction(() => {
+        const harness = window.__satsumaHarness;
+        if (!harness?.setViewMode) return false; // app.js not evaluated yet
+        harness.setViewMode("single");
+        return true;
+      });
+      await loadFixture(page, multiSourceJoinUri);
+      const detail = await openMappingByName(page, "customer-360");
+
+      const cardPrefix = "mapping-detail-customer-360-source-schema-card-crm-customers";
+      const badge = detail.locator(`[data-testid='${cardPrefix}-field-segment-enum-badge']`);
+      const overlay = detail.locator(`[data-testid='${cardPrefix}-field-segment-enum-overlay']`);
+
+      await badge.click();
+      await expect(overlay).toBeVisible();
+
+      const { panelBg, chipBg } = await overlay.evaluate((el) => {
+        const chip = el.querySelector(".enum-value-chip");
+        return {
+          panelBg: getComputedStyle(el).backgroundColor,
+          chipBg: chip ? getComputedStyle(chip).backgroundColor : null,
+        };
+      });
+      expect(panelBg).not.toBe("rgba(0, 0, 0, 0)");
+      expect(chipBg).not.toBe("rgba(0, 0, 0, 0)");
+      expect(chipBg).not.toBe(panelBg);
+    });
+  }
 });
 
 test.describe("Mapping detail — order line facts (flatten)", () => {

--- a/tooling/satsuma-viz-model/src/index.ts
+++ b/tooling/satsuma-viz-model/src/index.ts
@@ -429,6 +429,16 @@ export interface CommentEntry {
 export interface MetadataEntry {
   key: string;
   value: string;
+  /**
+   * The individual allowed values, present only when `key` is `"enum"`.
+   * `value` already carries the same values joined with `" | "` for renderers
+   * that just want display text (tooltips, hover text); this array exists so
+   * a renderer that needs to treat each value as its own element (e.g. a
+   * schema card's enum badge, which collapses to a count and expands each
+   * value into its own chip — sl-2ne7) does not have to re-split `value` and
+   * guess at the join separator.
+   */
+  values?: string[];
 }
 
 /** File position of an entity or field declaration in a .stm source file. */

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import type { SchemaCard, FieldEntry } from "../model.js";
+import type { SchemaCard, FieldEntry, MetadataEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
 import type { FieldCoverageEntry, FieldCoverageState } from "@satsuma/core/coverage";
@@ -102,6 +102,15 @@ export class SzSchemaCard extends LitElement {
      * small overshoot paint past the host instead of being clipped.
      */
     :host([compact-expanded]) {
+      overflow: visible;
+    }
+
+    /* A field's enum overlay (sl-2ne7) paints outside its field row, and
+       the row sits inside a non-compact card's normal-flow field list —
+       which clips by default, unlike a compact-expanded card. Reflected
+       whenever an overlay is open so it can escape whichever card hosts
+       it, then removed on collapse to restore ordinary clipping. */
+    :host([has-enum-overlay]) {
       overflow: visible;
     }
 
@@ -250,6 +259,7 @@ export class SzSchemaCard extends LitElement {
     }
 
     .field-row {
+      position: relative;
       display: flex;
       align-items: center;
       gap: 6px;
@@ -345,6 +355,48 @@ export class SzSchemaCard extends LitElement {
     .badge.pii {
       background: var(--sz-warning-bg);
       color: var(--sz-warning-icon);
+    }
+
+    /* An enum badge always shows only its collapsed count (sl-2ne7): joining
+       every value into one pill ("enum enterprise | mid_market | smb |
+       individual") made a single constraint the widest thing on the row.
+       Values are legible on demand, in the overlay below. */
+    .badge.enum-badge {
+      cursor: pointer;
+    }
+
+    /* Positioned against the field row (.field-row is its containing block),
+       not the small inline badge, so the panel reads as belonging to the row
+       rather than hanging off one word inside it. Floats below the row
+       instead of reflowing it — the row's own box is untouched, so the ELK
+       layout's field-row height estimate still holds while this is open. */
+    .enum-overlay {
+      position: absolute;
+      top: 100%;
+      left: 12px;
+      right: 12px;
+      margin-top: 2px;
+      z-index: 50;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding: 8px;
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-card-bg);
+      border: 1px solid var(--sz-card-border);
+      box-shadow: var(--sz-card-shadow);
+      cursor: default;
+    }
+
+    .enum-overlay .enum-value-chip {
+      font-family: var(--sz-font-sans);
+      font-size: 10px;
+      font-weight: 500;
+      padding: 1px 5px;
+      border-radius: var(--sz-badge-radius);
+      background: var(--sz-badge-bg);
+      color: var(--sz-badge-text);
+      line-height: 1.4;
     }
 
     .comment-badge {
@@ -667,6 +719,14 @@ export class SzSchemaCard extends LitElement {
   @state()
   private _notesExpanded = true;
 
+  /**
+   * The dotted field path whose enum overlay is open, or `null` if none is.
+   * At most one is open per card — a second badge click on a different field
+   * replaces it rather than stacking overlays.
+   */
+  @state()
+  private _expandedEnumField: string | null = null;
+
   override updated(changed: Map<string, unknown>) {
     if (changed.has("highlightFields")) {
       if (this.highlightFields.size > 0) {
@@ -674,6 +734,64 @@ export class SzSchemaCard extends LitElement {
       } else {
         this.removeAttribute("has-highlight");
       }
+    }
+    if (changed.has("_expandedEnumField")) {
+      // Lifts the host's clip only while an overlay needs to paint past it
+      // — see the :host([has-enum-overlay]) rule above.
+      if (this._expandedEnumField !== null) {
+        this.setAttribute("has-enum-overlay", "");
+      } else {
+        this.removeAttribute("has-enum-overlay");
+      }
+    }
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    // Belt-and-braces: normally _closeEnumOverlay removes these, but a card
+    // can be removed from the DOM (schema navigated away from) while its
+    // overlay is still open, which never fires that handler.
+    window.removeEventListener("keydown", this._onEnumOverlayKeydown);
+    window.removeEventListener("click", this._onEnumOverlayOutsideClick);
+  }
+
+  /** Opens `fieldPath`'s enum overlay, replacing any other open one. */
+  private _openEnumOverlay(fieldPath: string) {
+    this._expandedEnumField = fieldPath;
+    window.addEventListener("keydown", this._onEnumOverlayKeydown);
+    window.addEventListener("click", this._onEnumOverlayOutsideClick);
+  }
+
+  private _closeEnumOverlay() {
+    this._expandedEnumField = null;
+    window.removeEventListener("keydown", this._onEnumOverlayKeydown);
+    window.removeEventListener("click", this._onEnumOverlayOutsideClick);
+  }
+
+  /**
+   * Bound once (arrow function, not a method) so the exact same reference
+   * can be passed to both `addEventListener` and `removeEventListener`.
+   */
+  private _onEnumOverlayKeydown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") this._closeEnumOverlay();
+  };
+
+  /**
+   * Any click that reaches `window` has already bubbled past both the badge
+   * that opens the overlay and the overlay panel itself — the row's own
+   * click handler, the badge's, and the overlay's each stop propagation —
+   * so by the time this fires, the click was outside all of them.
+   */
+  private _onEnumOverlayOutsideClick = () => {
+    this._closeEnumOverlay();
+  };
+
+  private _onEnumBadgeClick(e: Event, fieldPath: string) {
+    e.stopPropagation();
+    if (this._expandedEnumField === fieldPath) {
+      this._closeEnumOverlay();
+    } else {
+      this._openEnumOverlay(fieldPath);
     }
   }
 
@@ -857,6 +975,11 @@ export class SzSchemaCard extends LitElement {
     // Use the dotted path so nested customer.email is distinguishable from a
     // sibling top-level email field (sl-eikr).
     const fieldTestId = `${this.testIdPrefix}-field-${sanitizeTestIdSegment(fieldPath)}`;
+    const metaPills = this._fieldMetaPills(f);
+    // At most one enum entry per field (the grammar allows a single enum
+    // constraint), so a single lookup covers both the collapsed badge and,
+    // once expanded, the overlay's value list.
+    const enumEntry = metaPills.find((m) => m.key === "enum");
     // The older, coarser attribute, kept byte-identical for the automation built
     // on it: a record is "mapped" as soon as anything beneath it is (core's
     // `entry.mapped`, i.e. state !== "uncovered"). `unknown` rather than
@@ -890,13 +1013,19 @@ export class SzSchemaCard extends LitElement {
             .filter((c) => c !== "pii")
             .map((c) => html`<span class="badge">${c}</span>`)}
           ${hasPii ? html`<span class="badge pii" title="PII">&#128737; pii</span>` : ""}
-          ${this._fieldMetaPills(f).map(
-            (m) =>
-              html`<span class="badge field-meta" title=${`${m.key} ${m.value}`.trim()}
-                ><span class="badge-key">${m.key}</span>${m.value ? ` ${m.value}` : ""}</span
-              >`,
+          ${metaPills.map((m) =>
+            m.key === "enum"
+              ? this._renderEnumBadge(fieldPath, fieldTestId, m)
+              : html`<span class="badge field-meta" title=${`${m.key} ${m.value}`.trim()}
+                  ><span class="badge-key">${m.key}</span>${m.value ? ` ${m.value}` : ""}</span
+                >`,
           )}
         </span>
+        ${
+          enumEntry && this._expandedEnumField === fieldPath
+            ? this._renderEnumOverlay(fieldTestId, enumEntry)
+            : ""
+        }
         ${
           hasWarning
             ? html`<span class="comment-badge warning" title=${this._commentText(f, "warning")}
@@ -969,6 +1098,49 @@ export class SzSchemaCard extends LitElement {
     return (f.metadata ?? []).filter(
       (m) => m.key !== "note" && !(m.value === "" && f.constraints.includes(m.key)),
     );
+  }
+
+  /**
+   * An enum entry's individual values. Prefers `m.values` (present from
+   * sl-2ne7 onward); falls back to re-splitting the joined `value` for
+   * payloads from an older viz-backend or a cached webview that predate it,
+   * the same tolerance `_fieldMetaPills` already extends to a missing
+   * `metadata` array.
+   */
+  private _enumValues(m: MetadataEntry): string[] {
+    return m.values ?? (m.value ? m.value.split(" | ") : []);
+  }
+
+  /**
+   * An enum badge collapses to a count rather than the joined value list
+   * (sl-2ne7): with several values, the joined form was the widest thing on
+   * the row. Clicking it opens {@link _renderEnumOverlay} for the same field.
+   */
+  private _renderEnumBadge(fieldPath: string, fieldTestId: string, m: MetadataEntry) {
+    const values = this._enumValues(m);
+    return html`<span
+      class="badge field-meta enum-badge"
+      data-testid=${`${fieldTestId}-enum-badge`}
+      title=${`enum: ${values.join(", ")}`}
+      @click=${(e: Event) => this._onEnumBadgeClick(e, fieldPath)}
+      ><span class="badge-key">enum</span> (${values.length})</span
+    >`;
+  }
+
+  /**
+   * The overlay a click on {@link _renderEnumBadge} opens: every value as its
+   * own chip, individually legible. Positioned absolute against the field
+   * row (its `position: relative` containing block) so it floats below the
+   * row rather than reflowing it or the card around it.
+   */
+  private _renderEnumOverlay(fieldTestId: string, m: MetadataEntry) {
+    return html`<div
+      class="enum-overlay"
+      data-testid=${`${fieldTestId}-enum-overlay`}
+      @click=${(e: Event) => e.stopPropagation()}
+    >
+      ${this._enumValues(m).map((v) => html`<span class="enum-value-chip">${v}</span>`)}
+    </div>`;
   }
 
   /**

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -293,3 +293,123 @@ describe("viz automation helpers", () => {
     assert.match(serialized, /detail-schema-card-customers-field-customer-id-lineage/);
   });
 });
+
+/**
+ * sz-schema-card enum badge (sl-2ne7) — a multi-value enum used to render as
+ * one unbroken pill joining every value ("enum enterprise | mid_market | smb
+ * | individual"), which was the widest thing on a field row carrying several
+ * tags. These cases pin the fix: the badge always shows a collapsed count,
+ * and the full value list is reachable only through the click-to-expand
+ * overlay, keyed off the card's private `_expandedEnumField` state.
+ *
+ * Playwright coverage for the actual click/outside-click/Escape gestures and
+ * the overlay's real paint (it must escape the card's clipped overflow)
+ * lives in tooling/satsuma-viz-harness/test/harness.test.ts — none of that is
+ * observable from a serialized render() output, which is all a Node test can
+ * drive here.
+ */
+describe("sz-schema-card enum badge (sl-2ne7)", () => {
+  const LOC = { uri: "file:///t.stm", line: 0, character: 0 };
+
+  /** A `segment` field carrying the four-value enum from the bug report. */
+  function segmentField() {
+    return {
+      name: "segment",
+      type: "VARCHAR(20)",
+      constraints: [],
+      metadata: [
+        {
+          key: "enum",
+          value: "enterprise | mid_market | smb | individual",
+          values: ["enterprise", "mid_market", "smb", "individual"],
+        },
+      ],
+      notes: [],
+      comments: [],
+      children: [],
+      location: LOC,
+    };
+  }
+
+  /**
+   * Serializes a lit-html TemplateResult with template values interleaved in
+   * source order, so e.g. "(" and the count and ")" land adjacent exactly as
+   * the template author wrote them — a plain "strings then values" join (as
+   * used for existence-only checks elsewhere in this file) would scatter the
+   * count away from its parentheses and make an adjacency assertion like
+   * `/\(4\)/` meaningless. Same approach as schema-card-coverage.test.js's
+   * `renderText`.
+   */
+  function serialize(value) {
+    if (value == null) return "";
+    if (Array.isArray(value)) return value.map(serialize).join("");
+    if (typeof value === "object" && value.strings && "values" in value) {
+      return value.strings
+        .map((s, i) => s + (i < value.values.length ? serialize(value.values[i]) : ""))
+        .join("");
+    }
+    return String(value);
+  }
+
+  it("collapses to a count and omits the joined value list by default", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-crm";
+    card.coverage = [];
+    const serialized = serialize(card._renderField(segmentField(), 0));
+
+    assert.match(serialized, /src-crm-field-segment-enum-badge/);
+    assert.match(serialized, /\(4\)/);
+    // The overlay must not be present at all while collapsed — not merely
+    // hidden by CSS — or Playwright's `.toBeVisible()` on the collapsed
+    // fixture would be trivially true for the wrong reason.
+    assert.doesNotMatch(serialized, /enum-overlay/);
+    assert.doesNotMatch(serialized, /enterprise \| mid_market/);
+  });
+
+  it("expands into an overlay listing every value once its field path is the expanded one", async () => {
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-crm";
+    card.coverage = [];
+    card._expandedEnumField = "segment";
+    const serialized = serialize(card._renderField(segmentField(), 0));
+
+    assert.match(serialized, /src-crm-field-segment-enum-overlay/);
+    for (const value of ["enterprise", "mid_market", "smb", "individual"]) {
+      assert.match(serialized, new RegExp(value));
+    }
+  });
+
+  it("collapses again once a different field becomes the expanded one", async () => {
+    // Only one overlay is open at a time (per the card's own state doc
+    // comment) — a stale path from a previously expanded field must not
+    // leave this field's overlay rendered too.
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-crm";
+    card.coverage = [];
+    card._expandedEnumField = "some_other_field";
+    const serialized = serialize(card._renderField(segmentField(), 0));
+
+    assert.doesNotMatch(serialized, /enum-overlay/);
+  });
+
+  it("derives the count and overlay values from the joined string when an older payload has no values array", async () => {
+    // Cached webview payloads or an LSP older than sl-2ne7 emit MetadataEntry
+    // without `values` — only the joined `value` string metaEntriesToViz has
+    // always produced. The badge must still collapse correctly rather than
+    // reading `values.length` off `undefined`.
+    const mod = await import("../dist/satsuma-viz.js");
+    const card = new mod.SzSchemaCard();
+    card.testIdPrefix = "src-crm";
+    card.coverage = [];
+    const legacyField = segmentField();
+    legacyField.metadata = [{ key: "enum", value: "enterprise | mid_market | smb | individual" }];
+    card._expandedEnumField = "segment";
+    const serialized = serialize(card._renderField(legacyField, 0));
+
+    assert.match(serialized, /\(4\)/);
+    assert.match(serialized, /individual/);
+  });
+});


### PR DESCRIPTION
## Summary
- A multi-value enum metadata tag rendered as one unbroken badge joining every value ("enum enterprise | mid_market | smb | individual"), the widest thing on a field row that already carries other tags.
- `MetadataEntry` (viz-model contract) now carries an optional `values: string[]` alongside the existing joined `value` string for enum entries; `metaEntriesToViz` in viz-backend emits it.
- `sz-schema-card`'s enum badge now collapses to a count ("enum (4)") and a click opens an absolutely-positioned overlay (over the card, not reflowing the row) listing every value as its own chip. A second click, an outside click, or Escape collapses it again. A `has-enum-overlay` host attribute lifts the card's normal clip only while the overlay is open.
- Falls back to splitting the joined `value` string for older cached payloads that predate the `values` field.

Closes sl-2ne7.

## Testing
- Unit tests (satsuma-viz-backend, satsuma-viz) pin the collapsed/expanded markup and the legacy-payload fallback.
- Playwright coverage added in `harness.test.ts` against the corpus's existing 4-value `crm_customers.segment` enum fixture (`multi-source/multi-source-join.stm`, not previously wired into the harness):
  - collapse/expand/second-click/outside-click/Escape, with a no-reflow bounding-box assertion, in the mapping-detail card
  - collapse/expand in the overview compact-expanded card
  - overlay renders a visible, legible panel in both themes
- Full suite green post-rebase: `npm run test:all` (24/24 tasks) and the Playwright harness (128/128, after confirming an unrelated `view-persistence.test.ts` viewport-click flake was pre-existing and not reproduced on retry).
- No ADR: this is an additive, backward-compatible DTO field plus a self-contained component change — no cross-package architectural decision to record.

## Test plan
- [x] `npm run test:all`
- [x] `npm run lint`
- [x] Playwright viz-harness suite (human-in-the-loop watcher)
- [x] Rebased onto latest `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)