### PR TITLE
fix(lsp): rename NL @ref schema segment when renaming the schema it names (gpt-fjo7)

### DIFF
--- a/.tickets/gpt-fjo7.md
+++ b/.tickets/gpt-fjo7.md
@@ -1,6 +1,6 @@
 ---
 id: gpt-fjo7
-status: open
+status: in_progress
 deps: []
 links: []
 created: 2026-08-06T18:45:19Z
@@ -35,3 +35,12 @@ Note the editor does not even show the damage afterwards, because the LSP report
 
 Renaming a schema rewrites the schema segment of every NL @ref that names one of its fields, in every file. The round-trip property in tooling/satsuma-lsp/test/generated-rename-roundtrip.test.js stops excluding entities an NL @ref mentions, and the pinned test recording today's behaviour is removed. Renaming a schema whose fields no @ref mentions is unaffected. Decide explicitly whether a @ref naming a *field* that is itself renamed is in scope, or a separate ticket.
 
+
+## Notes
+
+**2026-08-07T10:20:41Z**
+
+**2026-08-07T10:20:32Z**
+
+Cause: The workspace index filed a field-naming NL @ref (`@s0.field_1`) only under the full name it names ("s0.field_1", context "nl") — never under the schema key alone ("s0") — so `findReferences`/rename queried by the schema's key never saw it, and a schema rename left the @ref pointing at a name that no longer existed.
+Fix: Added core's `splitRefSchemaKey()` to isolate the schema segment of a dotted @ref (honouring backtick quoting and the grammar's "::"-before-first-"." guarantee), and used it in the workspace index to file a second "nl" entry under just the schema key with a range narrowed to that segment — so a schema rename now rewrites the schema segment of every such @ref, in every file in scope, while leaving the field part untouched. Renaming a FIELD an @ref names (rather than the schema) is explicitly out of scope: the LSP has no renameable `field_name` context today, through any path. (commit immediately after 02c3cb07)

--- a/.tickets/gpt-fjo7.md
+++ b/.tickets/gpt-fjo7.md
@@ -1,6 +1,6 @@
 ---
 id: gpt-fjo7
-status: in_progress
+status: closed
 deps: []
 links: []
 created: 2026-08-06T18:45:19Z

--- a/.tickets/gpt-fjo7.md
+++ b/.tickets/gpt-fjo7.md
@@ -38,8 +38,6 @@ Renaming a schema rewrites the schema segment of every NL @ref that names one of
 
 ## Notes
 
-**2026-08-07T10:20:41Z**
-
 **2026-08-07T10:20:32Z**
 
 Cause: The workspace index filed a field-naming NL @ref (`@s0.field_1`) only under the full name it names ("s0.field_1", context "nl") — never under the schema key alone ("s0") — so `findReferences`/rename queried by the schema's key never saw it, and a schema rename left the @ref pointing at a name that no longer existed.

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,9 +2,9 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 708,
+    "satsuma-core": 714,
     "satsuma-cli": 1157,
-    "satsuma-lsp": 323,
+    "satsuma-lsp": 327,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 197,
     "satsuma-viz": 201,

--- a/tooling/satsuma-core/src/index.ts
+++ b/tooling/satsuma-core/src/index.ts
@@ -220,6 +220,7 @@ export {
   extractAtRefs,
   computeNLRefPosition,
   classifyRef,
+  splitRefSchemaKey,
   resolveRef,
   extractNLRefData,
   resolveAllNLRefs,
@@ -229,6 +230,7 @@ export {
 export type {
   AtRef,
   RefClassification,
+  RefSchemaKeySplit,
   Resolution,
   MappingSourcesTargets,
   DefinitionLookup,

--- a/tooling/satsuma-core/src/nl-ref.ts
+++ b/tooling/satsuma-core/src/nl-ref.ts
@@ -295,6 +295,56 @@ export function classifyRef(ref: string): RefClassification {
   return classificationOf(parseRef(ref).separators);
 }
 
+/** The schema-key portion of a dotted @ref, plus how much of the raw ref text
+ *  it occupies. See {@link splitRefSchemaKey}. */
+export interface RefSchemaKeySplit {
+  /** The schema/fragment/transform key, flattened (backticks stripped) —
+   *  e.g. "s0" for "@s0.field" or "ns::s0" for "@ns::s0.field". */
+  schemaKey: string;
+  /** Length, in characters of the RAW (backtick-preserving) ref text, that the
+   *  schema key occupies — the offset of the "." that starts the field path.
+   *  Consumers slice `raw.slice(0, rawLength)` to recover the exact authored
+   *  span, which may differ from `schemaKey.length` when a segment is
+   *  backtick-quoted. */
+  rawLength: number;
+}
+
+/**
+ * Split a dotted @ref into its schema key and field path, without resolving
+ * either against an index. Returns null when the ref has no field path at all
+ * — a bare name or a namespace-qualified name with no "." names a
+ * schema/fragment/transform directly, and there is nothing to split.
+ *
+ * Grammar guarantee (AT_REF_PATTERN): the optional "::" separator always
+ * precedes the first "." — `ns::schema.field` never puts a "." before the
+ * "::" — so the schema key is exactly the raw text up to (but not including)
+ * the first "." that falls outside a backtick-quoted span (sl-g6ga: "." inside
+ * backticks is part of the name, not a separator). This lets the split be a
+ * single linear scan rather than a full {@link parseRef}.
+ *
+ * Introduced for rename (gpt-fjo7): renaming a schema must rewrite only the
+ * schema segment of a field-naming NL @ref (`@schema.field`), leaving the
+ * field part untouched. Pass the RAW (backtick-preserving) ref text, as with
+ * {@link classifyRef} — flattening first would make a literal name with an
+ * embedded "." indistinguishable from a path.
+ */
+export function splitRefSchemaKey(raw: string): RefSchemaKeySplit | null {
+  let inBacktick = false;
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === "`") {
+      inBacktick = !inBacktick;
+      continue;
+    }
+    if (raw[i] === "." && !inBacktick) {
+      // Flatten backticks the same way extractAtRefs does, so the returned
+      // key matches how the schema is keyed everywhere else in the index.
+      const schemaKey = raw.slice(0, i).replace(/`([^`]+)`/g, "$1");
+      return { schemaKey, rawLength: i };
+    }
+  }
+  return null;
+}
+
 // ── Resolution ────────────────────────────────────────────────────────────────
 
 interface MappingContext {

--- a/tooling/satsuma-core/test/nl-ref.test.js
+++ b/tooling/satsuma-core/test/nl-ref.test.js
@@ -13,6 +13,7 @@ import {
   extractNLRefData,
   computeNLRefPosition,
   classifyRef,
+  splitRefSchemaKey,
   resolveRef,
   resolveAllNLRefs,
   stripNLRefScopePrefix,
@@ -272,6 +273,61 @@ describe("classifyRef()", () => {
     assert.equal(classifyRef("crm::`my.schema`"), "namespace-qualified-schema");
     // The separator dot before the literal still makes this a dotted field.
     assert.equal(classifyRef("customers.`tax.rate`"), "dotted-field");
+  });
+});
+
+// ── splitRefSchemaKey ───────────────────────────────────────────────────────
+//
+// Introduced for gpt-fjo7: rename needs the schema segment of a field-naming
+// @ref isolated from the field part, so it can rewrite just that segment.
+
+describe("splitRefSchemaKey()", () => {
+  it("splits a dotted field ref at the first dot", () => {
+    assert.deepEqual(splitRefSchemaKey("schema.field"), { schemaKey: "schema", rawLength: 6 });
+  });
+
+  it("splits a namespace-qualified field ref after the schema, keeping the ns:: prefix", () => {
+    // Grammar guarantee: "::" always precedes the first ".", so the schema key
+    // naturally includes it without special-casing the classification.
+    assert.deepEqual(splitRefSchemaKey("crm::customers.email"), {
+      schemaKey: "crm::customers",
+      rawLength: 14,
+    });
+  });
+
+  it("splits a multi-segment field path at the FIRST dot only", () => {
+    // "address.city.zip" names field "city.zip" on schema "address" — the
+    // schema key must not swallow the extra segment.
+    assert.deepEqual(splitRefSchemaKey("address.city.zip"), {
+      schemaKey: "address",
+      rawLength: 7,
+    });
+  });
+
+  it("returns null for a ref with no field part", () => {
+    // "@schema" and "@ns::schema" already name the schema outright — there is
+    // no split to report, and the caller's existing full-name entry already
+    // is the schema-key entry.
+    assert.equal(splitRefSchemaKey("customers"), null);
+    assert.equal(splitRefSchemaKey("crm::customers"), null);
+  });
+
+  it("treats a backtick-quoted segment's dot as part of the name, not a separator (sl-g6ga)", () => {
+    // "`my.schema`" is one segment naming a schema literally called "my.schema";
+    // the boundary is the FIRST UNQUOTED dot, right after the closing backtick.
+    assert.deepEqual(splitRefSchemaKey("`my.schema`.field"), {
+      schemaKey: "my.schema",
+      rawLength: 11,
+    });
+  });
+
+  it("flattens the returned schemaKey but keeps rawLength measuring the raw (backtick-inclusive) text", () => {
+    // rawLength is how many RAW characters the caller must slice to recover
+    // the authored span, which is longer than schemaKey.length whenever the
+    // schema segment is backtick-quoted.
+    const split = splitRefSchemaKey("`order id`.status");
+    assert.equal(split.schemaKey, "order id");
+    assert.equal(split.rawLength, "`order id`".length);
   });
 });
 

--- a/tooling/satsuma-lsp/test/generated-rename-roundtrip.test.js
+++ b/tooling/satsuma-lsp/test/generated-rename-roundtrip.test.js
@@ -45,18 +45,20 @@
  * reads scenario data only. Nothing here derives an expectation by asking the
  * LSP what it did.
  *
- * ## One gap this file excludes by name
+ * ## gpt-fjo7: fixed for the schema; a field rename is a separate question
  *
- * Renaming a schema does **not** rewrite the `@ref` mentions of it inside NL
- * transform bodies, because the index files an `@ref` under the field path it
- * names (`s0.field_1`) rather than under the schema. The result parses and the
- * editor stays silent, but `satsuma validate` reports `unresolved-nl-ref` on it.
- * That is `gpt-fjo7`, and the reason the editor stays silent is `gpt-68ka`.
+ * Renaming a schema rewrites the schema segment of every NL `@ref` naming one
+ * of its fields (`@s0.field_1` → `@renamed_s0.field_1`): the index now files
+ * that ref under the schema key too, not only under the field path it names,
+ * so `findReferences`/rename for the schema reach it. `entitiesMentionedByNlRefs`
+ * used to compute an exclusion for this; it is kept below only as the
+ * vocabulary the two gpt-68ka/gpt-bc1x pins still need.
  *
- * The properties therefore skip an entity that an NL `@ref` mentions — computed
- * from the scenario by {@link entitiesMentionedByNlRefs}, never by asking the
- * toolchain — and the gap gets its own pinned test on a minimal fixture. When
- * `gpt-fjo7` is fixed, that pin turns red and the skip comes out.
+ * Renaming the FIELD an `@ref` names (rather than the schema) is a different
+ * question this ticket does not attempt: `prepareRename`'s renameable-context
+ * set has no `field_name` case, so the LSP does not offer to rename a field at
+ * all today, through any path. Whether an NL `@ref` should follow a future
+ * field rename is therefore out of scope here, not fixed.
  */
 
 const { describe, it, before } = require("node:test");
@@ -113,44 +115,18 @@ function siteLabels(sites) {
 }
 
 /**
- * The entities an NL `@ref` anywhere in the workspace mentions.
- *
- * Read from the scenario's own transform data, so the exclusion is stated
- * against the input rather than discovered by noticing the toolchain got it
- * wrong. See this file's header: the exclusion exists for `gpt-fjo7` and comes
- * out when that is fixed.
- */
-function entitiesMentionedByNlRefs(workspace) {
-  const mentioned = new Set();
-  const visit = (arrows) => {
-    for (const arrow of arrows) {
-      for (const ref of arrow.transform?.refs ?? []) mentioned.add(ref.schema);
-      if (arrow.children) visit(arrow.children);
-    }
-  };
-  for (const file of workspace.files) {
-    for (const mapping of file.mappings) visit(mapping.arrows);
-  }
-  return mentioned;
-}
-
-/**
  * Every entity of a workspace that this suite renames, with its ground truth.
  *
- * Excludes the NL-`@ref` mentions above, and asserts what is left is non-empty:
- * a sample with nothing to rename would let every property below pass without
- * doing anything.
+ * Used to exclude entities an NL `@ref` mentions, back when renaming such an
+ * entity left the `@ref` dangling (`gpt-fjo7`); now that the fix files the
+ * `@ref` under the schema key too, no exclusion is needed and every declared
+ * entity is fair game. Still asserts the entity list is non-empty: a sample
+ * with nothing to rename would let every property below pass without doing
+ * anything.
  */
 function renameableEntities(workspace, indexed) {
-  const mentioned = entitiesMentionedByNlRefs(workspace);
-  const entities = scenarioDeclaredEntities(workspace).filter(
-    (entity) => !mentioned.has(entity.name) && !mentioned.has(entity.key),
-  );
-  assert.ok(
-    entities.length > 0,
-    `every declared entity is mentioned by an NL @ref, so this sample renames ` +
-      `nothing (see gpt-fjo7):\n${indexed.sources}`,
-  );
+  const entities = scenarioDeclaredEntities(workspace);
+  assert.ok(entities.length > 0, `the workspace declares nothing to rename:\n${indexed.sources}`);
   return entities;
 }
 
@@ -332,18 +308,17 @@ describe("rename onto a name the workspace already declares", () => {
   });
 });
 
-// ── Pinned gaps: today's behaviour, recorded so a fix turns them red ────────
+// ── A fixed gap, kept as a concrete regression case ─────────────────────────
 //
-// Neither case below endorses what it asserts. Each states a defect precisely
-// enough that the day it is fixed, this file fails and says so.
+// This is the exact repro from gpt-fjo7's ticket. The generated properties
+// above now cover the same fix generically (`nlRefWorkspaceArbitrary` is part
+// of `workspaceScenarioArbitrary`, and `renameableEntities` no longer excludes
+// anything), but a minimal, readable case survives as its own test so a
+// regression here fails with a small, specific diff rather than only a fuzzed
+// counterexample.
 
-describe("known gap: rename does not rewrite NL @ref mentions (gpt-fjo7)", () => {
-  // Why this case exists: this is the exclusion the properties above depend on,
-  // so it must be measured rather than assumed. The index files an `@ref` under
-  // the field path it names, so a query for the schema's references never
-  // reaches it, and the rename leaves it pointing at a schema that no longer
-  // exists. The workspace still parses, which is what makes it silent.
-  it("leaves @s0.field_1 naming a schema the rename removed", () => {
+describe("gpt-fjo7: rename rewrites the schema segment of an NL @ref naming its field", () => {
+  it("turns @s0.field_1 into @renamed_s0.field_1 instead of leaving it dangling", () => {
     const workspace = scenarioWorkspace([
       scenarioFile({
         path: "entry.stm",
@@ -371,12 +346,14 @@ describe("known gap: rename does not rewrite NL @ref mentions (gpt-fjo7)", () =>
     const entity = { file: "entry.stm", name: "s0", keyword: "schema", key: "s0", namespace: null };
     const { edited } = renameFromDeclaration(indexed, entity);
 
-    // The declaration and the `source { }` entry were rewritten...
+    // The declaration and the `source { }` entry are rewritten, as before...
     assert.ok(edited.sources.includes("schema renamed_s0"), edited.sources);
     assert.ok(edited.sources.includes("source { renamed_s0 }"), edited.sources);
-    // ...and the @ref was not. `satsuma validate` reports `unresolved-nl-ref`
-    // for exactly this; the LSP reports nothing, which is `gpt-68ka`.
-    assert.ok(edited.sources.includes("@s0.field_1"), edited.sources);
+    // ...and now so is the @ref's schema segment, leaving the field part
+    // ("field_1") untouched: renaming a FIELD is a separate concern this
+    // ticket does not attempt (see this file's header).
+    assert.ok(edited.sources.includes("@renamed_s0.field_1"), edited.sources);
+    assert.ok(!edited.sources.includes("@s0.field_1"), edited.sources);
     assert.deepEqual(semanticProblems(edited), []);
   });
 });

--- a/tooling/satsuma-lsp/test/workspace-index.test.js
+++ b/tooling/satsuma-lsp/test/workspace-index.test.js
@@ -675,6 +675,75 @@ describe("reference range precision (sl-xf3f)", () => {
     assert.equal(textAt(source, refs[0].range), "customers");
   });
 
+  it("NL @ref naming a field also files a schema-key entry covering just the schema (gpt-fjo7)", () => {
+    // Before this fix, a field-naming @ref was filed only under the full
+    // name ("customers.first_name"), so a query for the SCHEMA's references
+    // (as a rename of `customers` issues) never reached it. The full-name
+    // entry stays, for field-level queries, and a new schema-key entry sits
+    // alongside it with a narrower range.
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  -> name { "see @customers.first_name here" }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+
+    const fieldRefs = (idx.references.get("customers.first_name") || []).filter(
+      (r) => r.context === "nl",
+    );
+    assert.equal(fieldRefs.length, 1);
+    assert.equal(textAt(source, fieldRefs[0].range), "customers.first_name");
+
+    const schemaRefs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(schemaRefs.length, 1);
+    // A range including ".first_name" would rewrite the field name too when
+    // renaming the schema — exactly the bug the schema-key entry exists for.
+    assert.equal(textAt(source, schemaRefs[0].range), "customers");
+  });
+
+  it("NL @ref schema-key entry keeps the ns:: qualifier the ref was authored with", () => {
+    // Grammar guarantee: "::" always precedes the first "." in an @ref, so the
+    // schema key includes it whenever the ref was written qualified.
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  -> name { "see @crm::customers.first_name here" }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const schemaRefs = (idx.references.get("crm::customers") || []).filter(
+      (r) => r.context === "nl",
+    );
+    assert.equal(schemaRefs.length, 1);
+    assert.equal(textAt(source, schemaRefs[0].range), "crm::customers");
+  });
+
+  it("does not file a schema-key entry for an @ref with no field part", () => {
+    // "@customers" alone already names the schema directly — its one entry
+    // IS the schema-key entry, so splitting would be redundant and would
+    // double the site a rename or find-references sees.
+    const source = `mapping test {
+  source { customers }
+  target { dim }
+  -> name { "see @customers here" }
+}`;
+    const idx = buildIndex({ "file:///a.stm": source });
+    const refs = (idx.references.get("customers") || []).filter((r) => r.context === "nl");
+    assert.equal(refs.length, 1);
+  });
+
+  it("a backtick-quoted schema segment keeps its literal dot out of the split (sl-g6ga)", () => {
+    // splitRefSchemaKey must treat the backtick span as opaque: the "." inside
+    // "my.schema" is part of the name, not the separator that starts the field
+    // path, so the first UNQUOTED "." — the one before "field" — is the real
+    // boundary.
+    const source =
+      'mapping test {\n  source { customers }\n  target { dim }\n  -> name { "see @`my.schema`.field here" }\n}';
+    const idx = buildIndex({ "file:///a.stm": source });
+    const schemaRefs = (idx.references.get("my.schema") || []).filter((r) => r.context === "nl");
+    assert.equal(schemaRefs.length, 1);
+    assert.equal(textAt(source, schemaRefs[0].range), "`my.schema`");
+  });
+
   it("fragment spread range covers only the label, not the ... sigil", () => {
     // sl-kf1r: fragment_spread = "..." + spread_label. A range including the
     // sigil deletes it on rename, leaving an invalid declaration. Covers both

--- a/tooling/satsuma-scenario-gen/src/ground-truth.js
+++ b/tooling/satsuma-scenario-gen/src/ground-truth.js
@@ -368,6 +368,10 @@ export const USAGE_KIND = Object.freeze({
   metricSource: "metric_source",
   /** The schema prefix of a qualified arrow path, e.g. the `s0` of `s0.field`. */
   arrow: "arrow",
+  /** The schema named by an NL `@ref` mentioning one of its fields, e.g. the
+   *  `s0` of `@s0.field_1` — the schema segment the index files separately
+   *  from the field-naming ref so a schema rename reaches it too (gpt-fjo7). */
+  nl: "nl",
 });
 
 /**
@@ -441,13 +445,16 @@ export function scenarioDeclaredEntities(workspace) {
  * from two mappings, and collapsing that to one site would hide a reference the
  * toolchain dropped.
  *
- * Two things are deliberately *not* sites. A `namespace` block is not one: the
- * scenario model has no namespace declaration to name, and a qualified reference
- * is filed under the whole `ns::name` key. Nor is the schema an NL `@ref`
- * mentions: `@raw.field_1` is a reference to the *field* `raw.field_1`, which is
- * how the index files it. The `@ref` still matters here, because a mention of
- * another file's schema is one of the things that forces an `import`, which is a
- * site.
+ * One thing is deliberately *not* a site: a `namespace` block. The scenario
+ * model has no namespace declaration to name, and a qualified reference is
+ * filed under the whole `ns::name` key.
+ *
+ * The schema an NL `@ref` mentions IS a site (`USAGE_KIND.nl`), one per ref,
+ * even though `@raw.field_1` is textually a reference to the *field*
+ * `raw.field_1`: the workspace index files that ref under the schema key too
+ * (`raw`), specifically so that renaming `raw` reaches it (gpt-fjo7) — and a
+ * mention of another file's schema is also one of the things that forces an
+ * `import`, which is a site of its own.
  *
  * Throws when the scenario references something it never declares — that is a
  * malformed scenario, not a toolchain failure, and failing loudly beats silently
@@ -485,6 +492,9 @@ export function scenarioDeclaredUsageSites(workspace) {
       for (const ref of mapping.targets) add(ref, mapping.namespace, file.path, USAGE_KIND.target);
       for (const ref of qualifiedArrowSchemas(mapping)) {
         add(ref, mapping.namespace, file.path, USAGE_KIND.arrow);
+      }
+      for (const ref of nlRefSchemas(mapping)) {
+        add(ref, mapping.namespace, file.path, USAGE_KIND.nl);
       }
     }
     for (const ref of importedRefs(file, workspace)) {
@@ -571,6 +581,21 @@ function sourceEndpointsOf(arrow) {
 /** Mirrors the renderer's `authoredEndpoint`: a side with one matching schema writes the path bare. */
 function namesItsSchema(endpoint, sideSchemas) {
   return !(sideSchemas.length === 1 && sideSchemas[0] === endpoint.schema);
+}
+
+/**
+ * The schemas an NL `@ref` mentions inside a mapping's arrow bodies, one entry
+ * per ref (mirroring `add`'s multiset semantics).
+ *
+ * Unlike {@link qualifiedArrowSchemas}, there is no `insideContainer` case to
+ * exclude: `renderTransform` always spells a ref absolutely (`@schema.path`),
+ * even inside an `each`/`flatten` block whose own arrow paths are written
+ * relative to the container.
+ */
+function nlRefSchemas(mapping) {
+  return flattenArrows(mapping.arrows).flatMap((arrow) =>
+    (arrow.transform?.refs ?? []).map((ref) => ref.schema),
+  );
 }
 
 /**

--- a/tooling/satsuma-scenario-gen/test/ground-truth.test.js
+++ b/tooling/satsuma-scenario-gen/test/ground-truth.test.js
@@ -435,6 +435,39 @@ describe("scenarioDeclaredUsageSites", () => {
     assert.deepEqual(sitesOf(usageSites, "s2"), ["target@entry.stm"]);
   });
 
+  it("counts the schema an NL @ref mentions, even though the ref names one of its fields (gpt-fjo7)", () => {
+    // `@s0.other` is textually a reference to the field `s0.other`, but the
+    // workspace index files it under the schema key too, specifically so a
+    // rename of `s0` reaches it. The oracle must agree, or the rename
+    // round-trip property (which asks the oracle, not the toolchain, what a
+    // rename should touch) would expect less than the fix actually does.
+    const schemas = ["s0", "s1"].map((name) =>
+      schemaDecl({ name, fields: [scalarField("id"), scalarField("other")] }),
+    );
+    const workspace = oneFile({
+      schemas,
+      mappings: [
+        mappingDecl({
+          name: "m0",
+          sources: ["s0"],
+          targets: ["s1"],
+          arrows: [
+            mapArrow(
+              [endpoint("s0", "id")],
+              endpoint("s1", "id"),
+              nlTransform("Combine.", [endpoint("s0", "other")]),
+            ),
+          ],
+        }),
+      ],
+    });
+
+    assert.deepEqual(sitesOf(scenarioDeclaredUsageSites(workspace), "s0"), [
+      "nl@entry.stm",
+      "source@entry.stm",
+    ]);
+  });
+
   it("counts the import statement the renderer derives for a cross-file reference", () => {
     // A scenario never authors its imports — `workspace-render.js` derives them
     // from usage — but an imported name is a reference site, and most of what the
@@ -528,6 +561,7 @@ describe("USAGE_KIND", () => {
       "arrow",
       "import",
       "metric_source",
+      "nl",
       "source",
       "spread",
       "target",

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -31,6 +31,7 @@ import {
   extractFieldTree,
   isMetricSchema,
   createAtRefRegex,
+  splitRefSchemaKey,
   renderFieldDeclType,
 } from "@satsuma/core";
 import type { FieldDecl, SatsumaCstType, SatsumaGrammarSymbol } from "@satsuma/core";
@@ -91,7 +92,10 @@ export interface ReferenceEntry {
   name: string;
   /** Semantic usage context for downstream queries. "arrow" marks structural
    *  src/tgt path references; "nl" marks @refs found inside NL prose strings
-   *  (arrow bodies, note tags/blocks, metadata values — sl-ellp). */
+   *  (arrow bodies, note tags/blocks, metadata values — sl-ellp). A
+   *  field-naming @ref (`@schema.field`) files TWO "nl" entries — one under
+   *  the full name for field-level queries, one under just the schema key so
+   *  a schema rename/find-references reaches it too (gpt-fjo7). */
   context: "source" | "target" | "spread" | "import" | "arrow" | "nl" | "metric_source";
   /** Qualified name of the mapping (or metric) whose body contains this
    *  reference. Set for "source"/"target"/"metric_source" contexts; lets
@@ -999,13 +1003,25 @@ function enclosingNamespace(node: SyntaxNode): string | null {
  * structural at_ref nodes that the grammar parses out of bare (unquoted)
  * pipe text — `a -> b { derived from @b }` has no nl_string at all, so a
  * string-only walk missed it entirely (bptar-l6n8).
+ *
+ * A field-naming ref (`@schema.field`, `@ns::schema.field`) is filed under
+ * TWO keys: the full name (`s0.field_1`), which is what field-level queries
+ * (e.g. right-click on a field declaration) look up, and — new for gpt-fjo7 —
+ * the schema key alone (`s0`), with the range narrowed to just that segment.
+ * Without the second entry, `findReferences`/rename for the SCHEMA never see
+ * this ref at all: it is filed only under a key that names a field, not the
+ * schema, so a schema rename left every such @ref pointing at a name that no
+ * longer existed (gpt-fjo7). A ref with no field part (`@s0`, `@ns::s0`) needs
+ * no second entry — its one key already IS the schema key.
  */
 function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void {
   walkDescendants(node, (n) => {
     if (n.type === "at_ref") {
-      // Strip the leading @ and any backtick delimiters, mirroring the
-      // regex path below.
-      const refName = n.text.slice(1).replace(/`([^`]+)`/g, "$1");
+      // Strip the leading @, keeping backticks for splitRefSchemaKey below;
+      // flatten only for the full-name entry, mirroring the regex path.
+      const rawRef = n.text.slice(1);
+      const refName = rawRef.replace(/`([^`]+)`/g, "$1");
+      const namespace = enclosingNamespace(n);
 
       // As below, the @ sigil stays outside the stored range (sl-xf3f).
       // An at_ref never spans lines, so a simple column bump is safe.
@@ -1019,8 +1035,17 @@ function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void
         ),
         name: refName,
         context: "nl",
-        namespace: enclosingNamespace(n),
+        namespace,
       });
+
+      addNlRefSchemaKeyEntry(
+        index,
+        uri,
+        rawRef,
+        namespace,
+        n.startPosition.row,
+        n.startPosition.column + 1,
+      );
       return;
     }
 
@@ -1029,6 +1054,7 @@ function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void
     const text = n.text;
     const startRow = n.startPosition.row;
     const startCol = n.startPosition.column;
+    const namespace = enclosingNamespace(n);
 
     // Index @refs
     NL_AT_REF_RE.lastIndex = 0;
@@ -1048,9 +1074,55 @@ function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void
         range,
         name: refName,
         context: "nl",
-        namespace: enclosingNamespace(n),
+        namespace,
       });
+
+      // The schema-key entry's range starts at the same offset (right after
+      // the @) but covers only the schema segment — see offsetToRange's
+      // `length` parameter below.
+      const schemaSplit = splitRefSchemaKey(rawRef);
+      if (schemaSplit) {
+        const schemaRange = offsetToRange(
+          text,
+          match.index + 1,
+          schemaSplit.rawLength,
+          startRow,
+          startCol,
+        );
+        addReference(index, schemaSplit.schemaKey, {
+          uri,
+          range: schemaRange,
+          name: schemaSplit.schemaKey,
+          context: "nl",
+          namespace,
+        });
+      }
     }
+  });
+}
+
+/**
+ * The at_ref counterpart of the schema-key entry added for the regex path
+ * above — split out because an at_ref's range comes from raw row/column
+ * arithmetic (it never spans lines) rather than {@link offsetToRange}, but the
+ * entry it produces must be identical in shape.
+ */
+function addNlRefSchemaKeyEntry(
+  index: WorkspaceIndex,
+  uri: string,
+  rawRef: string,
+  namespace: string | null,
+  startRow: number,
+  startCol: number,
+): void {
+  const schemaSplit = splitRefSchemaKey(rawRef);
+  if (!schemaSplit) return;
+  addReference(index, schemaSplit.schemaKey, {
+    uri,
+    range: Range.create(startRow, startCol, startRow, startCol + schemaSplit.rawLength),
+    name: schemaSplit.schemaKey,
+    context: "nl",
+    namespace,
   });
 }
 

--- a/tooling/satsuma-viz-backend/src/workspace-index.ts
+++ b/tooling/satsuma-viz-backend/src/workspace-index.ts
@@ -991,6 +991,9 @@ function enclosingNamespace(node: SyntaxNode): string | null {
   return null;
 }
 
+/** Length in characters of the `@` sigil that precedes every raw ref. */
+const AT_REF_SIGIL_LENGTH = 1;
+
 /**
  * Index every @ref inside NL prose under `node` as an "nl" reference.
  *
@@ -999,10 +1002,82 @@ function enclosingNamespace(node: SyntaxNode): string | null {
  * blocks at any level, and metadata value strings — all of which rename and
  * find-references must reach, or renames leave stale prose behind.
  *
- * Refs come in two CST shapes: regex matches inside quoted NL strings, and
- * structural at_ref nodes that the grammar parses out of bare (unquoted)
- * pipe text — `a -> b { derived from @b }` has no nl_string at all, so a
- * string-only walk missed it entirely (bptar-l6n8).
+ * Refs come in two CST shapes, handled by the two branches below: regex
+ * matches inside quoted NL strings, and structural at_ref nodes that the
+ * grammar parses out of bare (unquoted) pipe text — `a -> b { derived from
+ * @b }` has no nl_string at all, so a string-only walk missed it entirely
+ * (bptar-l6n8). Both branches delegate the actual entry-filing to
+ * {@link addNlRefEntries}, which is what decides how many keys a ref is
+ * filed under.
+ */
+function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void {
+  walkDescendants(node, (n) => {
+    if (n.type === "at_ref") {
+      indexAtRefNode(index, uri, n);
+      return;
+    }
+    if (n.type === "nl_string" || n.type === "multiline_string") {
+      indexNlStringRefs(index, uri, n);
+    }
+  });
+}
+
+/**
+ * File the reference entries for a structural at_ref node — the shape the
+ * grammar parses out of bare (unquoted) pipe text, e.g. `derived from @b`.
+ * An at_ref never spans lines, so its own text can stand in directly for the
+ * "text plus offset" that {@link addNlRefEntries} otherwise recovers from an
+ * nl_string via {@link offsetToRange}.
+ */
+function indexAtRefNode(index: WorkspaceIndex, uri: string, atRef: SyntaxNode): void {
+  // Strip the leading @, keeping backticks for splitRefSchemaKey inside
+  // addNlRefEntries; it flattens them itself for the full-name entry.
+  const rawRef = atRef.text.slice(1);
+  addNlRefEntries(
+    index,
+    uri,
+    rawRef,
+    enclosingNamespace(atRef),
+    atRef.text,
+    AT_REF_SIGIL_LENGTH,
+    atRef.startPosition.row,
+    atRef.startPosition.column,
+  );
+}
+
+/**
+ * File the reference entries for every @ref found by regex inside a quoted
+ * NL string (`nl_string`/`multiline_string`). Unlike an at_ref node, this
+ * text can span multiple lines, so each match's document position is
+ * recovered via {@link offsetToRange} rather than simple column arithmetic.
+ */
+function indexNlStringRefs(index: WorkspaceIndex, uri: string, nlString: SyntaxNode): void {
+  const text = nlString.text;
+  const startRow = nlString.startPosition.row;
+  const startCol = nlString.startPosition.column;
+  const namespace = enclosingNamespace(nlString);
+
+  NL_AT_REF_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = NL_AT_REF_RE.exec(text)) !== null) {
+    // Strip leading @ and backtick delimiters
+    const rawRef = match[0].slice(1);
+    addNlRefEntries(
+      index,
+      uri,
+      rawRef,
+      namespace,
+      text,
+      match.index + AT_REF_SIGIL_LENGTH,
+      startRow,
+      startCol,
+    );
+  }
+}
+
+/**
+ * File the one or two "nl"-context reference entries a single @ref produces,
+ * shared by both CST shapes {@link indexNlRefs} walks.
  *
  * A field-naming ref (`@schema.field`, `@ns::schema.field`) is filed under
  * TWO keys: the full name (`s0.field_1`), which is what field-level queries
@@ -1013,113 +1088,40 @@ function enclosingNamespace(node: SyntaxNode): string | null {
  * schema, so a schema rename left every such @ref pointing at a name that no
  * longer existed (gpt-fjo7). A ref with no field part (`@s0`, `@ns::s0`) needs
  * no second entry — its one key already IS the schema key.
+ *
+ * `text`/`offset`/`nodeStartRow`/`nodeStartCol` locate `rawRef` (the ref with
+ * its leading @ already stripped) within the source, in the terms
+ * {@link offsetToRange} expects. The @ sigil itself must stay outside every
+ * stored range — rename replaces a range verbatim, and including the sigil
+ * turned "@customers" into "clients", breaking the ref (sl-xf3f) — so callers
+ * pass an `offset` that already points past it.
  */
-function indexNlRefs(index: WorkspaceIndex, uri: string, node: SyntaxNode): void {
-  walkDescendants(node, (n) => {
-    if (n.type === "at_ref") {
-      // Strip the leading @, keeping backticks for splitRefSchemaKey below;
-      // flatten only for the full-name entry, mirroring the regex path.
-      const rawRef = n.text.slice(1);
-      const refName = rawRef.replace(/`([^`]+)`/g, "$1");
-      const namespace = enclosingNamespace(n);
-
-      // As below, the @ sigil stays outside the stored range (sl-xf3f).
-      // An at_ref never spans lines, so a simple column bump is safe.
-      addReference(index, refName, {
-        uri,
-        range: Range.create(
-          n.startPosition.row,
-          n.startPosition.column + 1,
-          n.endPosition.row,
-          n.endPosition.column,
-        ),
-        name: refName,
-        context: "nl",
-        namespace,
-      });
-
-      addNlRefSchemaKeyEntry(
-        index,
-        uri,
-        rawRef,
-        namespace,
-        n.startPosition.row,
-        n.startPosition.column + 1,
-      );
-      return;
-    }
-
-    if (n.type !== "nl_string" && n.type !== "multiline_string") return;
-
-    const text = n.text;
-    const startRow = n.startPosition.row;
-    const startCol = n.startPosition.column;
-    const namespace = enclosingNamespace(n);
-
-    // Index @refs
-    NL_AT_REF_RE.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = NL_AT_REF_RE.exec(text)) !== null) {
-      // Strip leading @ and backtick delimiters
-      const rawRef = match[0].slice(1);
-      const refName = rawRef.replace(/`([^`]+)`/g, "$1");
-
-      // The @ sigil is not part of the keyed name, so it must stay outside
-      // the stored range — rename replaces the range verbatim, and including
-      // the sigil turned "@customers" into "clients", breaking the ref
-      // (sl-xf3f). Skip one character past the @.
-      const range = offsetToRange(text, match.index + 1, match[0].length - 1, startRow, startCol);
-      addReference(index, refName, {
-        uri,
-        range,
-        name: refName,
-        context: "nl",
-        namespace,
-      });
-
-      // The schema-key entry's range starts at the same offset (right after
-      // the @) but covers only the schema segment — see offsetToRange's
-      // `length` parameter below.
-      const schemaSplit = splitRefSchemaKey(rawRef);
-      if (schemaSplit) {
-        const schemaRange = offsetToRange(
-          text,
-          match.index + 1,
-          schemaSplit.rawLength,
-          startRow,
-          startCol,
-        );
-        addReference(index, schemaSplit.schemaKey, {
-          uri,
-          range: schemaRange,
-          name: schemaSplit.schemaKey,
-          context: "nl",
-          namespace,
-        });
-      }
-    }
-  });
-}
-
-/**
- * The at_ref counterpart of the schema-key entry added for the regex path
- * above — split out because an at_ref's range comes from raw row/column
- * arithmetic (it never spans lines) rather than {@link offsetToRange}, but the
- * entry it produces must be identical in shape.
- */
-function addNlRefSchemaKeyEntry(
+function addNlRefEntries(
   index: WorkspaceIndex,
   uri: string,
   rawRef: string,
   namespace: string | null,
-  startRow: number,
-  startCol: number,
+  text: string,
+  offset: number,
+  nodeStartRow: number,
+  nodeStartCol: number,
 ): void {
+  const refName = rawRef.replace(/`([^`]+)`/g, "$1");
+  addReference(index, refName, {
+    uri,
+    range: offsetToRange(text, offset, rawRef.length, nodeStartRow, nodeStartCol),
+    name: refName,
+    context: "nl",
+    namespace,
+  });
+
   const schemaSplit = splitRefSchemaKey(rawRef);
   if (!schemaSplit) return;
   addReference(index, schemaSplit.schemaKey, {
     uri,
-    range: Range.create(startRow, startCol, startRow, startCol + schemaSplit.rawLength),
+    // Same start as the full-name entry above, narrowed to just the schema
+    // segment via schemaSplit.rawLength.
+    range: offsetToRange(text, offset, schemaSplit.rawLength, nodeStartRow, nodeStartCol),
     name: schemaSplit.schemaKey,
     context: "nl",
     namespace,


### PR DESCRIPTION
## Summary

- Renaming a schema through the LSP rewrote its declaration, `source`/`target` entries, spreads, imports and qualified arrow paths — but never the `@ref` mentions of it inside NL transform bodies. `@s0.field_1` stayed `@s0.field_1` after `s0` was renamed, leaving `satsuma validate` reporting `unresolved-nl-ref` on a workspace the editor thought it had fixed cleanly.
- Root cause: the workspace index filed a field-naming NL `@ref` only under the **field path** it names (`"s0.field_1"`, context `"nl"`), never under the schema key (`"s0"`) alone. `findReferences`/rename query by the schema's key, so this class of reference was invisible to both — corrupting the workspace on write, and (pre-existing, same root cause) making `where-used`/find-references miss it too.
- Fix: added `@satsuma/core`'s `splitRefSchemaKey()` — isolates the schema segment of a dotted `@ref` (`@schema.field`, `@ns::schema.field`), honouring backtick quoting (sl-g6ga) and the grammar's guarantee that `::` always precedes the first `.`. The workspace index now uses it to file a **second** `"nl"` entry under just the schema key, with its range narrowed to that segment — so a schema rename rewrites exactly the schema part and leaves the field part untouched, and find-references for the schema now reaches these refs too.
- **Scope decision (stated explicitly per the ticket):** renaming a *field* an `@ref` names (as opposed to the schema) is out of scope here and not attempted. The LSP's `prepareRename`/`computeRename` have no renameable `field_name` context at all today — through any path — so there is no existing field-rename behaviour for an `@ref` to follow. That is a separate, unstarted feature, not a gap in this fix.
- `tooling/satsuma-lsp/test/generated-rename-roundtrip.test.js` no longer excludes entities an NL `@ref` mentions (`entitiesMentionedByNlRefs` removed); the pin recording the broken behaviour was replaced with a concrete regression test asserting the fixed behaviour (`@s0.field_1` → `@renamed_s0.field_1`). `@satsuma/scenario-gen`'s `scenarioDeclaredUsageSites` ground truth gained a matching `USAGE_KIND.nl` site, since the schema an NL `@ref` mentions is now genuinely a usage site the index (and therefore `generated-reference-duality.test.js`'s find-references properties) reports.

## Test plan

- [x] `turbo run test --filter=@satsuma/core` — 714 tests green, including new `splitRefSchemaKey()` unit tests (dotted, ns-qualified, multi-segment, backtick-quoted, no-field-part cases).
- [x] `turbo run test --filter=@satsuma/viz-backend` — 197 tests green (workspace index that both LSP and CLI/viz build on).
- [x] `turbo run test --filter=@satsuma/scenario-gen` — 48 tests green, including the new ground-truth case for an NL-ref usage site.
- [x] `turbo run test --filter=@satsuma/lsp` — 327 tests green, including:
  - `computeRename`'s existing suite (unaffected schemas without NL refs pass unchanged).
  - New `workspace-index.test.js` cases pinning the new schema-key entry's range, the ns-qualified case, the backtick-with-literal-dot case, and the no-double-entry case for a schema-only `@ref`.
  - `generated-rename-roundtrip.test.js`'s full generated-domain properties now run over `nlRefWorkspaceArbitrary` without exclusion, plus the new gpt-fjo7 regression test.
  - `generated-reference-duality.test.js` (find-references/go-to-definition properties) still green against the updated ground truth.
- [x] `npm run test:all` — all 24 workspace tasks green, 0 failures anywhere.
- [x] `./scripts/run-repo-checks.sh` (full pre-commit suite: lint, root script tests, tree-sitter generator/corpus, Python/smoke tests, `npm run test:all`) — green, ran via the actual pre-commit hook on both commits.
- [x] `tk` ticket workflow: started, closing note added referencing this branch's fix commit, closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)