### PR TITLE
fix(lsp): resolve go-to-definition at three missing usage kinds

### DIFF
--- a/.tickets/gpt-jwek.md
+++ b/.tickets/gpt-jwek.md
@@ -1,6 +1,6 @@
 ---
 id: gpt-jwek
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-08-06T15:22:41Z
@@ -25,3 +25,9 @@ These are worth one ticket because they are one cause seen three times: `findNod
 
 Each of the three navigates to its declaration. The corresponding pinned test is deleted and the usage kind removed from RESOLVABLE_USAGE_KINDS (or from declaredEntities for the namespace case), so the duality properties then cover it positively rather than excluding it — that widening is the real acceptance signal, not the pins going green.
 
+
+## Notes
+
+**2026-08-07T11:47:17Z**
+
+Cause: findNodeContext's case list was narrower than what workspace-index actually indexes as a reference, so go-to-definition answered nothing at a metric source token (no case for a metadata value), the schema prefix of a qualified arrow path (its first segment was looked up as a field, and a schema name never is one), and a namespace's own name (a plain identifier, not a block_label). Fix: added a value_text case for a metric's source metadata value and two identifier-shape detectors (tryArrowSchemaPrefixContext, tryNamespaceNameContext), all resolving through the existing resolveDefinition path; widened RESOLVABLE_USAGE_KINDS to cover metric_source and arrow, and added a dedicated positive test for the namespace-name self-reference case since a namespace has no scenario-gen usage site to fold into the generic duality properties. (commit immediately after 1bf0e046)

--- a/test-stats.json
+++ b/test-stats.json
@@ -4,7 +4,7 @@
   "packages": {
     "satsuma-core": 714,
     "satsuma-cli": 1157,
-    "satsuma-lsp": 327,
+    "satsuma-lsp": 325,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 197,
     "satsuma-viz": 201,

--- a/tooling/satsuma-lsp/src/action-context.ts
+++ b/tooling/satsuma-lsp/src/action-context.ts
@@ -116,6 +116,13 @@ function inferSchemaName(ctx: NodeContext): string | null {
     case "arrow_target":
       return inferSchemaFromPath(ctx.mappingTargets ?? [], ctx.rawPath ?? null);
 
+    // The schema prefix of a qualified arrow path (`customers` in
+    // `customers.email`). Which side it belongs to is not carried on the
+    // context — checking both lists together is safe because only the one
+    // schema actually named by `rawPath` can ever match (gpt-jwek).
+    case "arrow_schema":
+      return inferSchemaFromPath(arrowSchemaCandidates(ctx), ctx.rawPath ?? null);
+
     case "nl_ref":
       return inferSchemaFromNlRef(ctx.name);
 
@@ -135,12 +142,23 @@ function inferFieldPath(ctx: NodeContext): string | null {
     case "arrow_target":
       return inferArrowFieldPath(ctx.mappingTargets ?? [], ctx.rawPath ?? null);
 
+    case "arrow_schema":
+      return inferArrowFieldPath(arrowSchemaCandidates(ctx), ctx.rawPath ?? null);
+
     case "nl_ref":
       return ctx.name.includes(".") ? stripPathDecorators(ctx.name) : null;
 
     default:
       return null;
   }
+}
+
+/**
+ * Both of a mapping's schema lists, combined, for a context that names the
+ * qualified prefix of an arrow path without recording which side it is on.
+ */
+function arrowSchemaCandidates(ctx: NodeContext): string[] {
+  return [...(ctx.mappingSources ?? []), ...(ctx.mappingTargets ?? [])];
 }
 
 function inferSchemaFromNlRef(name: string): string | null {

--- a/tooling/satsuma-lsp/src/definition.ts
+++ b/tooling/satsuma-lsp/src/definition.ts
@@ -42,6 +42,9 @@ export interface NodeContext {
     | "arrow_source"
     | "arrow_target"
     | "nl_ref"
+    | "metric_source"
+    | "arrow_schema"
+    | "namespace_name"
     | "unknown";
   name: string;
   namespace: string | null;
@@ -176,8 +179,40 @@ function tryContext(node: SyntaxNode): NodeContext | null {
       };
     }
 
+    // A metric's declared provenance: the value of a `source` tag inside a
+    // metric's metadata block, e.g. `(metric, source fact_orders)`.
+    // `workspace-index` indexes this value_text node as a "metric_source"
+    // reference to the source schema, so find-references already reports
+    // it; go-to-definition had no case for a metadata value at all until
+    // now (gpt-jwek).
+    case "value_text": {
+      const tag = node.parent;
+      if (!tag || tag.type !== "tag_with_value") return null;
+      const key = tag.namedChildren[0];
+      if (key?.text !== "source") return null;
+      const name = node.text;
+      if (!name) return null;
+      return { kind: "metric_source", name, namespace: ns, node };
+    }
+
     // Handle identifiers and backtick_names that are inside source_ref, spread, etc.
-    case "identifier":
+    case "identifier": {
+      // Two reference shapes are plain `identifier` nodes with no dedicated
+      // grammar rule of their own, so they must be detected here before
+      // falling through: the schema prefix of a qualified arrow path
+      // (`s0` in `s0.field_0`) and a namespace's own declared name. Both
+      // are indexed as references elsewhere (rename rewrites the arrow
+      // prefix; find-references lists the namespace) but neither had a
+      // go-to-definition case (gpt-jwek).
+      const namespaceCtx = tryNamespaceNameContext(node);
+      if (namespaceCtx) return namespaceCtx;
+      const arrowSchemaCtx = tryArrowSchemaPrefixContext(node, ns);
+      if (arrowSchemaCtx) return arrowSchemaCtx;
+      // Neither shape matched — let the parent (source_ref, block_label,
+      // src_path, ...) handle it, same as before.
+      return null;
+    }
+
     case "backtick_name":
     case "qualified_name":
     case "nl_string":
@@ -189,6 +224,81 @@ function tryContext(node: SyntaxNode): NodeContext | null {
   }
 }
 
+/**
+ * A `namespace`'s own declared name (`namespace ns_a { ... }`). It is a plain
+ * `identifier` — namespaces use `field("name", $.identifier)`, not the
+ * `block_label` syntax schemas and mappings share — so nothing in
+ * `tryContext`'s other cases ever matched it (gpt-jwek).
+ */
+function tryNamespaceNameContext(identifierNode: SyntaxNode): NodeContext | null {
+  const block = identifierNode.parent;
+  if (!block || block.type !== "namespace_block") return null;
+  // Compared with `.equals()`, not `===` — see the identical note in
+  // tryArrowSchemaPrefixContext.
+  if (!block.childForFieldName("name").equals(identifierNode)) return null;
+  // A namespace_block is never nested (spec: namespaces are flat), so this
+  // name is never itself inside another namespace.
+  return {
+    kind: "namespace_name",
+    name: identifierNode.text,
+    namespace: null,
+    node: identifierNode,
+  };
+}
+
+/**
+ * The schema prefix of a qualified arrow path (`s0` in `s0.field_0`), written
+ * when a mapping's side has more than one schema. `workspace-index` indexes
+ * this identifier as a reference to the schema itself — which is what makes
+ * renaming the schema rewrite the prefix — but the enclosing `src_path`/
+ * `tgt_path` case always treats a path's first segment as a *field* name of
+ * the mapping's schemas, and a schema name never is one (gpt-jwek). Detected
+ * at the identifier itself so a later segment (the real field name) still
+ * falls through unchanged to that case.
+ */
+function tryArrowSchemaPrefixContext(
+  identifierNode: SyntaxNode,
+  ns: string | null,
+): NodeContext | null {
+  const pathNode = identifierNode.parent;
+  if (!pathNode || pathNode.type !== "field_path") return null;
+  // Only a path's first segment can name a schema; later segments are never
+  // this identifier once the length check below passes. Compared with
+  // `.equals()` rather than `===` — web-tree-sitter mints a fresh wrapper
+  // object on every `.namedChildren` access, so two wrappers over the same
+  // underlying node are never reference-equal.
+  const firstSegment = pathNode.namedChildren[0];
+  if (!firstSegment || !firstSegment.equals(identifierNode) || pathNode.namedChildren.length < 2) {
+    return null;
+  }
+
+  const wrapper = pathNode.parent;
+  const isSource = wrapper?.type === "src_path";
+  const isTarget = wrapper?.type === "tgt_path";
+  if (!wrapper || (!isSource && !isTarget)) return null;
+
+  const mapping = findEnclosingMapping(wrapper);
+  const schemas = mapping
+    ? getMappingSchemaRefs(mapping, isSource ? "source_block" : "target_block")
+    : [];
+  const name = identifierNode.text;
+  if (!schemas.includes(name)) return null;
+
+  // Carried alongside the schema name, not used to find it: `action-context.ts`
+  // reads the same `rawPath` + schema-list shape `src_path`/`tgt_path` contexts
+  // carry to keep inferring the full field path (e.g. "customers.email") at
+  // this position, exactly as it did before the prefix had its own case.
+  return {
+    kind: "arrow_schema",
+    name,
+    namespace: ns,
+    node: identifierNode,
+    rawPath: extractPathText(wrapper) ?? undefined,
+    mappingSources: mapping ? getMappingSchemaRefs(mapping, "source_block") : [],
+    mappingTargets: mapping ? getMappingSchemaRefs(mapping, "target_block") : [],
+  };
+}
+
 // ---------- Resolution ----------
 
 function resolveContext(
@@ -198,7 +308,13 @@ function resolveContext(
 ): Location | Location[] | null {
   switch (ctx.kind) {
     case "source_ref":
-    case "target_ref": {
+    case "target_ref":
+    case "metric_source":
+    case "arrow_schema":
+    case "namespace_name": {
+      // A metric's `source` value, an arrow's qualified schema prefix and a
+      // namespace's own name all resolve the same way as a plain source/
+      // target reference: look the name up as a definition directly (gpt-jwek).
       const defs = resolveDefinition(index, ctx.name, ctx.namespace);
       return defsToLocations(defs);
     }

--- a/tooling/satsuma-lsp/test/generated-reference-duality.test.js
+++ b/tooling/satsuma-lsp/test/generated-reference-duality.test.js
@@ -30,14 +30,19 @@
  * `scopeIndex(uri)`. The scoping layer changes the answer, so it is a question of
  * its own — see the last pinned test.
  *
- * ## Four gaps this suite pins rather than hides
+ * ## One gap this suite still pins rather than hides
  *
- * `go-to-definition` answers nothing at a metric `source` token, nothing at the
- * schema prefix of a qualified arrow path, and nothing at all at a `namespace`
- * name; and import scope drops every usage in a file the declaring file does not
- * itself import. Each is a real gap and each has a pinned test at the end of this
- * file, so the properties above can exclude them by name instead of quietly
- * narrowing.
+ * Import scope drops every usage in a file the declaring file does not itself
+ * import. That is a real gap (`gpt-bc1x`) and has a pinned test at the end of
+ * this file, so the properties above can exclude it by name instead of
+ * quietly narrowing.
+ *
+ * Three sibling gaps used to live here too: `go-to-definition` answered
+ * nothing at a metric `source` token, at the schema prefix of a qualified
+ * arrow path, or at a `namespace` name. All three are fixed as of `gpt-jwek`
+ * — `findNodeContext`'s case list was narrower than what `workspace-index`
+ * actually indexes as a reference — and the properties above now cover all
+ * three positively instead of excluding them.
  */
 
 const { describe, it, before } = require("node:test");
@@ -47,9 +52,7 @@ const {
   GENERATED_PROPERTY_PARAMETERS,
   USAGE_KIND,
   bareNamespacedWorkspaceArbitrary,
-  metricWorkspaceArbitrary,
   multiFileWorkspaceArbitrary,
-  multiSourceWorkspaceArbitrary,
   namespacedWorkspaceArbitrary,
   scenarioDeclaredEntities,
   scenarioDeclaredUsageSites,
@@ -70,11 +73,11 @@ const {
  * The usage kinds the LSP's definition provider resolves back to a declaration
  * today.
  *
- * `metric_source` and `arrow` are absent because the provider answers nothing at
- * either: `findNodeContext` has no case for a metadata value, and an arrow path's
- * first segment is looked up as a *field* of the mapping's schemas, which a
- * schema name never is. Both are pinned by their own tests at the end of this
- * file rather than quietly skipped, so the day either is fixed a test says so.
+ * `metric_source` and `arrow` joined this list once `findNodeContext` grew a
+ * case for a metric's `source` metadata value and for the schema prefix of a
+ * qualified arrow path (`gpt-jwek`): both are indexed as a reference to a
+ * declared schema, so `resolvableProbeSites` below now probes them like any
+ * other resolvable kind.
  *
  * This list stays here rather than moving to `@satsuma/scenario-gen` with the
  * rest of the oracle (`gpt-l9rp`): it is a statement about what *this* LSP does
@@ -85,6 +88,8 @@ const RESOLVABLE_USAGE_KINDS = Object.freeze([
   USAGE_KIND.target,
   USAGE_KIND.spread,
   USAGE_KIND.import,
+  USAGE_KIND.metricSource,
+  USAGE_KIND.arrow,
 ]);
 
 before(async () => {
@@ -443,87 +448,70 @@ describe("includeDeclaration toggles exactly the declaration site", () => {
   });
 });
 
+describe("a namespace name resolves to its own declaration", () => {
+  it("answers both references and a definition at a namespace name (gpt-jwek)", () => {
+    // A `namespace` name is a plain `identifier`, not a `block_label`
+    // (`namespace_block` declares it via `field("name", $.identifier)`), so
+    // `findNodeContext` used to return nothing there at all — not even the
+    // declaration itself was reachable, the one case in this suite where
+    // *both* providers answered nothing rather than just one.
+    //
+    // This does not reuse `assertReferencesAreTheDeclaredSites` and friends:
+    // those walk `scenarioDeclaredEntities`, which deliberately has no
+    // `namespace` entry (adding one would make `generated-rename-roundtrip
+    // .test.js` try to rename a namespace too, which dangles every `ns::`
+    // qualifier the rename does not know to rewrite — a real gap, but a
+    // separate one from go-to-definition). A namespace also has no usage
+    // site of its own to fold into those properties: Satsuma names one only
+    // as a qualifier on some other entity (`ns_a::s0`), never bare, so the
+    // only thing to check here is the declaration resolving to itself.
+    fc.assert(
+      fc.property(namespacedWorkspaceArbitrary, ({ workspace, namespaces }) => {
+        const { indexed } = indexWithGroundTruth(workspace);
+        // The domain guarantees at least one namespaced schema.
+        const namespace = namespaces.find(Boolean);
+        const site = declarationSite(indexed, {
+          file: indexed.files[0].path,
+          name: namespace,
+          keyword: "namespace",
+        });
+        assert.deepEqual(
+          findReferenceSites(indexed, namespace, site, true).map(positionLabel),
+          [positionLabel(site)],
+          `find-references does not answer with the declaration itself at a namespace ` +
+            `name\n${indexed.sources}`,
+        );
+        assert.deepEqual(
+          definitionSites(indexed, site).map(positionLabel),
+          [positionLabel(site)],
+          `go-to-definition does not resolve a namespace name to its own declaration\n${indexed.sources}`,
+        );
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+});
+
 // ── Pinned gaps ────────────────────────────────────────────────────────────
 //
-// ⚠️ The four tests below assert what the LSP does **today**, not what it
-// should do. They exist because the properties above exclude these usage kinds,
-// and an exclusion nobody can see is how a gap becomes permanent. Each will go
-// red the moment its gap is fixed — at which point delete the pin and remove the
-// exclusion from RESOLVABLE_USAGE_KINDS (or from scenarioDeclaredEntities, for the
-// namespace case). All four were found by this suite while implementing gpt-21jp;
-// none is endorsed here. They are filed as:
+// ⚠️ The test below asserts what the LSP does **today**, not what it should
+// do. It exists because the property above excludes this usage kind, and an
+// exclusion nobody can see is how a gap becomes permanent. It will go red the
+// moment the gap is fixed — at which point delete the pin. Found by this
+// suite while implementing gpt-21jp; not endorsed here. Filed as:
 //
-//   - `gpt-jwek` — the three go-to-definition gaps (metric `source` token, the
-//     schema prefix of a qualified arrow path, a `namespace` name). One cause
-//     seen three times: `findNodeContext`'s case list is narrower than what
-//     `workspace-index` indexes.
 //   - `gpt-bc1x` — the import-scope gap, which is a *rename correctness* bug
 //     rather than a navigation one: rename is scoped identically, so renaming
 //     from a downstream declaration leaves an upstream import naming a symbol
 //     that no longer exists.
+//
+// Three sibling gaps used to live here too — a metric `source` token, the
+// schema prefix of a qualified arrow path, and a `namespace` name all
+// answered nothing at go-to-definition — and are now fixed (`gpt-jwek`,
+// widening `findNodeContext`'s case list) and covered positively above
+// instead of pinned.
 
-describe("gaps these properties therefore exclude", () => {
-  it("answers nothing at a metric `source` token, though find-references reports it", () => {
-    // `findNodeContext` has no case for a metadata value, so a metric's declared
-    // provenance is navigable in one direction only.
-    fc.assert(
-      fc.property(
-        metricWorkspaceArbitrary.map(({ workspace }) => workspace),
-        (workspace) => {
-          const { indexed } = indexWithGroundTruth(workspace);
-          const tokens = indexedReferenceSites(indexed).filter(
-            (site) => site.kind === USAGE_KIND.metricSource,
-          );
-          assert.equal(
-            tokens.length,
-            1,
-            `the metric domain must produce exactly one source token:\n${indexed.sources}`,
-          );
-          assert.deepEqual(
-            definitionSites(indexed, tokens[0]).map(positionLabel),
-            [],
-            `go-to-definition now answers at a metric source token — read this test's ` +
-              `comment before updating it\n${indexed.sources}`,
-          );
-        },
-      ),
-      GENERATED_PROPERTY_PARAMETERS,
-    );
-  });
-
-  it("answers nothing at the schema prefix of a qualified arrow path", () => {
-    // `s0.field_0` on a multi-schema side indexes `s0` as a reference to the
-    // schema — which is what makes renaming the schema rewrite the prefix — but
-    // the definition provider looks the first segment up as a *field* of the
-    // mapping's schemas, and a schema name never is one.
-    fc.assert(
-      fc.property(
-        multiSourceWorkspaceArbitrary.map(({ workspace }) => workspace),
-        (workspace) => {
-          const { indexed, entities } = indexWithGroundTruth(workspace);
-          const keys = new Set(entities.map((entity) => entity.key));
-          const prefixes = indexedReferenceSites(indexed).filter(
-            (site) => site.kind === USAGE_KIND.arrow && keys.has(site.key),
-          );
-          assert.equal(
-            prefixes.length,
-            2,
-            `the multi-source domain must qualify both arrow sources:\n${indexed.sources}`,
-          );
-          for (const site of prefixes) {
-            assert.deepEqual(
-              definitionSites(indexed, site).map(positionLabel),
-              [],
-              `go-to-definition now answers at ${describeSite(site)} — read this test's ` +
-                `comment before updating it\n${indexed.sources}`,
-            );
-          }
-        },
-      ),
-      GENERATED_PROPERTY_PARAMETERS,
-    );
-  });
-
+describe("gaps this property therefore excludes", () => {
   it("loses the usages in an importing file once import scope is applied", () => {
     // The properties above ask the whole-folder index — what a client
     // establishes by opening a folder. Every real request asks
@@ -534,7 +522,7 @@ describe("gaps these properties therefore exclude", () => {
     // `import { s1 }` that made it legal — vanish from the answer. Rename is
     // scoped identically (`server.ts` onRenameRequest), so a rename driven from
     // a declaration leaves that import naming a schema that no longer exists.
-    // Pinned, not endorsed: this is the exclusion the four properties above rely
+    // Pinned, not endorsed: this is the exclusion the properties above rely
     // on, and R4's round-trip has to choose which index it asks.
     fc.assert(
       fc.property(
@@ -572,37 +560,6 @@ describe("gaps these properties therefore exclude", () => {
           }
         },
       ),
-      GENERATED_PROPERTY_PARAMETERS,
-    );
-  });
-
-  it("answers neither references nor a definition at a namespace name", () => {
-    // A `namespace` name is not a `block_label`, so `findNodeContext` returns
-    // nothing there — even `includeDeclaration` cannot report the declaration the
-    // cursor is sitting on.
-    fc.assert(
-      fc.property(namespacedWorkspaceArbitrary, ({ workspace, namespaces }) => {
-        const { indexed } = indexWithGroundTruth(workspace);
-        // The domain guarantees at least one namespaced schema.
-        const namespace = namespaces.find(Boolean);
-        const site = declarationSite(indexed, {
-          file: indexed.files[0].path,
-          name: namespace,
-          keyword: "namespace",
-        });
-        assert.deepEqual(
-          findReferenceSites(indexed, namespace, site, true).map(positionLabel),
-          [],
-          `find-references now answers at a namespace name — read this test's comment ` +
-            `before updating it\n${indexed.sources}`,
-        );
-        assert.deepEqual(
-          definitionSites(indexed, site).map(positionLabel),
-          [],
-          `go-to-definition now answers at a namespace name — read this test's comment ` +
-            `before updating it\n${indexed.sources}`,
-        );
-      }),
       GENERATED_PROPERTY_PARAMETERS,
     );
   });


### PR DESCRIPTION
## Summary

Feature 46 R3's generated duality properties (gpt-21jp) found three usage
kinds where find-references and go-to-definition disagreed: a reference was
indexed and reported by find-references, but navigating from it with
go-to-definition answered nothing.

- A metric's `source` metadata value (no `findNodeContext` case for a
  metadata value token).
- The schema prefix of a qualified arrow path (`s0` in `s0.field_0`) — the
  definition provider looked the first segment up as a field, and a schema
  name is never a field.
- A `namespace`'s own declared name (excluded from `declaredEntities` rather
  than from `RESOLVABLE_USAGE_KINDS`).

All three traced back to one cause: `findNodeContext`'s case list was
narrower than what `workspace-index` actually indexes as a reference.

## Fix

- Added a `value_text` case for a metric's `source` metadata value.
- Added `tryArrowSchemaPrefixContext` and `tryNamespaceNameContext` identifier-shape
  detectors, both resolving through the existing `resolveDefinition` path.
- Widened `RESOLVABLE_USAGE_KINDS` to cover `metric_source` and `arrow`.
- Deleted the three pinned "gaps these properties therefore exclude" tests in
  `generated-reference-duality.test.js` and let the duality properties cover
  the cases positively instead. Added a dedicated positive test for the
  namespace-name self-reference case, since a namespace has no scenario-gen
  usage site to fold into the generic duality properties.

## Test plan

- [x] `turbo run test --filter=@satsuma/lsp` — 325/325 passing
- [x] Rebased onto latest `origin/main`; no conflicts

Closes gpt-jwek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)