### PR TITLE
fix(cli): unenumerated-record-target fires for resolved spreads (gpt-i1uv)

### DIFF
--- a/.tickets/gpt-i1uv.md
+++ b/.tickets/gpt-i1uv.md
@@ -1,6 +1,6 @@
 ---
 id: gpt-i1uv
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-06T15:20:48Z
@@ -30,3 +30,9 @@ Found while building Feature 46's defect mutators (gpt-pwze). The mutator target
 
 The rule fires for a schema whose spreads all resolve, and stays silent only when a spread cannot be resolved — matching what the doc-comment already claims. A test pins both halves using the differential pair above (same arrow, spread and no spread). Whatever notion of 'unresolved' the fix uses is available to the rule without re-implementing spread expansion; check whether core already exposes it before adding a second mechanism.
 
+
+## Notes
+
+**2026-08-07T11:32:29Z**
+
+Cause: endpointKind in lint-engine.ts skipped any schema with hasSpreads set (extract.ts sets it for every fragment spread regardless of resolution), so unenumerated-record-target went silent for spread-bearing schemas even when the spread fully resolved. Fix: endpointKind now calls core's expandSpreads (via the CLI's spread-expand.ts adapter) to distinguish unresolved from resolved spreads, skipping only the former and, for the latter, judging containerness against the fully expanded field list from expandDeclaredFields instead of the raw unexpanded fields. (commit immediately after 1bf0e046)

--- a/test-stats.json
+++ b/test-stats.json
@@ -3,7 +3,7 @@
   "parserCorpusTests": 318,
   "packages": {
     "satsuma-core": 715,
-    "satsuma-cli": 1157,
+    "satsuma-cli": 1159,
     "satsuma-lsp": 325,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 197,

--- a/tooling/satsuma-cli/src/lint-engine.ts
+++ b/tooling/satsuma-cli/src/lint-engine.ts
@@ -27,7 +27,7 @@ import type {
   LineageSchemaIdResolver,
   LintFinding,
 } from "@satsuma/core";
-import { expandDeclaredFields } from "./spread-expand.js";
+import { expandDeclaredFields, expandSpreads } from "./spread-expand.js";
 import {
   extractAtRefs,
   computeNLRefPosition,
@@ -606,9 +606,14 @@ function qualifiedMappingKey(arrow: { mapping: string | null; namespace: string 
  * Delegates the two hard parts to core — stripping a schema prefix
  * (`schemaLocalFieldPath`) and walking the field tree (`declaredFieldKind`) — so
  * this rule and coverage cannot disagree about what a path names. A schema with
- * unresolved spreads is skipped: its field list is incomplete, and reporting an
- * arrow as under-specified because a spread has not been expanded would be a
- * false positive.
+ * an *unresolved* spread is skipped: its field list is incomplete, and reporting
+ * an arrow as under-specified because a spread has not been expanded would be a
+ * false positive. A schema whose spreads all resolve has nothing to hide, so its
+ * fields are expanded first (the same field tree coverage sees, via
+ * `expandDeclaredFields`) rather than skipped — gpt-i1uv found this rule going
+ * silent for every spread-bearing schema, resolved or not, because it read
+ * `hasSpreads` (set for any spread at extraction time, see extract.ts) as a proxy
+ * for "unresolved" when the two are not the same thing.
  */
 function endpointKind(
   path: string,
@@ -618,16 +623,35 @@ function endpointKind(
   for (const ref of schemaRefs) {
     const canonicalKey = resolveCanonicalKey(ref);
     const schema = index.schemas.get(canonicalKey);
-    if (!schema || schema.hasSpreads) continue;
+    if (!schema) continue;
+
+    let fields = schema.fields;
+    if (schema.hasSpreads) {
+      // `expandSpreads` walks the same fragment graph `expandDeclaredFields` does
+      // and hands back whether any spread in it failed to resolve — the resolved/
+      // unresolved distinction the doc-comment above promises. Only a genuinely
+      // unresolved spread earns the skip; a resolved one is expanded and judged
+      // on its full field list like any other schema.
+      const namespace = schema.namespace ?? null;
+      const hasUnresolvedSpread = expandSpreads(
+        [canonicalKey],
+        namespace,
+        index,
+        new Set<string>(),
+      );
+      if (hasUnresolvedSpread) continue;
+      fields = expandDeclaredFields(schema, namespace, index);
+    }
+
     const local = schemaLocalFieldPath(
       createContainerQualifiedFieldRef(path),
       createAuthoredEntityRef(ref),
       createCanonicalEntityRef(canonicalKey.includes("::") ? canonicalKey : `::${canonicalKey}`),
       schemaRefs.filter((r) => r !== ref).map(createAuthoredEntityRef),
-      (name) => schema.fields.some((f) => f.name === name),
+      (name) => fields.some((f) => f.name === name),
     );
     if (local === null) continue;
-    const kind = declaredFieldKind(local, schema.fields);
+    const kind = declaredFieldKind(local, fields);
     if (kind) return kind;
   }
   return null;

--- a/tooling/satsuma-cli/test/lint-engine.test.ts
+++ b/tooling/satsuma-cli/test/lint-engine.test.ts
@@ -13,8 +13,16 @@ interface MockSchema {
   fields: Array<{ name: string; children?: Array<{ name: string }> }>;
   /** Set when the schema spreads a fragment that has not been expanded — its field list is then incomplete. */
   hasSpreads?: boolean;
+  /** Fragment names this schema spreads (`...name`), resolved against `fragments` passed to makeIndex. */
+  spreads?: string[];
   file?: string;
   row?: number;
+}
+
+/** Shape of a mock fragment passed to makeIndex, resolved by name for a MockSchema's `spreads`. */
+interface MockFragment {
+  name: string;
+  fields: Array<{ name: string; children?: Array<{ name: string }> }>;
 }
 
 /** Shape of a mock mapping passed to makeIndex. */
@@ -62,11 +70,13 @@ function makeIndex({
   mappings = [],
   nlRefData = [],
   arrows = [],
+  fragments = [],
 }: {
   schemas?: MockSchema[];
   mappings?: MockMapping[];
   nlRefData?: MockNLRef[];
   arrows?: MockArrow[];
+  fragments?: MockFragment[];
 } = {}): ExtractedWorkspace {
   const schemaMap = new Map<string, any>();
   for (const s of schemas) {
@@ -76,11 +86,15 @@ function makeIndex({
   for (const m of mappings) {
     mappingMap.set(m.name, { ...m, file: m.file ?? "test.stm", row: m.row ?? 0 });
   }
+  const fragmentMap = new Map<string, any>();
+  for (const f of fragments) {
+    fragmentMap.set(f.name, { ...f, hasSpreads: false, spreads: [], file: "test.stm", row: 0 });
+  }
   return {
     schemas: schemaMap,
     mappings: mappingMap,
     metrics: new Map(),
-    fragments: new Map(),
+    fragments: fragmentMap,
     transforms: new Map(),
     notes: [],
     warnings: [],
@@ -816,7 +830,9 @@ describe("lint: unenumerated-record-target", () => {
 
   it("stays silent when the target schema has unresolved spreads", () => {
     // The field list is incomplete, so "targets a record" cannot be established
-    // — reporting on it would blame the author for an unexpanded fragment.
+    // — reporting on it would blame the author for an unexpanded fragment. This
+    // schema declares `hasSpreads` with no matching fragment registered, the
+    // mock's stand-in for a spread naming a fragment the workspace never defines.
     const index = makeIndex({
       schemas: [
         { name: "src", fields: [{ name: "full_name" }] },
@@ -824,11 +840,57 @@ describe("lint: unenumerated-record-target", () => {
           name: "tgt",
           fields: [{ name: "address", children: [{ name: "line1" }] }],
           hasSpreads: true,
+          spreads: ["missing_fragment"],
         },
       ],
       mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
       arrows: [{ mapping: "load", sources: ["full_name"], target: "address" }],
     });
     assert.deepEqual(run(index), []);
+  });
+
+  // ── gpt-i1uv differential pair ──────────────────────────────────────────
+  //
+  // Two mappings with a byte-identical arrow shape (`full_name -> address`),
+  // differing only in whether the target schema spreads a fragment declared
+  // in the same workspace and fully resolved. The rule must fire for both:
+  // a *resolved* spread leaves nothing hidden about the target's field list,
+  // so it is not the "incomplete field list" case the skip above exists for.
+  // Before the fix, `endpointKind` skipped any schema with `hasSpreads` set —
+  // resolved or not — so the with-spread mapping went unreported.
+
+  const differentialPair = (targetHasSpread: boolean) =>
+    makeIndex({
+      schemas: [
+        { name: "src", fields: [{ name: "full_name" }] },
+        {
+          name: "tgt",
+          fields: [{ name: "address", children: [{ name: "line1" }] }],
+          ...(targetHasSpread ? { hasSpreads: true, spreads: ["audit_fields"] } : {}),
+        },
+      ],
+      fragments: [{ name: "audit_fields", fields: [{ name: "loaded_at" }] }],
+      mappings: [{ name: "load", sources: ["src"], targets: ["tgt"] }],
+      arrows: [{ mapping: "load", sources: ["full_name"], target: "address" }],
+    });
+
+  it("flags an unenumerated record target with no spread", () => {
+    // Control half of the differential pair: same arrow shape as the
+    // spread-bearing case below, minus the spread. Establishes the baseline
+    // the with-spread case must match once the spread resolves.
+    const diags = run(differentialPair(false));
+    assert.equal(diags.length, 1);
+    assert.match(diags[0].message, /targets a record/);
+  });
+
+  it("flags an unenumerated record target whose schema spreads a resolved fragment", () => {
+    // gpt-i1uv: `tgt` spreads `audit_fields`, which is declared and resolves —
+    // the arrow's target path ("address") is a directly-declared field the
+    // spread never touches, so a resolved spread elsewhere in the schema must
+    // not suppress the diagnostic. Before the fix this reported nothing at
+    // all, because `endpointKind` skipped every `hasSpreads` schema outright.
+    const diags = run(differentialPair(true));
+    assert.equal(diags.length, 1);
+    assert.match(diags[0].message, /targets a record/);
   });
 });


### PR DESCRIPTION
## Summary

`endpointKind` in `lint-engine.ts` skipped **any** schema with `hasSpreads`
set, but `hasSpreads` is set at extraction time for every fragment spread
regardless of whether it resolves (see `extract.ts`). The rule's own
doc-comment said only *unresolved* spreads should be skipped, since an
incomplete field list would make the rule a false positive — but the code
did not honour that distinction, so `unenumerated-record-target` went
silent for every spread-bearing schema, resolved or not.

The fix makes `endpointKind` call core's `expandSpreads` (via the CLI's
existing `spread-expand.ts` adapter) to tell resolved spreads from
unresolved ones. Only an unresolved spread still earns the skip; a
resolved one is expanded via `expandDeclaredFields` and judged against its
full field list, same as any non-spreading schema.

## Proof

The ticket's differential pair — two mappings with byte-identical arrow
shape, differing only in whether the target schema spreads a
same-file, fully-resolving fragment — is pinned as a test in
`lint-engine.test.ts`: the rule now fires for both the spread and
no-spread targets, where before it fired only for the no-spread one.

## Test plan

- [x] `npx turbo run test --filter=satsuma-cli` — 1159 pass, 0 fail
- [x] `npx turbo run test --filter=@satsuma/core` — 714 pass, 0 fail
      (`lint-engine.ts` imports from core)

Closes gpt-i1uv.