### PR TITLE
fix(scenario-gen): generate dotted and undotted container-header targets (tced-vrul, tced-ninm)

### DIFF
--- a/.tickets/tced-ninm.md
+++ b/.tickets/tced-ninm.md
@@ -1,6 +1,6 @@
 ---
 id: tced-ninm
-status: open
+status: closed
 deps: []
 links: [tced-ewd4]
 created: 2026-08-07T11:36:28Z
@@ -24,4 +24,11 @@ Raised rather than silently reaching for the nearest already-wired fixture, whic
 - A canonical example (or a new one) writes a top-level `each <list> -> .<target>`, so the shape is represented in `examples/` and therefore reachable by the harness.
 - A Playwright case in `harness.test.ts` hovers an arrow row on that mapping and asserts the `.hl` class lands on the expected source and target field rows — extending the existing "Hover highlighting between arrows and field rows" describe block rather than adding a parallel one.
 - Whatever derived artifacts a new corpus file feeds (test-stats.json, the eval static-compactness outputs) are regenerated in the same change.
+
+## Notes
+
+**2026-08-10T11:50:00Z**
+
+Cause: The corpus only wrote a dotted each target nested inside another each; no top-level form existed, so the harness could not exercise hover highlighting on that shape in a real browser.
+Fix: Added `examples/top-level-dotted-each/pipeline.stm` with a top-level `each parties -> .rows`, extended the existing "Hover highlighting between arrows and field rows" Playwright describe block with a case asserting `.hl` lands on `parties.party_role` and `rows.role`, and regenerated static-compactness and test-stats. (commit immediately after 27a6186c)
 

--- a/.tickets/tced-vrul.md
+++ b/.tickets/tced-vrul.md
@@ -1,6 +1,6 @@
 ---
 id: tced-vrul
-status: open
+status: closed
 deps: []
 links: [tced-ewd4]
 created: 2026-08-07T11:35:16Z
@@ -24,4 +24,11 @@ Raised from tced-ewd4's acceptance criteria, which asked for this gap to be file
 - A generated container block can render its header target either dotted or undotted, chosen by the arbitrary rather than fixed, at mapping-body level and nested.
 - The choice is ground-truth-neutral: the two spellings resolve to the same field, so the scenario's stated ground truth must not change with it. A property asserting that the two renderings of one scenario produce identical downstream results is the natural way to pin it.
 - The generated coverage oracle reaches the top-level dotted header, so a regression of tced-ewd4 would fail a property suite rather than only the targeted unit test.
+
+## Notes
+
+**2026-08-10T10:35:00Z**
+
+Cause: `authoredEndpoint` never emitted a leading dot, and `relativeEndpoint` always did, so the generator could not express the opposite choice at either nesting level. This left the top-level dotted form (`each parties -> .rows`) unreachable in generated tests, which is why tced-ewd4's coverage crash was only caught by a hand-written unit test.
+Fix: added optional `dottedTarget` to `eachBlock`/`flattenBlock` in `workspace-model.js` and taught `renderArrow` in `workspace-render.js` to honour it: `true` forces a dotted header target, `false` forces undotted, and `undefined` preserves the old default. Updated `containerWorkspaceArbitrary` to draw a boolean per block level, so both forms are generated randomly. Added a scenario-gen unit test verifying the rendered text differs and the ground truth does not, and a CLI property test asserting that flipping every `dottedTarget` leaves the graph edge set unchanged. (commit immediately after bcba31de)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ The CLI requires a `.stm` file entry point (not a directory). The workspace is d
 | [`reports-and-models/`](reports-and-models/) | `pipeline.stm` | Reports, dashboards, and ML models as first-class pipeline consumers |
 | [`sap-po-to-mfcs/`](sap-po-to-mfcs/) | `pipeline.stm` | SAP ERP purchase order to Oracle MFCS ingestion contract |
 | [`seabird-colony-lineage/`](seabird-colony-lineage/) | `platform.stm` | Deeply nested field lineage and coverage across files and namespaces |
+| [`top-level-dotted-each/`](top-level-dotted-each/) | `pipeline.stm` | Top-level `each` with a dotted header target — minimal fixture for tced-ninm |
 | [`sfdc-to-snowflake/`](sfdc-to-snowflake/) | `pipeline.stm` | Salesforce Opportunity/Account objects to Snowflake analytics |
 | [`xml-to-parquet/`](xml-to-parquet/) | `pipeline.stm` | Commerce order XML to Lakehouse Parquet |
 

--- a/examples/top-level-dotted-each/pipeline.stm
+++ b/examples/top-level-dotted-each/pipeline.stm
@@ -1,0 +1,28 @@
+// Minimal fixture: a top-level each block whose header target carries the
+// leading dot.  This shape is semantically identical to the undotted spelling
+// (spec §4.6) but was absent from the corpus until tced-ninm.
+
+schema src {
+  id  VARCHAR(10)  (pk)
+  parties list_of record {
+    party_role  VARCHAR(20)  (required)
+  }
+}
+
+schema tgt {
+  k  VARCHAR(10)  (required)
+  rows list_of record {
+    role  VARCHAR(20)  (required)
+  }
+}
+
+mapping m {
+  source { src }
+  target { tgt }
+
+  id -> k
+
+  each parties -> .rows {
+    .party_role -> .role
+  }
+}

--- a/reference/static-compactness.json
+++ b/reference/static-compactness.json
@@ -343,6 +343,23 @@
         }
       },
       {
+        "name": "top-level-dotted-each",
+        "fileCount": 1,
+        "lineCount": 29,
+        "arms": {
+          "S": 98,
+          "Sauthored": 150,
+          "Y": 142,
+          "J": 252
+        },
+        "ratios": {
+          "vsYaml": 31,
+          "vsJson": 61.1,
+          "authoredVsYaml": -5.6,
+          "savingVsYaml": 44
+        }
+      },
+      {
         "name": "xml-to-parquet",
         "fileCount": 1,
         "lineCount": 186,
@@ -700,6 +717,23 @@
         "vsJson": 35.1,
         "authoredVsYaml": -8.4,
         "savingVsYaml": -22
+      }
+    },
+    {
+      "name": "top-level-dotted-each",
+      "fileCount": 1,
+      "lineCount": 29,
+      "arms": {
+        "S": 326,
+        "Sauthored": 543,
+        "Y": 512,
+        "J": 951
+      },
+      "ratios": {
+        "vsYaml": 36.3,
+        "vsJson": 65.7,
+        "authoredVsYaml": -6.1,
+        "savingVsYaml": 186
       }
     },
     {

--- a/reference/static-compactness.md
+++ b/reference/static-compactness.md
@@ -14,7 +14,7 @@ The YAML design is deliberately **charitable to YAML** — see
 [evals/static-compactness/SERIALISATION-DESIGN.md](../evals/static-compactness/SERIALISATION-DESIGN.md).
 Every ratio below is therefore a **lower bound** on Satsuma's advantage.
 
-Corpus: 21 specs under `examples/`.
+Corpus: 22 specs under `examples/`.
 
 ## Which tokenizers these figures carry
 
@@ -67,19 +67,20 @@ All three arms are comment-free, so the comparison is like-for-like. The
 | `sap-po-to-mfcs` | 180 | 1477 | 1510 | 1629 | 2183 | 9.3% | 32.3% |
 | `seabird-colony-lineage` | 87 | 408 | 461 | 524 | 807 | 22.1% | 49.4% |
 | `sfdc-to-snowflake` | 104 | 768 | 812 | 814 | 1153 | 5.7% | 33.4% |
+| `top-level-dotted-each` | 29 | 98 | 150 | 142 | 252 | 31% | 61.1% |
 | `xml-to-parquet` | 186 | 1508 | 1544 | 1794 | 2627 | 15.9% | 42.6% |
 
 ### Corpus summary
 
-- Median reduction vs YAML: **9%**
-- Median reduction vs JSON (2-space): **36.1%**
-- Median reduction vs YAML using the file as authored: **1.2%**
+- Median reduction vs YAML: **9.2%**
+- Median reduction vs JSON (2-space): **36.8%**
+- Median reduction vs YAML using the file as authored: **1.1%**
 
 Median of per-spec ratios, not the ratio of corpus totals — the latter lets the
 largest spec set the headline and systematically overstates the effect. The PRD
 calls that the single most common error in published comparisons of this kind.
 
-YAML is **smaller** than `.stm` on 0 of 21 specs.
+YAML is **smaller** than `.stm` on 0 of 22 specs.
 
 ### The agent-reference overhead is never repaid
 
@@ -101,8 +102,8 @@ token headline were an artifact of one tokenizer, these would disagree with it.
 
 ### Corpus summary
 
-- Median reduction vs YAML: **7.7%**
-- Median reduction vs JSON (2-space): **38.7%**
-- Median reduction vs YAML using the file as authored: **-1.7%**
+- Median reduction vs YAML: **8.2%**
+- Median reduction vs JSON (2-space): **39%**
+- Median reduction vs YAML using the file as authored: **-3%**
 
 

--- a/test-stats.json
+++ b/test-stats.json
@@ -2,11 +2,11 @@
   "cliCommands": 23,
   "parserCorpusTests": 318,
   "packages": {
-    "satsuma-core": 715,
-    "satsuma-cli": 1162,
+    "satsuma-core": 718,
+    "satsuma-cli": 1163,
     "satsuma-lsp": 325,
     "satsuma-viz-model": 7,
-    "satsuma-viz-backend": 197,
+    "satsuma-viz-backend": 198,
     "satsuma-viz": 201,
     "integration-tests": 3,
     "vscode-satsuma": 48

--- a/test-stats.json
+++ b/test-stats.json
@@ -3,7 +3,7 @@
   "parserCorpusTests": 318,
   "packages": {
     "satsuma-core": 718,
-    "satsuma-cli": 1163,
+    "satsuma-cli": 1164,
     "satsuma-lsp": 325,
     "satsuma-viz-model": 7,
     "satsuma-viz-backend": 198,

--- a/tooling/satsuma-cli/test/generated-edge-invariants.test.ts
+++ b/tooling/satsuma-cli/test/generated-edge-invariants.test.ts
@@ -41,6 +41,7 @@ import {
   GENERATED_PROPERTY_PARAMETERS,
   containerWorkspaceArbitrary,
   namespacedWorkspaceArbitrary,
+  renderWorkspace,
   scenarioDeclaredFieldPaths,
   scenarioFieldEdges,
   splitWorkspaceAcrossFiles,
@@ -121,6 +122,55 @@ async function withGraph(
   } finally {
     disposeGeneratedWorkspace(loaded);
   }
+}
+
+/** Like {@link withGraph}, but returns the result of `check` instead of void. */
+async function withGraphReturning<T>(
+  workspace: ScenarioWorkspace,
+  check: (graph: WorkspaceGraph) => T,
+  opts?: Parameters<typeof graphFor>[1],
+): Promise<T> {
+  const loaded = await loadGeneratedWorkspace(workspace);
+  try {
+    return check(graphFor(loaded, opts));
+  } finally {
+    disposeGeneratedWorkspace(loaded);
+  }
+}
+
+/** Rendered sources of a workspace, for inclusion in failure messages. */
+function renderedSources(workspace: ScenarioWorkspace): string {
+  return renderWorkspace(workspace)
+    .map((file) => `── ${file.path}\n${file.source}`)
+    .join("\n");
+}
+
+/**
+ * Flip every container block's `dottedTarget` flag in a deep-cloned workspace.
+ *
+ * `true` becomes `false` and `false` becomes `true`; blocks with no explicit
+ * flag keep their default behaviour and are left untouched.
+ */
+function flipContainerDottedTargets(workspace: ScenarioWorkspace): ScenarioWorkspace {
+  const cloned: ScenarioWorkspace = structuredClone(workspace);
+  for (const file of cloned.files) {
+    for (const mapping of file.mappings) {
+      mapping.arrows = mapping.arrows.map(flipArrowDottedTarget);
+    }
+  }
+  return cloned;
+}
+
+/** Recursively flip `dottedTarget` on every container arrow. */
+function flipArrowDottedTarget(arrow: any): any {
+  const flipped = { ...arrow };
+  if ((arrow.kind === "each" || arrow.kind === "flatten") && arrow.dottedTarget !== undefined) {
+    flipped.dottedTarget = !arrow.dottedTarget;
+  }
+  if (arrow.children) {
+    flipped.children = arrow.children.map(flipArrowDottedTarget);
+  }
+  return flipped;
 }
 
 describe("nothing invented: every emitted endpoint is a declared field (sl-hi0z)", () => {
@@ -248,6 +298,27 @@ describe("nothing dropped: the emitted edge set is exactly the declared one (sl-
             `${kind} nested ${depth} deep lost or invented an edge:\n${sources}`,
           );
         });
+      }),
+      GENERATED_PROPERTY_PARAMETERS,
+    );
+  });
+
+  it("produces the same graph edges whether a container header is dotted or undotted (tced-vrul)", async () => {
+    // Spec §4.6: `sku` and `.sku` inside a block both mean the same thing.
+    // The same applies to container headers: `each src -> tgt` and `each src -> .tgt`
+    // resolve to identical field paths, so the downstream edge set must not move.
+    // This is the property that would have caught tced-ewd4 in a suite rather
+    // than only in a targeted unit test.
+    await fc.assert(
+      fc.asyncProperty(containerWorkspaceArbitrary, async ({ workspace }) => {
+        const flipped = flipContainerDottedTargets(workspace);
+        const originalEdges = await withGraphReturning(workspace, (graph) => edgeKeys(graph.edges));
+        const flippedEdges = await withGraphReturning(flipped, (graph) => edgeKeys(graph.edges));
+        assert.deepEqual(
+          flippedEdges,
+          originalEdges,
+          `flipping dotted targets changed the graph edge set:\nORIGINAL\n${renderedSources(workspace)}\nFLIPPED\n${renderedSources(flipped)}`,
+        );
       }),
       GENERATED_PROPERTY_PARAMETERS,
     );

--- a/tooling/satsuma-scenario-gen/src/workspace-arbitraries.js
+++ b/tooling/satsuma-scenario-gen/src/workspace-arbitraries.js
@@ -345,7 +345,17 @@ export const containerWorkspaceArbitrary = fc
     kind: fc.constantFrom("each", "flatten"),
     depth: fc.integer({ min: 1, max: 2 }),
   })
-  .map(({ kind, depth }) => {
+  .chain(({ kind, depth }) =>
+    // Choose dotted/undotted independently for every block level, so the
+    // generator explores both the top-level dotted form (tced-ewd4) and the
+    // nested undotted form (tced-vrul).
+    fc.array(fc.boolean(), { minLength: depth, maxLength: depth }).map((dottedTargets) => ({
+      kind,
+      depth,
+      dottedTargets,
+    })),
+  )
+  .map(({ kind, depth, dottedTargets }) => {
     // A record chain exactly `depth` levels deep — `group_0 { field_0 }` at depth
     // 1, `group_0 { group_1 { field_0 } }` at depth 2 — list-typed at every level
     // so each iteration really is over something iterable. The leaves must sit at
@@ -373,7 +383,14 @@ export const containerWorkspaceArbitrary = fc
     );
     for (let level = depth - 1; level >= 0; level -= 1) {
       const block = kind === "each" ? eachBlock : flattenBlock;
-      body = [block(endpoint(source, blockPath(level)), endpoint(target, blockPath(level)), body)];
+      body = [
+        block(
+          endpoint(source, blockPath(level)),
+          endpoint(target, blockPath(level)),
+          body,
+          dottedTargets[level],
+        ),
+      ];
     }
 
     return {

--- a/tooling/satsuma-scenario-gen/src/workspace-model.js
+++ b/tooling/satsuma-scenario-gen/src/workspace-model.js
@@ -143,13 +143,35 @@ export function computedArrow(target, transform) {
  * (spec §4.4), so a child naming anything else would not be a declared field.
  * {@link renderWorkspace} asserts it rather than emitting invalid Satsuma.
  */
-export function eachBlock(source, target, children) {
-  return { kind: "each", source, target, children };
+/**
+ * `each source -> target { children }`.
+ *
+ * `dottedTarget` chooses whether the header target is written with a leading
+ * dot — `each src -> .tgt` rather than `each src -> tgt`. Both spellings are
+ * semantically identical (spec §4.6), and generating both is what lets property
+ * suites reach the top-level dotted form that tced-ewd4 escaped.
+ *
+ * `undefined` (the default) preserves current behaviour: undotted at mapping
+ * level, dotted when nested. `true` forces dotted; `false` forces undotted.
+ *
+ * Every child endpoint must sit under this block's own paths and name the same
+ * schemas: Satsuma has no notation for reaching an ancestor from inside a block
+ * (spec §4.4), so a child naming anything else would not be a declared field.
+ * {@link renderWorkspace} asserts it rather than emitting invalid Satsuma.
+ */
+export function eachBlock(source, target, children, dottedTarget = undefined) {
+  const block = { kind: "each", source, target, children };
+  if (dottedTarget !== undefined) block.dottedTarget = dottedTarget;
+  return block;
 }
 
-/** `flatten source -> target { children }`; same child rules as {@link eachBlock}. */
-export function flattenBlock(source, target, children) {
-  return { kind: "flatten", source, target, children };
+/**
+ * `flatten source -> target { children }`; same child rules as {@link eachBlock}.
+ */
+export function flattenBlock(source, target, children, dottedTarget = undefined) {
+  const block = { kind: "flatten", source, target, children };
+  if (dottedTarget !== undefined) block.dottedTarget = dottedTarget;
+  return block;
 }
 
 // ── Declarations, files and workspaces ─────────────────────────────────────

--- a/tooling/satsuma-scenario-gen/src/workspace-render.js
+++ b/tooling/satsuma-scenario-gen/src/workspace-render.js
@@ -71,6 +71,29 @@ function relativeEndpoint(child, blockSchema, blockPath) {
   return `.${child.path.slice(blockPath.length + 1)}`;
 }
 
+/**
+ * The relative suffix of a child endpoint under its block path, without the dot.
+ *
+ * Used for container-block headers when `dottedTarget` is false: `sku` instead
+ * of `.sku` inside `each lines -> items` (spec §4.6: the dot documents
+ * relativity but does not decide it).
+ */
+function relativeSuffix(child, blockSchema, blockPath) {
+  if (child.schema !== blockSchema) {
+    throw new Error(
+      `scenario error: arrow inside a block on '${blockSchema}' names schema ` +
+        `'${child.schema}'; Satsuma has no notation for that (spec §4.4)`,
+    );
+  }
+  if (child.path !== blockPath && !child.path.startsWith(`${blockPath}.`)) {
+    throw new Error(
+      `scenario error: '${child.path}' is not under block path '${blockPath}'; ` +
+        `Satsuma has no notation for reaching an ancestor (spec §4.4)`,
+    );
+  }
+  return child.path === blockPath ? "" : child.path.slice(blockPath.length + 1);
+}
+
 // ── Transform bodies ───────────────────────────────────────────────────────
 
 /**
@@ -120,7 +143,41 @@ function renderArrow(arrow, mapping, indent, context) {
     return `${indent}-> ${target(arrow.target)}${body}`;
   }
 
-  const header = `${indent}${arrow.kind} ${source(arrow.source)} -> ${target(arrow.target)}`;
+  // Container-block header target: dotted or undotted, at every nesting level.
+  // The spec says both spellings are identical (spec §4.6); the choice is a
+  // rendering concern and must not change the ground truth.
+  const isContainer = arrow.kind === "each" || arrow.kind === "flatten";
+  const headerTarget = (ep) => {
+    if (!isContainer || arrow.dottedTarget !== true) {
+      return target(ep);
+    }
+    if (context.targetPath === null) {
+      // Mapping level: `.path` documents relativity to the mapping's target root.
+      return `.${ep.path}`;
+    }
+    // Nested: dotted relative form, same as `relativeEndpoint`.
+    return relativeEndpoint(ep, context.targetSchema, context.targetPath);
+  };
+  const headerTargetUndotted = (ep) => {
+    if (!isContainer || arrow.dottedTarget !== false) {
+      return target(ep);
+    }
+    if (context.targetPath === null) {
+      // Mapping level: bare path, same as `authoredEndpoint`.
+      return authoredEndpoint(ep, mapping.targets);
+    }
+    // Nested: undotted relative form.
+    return relativeSuffix(ep, context.targetSchema, context.targetPath);
+  };
+
+  const effectiveTarget = (ep) => {
+    if (!isContainer) return target(ep);
+    if (arrow.dottedTarget === true) return headerTarget(ep);
+    if (arrow.dottedTarget === false) return headerTargetUndotted(ep);
+    return target(ep);
+  };
+
+  const header = `${indent}${arrow.kind} ${source(arrow.source)} -> ${effectiveTarget(arrow.target)}`;
   const nested = arrow.children.map((child) =>
     renderArrow(child, mapping, indent + INDENT, {
       sourceSchema: arrow.source.schema,

--- a/tooling/satsuma-scenario-gen/test/ground-truth.test.js
+++ b/tooling/satsuma-scenario-gen/test/ground-truth.test.js
@@ -641,3 +641,127 @@ describe("scenarioChangedDeclarations", () => {
     assert.deepEqual(scenarioChangedDeclarations(before, after), []);
   });
 });
+
+// ── Container header spelling (tced-vrul) ──────────────────────────────────
+
+describe("container header dotted target rendering", () => {
+  it("renders a mapping-level dotted target with a leading dot", () => {
+    const workspace = oneFile({
+      schemas: [
+        schemaDecl({ name: "s0", fields: [listRecordField("lines", [scalarField("sku")])] }),
+        schemaDecl({ name: "s1", fields: [listRecordField("lines", [scalarField("sku")])] }),
+      ],
+      mappings: [
+        mappingDecl({
+          name: "m0",
+          sources: ["s0"],
+          targets: ["s1"],
+          arrows: [
+            eachBlock(
+              endpoint("s0", "lines"),
+              endpoint("s1", "lines"),
+              [mapArrow([endpoint("s0", "lines.sku")], endpoint("s1", "lines.sku"))],
+              true,
+            ),
+          ],
+        }),
+      ],
+    });
+    const source = renderWorkspace(workspace)[0].source;
+    assert.match(source, /each lines -> \.lines \{/);
+  });
+
+  it("renders a nested undotted target without a leading dot", () => {
+    const workspace = oneFile({
+      schemas: [
+        schemaDecl({
+          name: "s0",
+          fields: [listRecordField("group_0", [listRecordField("group_1", [scalarField("sku")])])],
+        }),
+        schemaDecl({
+          name: "s1",
+          fields: [listRecordField("group_0", [listRecordField("group_1", [scalarField("sku")])])],
+        }),
+      ],
+      mappings: [
+        mappingDecl({
+          name: "m0",
+          sources: ["s0"],
+          targets: ["s1"],
+          arrows: [
+            eachBlock(
+              endpoint("s0", "group_0"),
+              endpoint("s1", "group_0"),
+              [
+                eachBlock(
+                  endpoint("s0", "group_0.group_1"),
+                  endpoint("s1", "group_0.group_1"),
+                  [
+                    mapArrow(
+                      [endpoint("s0", "group_0.group_1.sku")],
+                      endpoint("s1", "group_0.group_1.sku"),
+                    ),
+                  ],
+                  false,
+                ),
+              ],
+              true,
+            ),
+          ],
+        }),
+      ],
+    });
+    const source = renderWorkspace(workspace)[0].source;
+    assert.match(source, /each group_0 -> \.group_0 \{/);
+    assert.match(source, /each \.group_1 -> group_1 \{/);
+  });
+
+  it("keeps the ground truth identical whether the header is dotted or not", () => {
+    // Spec §4.6: the dot documents relativity but does not decide it, so the
+    // scenario's own field-edge oracle must not move.
+    const dotted = oneFile({
+      schemas: [
+        schemaDecl({ name: "s0", fields: [listRecordField("lines", [scalarField("sku")])] }),
+        schemaDecl({ name: "s1", fields: [listRecordField("lines", [scalarField("sku")])] }),
+      ],
+      mappings: [
+        mappingDecl({
+          name: "m0",
+          sources: ["s0"],
+          targets: ["s1"],
+          arrows: [
+            eachBlock(
+              endpoint("s0", "lines"),
+              endpoint("s1", "lines"),
+              [mapArrow([endpoint("s0", "lines.sku")], endpoint("s1", "lines.sku"))],
+              true,
+            ),
+          ],
+        }),
+      ],
+    });
+    const undotted = oneFile({
+      schemas: [
+        schemaDecl({ name: "s0", fields: [listRecordField("lines", [scalarField("sku")])] }),
+        schemaDecl({ name: "s1", fields: [listRecordField("lines", [scalarField("sku")])] }),
+      ],
+      mappings: [
+        mappingDecl({
+          name: "m0",
+          sources: ["s0"],
+          targets: ["s1"],
+          arrows: [
+            eachBlock(
+              endpoint("s0", "lines"),
+              endpoint("s1", "lines"),
+              [mapArrow([endpoint("s0", "lines.sku")], endpoint("s1", "lines.sku"))],
+              false,
+            ),
+          ],
+        }),
+      ],
+    });
+    assert.deepEqual(scenarioFieldEdges(dotted), scenarioFieldEdges(undotted));
+    assert.deepEqual(scenarioDeclaredFieldPaths(dotted), scenarioDeclaredFieldPaths(undotted));
+  });
+});

--- a/tooling/satsuma-viz-harness/test/harness.test.ts
+++ b/tooling/satsuma-viz-harness/test/harness.test.ts
@@ -51,6 +51,8 @@ const ffgUri = libraryUri("filter-flatten-governance/filter-flatten-governance.s
 const buyToOmUri = libraryUri("contracts/buy-to-om-order.stm");
 /** Nested each/flatten fixture — doubly-nested arrows (sl-rj78). */
 const nestedIterationUri = libraryUri("nested-iteration/pipeline.stm");
+/** Minimal fixture with a top-level dotted each target (tced-ninm). */
+const topLevelDottedEachUri = libraryUri("top-level-dotted-each/pipeline.stm");
 /**
  * Governance fixture's own mapping — a two-source join (crm_customers,
  * finance_transactions) with computed arrows whose NL text names source
@@ -1692,6 +1694,37 @@ test.describe("Hover highlighting between arrows and field rows", () => {
       "[data-testid='mapping-detail-opportunity-ingestion-source-schema-card-sfdc-opportunity-field-amount']",
     );
     await expect(sourceField).toHaveClass(/\bhl\b/);
+  });
+
+  test("hovering a top-level dotted-each arrow row highlights the source and target field rows (tced-ninm)", async ({
+    page,
+  }) => {
+    // The `m` mapping writes `each parties -> .rows` at mapping-body level,
+    // a shape the corpus previously lacked.  The dot is a relativity marker
+    // only; the resolved path is `rows.role`, and the hover highlight must
+    // land on the nested target field row just as it does for the undotted
+    // spelling.
+    await page.goto("/");
+    await page.waitForFunction(() => {
+      const harness = window.__satsumaHarness;
+      if (!harness?.setViewMode) return false;
+      harness.setViewMode("single");
+      return true;
+    });
+    await loadFixture(page, topLevelDottedEachUri);
+    const detail = await openMappingByName(page, "m");
+
+    await detail.locator("[data-testid='mapping-detail-m-arrow-row-each-rows-role']").hover();
+
+    const sourceField = detail.locator(
+      "[data-testid='mapping-detail-m-source-schema-card-src-field-parties-party-role']",
+    );
+    const targetField = detail.locator(
+      "[data-testid='mapping-detail-m-target-schema-card-tgt-field-rows-role']",
+    );
+
+    await expect(sourceField).toHaveClass(/\bhl\b/);
+    await expect(targetField).toHaveClass(/\bhl\b/);
   });
 });
 


### PR DESCRIPTION
## Summary

Resurrects finished work from `origin/fix/tced-vrul` (last touched 2026-08-10, never had a PR opened). Rebased onto current `main` — clean, no conflicts. All relevant suites green locally (scenario-gen, core, cli, viz-harness).

Closes two sibling tickets that both stem from **tced-ewd4** (the `satsuma coverage` crash on a top-level `each list -> .target`):

### tced-vrul — scenario-gen cannot reach the top-level dotted `each` form
`authoredEndpoint` never emitted a leading dot and `relativeEndpoint` always did, so the generator could only express one spelling at each nesting level. The top-level dotted form (`each parties -> .rows`) was unreachable in generated tests — which is why tced-ewd4 was caught only by a hand-written unit test, never by a property suite.

**Fix:** added optional `dottedTarget` to `eachBlock`/`flattenBlock` in `workspace-model.js`; `renderArrow` in `workspace-render.js` honours it (`true` forces dotted, `false` forces undotted, `undefined` preserves the old default). `containerWorkspaceArbitrary` now draws a boolean per block level so both forms are generated randomly. The choice is ground-truth-neutral (both spellings resolve to the same field).

### tced-ninm — viz: no fixture reaches a top-level dotted each
The corpus only wrote a dotted `each` target *nested* inside another `each`; no top-level form existed, so the Playwright harness could not exercise hover highlighting on that shape in a real browser.

**Fix:** added `examples/top-level-dotted-each/pipeline.stm` with a top-level `each parties -> .rows`, and extended the existing "Hover highlighting between arrows and field rows" describe block with a case asserting `.hl` lands on `parties.party_role` and `rows.role`.

## Verification

- `npx turbo run test --filter=@satsuma/scenario-gen` — 51 pass
- `npx turbo run test --filter=@satsuma/core` — 718 pass
- `npx turbo run test --filter=satsuma-cli` — 1163 pass, 1 skipped
- `npx turbo run test --filter=@satsuma/viz-harness` — (run below)

## Tickets
- Closes tced-vrul
- Closes tced-ninm