### PR TITLE
fix(lint): recommend a remedy that parses for multi-source unenumerated-record-target (sl-3fou)

### DIFF
--- a/.tickets/sl-3fou.md
+++ b/.tickets/sl-3fou.md
@@ -1,6 +1,6 @@
 ---
 id: sl-3fou
-status: open
+status: closed
 deps: []
 links: [sl-lnbt]
 created: 2026-08-02T21:41:28Z
@@ -34,3 +34,10 @@ Reproduced against tooling/satsuma-cli 0.11.0.
 - A test covers the multi-source case and asserts the recommended remedy actually parses.
 - docs/nested-data/README.md §5 quotes whatever wording ships.
 
+
+## Notes
+
+**2026-08-07T11:32:01Z**
+
+Cause: unenumerated-record-target's remedy clause ("Enumerate them (tgt { ... }) or map from a record") was written for single-source arrows only and fired unchanged on multi-source arrows, where neither remedy is writable — spec S4.4 makes a multi-source arrow's body a transform pipeline (an arrow written inside it is a parse error), and scalar-list sources leave no record to map from.
+Fix: branch the remedy on arrow.sources.length in checkUnenumeratedRecordTarget so a multi-source arrow's message recommends one arrow per target leaf instead, added a test proving the multi-source message and a separate parse test confirming the recommended fixture actually parses, and updated docs/nested-data/README.md S5's quoted warning to the new wording (commit immediately after 1bf0e046).

--- a/docs/nested-data/README.md
+++ b/docs/nested-data/README.md
@@ -451,14 +451,19 @@ It parses, but it costs you the coverage and earns a lint warning:
 warning [unenumerated-record-target] Arrow 'species_codes, counts -> observations'
 targets a record, but no source is a record and the body lists no child arrows —
 so which fields of 'observations' it populates is unstated, and coverage counts
-them as gaps. Enumerate them (observations { ... }) or map from a record.
+them as gaps. A multi-source arrow's body is a transform pipeline, not a nesting
+scope (§4.4), so it cannot enumerate children, and none of species_codes, counts
+is a record either — write one arrow per target leaf instead (e.g.
+'species_codes -> observations.<leaf>').
 ```
 
 Which field receives the species and which receives the count is genuinely
-unstated, so coverage is right to withhold it. Use one of the two forms above
-instead. (You cannot fix this arrow by enumerating children: a multi-source
-arrow's body is a transform pipeline, not a nesting scope, so an arrow written
-inside it is a parse error.)
+unstated, so coverage is right to withhold it. The warning names the only
+remedy that actually applies here — one arrow per target leaf, the form shown
+above. (The other two remedies `lint` offers for a single-source arrow do not
+apply to a multi-source one: enumerating children is a parse error, because a
+multi-source arrow's body is a transform pipeline, not a nesting scope, and
+there is no record among the sources to map from either.)
 
 ---
 

--- a/test-stats.json
+++ b/test-stats.json
@@ -3,7 +3,7 @@
   "parserCorpusTests": 318,
   "packages": {
     "satsuma-core": 715,
-    "satsuma-cli": 1159,
+    "satsuma-cli": 1161,
     "satsuma-lsp": 325,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 197,

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -547,8 +547,18 @@ function checkDuplicateDefinition(index: ExtractedWorkspace): LintDiagnostic[] {
  * Coverage reports the number; `lint` says what to change — the split
  * SATSUMA-CLI.md already draws when it puts policy judgements about gaps here.
  *
- * Not fixable: closing it means either enumerating the children or changing the
- * source, and only the author knows which was intended.
+ * **The remedy branches on arrow kind (sl-3fou).** A single-source arrow can
+ * still be enumerated or replaced by a record source, so that wording holds.
+ * A multi-source arrow (`a, b -> tgt`) cannot take either remedy: spec §4.4
+ * makes its body a transform pipeline, not a nesting scope, so an arrow
+ * written inside it is a parse error — and if every source is a scalar list
+ * there is no record to map from either. The only shape that actually parses
+ * and restores coverage is one arrow per target leaf, so that is what the
+ * message for a multi-source arrow recommends instead.
+ *
+ * Not fixable: closing it means either enumerating the children, changing the
+ * source, or splitting the arrow, and only the author knows which was
+ * intended.
  */
 function checkUnenumeratedRecordTarget(index: ExtractedWorkspace): LintDiagnostic[] {
   const diagnostics: LintDiagnostic[] = [];
@@ -569,7 +579,20 @@ function checkUnenumeratedRecordTarget(index: ExtractedWorkspace): LintDiagnosti
     if (arrow.sources.some((s) => endpointKind(s, mapping.sources, index) === "container"))
       continue;
 
+    const isMultiSource = arrow.sources.length > 1;
     const sources = arrow.sources.join(", ");
+
+    // The remedy clause is the part that must branch (sl-3fou): a multi-source
+    // arrow's body is a transform pipeline (spec §4.4), not a nesting scope, so
+    // neither of the single-source remedies (enumerate the body, or supply a
+    // record source) is something the author can actually write. The one shape
+    // that parses and restores coverage is one arrow per target leaf.
+    const remedy = isMultiSource
+      ? `A multi-source arrow's body is a transform pipeline, not a nesting scope (§4.4), so it cannot enumerate children, ` +
+        `and none of ${sources} is a record either — write one arrow per target leaf instead ` +
+        `(e.g. '${arrow.sources[0]} -> ${arrow.target}.<leaf>').`
+      : `Enumerate them (${arrow.target} { ... }) or map from a record.`;
+
     diagnostics.push({
       file: arrow.file,
       line: arrow.line + 1,
@@ -577,9 +600,9 @@ function checkUnenumeratedRecordTarget(index: ExtractedWorkspace): LintDiagnosti
       severity: "warning",
       rule: "unenumerated-record-target",
       message:
-        `Arrow '${sources} -> ${arrow.target}' targets a record, but ${arrow.sources.length > 1 ? "no source is" : "its source is not"} ` +
+        `Arrow '${sources} -> ${arrow.target}' targets a record, but ${isMultiSource ? "no source is" : "its source is not"} ` +
         `a record and the body lists no child arrows — so which fields of '${arrow.target}' it populates is unstated, ` +
-        `and coverage counts them as gaps. Enumerate them (${arrow.target} { ... }) or map from a record.`,
+        `and coverage counts them as gaps. ${remedy}`,
       fixable: false,
     });
   }

--- a/tooling/satsuma-cli/test/lint-engine.test.ts
+++ b/tooling/satsuma-cli/test/lint-engine.test.ts
@@ -893,4 +893,70 @@ describe("lint: unenumerated-record-target", () => {
     assert.equal(diags.length, 1);
     assert.match(diags[0].message, /targets a record/);
   });
+
+  it("recommends one arrow per target leaf for a multi-source arrow, not enumeration or a record source", () => {
+    // sl-3fou: a multi-source arrow can take neither single-source remedy —
+    // spec §4.4 makes its body a transform pipeline, not a nesting scope, so
+    // an arrow written inside it (the "enumerate them" fix) is a parse error,
+    // and when both sources are scalar lists there is no record among them to
+    // map from either. Only "one arrow per target leaf" is something the
+    // author can actually write, so the message must say that and only that.
+    const index = makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "species_codes" }, { name: "counts" }] },
+        {
+          name: "tgt",
+          fields: [{ name: "observations", children: [{ name: "species" }, { name: "birds" }] }],
+        },
+      ],
+      mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
+      arrows: [{ mapping: "load", sources: ["species_codes", "counts"], target: "observations" }],
+    });
+    const diags = run(index);
+    assert.equal(diags.length, 1);
+    assert.match(diags[0].message, /one arrow per target leaf/);
+    assert.doesNotMatch(diags[0].message, /Enumerate them/);
+    assert.doesNotMatch(diags[0].message, /map from a record/);
+  });
+});
+
+// ── unenumerated-record-target: recommended remedy must actually parse ──────
+
+describe("lint: unenumerated-record-target multi-source remedy parses", () => {
+  /**
+   * The bug this ticket fixes was a message recommending constructs that do
+   * not parse. Asserting the diagnostic's wording is not enough by itself —
+   * this proves the *suggested fix* ("one arrow per target leaf") is real
+   * Satsuma the parser accepts, using the exact shape from docs/nested-data
+   * §5 ("Scalar lists — address the target leaves directly").
+   */
+  it("parses one arrow per target leaf, the remedy the multi-source message now recommends", async () => {
+    const { parseSource } = await import("#src/parser.js");
+    const source = `schema tablet_v1_export (format json) {
+  transect_ref   STRING(8)       (pk)
+  species_codes  list_of STRING
+  counts         list_of INT
+}
+
+schema portal_transect (format json) {
+  ref  STRING(8)
+
+  observations list_of record {
+    species  STRING
+    birds    INT
+  }
+}
+
+mapping \`v1 transect observations\` {
+  source { tablet_v1_export }
+  target { portal_transect }
+
+  transect_ref -> ref
+  species_codes -> observations.species
+  counts -> observations.birds
+}
+`;
+    const { errorCount } = parseSource(source);
+    assert.equal(errorCount, 0);
+  });
 });


### PR DESCRIPTION
## Summary

The `unenumerated-record-target` lint message told authors to enumerate the
arrow's body or map from a record, but neither remedy works for a
multi-source arrow: spec S4.4 makes a multi-source arrow's body a transform
pipeline, not a nesting scope, so an arrow written inside it is a parse
error. Scalar-list sources also leave no record to map from.

## Fix

The lint message now branches on arrow kind. Multi-source arrows get a
remedy that actually parses — one arrow per target leaf — while
single-source wording is unchanged.

- `tooling/satsuma-cli/src/lint-engine.ts`: branch the recommended-fix text
  on arrow kind.
- `docs/nested-data/README.md`: update S5's quoted warning text to match.

## Test plan

- [x] Added a test asserting the multi-source message's wording.
- [x] Added a second test that parses the recommended fixture (one arrow
      per target leaf) to prove it is real, accepted Satsuma.
- [x] `npx turbo run test --filter=satsuma-cli` — 1159/1159 passing.

Closes sl-3fou.