### PR TITLE
chore(tickets): file sl-13p5 for non-release build versioning (CLI/LSP/VSIX)

### DIFF
--- a/.tickets/sl-13p5.md
+++ b/.tickets/sl-13p5.md
@@ -1,0 +1,60 @@
+---
+id: sl-13p5
+status: open
+deps: []
+links: []
+created: 2026-08-10T16:20:05Z
+type: feature
+priority: 1
+assignee: Thorben Louw
+tags: [ci, release, cli, lsp, vsix, versioning]
+---
+# Non-release builds (built off main) must carry a distinct version with the commit sha for CLI, LSP, and VSIX
+
+A user installing the latest VSIX sees 0.13.0 — identical to the tagged 0.13.0 release — so they cannot tell whether they have a cutting-edge main build or the tagged release:
+
+> When I take the latest VSIX and install it, it still shows 0.13.0 as the release version. Should it show a 0.13.X version instead, or has a new VSIX not been built. I'm raising a bug at the moment and wanted to indicate that I have taken the cutting edge release rather than tagged 0.13.0
+
+Today the rolling 'latest' prerelease (built on every push to main by .github/workflows/release.yml) ships the same version numbers as the last tagged release, because CLI/LSP/VSIX all read their version straight from package.json / VERSION. Make every non-release build self-identifying by deriving a suffixed version containing the commit sha, and surface that version in the CLI, the LSP, and the VSIX.
+
+## Design
+
+## Version identity rule
+Derive the version from git, not from whatever happens to be in package.json:
+- HEAD exactly at a release tag (or CI is the tagged workflow_dispatch path) → clean version from VERSION (e.g. 0.13.0). This is the only path that may ship X.Y.Z.
+- Anything else (push to main's 'latest' build, a local build from a non-tagged worktree/branch) → `<VERSION>-dev.<shorthash>` (e.g. 0.13.0-dev.ec46db7). The exact label ('dev' vs 'main') and whether to include the branch name are open decisions; it must remain valid semver so both npm pack and vsce package accept it. Short sha (git rev-parse --short HEAD) is the proposal; full sha is an option.
+
+'git describe --exact-match' cleanly distinguishes the two cases for both CI and local builds; in CI the tagged path can equivalently key off github.event_name == 'workflow_dispatch'.
+
+## Where the version surfaces
+- CLI: `satsuma --version` — currently reads ../package.json at runtime.
+- LSP: report the build version in the initialize serverInfo (and/or a --version entry point on bin/satsuma-lsp.js) so clients can display it. The LSP does not advertise any version today.
+- VSIX: the version VS Code shows in the Extensions view comes from package.json via vsce package.
+
+## Injection mechanism (release workflow)
+'.github/workflows/release.yml' artifacts job builds via ./scripts/build-artifacts.sh (CLI pack, LSP pack, vsce package all read the package.json version). For the push-to-main path only, compute BUILD_VERSION and write it into the CLI/LSP/VSIX package.json 'version' before that script runs, so the packed artifacts carry it. This mutates files only inside the CI checkout — nothing is committed. Tagged (workflow_dispatch) builds skip the rewrite and keep the release-metadata.mjs validation path unchanged.
+
+## Local builds
+Reuse the same git-derived logic in each package's prebuild so a developer's local build also bakes the sha into --version. Prefer a generated source module (like the existing prebuild.js that bakes agent-reference) over mutating the tracked package.json where possible; for the VSIX this cannot be a generated module because vsce reads only package.json, so the rewrite there is package-time only and must never be committed.
+
+## Docs + tests
+Update docs/developer/CI-WORKFLOWS.md (its release section is already stale per mbt-1s1s), the packaging/install guides, and extend release-metadata.test.mjs / packaging tests to cover version derivation and injection. Run repo checks before commit.
+
+## Acceptance Criteria
+
+- A push-to-main 'latest' build ships CLI/LSP/VSIX whose reported version is clearly a non-release build carrying the commit sha (e.g. 0.13.0-dev.<shorthash>), never the bare 0.13.0.
+- satsuma --version prints the suffixed version for a main build and the clean X.Y.Z for a tagged release.
+- The LSP advertises the same build version (initialize serverInfo or --version) so clients can display it.
+- The VSIX version shown in VS Code's Extensions view reflects the suffixed build version for a main build.
+- Tagged releases are unaffected: still clean X.Y.Z, still validated against VERSION + changelog by release-metadata.mjs.
+- The release workflow computes the sha and injects the version at build time, and makes no commit to main.
+- A local build from a non-tagged worktree/branch also bakes the sha into --version; a local build at a release tag stays clean.
+- All produced npm tarballs and the .vsix remain valid (npm pack and vsce package accept the suffixed semver).
+- Docs updated and tests added/extended; repo checks (scripts/run-repo-checks.sh) pass before the PR is opened.
+
+
+## Notes
+
+**2026-08-10T16:26:29Z**
+
+Scope clarification (review): this ticket covers only the CLI, LSP, and VSIX artifact versions. The docs-site version (site data 'version'/'version_tag', written by release-metadata.mjs 'bump') is out of scope — it is set manually before a tagged release and is never touched on the push-to-main path, so it is not part of the non-release-build identity problem. Do not change it here.


### PR DESCRIPTION
Closes satsuma-sl-13p5

Adds ticket sl-13p5 to the issue trackers. No code changes — a single `.tickets/` markdown file.

## What the ticket proposes

A user installing the latest VSIX (the rolling `latest` prerelease built on every push to main) sees `0.13.0` — identical to the tagged `0.13.0` release — so they cannot tell a cutting-edge build from a tagged release. The ticket captures the feature to make non-release builds self-identifying:

- Derive the version from git (**`<VERSION>-dev.<shorthash>`** for non-release, clean `X.Y.Z` only for tagged releases), distinguished via `git describe --exact-match` locally / `github.event_name == 'workflow_dispatch'` in CI.
- Surface it in `satsuma --version`, the LSP initialize `serverInfo` (which advertises no version today), and the VSIX version shown in the Extensions view.
- The release workflow computes the sha and injects the version into each package.json at build time *without committing*; tagged releases keep the existing `release-metadata.mjs` validation untouched.
- Bake the same git-derived version into `--version` for local builds.
- Scope note added during review: the docs-site version is **out of scope** (only set manually pre-tagged-release, never on the push path).

Pre-commit repo checks (`scripts/run-repo-checks.sh`) passed on the commit.