### PR TITLE
fix(cli): make a fully qualified nested-path arrows query exact (gpt-qhfo)

### DIFF
--- a/.tickets/gpt-qhfo.md
+++ b/.tickets/gpt-qhfo.md
@@ -1,6 +1,6 @@
 ---
 id: gpt-qhfo
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-06T15:21:01Z
@@ -25,3 +25,14 @@ Found by Feature 46 R6 (gpt-clpj) and pinned there so it cannot change unnoticed
 
 A fully qualified nested-path query returns exactly the arrows touching that path and no others. The pinned case in generated-inverse-relations.test.ts is converted from a pin of the current wrong answer into an assertion of the right one. The bare-leaf-name behaviour sl-xj4p blessed is unchanged.
 
+
+## Notes
+
+**2026-08-07T10:08:35Z**
+
+## Notes
+
+**2026-08-07T00:00:00Z**
+
+Cause: `arrows.ts`'s `altKey` fallback loop admitted a candidate arrow whenever its path existed *somewhere* in the queried schema's field tree (`pathExistsInSchema`), and the later nested-path filter's `arrowPathMatches` accepted a match in either direction (`requestedPath.endsWith('.' + arrowPath)` as well as the reverse), so a shorter arrow path (e.g. top-level `field_0`) satisfied a longer, fully qualified query (e.g. `lines.field_0`) for an unrelated field.
+Fix: `pathExistsInSchema` now requires an exact path match whenever the queried field name is dotted (a fully qualified nested path), leaving the bare-leaf-name fallback sl-xj4p blessed untouched; `arrowPathMatches` no longer accepts a shorter arrow path matching a longer request. The pinned "known behaviour" case in `generated-inverse-relations.test.ts` is now a regression test asserting the correct empty answer. (commit immediately after 02c3cb07)

--- a/.tickets/gpt-qhfo.md
+++ b/.tickets/gpt-qhfo.md
@@ -30,9 +30,5 @@ A fully qualified nested-path query returns exactly the arrows touching that pat
 
 **2026-08-07T10:08:35Z**
 
-## Notes
-
-**2026-08-07T00:00:00Z**
-
 Cause: `arrows.ts`'s `altKey` fallback loop admitted a candidate arrow whenever its path existed *somewhere* in the queried schema's field tree (`pathExistsInSchema`), and the later nested-path filter's `arrowPathMatches` accepted a match in either direction (`requestedPath.endsWith('.' + arrowPath)` as well as the reverse), so a shorter arrow path (e.g. top-level `field_0`) satisfied a longer, fully qualified query (e.g. `lines.field_0`) for an unrelated field.
 Fix: `pathExistsInSchema` now requires an exact path match whenever the queried field name is dotted (a fully qualified nested path), leaving the bare-leaf-name fallback sl-xj4p blessed untouched; `arrowPathMatches` no longer accepts a shorter arrow path matching a longer request. The pinned "known behaviour" case in `generated-inverse-relations.test.ts` is now a regression test asserting the correct empty answer. (commit immediately after 02c3cb07)

--- a/tooling/satsuma-cli/src/commands/arrows.ts
+++ b/tooling/satsuma-cli/src/commands/arrows.ts
@@ -125,13 +125,26 @@ Examples:
               const mapping = index.mappings.get(qMapping);
               if (!mapping) continue;
 
-              // Verify the arrow's source or target field path exists in the queried schema's
-              // field tree. Strip any schema prefix before the lookup.
+              // Verify the arrow's source or target field path belongs to the queried
+              // field. Strip any schema prefix before the comparison.
+              //
+              // A bare (undotted) query is deliberately ambiguous — sl-xj4p's
+              // criterion 2 blesses "does this path exist anywhere in the schema's
+              // field tree" so a leaf name shared by several nested fields still
+              // surfaces every match. A fully qualified nested-path query is NOT
+              // ambiguous, though: the candidate must be the exact path asked for,
+              // not merely some other field that happens to exist in the same
+              // schema. Without this, querying `staged.lines.field_0` would accept
+              // any arrow touching the unrelated top-level `staged.field_0` purely
+              // because a field named `field_0` exists somewhere in `staged` — the
+              // other half of gpt-qhfo (the sibling defect is `arrowPathMatches`'s
+              // over-permissive suffix check below).
               const pathExistsInSchema = (rawPath: string): boolean => {
                 const bare = rawPath.replace(/^\./, "");
                 const path = bare.startsWith(schemaKey + ".")
                   ? bare.slice(schemaKey.length + 1)
                   : bare;
+                if (fieldName.includes(".")) return path === fieldName;
                 return (
                   findFieldByPath(allFields, path) !== null ||
                   collectFieldNames(allFields).includes(path)
@@ -368,23 +381,24 @@ Examples:
 
 /**
  * Check if an arrow's source/target path matches the user's requested nested path.
+ *
  * For example, if the arrow source is "CdtTrfTxInf.DbtrAgt.BIC" and the user
- * requested "CdtTrfTxInf.DbtrAgt.BIC", this returns true.
- * Also matches if the arrow path ends with the requested path (suffix match).
+ * requested "CdtTrfTxInf.DbtrAgt.BIC", this returns true. It also returns true
+ * when the arrow's own path carries a schema prefix the caller has already
+ * resolved away (e.g. arrow path "staged.lines.field_0" against a request of
+ * "lines.field_0") — that is a longer, more-qualified spelling of the same path.
+ *
+ * The reverse is deliberately NOT accepted: a *shorter* arrow path must never
+ * match a *longer* requested path (e.g. arrow path "field_0" against a request
+ * of "lines.field_0"). That direction used to be allowed and let a fully
+ * qualified nested-path query return an unrelated, shallower field's arrow —
+ * gpt-qhfo. A shorter arrow path names a different, less-specific field, not
+ * a looser spelling of the one the user asked for.
  */
 function arrowPathMatches(arrowPath: string | null, requestedPath: string): boolean {
   if (!arrowPath) return false;
   if (arrowPath === requestedPath) return true;
-  // Suffix match: arrow path ends with the requested path
-  if (arrowPath.endsWith(`.${requestedPath}`)) return true;
-  // The requested path ends with the arrow path (arrow has shorter dotted path)
-  if (requestedPath.endsWith(`.${arrowPath}`)) return true;
-  // Exact match on leaf only when the full path also has matching intermediate segments
-  if (requestedPath.endsWith(arrowPath) && arrowPath === requestedPath.split(".").pop()) {
-    // Leaf-only match — only accept if no deeper path was specified
-    return false;
-  }
-  return false;
+  return arrowPath.endsWith(`.${requestedPath}`);
 }
 
 /**

--- a/tooling/satsuma-cli/test/generated-inverse-relations.test.ts
+++ b/tooling/satsuma-cli/test/generated-inverse-relations.test.ts
@@ -72,16 +72,23 @@
  * - `arrows ::raw.field_0` returning `raw.lines.field_0`'s arrow is criterion 2
  *   applied to a query that *also* names a declared top-level path exactly.
  *   Whether an exact path should beat the leaf fallback is undecided, and nothing
- *   here decides it.
- * - `arrows warehouse::staged.lines.field_0 --as-source` returning
+ *   here decides it. Pinned below by {@link describe} "known behaviour" so it
+ *   cannot change unnoticed.
+ * - `arrows warehouse::staged.lines.field_0 --as-source` used to return
  *   `staged.field_0 → revenue_metric.field_0` — a different field's arrow, and the
- *   *only* answer, since the queried field has no outgoing arrow — contradicts
- *   criterion 1 outright. That one is a defect, filed as `gpt-qhfo`.
+ *   *only* answer, since the queried field has no outgoing arrow. That contradicted
+ *   criterion 1 outright and was filed as `gpt-qhfo`. `warehouse::staged.lines.field_0`
+ *   is a fully qualified nested path, not a bare leaf name, so it was never covered
+ *   by criterion 2's "show all matches" — the fix tightens the `altKey` loop's
+ *   `pathExistsInSchema` guard and `arrowPathMatches`'s suffix check (both in
+ *   `arrows.ts`) to require the exact path when one was given, and the case below
+ *   now asserts the corrected empty answer instead of pinning the old wrong one.
  *
- * Both are pinned below by {@link describe} "known behaviour" so neither can
- * change unnoticed, and the exact-set property skips exactly the affected paths
- * via {@link leafAmbiguousPaths} rather than skipping the workspace that contains
- * them. Every unambiguous path of that same workspace is still asserted.
+ * The exact-set property still skips both affected paths via
+ * {@link leafAmbiguousPaths} rather than skipping the workspace that contains them —
+ * the leaf-name conflation the property sidesteps is itself unchanged by the
+ * `gpt-qhfo` fix, since `field_0` and `lines.field_0` still share a leaf name.
+ * Every unambiguous path of that same workspace is still asserted.
  */
 
 import assert from "node:assert/strict";
@@ -578,15 +585,17 @@ describe("arrows: every declared arrow is reachable from both of its endpoints (
 });
 
 describe("arrows: known behaviour — a shared leaf name merges two paths' arrows", () => {
-  // ⚠️ BOTH CASES BELOW PIN WHAT `arrows` DOES TODAY, not what it should do, so
-  // both go red the moment the leaf-name fallback changes — at which point read
-  // this module's header, re-decide each case against `sl-xj4p`, and remove
+  // ⚠️ THIS CASE PINS WHAT `arrows` DOES TODAY, not what it should do, so it goes
+  // red the moment the leaf-name fallback changes — at which point read this
+  // module's header, re-decide it against `sl-xj4p`, and remove
   // `leafAmbiguousPaths` from the exact-set property above.
   //
-  // The mechanism both share: `raw` declares `field_0` *and* `lines.field_0`, so
-  // after resolving the qualified key `arrows` also looks the bare leaf name up
-  // (`arrows.ts`'s `altKey` loop), and that loop's guard only checks the arrow's
-  // path exists *somewhere* in the queried schema.
+  // The mechanism: `raw` declares `field_0` *and* `lines.field_0`, so after
+  // resolving the qualified key `arrows` also looks the bare leaf name up
+  // (`arrows.ts`'s `altKey` loop), and — for a query with no dotted path of its
+  // own, as `field_0` here — that loop's guard accepts any path that exists
+  // *somewhere* in the queried schema, which is the sl-xj4p criterion-2 fallback
+  // rather than a bug.
   //
   // Pinned rather than skipped: a skipped test proves nothing, and node's JUnit
   // reporter puts a `failure=` attribute on a failing `todo` case, which fails
@@ -611,24 +620,25 @@ describe("arrows: known behaviour — a shared leaf name merges two paths' arrow
       );
     });
   });
+});
 
-  it("answers a nested field's --as-source query with a different field's outgoing arrow", async () => {
-    // The indefensible half, filed as `gpt-qhfo` rather than decided here:
-    // `staged.lines.field_0` is a fully qualified nested path, which
-    // `sl-xj4p`'s criterion 1 says must resolve correctly. It has no outgoing
-    // arrow at all, so the leaf fallback does not merely *add* a wrong answer —
-    // the only arrow reported belongs to `staged.field_0`, one nesting level up.
-    // A reader tracing lineage out of a nested field gets a confident wrong answer.
+describe("arrows: a fully qualified nested-path query is exact (gpt-qhfo)", () => {
+  it("reports no arrows for a nested field with no outgoing arrow, rather than a shallower field's", async () => {
+    // Regression test for gpt-qhfo. `staged.lines.field_0` is a fully qualified
+    // nested path — unlike the bare `field_0` query pinned above, this one names
+    // no ambiguous leaf, so sl-xj4p's criterion 1 ("a deeply nested path resolves
+    // correctly") applies without qualification. `staged` also declares a
+    // top-level `field_0`, which DOES have an outgoing arrow
+    // (`staged.field_0 -> revenue_metric.field_0`); before the fix, the `altKey`
+    // loop's `pathExistsInSchema` guard and `arrowPathMatches`'s suffix check
+    // (both in `arrows.ts`) let that shallower field's arrow satisfy the query
+    // for the nested one. The nested field has no outgoing arrow of its own, so
+    // the correct answer is empty, not a confident wrong one.
     await withGenerated(kitchenSinkWorkspace, async (loaded) => {
       const { edgeKeys } = await arrowEdgesFor(loaded, "warehouse::staged.lines.field_0", [
         "--as-source",
       ]);
-      assert.deepEqual(
-        sortedEdgeKeys(edgeKeys),
-        ["warehouse::staged.field_0 -> ::revenue_metric.field_0 | ::load_metric | none"],
-        `the leaf-name conflation changed shape — read this describe block's comments ` +
-          `before updating the expectation:\n${loaded.sources}`,
-      );
+      assert.deepEqual(edgeKeys, [], `expected no arrows, found:\n${loaded.sources}`);
     });
   });
 });


### PR DESCRIPTION
## Summary
- `satsuma arrows <schema.field> --as-source`/`--as-target` could return a *different*, shallower field's arrow when the query was a fully qualified nested path, instead of the queried field's own arrows (or none, when correct). On Feature 46's kitchen-sink workspace, `arrows warehouse::staged.lines.field_0 --as-source` returned `staged.field_0 -> ::revenue_metric.field_0` — a different field's arrow — even though `staged.lines.field_0` has no outgoing arrow at all.
- Two mechanisms in `tooling/satsuma-cli/src/commands/arrows.ts` combined to cause this: the `altKey` fallback loop's `pathExistsInSchema` guard accepted any candidate whose path existed *somewhere* in the queried schema rather than requiring it be the exact path asked for, and `arrowPathMatches`'s suffix check accepted a *shorter* arrow path matching a *longer* requested path (in addition to the correct reverse direction).
- Fixed both: `pathExistsInSchema` now requires an exact match when the queried field name is dotted (a fully qualified nested path — bare/unqualified queries keep the looser sl-xj4p-blessed "exists somewhere" fallback), and `arrowPathMatches` drops the erroneous "request ends with arrow path" branch.
- The bare-leaf-name ambiguity behaviour sl-xj4p blessed (an ambiguous unqualified query shows every match) is untouched — verified by the existing pinned regression test and the `sl-xj4p` deep-nested-path integration tests.
- The pinned "known behaviour" case in `generated-inverse-relations.test.ts` is converted from asserting the old wrong answer to asserting the corrected empty answer, with updated module/describe-block commentary reflecting that this half of the shape is now fixed rather than still open.

## Test plan
- [x] `turbo run test --filter=satsuma-cli` — 1157/1157 passing (was 1156/1157, with the one pinned failure now converted to the correct expectation)
- [x] `npx tsc --noEmit` in `tooling/satsuma-cli` — clean
- [x] `npx eslint` on the changed files — clean
- [x] Pre-commit hook (`scripts/run-repo-checks.sh`) ran and passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)