### PR TITLE
fix(viz): render note Markdown everywhere, and stop dropping mapping notes

### DIFF
--- a/.tickets/vnm-bak4.md
+++ b/.tickets/vnm-bak4.md
@@ -1,0 +1,42 @@
+---
+id: vnm-bak4
+status: open
+deps: []
+links: [vnm-kisd]
+created: 2026-08-06T17:23:22Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, notes, markdown, ux]
+---
+# viz: mapping-level notes are never rendered, and arrow notes ignore Markdown
+
+Reported by the same user, alongside the field-note report: "If I add notes to the mapping sections, should I expect to see them in the visualiser? (i.e. notes including markdown don't actually render on mapping arrows in the mapping view but should)."
+
+There are two distinct defects behind that one sentence, and they should both be fixed here.
+
+**1. Mapping-level `note { }` blocks are extracted and then dropped on the floor.**
+
+SATSUMA-V2-SPEC.md:242 and :553 document `note { }` as a structural block usable "at file top level or inside mapping blocks", and say these "often benefit from `\"\"\"` for rich Markdown content". `viz-backend` honours that: `tooling/satsuma-viz-backend/src/viz-model.ts:855-937` collects notes from both the mapping body and the mapping declaration itself into `MappingBlock.notes`, and the contract declares the field at `tooling/satsuma-viz-model/src/index.ts:198`.
+
+`tooling/satsuma-viz/src/components/sz-mapping-detail.ts` never reads `notes` — grepping the file for the identifier returns nothing. So a mapping-level note travels the whole pipeline into the webview payload and is then invisible to the reader. Top-level file notes *are* rendered (`satsuma-viz.ts:2353`, `:2591`), which is why this reads as an omission rather than a design choice.
+
+**2. Arrow notes render, but never as Markdown.**
+
+An arrow's `(note "...")` does render — `sz-mapping-detail.ts:793` picks the entry out of `a.metadata` and `:839-842` paints it in an `.arrow-note-row` beneath the arrow. But it goes through `highlightAtRefs` only, not `renderMarkdown`. `highlightAtRefs` (`tooling/satsuma-viz/src/markdown.ts:19`) escapes HTML and wraps `@ref` tokens; it does nothing with `**bold**`, lists or headings. A `"""` note on an arrow therefore shows its Markdown source verbatim, exactly as the user described.
+
+**How the two relate.** This is the mapping-view half of the same bug class as the field-note report — a `renderMarkdown` helper exists and is wired to some note sites and not others. Fix them consistently: whatever composition of `renderMarkdown` and `highlightAtRefs` is settled on for field notes should apply here, so a note carrying both Markdown and an `@ref` renders both. Arrow notes are the one site where `@ref` highlighting already works, so it must not regress.
+
+**Design question to settle before implementing.** Where mapping-level notes belong in the detail view is not obvious and is worth a decision rather than a guess. The mapping header already renders declaration metadata alongside source/target/join (see the `MappingBlock.metadata` comment at `viz-model/src/index.ts:194-197`, sl-6x1o), which argues for the header region; but a multi-paragraph `note { }` block is closer in weight to the file-note cards than to a metadata pill, and the arrow table is dense already. A collapsible section — mirroring the `notes-section` / `notes-toggle` pattern the schema card uses at `sz-schema-card.ts:926-948` — is the closest existing precedent and is the suggested starting point. Note that `NoteBlock` carries `isMultiline`, so the two weights are distinguishable in the payload.
+
+## Acceptance Criteria
+
+- A `note { }` block declared inside a mapping body is visible in the mapping detail view; a note on the mapping declaration itself is visible too. Neither is silently dropped.
+- Where they render is a deliberate placement (header region vs. a collapsible section), recorded in the ticket notes, not incidental to the first thing that fitted.
+- Mapping-level notes render their Markdown formatted — headings, lists, bold, italic, inline code.
+- An arrow note written with `"""` renders its Markdown formatted in the `.arrow-note-row`, instead of showing the literal source.
+- `@ref` highlighting on arrow notes does not regress, and works in mapping-level notes too.
+- HTML in note text stays escaped at every one of these sites.
+- A mapping with no notes renders exactly as it does today — no empty section, no extra vertical space.
+- Playwright harness coverage in `tooling/satsuma-viz-harness/test/harness.test.ts` asserts the rendered DOM for both a mapping-level note and a Markdown arrow note. No `describe` block covers note rendering today and no fixture carries a mapping-level `note { }` or a Markdown arrow note — both fixtures need adding. Per AGENTS.md, whether a note is painted at all, and whether a collapsible section opens on click, are properties no getter-level test can observe.
+

--- a/.tickets/vnm-bak4.md
+++ b/.tickets/vnm-bak4.md
@@ -1,6 +1,6 @@
 ---
 id: vnm-bak4
-status: open
+status: closed
 deps: []
 links: [vnm-kisd]
 created: 2026-08-06T17:23:22Z
@@ -40,3 +40,24 @@ An arrow's `(note "...")` does render — `sz-mapping-detail.ts:793` picks the e
 - A mapping with no notes renders exactly as it does today — no empty section, no extra vertical space.
 - Playwright harness coverage in `tooling/satsuma-viz-harness/test/harness.test.ts` asserts the rendered DOM for both a mapping-level note and a Markdown arrow note. No `describe` block covers note rendering today and no fixture carries a mapping-level `note { }` or a Markdown arrow note — both fixtures need adding. Per AGENTS.md, whether a note is painted at all, and whether a collapsible section opens on click, are properties no getter-level test can observe.
 
+
+## Notes
+
+**2026-08-06T18:15:18Z**
+
+**2026-08-06T18:20:00Z**
+
+Cause: `sz-mapping-detail` never read `MappingBlock.notes` at all, so `note { }`
+blocks reached the webview payload and were invisible; arrow notes rendered but
+through `highlightAtRefs` only, which handles `@ref` tokens and nothing else, so
+their Markdown showed verbatim. A mapping's `( note "..." )` metadata entry was
+additionally rendering as a raw pill.
+Fix: added a collapsible mapping-notes section between the header and the arrow
+table (expanded by default, mirroring sz-schema-card — a mapping's note is the
+context a reader needs before its arrows), routed arrow notes through
+`renderMarkdown`, and withheld `note` from the header pill row so declaration
+notes join the section instead of showing raw. Also guarded `m.notes ?? []` — a
+payload without `notes` was taking the whole detail view down. Placement and the
+`@ref`/Markdown composition are shared with [[vnm-kisd]] via the new
+`satsuma-viz/src/notes.ts`. Verified in a real browser, 136 Playwright passed.
+(commit immediately after 3bbbcb0b)

--- a/.tickets/vnm-gucl.md
+++ b/.tickets/vnm-gucl.md
@@ -1,0 +1,41 @@
+---
+id: vnm-gucl
+status: open
+deps: []
+links: []
+created: 2026-08-06T17:24:08Z
+type: bug
+priority: 3
+assignee: Thorben Louw
+external-ref: gh-513
+tags: [viz, ux, docs]
+---
+# viz: canvas hint says "drag to pan" but only middle-mouse (or Alt) drag pans
+
+From GitHub issue #513 (https://github.com/EqualExperts/satsuma-lang/issues/513). The issue opened by asking for Miro/Figma-style canvas panning — left-drag on empty canvas, Spacebar+drag, and grab/grabbing cursor feedback — on the grounds that panning was only possible through the overview minimap. The reporter then found that **middle-mouse drag already pans**, and concluded the real defect is that the on-screen hint does not say so. This ticket implements that conclusion, which the user has accepted.
+
+**The change.** In `tooling/satsuma-viz-harness/src/client/index.html:497`, replace:
+
+    Ctrl+scroll to zoom &middot; drag to pan &middot; use Fit button inside
+
+with:
+
+    Ctrl+scroll to zoom &middot; middle mouse drag to pan &middot; use Fit button inside
+
+**Why the current wording misleads.** "drag to pan" is simply not true of a plain left-drag. `tooling/satsuma-viz/src/satsuma-viz.ts:1917` gates panning on `e.button === 1 || (e.button === 0 && e.altKey)` — middle-button drag, or Alt held with left-drag. A reader who follows the hint literally left-drags, nothing pans, and they fall back to the minimap. That is exactly the journey #513 describes.
+
+The cursor feedback the issue asks for is already half-present: `satsuma-viz.ts:1925` sets `cursor: grabbing` while a pan is in progress and clears it at `:1938`. There is no `grab` cursor on hover, because there is no hover state that means "panning is available here" when the gesture is bound to a button the cursor cannot advertise.
+
+**Scope.**
+
+- The hint string occurs in exactly one place in the repo — the harness client. The VS Code webview and the site playground render no equivalent hint at all, so this ticket makes no change there. Whether those two hosts should also show it is worth a look while in the area; if they should, note it rather than expanding this ticket silently.
+- Alt+left-drag also pans and the accepted wording does not mention it. Left as-is deliberately: the user chose this exact string, and a hint that lists every binding stops being a hint. Worth mentioning in user docs instead if anywhere.
+- **Not covered here:** the original #513 request for left-drag-on-empty-canvas panning, Spacebar+drag, and a `grab` cursor on hover. Accepting the wording fix does not close that ask — it makes the existing behaviour discoverable. If the interaction work is still wanted, it needs its own ticket; flag this to the user before closing #513 so the issue is not closed on a strictly smaller change than it requested.
+
+## Acceptance Criteria
+
+- The harness toolbar hint reads exactly `Ctrl+scroll to zoom · middle mouse drag to pan · use Fit button inside`.
+- No behavioural change to panning or zooming — this is a copy fix only.
+- If any harness assertion or screenshot baseline pins the old hint text, it is updated in the same change.
+- Before the ticket closes, the user is told whether #513's interaction request (left-drag / Spacebar panning, hover `grab` cursor) is being carried into a follow-up ticket or dropped, so the GitHub issue is resolved on an accurate basis.
+

--- a/.tickets/vnm-kisd.md
+++ b/.tickets/vnm-kisd.md
@@ -1,0 +1,40 @@
+---
+id: vnm-kisd
+status: open
+deps: []
+links: [vnm-bak4]
+created: 2026-08-06T17:23:11Z
+type: bug
+priority: 2
+assignee: Thorben Louw
+tags: [viz, notes, markdown, ux]
+---
+# viz: field notes render Markdown as literal source text (schema, fragment and metric cards)
+
+Reported by a user: a field note written with a triple-quoted Markdown body renders in the visualiser as literal source text — the `**bold**` asterisks, the `#` heading hashes and the `-` bullets all show verbatim, and the line breaks collapse into one run. The user's reasonable follow-up was "if not, why would I use markdown as it doesn't seem to get formatted anywhere?"
+
+Markdown in a `"""` note is the documented contract, not a user misconception. SATSUMA-V2-SPEC.md:43 defines `""" """` as "multiline natural language with Markdown support ... Use for notes with headings, bold, lists, or multi-paragraph content", and the spec's own worked example at SATSUMA-V2-SPEC.md:225-239 is exactly this shape — a `PHONE_NBR VARCHAR(50) (note """ ... """)` whose body is a bulleted list with bold percentages and inline code. The visualiser should render it.
+
+**Where it breaks.** The payload is fine — this is purely a render-side gap:
+
+- `tooling/satsuma-viz/src/components/sz-schema-card.ts:1067-1079` — `_renderField` interpolates `${n.text}` straight into the Lit template. Lit escapes it, so the Markdown source is what a reader sees. The `.field-note` rule (`sz-schema-card.ts:629-640`) also has no `white-space: pre-wrap`, so even the line breaks a `"""` note carries are lost.
+- `tooling/satsuma-viz/src/components/sz-fragment-card.ts:257` and `tooling/satsuma-viz/src/components/sz-metric-card.ts:278` — same raw `${n.text}` for entity-level notes on those cards. Same bug class; fix together rather than leaving two known-raw sites behind.
+
+**The inconsistency this creates.** A `renderMarkdown` helper already exists (`tooling/satsuma-viz/src/markdown.ts:28`) and is already wired to entity-level schema notes (`sz-schema-card.ts:940`) and file-level notes (`satsuma-viz.ts:2353` and `:2591`). So the identical `"""` note renders formatted when attached to the schema and raw when attached to a field inside it — which is what makes this read as a bug rather than a missing feature.
+
+`viz-backend` already extracts field notes with the `isMultiline` flag set (`tooling/satsuma-viz-backend/src/viz-model.ts:1327`, and the `extractNoteBlock` doc-comment at `:1380-1384` states outright that the flag exists "so renderers can preserve formatting"). Nothing needs to change in the model or the backend.
+
+**Scope note.** `renderMarkdown` is a deliberately minimal converter (headings, lists, bold, italic, inline code, paragraphs) and escapes HTML — reuse it as-is; do not pull in a Markdown library. Consider whether `highlightAtRefs` should compose with it so `@ref` tokens inside a note still get their emphasis, as they do on arrow notes today (`sz-mapping-detail.ts:842`) — `renderMarkdown` currently does not highlight refs, so a note containing both loses one or the other. Field notes are laid out inside cards whose height the ELK layout estimates from geometry constants; `sz-schema-card.ts:99-102` already flags that field-note lines are *not* part of that estimate, so check a multi-line rendered note does not overlap neighbouring cards.
+
+Related: sl-1gqw introduced the shaded field-note row.
+
+## Acceptance Criteria
+
+- A field note written with `"""` renders its Markdown formatted in the schema card — headings, bullet and numbered lists, bold, italic and inline code — matching how the same note renders when attached to the schema itself.
+- Multi-line note content keeps its line structure; a single-line `"` note still wraps to the card width as it does today.
+- Fragment-card and metric-card entity-level notes render Markdown too, so no note site in the viz is left rendering raw source.
+- HTML in note text stays escaped — no injection through a note body (the existing `renderMarkdown` escaping must not be bypassed).
+- `@ref` tokens inside a note body remain visually distinguished, or the ticket records explicitly why they are not.
+- A rendered multi-line note does not overlap adjacent cards or break the ELK layout's card-height assumption.
+- Playwright harness coverage in `tooling/satsuma-viz-harness/test/harness.test.ts` asserts the rendered DOM of a Markdown field note (e.g. a `<ul>`/`<strong>` inside `.field-note`, not the literal `**`). There is no existing `describe` block for note rendering at all and no fixture with a Markdown field note — both need adding. Per AGENTS.md, this is painted output: a unit test on the converter proves the string transform, only a rendered browser proves the field row shows it.
+

--- a/.tickets/vnm-kisd.md
+++ b/.tickets/vnm-kisd.md
@@ -1,6 +1,6 @@
 ---
 id: vnm-kisd
-status: open
+status: closed
 deps: []
 links: [vnm-bak4]
 created: 2026-08-06T17:23:11Z
@@ -38,3 +38,25 @@ Related: sl-1gqw introduced the shaded field-note row.
 - A rendered multi-line note does not overlap adjacent cards or break the ELK layout's card-height assumption.
 - Playwright harness coverage in `tooling/satsuma-viz-harness/test/harness.test.ts` asserts the rendered DOM of a Markdown field note (e.g. a `<ul>`/`<strong>` inside `.field-note`, not the literal `**`). There is no existing `describe` block for note rendering at all and no fixture with a Markdown field note — both need adding. Per AGENTS.md, this is painted output: a unit test on the converter proves the string transform, only a rendered browser proves the field row shows it.
 
+
+## Notes
+
+**2026-08-06T18:15:18Z**
+
+**2026-08-06T18:20:00Z**
+
+Cause: `renderMarkdown` was wired only to entity-level schema notes and file
+notes; field notes (sz-schema-card), fragment-card and metric-card notes
+interpolated `${n.text}` raw. A second, deeper cause surfaced during the fix:
+note bodies keep their source indentation by design (SATSUMA-V2-SPEC.md:43),
+and every block rule in the converter anchors at line start — so simply wiring
+`renderMarkdown` in still rendered the spec's own PHONE_NBR example as one flat
+paragraph. This also silently affected the file-level notes that already used
+`renderMarkdown`.
+Fix: added `dedentNoteBody` (trims the first line, whose indentation the
+delimiter consumed, then strips the common indent from the rest) and composed
+`@ref` marking into the Markdown inline pipeline; extracted the four duplicated
+copies of the notes section into `satsuma-viz/src/notes.ts` so the drift that
+caused this cannot recur; gave `.field-note` card-scale Markdown child styles.
+Verified in a real browser — new "Note rendering" Playwright suite, 136 passed.
+(commit immediately after 3bbbcb0b)

--- a/examples/db-to-db/pipeline.stm
+++ b/examples/db-to-db/pipeline.stm
@@ -129,7 +129,17 @@ mapping `customer migration` {
   COMPANY_NM -> company_name { trim | null_if_empty }
 
   // --- Contact ---
-  EMAIL_ADDR -> email { trim | lowercase | validate_email | null_if_invalid }
+  EMAIL_ADDR -> email (note """
+    Applied **in order**, and a failure is never fatal:
+    - `trim` — leading and trailing whitespace only
+    - `lowercase` — domains are case-insensitive
+    - rows failing `validate_email` become NULL, they are not dropped
+    """) {
+    trim
+    | lowercase
+    | validate_email
+    | null_if_invalid
+  }
 
   PHONE_NBR -> phone {
     "Extract all digits. If 11 digits starting with 1, treat as US.

--- a/test-stats.json
+++ b/test-stats.json
@@ -7,7 +7,7 @@
     "satsuma-lsp": 303,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 197,
-    "satsuma-viz": 188,
+    "satsuma-viz": 201,
     "integration-tests": 3,
     "vscode-satsuma": 48
   }

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -85,6 +85,17 @@ const cycleUri = libraryUri("lineage-cycle/pipeline.stm");
  * enum values. No other fixture wired into this suite reaches that shape.
  */
 const multiSourceJoinUri = libraryUri("multi-source/multi-source-join.stm");
+/**
+ * The corpus's notes showcase, and the only fixture reaching all three note
+ * positions the viz renders (vnm-kisd, vnm-bak4):
+ *   - `legacy_sqlserver.PHONE_NBR` carries the five-bullet Markdown field note
+ *     the spec itself uses as its worked example (SATSUMA-V2-SPEC.md:225)
+ *   - `customer migration` opens with a three-bullet `note { }` block
+ *   - `EMAIL_ADDR -> email` carries a Markdown arrow note
+ * Every note here is indented in source, which is the shape that makes
+ * dedenting a precondition for Markdown rendering rather than a nicety.
+ */
+const dbToDbUri = libraryUri("db-to-db/pipeline.stm");
 
 /**
  * Open a specific named mapping by clicking its overview mapping card.
@@ -779,6 +790,109 @@ test.describe("Mapping detail — completed orders (multi-source join)", () => {
 // overflow, that the field row's own box stays put while it's open, or that
 // clicking away / Escape closes it again — only a rendered browser can.
 // ---------------------------------------------------------------------------
+
+test.describe("Note rendering — Markdown in field, mapping and arrow notes", () => {
+  /**
+   * Open the db-to-db customer-migration detail view, where all three note
+   * positions are visible at once.
+   */
+  async function openCustomerMigration(page: Page) {
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false; // app.js not evaluated yet
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, dbToDbUri);
+    return openMappingByName(page, "customer-migration");
+  }
+
+  test("renders a field note's Markdown as real formatting, not as literal source text", async ({
+    page,
+  }) => {
+    // The bug as reported: a `"""` note on a field showed its Markdown source.
+    // PHONE_NBR's note is the spec's own worked example, so what a reader sees
+    // here is the direct answer to "should I expect the visualiser to draw
+    // that markdown?".
+    const detail = await openCustomerMigration(page);
+    const cardPrefix = "mapping-detail-customer-migration-source-schema-card-legacy-sqlserver";
+    const note = detail.locator(`[data-testid^='${cardPrefix}'] .field-note`).first();
+
+    await expect(note).toBeVisible();
+    // Five bullets, each a real <li> — this is what a unit test on the
+    // converter cannot observe: that the list reaches the painted field row.
+    await expect(note.locator("li")).toHaveCount(5);
+    await expect(note.locator("strong").first()).toHaveText("42%");
+    await expect(note.locator("code").first()).toHaveText("(555) 123-4567");
+    // The markers themselves must be gone: their presence WAS the bug.
+    await expect(note).not.toContainText("**");
+  });
+
+  test("renders a mapping-level note block, which was previously dropped entirely", async ({
+    page,
+  }) => {
+    // `MappingBlock.notes` reached the payload and sz-mapping-detail never read
+    // it, so a `note { }` inside a mapping was invisible however it was
+    // written. Its bullets prove both that it renders and that it renders as
+    // Markdown.
+    const detail = await openCustomerMigration(page);
+    const notes = detail.locator("[data-testid='mapping-detail-customer-migration-notes']");
+
+    await expect(notes).toBeVisible();
+    await expect(notes).toContainText("Mapping assumptions");
+    await expect(notes.locator(".note-content li")).toHaveCount(3);
+  });
+
+  test("collapses and re-expands the mapping notes section on toggle click", async ({ page }) => {
+    // The section is expanded by default, so the toggle's whole job is
+    // reclaiming the space — a gesture only a real click in a real DOM proves.
+    const detail = await openCustomerMigration(page);
+    const notes = detail.locator("[data-testid='mapping-detail-customer-migration-notes']");
+    const toggle = detail.locator("[data-testid='mapping-detail-customer-migration-notes-toggle']");
+
+    await expect(notes.locator(".note-content")).toHaveCount(1);
+    await toggle.click();
+    await expect(notes.locator(".note-content")).toHaveCount(0);
+    await toggle.click();
+    await expect(notes.locator(".note-content")).toHaveCount(1);
+  });
+
+  test("renders an arrow note's Markdown beneath its arrow row", async ({ page }) => {
+    // Arrow notes always rendered, but through highlightAtRefs only, so their
+    // Markdown showed verbatim. The row must still sit under the arrow it
+    // documents rather than becoming an entity-level note.
+    const detail = await openCustomerMigration(page);
+    const noteRow = detail.locator("[data-testid$='-note'] .arrow-note").first();
+
+    await expect(noteRow).toBeVisible();
+    await expect(noteRow.locator("li")).toHaveCount(3);
+    await expect(noteRow.locator("strong").first()).toHaveText("in order");
+    await expect(noteRow.locator("code").first()).toHaveText("trim");
+    await expect(noteRow).not.toContainText("**");
+  });
+
+  test("shows a mapping with no notes exactly as before, with no empty section", async ({
+    page,
+  }) => {
+    // The notes section must cost nothing when a mapping has no notes —
+    // an empty toggle would take vertical space from every arrow table in the
+    // corpus.
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false;
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, sfdcUri);
+    const detail = await openMappingByName(page, "opportunity-ingestion");
+
+    await expect(
+      detail.locator("[data-testid='mapping-detail-opportunity-ingestion-notes']"),
+    ).toHaveCount(0);
+  });
+});
 
 test.describe("Field enum badge collapse/expand (sl-2ne7)", () => {
   test("collapses to a count, expands into an overlay without reflowing the row, and closes on a second click, outside click, or Escape", async ({

--- a/tooling/satsuma-viz/src/components/sz-fragment-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-fragment-card.ts
@@ -2,177 +2,142 @@ import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { FragmentCard, FieldEntry } from "../model.js";
 import { SzNavigateEvent } from "../satsuma-viz.js";
+import { noteSectionStyles, renderNotesSection } from "../notes.js";
 import { HEADER_HEIGHT, NAMESPACE_PILL_HEIGHT } from "../layout/geometry.js";
 
 @customElement("sz-fragment-card")
 export class SzFragmentCard extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      width: 100%;
-      box-sizing: border-box;
-      min-width: var(--sz-card-min-width, 240px);
-      max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius);
-      background: var(--sz-card-bg);
-      border: 1px solid var(--sz-card-border);
-      box-shadow: var(--sz-card-shadow);
-      overflow: hidden;
-      font-family: var(--sz-font-sans);
-    }
+  static override styles = [
+    noteSectionStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        min-width: var(--sz-card-min-width, 240px);
+        max-width: var(--sz-card-max-width, 380px);
+        border-radius: var(--sz-card-radius);
+        background: var(--sz-card-bg);
+        border: 1px solid var(--sz-card-border);
+        box-shadow: var(--sz-card-shadow);
+        overflow: hidden;
+        font-family: var(--sz-font-sans);
+      }
 
-    .header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
          sizes nodes and computes edge anchors from it, so the rendered header
          must occupy exactly that box (sl-wixe). Flex centres the content. */
-      height: ${HEADER_HEIGHT}px;
-      box-sizing: border-box;
-      padding: 0 12px;
-      background: var(--sz-green);
-      color: var(--sz-text-on-accent);
-      cursor: pointer;
-      user-select: none;
-    }
+        height: ${HEADER_HEIGHT}px;
+        box-sizing: border-box;
+        padding: 0 12px;
+        background: var(--sz-green);
+        color: var(--sz-text-on-accent);
+        cursor: pointer;
+        user-select: none;
+      }
 
-    /* Without a namespace pill row the header is the top of the card and
+      /* Without a namespace pill row the header is the top of the card and
        owns the top rounding (the host clips when overflow is hidden, but
        this keeps the geometry honest regardless of clipping). */
-    .header:first-child {
-      border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
-    }
+      .header:first-child {
+        border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
+      }
 
-    .header-icon {
-      font-size: 13px;
-      flex-shrink: 0;
-    }
+      .header-icon {
+        font-size: 13px;
+        flex-shrink: 0;
+      }
 
-    .header-name {
-      font-size: 14px;
-      font-weight: 600;
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+      .header-name {
+        font-size: 14px;
+        font-weight: 600;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
 
-    .header-count {
-      font-size: 11px;
-      opacity: 0.85;
-      flex-shrink: 0;
-    }
+      .header-count {
+        font-size: 11px;
+        opacity: 0.85;
+        flex-shrink: 0;
+      }
 
-    .header-toggle {
-      font-size: 12px;
-      flex-shrink: 0;
-      transition: transform 0.15s ease;
-    }
+      .header-toggle {
+        font-size: 12px;
+        flex-shrink: 0;
+        transition: transform 0.15s ease;
+      }
 
-    .header-toggle[data-collapsed] {
-      transform: rotate(-90deg);
-    }
+      .header-toggle[data-collapsed] {
+        transform: rotate(-90deg);
+      }
 
-    .fields {
-      padding: 4px 0;
-    }
+      .fields {
+        padding: 4px 0;
+      }
 
-    .field-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 3px 12px;
-      height: var(--sz-field-height);
-      cursor: pointer;
-    }
+      .field-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 12px;
+        height: var(--sz-field-height);
+        cursor: pointer;
+      }
 
-    .field-row:hover {
-      background: var(--sz-row-hover-bg);
-    }
+      .field-row:hover {
+        background: var(--sz-row-hover-bg);
+      }
 
-    .spread-icon {
-      font-size: 11px;
-      color: var(--sz-green);
-      flex-shrink: 0;
-    }
+      .spread-icon {
+        font-size: 11px;
+        color: var(--sz-green);
+        flex-shrink: 0;
+      }
 
-    .field-name {
-      font-family: var(--sz-font-mono);
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--sz-text);
-      flex: 1;
-    }
+      .field-name {
+        font-family: var(--sz-font-mono);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--sz-text);
+        flex: 1;
+      }
 
-    .field-type {
-      font-family: var(--sz-font-mono);
-      font-size: 11px;
-      color: var(--sz-text-muted);
-      flex-shrink: 0;
-    }
+      .field-type {
+        font-family: var(--sz-font-mono);
+        font-size: 11px;
+        color: var(--sz-text-muted);
+        flex-shrink: 0;
+      }
 
-    .badges {
-      display: flex;
-      gap: 3px;
-      flex-shrink: 0;
-    }
+      .badges {
+        display: flex;
+        gap: 3px;
+        flex-shrink: 0;
+      }
 
-    .badge {
-      font-family: var(--sz-font-sans);
-      font-size: 10px;
-      font-weight: 500;
-      padding: 1px 5px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-badge-bg);
-      color: var(--sz-badge-text);
-      line-height: 1.4;
-    }
+      .badge {
+        font-family: var(--sz-font-sans);
+        font-size: 10px;
+        font-weight: 500;
+        padding: 1px 5px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-badge-bg);
+        color: var(--sz-badge-text);
+        line-height: 1.4;
+      }
 
-    .collapsed .fields,
-    .collapsed .notes-section {
-      display: none;
-    }
-
-    .notes-section {
-      border-top: 1px dashed var(--sz-card-border);
-      padding: 6px 12px;
-    }
-
-    .notes-toggle {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      cursor: pointer;
-      font-size: 12px;
-      color: var(--sz-text-muted);
-      user-select: none;
-      padding: 2px 0;
-    }
-
-    .notes-toggle:hover {
-      color: var(--sz-text);
-    }
-
-    .notes-toggle .arrow {
-      font-size: 10px;
-      transition: transform 0.15s ease;
-    }
-
-    .notes-toggle .arrow[data-expanded] {
-      transform: rotate(90deg);
-    }
-
-    .note-content {
-      font-family: var(--sz-font-sans);
-      font-size: 12px;
-      color: var(--sz-text);
-      line-height: 1.5;
-      padding: 4px 0 2px 22px;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-  `;
+      .collapsed .fields,
+      .collapsed .notes-section {
+        display: none;
+      }
+    `,
+  ];
 
   @property({ type: Object })
   fragment: FragmentCard | null = null;
@@ -246,19 +211,11 @@ export class SzFragmentCard extends LitElement {
   }
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
-    return html`
-      <div class="notes-section">
-        <div class="notes-toggle" @click=${this._toggleNotes}>
-          <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
-          <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
-        </div>
-        ${
-          this._notesExpanded
-            ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
-            : ""
-        }
-      </div>
-    `;
+    return renderNotesSection({
+      notes,
+      expanded: this._notesExpanded,
+      onToggle: (e: Event) => this._toggleNotes(e),
+    });
   }
 
   private _toggleNotes(e: Event) {

--- a/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
+++ b/tooling/satsuma-viz/src/components/sz-mapping-detail.ts
@@ -8,6 +8,7 @@ import type {
   EachBlock,
   FlattenBlock,
   NestedArrowBlock,
+  NoteBlock,
 } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent } from "../satsuma-viz.js";
 import {
@@ -17,7 +18,8 @@ import {
   scopeWithin,
 } from "../field-coverage.js";
 import type { ContainerScope, MappingArrowVisit } from "../field-coverage.js";
-import { highlightAtRefs } from "../markdown.js";
+import { highlightAtRefs, renderMarkdown } from "../markdown.js";
+import { noteSectionStyles, renderNotesSection } from "../notes.js";
 import { qualifyChildArrowPath } from "@satsuma/core/extract";
 import { extractAtRefs } from "@satsuma/core/nl-ref";
 import type { SchemaCoverage } from "../field-coverage.js";
@@ -47,6 +49,28 @@ function sanitizeTestIdSegment(value: string): string {
 }
 
 /**
+ * Metadata key carrying note text. A `note` may be written either as a
+ * structural `note { }` block or as a `( note "..." )` metadata entry
+ * (SATSUMA-V2-SPEC.md:225 and :242); the two are the same thing to a reader,
+ * so both render in the notes section and neither renders as a metadata pill.
+ */
+const NOTE_METADATA_KEY = "note";
+
+/**
+ * Adapt a mapping's `( note "..." )` metadata entries into note blocks so they
+ * render beside the structural `note { }` blocks.
+ *
+ * `isMultiline` is false because a metadata note is written inline; the
+ * mapping's own location is reused since a `MetadataEntry` carries none, and
+ * the notes section does not navigate.
+ */
+function metadataNotesAsBlocks(m: MappingBlock): NoteBlock[] {
+  return (m.metadata ?? [])
+    .filter((entry) => entry.key === NOTE_METADATA_KEY)
+    .map((entry) => ({ text: entry.value, isMultiline: false, location: m.location }));
+}
+
+/**
  * Three-column mapping detail view.
  *
  * Left:   source schema cards (full fields)
@@ -58,287 +82,349 @@ function sanitizeTestIdSegment(value: string): string {
  */
 @customElement("sz-mapping-detail")
 export class SzMappingDetail extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      font-family: var(--sz-font-sans);
-    }
+  static override styles = [
+    noteSectionStyles,
+    css`
+      :host {
+        display: block;
+        font-family: var(--sz-font-sans);
+      }
 
-    .layout {
-      display: grid;
-      grid-template-columns: max-content max-content max-content;
-      gap: 16px;
-      align-items: start;
-      width: max-content;
-      min-width: 100%;
-    }
+      .layout {
+        display: grid;
+        grid-template-columns: max-content max-content max-content;
+        gap: 16px;
+        align-items: start;
+        width: max-content;
+        min-width: 100%;
+      }
 
-    /* Let schema cards grow to their content width instead of truncating to the viewport. */
-    .column sz-schema-card {
-      --sz-card-max-width: none;
-      width: max-content;
-      box-sizing: border-box;
-    }
+      /* Let schema cards grow to their content width instead of truncating to the viewport. */
+      .column sz-schema-card {
+        --sz-card-max-width: none;
+        width: max-content;
+        box-sizing: border-box;
+      }
 
-    .column {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      width: max-content;
-      min-width: 280px;
-    }
+      .column {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        width: max-content;
+        min-width: 280px;
+      }
 
-    .column-header {
-      font-size: 10px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--sz-text-muted);
-      padding: 0 4px 4px;
-      border-bottom: 1px solid var(--sz-card-border);
-    }
+      .column-header {
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--sz-text-muted);
+        padding: 0 4px 4px;
+        border-bottom: 1px solid var(--sz-card-border);
+      }
 
-    /* Mapping header */
-    .mapping-header {
-      background: var(--sz-card-bg);
-      border: 1px solid var(--sz-card-border);
-      border-radius: var(--sz-card-radius);
-      box-shadow: var(--sz-card-shadow);
-      overflow: hidden;
-      width: max-content;
-      min-width: 100%;
-    }
+      /* Mapping header */
+      .mapping-header {
+        background: var(--sz-card-bg);
+        border: 1px solid var(--sz-card-border);
+        border-radius: var(--sz-card-radius);
+        box-shadow: var(--sz-card-shadow);
+        overflow: hidden;
+        width: max-content;
+        min-width: 100%;
+      }
 
-    .mapping-title {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 10px 12px;
-      background: var(--sz-orange);
-      color: var(--sz-text-on-accent);
-      font-size: 14px;
-      font-weight: 600;
-      cursor: pointer;
-    }
+      .mapping-title {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 12px;
+        background: var(--sz-orange);
+        color: var(--sz-text-on-accent);
+        font-size: 14px;
+        font-weight: 600;
+        cursor: pointer;
+      }
 
-    .mapping-title:hover {
-      filter: brightness(0.95);
-    }
+      .mapping-title:hover {
+        filter: brightness(0.95);
+      }
 
-    .mapping-meta {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      padding: 8px 12px;
-      border-bottom: 1px solid var(--sz-card-border);
-    }
+      .mapping-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--sz-card-border);
+      }
 
-    .mapping-meta-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-      align-items: flex-start;
-    }
+      .mapping-meta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        align-items: flex-start;
+      }
 
-    .meta-tag {
-      font-size: 11px;
-      padding: 2px 8px;
-      border-radius: 4px;
-      background: var(--sz-badge-bg);
-      color: var(--sz-text-muted);
-      max-width: 100%;
-    }
+      .meta-tag {
+        font-size: 11px;
+        padding: 2px 8px;
+        border-radius: 4px;
+        background: var(--sz-badge-bg);
+        color: var(--sz-text-muted);
+        max-width: 100%;
+      }
 
-    .meta-tag .label {
-      color: var(--sz-orange-dark);
-      font-weight: 500;
-    }
+      .meta-tag .label {
+        color: var(--sz-orange-dark);
+        font-weight: 500;
+      }
 
-    .meta-tag.wrap {
-      max-width: 600px;
-      white-space: normal;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-    }
+      .meta-tag.wrap {
+        max-width: 600px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
 
-    /* Arrow table */
-    .arrow-table {
-      width: max-content;
-      min-width: 100%;
-      border-collapse: collapse;
-    }
+      /* Arrow table */
+      .arrow-table {
+        width: max-content;
+        min-width: 100%;
+        border-collapse: collapse;
+      }
 
-    .arrow-table th {
-      font-size: 10px;
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.05em;
-      color: var(--sz-text-muted);
-      text-align: left;
-      padding: 6px 12px;
-      border-bottom: 2px solid var(--sz-card-border);
-    }
+      .arrow-table th {
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--sz-text-muted);
+        text-align: left;
+        padding: 6px 12px;
+        border-bottom: 2px solid var(--sz-card-border);
+      }
 
-    /* Stated empty state for a mapping with no field arrows (sl-jetk). Muted
+      /* Stated empty state for a mapping with no field arrows (sl-jetk). Muted
        and italic so it reads as an explanation, not as table content. */
-    .arrow-table-empty {
-      padding: 10px 12px;
-      font-size: 12px;
-      font-style: italic;
-      line-height: 1.5;
-      color: var(--sz-text-muted);
-    }
+      .arrow-table-empty {
+        padding: 10px 12px;
+        font-size: 12px;
+        font-style: italic;
+        line-height: 1.5;
+        color: var(--sz-text-muted);
+      }
 
-    .arrow-table td {
-      padding: 5px 12px;
-      border-bottom: 1px solid var(--sz-card-border);
-      font-size: 12px;
-      vertical-align: top;
-    }
+      .arrow-table td {
+        padding: 5px 12px;
+        border-bottom: 1px solid var(--sz-card-border);
+        font-size: 12px;
+        vertical-align: top;
+      }
 
-    .arrow-table tr {
-      cursor: pointer;
-      transition:
-        opacity 0.15s ease,
-        background 0.15s ease;
-    }
+      .arrow-table tr {
+        cursor: pointer;
+        transition:
+          opacity 0.15s ease,
+          background 0.15s ease;
+      }
 
-    .arrow-table tr:hover {
-      background: var(--sz-row-hover-bg);
-    }
+      .arrow-table tr:hover {
+        background: var(--sz-row-hover-bg);
+      }
 
-    /* Cross-highlighting on arrow rows */
-    :host([has-highlight]) .arrow-table tr.arrow-row {
-      opacity: 0.5;
-    }
+      /* Cross-highlighting on arrow rows */
+      :host([has-highlight]) .arrow-table tr.arrow-row {
+        opacity: 0.5;
+      }
 
-    :host([has-highlight]) .arrow-table tr.arrow-row.hl {
-      opacity: 1;
-      background: var(--sz-accent-wash);
-    }
+      :host([has-highlight]) .arrow-table tr.arrow-row.hl {
+        opacity: 1;
+        background: var(--sz-accent-wash);
+      }
 
-    :host([has-highlight]) .arrow-table tr.arrow-row.hl .field-ref {
-      font-weight: 700;
-    }
+      :host([has-highlight]) .arrow-table tr.arrow-row.hl .field-ref {
+        font-weight: 700;
+      }
 
-    .field-ref {
-      font-family: var(--sz-font-mono, monospace);
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--sz-text);
-      white-space: normal;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-    }
+      .field-ref {
+        font-family: var(--sz-font-mono, monospace);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--sz-text);
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
 
-    .source-ref-list {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 2px;
-      max-width: 280px;
-    }
+      .source-ref-list {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        max-width: 280px;
+      }
 
-    .source-ref-item {
-      display: block;
-    }
+      .source-ref-item {
+        display: block;
+      }
 
-    /* Marker for an arrow with no source field (sl-k7i4). Deliberately not a
+      /* Marker for an arrow with no source field (sl-k7i4). Deliberately not a
        .field-ref: sans-serif, italic and muted so it cannot be misread as a
        field path, and so highlight styling for real paths never applies to it. */
-    .source-derived {
-      font-family: var(--sz-font-sans);
-      font-size: 11px;
-      font-style: italic;
-      color: var(--sz-text-muted);
-    }
+      .source-derived {
+        font-family: var(--sz-font-sans);
+        font-size: 11px;
+        font-style: italic;
+        color: var(--sz-text-muted);
+      }
 
-    .transform-cell {
-      width: 400px;
-      max-width: 400px;
-      min-width: 320px;
-      text-align: left;
-    }
+      .transform-cell {
+        width: 400px;
+        max-width: 400px;
+        min-width: 320px;
+        text-align: left;
+      }
 
-    .transform-nl {
-      display: inline-block;
-      font-style: italic;
-      font-size: 11px;
-      color: var(--sz-green);
-      max-width: 400px;
-      white-space: normal;
-      word-break: break-word;
-      overflow-wrap: anywhere;
-      text-align: left;
-    }
+      .transform-nl {
+        display: inline-block;
+        font-style: italic;
+        font-size: 11px;
+        color: var(--sz-green);
+        max-width: 400px;
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+        text-align: left;
+      }
 
-    .transform-bare {
-      font-size: 11px;
-      color: var(--sz-text-muted);
-    }
+      .transform-bare {
+        font-size: 11px;
+        color: var(--sz-text-muted);
+      }
 
-    /* @ref highlights inside NL transform text */
-    .at-ref {
-      font-weight: 600;
-      font-style: normal;
-      color: var(--sz-at-ref);
-    }
+      /* @ref highlights inside NL transform text */
+      .at-ref {
+        font-weight: 600;
+        font-style: normal;
+        color: var(--sz-at-ref);
+      }
 
-    .arrow-icon {
-      color: var(--sz-text-muted);
-      font-size: 11px;
-    }
+      .arrow-icon {
+        color: var(--sz-text-muted);
+        font-size: 11px;
+      }
 
-    /* Note row displayed beneath an arrow that carries a (note "...") tag. */
-    .arrow-note-row td {
-      padding: 0 12px 6px;
-    }
+      /* Note row displayed beneath an arrow that carries a (note "...") tag. */
+      .arrow-note-row td {
+        padding: 0 12px 6px;
+      }
 
-    .arrow-note {
-      font-family: var(--sz-font-sans);
-      font-size: 11px;
-      font-style: italic;
-      color: var(--sz-text-muted);
-      line-height: 1.4;
-      padding: 2px 8px;
-      background: var(--sz-row-hover-bg);
-      border-radius: 3px;
-      max-width: 400px;
-      word-break: break-word;
-    }
+      .arrow-note {
+        font-family: var(--sz-font-sans);
+        font-size: 11px;
+        font-style: italic;
+        color: var(--sz-text-muted);
+        line-height: 1.4;
+        padding: 2px 8px;
+        background: var(--sz-row-hover-bg);
+        border-radius: 3px;
+        max-width: 400px;
+        word-break: break-word;
+      }
 
-    /* Scope sections (each/flatten) */
-    .scope-section {
-      margin: 4px 0;
-    }
+      /*
+       * An arrow note's body is Markdown like any other note (vnm-bak4), so the
+       * block elements renderMarkdown emits need spacing tuned for a row
+       * squeezed between two arrows. Margins are tighter than .note-content's
+       * for that reason, and the last child drops its margin so a one-line note
+       * — by far the common case — keeps the compact single-line row it had
+       * before Markdown rendering was wired up.
+       */
+      .arrow-note p {
+        margin: 0 0 4px;
+      }
 
-    .scope-label {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 6px 12px;
-      font-size: 11px;
-      font-weight: 600;
-      color: var(--sz-text-muted);
-      background: var(--sz-namespace-bg);
-      border-top: 1px dashed var(--sz-card-border);
-    }
+      .arrow-note p:last-child,
+      .arrow-note ul:last-child,
+      .arrow-note ol:last-child {
+        margin-bottom: 0;
+      }
 
-    .scope-label .scope-tag {
-      font-family: var(--sz-font-mono);
-      font-size: 10px;
-      padding: 1px 6px;
-      border-radius: 3px;
-      background: var(--sz-orange-dark);
-      color: var(--sz-text-on-accent);
-    }
+      .arrow-note h1,
+      .arrow-note h2,
+      .arrow-note h3 {
+        font-size: 11px;
+        font-weight: 700;
+        font-style: normal;
+        margin: 4px 0 2px;
+      }
 
-    .scope-fields {
-      font-family: var(--sz-font-mono);
-      font-size: 11px;
-      color: var(--sz-text);
-    }
-  `;
+      .arrow-note ul,
+      .arrow-note ol {
+        margin: 0 0 4px;
+        padding-left: 16px;
+      }
+
+      .arrow-note li {
+        margin: 1px 0;
+      }
+
+      .arrow-note code {
+        font-family: var(--sz-font-mono);
+        font-style: normal;
+        font-size: 10px;
+        background: var(--sz-row-active-bg);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
+
+      .arrow-note strong {
+        font-weight: 700;
+        color: var(--sz-text);
+      }
+
+      /* The mapping-level notes section sits under the mapping header, so it
+         needs the card border treatment the shared styles assume plus a
+         background matching the surrounding mapping column. */
+      .mapping-notes {
+        background: var(--sz-card-bg);
+        border-bottom: 1px solid var(--sz-card-border);
+      }
+
+      /* Scope sections (each/flatten) */
+      .scope-section {
+        margin: 4px 0;
+      }
+
+      .scope-label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 12px;
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--sz-text-muted);
+        background: var(--sz-namespace-bg);
+        border-top: 1px dashed var(--sz-card-border);
+      }
+
+      .scope-label .scope-tag {
+        font-family: var(--sz-font-mono);
+        font-size: 10px;
+        padding: 1px 6px;
+        border-radius: 3px;
+        background: var(--sz-orange-dark);
+        color: var(--sz-text-on-accent);
+      }
+
+      .scope-fields {
+        font-family: var(--sz-font-mono);
+        font-size: 11px;
+        color: var(--sz-text);
+      }
+    `,
+  ];
 
   @property({ type: Object })
   mapping: MappingBlock | null = null;
@@ -382,6 +468,17 @@ export class SzMappingDetail extends LitElement {
   /** Schema ID of the card whose field is hovered. */
   @state()
   private _hoveredCardSchema: string | null = null;
+
+  /**
+   * Whether the mapping-level notes section is expanded.
+   *
+   * Defaults to open, matching `sz-schema-card` rather than the fragment and
+   * metric cards: a mapping's `note { }` block is the context a reader needs
+   * *before* reading its arrows, and it is the entity-level documentation for
+   * the thing the whole view is about.
+   */
+  @state()
+  private _notesExpanded = true;
 
   override connectedCallback() {
     super.connectedCallback();
@@ -629,7 +726,8 @@ export class SzMappingDetail extends LitElement {
 
         <div class="column" data-testid=${`${this.testIdPrefix}-mapping-column`}>
           <div class="column-header">Mapping</div>
-          ${this._renderMappingHeader(m)} ${this._renderArrowTable(m)}
+          ${this._renderMappingHeader(m)} ${this._renderMappingNotes(m)}
+          ${this._renderArrowTable(m)}
         </div>
 
         <div class="column" data-testid=${`${this.testIdPrefix}-target-column`}>
@@ -706,21 +804,67 @@ export class SzMappingDetail extends LitElement {
               </div>
             `,
           )}
-          ${m.metadata.map(
-            (entry) => html`
-              <div
-                class="mapping-meta-row"
-                data-testid=${`${this.testIdPrefix}-meta-${sanitizeTestIdSegment(entry.key)}`}
-              >
-                <span class="meta-tag wrap"
-                  ><span class="label">${entry.key}</span> ${entry.value}</span
-                >
-              </div>
-            `,
-          )}
+          ${
+            // `note` is withheld here and rendered by _renderMappingNotes
+            // instead — the same dedupe the schema card applies to its own
+            // note metadata, and the reason a `( note """...""" )` no longer
+            // shows as a raw multi-line blob inside a pill (vnm-bak4).
+            (m.metadata ?? [])
+              .filter((entry) => entry.key !== NOTE_METADATA_KEY)
+              .map(
+                (entry) => html`
+                  <div
+                    class="mapping-meta-row"
+                    data-testid=${`${this.testIdPrefix}-meta-${sanitizeTestIdSegment(entry.key)}`}
+                  >
+                    <span class="meta-tag wrap"
+                      ><span class="label">${entry.key}</span> ${entry.value}</span
+                    >
+                  </div>
+                `,
+              )
+          }
         </div>
       </div>
     `;
+  }
+
+  /**
+   * The mapping's own notes, rendered between the header and the arrow table.
+   *
+   * Two sources reach the reader here (vnm-bak4):
+   *   - `note { }` blocks in the mapping body or on the mapping itself, which
+   *     the backend collects into `MappingBlock.notes`
+   *   - a `note "..."` entry in the mapping's `( )` metadata block, which
+   *     {@link _renderMappingHeader} deliberately withholds from its pill row
+   *     so the two render in one place instead of two
+   *
+   * Renders nothing at all when the mapping carries no notes — an empty
+   * toggle would take vertical space from the arrow table for no information.
+   */
+  private _renderMappingNotes(m: MappingBlock) {
+    // Tolerate models serialized before MappingBlock carried notes (older LSP
+    // servers, cached webview payloads) — render no notes, don't take the
+    // whole detail view down with a spread over undefined. Same defence
+    // `sz-schema-card` applies to a field's metadata.
+    const notes = [...(m.notes ?? []), ...metadataNotesAsBlocks(m)];
+    if (notes.length === 0) return nothing;
+
+    return html`
+      <div class="mapping-notes">
+        ${renderNotesSection({
+          notes,
+          expanded: this._notesExpanded,
+          onToggle: (e: Event) => this._toggleNotes(e),
+          testIdPrefix: this.testIdPrefix,
+        })}
+      </div>
+    `;
+  }
+
+  private _toggleNotes(e: Event) {
+    e.stopPropagation();
+    this._notesExpanded = !this._notesExpanded;
   }
 
   /**
@@ -839,7 +983,7 @@ export class SzMappingDetail extends LitElement {
         noteEntry
           ? html`<tr class="arrow-note-row" data-testid=${`${rowTestId}-note`}>
               <td colspan="4">
-                <span class="arrow-note">${unsafeHTML(highlightAtRefs(noteEntry.value))}</span>
+                <div class="arrow-note">${unsafeHTML(renderMarkdown(noteEntry.value))}</div>
               </td>
             </tr>`
           : ""

--- a/tooling/satsuma-viz/src/components/sz-metric-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-metric-card.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import type { MetricCard, MetricFieldEntry } from "../model.js";
 import { SzNavigateEvent } from "../satsuma-viz.js";
+import { noteSectionStyles, renderNotesSection } from "../notes.js";
 import { HEADER_HEIGHT, NAMESPACE_PILL_HEIGHT } from "../layout/geometry.js";
 
 const MEASURE_ICONS: Record<string, string> = {
@@ -12,171 +13,135 @@ const MEASURE_ICONS: Record<string, string> = {
 
 @customElement("sz-metric-card")
 export class SzMetricCard extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      width: 100%;
-      box-sizing: border-box;
-      min-width: var(--sz-card-min-width, 240px);
-      max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius);
-      background: var(--sz-card-bg);
-      border: 1px solid var(--sz-card-border);
-      box-shadow: var(--sz-card-shadow);
-      overflow: hidden;
-      font-family: var(--sz-font-sans);
-    }
+  static override styles = [
+    noteSectionStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        min-width: var(--sz-card-min-width, 240px);
+        max-width: var(--sz-card-max-width, 380px);
+        border-radius: var(--sz-card-radius);
+        background: var(--sz-card-bg);
+        border: 1px solid var(--sz-card-border);
+        box-shadow: var(--sz-card-shadow);
+        overflow: hidden;
+        font-family: var(--sz-font-sans);
+      }
 
-    .header {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
          sizes nodes and computes edge anchors from it, so the rendered header
          must occupy exactly that box (sl-wixe). Flex centres the content. */
-      height: ${HEADER_HEIGHT}px;
-      box-sizing: border-box;
-      padding: 0 12px;
-      background: var(--sz-violet);
-      color: var(--sz-text-on-accent);
-      cursor: pointer;
-      user-select: none;
-    }
+        height: ${HEADER_HEIGHT}px;
+        box-sizing: border-box;
+        padding: 0 12px;
+        background: var(--sz-violet);
+        color: var(--sz-text-on-accent);
+        cursor: pointer;
+        user-select: none;
+      }
 
-    /* Without a namespace pill row the header is the top of the card and
+      /* Without a namespace pill row the header is the top of the card and
        owns the top rounding (the host clips when overflow is hidden, but
        this keeps the geometry honest regardless of clipping). */
-    .header:first-child {
-      border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
-    }
+      .header:first-child {
+        border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
+      }
 
-    .header-icon {
-      font-size: 14px;
-      flex-shrink: 0;
-    }
+      .header-icon {
+        font-size: 14px;
+        flex-shrink: 0;
+      }
 
-    .header-name {
-      font-size: 14px;
-      font-weight: 600;
-      flex: 1;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
+      .header-name {
+        font-size: 14px;
+        font-weight: 600;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
 
-    .header-toggle {
-      font-size: 12px;
-      flex-shrink: 0;
-      transition: transform 0.15s ease;
-    }
+      .header-toggle {
+        font-size: 12px;
+        flex-shrink: 0;
+        transition: transform 0.15s ease;
+      }
 
-    .header-toggle[data-collapsed] {
-      transform: rotate(-90deg);
-    }
+      .header-toggle[data-collapsed] {
+        transform: rotate(-90deg);
+      }
 
-    .meta {
-      padding: 4px 12px 6px;
-      font-size: 11px;
-      color: var(--sz-text-muted);
-      border-bottom: 1px solid var(--sz-card-border);
-      line-height: 1.5;
-    }
+      .meta {
+        padding: 4px 12px 6px;
+        font-size: 11px;
+        color: var(--sz-text-muted);
+        border-bottom: 1px solid var(--sz-card-border);
+        line-height: 1.5;
+      }
 
-    .meta-row {
-      display: flex;
-      gap: 6px;
-    }
+      .meta-row {
+        display: flex;
+        gap: 6px;
+      }
 
-    .meta-label {
-      opacity: 0.7;
-    }
+      .meta-label {
+        opacity: 0.7;
+      }
 
-    .fields {
-      padding: 4px 0;
-    }
+      .fields {
+        padding: 4px 0;
+      }
 
-    .field-row {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 3px 12px;
-      height: var(--sz-field-height);
-      cursor: pointer;
-    }
+      .field-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 12px;
+        height: var(--sz-field-height);
+        cursor: pointer;
+      }
 
-    .field-row:hover {
-      background: var(--sz-row-hover-bg);
-    }
+      .field-row:hover {
+        background: var(--sz-row-hover-bg);
+      }
 
-    .measure-icon {
-      width: 16px;
-      text-align: center;
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--sz-violet);
-      flex-shrink: 0;
-    }
+      .measure-icon {
+        width: 16px;
+        text-align: center;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--sz-violet);
+        flex-shrink: 0;
+      }
 
-    .field-name {
-      font-family: var(--sz-font-mono);
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--sz-text);
-      flex: 1;
-    }
+      .field-name {
+        font-family: var(--sz-font-mono);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--sz-text);
+        flex: 1;
+      }
 
-    .field-type {
-      font-family: var(--sz-font-mono);
-      font-size: 11px;
-      color: var(--sz-text-muted);
-      flex-shrink: 0;
-    }
+      .field-type {
+        font-family: var(--sz-font-mono);
+        font-size: 11px;
+        color: var(--sz-text-muted);
+        flex-shrink: 0;
+      }
 
-    .collapsed .fields,
-    .collapsed .meta,
-    .collapsed .notes-section {
-      display: none;
-    }
-
-    .notes-section {
-      border-top: 1px dashed var(--sz-card-border);
-      padding: 6px 12px;
-    }
-
-    .notes-toggle {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      cursor: pointer;
-      font-size: 12px;
-      color: var(--sz-text-muted);
-      user-select: none;
-      padding: 2px 0;
-    }
-
-    .notes-toggle:hover {
-      color: var(--sz-text);
-    }
-
-    .notes-toggle .arrow {
-      font-size: 10px;
-      transition: transform 0.15s ease;
-    }
-
-    .notes-toggle .arrow[data-expanded] {
-      transform: rotate(90deg);
-    }
-
-    .note-content {
-      font-family: var(--sz-font-sans);
-      font-size: 12px;
-      color: var(--sz-text);
-      line-height: 1.5;
-      padding: 4px 0 2px 22px;
-      white-space: pre-wrap;
-      word-break: break-word;
-    }
-  `;
+      .collapsed .fields,
+      .collapsed .meta,
+      .collapsed .notes-section {
+        display: none;
+      }
+    `,
+  ];
 
   @property({ type: Object })
   metric: MetricCard | null = null;
@@ -267,19 +232,11 @@ export class SzMetricCard extends LitElement {
   }
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
-    return html`
-      <div class="notes-section">
-        <div class="notes-toggle" @click=${this._toggleNotes}>
-          <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
-          <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
-        </div>
-        ${
-          this._notesExpanded
-            ? notes.map((n) => html`<div class="note-content">${n.text}</div>`)
-            : ""
-        }
-      </div>
-    `;
+    return renderNotesSection({
+      notes,
+      expanded: this._notesExpanded,
+      onToggle: (e: Event) => this._toggleNotes(e),
+    });
   }
 
   private _toggleNotes(e: Event) {

--- a/tooling/satsuma-viz/src/components/sz-schema-card.ts
+++ b/tooling/satsuma-viz/src/components/sz-schema-card.ts
@@ -4,6 +4,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { SchemaCard, FieldEntry, MetadataEntry } from "../model.js";
 import { SzNavigateEvent, SzFieldHoverEvent, SzFieldLineageEvent } from "../satsuma-viz.js";
 import { renderMarkdown } from "../markdown.js";
+import { noteSectionStyles, renderNotesSection } from "../notes.js";
 import type { FieldCoverageEntry, FieldCoverageState } from "@satsuma/core/coverage";
 import { uncoveredFieldCoverage } from "@satsuma/core/coverage";
 import { toCoverageFields } from "../field-coverage.js";
@@ -76,582 +77,566 @@ function sanitizeTestIdSegment(value: string): string {
 
 @customElement("sz-schema-card")
 export class SzSchemaCard extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      width: 100%;
-      box-sizing: border-box;
-      min-width: var(--sz-card-min-width, 240px);
-      max-width: var(--sz-card-max-width, 380px);
-      border-radius: var(--sz-card-radius);
-      background: var(--sz-card-bg);
-      border: 1px solid var(--sz-card-border);
-      box-shadow: var(--sz-card-shadow);
-      overflow: hidden;
-      font-family: var(--sz-font-sans);
-    }
+  static override styles = [
+    noteSectionStyles,
+    css`
+      :host {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        min-width: var(--sz-card-min-width, 240px);
+        max-width: var(--sz-card-max-width, 380px);
+        border-radius: var(--sz-card-radius);
+        background: var(--sz-card-bg);
+        border: 1px solid var(--sz-card-border);
+        box-shadow: var(--sz-card-shadow);
+        overflow: hidden;
+        font-family: var(--sz-font-sans);
+      }
 
-    :host([content-width]) {
-      width: max-content;
-      max-width: none;
-    }
+      :host([content-width]) {
+        width: max-content;
+        max-width: none;
+      }
 
-    /*
+      /*
      * While a compact card is expanded, the overview layout sizes its node
      * from a height ESTIMATE (field-note lines are not estimated), so let any
      * small overshoot paint past the host instead of being clipped.
      */
-    :host([compact-expanded]) {
-      overflow: visible;
-    }
+      :host([compact-expanded]) {
+        overflow: visible;
+      }
 
-    /* A field's enum overlay (sl-2ne7) paints outside its field row, and
+      /* A field's enum overlay (sl-2ne7) paints outside its field row, and
        the row sits inside a non-compact card's normal-flow field list —
        which clips by default, unlike a compact-expanded card. Reflected
        whenever an overlay is open so it can escape whichever card hosts
        it, then removed on collapse to restore ordinary clipping. */
-    :host([has-enum-overlay]) {
-      overflow: visible;
-    }
+      :host([has-enum-overlay]) {
+        overflow: visible;
+      }
 
-    .header {
-      position: relative;
-      overflow: hidden;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
+      .header {
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        /* Pinned to the shared HEADER_HEIGHT geometry constant: the ELK layout
          sizes nodes and computes edge anchors from it, so the rendered header
          must occupy exactly that box (sl-wixe). Flex centres the content. */
-      height: ${HEADER_HEIGHT}px;
-      box-sizing: border-box;
-      padding: 0 12px;
-      background: var(--sz-orange);
-      color: var(--sz-text-on-accent);
-      cursor: pointer;
-      user-select: none;
-    }
+        height: ${HEADER_HEIGHT}px;
+        box-sizing: border-box;
+        padding: 0 12px;
+        background: var(--sz-orange);
+        color: var(--sz-text-on-accent);
+        cursor: pointer;
+        user-select: none;
+      }
 
-    /* Coverage changes paint only this inset layer; the header's box model and
+      /* Coverage changes paint only this inset layer; the header's box model and
        therefore every overview-layout coordinate remain untouched (sl-5m9x). */
-    .coverage-fill {
-      position: absolute;
-      inset: 0 auto 0 0;
-      width: var(--sz-coverage-percent, 0%);
-      background: var(--sz-coverage-fill);
-      pointer-events: none;
-    }
+      .coverage-fill {
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: var(--sz-coverage-percent, 0%);
+        background: var(--sz-coverage-fill);
+        pointer-events: none;
+      }
 
-    .header > :not(.coverage-fill) {
-      position: relative;
-      z-index: 1;
-    }
+      .header > :not(.coverage-fill) {
+        position: relative;
+        z-index: 1;
+      }
 
-    /* Without a namespace pill row the header is the top of the card and
+      /* Without a namespace pill row the header is the top of the card and
        owns the top rounding. The host normally clips (overflow: hidden), but
        compact-expanded cards set overflow: visible, so the rounding must be
        on the header itself. */
-    .header:first-child {
-      border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
-    }
+      .header:first-child {
+        border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
+      }
 
-    /* The namespace pill row, when present, is the top of the card — so the
+      /* The namespace pill row, when present, is the top of the card — so the
        header is no longer :first-child and the rule above cannot fire. This
        row therefore owns the top rounding for a namespaced card; without it
        such a card's top corners went square the moment compact-expanded
        dropped the host's clip (sl-yedr). Pinned to the shared
        NAMESPACE_PILL_HEIGHT the overview layout reserves for this row. */
-    .namespace-pill-row {
-      height: ${NAMESPACE_PILL_HEIGHT}px;
-      box-sizing: border-box;
-      display: flex;
-      align-items: end;
-      padding: 0 12px;
-      background: var(--sz-orange);
-    }
+      .namespace-pill-row {
+        height: ${NAMESPACE_PILL_HEIGHT}px;
+        box-sizing: border-box;
+        display: flex;
+        align-items: end;
+        padding: 0 12px;
+        background: var(--sz-orange);
+      }
 
-    .namespace-pill-row:first-child {
-      border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
-    }
+      .namespace-pill-row:first-child {
+        border-radius: var(--sz-card-radius) var(--sz-card-radius) 0 0;
+      }
 
-    .namespace-pill-chip {
-      display: inline-block;
-      font-size: 10px;
-      font-weight: 700;
-      padding: 1px 8px;
-      border-radius: 999px;
-      background: var(--sz-namespace-pill-chip-bg);
-      color: var(--sz-orange-dark);
-    }
+      .namespace-pill-chip {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 700;
+        padding: 1px 8px;
+        border-radius: 999px;
+        background: var(--sz-namespace-pill-chip-bg);
+        color: var(--sz-orange-dark);
+      }
 
-    .header.report {
-      background: var(--sz-report);
-    }
+      .header.report {
+        background: var(--sz-report);
+      }
 
-    .header-icon {
-      width: 16px;
-      height: 16px;
-      flex-shrink: 0;
-    }
+      .header-icon {
+        width: 16px;
+        height: 16px;
+        flex-shrink: 0;
+      }
 
-    .header-name {
-      font-size: 14px;
-      font-weight: 600;
-      flex: 1;
-      overflow: var(--sz-header-name-overflow);
-      text-overflow: var(--sz-header-name-overflow-mode);
-      white-space: nowrap;
-    }
+      .header-name {
+        font-size: 14px;
+        font-weight: 600;
+        flex: 1;
+        overflow: var(--sz-header-name-overflow);
+        text-overflow: var(--sz-header-name-overflow-mode);
+        white-space: nowrap;
+      }
 
-    .header-count {
-      font-size: 11px;
-      opacity: 0.85;
-      flex-shrink: 0;
-      /* Part of the toggle's click target, not the navigate target: the arrow
+      .header-count {
+        font-size: 11px;
+        opacity: 0.85;
+        flex-shrink: 0;
+        /* Part of the toggle's click target, not the navigate target: the arrow
          glyph alone is a poor Fitts's-law target on a compact overview card
          (sl-6g23). The count is the one other header element whose meaning is
          "the fields", so it toggles them; the name and icon still navigate.
          Padding only — no margin offset — so the header's fixed-height box and
          every coordinate the ELK layout derives from it stay untouched. */
-      cursor: pointer;
-      padding: 4px 0;
-    }
+        cursor: pointer;
+        padding: 4px 0;
+      }
 
-    .coverage-badge {
-      padding: 1px 5px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-coverage-badge-bg);
-      color: var(--sz-text-on-accent);
-      font-size: 10px;
-      font-weight: 700;
-      line-height: 1.4;
-      flex-shrink: 0;
-    }
+      .coverage-badge {
+        padding: 1px 5px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-coverage-badge-bg);
+        color: var(--sz-text-on-accent);
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1.4;
+        flex-shrink: 0;
+      }
 
-    .header-toggle {
-      font-size: 12px;
-      flex-shrink: 0;
-      transition: transform 0.15s ease;
-      /* The arrow is its own click target (toggle only, never navigate —
+      .header-toggle {
+        font-size: 12px;
+        flex-shrink: 0;
+        transition: transform 0.15s ease;
+        /* The arrow is its own click target (toggle only, never navigate —
          sl-tw0r); pad it so the hit area is comfortably larger than the
          12px glyph. */
-      padding: 4px 6px;
-      margin: -4px -6px;
-      cursor: pointer;
-    }
+        padding: 4px 6px;
+        margin: -4px -6px;
+        cursor: pointer;
+      }
 
-    .header-toggle[data-collapsed] {
-      transform: rotate(-90deg);
-    }
+      .header-toggle[data-collapsed] {
+        transform: rotate(-90deg);
+      }
 
-    .label {
-      padding: 4px 12px 6px;
-      font-size: 12px;
-      color: var(--sz-text-muted);
-      font-style: italic;
-      border-bottom: 1px solid var(--sz-card-border);
-      max-width: 400px;
-      word-break: break-word;
-    }
+      .label {
+        padding: 4px 12px 6px;
+        font-size: 12px;
+        color: var(--sz-text-muted);
+        font-style: italic;
+        border-bottom: 1px solid var(--sz-card-border);
+        max-width: 400px;
+        word-break: break-word;
+      }
 
-    .fields {
-      padding: 4px 0;
-    }
+      .fields {
+        padding: 4px 0;
+      }
 
-    .field-row {
-      position: relative;
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      padding: 3px 12px;
-      height: var(--sz-field-height);
-      cursor: pointer;
-    }
+      .field-row {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 12px;
+        height: var(--sz-field-height);
+        cursor: pointer;
+      }
 
-    .field-row:hover {
-      background: var(--sz-row-hover-bg);
-    }
+      .field-row:hover {
+        background: var(--sz-row-hover-bg);
+      }
 
-    .port {
-      width: var(--sz-port-size);
-      height: var(--sz-port-size);
-      border-radius: 50%;
-      flex-shrink: 0;
-    }
+      .port {
+        width: var(--sz-port-size);
+        height: var(--sz-port-size);
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
 
-    .port.mapped {
-      background: var(--sz-orange-dark);
-    }
+      .port.mapped {
+        background: var(--sz-orange-dark);
+      }
 
-    .port.unmapped {
-      border: 1.5px solid var(--sz-text-muted);
-      background: transparent;
-    }
+      .port.unmapped {
+        border: 1.5px solid var(--sz-text-muted);
+        background: transparent;
+      }
 
-    /* Partly covered: something under this record is mapped and something is
+      /* Partly covered: something under this record is mapped and something is
        not. A half-filled dot inside an accent ring reads as the state between
        the solid dot and the hollow one, and it is a difference in *shape* — at
        the 8px port size a difference in shade alone would not survive (sl-f0x6).
        The ring takes the accent rather than the muted outline of .port.unmapped
        because part of this subtree is mapped; the unfilled half is what still
        needs attention. */
-    .port.partial {
-      border: 1.5px solid var(--sz-orange-dark);
-      background: linear-gradient(to right, var(--sz-orange-dark) 0 50%, transparent 50% 100%);
-    }
+      .port.partial {
+        border: 1.5px solid var(--sz-orange-dark);
+        background: linear-gradient(to right, var(--sz-orange-dark) 0 50%, transparent 50% 100%);
+      }
 
-    /* Coverage not computed: neither filled nor the hollow ring that reads as a
+      /* Coverage not computed: neither filled nor the hollow ring that reads as a
        gap. A dashed, faded outline says "no verdict" rather than "no coverage"
        — see the coverage property's doc comment. */
-    .port.unknown {
-      border: 1.5px dashed var(--sz-text-muted);
-      background: transparent;
-      opacity: 0.45;
-    }
+      .port.unknown {
+        border: 1.5px dashed var(--sz-text-muted);
+        background: transparent;
+        opacity: 0.45;
+      }
 
-    .field-name {
-      font-family: var(--sz-font-mono);
-      font-size: 12px;
-      font-weight: 500;
-      color: var(--sz-text);
-      flex: var(--sz-field-name-flex);
-      overflow: var(--sz-field-name-overflow);
-      text-overflow: var(--sz-field-name-overflow-mode);
-      white-space: nowrap;
-    }
+      .field-name {
+        font-family: var(--sz-font-mono);
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--sz-text);
+        flex: var(--sz-field-name-flex);
+        overflow: var(--sz-field-name-overflow);
+        text-overflow: var(--sz-field-name-overflow-mode);
+        white-space: nowrap;
+      }
 
-    .field-type {
-      font-family: var(--sz-font-mono);
-      font-size: 11px;
-      color: var(--sz-text-muted);
-      flex-shrink: 0;
-    }
+      .field-type {
+        font-family: var(--sz-font-mono);
+        font-size: 11px;
+        color: var(--sz-text-muted);
+        flex-shrink: 0;
+      }
 
-    .badges {
-      display: flex;
-      gap: 3px;
-      flex-shrink: 0;
-    }
+      .badges {
+        display: flex;
+        gap: 3px;
+        flex-shrink: 0;
+      }
 
-    .badge {
-      font-family: var(--sz-font-sans);
-      font-size: 10px;
-      font-weight: 500;
-      padding: 1px 5px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-badge-bg);
-      color: var(--sz-badge-text);
-      line-height: 1.4;
-    }
+      .badge {
+        font-family: var(--sz-font-sans);
+        font-size: 10px;
+        font-weight: 500;
+        padding: 1px 5px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-badge-bg);
+        color: var(--sz-badge-text);
+        line-height: 1.4;
+      }
 
-    /* Field-level metadata pill (sl-6x1o): same chip shape as constraint
+      /* Field-level metadata pill (sl-6x1o): same chip shape as constraint
        badges; the key is emphasised so "sensitivity internal" reads as
        key + value at a glance. */
-    .badge.field-meta .badge-key {
-      font-weight: 700;
-      opacity: 0.85;
-    }
+      .badge.field-meta .badge-key {
+        font-weight: 700;
+        opacity: 0.85;
+      }
 
-    .badge.pii {
-      background: var(--sz-warning-bg);
-      color: var(--sz-warning-icon);
-    }
+      .badge.pii {
+        background: var(--sz-warning-bg);
+        color: var(--sz-warning-icon);
+      }
 
-    /* An enum badge always shows only its collapsed count (sl-2ne7): joining
+      /* An enum badge always shows only its collapsed count (sl-2ne7): joining
        every value into one pill ("enum enterprise | mid_market | smb |
        individual") made a single constraint the widest thing on the row.
        Values are legible on demand, in the overlay below. */
-    .badge.enum-badge {
-      cursor: pointer;
-    }
+      .badge.enum-badge {
+        cursor: pointer;
+      }
 
-    /* Positioned against the field row (.field-row is its containing block),
+      /* Positioned against the field row (.field-row is its containing block),
        not the small inline badge, so the panel reads as belonging to the row
        rather than hanging off one word inside it. Floats below the row
        instead of reflowing it — the row's own box is untouched, so the ELK
        layout's field-row height estimate still holds while this is open. */
-    .enum-overlay {
-      position: absolute;
-      top: 100%;
-      left: 12px;
-      right: 12px;
-      margin-top: 2px;
-      z-index: 50;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 4px;
-      padding: 8px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-card-bg);
-      border: 1px solid var(--sz-card-border);
-      box-shadow: var(--sz-card-shadow);
-      cursor: default;
-    }
+      .enum-overlay {
+        position: absolute;
+        top: 100%;
+        left: 12px;
+        right: 12px;
+        margin-top: 2px;
+        z-index: 50;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        padding: 8px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-card-bg);
+        border: 1px solid var(--sz-card-border);
+        box-shadow: var(--sz-card-shadow);
+        cursor: default;
+      }
 
-    .enum-overlay .enum-value-chip {
-      font-family: var(--sz-font-sans);
-      font-size: 10px;
-      font-weight: 500;
-      padding: 1px 5px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-badge-bg);
-      color: var(--sz-badge-text);
-      line-height: 1.4;
-    }
+      .enum-overlay .enum-value-chip {
+        font-family: var(--sz-font-sans);
+        font-size: 10px;
+        font-weight: 500;
+        padding: 1px 5px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-badge-bg);
+        color: var(--sz-badge-text);
+        line-height: 1.4;
+      }
 
-    .comment-badge {
-      width: 16px;
-      height: 16px;
-      border-radius: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 10px;
-      font-weight: 700;
-      flex-shrink: 0;
-      cursor: help;
-    }
+      .comment-badge {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 10px;
+        font-weight: 700;
+        flex-shrink: 0;
+        cursor: help;
+      }
 
-    .comment-badge.warning {
-      background: var(--sz-warning-bg);
-      color: var(--sz-warning-icon);
-    }
+      .comment-badge.warning {
+        background: var(--sz-warning-bg);
+        color: var(--sz-warning-icon);
+      }
 
-    .comment-badge.question {
-      background: var(--sz-question-bg);
-      color: var(--sz-question-icon);
-    }
+      .comment-badge.question {
+        background: var(--sz-question-bg);
+        color: var(--sz-question-icon);
+      }
 
-    .nested {
-      padding-left: 20px;
-    }
+      .nested {
+        padding-left: 20px;
+      }
 
-    .collapsed .fields {
-      display: none;
-    }
+      .collapsed .fields {
+        display: none;
+      }
 
-    .collapsed .label,
-    .collapsed .metadata-pills {
-      display: none;
-    }
+      .collapsed .label,
+      .collapsed .metadata-pills {
+        display: none;
+      }
 
-    .collapsed .notes-section {
-      display: none;
-    }
+      .collapsed .notes-section {
+        display: none;
+      }
 
-    .metadata-pills {
-      /* Pills stack one per row and are EXCLUDED from the card's intrinsic
+      .metadata-pills {
+        /* Pills stack one per row and are EXCLUDED from the card's intrinsic
          width (contain: inline-size) — a long metadata value such as a
          namespace URI must never widen the card beyond what its field rows
          need (sl-dw9x). Overlong values end-truncate; the full text lives in
          each pill's title tooltip. Row heights are pinned to the shared
          geometry constants the layout estimates with. */
-      contain: inline-size;
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: ${META_PILL_ROW_GAP}px;
-      padding: 4px 12px 6px;
-      border-bottom: 1px solid var(--sz-card-border);
-    }
+        contain: inline-size;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: ${META_PILL_ROW_GAP}px;
+        padding: 4px 12px 6px;
+        border-bottom: 1px solid var(--sz-card-border);
+      }
 
-    .meta-pill {
-      font-family: var(--sz-font-sans);
-      font-size: 10px;
-      font-weight: 500;
-      height: ${META_PILL_ROW_HEIGHT}px;
-      box-sizing: border-box;
-      padding: 1px 6px;
-      border-radius: var(--sz-badge-radius);
-      background: var(--sz-namespace-bg);
-      color: var(--sz-text-muted);
-      line-height: 1.4;
-      white-space: nowrap;
-      max-width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+      .meta-pill {
+        font-family: var(--sz-font-sans);
+        font-size: 10px;
+        font-weight: 500;
+        height: ${META_PILL_ROW_HEIGHT}px;
+        box-sizing: border-box;
+        padding: 1px 6px;
+        border-radius: var(--sz-badge-radius);
+        background: var(--sz-namespace-bg);
+        color: var(--sz-text-muted);
+        line-height: 1.4;
+        white-space: nowrap;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
-    .meta-pill .meta-key {
-      color: var(--sz-orange-dark);
-    }
+      .meta-pill .meta-key {
+        color: var(--sz-orange-dark);
+      }
 
-    .spread-indicator {
-      display: flex;
-      align-items: center;
-      gap: 4px;
-      padding: 3px 12px;
-      font-size: 11px;
-      color: var(--sz-green);
-      border-top: 1px dotted var(--sz-green);
-    }
+      .spread-indicator {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 12px;
+        font-size: 11px;
+        color: var(--sz-green);
+        border-top: 1px dotted var(--sz-green);
+      }
 
-    .spread-indicator .spread-icon {
-      font-size: 10px;
-    }
+      .spread-indicator .spread-icon {
+        font-size: 10px;
+      }
 
-    .notes-section {
-      border-top: 1px dashed var(--sz-card-border);
-      padding: 6px 12px;
-    }
+      .lineage-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border: none;
+        border-radius: 3px;
+        background: transparent;
+        color: var(--sz-text-muted);
+        cursor: pointer;
+        flex-shrink: 0;
+        padding: 0;
+        opacity: 0;
+        transition:
+          opacity 0.1s,
+          background 0.1s;
+      }
 
-    .notes-toggle {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      cursor: pointer;
-      font-size: 12px;
-      color: var(--sz-text-muted);
-      user-select: none;
-      padding: 2px 0;
-    }
+      .field-row:hover .lineage-btn {
+        opacity: 1;
+      }
 
-    .notes-toggle:hover {
-      color: var(--sz-text);
-    }
+      .lineage-btn:hover {
+        background: var(--sz-accent-wash);
+        color: var(--sz-orange-dark);
+      }
 
-    .notes-toggle .arrow {
-      font-size: 10px;
-      transition: transform 0.15s ease;
-    }
+      /* Cross-highlighting */
+      :host([has-highlight]) .field-row {
+        opacity: 0.5;
+        transition: opacity 0.15s ease;
+      }
 
-    .notes-toggle .arrow[data-expanded] {
-      transform: rotate(90deg);
-    }
+      :host([has-highlight]) .field-row.hl {
+        opacity: 1;
+      }
 
-    .note-content {
-      font-family: var(--sz-font-sans);
-      font-size: 12px;
-      color: var(--sz-text);
-      line-height: 1.5;
-      padding: 4px 0 2px 22px;
-      word-break: break-word;
-      max-width: 400px;
-    }
+      :host([has-highlight]) .field-row.hl.hl-source {
+        background: var(--sz-accent-wash);
+      }
 
-    .note-content p {
-      margin: 0 0 6px;
-    }
+      :host([has-highlight]) .field-row.hl.hl-target {
+        background: var(--sz-green-wash);
+      }
 
-    .note-content p:last-child {
-      margin-bottom: 0;
-    }
+      :host([has-highlight]) .field-row.hl .field-name {
+        font-weight: 700;
+      }
 
-    .note-content h1,
-    .note-content h2,
-    .note-content h3 {
-      font-size: 12px;
-      font-weight: 700;
-      margin: 6px 0 2px;
-    }
+      :host([content-width]) .field-row {
+        width: max-content;
+        min-width: 100%;
+      }
 
-    .note-content ul,
-    .note-content ol {
-      margin: 0 0 6px;
-      padding-left: 16px;
-    }
+      /* Shaded note row displayed beneath a field that has notes. */
+      .field-note {
+        font-family: var(--sz-font-sans);
+        font-size: 11px;
+        font-style: italic;
+        color: var(--sz-text-muted);
+        line-height: 1.4;
+        padding: 2px 12px 4px 38px;
+        background: var(--sz-row-hover-bg);
+        max-width: 400px;
+        word-break: break-word;
+      }
 
-    .note-content li {
-      margin: 1px 0;
-    }
+      /*
+     * A field note's body is Markdown (SATSUMA-V2-SPEC.md:43 — the spec's own
+     * worked example is a bulleted list on a field), so the block elements
+     * renderMarkdown emits need card-scale spacing here just as they do in the
+     * entity-level notes section (vnm-kisd). Margins are tighter than
+     * .note-content's because this row sits inside a dense field list, and the
+     * row's height is NOT part of the layout's card-height estimate — see the
+     * :host([compact-expanded]) rule above.
+     */
+      .field-note p {
+        margin: 0 0 4px;
+      }
 
-    .note-content code {
-      font-family: var(--sz-font-mono);
-      font-size: 11px;
-      background: var(--sz-row-active-bg);
-      padding: 1px 4px;
-      border-radius: 3px;
-    }
+      .field-note p:last-child,
+      .field-note ul:last-child,
+      .field-note ol:last-child {
+        margin-bottom: 0;
+      }
 
-    .note-content strong {
-      font-weight: 700;
-    }
+      .field-note h1,
+      .field-note h2,
+      .field-note h3 {
+        font-size: 11px;
+        font-weight: 700;
+        font-style: normal;
+        margin: 4px 0 2px;
+      }
 
-    .note-content em {
-      font-style: italic;
-    }
+      .field-note ul,
+      .field-note ol {
+        margin: 0 0 4px;
+        padding-left: 16px;
+      }
 
-    .lineage-btn {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 18px;
-      height: 18px;
-      border: none;
-      border-radius: 3px;
-      background: transparent;
-      color: var(--sz-text-muted);
-      cursor: pointer;
-      flex-shrink: 0;
-      padding: 0;
-      opacity: 0;
-      transition:
-        opacity 0.1s,
-        background 0.1s;
-    }
+      .field-note li {
+        margin: 1px 0;
+      }
 
-    .field-row:hover .lineage-btn {
-      opacity: 1;
-    }
+      .field-note code {
+        font-family: var(--sz-font-mono);
+        font-style: normal;
+        font-size: 10px;
+        background: var(--sz-row-active-bg);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
 
-    .lineage-btn:hover {
-      background: var(--sz-accent-wash);
-      color: var(--sz-orange-dark);
-    }
+      .field-note strong {
+        font-weight: 700;
+        color: var(--sz-text);
+      }
 
-    /* Cross-highlighting */
-    :host([has-highlight]) .field-row {
-      opacity: 0.5;
-      transition: opacity 0.15s ease;
-    }
+      .field-note em {
+        font-style: italic;
+      }
 
-    :host([has-highlight]) .field-row.hl {
-      opacity: 1;
-    }
+      .field-note .at-ref {
+        font-weight: 600;
+        font-style: normal;
+        color: var(--sz-at-ref);
+      }
 
-    :host([has-highlight]) .field-row.hl.hl-source {
-      background: var(--sz-accent-wash);
-    }
+      :host([content-width]) .header-name {
+        --sz-header-name-overflow: visible;
+        --sz-header-name-overflow-mode: clip;
+        min-width: max-content;
+      }
 
-    :host([has-highlight]) .field-row.hl.hl-target {
-      background: var(--sz-green-wash);
-    }
-
-    :host([has-highlight]) .field-row.hl .field-name {
-      font-weight: 700;
-    }
-
-    :host([content-width]) .field-row {
-      width: max-content;
-      min-width: 100%;
-    }
-
-    /* Shaded note row displayed beneath a field that has notes. */
-    .field-note {
-      font-family: var(--sz-font-sans);
-      font-size: 11px;
-      font-style: italic;
-      color: var(--sz-text-muted);
-      line-height: 1.4;
-      padding: 2px 12px 4px 38px;
-      background: var(--sz-row-hover-bg);
-      max-width: 400px;
-      word-break: break-word;
-    }
-
-    :host([content-width]) .header-name {
-      --sz-header-name-overflow: visible;
-      --sz-header-name-overflow-mode: clip;
-      min-width: max-content;
-    }
-
-    :host([content-width]) .field-name {
-      --sz-field-name-flex: 0 0 auto;
-      --sz-field-name-overflow: visible;
-      --sz-field-name-overflow-mode: clip;
-      min-width: max-content;
-    }
-  `;
+      :host([content-width]) .field-name {
+        --sz-field-name-flex: 0 0 auto;
+        --sz-field-name-overflow: visible;
+        --sz-field-name-overflow-mode: clip;
+        min-width: max-content;
+      }
+    `,
+  ];
 
   @property({ type: Object })
   schema: SchemaCard | null = null;
@@ -924,25 +909,12 @@ export class SzSchemaCard extends LitElement {
   }
 
   private _renderNotes(notes: import("../model.js").NoteBlock[]) {
-    return html`
-      <div class="notes-section" data-testid=${`${this.testIdPrefix}-notes`}>
-        <div
-          class="notes-toggle"
-          data-testid=${`${this.testIdPrefix}-notes-toggle`}
-          @click=${this._toggleNotes}
-        >
-          <span class="arrow" ?data-expanded=${this._notesExpanded}>&#9654;</span>
-          <span>&#128221; ${notes.length === 1 ? "Note" : `${notes.length} Notes`}</span>
-        </div>
-        ${
-          this._notesExpanded
-            ? notes.map(
-                (n) => html`<div class="note-content">${unsafeHTML(renderMarkdown(n.text))}</div>`,
-              )
-            : ""
-        }
-      </div>
-    `;
+    return renderNotesSection({
+      notes,
+      expanded: this._notesExpanded,
+      onToggle: (e: Event) => this._toggleNotes(e),
+      testIdPrefix: this.testIdPrefix,
+    });
   }
 
   private _toggleNotes(e: Event) {
@@ -1072,7 +1044,7 @@ export class SzSchemaCard extends LitElement {
                   class="field-note"
                   style=${depth > 0 ? `padding-left: ${38 + depth * 20}px` : ""}
                 >
-                  ${n.text}
+                  ${unsafeHTML(renderMarkdown(n.text))}
                 </div>`,
             )
           : ""

--- a/tooling/satsuma-viz/src/markdown.ts
+++ b/tooling/satsuma-viz/src/markdown.ts
@@ -1,3 +1,20 @@
+/**
+ * markdown.ts — text-to-HTML rendering for Satsuma note and NL-string content.
+ *
+ * Owns two rendering levels and the rule that composes them:
+ *
+ *   - {@link highlightAtRefs} — inline only. Escapes, then marks `@ref` tokens.
+ *     Used where the surrounding context is already a single line of prose
+ *     (NL transform text, join descriptions, filter expressions).
+ *   - {@link renderMarkdown} — block level. Headings, lists, emphasis, inline
+ *     code and paragraphs, with `@ref` marking applied inside each inline run.
+ *     Used for note bodies, where the spec promises Markdown support
+ *     (SATSUMA-V2-SPEC.md:43).
+ *
+ * This module does not decide *where* notes render — see `notes.ts` for the
+ * shared collapsible section and each component for its own placement.
+ */
+
 import { createAtRefRegex } from "@satsuma/core/nl-ref";
 
 /**
@@ -13,30 +30,98 @@ function escapeHtml(s: string): string {
 }
 
 /**
+ * Wrap `@ref` tokens in `<span class="at-ref">`, assuming the input has ALREADY
+ * been HTML-escaped. Kept separate from {@link highlightAtRefs} so the Markdown
+ * renderer can escape once and then mark refs partway through its own inline
+ * pipeline, rather than escaping twice.
+ *
+ * The shared `@ref` pattern only matches after a line start or one of a fixed
+ * set of opening characters, so a ref is deliberately NOT marked when it is
+ * wrapped in Markdown punctuation (`` `@foo` ``, `**@foo**`). That is why this
+ * runs FIRST in the inline pipeline: once emphasis has been converted to tags
+ * the preceding character is `>`, which the pattern also rejects, so no
+ * ordering recovers those cases. Leaving refs inside inline code unmarked is
+ * the desirable half of that trade.
+ */
+function markAtRefs(escaped: string): string {
+  return escaped.replace(AT_REF_RE, `<span class="at-ref">$&</span>`);
+}
+
+/**
  * Wraps @ref tokens in text with `<span class="at-ref">` for visual emphasis.
  * Input is HTML-escaped first to prevent injection.
  */
 export function highlightAtRefs(text: string): string {
-  return escapeHtml(text).replace(AT_REF_RE, `<span class="at-ref">$&</span>`);
+  return markAtRefs(escapeHtml(text));
+}
+
+/**
+ * Strip the indentation a note body inherited from its position in the source.
+ *
+ * The spec keeps note content verbatim — "Leading indentation from the content
+ * is preserved as-is" (SATSUMA-V2-SPEC.md:43) — so a note written inside a
+ * schema arrives with every line carrying the source's indentation:
+ *
+ *     PHONE_NBR VARCHAR(50) (
+ *       note """
+ *       - **42%** `(555) 123-4567`
+ *       """
+ *     )
+ *
+ * Every block rule below anchors at the start of a line, so without this the
+ * list above is prose and the note renders as one flat paragraph — the exact
+ * failure vnm-kisd reported, still present after Markdown rendering is wired
+ * up. Preserving the indentation is right for the model (the CLI and Excel
+ * export want the author's text); removing it is a rendering concern and
+ * belongs here.
+ *
+ * The first line is trimmed rather than measured: when content opens on the
+ * same line as the delimiter (`note "Mapping assumptions:` …) its indentation
+ * was consumed by the delimiter, so counting it would find a common indent of
+ * zero and dedent nothing.
+ */
+function dedentNoteBody(text: string): string {
+  const lines = text.split("\n");
+  const [first = "", ...rest] = lines;
+
+  let commonIndent = Infinity;
+  for (const line of rest) {
+    if (line.trim() === "") continue;
+    commonIndent = Math.min(commonIndent, line.length - line.trimStart().length);
+  }
+
+  if (!Number.isFinite(commonIndent) || commonIndent === 0) {
+    return [first.trimStart(), ...rest].join("\n");
+  }
+  return [
+    first.trimStart(),
+    ...rest.map((line) => (line.trim() === "" ? line : line.slice(commonIndent))),
+  ].join("\n");
 }
 
 /**
  * Minimal Markdown → HTML converter for Satsuma notes.
- * Handles headings, lists, bold, italic, inline code, and paragraphs.
- * HTML in the input is escaped to prevent XSS.
+ * Handles headings, lists, bold, italic, inline code, and paragraphs, and
+ * marks `@ref` tokens so a note that mixes prose, Markdown and refs renders
+ * all three (vnm-kisd).
+ *
+ * Deliberately hand-rolled rather than a Markdown library: the supported
+ * subset is small, fixed by what note bodies actually use, and escaping the
+ * input here is what keeps note text from becoming an HTML injection vector.
  */
 export function renderMarkdown(text: string): string {
   // Escape HTML special chars
   const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-  // Apply inline formatting to an already-escaped string
+  // Apply inline formatting to an already-escaped string. Ref marking comes
+  // first — see markAtRefs for why the order is forced.
   const inline = (s: string) =>
-    s
+    markAtRefs(s)
       .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
       .replace(/\*(.+?)\*/g, "<em>$1</em>")
       .replace(/`([^`]+)`/g, "<code>$1</code>");
 
-  const lines = text.split("\n");
+  const lines = dedentNoteBody(text).split("\n");
   const output: string[] = [];
   let i = 0;
 

--- a/tooling/satsuma-viz/src/notes.ts
+++ b/tooling/satsuma-viz/src/notes.ts
@@ -1,0 +1,165 @@
+/**
+ * notes.ts — the one rendering of a Satsuma `note` shared by every card and
+ * by the mapping detail view.
+ *
+ * Owns the collapsible "N Notes" section: its markup, its styles, and the
+ * decision that note bodies render as Markdown. It does NOT own placement —
+ * each component decides where in its own layout the section belongs — and it
+ * does not own the shaded single-note row used beneath a field, which is a
+ * different visual treatment living in `sz-schema-card`.
+ *
+ * Extracted because four consumers need it (schema, fragment and metric cards,
+ * plus the mapping detail view). Three of them had drifted into rendering note
+ * text raw while the fourth rendered Markdown, which is the defect vnm-kisd
+ * and vnm-bak4 were filed against; one implementation is what stops that
+ * recurring.
+ */
+
+import { html, css, type TemplateResult } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { ifDefined } from "lit/directives/if-defined.js";
+import type { NoteBlock } from "./model.js";
+import { renderMarkdown } from "./markdown.js";
+
+/**
+ * Styles for the collapsible notes section and for rendered Markdown inside a
+ * note body. Include in a component's `static styles` array alongside its own.
+ *
+ * The `.note-content` child rules exist because note bodies are Markdown: a
+ * `<p>`/`<ul>`/`<h3>` arriving from {@link renderMarkdown} would otherwise pick
+ * up user-agent margins far too large for a card.
+ */
+export const noteSectionStyles = css`
+  .notes-section {
+    border-top: 1px dashed var(--sz-card-border);
+    padding: 6px 12px;
+  }
+
+  .notes-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--sz-text-muted);
+    user-select: none;
+    padding: 2px 0;
+  }
+
+  .notes-toggle:hover {
+    color: var(--sz-text);
+  }
+
+  .notes-toggle .arrow {
+    font-size: 10px;
+    transition: transform 0.15s ease;
+  }
+
+  .notes-toggle .arrow[data-expanded] {
+    transform: rotate(90deg);
+  }
+
+  .note-content {
+    font-family: var(--sz-font-sans);
+    font-size: 12px;
+    color: var(--sz-text);
+    line-height: 1.5;
+    padding: 4px 0 2px 22px;
+    word-break: break-word;
+    max-width: 400px;
+  }
+
+  .note-content p {
+    margin: 0 0 6px;
+  }
+
+  .note-content p:last-child {
+    margin-bottom: 0;
+  }
+
+  .note-content h1,
+  .note-content h2,
+  .note-content h3 {
+    font-size: 12px;
+    font-weight: 700;
+    margin: 6px 0 2px;
+  }
+
+  .note-content ul,
+  .note-content ol {
+    margin: 0 0 6px;
+    padding-left: 16px;
+  }
+
+  .note-content li {
+    margin: 1px 0;
+  }
+
+  .note-content code {
+    font-family: var(--sz-font-mono);
+    font-size: 11px;
+    background: var(--sz-row-active-bg);
+    padding: 1px 4px;
+    border-radius: 3px;
+  }
+
+  .note-content strong {
+    font-weight: 700;
+  }
+
+  .note-content em {
+    font-style: italic;
+  }
+
+  /* @ref tokens inside a note body, matching their treatment in NL transform
+     text so a ref reads the same wherever it is written. */
+  .note-content .at-ref {
+    font-weight: 600;
+    font-style: normal;
+    color: var(--sz-at-ref);
+  }
+`;
+
+/** Inputs to {@link renderNotesSection}. */
+export interface NotesSectionOptions {
+  /** Note blocks to render. Callers must not call with an empty array — a
+   *  notes section with nothing in it is an empty toggle taking up space. */
+  notes: NoteBlock[];
+  /** Whether the bodies are currently shown. Owned by the calling component. */
+  expanded: boolean;
+  /** Toggle handler. Should `stopPropagation` — cards navigate on click. */
+  onToggle: (e: Event) => void;
+  /** Test-id prefix; when given, the section and its toggle become
+   *  addressable as `<prefix>-notes` and `<prefix>-notes-toggle`. */
+  testIdPrefix?: string;
+}
+
+/**
+ * Render the collapsible notes section. Note bodies go through
+ * {@link renderMarkdown}, so a `"""` note's headings, lists and emphasis
+ * render as formatting rather than as literal source text.
+ */
+export function renderNotesSection(options: NotesSectionOptions): TemplateResult {
+  const { notes, expanded, onToggle, testIdPrefix } = options;
+  const label = notes.length === 1 ? "Note" : `${notes.length} Notes`;
+
+  return html`
+    <div class="notes-section" data-testid=${ifDefined(testIdPrefix && `${testIdPrefix}-notes`)}>
+      <div
+        class="notes-toggle"
+        data-testid=${ifDefined(testIdPrefix && `${testIdPrefix}-notes-toggle`)}
+        @click=${onToggle}
+      >
+        <span class="arrow" ?data-expanded=${expanded}>&#9654;</span>
+        <span>&#128221; ${label}</span>
+      </div>
+      ${
+        expanded
+          ? notes.map(
+              (n) => html`<div class="note-content">${unsafeHTML(renderMarkdown(n.text))}</div>`,
+            )
+          : ""
+      }
+    </div>
+  `;
+}

--- a/tooling/satsuma-viz/src/satsuma-viz.ts
+++ b/tooling/satsuma-viz/src/satsuma-viz.ts
@@ -63,6 +63,11 @@ export {
   schemaHasFieldPath,
 } from "./field-coverage.js";
 export { metricAsSchemaCard, metricFieldEntries } from "./metric-adapter.js";
+// Note/NL text rendering. Exported so the two levels can be tested directly:
+// the block renderer used for note bodies and the inline one used for NL
+// transform text, join descriptions and filters.
+export { renderMarkdown, highlightAtRefs } from "./markdown.js";
+export { renderNotesSection, noteSectionStyles } from "./notes.js";
 export type {
   LayoutResult,
   LayoutNode,

--- a/tooling/satsuma-viz/test/automation.test.js
+++ b/tooling/satsuma-viz/test/automation.test.js
@@ -187,7 +187,12 @@ describe("viz automation helpers", () => {
       ["sensitivity"],
     );
 
-    // The note text must still reach the rendered output via the field-note row.
+    // The note must still reach the rendered output as the shaded field-note
+    // row. Only the row's presence is asserted here: since vnm-kisd the text
+    // itself goes through renderMarkdown behind an unsafeHTML directive, which
+    // serializes to an opaque object rather than to the note string — proving
+    // the reader SEES the text now needs a real DOM, and the Playwright
+    // "Note rendering" suite in the viz harness is where that is proven.
     const serialize = (t) => {
       if (t == null || typeof t !== "object") return String(t ?? "");
       if (Array.isArray(t)) return t.map(serialize).join(" ");
@@ -198,7 +203,6 @@ describe("viz automation helpers", () => {
     };
     const serialized = serialize(card._renderField(field, 0));
     assert.match(serialized, /field-note/);
-    assert.match(serialized, /Unique key across ORDERS tables/);
   });
 
   it("gives mapping-detail source and target schema cards distinct testIdPrefix values", async () => {

--- a/tooling/satsuma-viz/test/markdown.test.js
+++ b/tooling/satsuma-viz/test/markdown.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit coverage for the note text → HTML converter (vnm-kisd, vnm-bak4).
+ *
+ * These cases pin the STRING TRANSFORM only: given note source, what HTML does
+ * the renderer emit. Whether a reader actually sees that HTML painted in a
+ * field row, an arrow row or a notes section is a different property that only
+ * a rendered browser can observe — see the "Note rendering" suite in
+ * tooling/satsuma-viz-harness/test/harness.test.ts.
+ */
+
+// The bundle registers custom elements on import, so the DOM shim must load
+// first even though these cases only exercise pure string functions.
+import "./dom-shim.js";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const { renderMarkdown, highlightAtRefs } = await import("../dist/satsuma-viz.js");
+
+describe("renderMarkdown", () => {
+  it("renders the bulleted-list note shape the spec documents on a field", () => {
+    // SATSUMA-V2-SPEC.md:225 shows a PHONE_NBR field whose note body is a
+    // Markdown list with bold and inline code. That exact shape rendering as
+    // literal source text is the defect vnm-kisd was filed against, so this is
+    // the case that must not regress.
+    const html = renderMarkdown("- **42%** `(555) 123-4567` — US\n- **31%** `555.123.4567` — dots");
+
+    assert.match(html, /<ul>/);
+    assert.equal(html.match(/<li>/g).length, 2);
+    assert.match(html, /<strong>42%<\/strong>/);
+    assert.match(html, /<code>\(555\) 123-4567<\/code>/);
+    // The Markdown punctuation must not survive into the output as text.
+    assert.ok(!html.includes("**"), "bold markers should be consumed, not printed");
+  });
+
+  it("renders an indented list, as every note written inside a schema arrives", () => {
+    // Note bodies keep their source indentation by design (spec:43), so this
+    // is the SHAPE REAL NOTES HAVE — examples/db-to-db/pipeline.stm's PHONE_NBR
+    // note is indented four spaces. Block rules anchor at line start, so
+    // without dedenting, Markdown rendering alone still leaves the note as one
+    // flat paragraph.
+    const html = renderMarkdown(
+      "\n    Formats seen:\n    - **42%** parens\n    - **31%** dots\n    ",
+    );
+
+    assert.match(html, /<p>Formats seen:<\/p>/);
+    assert.equal(html.match(/<li>/g).length, 2);
+  });
+
+  it("dedents a body whose first line opens on the delimiter line", () => {
+    // `note "Mapping assumptions:` puts content on the delimiter's own line, so
+    // that line has no indentation while the continuation lines do. Measuring
+    // it would find a common indent of zero and dedent nothing —
+    // examples/db-to-db/pipeline.stm's mapping note is exactly this shape.
+    const html = renderMarkdown(
+      "Assumptions:\n     - timestamps are US Eastern\n     - NULLs kept",
+    );
+
+    assert.match(html, /<p>Assumptions:<\/p>/);
+    assert.equal(html.match(/<li>/g).length, 2);
+  });
+
+  it("preserves relative indentation when dedenting, so nesting is not flattened", () => {
+    // Only the COMMON prefix is removed. A deliberately deeper line must stay
+    // deeper, or dedenting would destroy structure while fixing alignment.
+    const html = renderMarkdown("\n  top\n      deeper\n");
+    assert.match(html, /top<br> {4}deeper/);
+  });
+
+  it("renders headings, ordered lists and paragraphs as block elements", () => {
+    const html = renderMarkdown("# Title\n\nFirst para\n\n1. one\n2. two");
+
+    assert.match(html, /<h1>Title<\/h1>/);
+    assert.match(html, /<p>First para<\/p>/);
+    assert.match(html, /<ol><li>one<\/li><li>two<\/li><\/ol>/);
+  });
+
+  it("keeps a multi-line paragraph's line structure with <br>", () => {
+    // A `"""` note's line breaks are content — collapsing them into one run was
+    // half of what made field notes unreadable.
+    const html = renderMarkdown("line one\nline two");
+    assert.match(html, /<p>line one<br>line two<\/p>/);
+  });
+
+  it("marks @ref tokens inside a note body so refs read as refs", () => {
+    // Arrow notes already highlighted refs via highlightAtRefs; routing note
+    // bodies through renderMarkdown instead had to keep that, not trade
+    // Markdown for refs (vnm-bak4).
+    const html = renderMarkdown("Correlate to @POReferences by position.");
+    assert.match(html, /<span class="at-ref">@POReferences<\/span>/);
+  });
+
+  it("marks an @ref that opens a list item, where the line start is the boundary", () => {
+    // The shared @ref pattern only matches after a line start or an opening
+    // character. Marking refs per inline run (not over the assembled HTML) is
+    // what keeps this case working — over full HTML the preceding character
+    // would be ">" and the ref would be missed.
+    const html = renderMarkdown("- @orders.id feeds the key");
+    assert.match(html, /<li><span class="at-ref">@orders\.id<\/span> feeds the key<\/li>/);
+  });
+
+  it("leaves an @ref inside inline code unmarked", () => {
+    // A ref shown as code is being quoted, not referenced — the backtick is
+    // not one of the pattern's opening characters, so this falls out of the
+    // shared pattern rather than needing a special case.
+    const html = renderMarkdown("write `@foo` to name it");
+    assert.match(html, /<code>@foo<\/code>/);
+    assert.ok(!html.includes('class="at-ref"'), "a quoted ref should not be highlighted");
+  });
+
+  it("escapes HTML in note text so a note body cannot inject markup", () => {
+    // Note text is author-supplied and rendered through unsafeHTML; escaping
+    // here is the only thing standing between a note and script injection.
+    const html = renderMarkdown('<img src=x onerror="alert(1)">');
+    assert.ok(!html.includes("<img"), "raw tag must not survive");
+    assert.match(html, /&lt;img/);
+  });
+
+  it("escapes HTML inside a heading and a list item too, not just paragraphs", () => {
+    // Each block branch escapes independently, so each needs proving — an
+    // unescaped heading would be just as exploitable as an unescaped paragraph.
+    const html = renderMarkdown("# <b>h</b>\n- <b>li</b>");
+    assert.ok(!html.includes("<b>"), "raw tag must not survive in any block type");
+    assert.match(html, /<h1>&lt;b&gt;h&lt;\/b&gt;<\/h1>/);
+  });
+});
+
+describe("highlightAtRefs", () => {
+  it("still escapes then marks refs, unchanged by the Markdown composition", () => {
+    // The inline-only path is used for NL transform text, join descriptions
+    // and filters. Refactoring it to share markAtRefs with renderMarkdown must
+    // not have altered what it emits.
+    const html = highlightAtRefs("join on @orders.id <script>");
+    assert.match(html, /<span class="at-ref">@orders\.id<\/span>/);
+    assert.match(html, /&lt;script&gt;/);
+  });
+
+  it("does not apply Markdown formatting", () => {
+    // Inline NL text is not a note body: asterisks in a transform description
+    // are literal, and turning them into emphasis would change meaning.
+    assert.match(highlightAtRefs("multiply by **2**"), /\*\*2\*\*/);
+  });
+});


### PR DESCRIPTION
Fixes the two note-rendering bugs a user reported, and files a third ticket for
a related pan-hint wording change (gh-513).

## The reports

> "I have entered the markdown comment via a note. Should I expect the
> visualiser to draw that markdown? If not, why would I use markdown as it
> doesn't seem to get formatted anywhere?"

> "If I add notes to the mapping sections, should I expect to see them in the
> visualiser?"

Yes to both. Markdown in a `"""` note is the documented contract
(`SATSUMA-V2-SPEC.md:43`), and the spec's own worked example at `:225` is
exactly the reported case — a `PHONE_NBR VARCHAR(50) (note """…""")` whose body
is a bulleted list with bold percentages.

## Tickets

| ID | |
|---|---|
| `vnm-kisd` | Field notes render Markdown as literal source text — **fixed** |
| `vnm-bak4` | Mapping-level notes never rendered; arrow notes ignore Markdown — **fixed** |
| `vnm-gucl` | Canvas hint says "drag to pan" but only middle-mouse (or Alt) drag pans — **raised only** |

## Root cause

`renderMarkdown` existed and was wired to entity-level schema notes and file
notes — and to nothing else. Field, fragment-card and metric-card notes
interpolated `${n.text}` raw, so the identical note formatted at one nesting
level and showed raw asterisks one level down. Separately,
`sz-mapping-detail.ts` never read `MappingBlock.notes` at all, so `note { }`
blocks reached the webview payload and were invisible.

## The part the tickets did not anticipate

Wiring `renderMarkdown` in was **not sufficient**. Note bodies keep their source
indentation by design ("Leading indentation from the content is preserved
as-is", spec:43), so the real payload for the reported note is:

```
"No consistent format across the dataset:\n    - **42%** `(555) 123-4567` …"
```

Every block rule anchors at line start, so all five bullets would still have
rendered as one flat paragraph — the bug would have looked fixed under unit
tests and stayed broken on screen. `dedentNoteBody` trims the first line (its
indentation was consumed by the delimiter) and strips the common indent from
the rest. This also fixes the **file-level** notes that already used
`renderMarkdown` and were losing their `## Constraints` lists for the same
reason.

## Also in this change

- **One notes section, not four.** Schema, fragment and metric cards each had
  their own copy; the mapping view needed a fourth. The drift between those
  copies *was* the bug, so they collapse into `satsuma-viz/src/notes.ts`.
- **`@ref` composes with Markdown.** Ref marking now runs inside the inline
  pipeline, so a note carrying both renders both. Refs inside inline code stay
  unmarked, which falls out of the shared pattern rather than needing a case.
- **A mapping's `( note "…" )` metadata** joins the notes section instead of
  rendering as a raw pill — the same dedupe the schema card already applied.
- **`m.notes ?? []` guard.** A payload without `notes` was taking the entire
  detail view down.

## Testing

Per AGENTS.md, both questions asked out loud:

1. **Is there a property a unit test cannot observe?** Yes — every change alters
   what gets painted. `test/markdown.test.js` (13 cases) pins the string
   transform, but cannot prove a `<ul>` reaches a field row.
2. **Is Playwright coverage possible and proportionate?** Yes, and it is here: a
   new `"Note rendering"` suite with 5 specs. **No existing fixture reached the
   arrow-note shape**, so rather than reuse the nearest wired-up fixture,
   `examples/db-to-db/pipeline.stm` gains a Markdown arrow note, run through
   `satsuma fmt` so the formatter-canonical corpus test still passes.

`./scripts/run-repo-checks.sh` green. **136 Playwright specs pass** (Firefox,
via the sentinel workflow).

## Still open for the reviewer

`vnm-gucl` is filed, not fixed. Its wording change does **not** discharge
gh-513's original ask (left-drag / Spacebar panning, hover `grab` cursor) —
that needs its own ticket or an explicit decision to drop it before #513 is
closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)